### PR TITLE
STYLE: Use auto for variable type matches

### DIFF
--- a/Examples/RegistrationITKv4/ModelToImageRegistration1.cxx
+++ b/Examples/RegistrationITKv4/ModelToImageRegistration1.cxx
@@ -337,10 +337,10 @@ public:
     this->m_Transform->SetParameters(parameters);
 
     value = 0;
-    for (auto it : m_PointList)
+    for (auto point : m_PointList)
     {
       const PointType transformedPoint =
-        this->m_Transform->TransformPoint(it);
+        this->m_Transform->TransformPoint(point);
       if (this->m_Interpolator->IsInsideBuffer(transformedPoint))
       {
         value += this->m_Interpolator->Evaluate(transformedPoint);

--- a/Modules/Core/Common/include/itkBoundingBox.hxx
+++ b/Modules/Core/Common/include/itkBoundingBox.hxx
@@ -287,7 +287,7 @@ auto
 BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::GetDiagonalLength2() const
   -> AccumulateType
 {
-  typename NumericTraits<CoordinateType>::AccumulateType dist2 = CoordinateType{};
+  typename NumericTraits<CoordinateType>::AccumulateType dist2{};
 
   if (this->ComputeBoundingBox())
   {

--- a/Modules/Core/Common/include/itkColorTable.hxx
+++ b/Modules/Core/Common/include/itkColorTable.hxx
@@ -242,11 +242,11 @@ ColorTable<TComponent>::UseRandomColors(unsigned int n)
   }
   for (unsigned int i = 0; i < n; ++i)
   {
-    TComponent r = static_cast<TComponent>(vnl_sample_uniform(minimum, maximum));
+    auto r = static_cast<TComponent>(vnl_sample_uniform(minimum, maximum));
     m_Color[i][0] = r;
-    TComponent g = static_cast<TComponent>(vnl_sample_uniform(minimum, maximum));
+    auto g = static_cast<TComponent>(vnl_sample_uniform(minimum, maximum));
     m_Color[i][1] = g;
-    TComponent b = static_cast<TComponent>(vnl_sample_uniform(minimum, maximum));
+    auto b = static_cast<TComponent>(vnl_sample_uniform(minimum, maximum));
     m_Color[i][2] = b;
     std::ostringstream name;
     name << "Random(" << std::fixed << std::setprecision(2) << static_cast<float>(r) << ',' << static_cast<float>(g)

--- a/Modules/Core/Common/include/itkCovariantVector.hxx
+++ b/Modules/Core/Common/include/itkCovariantVector.hxx
@@ -113,7 +113,7 @@ template <typename T, unsigned int VVectorDimension>
 typename CovariantVector<T, VVectorDimension>::ValueType
 CovariantVector<T, VVectorDimension>::operator*(const Vector<T, VVectorDimension> & other) const
 {
-  typename NumericTraits<T>::AccumulateType value = T{};
+  typename NumericTraits<T>::AccumulateType value{};
   for (unsigned int i = 0; i < VVectorDimension; ++i)
   {
     value += (*this)[i] * other[i];

--- a/Modules/Core/Common/include/itkGaussianOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianOperator.hxx
@@ -53,7 +53,7 @@ GaussianOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> Coef
     }
   }
   // Normalize the coefficients so that their sum is one.
-  for (typename CoefficientVector::iterator it = coeff.begin(); it < coeff.end(); ++it)
+  for (auto it = coeff.begin(); it < coeff.end(); ++it)
   {
     *it /= sum;
   }
@@ -63,7 +63,7 @@ GaussianOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> Coef
   coeff.insert(coeff.begin(), j, 0);
   {
     int i = 0;
-    for (typename CoefficientVector::iterator it = coeff.end() - 1; i < j; --it, ++i)
+    for (auto it = coeff.end() - 1; i < j; --it, ++i)
     {
       coeff[i] = *it;
     }

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -343,7 +343,7 @@ namespace itk
 #define itkFactorylessNewMacro(x) \
   static Pointer New()            \
   {                               \
-    x *     rawPtr = new x();     \
+    auto *  rawPtr = new x();     \
     Pointer smartPtr = rawPtr;    \
     rawPtr->UnRegister();         \
     return smartPtr;              \

--- a/Modules/Core/Common/include/itkNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodIterator.hxx
@@ -125,7 +125,7 @@ NeighborhoodIterator<TImage, TBoundaryCondition>::SetPixel(const unsigned int n,
       if (!this->m_InBounds[i]) // Part of dimension spills out of bounds
       {
         const typename OffsetType::OffsetValueType OverlapLow = this->m_InnerBoundsLow[i] - this->m_Loop[i];
-        const typename OffsetType::OffsetValueType OverlapHigh =
+        const auto                                 OverlapHigh =
           static_cast<OffsetValueType>(this->GetSize(i) - ((this->m_Loop[i] + 2) - this->m_InnerBoundsHigh[i]));
         if (temp[i] < OverlapLow || OverlapHigh < temp[i])
         {

--- a/Modules/Core/Common/include/itkResourceProbesCollectorBase.hxx
+++ b/Modules/Core/Common/include/itkResourceProbesCollectorBase.hxx
@@ -67,8 +67,8 @@ template <typename TProbe>
 void
 ResourceProbesCollectorBase<TProbe>::Report(std::ostream & os, bool printSystemInfo, bool printReportHead, bool useTabs)
 {
-  auto                                   probe = this->m_Probes.begin();
-  const typename MapType::const_iterator end = this->m_Probes.end();
+  auto       probe = this->m_Probes.begin();
+  const auto end = this->m_Probes.end();
 
   if (probe == end)
   {
@@ -122,8 +122,8 @@ ResourceProbesCollectorBase<TProbe>::ExpandedReport(std::ostream & os,
                                                     bool           printReportHead,
                                                     bool           useTabs)
 {
-  auto                                   probe = this->m_Probes.begin();
-  const typename MapType::const_iterator end = this->m_Probes.end();
+  auto       probe = this->m_Probes.begin();
+  const auto end = this->m_Probes.end();
 
   if (probe == end)
   {
@@ -174,8 +174,8 @@ template <typename TProbe>
 void
 ResourceProbesCollectorBase<TProbe>::JSONReport(std::ostream & os, bool printSystemInfo)
 {
-  auto                                   probe = this->m_Probes.begin();
-  const typename MapType::const_iterator end = this->m_Probes.end();
+  auto       probe = this->m_Probes.begin();
+  const auto end = this->m_Probes.end();
 
   if (probe == end)
   {

--- a/Modules/Core/Common/include/itkSparseFieldLayer.hxx
+++ b/Modules/Core/Common/include/itkSparseFieldLayer.hxx
@@ -51,9 +51,8 @@ auto
 SparseFieldLayer<TNodeType>::SplitRegions(int num) const -> RegionListType
 {
   const unsigned int size = Size();
-  const unsigned int regionsize =
-    static_cast<unsigned int>(std::ceil(static_cast<float>(size) / static_cast<float>(num)));
-  ConstIterator       position = Begin();
+  const auto    regionsize = static_cast<unsigned int>(std::ceil(static_cast<float>(size) / static_cast<float>(num)));
+  ConstIterator position = Begin();
   const ConstIterator last = End();
 
   std::vector<RegionType> regionlist;

--- a/Modules/Core/Common/include/itkThreadLogger.h
+++ b/Modules/Core/Common/include/itkThreadLogger.h
@@ -59,14 +59,14 @@ public:
   using DelayType = unsigned int;
 
   /** Definition of types of operations for ThreadLogger. */
-  typedef enum
+  enum OperationType
   {
     SET_PRIORITY_LEVEL,
     SET_LEVEL_FOR_FLUSHING,
     ADD_LOG_OUTPUT,
     WRITE,
     FLUSH
-  } OperationType;
+  };
 
   /** Set the priority level for the current logger. Only messages that have
    * priorities equal or greater than the one set here will be posted to the

--- a/Modules/Core/Common/include/itkVector.hxx
+++ b/Modules/Core/Common/include/itkVector.hxx
@@ -103,7 +103,7 @@ template <typename T, unsigned int TVectorDimension>
 auto
 Vector<T, TVectorDimension>::GetSquaredNorm() const -> RealValueType
 {
-  typename NumericTraits<RealValueType>::AccumulateType sum = T{};
+  auto sum = T{};
   for (unsigned int i = 0; i < TVectorDimension; ++i)
   {
     const RealValueType value = (*this)[i];
@@ -198,7 +198,7 @@ template <typename T, unsigned int TVectorDimension>
 typename Vector<T, TVectorDimension>::ValueType
 Vector<T, TVectorDimension>::operator*(const Self & other) const
 {
-  typename NumericTraits<T>::AccumulateType value = T{};
+  auto value = T{};
   for (unsigned int i = 0; i < TVectorDimension; ++i)
   {
     value += (*this)[i] * other[i];

--- a/Modules/Core/Common/src/itkMetaDataDictionary.cxx
+++ b/Modules/Core/Common/src/itkMetaDataDictionary.cxx
@@ -44,7 +44,7 @@ void
 MetaDataDictionary::Print(std::ostream & os) const
 {
   os << "Dictionary use_count: " << m_Dictionary.use_count() << std::endl;
-  for (MetaDataDictionaryMapType::const_iterator it = m_Dictionary->begin(); it != m_Dictionary->end(); ++it)
+  for (auto it = m_Dictionary->begin(); it != m_Dictionary->end(); ++it)
   {
     os << it->first << "  ";
     it->second->Print(os);
@@ -102,7 +102,7 @@ MetaDataDictionary::GetKeys() const
   using VectorType = std::vector<std::string>;
   VectorType ans;
 
-  for (MetaDataDictionaryMapType::const_iterator it = m_Dictionary->begin(); it != m_Dictionary->end(); ++it)
+  for (auto it = m_Dictionary->begin(); it != m_Dictionary->end(); ++it)
   {
     ans.push_back(it->first);
   }
@@ -179,8 +179,8 @@ MetaDataDictionary::MakeUnique()
 bool
 MetaDataDictionary::Erase(const std::string & key)
 {
-  auto                                      it = m_Dictionary->find(key);
-  const MetaDataDictionaryMapType::iterator end = m_Dictionary->end();
+  auto       it = m_Dictionary->find(key);
+  const auto end = m_Dictionary->end();
 
   if (it != end)
   {

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -130,8 +130,8 @@ public:
 auto
 ObjectFactoryBase::GetPimplGlobalsPointer() -> ObjectFactoryBasePrivate *
 {
-  const auto                 deleteLambda = []() { m_PimplGlobals->UnRegister(); };
-  ObjectFactoryBasePrivate * globalInstance = Singleton<ObjectFactoryBasePrivate>("ObjectFactoryBase", deleteLambda);
+  const auto deleteLambda = []() { m_PimplGlobals->UnRegister(); };
+  auto *     globalInstance = Singleton<ObjectFactoryBasePrivate>("ObjectFactoryBase", deleteLambda);
   if (globalInstance != m_PimplGlobals)
   {
     SynchronizeObjectFactoryBase(globalInstance);

--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -434,7 +434,7 @@ ProcessObject::SetOutput(const DataObjectIdentifierType & name, DataObject * out
   }
 
   // does this change anything?
-  const DataObjectPointerMap::const_iterator it = m_Outputs.find(key);
+  const auto it = m_Outputs.find(key);
   if (it != m_Outputs.end() && it->second.GetPointer() == output)
   {
     return;

--- a/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
@@ -300,8 +300,8 @@ itkConstShapedNeighborhoodIteratorTest(int, char *[])
   std::cout << "it.GetActiveIndexListSize()=" << it.GetActiveIndexListSize();
 
   println("Testing GetActiveIndexList()");
-  itk::ConstShapedNeighborhoodIterator<TestImageType>::IndexListType                  l = it.GetActiveIndexList();
-  itk::ConstShapedNeighborhoodIterator<TestImageType>::IndexListType ::const_iterator ali = l.begin();
+  itk::ConstShapedNeighborhoodIterator<TestImageType>::IndexListType l = it.GetActiveIndexList();
+  auto                                                               ali = l.begin();
   while (ali != l.end())
   {
     std::cout << *ali << ' ';

--- a/Modules/Core/Common/test/itkImageTest.cxx
+++ b/Modules/Core/Common/test/itkImageTest.cxx
@@ -174,7 +174,7 @@ itkImageTest(int, char *[])
   volume->SetRegions(cuboid);
 
   using ProjectionTransformType = TestTransform<Image3D::ImageDimension>;
-  ProjectionTransformType * projectionTransform = new ProjectionTransformType;
+  auto * projectionTransform = new ProjectionTransformType;
 
   const Image::RegionType rectangleRegion = itk::ImageAlgorithm::EnlargeRegionOverBox(
     volume->GetLargestPossibleRegion(), volume.GetPointer(), imageRef.GetPointer(), projectionTransform);
@@ -192,7 +192,7 @@ itkImageTest(int, char *[])
   }
 
   using TestIdentityTransformType = TestTransform<Image::ImageDimension>;
-  TestIdentityTransformType * testIdentityTransform = new TestIdentityTransformType;
+  auto * testIdentityTransform = new TestIdentityTransformType;
 
   const Image::RegionType tesBoxRegion = itk::ImageAlgorithm::EnlargeRegionOverBox(
     image->GetLargestPossibleRegion(), image.GetPointer(), imageRef.GetPointer(), testIdentityTransform);

--- a/Modules/Core/Common/test/itkLineIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkLineIteratorTest.cxx
@@ -114,7 +114,7 @@ itkLineIteratorTest(int argc, char * argv[])
   endIndex.Fill(189);
   LineIteratorType it(output, startIndex, endIndex);
 
-  std::vector<IndexType>::iterator itBaseline = baselineIndex.begin();
+  auto itBaseline = baselineIndex.begin();
   while (!it.IsAtEnd())
   {
     it.Set(255);

--- a/Modules/Core/Common/test/itkMathRoundProfileTest1.cxx
+++ b/Modules/Core/Common/test/itkMathRoundProfileTest1.cxx
@@ -98,10 +98,10 @@ itkMathRoundProfileTest1(int, char *[])
     // Count the time of simply assigning values in an std::vector
     //
     //
-    IntArrayType::const_iterator outItr1src = output1.begin();
-    auto                         outItr2dst = output2.begin();
+    auto outItr1src = output1.begin();
+    auto outItr2dst = output2.begin();
 
-    const IntArrayType::const_iterator outEnd1 = output1.end();
+    const auto outEnd1 = output1.end();
 
     chronometer.Start("std::vector");
 
@@ -112,8 +112,8 @@ itkMathRoundProfileTest1(int, char *[])
 
     chronometer.Stop("std::vector");
 
-    ArrayType::const_iterator inpItr = input.begin();
-    ArrayType::const_iterator inputEnd = input.end();
+    auto inpItr = input.begin();
+    auto inputEnd = input.end();
 
     auto outItr1nc = output1.begin();
 
@@ -191,11 +191,11 @@ itkMathRoundProfileTest1(int, char *[])
   //
   // Now test the correctness of the output
   //
-  ArrayType::const_iterator       inpItr = input.begin();
-  const ArrayType::const_iterator inputEnd = input.end();
+  auto       inpItr = input.begin();
+  const auto inputEnd = input.end();
 
-  IntArrayType::const_iterator outItr1 = output1.begin();
-  IntArrayType::const_iterator outItr2 = output2.begin();
+  auto outItr1 = output1.begin();
+  auto outItr2 = output2.begin();
 
   bool roundMismatch = false;
 

--- a/Modules/Core/Common/test/itkObjectFactoryOnlyNewTest.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryOnlyNewTest.cxx
@@ -157,14 +157,14 @@ itkObjectFactoryOnlyNewTest(int, char *[])
     std::cout << "  Factory version: " << oneFactory->GetITKSourceVersion() << std::endl
               << "  Factory description: " << oneFactory->GetDescription() << std::endl;
 
-    std::list<std::string>                 overrides = oneFactory->GetClassOverrideNames();
-    std::list<std::string>                 names = oneFactory->GetClassOverrideWithNames();
-    std::list<std::string>                 descriptions = oneFactory->GetClassOverrideDescriptions();
-    std::list<bool>                        enableflags = oneFactory->GetEnableFlags();
-    std::list<std::string>::const_iterator n = names.begin();
-    std::list<std::string>::const_iterator d = descriptions.begin();
-    std::list<bool>::const_iterator        e = enableflags.begin();
-    for (std::list<std::string>::const_iterator o = overrides.begin(); o != overrides.end(); ++o, ++n, ++d, ++e)
+    std::list<std::string> overrides = oneFactory->GetClassOverrideNames();
+    std::list<std::string> names = oneFactory->GetClassOverrideWithNames();
+    std::list<std::string> descriptions = oneFactory->GetClassOverrideDescriptions();
+    std::list<bool>        enableflags = oneFactory->GetEnableFlags();
+    auto                   n = names.begin();
+    auto                   d = descriptions.begin();
+    auto                   e = enableflags.begin();
+    for (auto o = overrides.begin(); o != overrides.end(); ++o, ++n, ++d, ++e)
     {
       std::cout << "    Override " << *o << " with " << *n << std::endl
                 << "      described as \"" << *d << '"' << std::endl

--- a/Modules/Core/Common/test/itkObjectFactoryTest.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryTest.cxx
@@ -158,14 +158,14 @@ itkObjectFactoryTest(int, char *[])
     std::cout << "  Factory version: " << oneFactory->GetITKSourceVersion() << std::endl
               << "  Factory description: " << oneFactory->GetDescription() << std::endl;
 
-    std::list<std::string>                 overrides = oneFactory->GetClassOverrideNames();
-    std::list<std::string>                 names = oneFactory->GetClassOverrideWithNames();
-    std::list<std::string>                 descriptions = oneFactory->GetClassOverrideDescriptions();
-    std::list<bool>                        enableflags = oneFactory->GetEnableFlags();
-    std::list<std::string>::const_iterator n = names.begin();
-    std::list<std::string>::const_iterator d = descriptions.begin();
-    std::list<bool>::const_iterator        e = enableflags.begin();
-    for (std::list<std::string>::const_iterator o = overrides.begin(); o != overrides.end(); ++o, ++n, ++d, ++e)
+    std::list<std::string> overrides = oneFactory->GetClassOverrideNames();
+    std::list<std::string> names = oneFactory->GetClassOverrideWithNames();
+    std::list<std::string> descriptions = oneFactory->GetClassOverrideDescriptions();
+    std::list<bool>        enableflags = oneFactory->GetEnableFlags();
+    auto                   n = names.begin();
+    auto                   d = descriptions.begin();
+    auto                   e = enableflags.begin();
+    for (auto o = overrides.begin(); o != overrides.end(); ++o, ++n, ++d, ++e)
     {
       std::cout << "    Override " << *o << " with " << *n << std::endl
                 << "      described as \"" << *d << '"' << std::endl

--- a/Modules/Core/Common/test/itkObjectFactoryTest2.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryTest2.cxx
@@ -142,14 +142,14 @@ itkObjectFactoryTest2(int argc, char * argv[])
       std::cout << "  Factory version: " << factory->GetITKSourceVersion() << std::endl
                 << "  Factory description: " << factory->GetDescription() << std::endl;
 
-      std::list<std::string>                 overrides = factory->GetClassOverrideNames();
-      std::list<std::string>                 names = factory->GetClassOverrideWithNames();
-      std::list<std::string>                 descriptions = factory->GetClassOverrideDescriptions();
-      std::list<bool>                        enableflags = factory->GetEnableFlags();
-      std::list<std::string>::const_iterator n = names.begin();
-      std::list<std::string>::const_iterator d = descriptions.begin();
-      std::list<bool>::const_iterator        e = enableflags.begin();
-      for (std::list<std::string>::const_iterator o = overrides.begin(); o != overrides.end(); ++o, ++n, ++d, ++e)
+      std::list<std::string> overrides = factory->GetClassOverrideNames();
+      std::list<std::string> names = factory->GetClassOverrideWithNames();
+      std::list<std::string> descriptions = factory->GetClassOverrideDescriptions();
+      std::list<bool>        enableflags = factory->GetEnableFlags();
+      auto                   n = names.begin();
+      auto                   d = descriptions.begin();
+      auto                   e = enableflags.begin();
+      for (auto o = overrides.begin(); o != overrides.end(); ++o, ++n, ++d, ++e)
       {
         std::cout << "    Override " << *o << " with " << *n << std::endl
                   << "      described as \"" << *d << '"' << std::endl

--- a/Modules/Core/Common/test/itkPriorityQueueTest.cxx
+++ b/Modules/Core/Common/test/itkPriorityQueueTest.cxx
@@ -50,8 +50,8 @@ itkPriorityQueueTest(int, char *[])
   sequence.push_back(1.);
   sequence.push_back(-1.);
 
-  std::list<double>::const_iterator it = sequence.begin();
-  size_t                            i = 0;
+  auto   it = sequence.begin();
+  size_t i = 0;
   for (; it != sequence.end(); ++it, ++i)
   {
     min_priority_queue->Push(MinPQElementType(i, *it));

--- a/Modules/Core/Common/test/itkSTLContainerAdaptorTest.cxx
+++ b/Modules/Core/Common/test/itkSTLContainerAdaptorTest.cxx
@@ -68,7 +68,7 @@ itkSTLContainerAdaptorTest(int, char *[])
       targetRef.reserve(vectorSource.size());
       targetRef.assign(vectorSource.begin(), vectorSource.end());
 
-      STLVectorType::const_iterator      it = vectorSource.begin();
+      auto                               it = vectorSource.begin();
       VectorContainerType::ConstIterator cIter = vectorContainer->Begin();
       while (it != vectorSource.end() && cIter != vectorContainer->End())
       {
@@ -116,7 +116,7 @@ itkSTLContainerAdaptorTest(int, char *[])
       std::cout << "Testing reading assignment... ";
       destination.assign(constTargetRef.begin(), constTargetRef.end());
 
-      STLVectorType::const_iterator      it = destination.begin();
+      auto                               it = destination.begin();
       VectorContainerType::ConstIterator cIter = vectorContainer->Begin();
       while (it != destination.end() && cIter != vectorContainer->End())
       {
@@ -193,7 +193,7 @@ itkSTLContainerAdaptorTest(int, char *[])
         targetRef[i] = mapSource[i];
       }
 
-      STLMapType::const_iterator      it = mapSource.begin();
+      auto                            it = mapSource.begin();
       MapContainerType::ConstIterator cIter = mapContainer->Begin();
       while (it != mapSource.end() && cIter != mapContainer->End())
       {
@@ -244,7 +244,7 @@ itkSTLContainerAdaptorTest(int, char *[])
         destination[i] = constTargetRef.find(i)->second;
       }
 
-      STLMapType::const_iterator      it = destination.begin();
+      auto                            it = destination.begin();
       MapContainerType::ConstIterator cIter = mapContainer->Begin();
       while (it != destination.end() && cIter != mapContainer->End())
       {

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorTest.cxx
@@ -486,7 +486,7 @@ itkSymmetricSecondRankTensorTest(int, char *[])
     Float3DTensorType floatTensor2 = intTensor;
 
     // Test casting
-    Float3DTensorType floatTensor3 = static_cast<Float3DTensorType>(intTensor);
+    auto floatTensor3 = static_cast<Float3DTensorType>(intTensor);
 
     // Check that all floatTensors have are the same
     const float precision = 1e-6;

--- a/Modules/Core/Common/test/itkVNLRoundProfileTest1.cxx
+++ b/Modules/Core/Common/test/itkVNLRoundProfileTest1.cxx
@@ -92,10 +92,10 @@ itkVNLRoundProfileTest1(int, char *[])
     // Count the time of simply assigning values in an std::vector
     //
     //
-    ArrayType::const_iterator outItr1src = output1.begin();
-    auto                      outItr2dst = output2.begin();
+    auto outItr1src = output1.begin();
+    auto outItr2dst = output2.begin();
 
-    const ArrayType::const_iterator outEnd1 = output1.end();
+    const auto outEnd1 = output1.end();
 
     chronometer.Start("std::vector");
 
@@ -108,8 +108,8 @@ itkVNLRoundProfileTest1(int, char *[])
 
     chronometer.Stop("std::vector");
 
-    ArrayType::const_iterator inpItr = input.begin();
-    ArrayType::const_iterator inputEnd = input.end();
+    auto inpItr = input.begin();
+    auto inputEnd = input.end();
 
     auto outItr1nc = output1.begin();
 
@@ -198,11 +198,11 @@ itkVNLRoundProfileTest1(int, char *[])
   //
   // Now test the correctness of the output
   //
-  ArrayType::const_iterator       inpItr = input.begin();
-  const ArrayType::const_iterator inputEnd = input.end();
+  auto       inpItr = input.begin();
+  const auto inputEnd = input.end();
 
-  ArrayType::const_iterator outItr1 = output1.begin();
-  ArrayType::const_iterator outItr2 = output2.begin();
+  auto outItr1 = output1.begin();
+  auto outItr2 = output2.begin();
 
   const double tolerance = 1e-5;
 

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.hxx
@@ -91,7 +91,7 @@ FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::Appl
 {
   const ThreadIdType workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
   const ThreadIdType workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
-  FDThreadStruct *   str = (FDThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
+  auto *             str = (FDThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
 
   // Execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.
@@ -181,7 +181,7 @@ FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::Calc
   const ThreadIdType workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
   const ThreadIdType workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
 
-  FDThreadStruct * str = (FDThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
+  auto * str = (FDThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
 
   // Execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.
@@ -207,7 +207,7 @@ FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::Prec
   const ThreadIdType workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
   const ThreadIdType workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
 
-  FDThreadStruct * str = (FDThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
+  auto * str = (FDThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
 
   // Execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.

--- a/Modules/Core/ImageAdaptors/include/itkNthElementPixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkNthElementPixelAccessor.h
@@ -156,7 +156,7 @@ public:
   inline ExternalType
   Get(const ActualPixelType & input) const
   {
-    const ExternalType output = static_cast<ExternalType>(input[m_ElementNumber]);
+    const auto output = static_cast<ExternalType>(input[m_ElementNumber]);
     return output;
   }
 

--- a/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
@@ -914,8 +914,8 @@ itkVectorImageTest(int, char * argv[])
         offset1[2] = -1;
         cSnit.ActivateOffset(offset1);
 
-        ConstShapedNeighborhoodIteratorType::IndexListType                 l = cSnit.GetActiveIndexList();
-        ConstShapedNeighborhoodIteratorType::IndexListType::const_iterator ali = l.begin();
+        ConstShapedNeighborhoodIteratorType::IndexListType l = cSnit.GetActiveIndexList();
+        auto                                               ali = l.begin();
         while (ali != l.end())
         {
           std::cout << *ali << ' ';

--- a/Modules/Core/ImageFunction/include/itkMeanImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMeanImageFunction.hxx
@@ -34,7 +34,7 @@ template <typename TInputImage, typename TCoordinate>
 auto
 MeanImageFunction<TInputImage, TCoordinate>::EvaluateAtIndex(const IndexType & index) const -> RealType
 {
-  RealType sum = RealType{};
+  auto sum = RealType{};
 
   const InputImageType * const image = this->GetInputImage();
 

--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
@@ -1003,17 +1003,17 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::Reset(
 
   else
   {
-    for (double & it : m_RayVoxelStartPosition)
+    for (double & coordinate : m_RayVoxelStartPosition)
     {
-      it = 0.;
+      coordinate = 0.;
     }
-    for (double & it : m_RayVoxelEndPosition)
+    for (double & coordinate : m_RayVoxelEndPosition)
     {
-      it = 0.;
+      coordinate = 0.;
     }
-    for (double & it : m_VoxelIncrement)
+    for (double & incr : m_VoxelIncrement)
     {
-      it = 0.;
+      incr = 0.;
     }
     m_TraversalDirection = TraversalDirectionEnum::UNDEFINED_DIRECTION;
 
@@ -1023,9 +1023,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::Reset(
     {
       m_RayIntersectionVoxel = nullptr;
     }
-    for (int & it : m_RayIntersectionVoxelIndex)
+    for (int & idx : m_RayIntersectionVoxelIndex)
     {
-      it = 0;
+      idx = 0;
     }
   }
 }
@@ -1304,25 +1304,25 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::ZeroSt
   m_VoxelDimensionInY = 0;
   m_VoxelDimensionInZ = 0;
 
-  for (double & it : m_CurrentRayPositionInMM)
+  for (double & pos : m_CurrentRayPositionInMM)
   {
-    it = 0.;
+    pos = 0.;
   }
-  for (double & it : m_RayDirectionInMM)
+  for (double & dir : m_RayDirectionInMM)
   {
-    it = 0.;
+    dir = 0.;
   }
-  for (double & it : m_RayVoxelStartPosition)
+  for (double & pos : m_RayVoxelStartPosition)
   {
-    it = 0.;
+    pos = 0.;
   }
-  for (double & it : m_RayVoxelEndPosition)
+  for (double & pos : m_RayVoxelEndPosition)
   {
-    it = 0.;
+    pos = 0.;
   }
-  for (double & it : m_VoxelIncrement)
+  for (double & incr : m_VoxelIncrement)
   {
-    it = 0.;
+    incr = 0.;
   }
   m_TraversalDirection = TraversalDirectionEnum::UNDEFINED_DIRECTION;
 
@@ -1333,9 +1333,9 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::ZeroSt
   {
     m_RayIntersectionVoxel = nullptr;
   }
-  for (int & it : m_RayIntersectionVoxelIndex)
+  for (int & idx : m_RayIntersectionVoxelIndex)
   {
-    it = 0;
+    idx = 0;
   }
 }
 

--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
@@ -1203,10 +1203,10 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::GetCur
   {
     return 0;
   }
-  const double a = static_cast<double>(*m_RayIntersectionVoxels[0]);
-  const double b = static_cast<double>(*m_RayIntersectionVoxels[1] - a);
-  const double c = static_cast<double>(*m_RayIntersectionVoxels[2] - a);
-  const double d = static_cast<double>(*m_RayIntersectionVoxels[3] - a - b - c);
+  const auto a = static_cast<double>(*m_RayIntersectionVoxels[0]);
+  const auto b = static_cast<double>(*m_RayIntersectionVoxels[1] - a);
+  const auto c = static_cast<double>(*m_RayIntersectionVoxels[2] - a);
+  const auto d = static_cast<double>(*m_RayIntersectionVoxels[3] - a - b - c);
 
   double y;
   double z;

--- a/Modules/Core/ImageFunction/include/itkSumOfSquaresImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkSumOfSquaresImageFunction.hxx
@@ -35,7 +35,7 @@ template <typename TInputImage, typename TCoordinate>
 auto
 SumOfSquaresImageFunction<TInputImage, TCoordinate>::EvaluateAtIndex(const IndexType & index) const -> RealType
 {
-  RealType sumOfSquares = RealType{};
+  auto sumOfSquares = RealType{};
 
   const InputImageType * const image = this->GetInputImage();
 

--- a/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
@@ -1378,9 +1378,9 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
 
   typename TriCell::CellAutoPointer        insertCell;
   typename OutputMeshType::PointIdentifier tripoints[3];
-  unsigned char *                          tp = (unsigned char *)malloc(3 * sizeof(unsigned char));
+  auto *                                   tp = (unsigned char *)malloc(3 * sizeof(unsigned char));
 
-  IdentifierType * tpl = (IdentifierType *)malloc(3 * sizeof(IdentifierType));
+  auto * tpl = (IdentifierType *)malloc(3 * sizeof(IdentifierType));
 
   switch (static_cast<int>(celltype))
   {

--- a/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.hxx
@@ -133,7 +133,7 @@ TriangleMeshCurvatureCalculator<TInputMesh>::ComputeGaussCurvature(const InputMe
     const double alpha2 = itk::Math::pi - angle(e0.GetVnlVector(), e1.GetVnlVector());
 
     // Surface area
-    const double A = static_cast<double>(
+    const auto A = static_cast<double>(
       itk::Math::abs(vnl_cross_3d((v1 - v0).GetVnlVector(), (v2 - v0).GetVnlVector()).two_norm() / 2.0));
 
     dA[point_ids[0]] += A;

--- a/Modules/Core/Mesh/test/itkMeshTest.cxx
+++ b/Modules/Core/Mesh/test/itkMeshTest.cxx
@@ -206,10 +206,10 @@ itkMeshTest(int, char *[])
     auto          cellVectorContainer = MeshType::CellsVectorContainer::New();
     int           index = 0;
     unsigned long value = 1;
-    for (auto & iter : cellPointMap)
+    for (auto & pair : cellPointMap)
     {
-      const itk::CellGeometryEnum cellType = iter.first;
-      const unsigned int          numOfPoints = iter.second;
+      const itk::CellGeometryEnum cellType = pair.first;
+      const unsigned int          numOfPoints = pair.second;
 
       // Insert cell type
       cellVectorContainer->InsertElement(index++, static_cast<unsigned long>(cellType));
@@ -229,9 +229,9 @@ itkMeshTest(int, char *[])
 
     // Check if right cells are recovered
     index = 0;
-    for (auto & iter : cellPointMap)
+    for (auto & pair : cellPointMap)
     {
-      const unsigned int numOfPoints = iter.second;
+      const unsigned int numOfPoints = pair.second;
       CellAutoPointer    temp_cell;
 
       if (mesh0->GetCell(index++, temp_cell))

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
@@ -849,8 +849,8 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::DeleteEdge(QEPrimal * e)
 
   // we checked all the cells in the container
   // now delete the elements in the map
-  auto                                     dit = cellsToDelete.begin();
-  const typename DeleteCellsCont::iterator dend = cellsToDelete.end();
+  auto       dit = cellsToDelete.begin();
+  const auto dend = cellsToDelete.end();
   while (dit != dend)
   {
     const CellType * cellToBeDeleted = this->GetCells()->GetElement(*dit);

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
@@ -105,7 +105,7 @@ ContourSpatialObject<TDimension>::SetControlPoints(const ContourPointListType & 
 {
   m_ControlPoints.clear();
 
-  typename ContourPointListType::const_iterator it = points.begin();
+  auto it = points.begin();
   while (it != points.end())
   {
     m_ControlPoints.push_back(*it);

--- a/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.hxx
@@ -156,7 +156,7 @@ MetaMeshConverter<VDimension, PixelType, TMeshTraits>::MetaObjectToSpatialObject
   {
     typename MeshType::PointCellLinksContainer pcl;
 
-    std::list<int>::const_iterator it_link = (*it_links)->m_Links.begin();
+    auto it_link = (*it_links)->m_Links.begin();
     while (it_link != (*it_links)->m_Links.end())
     {
       pcl.insert(*it_link);

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -411,7 +411,7 @@ template <unsigned int TDimension>
 void
 SpatialObject<TDimension>::AddChild(Self * pointer)
 {
-  const typename ChildrenListType::iterator pos = std::find(m_ChildrenList.begin(), m_ChildrenList.end(), pointer);
+  const auto pos = std::find(m_ChildrenList.begin(), m_ChildrenList.end(), pointer);
   if (pos == m_ChildrenList.end())
   {
     m_ChildrenList.push_back(pointer);
@@ -431,7 +431,7 @@ template <unsigned int TDimension>
 bool
 SpatialObject<TDimension>::RemoveChild(Self * pointer)
 {
-  const typename ChildrenListType::iterator pos = std::find(m_ChildrenList.begin(), m_ChildrenList.end(), pointer);
+  const auto pos = std::find(m_ChildrenList.begin(), m_ChildrenList.end(), pointer);
   if (pos != m_ChildrenList.end())
   {
     m_ChildrenList.erase(pos);

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectDuplicator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectDuplicator.hxx
@@ -41,8 +41,8 @@ SpatialObjectDuplicator<TInputSpatialObject>::CopyObject(const InternalSpatialOb
   destination->Update();
 
   using ChildrenListType = typename TInputSpatialObject::ChildrenListType;
-  ChildrenListType *                        children = source->GetChildren();
-  typename ChildrenListType::const_iterator it = children->begin();
+  ChildrenListType * children = source->GetChildren();
+  auto               it = children->begin();
   while (it != children->end())
   {
     this->CopyObject(*it, newSO);
@@ -78,8 +78,8 @@ SpatialObjectDuplicator<TInputSpatialObject>::Update()
 
   // Create the children
   using ChildrenListType = typename TInputSpatialObject::ChildrenListType;
-  ChildrenListType *                        children = m_Input->GetChildren();
-  typename ChildrenListType::const_iterator it = children->begin();
+  ChildrenListType * children = m_Input->GetChildren();
+  auto               it = children->begin();
   while (it != children->end())
   {
     this->CopyObject(*it, m_DuplicateSpatialObject);

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToPointSetFilter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToPointSetFilter.hxx
@@ -79,8 +79,8 @@ SpatialObjectToPointSetFilter<TPointBasedSpatialObject, TOutputPointSet>::Genera
     numberOfPoints = inputSO->GetNumberOfPoints() / m_SamplingFactor;
   }
 
-  ChildrenListType *                        children = inputObject->GetChildren(m_ChildrenDepth);
-  typename ChildrenListType::const_iterator it = children->begin();
+  ChildrenListType * children = inputObject->GetChildren(m_ChildrenDepth);
+  auto               it = children->begin();
 
   while (it != children->end())
   {

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.hxx
@@ -118,8 +118,8 @@ SurfaceSpatialObject<TDimension, TSurfacePointType>::ComputeNormals()
           continue;
         }
 
-        bool                           badPoint = false;
-        std::list<int>::const_iterator itBadId = badId.begin();
+        bool badPoint = false;
+        auto itBadId = badId.begin();
         while (itBadId != badId.end())
         {
           if (*itBadId == i)

--- a/Modules/Core/SpatialObjects/test/itkBlobSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkBlobSpatialObjectTest.cxx
@@ -85,7 +85,7 @@ itkBlobSpatialObjectTest(int, char *[])
   // Point consistency
   std::cout << "Point consistency: ";
 
-  BlobType::BlobPointListType::const_iterator it = blob->GetPoints().begin();
+  auto it = blob->GetPoints().begin();
 
   unsigned int i = 0;
   while (it != blob->GetPoints().end())

--- a/Modules/Core/SpatialObjects/test/itkLandmarkSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkLandmarkSpatialObjectTest.cxx
@@ -79,7 +79,7 @@ itkLandmarkSpatialObjectTest(int, char *[])
   // Point consistency
   std::cout << "Point consistency: ";
 
-  LandmarkType::LandmarkPointListType::const_iterator it = landmark->GetPoints().begin();
+  auto it = landmark->GetPoints().begin();
 
   unsigned int i = 0;
   while (it != landmark->GetPoints().end())

--- a/Modules/Core/SpatialObjects/test/itkLineSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkLineSpatialObjectTest.cxx
@@ -83,7 +83,7 @@ itkLineSpatialObjectTest(int, char *[])
   // Point consistency
   std::cout << "Point consistency: ";
 
-  LineType::LinePointListType::const_iterator it = line->GetPoints().begin();
+  auto it = line->GetPoints().begin();
 
   unsigned int i = 0;
   while (it != line->GetPoints().end())

--- a/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
@@ -77,7 +77,7 @@ itkSurfaceSpatialObjectTest(int, char *[])
   // Point consistency
   std::cout << "Point consistency: ";
 
-  SurfaceType::SurfacePointListType::const_iterator it = Surface->GetPoints().begin();
+  auto it = Surface->GetPoints().begin();
 
   unsigned int i = 0;
   while (it != Surface->GetPoints().end())

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkGradientNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkGradientNDAnisotropicDiffusionFunction.hxx
@@ -78,7 +78,7 @@ GradientNDAnisotropicDiffusionFunction<TImage>::ComputeUpdate(const Neighborhood
                                                               const FloatOffsetType &) -> PixelType
 {
   // PixelType is scalar in this context
-  PixelRealType delta = PixelRealType{};
+  auto delta = PixelRealType{};
 
   // Calculate the centralized derivatives for each dimension.
   PixelRealType dx[ImageDimension];

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorAnisotropicDiffusionFunction.hxx
@@ -49,13 +49,13 @@ VectorAnisotropicDiffusionFunction<TImage>::CalculateAverageGradientMagnitudeSqu
   }
 
   // Get the various region "faces" that are on the data set boundary.
-  BFC_type                                  bfc;
-  typename BFC_type::FaceListType           faceList = bfc(ip, ip->GetRequestedRegion(), radius);
-  typename BFC_type::FaceListType::iterator fit = faceList.begin();
+  BFC_type                        bfc;
+  typename BFC_type::FaceListType faceList = bfc(ip, ip->GetRequestedRegion(), radius);
+  auto                            fit = faceList.begin();
 
   // Now do the actual processing
-  double        accumulator = 0.0;
-  SizeValueType counter = SizeValueType{};
+  double accumulator = 0.0;
+  auto   counter = SizeValueType{};
 
   // First process the non-boundary region
 

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -28,9 +28,9 @@ MRIBiasEnergyFunction<TImage, TImageMask, TBiasField>::MRIBiasEnergyFunction()
   , m_Image(nullptr)
   , m_Mask(nullptr)
 {
-  for (unsigned int & it : m_SamplingFactor)
+  for (unsigned int & factor : m_SamplingFactor)
   {
-    it = 1;
+    factor = 1;
   }
 }
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
@@ -307,10 +307,8 @@ BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
                   // paint the structuring element
                   NeighborIndexContainer & indexDifferenceSet = this->GetDifferenceSet(i);
 
-                  const typename NeighborIndexContainer::const_iterator staticEndIt = indexDifferenceSet.end();
-                  for (typename NeighborIndexContainer::const_iterator itIndex = indexDifferenceSet.begin();
-                       itIndex != staticEndIt;
-                       ++itIndex)
+                  const auto staticEndIt = indexDifferenceSet.end();
+                  for (auto itIndex = indexDifferenceSet.begin(); itIndex != staticEndIt; ++itIndex)
                   {
                     const IndexType idx(neighbIndex + *itIndex);
                     if (outputRegion.IsInside(idx))

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
@@ -298,11 +298,9 @@ BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
                   propagQueue.push(neighbIndex);
 
                   // paint the structuring element
-                  NeighborIndexContainer &                              indexDifferenceSet = this->GetDifferenceSet(i);
-                  const typename NeighborIndexContainer::const_iterator staticEndIndex = indexDifferenceSet.end();
-                  for (typename NeighborIndexContainer::const_iterator itIndex = indexDifferenceSet.begin();
-                       itIndex != staticEndIndex;
-                       ++itIndex)
+                  NeighborIndexContainer & indexDifferenceSet = this->GetDifferenceSet(i);
+                  const auto               staticEndIndex = indexDifferenceSet.end();
+                  for (auto itIndex = indexDifferenceSet.begin(); itIndex != staticEndIndex; ++itIndex)
                   {
                     const IndexType idx(neighbIndex + *itIndex);
                     if (outputRegion.IsInside(idx))

--- a/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
@@ -57,8 +57,8 @@ FFTConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrec
 
     // Crop the output requested region to fit within the largest
     // possible region.
-    InputImageType * inputPtr = itkDynamicCastInDebugMode<InputImageType *>(this->GetPrimaryInput());
-    const bool       wasPartiallyInside = inputRegion.Crop(inputPtr->GetLargestPossibleRegion());
+    auto *     inputPtr = itkDynamicCastInDebugMode<InputImageType *>(this->GetPrimaryInput());
+    const bool wasPartiallyInside = inputRegion.Crop(inputPtr->GetLargestPossibleRegion());
     if (!wasPartiallyInside)
     {
       itkExceptionMacro("Requested region is outside the largest possible region.");

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -701,7 +701,7 @@ typename PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ThreadDataSt
   FaceListType       faceList = faceCalculator(img, regionToProcess, radius);
   bool               foundMinMax = false;
 
-  for (typename FaceListType::iterator fIt = faceList.begin(); fIt != faceList.end(); ++fIt)
+  for (auto fIt = faceList.begin(); fIt != faceList.end(); ++fIt)
   {
     if (!(fIt->GetNumberOfPixels()))
     {
@@ -1536,7 +1536,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ThreadedComputeSigmaU
 
   // Only use pixels whose patch is entirely in bounds
   // for the sigma calculation
-  const typename FaceListType::iterator fIt = faceList.begin();
+  const auto fIt = faceList.begin();
   if (!(fIt->GetNumberOfPixels()))
   {
     // Empty region, don't use.
@@ -1955,7 +1955,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ThreadedComputeImageU
 
   FaceListType faceList = faceCalculator(output, regionToProcess, radius);
 
-  for (typename FaceListType::iterator fIt = faceList.begin(); fIt != faceList.end(); ++fIt)
+  for (auto fIt = faceList.begin(); fIt != faceList.end(); ++fIt)
   {
 
     if (!(fIt->GetNumberOfPixels()))

--- a/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DTest.cxx
@@ -462,7 +462,7 @@ itkDiffusionTensor3DTest(int, char *[])
     Float3DTensorType floatTensor2 = intTensor;
 
     // Test casting
-    Float3DTensorType floatTensor3 = static_cast<Float3DTensorType>(intTensor);
+    auto floatTensor3 = static_cast<Float3DTensorType>(intTensor);
 
     // Check that all floatTensors have are the same
     const float precision = 1e-6;

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
@@ -264,8 +264,8 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::ThreadedGenerateDataBa
   // 1. Initialize whole output image (done in ThreadedGenerateData)
   // 2. Wait for threads (done in ThreadedGenerateData)
   // 3. Computation over the narrowband
-  ConstBandIterator       bandIt = m_NarrowBandRegion[threadId].Begin;
-  const ConstBandIterator bandEnd = m_NarrowBandRegion[threadId].End;
+  auto       bandIt = m_NarrowBandRegion[threadId].Begin;
+  const auto bandEnd = m_NarrowBandRegion[threadId].End;
 
   unsigned int n;
 

--- a/Modules/Filtering/DistanceMap/test/itkFastChamferDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkFastChamferDistanceImageFilterTest.cxx
@@ -121,9 +121,8 @@ FastChamferDistanceImageFilterTest(unsigned int iPositive, unsigned int iNegativ
   std::cout << "Band size: " << band->Size() << std::endl;
 
   // Loop through the band
-  using itNBType = typename NarrowBandType::ConstIterator;
-  itNBType       itNB = band->Begin();
-  const itNBType itNBend = band->End();
+  auto       itNB = band->Begin();
+  const auto itNBend = band->End();
 
   //  BandNodeType *tmp;
   unsigned int innerpositive = 0;

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -276,7 +276,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::Solve(OutputImageType *           
 
   for (const auto & neighbor : iNeighbors)
   {
-    const double value = static_cast<double>(neighbor.m_Value);
+    const auto value = static_cast<double>(neighbor.m_Value);
 
     if (oSolution >= value)
     {

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingReachedTargetNodesStoppingCriterion.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingReachedTargetNodesStoppingCriterion.h
@@ -134,8 +134,8 @@ public:
       // there is at least one TargetPoint.
       if (!m_TargetNodes.empty())
       {
-        typename std::vector<NodeType>::const_iterator       pointsIter = m_TargetNodes.begin();
-        const typename std::vector<NodeType>::const_iterator pointsEnd = m_TargetNodes.end();
+        auto       pointsIter = m_TargetNodes.begin();
+        const auto pointsEnd = m_TargetNodes.end();
 
         while (pointsIter != pointsEnd)
         {

--- a/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
@@ -267,16 +267,16 @@ BilateralImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
     while (!b_iter.IsAtEnd())
     {
       // Setup
-      const OutputPixelRealType centerPixel = static_cast<OutputPixelRealType>(b_iter.GetCenterPixel());
-      OutputPixelRealType       val = 0.0;
-      OutputPixelRealType       normFactor = 0.0;
+      const auto          centerPixel = static_cast<OutputPixelRealType>(b_iter.GetCenterPixel());
+      OutputPixelRealType val = 0.0;
+      OutputPixelRealType normFactor = 0.0;
 
       // Walk the neighborhood of the input and the kernel
       KernelConstIteratorType k_it = m_GaussianKernel.Begin();
       for (typename TInputImage::IndexValueType i = 0; k_it < kernelEnd; ++k_it, ++i)
       {
         // range distance between neighborhood pixel and neighborhood center
-        const OutputPixelRealType pixel = static_cast<OutputPixelRealType>(b_iter.GetPixel(i));
+        const auto pixel = static_cast<OutputPixelRealType>(b_iter.GetPixel(i));
         // flip sign if needed
         const OutputPixelRealType rangeDistance = std::abs(pixel - centerPixel);
 

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.hxx
@@ -109,7 +109,7 @@ LaplacianSharpeningImageFilter<TInputImage, TOutputImage>::GenerateData()
   filteredMinMaxFilter->SetInput(laplacianFilter->GetOutput());
   filteredMinMaxFilter->Update();
 
-  const RealType filteredShift = static_cast<RealType>(filteredMinMaxFilter->GetMinimum());
+  const auto     filteredShift = static_cast<RealType>(filteredMinMaxFilter->GetMinimum());
   const RealType filteredScale = static_cast<RealType>(filteredMinMaxFilter->GetMaximum()) - filteredShift;
   filteredMinMaxFilter = nullptr;
 

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
@@ -427,7 +427,7 @@ itkHoughTransform2DCirclesImageTest(int, char *[])
 
   const double radiusTolerance = 2.0;
 
-  HoughTransformFilterType::CirclesListType::const_iterator it = circleList.begin();
+  auto it = circleList.begin();
 
   unsigned int i = 0;
   while (it != circleList.end())

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
@@ -321,7 +321,7 @@ protected:
     unsigned int j;
     TRealType    dx;
     TRealType    sum;
-    TRealType    accum = TRealType{};
+    auto         accum = TRealType{};
     for (i = 0; i < ImageDimension; ++i)
     {
       sum = TRealType{};

--- a/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
@@ -157,8 +157,8 @@ BinShrinkImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   {
     const OutputIndexType outputIndex = outputIterator.GetIndex();
 
-    typename std::vector<OutputOffsetType>::const_iterator offset = offsets.begin();
-    const InputIndexType                                   startInputIndex = outputIndex * factorSize;
+    auto                 offset = offsets.begin();
+    const InputIndexType startInputIndex = outputIndex * factorSize;
 
     inputIterator.SetIndex(startInputIndex + *offset);
     for (size_t i = 0; i < ln; ++i)

--- a/Modules/Filtering/ImageIntensity/include/itkNaryFunctorImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkNaryFunctorImageFilter.hxx
@@ -73,8 +73,8 @@ NaryFunctorImageFilter<TInputImage, TOutputImage, TFunction>::DynamicThreadedGen
 
   const OutputImagePointer outputPtr = this->GetOutput(0);
 
-  typename std::vector<ImageScanlineConstIteratorType *>::iterator             regionIterators;
-  const typename std::vector<ImageScanlineConstIteratorType *>::const_iterator regionItEnd = inputItrVector.end();
+  typename std::vector<ImageScanlineConstIteratorType *>::iterator regionIterators;
+  const auto                                                       regionItEnd = inputItrVector.end();
 
   typename NaryArrayType::iterator arrayIt;
 

--- a/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.hxx
+++ b/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.hxx
@@ -202,7 +202,7 @@ BinaryContourImageFilter<TInputImage, TOutputImage>::ThreadedIntegrateData(const
     const SizeValueType thisIdx = this->IndexToLinearIndex(outLineIt.GetIndex());
     if (!m_ForegroundLineMap[thisIdx].empty())
     {
-      for (OffsetVectorConstIterator I = this->m_LineOffsets.begin(); I != this->m_LineOffsets.end(); ++I)
+      for (auto I = this->m_LineOffsets.begin(); I != this->m_LineOffsets.end(); ++I)
       {
         const OffsetValueType neighIdx = thisIdx + (*I);
 

--- a/Modules/Filtering/ImageLabel/include/itkChangeLabelImageFilter.h
+++ b/Modules/Filtering/ImageLabel/include/itkChangeLabelImageFilter.h
@@ -92,7 +92,7 @@ public:
   inline TOutput
   operator()(const TInput & A) const
   {
-    const typename ChangeMapType::const_iterator it = m_ChangeMap.find(A);
+    const auto it = m_ChangeMap.find(A);
     if (it != m_ChangeMap.end())
     {
       return it->second;

--- a/Modules/Filtering/ImageLabel/include/itkLabelContourImageFilter.hxx
+++ b/Modules/Filtering/ImageLabel/include/itkLabelContourImageFilter.hxx
@@ -166,7 +166,7 @@ LabelContourImageFilter<TInputImage, TOutputImage>::ThreadedIntegrateData(
     const SizeValueType thisIdx = this->IndexToLinearIndex(outLineIt.GetIndex());
     if (!m_LineMap[thisIdx].empty())
     {
-      for (OffsetVectorConstIterator I = this->m_LineOffsets.begin(); I != this->m_LineOffsets.end(); ++I)
+      for (auto I = this->m_LineOffsets.begin(); I != this->m_LineOffsets.end(); ++I)
       {
         const OffsetValueType neighIdx = thisIdx + (*I);
 

--- a/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
+++ b/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
@@ -157,12 +157,12 @@ protected:
   {
     m_UnionFind = UnionFindType(numberOfLabels + 1);
 
-    const typename LineMapType::iterator MapBegin = m_LineMap.begin();
-    const typename LineMapType::iterator MapEnd = m_LineMap.end();
-    InternalLabelType                    label = 1;
+    const auto        MapBegin = m_LineMap.begin();
+    const auto        MapEnd = m_LineMap.end();
+    InternalLabelType label = 1;
     for (typename LineMapType::iterator LineIt = MapBegin; LineIt != MapEnd; ++LineIt)
     {
-      for (LineEncodingIterator cIt = LineIt->begin(); cIt != LineIt->end(); ++cIt)
+      for (auto cIt = LineIt->begin(); cIt != LineIt->end(); ++cIt)
       {
         cIt->label = label;
         m_UnionFind[label] = label;
@@ -284,9 +284,9 @@ protected:
       offset = 1;
     }
 
-    LineEncodingConstIterator mIt = Neighbour.begin(); // out marker iterator
+    auto mIt = Neighbour.begin(); // out marker iterator
 
-    for (LineEncodingConstIterator cIt = current.begin(); cIt != current.end(); ++cIt)
+    for (auto cIt = current.begin(); cIt != current.end(); ++cIt)
     {
       if (!labelCompare || cIt->label != InternalLabelType(background))
       {
@@ -298,7 +298,7 @@ protected:
           mIt = Neighbour.begin();
         }
 
-        for (LineEncodingConstIterator nIt = mIt; nIt != Neighbour.end(); ++nIt)
+        for (auto nIt = mIt; nIt != Neighbour.end(); ++nIt)
         {
           if (!labelCompare || cIt->label != nIt->label)
           {
@@ -426,9 +426,7 @@ protected:
     const PretendIndexType idx = LineRegion.GetIndex();
     const OffsetValueType  offset = fakeImage->ComputeOffset(idx);
 
-    for (typename LineNeighborhoodType::IndexListType::const_iterator LI = ActiveIndexes.begin();
-         LI != ActiveIndexes.end();
-         ++LI)
+    for (auto LI = ActiveIndexes.begin(); LI != ActiveIndexes.end(); ++LI)
     {
       m_LineOffsets.push_back(fakeImage->ComputeOffset(idx + lnit.GetOffset(*LI)) - offset);
     }

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.hxx
@@ -75,9 +75,7 @@ ImagePCADecompositionCalculator<TInputImage, TBasisImage>::CalculateBasisMatrix(
   m_BasisMatrix = BasisMatrixType(static_cast<unsigned int>(m_BasisImages.size()), m_NumPixels);
 
   int i = 0;
-  for (typename BasisImagePointerVector::const_iterator basis_it = m_BasisImages.begin();
-       basis_it != m_BasisImages.end();
-       ++basis_it)
+  for (auto basis_it = m_BasisImages.begin(); basis_it != m_BasisImages.end(); ++basis_it)
   {
     if ((*basis_it)->GetRequestedRegion().GetSize() != m_Size)
     {

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
@@ -271,7 +271,7 @@ template <typename TInputImage, typename TLabelImage>
 auto
 LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMinimum(LabelPixelType label) const -> RealType
 {
-  const MapConstIterator mapIt = m_LabelStatistics.find(label);
+  const auto mapIt = m_LabelStatistics.find(label);
   if (mapIt == m_LabelStatistics.end())
   {
     // label does not exist, return a default value
@@ -287,7 +287,7 @@ template <typename TInputImage, typename TLabelImage>
 auto
 LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMaximum(LabelPixelType label) const -> RealType
 {
-  const MapConstIterator mapIt = m_LabelStatistics.find(label);
+  const auto mapIt = m_LabelStatistics.find(label);
   if (mapIt == m_LabelStatistics.end())
   {
     // label does not exist, return a default value
@@ -303,7 +303,7 @@ template <typename TInputImage, typename TLabelImage>
 auto
 LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMean(LabelPixelType label) const -> RealType
 {
-  const MapConstIterator mapIt = m_LabelStatistics.find(label);
+  const auto mapIt = m_LabelStatistics.find(label);
   if (mapIt == m_LabelStatistics.end())
   {
     // label does not exist, return a default value
@@ -319,7 +319,7 @@ template <typename TInputImage, typename TLabelImage>
 auto
 LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetSum(LabelPixelType label) const -> RealType
 {
-  const MapConstIterator mapIt = m_LabelStatistics.find(label);
+  const auto mapIt = m_LabelStatistics.find(label);
   if (mapIt == m_LabelStatistics.end())
   {
     // label does not exist, return a default value
@@ -335,7 +335,7 @@ template <typename TInputImage, typename TLabelImage>
 auto
 LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetSigma(LabelPixelType label) const -> RealType
 {
-  const MapConstIterator mapIt = m_LabelStatistics.find(label);
+  const auto mapIt = m_LabelStatistics.find(label);
   if (mapIt == m_LabelStatistics.end())
   {
     // label does not exist, return a default value
@@ -351,7 +351,7 @@ template <typename TInputImage, typename TLabelImage>
 auto
 LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetVariance(LabelPixelType label) const -> RealType
 {
-  const MapConstIterator mapIt = m_LabelStatistics.find(label);
+  const auto mapIt = m_LabelStatistics.find(label);
   if (mapIt == m_LabelStatistics.end())
   {
     // label does not exist, return a default value
@@ -367,7 +367,7 @@ template <typename TInputImage, typename TLabelImage>
 auto
 LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetBoundingBox(LabelPixelType label) const -> BoundingBoxType
 {
-  const MapConstIterator mapIt = m_LabelStatistics.find(label);
+  const auto mapIt = m_LabelStatistics.find(label);
   if (mapIt == m_LabelStatistics.end())
   {
     BoundingBoxType emptyBox;
@@ -384,7 +384,7 @@ template <typename TInputImage, typename TLabelImage>
 auto
 LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetRegion(LabelPixelType label) const -> RegionType
 {
-  const MapConstIterator mapIt = m_LabelStatistics.find(label);
+  const auto mapIt = m_LabelStatistics.find(label);
 
   if (mapIt == m_LabelStatistics.end())
   {
@@ -413,7 +413,7 @@ template <typename TInputImage, typename TLabelImage>
 auto
 LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetCount(LabelPixelType label) const -> MapSizeType
 {
-  const MapConstIterator mapIt = m_LabelStatistics.find(label);
+  const auto mapIt = m_LabelStatistics.find(label);
   if (mapIt == m_LabelStatistics.end())
   {
     // label does not exist, return a default value
@@ -429,8 +429,8 @@ template <typename TInputImage, typename TLabelImage>
 auto
 LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMedian(LabelPixelType label) const -> RealType
 {
-  RealType               median = 0.0;
-  const MapConstIterator mapIt = m_LabelStatistics.find(label);
+  RealType   median = 0.0;
+  const auto mapIt = m_LabelStatistics.find(label);
   if (mapIt == m_LabelStatistics.end() || !m_UseHistograms)
   {
     // label does not exist OR histograms not enabled, return the default value
@@ -466,7 +466,7 @@ template <typename TInputImage, typename TLabelImage>
 auto
 LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetHistogram(LabelPixelType label) const -> HistogramPointer
 {
-  const MapConstIterator mapIt = m_LabelStatistics.find(label);
+  const auto mapIt = m_LabelStatistics.find(label);
   if (mapIt == m_LabelStatistics.end())
   {
     // label does not exist, return a default value

--- a/Modules/Filtering/LabelMap/include/itkAttributeKeepNObjectsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAttributeKeepNObjectsLabelMapFilter.hxx
@@ -77,7 +77,7 @@ AttributeKeepNObjectsLabelMapFilter<TImage, TAttributeAccessor>::GenerateData()
     //   progress.CompletedPixel();
 
     // and move the last objects to the second output
-    for (typename VectorType::const_iterator it = end; it != labelObjects.end(); ++it)
+    for (auto it = end; it != labelObjects.end(); ++it)
     {
       output->RemoveLabelObject(*it);
       output2->AddLabelObject(*it);

--- a/Modules/Filtering/LabelMap/include/itkAttributeRelabelLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAttributeRelabelLabelMapFilter.hxx
@@ -69,7 +69,7 @@ AttributeRelabelLabelMapFilter<TImage, TAttributeAccessor>::GenerateData()
   // and put back the objects in the map
   output->ClearLabels();
   unsigned int label = 0;
-  for (typename VectorType::const_iterator it = labelObjects.begin(); it != labelObjects.end(); ++it)
+  for (auto it = labelObjects.begin(); it != labelObjects.end(); ++it)
   {
     // avoid the background label if it is used
     if (label == output->GetBackgroundValue())

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.hxx
@@ -128,8 +128,8 @@ BinaryImageToLabelMapFilter<TInputImage, TOutputImage>::GenerateData()
   for (SizeValueType thisIdx = 0; thisIdx < linecount; ++thisIdx)
   {
     // now fill the labelled sections
-    LineEncodingConstIterator       cIt = this->m_LineMap[thisIdx].begin();
-    const LineEncodingConstIterator cEnd = this->m_LineMap[thisIdx].end();
+    auto       cIt = this->m_LineMap[thisIdx].begin();
+    const auto cEnd = this->m_LineMap[thisIdx].end();
 
     while (cIt != cEnd)
     {

--- a/Modules/Filtering/LabelMap/include/itkChangeLabelLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkChangeLabelLabelMapFilter.hxx
@@ -85,7 +85,7 @@ ChangeLabelLabelMapFilter<TImage>::GenerateData()
 
   VectorType labelObjectsToBeRelabeled;
 
-  ChangeMapIterator pairToReplace = m_MapOfLabelToBeReplaced.begin();
+  auto pairToReplace = m_MapOfLabelToBeReplaced.begin();
 
   while (pairToReplace != m_MapOfLabelToBeReplaced.end())
   {
@@ -107,8 +107,8 @@ ChangeLabelLabelMapFilter<TImage>::GenerateData()
   // ChangeBackgroundIfNeeded
 
   // Check if the background is among the list of labels to relabel.
-  const ChangeMapIterator backgroundLabelItr = m_MapOfLabelToBeReplaced.find(output->GetBackgroundValue());
-  const bool              backgroundLabelMustBeReplaced = (backgroundLabelItr != m_MapOfLabelToBeReplaced.end());
+  const auto backgroundLabelItr = m_MapOfLabelToBeReplaced.find(output->GetBackgroundValue());
+  const bool backgroundLabelMustBeReplaced = (backgroundLabelItr != m_MapOfLabelToBeReplaced.end());
 
   // Then change the label of the background if needed
   if (backgroundLabelMustBeReplaced)

--- a/Modules/Filtering/LabelMap/include/itkLabelMap.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMap.hxx
@@ -521,7 +521,7 @@ template <typename TLabelObject>
 void
 LabelMap<TLabelObject>::Optimize()
 {
-  for (LabelObjectContainerConstIterator it = m_LabelObjectContainer.begin(); it != m_LabelObjectContainer.end(); ++it)
+  for (auto it = m_LabelObjectContainer.begin(); it != m_LabelObjectContainer.end(); ++it)
   {
     assert((it->second.IsNotNull()));
     it->second->Optimize();

--- a/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
@@ -318,7 +318,7 @@ LabelObject<TLabel, VImageDimension>::Optimize()
     IndexType  currentIdx = lineContainer.begin()->GetIndex();
     LengthType currentLength = lineContainer.begin()->GetLength();
 
-    typename LineContainerType::const_iterator it = lineContainer.begin();
+    auto it = lineContainer.begin();
 
     while (it != lineContainer.end())
     {

--- a/Modules/Filtering/LabelMap/include/itkShapeKeepNObjectsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeKeepNObjectsLabelMapFilter.h
@@ -164,7 +164,7 @@ protected:
       progress.CompletedPixel();
 
       // and remove the last objects of the map
-      for (typename VectorType::const_iterator it2 = end; it2 != labelObjects.end(); ++it2)
+      for (auto it2 = end; it2 != labelObjects.end(); ++it2)
       {
         output2->AddLabelObject(*it2);
         output->RemoveLabelObject(*it2);

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -465,7 +465,7 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ComputeFeretDiameter(LabelObjectType *
 
   // We can now search the feret diameter
   double feretDiameter = 0;
-  for (typename IndexListType::const_iterator iIt1 = idxList.begin(); iIt1 != idxList.end(); ++iIt1)
+  for (auto iIt1 = idxList.begin(); iIt1 != idxList.end(); ++iIt1)
   {
     auto iIt2 = iIt1;
     for (iIt2++; iIt2 != idxList.end(); ++iIt2)

--- a/Modules/Filtering/LabelMap/include/itkShapeRelabelLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeRelabelLabelMapFilter.h
@@ -152,8 +152,8 @@ protected:
 
     // and put back the objects in the map
     output->ClearLabels();
-    PixelType                           label{};
-    typename VectorType::const_iterator it2 = labelObjects.begin();
+    PixelType label{};
+    auto      it2 = labelObjects.begin();
     while (it2 != labelObjects.end())
     {
       // Avoid the background label if it is used

--- a/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.hxx
@@ -259,9 +259,8 @@ ReconstructionImageFilter<TInputImage, TOutputImage, TCompare>::GenerateData()
 
     // now put indexes in the fifo
     // typename CNInputIterator::ConstIterator mIt;
-    typename NOutputIterator::IndexListType::const_iterator mLIt = mIndexList.begin();
-    for (typename NOutputIterator::IndexListType::const_iterator oLIt = oIndexList.begin(); oLIt != oIndexList.end();
-         ++oLIt, ++mLIt)
+    auto mLIt = mIndexList.begin();
+    for (auto oLIt = oIndexList.begin(); oLIt != oIndexList.end(); ++oLIt, ++mLIt)
     {
       const InputImagePixelType VN = outNIt.GetPixel(*oLIt);
       const InputImagePixelType iN = mskNIt.GetPixel(*mLIt);
@@ -293,10 +292,9 @@ ReconstructionImageFilter<TInputImage, TOutputImage, TCompare>::GenerateData()
     // reposition the iterators
     outNIt += I - outNIt.GetIndex();
     mskNIt += I - mskNIt.GetIndex();
-    const InputImagePixelType                               V = outNIt.GetCenterPixel();
-    typename NOutputIterator::IndexListType::const_iterator mLIt = mIndexList.begin();
-    for (typename NOutputIterator::IndexListType::const_iterator oLIt = oIndexList.begin(); oLIt != oIndexList.end();
-         ++oLIt, ++mLIt)
+    const InputImagePixelType V = outNIt.GetCenterPixel();
+    auto                      mLIt = mIndexList.begin();
+    for (auto oLIt = oIndexList.begin(); oLIt != oIndexList.end(); ++oLIt, ++mLIt)
     {
       const InputImagePixelType VN = outNIt.GetPixel(*oLIt);
       const InputImagePixelType iN = mskNIt.GetPixel(*mLIt);

--- a/Modules/Filtering/MathematicalMorphology/include/itkSharedMorphologyUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkSharedMorphologyUtilities.hxx
@@ -323,7 +323,7 @@ MakeEnlargedFace(const typename TInputImage::ConstPointer itkNotUsed(input),
     faceList.push_back(R2);
     //    std::cout << R1 << R2 << std::endl;
   }
-  typename FaceListType::iterator fit = faceList.begin();
+  auto fit = faceList.begin();
 
   bool         foundFace = false;
   float        MaxComp = NumericTraits<float>::NonpositiveMin();

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
@@ -438,9 +438,9 @@ ContourExtractor2DImageFilter<TInputImage>::AddSegment(VertexType from, VertexTy
   }
 
   // Try to find an existing contour that starts where the new segment ends.
-  const VertexToContourContainerIteratorMapIterator newTail(contourData.m_ContourStarts.find(to));
+  const auto newTail(contourData.m_ContourStarts.find(to));
   // Try to find an existing contour that ends where the new segment starts.
-  const VertexToContourContainerIteratorMapIterator newHead(contourData.m_ContourEnds.find(from));
+  const auto newHead(contourData.m_ContourEnds.find(from));
 
   if (newTail != contourData.m_ContourStarts.end() && newHead != contourData.m_ContourEnds.end())
   {

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.hxx
@@ -262,7 +262,7 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::RadiusMaxSquare() -> InputCoo
   for (auto BoundaryPtIterator = this->m_BoundaryPtMap.begin(); BoundaryPtIterator != this->m_BoundaryPtMap.end();
        ++BoundaryPtIterator)
   {
-    const InputCoordinateType r =
+    const auto r =
       static_cast<InputCoordinateType>(center.SquaredEuclideanDistanceTo(input->GetPoint(BoundaryPtIterator->first)));
     if (r > oRmax)
     {

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
@@ -226,7 +226,7 @@ LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::
 
         do
         {
-          const CoefficientMapConstIterator coeffIt = m_CoefficientMap.find(temp);
+          const auto coeffIt = m_CoefficientMap.find(temp);
 
           if (coeffIt != m_CoefficientMap.end())
           {
@@ -242,8 +242,8 @@ LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::
           {
             if (m_AreaComputationType != AreaEnum::NONE)
             {
-              const AreaMapConstIterator mixedIt = m_MixedAreaMap.find(vId);
-              OutputCoordinateType       mixedArea = NumericTraits<OutputCoordinateType>::OneValue();
+              const auto           mixedIt = m_MixedAreaMap.find(vId);
+              OutputCoordinateType mixedArea = NumericTraits<OutputCoordinateType>::OneValue();
 
               if (mixedIt != m_MixedAreaMap.end())
               {

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraints.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraints.hxx
@@ -57,8 +57,8 @@ LaplacianDeformationQuadEdgeMeshFilterWithHardConstraints<TInputMesh, TOutputMes
   VectorType & iBy,
   VectorType & iBz)
 {
-  OutputMapPointIdentifierConstIterator       it = this->m_InternalMap.begin();
-  const OutputMapPointIdentifierConstIterator end = this->m_InternalMap.end();
+  auto       it = this->m_InternalMap.begin();
+  const auto end = this->m_InternalMap.end();
 
   while (it != end)
   {
@@ -68,15 +68,15 @@ LaplacianDeformationQuadEdgeMeshFilterWithHardConstraints<TInputMesh, TOutputMes
     RowType row;
     this->FillMatrixRow(vId1, this->m_Order, NumericTraits<OutputCoordinateType>::OneValue(), row);
 
-    RowConstIterator       rIt = row.begin();
-    const RowConstIterator rEnd = row.end();
+    auto       rIt = row.begin();
+    const auto rEnd = row.end();
 
     while (rIt != rEnd)
     {
       const OutputPointIdentifier vId2 = rIt->first;
       const OutputCoordinateType  weight = rIt->second;
 
-      const ConstraintMapConstIterator cIt = this->m_Constraints.find(vId2);
+      const auto cIt = this->m_Constraints.find(vId2);
       if (cIt != this->m_Constraints.end())
       {
         iBx[internalId1] -= weight * (cIt->second)[0];
@@ -137,8 +137,8 @@ LaplacianDeformationQuadEdgeMeshFilterWithHardConstraints<TInputMesh, TOutputMes
 
     typename OutputMeshType::PointsContainer * points = output->GetPoints();
 
-    OutputMapPointIdentifierConstIterator       it = this->m_InternalMap.begin();
-    const OutputMapPointIdentifierConstIterator end = this->m_InternalMap.end();
+    auto       it = this->m_InternalMap.begin();
+    const auto end = this->m_InternalMap.end();
 
     while (it != end)
     {
@@ -159,8 +159,8 @@ LaplacianDeformationQuadEdgeMeshFilterWithHardConstraints<TInputMesh, TOutputMes
       ++it;
     }
 
-    ConstraintMapConstIterator       cIt = this->m_Constraints.begin();
-    const ConstraintMapConstIterator cEnd = this->m_Constraints.end();
+    auto       cIt = this->m_Constraints.begin();
+    const auto cEnd = this->m_Constraints.end();
 
     while (cIt != cEnd)
     {

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraints.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraints.hxx
@@ -70,8 +70,8 @@ LaplacianDeformationQuadEdgeMeshFilterWithSoftConstraints<TInputMesh, TOutputMes
 {
   OutputMeshType * output = this->GetOutput();
 
-  OutputMapPointIdentifierConstIterator       it = this->m_InternalMap.begin();
-  const OutputMapPointIdentifierConstIterator end = this->m_InternalMap.end();
+  auto       it = this->m_InternalMap.begin();
+  const auto end = this->m_InternalMap.end();
 
   while (it != end)
   {
@@ -81,8 +81,8 @@ LaplacianDeformationQuadEdgeMeshFilterWithSoftConstraints<TInputMesh, TOutputMes
     RowType row;
     this->FillMatrixRow(vId1, this->m_Order, NumericTraits<OutputCoordinateType>::OneValue(), row);
 
-    RowConstIterator       rIt = row.begin();
-    const RowConstIterator rEnd = row.end();
+    auto       rIt = row.begin();
+    const auto rEnd = row.end();
 
     while (rIt != rEnd)
     {
@@ -148,7 +148,7 @@ LaplacianDeformationQuadEdgeMeshFilterWithSoftConstraints<TInputMesh, TOutputMes
 
     typename OutputMeshType::PointsContainer * points = output->GetPoints();
 
-    for (ConstraintMapConstIterator cIt = this->m_Constraints.begin(); cIt != this->m_Constraints.end(); ++cIt)
+    for (auto cIt = this->m_Constraints.begin(); cIt != this->m_Constraints.end(); ++cIt)
     {
       const OutputPointIdentifier vId = cIt->first;
       OutputPointType             p = points->GetElement(vId);
@@ -158,8 +158,7 @@ LaplacianDeformationQuadEdgeMeshFilterWithSoftConstraints<TInputMesh, TOutputMes
 
       OutputCoordinateType l2 = m_LambdaSquare;
 
-      const typename std::unordered_map<OutputPointIdentifier, OutputCoordinateType>::const_iterator lambdaIt =
-        this->m_LocalLambdaSquare.find(vId);
+      const auto lambdaIt = this->m_LocalLambdaSquare.find(vId);
       if (lambdaIt != this->m_LocalLambdaSquare.end())
       {
         l2 = lambdaIt->second;
@@ -183,8 +182,8 @@ LaplacianDeformationQuadEdgeMeshFilterWithSoftConstraints<TInputMesh, TOutputMes
 
     this->SolveLinearSystems(A, Cx, Cy, Cz, X, Y, Z);
 
-    OutputMapPointIdentifierConstIterator       it = this->m_InternalMap.begin();
-    const OutputMapPointIdentifierConstIterator end = this->m_InternalMap.end();
+    auto       it = this->m_InternalMap.begin();
+    const auto end = this->m_InternalMap.end();
 
     while (it != end)
     {

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkParameterizationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkParameterizationQuadEdgeMeshFilter.hxx
@@ -100,8 +100,8 @@ ParameterizationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::Fill
     InputQEType * temp = edge;
     do
     {
-      const InputPointIdentifier            id2 = temp->GetDestination();
-      const InputMapPointIdentifierIterator it = m_BoundaryPtMap.find(id2);
+      const InputPointIdentifier id2 = temp->GetDestination();
+      const auto                 it = m_BoundaryPtMap.find(id2);
       if (it != m_BoundaryPtMap.end())
       {
         const InputCoordinateType value = (*m_CoefficientsMethod)(input, temp);

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest.cxx
@@ -99,7 +99,7 @@ itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest(int argc, char 
   constraints[40] = e;
   constraints[371] = e;
 
-  std::map<MeshType::PointIdentifier, MeshType::VectorType>::const_iterator it = constraints.begin();
+  auto it = constraints.begin();
   while (it != constraints.end())
   {
     filter->SetDisplacement(it->first, it->second);

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest.cxx
@@ -99,7 +99,7 @@ itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest(int argc, char 
   constraints[40] = e;
   constraints[371] = e;
 
-  std::map<MeshType::PointIdentifier, MeshType::VectorType>::const_iterator it = constraints.begin();
+  auto it = constraints.begin();
   while (it != constraints.end())
   {
     filter->SetDisplacement(it->first, it->second);

--- a/Modules/Filtering/Thresholding/include/itkThresholdLabelerImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkThresholdLabelerImageFilter.h
@@ -158,7 +158,7 @@ public:
   {
     m_Thresholds = thresholds;
     m_RealThresholds.clear();
-    typename ThresholdVector::const_iterator itr = m_Thresholds.begin();
+    auto itr = m_Thresholds.begin();
     while (itr != m_Thresholds.end())
     {
       m_RealThresholds.push_back(static_cast<RealThresholdType>(*itr));
@@ -180,7 +180,7 @@ public:
   {
     m_RealThresholds = thresholds;
     m_Thresholds.clear();
-    typename RealThresholdVector::const_iterator itr = m_RealThresholds.begin();
+    auto itr = m_RealThresholds.begin();
     while (itr != m_RealThresholds.end())
     {
       m_Thresholds.push_back(static_cast<InputPixelType>(*itr));

--- a/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
+++ b/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
@@ -69,14 +69,14 @@ struct bioradheader
   unsigned char reserved[6];   // 70  6    NOT USED (old ver.=real lens mag.)
 };
 
-typedef enum
+enum biorad_notestatus
 {
   NOTE_STATUS_ALL = 0x0100,
   NOTE_STATUS_DISPLAY = 0x0200,
   NOTE_STATUS_POSITION = 0x0400
-} biorad_notestatus;
+};
 
-typedef enum
+enum biorad_notetype
 {
   NOTE_TYPE_LIVE = 1,       // info about live collection
   NOTE_TYPE_FILE1 = 2,      // note from image #1
@@ -93,7 +93,7 @@ typedef enum
   NOTE_TYPE_STRUCTURE = 21, // again internal variable, as a
                             // structure.
   NOTE_TYPE_4D_SERIES = 22  // 4D acquisition information
-} biorad_notetype;
+};
 
 struct bioradnote
 {

--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
@@ -546,8 +546,8 @@ Bruker2dseqImageIO::Read(void * buffer)
   }
 
   const MetaDataDictionary & dict = this->GetMetaDataDictionary();
-  const std::vector<double>  slopes = GetParameter<std::vector<double>>(dict, "VisuCoreDataSlope");
-  const std::vector<double>  offsets = GetParameter<std::vector<double>>(dict, "VisuCoreDataOffs");
+  const auto                 slopes = GetParameter<std::vector<double>>(dict, "VisuCoreDataSlope");
+  const auto                 offsets = GetParameter<std::vector<double>>(dict, "VisuCoreDataOffs");
   const SizeType             frameCount = static_cast<SizeType>(GetParameter<double>(dict, "VisuCoreFrameCount"));
   const SizeType             frameDim = static_cast<SizeType>(GetParameter<double>(dict, "VisuCoreDim"));
   SizeType                   frameSize = this->GetDimensions(0) * this->GetDimensions(1);
@@ -731,7 +731,7 @@ Bruker2dseqImageIO::ReadImageInformation()
     ReadJCAMPDX(methodFilename, dict);
   }
 
-  const std::string wordType = GetParameter<std::string>(dict, "VisuCoreWordType");
+  const auto wordType = GetParameter<std::string>(dict, "VisuCoreWordType");
   if (wordType == BRUKER_SIGNED_CHAR)
   {
     this->m_ComponentType = IOComponentEnum::CHAR;
@@ -772,7 +772,7 @@ Bruker2dseqImageIO::ReadImageInformation()
     this->m_ComponentType = IOComponentEnum::FLOAT;
   }
 
-  const std::string byteOrder = GetParameter<std::string>(dict, "VisuCoreByteOrder");
+  const auto byteOrder = GetParameter<std::string>(dict, "VisuCoreByteOrder");
   if (byteOrder == BRUKER_LITTLE_ENDIAN)
   {
     this->m_ByteOrder = IOByteOrderEnum::LittleEndian;
@@ -786,10 +786,10 @@ Bruker2dseqImageIO::ReadImageInformation()
     itkExceptionMacro("VisuCoreByteOrder parameter is invalid: " << byteOrder);
   }
 
-  const SizeType            brukerDim = static_cast<SizeType>(GetParameter<double>(dict, "VisuCoreDim"));
-  const SizeType            frames = static_cast<SizeType>(GetParameter<double>(dict, "VisuCoreFrameCount"));
-  const std::vector<double> size = GetParameter<std::vector<double>>(dict, "VisuCoreSize");
-  const std::vector<double> FoV = GetParameter<std::vector<double>>(dict, "VisuCoreExtent");
+  const SizeType brukerDim = static_cast<SizeType>(GetParameter<double>(dict, "VisuCoreDim"));
+  const SizeType frames = static_cast<SizeType>(GetParameter<double>(dict, "VisuCoreFrameCount"));
+  const auto     size = GetParameter<std::vector<double>>(dict, "VisuCoreSize");
+  const auto     FoV = GetParameter<std::vector<double>>(dict, "VisuCoreExtent");
 
   if (brukerDim == 1)
   {
@@ -803,7 +803,7 @@ Bruker2dseqImageIO::ReadImageInformation()
   }
   else
   {
-    const std::vector<double> position = GetParameter<std::vector<double>>(dict, "VisuCorePosition");
+    const auto position = GetParameter<std::vector<double>>(dict, "VisuCorePosition");
     // Bruker 'origin' is corner of slice/volume. Needs shifting by half-voxel to be ITK origin
     // But for 2D images, the slice position is correct (center of slice)
     vnl_vector<double> halfStep(3);
@@ -896,7 +896,7 @@ Bruker2dseqImageIO::ReadImageInformation()
     // It is possible for every slice to have a different orientation,
     // but ITK doesn't support this so concatenate all slices as if they
     // had the same orientation
-    const std::vector<double> orient = GetParameter<std::vector<double>>(dict, "VisuCoreOrientation");
+    const auto orient = GetParameter<std::vector<double>>(dict, "VisuCoreOrientation");
 
     // The Bruker orient field is scanner-to-image. ITK is image-to-scanner.
     // However, ITK stores column-wise, Bruker row-wise. So the below is

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -842,8 +842,8 @@ GDCMImageIO::Write(const void * buffer)
 
   MetaDataDictionary & dict = this->GetMetaDataDictionary();
 
-  itk::MetaDataDictionary::ConstIterator       itr = dict.Begin();
-  const itk::MetaDataDictionary::ConstIterator end = dict.End();
+  auto       itr = dict.Begin();
+  const auto end = dict.End();
 
   gdcm::StringFilter sf;
   sf.SetFile(writer.GetFile());

--- a/Modules/IO/GE/src/itkGE5ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE5ImageIO.cxx
@@ -175,7 +175,7 @@ GE5ImageIO::ReadHeader(const char * FileNameToRead)
                                                         << "Reason: " << reason);
   }
 
-  GEImageHeader * curImage = new GEImageHeader();
+  auto * curImage = new GEImageHeader();
 
   std::ifstream f;
   this->OpenFileForReading(f, FileNameToRead);

--- a/Modules/IO/ImageBase/src/itkArchetypeSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkArchetypeSeriesFileNames.cxx
@@ -173,7 +173,7 @@ ArchetypeSeriesFileNames::Scan()
   // Use a RegularExpressionSeriesFileNames to find the files to return
   StringVectorType names;
 
-  StringVectorType::const_iterator regExpFileNameVectorItr = regExpFileNameVector.begin();
+  auto regExpFileNameVectorItr = regExpFileNameVector.begin();
   while (regExpFileNameVectorItr != regExpFileNameVector.end())
   {
     auto fit = itk::RegularExpressionSeriesFileNames::New();
@@ -183,7 +183,7 @@ ArchetypeSeriesFileNames::Scan()
     fit->NumericSortOn();
     names = fit->GetFileNames();
 
-    const std::vector<std::string>::iterator ait = std::find(names.begin(), names.end(), pathPrefix + unixArchetype);
+    const auto ait = std::find(names.begin(), names.end(), pathPrefix + unixArchetype);
 
     // Accept the list if it contains the archetype and is not the
     // "trivial" list (containing only the archetype)
@@ -219,9 +219,9 @@ ArchetypeSeriesFileNames::PrintSelf(std::ostream & os, Indent indent) const
   for (unsigned int j = 0; j < const_cast<ArchetypeSeriesFileNames *>(this)->GetNumberOfGroupings(); ++j)
   {
     os << indent << "Grouping #" << j << std::endl;
-    StringVectorType                 group = const_cast<ArchetypeSeriesFileNames *>(this)->GetFileNames(j);
-    StringVectorType::const_iterator groupItr = group.begin();
-    unsigned int                     i = 0;
+    StringVectorType group = const_cast<ArchetypeSeriesFileNames *>(this)->GetFileNames(j);
+    auto             groupItr = group.begin();
+    unsigned int     i = 0;
     while (groupItr != group.end())
     {
       os << indent << indent << "FileNames[" << i << "]: " << *groupItr << std::endl;

--- a/Modules/IO/ImageBase/test/itkIOPluginTest.cxx
+++ b/Modules/IO/ImageBase/test/itkIOPluginTest.cxx
@@ -52,14 +52,14 @@ itkIOPluginTest(int argc, char * argv[])
       std::cout << "  Factory version: " << factory->GetITKSourceVersion() << std::endl
                 << "  Factory description: " << factory->GetDescription() << std::endl;
 
-      std::list<std::string>                 overrides = factory->GetClassOverrideNames();
-      std::list<std::string>                 names = factory->GetClassOverrideWithNames();
-      std::list<std::string>                 descriptions = factory->GetClassOverrideDescriptions();
-      std::list<bool>                        enableflags = factory->GetEnableFlags();
-      std::list<std::string>::const_iterator n = names.begin();
-      std::list<std::string>::const_iterator d = descriptions.begin();
-      std::list<bool>::const_iterator        e = enableflags.begin();
-      for (std::list<std::string>::const_iterator o = overrides.begin(); o != overrides.end(); ++o, ++n, ++d, e++)
+      std::list<std::string> overrides = factory->GetClassOverrideNames();
+      std::list<std::string> names = factory->GetClassOverrideWithNames();
+      std::list<std::string> descriptions = factory->GetClassOverrideDescriptions();
+      std::list<bool>        enableflags = factory->GetEnableFlags();
+      auto                   n = names.begin();
+      auto                   d = descriptions.begin();
+      auto                   e = enableflags.begin();
+      for (auto o = overrides.begin(); o != overrides.end(); ++o, ++n, ++d, e++)
       {
         std::cout << "    Override " << *o << " with " << *n << std::endl
                   << "      described as \"" << *d << '"' << std::endl

--- a/Modules/IO/ImageBase/test/itkReadWriteImageWithDictionaryTest.cxx
+++ b/Modules/IO/ImageBase/test/itkReadWriteImageWithDictionaryTest.cxx
@@ -159,7 +159,7 @@ itkReadWriteImageWithDictionaryTest(int argc, char * argv[])
   int numWrongMetaData2 = 0;
   int numAddedMetaData2 = 0;
 
-  for (itk::MetaDataDictionary::ConstIterator it = inputDictionary.Begin(); it != inputDictionary.End(); ++it)
+  for (auto it = inputDictionary.Begin(); it != inputDictionary.End(); ++it)
   {
     if (!outputDictionary.HasKey(it->first))
     {
@@ -168,7 +168,7 @@ itkReadWriteImageWithDictionaryTest(int argc, char * argv[])
     }
     else
     {
-      const itk::MetaDataDictionary::ConstIterator it2 = outputDictionary.Find(it->first);
+      const auto it2 = outputDictionary.Find(it->first);
       if (it->second->GetMetaDataObjectTypeInfo() != it2->second->GetMetaDataObjectTypeInfo())
       {
         std::cout << "input_meta=" << it->second;
@@ -178,7 +178,7 @@ itkReadWriteImageWithDictionaryTest(int argc, char * argv[])
     }
   }
 
-  for (itk::MetaDataDictionary::ConstIterator it = outputDictionary.Begin(); it != outputDictionary.End(); ++it)
+  for (auto it = outputDictionary.Begin(); it != outputDictionary.End(); ++it)
   {
     if (!inputDictionary.HasKey(it->first))
     {

--- a/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
+++ b/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
@@ -42,7 +42,7 @@ extern "C"
   {
     /* cinfo->err really points to an itk_jpeg_error_mgr struct, so coerce pointer
      */
-    itk_jpeg_error_mgr * myerr = (itk_jpeg_error_mgr *)cinfo->err;
+    auto * myerr = (itk_jpeg_error_mgr *)cinfo->err;
 
     /* Always display the message. */
     /* We could postpone this until after returning, if we chose. */

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -1225,7 +1225,7 @@ MINCImageIO::WriteImageInformation()
   // by default valid range will be equal to range, to avoid scaling
   miset_volume_range(m_MINCPImpl->m_Volume, valid_max, valid_min);
 
-  for (MetaDataDictionary::ConstIterator it = thisDic.Begin(); it != thisDic.End(); ++it)
+  for (auto it = thisDic.Begin(); it != thisDic.End(); ++it)
   {
     // don't store some internal ITK junk
     if (it->first == "ITK_InputFilterName" || it->first == "NRRD_content" || it->first == "NRRD_centerings[0]" ||

--- a/Modules/IO/MRC/test/itkMRCImageIOTest2.cxx
+++ b/Modules/IO/MRC/test/itkMRCImageIOTest2.cxx
@@ -49,8 +49,8 @@ Test(const std::string & inFileName, const std::string & outFileName, const std:
   // prepare to iterate over the dictionary
   DictionaryType & dic = image->GetMetaDataDictionary();
 
-  DictionaryType::ConstIterator       itr = dic.Begin();
-  const DictionaryType::ConstIterator end = dic.End();
+  auto       itr = dic.Begin();
+  const auto end = dic.End();
 
   while (itr != end)
   {

--- a/Modules/IO/Meta/test/testMetaMesh.cxx
+++ b/Modules/IO/Meta/test/testMetaMesh.cxx
@@ -32,8 +32,7 @@ TestingMetaMesh(MetaMesh * _mesh)
 
   // Testing Points
   std::cout << "Testing Points : ";
-  using PointListType = MetaMesh::PointListType;
-  PointListType::const_iterator it2 = _mesh->GetPoints().begin();
+  auto it2 = _mesh->GetPoints().begin();
   for (int j = 0; j < static_cast<int>(_mesh->GetPoints().size()); ++j)
   {
     if (((*it2)->m_Id != j) || (itk::Math::NotExactlyEquals((*it2)->m_X[0], j)) ||
@@ -50,8 +49,7 @@ TestingMetaMesh(MetaMesh * _mesh)
 
   // Testing cells
   std::cout << "Testing Cells : ";
-  using CellListType = MetaMesh::CellListType;
-  CellListType::const_iterator it3 = _mesh->GetCells(MET_TETRAHEDRON_CELL).begin();
+  auto it3 = _mesh->GetCells(MET_TETRAHEDRON_CELL).begin();
   for (int j = 0; j < static_cast<int>(_mesh->GetCells(MET_TETRAHEDRON_CELL).size()); ++j)
   {
     if (((*it3)->m_Dim != 4) || ((*it3)->m_Id != j))
@@ -96,8 +94,7 @@ TestingMetaMesh(MetaMesh * _mesh)
 
   // Testing cell links
   std::cout << "Testing CellLinks : ";
-  using CellLinkListType = MetaMesh::CellLinkListType;
-  CellLinkListType::const_iterator it_link = _mesh->GetCellLinks().begin();
+  auto it_link = _mesh->GetCellLinks().begin();
   for (int j = 0; j < static_cast<int>(_mesh->GetCellLinks().size()); ++j)
   {
     if ((*it_link)->m_Id != j)
@@ -106,7 +103,7 @@ TestingMetaMesh(MetaMesh * _mesh)
       std::cout << "[FAILED]" << std::endl;
       return EXIT_FAILURE;
     }
-    std::list<int>::const_iterator it_link2 = (*it_link)->m_Links.begin();
+    auto it_link2 = (*it_link)->m_Links.begin();
     while (it_link2 != (*it_link)->m_Links.end())
     {
       if (*it_link2 != j + 1)
@@ -122,8 +119,7 @@ TestingMetaMesh(MetaMesh * _mesh)
 
   // Testing PointData
   std::cout << "Testing PointData : ";
-  using PointDataListType = MetaMesh::PointDataListType;
-  PointDataListType::const_iterator it_pd = _mesh->GetPointData().begin();
+  auto it_pd = _mesh->GetPointData().begin();
   for (int j = 0; j < static_cast<int>(_mesh->GetPointData().size()); ++j)
   {
     if (((*it_pd)->m_Id != j) || (static_cast<int>(static_cast<MeshData<int> *>(*it_pd)->m_Data) != j))
@@ -139,9 +135,8 @@ TestingMetaMesh(MetaMesh * _mesh)
 
   // Testing CellData
   std::cout << "Testing CellData : ";
-  using CellDataListType = MetaMesh::CellDataListType;
-  CellDataListType::const_iterator it_cd = _mesh->GetCellData().begin();
-  auto                             f = static_cast<float>(0.1);
+  auto it_cd = _mesh->GetCellData().begin();
+  auto f = static_cast<float>(0.1);
   for (int j = 0; j < static_cast<int>(_mesh->GetCellData().size()); ++j)
   {
     if (((*it_cd)->m_Id != j) ||

--- a/Modules/IO/TIFF/src/itkTIFFReaderInternal.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFReaderInternal.cxx
@@ -45,7 +45,7 @@ itkTIFFErrorHandlerExtR([[maybe_unused]] TIFF * tif,
                         const char *            fmt,
                         va_list                 ap)
 {
-  TIFFReaderInternal * self = reinterpret_cast<TIFFReaderInternal *>(user_data);
+  auto * self = reinterpret_cast<TIFFReaderInternal *>(user_data);
   if (::itk::Object::GetGlobalWarningDisplay() && !self->m_ErrorSilence)
   {
     char out[256];
@@ -68,7 +68,7 @@ itkTIFFWarningHandlerExtR([[maybe_unused]] TIFF * tif,
                           va_list                 ap)
 {
 
-  TIFFReaderInternal * self = reinterpret_cast<TIFFReaderInternal *>(user_data);
+  auto * self = reinterpret_cast<TIFFReaderInternal *>(user_data);
   if (::itk::Object::GetGlobalWarningDisplay() && !self->m_WarningSilence)
   {
     char out[256];

--- a/Modules/IO/TransformBase/src/itkTransformFileReader.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformFileReader.cxx
@@ -172,8 +172,8 @@ TransformFileReaderTemplate<TParametersValueType>::Update()
   const std::string firstTransformName = ioTransformList.front()->GetNameOfClass();
   if (firstTransformName.find("CompositeTransform") != std::string::npos)
   {
-    const typename TransformListType::const_iterator tit = ioTransformList.begin();
-    const typename TransformType::Pointer            composite = tit->GetPointer();
+    const auto                            tit = ioTransformList.begin();
+    const typename TransformType::Pointer composite = tit->GetPointer();
 
     // CompositeTransformIOHelperTemplate knows how to assign to the composite
     // transform's internal list

--- a/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
+++ b/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
@@ -448,11 +448,11 @@ HDF5TransformIOTemplate<TParametersValueType>::Write()
       transformList = helper.GetTransformList(transformList.front().GetPointer());
     }
 
-    const typename ConstTransformListType::const_iterator end = transformList.end();
+    const auto end = transformList.end();
 
     int count = 0;
 
-    for (typename ConstTransformListType::const_iterator it = transformList.begin(); it != end; ++it, ++count)
+    for (auto it = transformList.begin(); it != end; ++it, ++count)
     {
       this->WriteOneTransform(count, it->GetPointer());
     }

--- a/Modules/IO/TransformInsightLegacy/src/itkTxtTransformIO.cxx
+++ b/Modules/IO/TransformInsightLegacy/src/itkTxtTransformIO.cxx
@@ -274,9 +274,9 @@ TxtTransformIOTemplate<TParametersValueType>::Write()
   }
   int count = 0;
 
-  const typename ConstTransformListType::const_iterator end = transformList.end();
+  const auto end = transformList.end();
 
-  for (typename ConstTransformListType::const_iterator it = transformList.begin(); it != end; ++it, ++count)
+  for (auto it = transformList.begin(); it != end; ++it, ++count)
   {
     const std::string TransformTypeName = (*it)->GetTransformTypeAsString();
     out << "#Transform " << count << std::endl << "Transform: " << (*it)->GetTransformTypeAsString() << std::endl;

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -724,8 +724,8 @@ WriteTensorBuffer(std::ostream &              os,
   ImageIOBase::SizeType i = 0;
   if (components == 3)
   {
-    const PrintType zero(TComponent{});
-    PrintType       e12;
+    const auto zero(TComponent{});
+    PrintType  e12;
     while (i < num)
     {
       // row 1

--- a/Modules/Numerics/NarrowBand/test/itkNarrowBandTest.cxx
+++ b/Modules/Numerics/NarrowBand/test/itkNarrowBandTest.cxx
@@ -50,10 +50,8 @@ itkNarrowBandTest(int, char *[])
 
   std::cout << "Band size: " << band->Size() << std::endl;
   // Iterate over the band
-  using itType = BandType::ConstIterator;
-
-  itType       it = band->Begin();
-  const itType itend = band->End();
+  auto       it = band->Begin();
+  const auto itend = band->End();
 
   //  BandNodeType *tmp;
   for (unsigned int i = 0; it != itend; ++it)
@@ -64,10 +62,8 @@ itkNarrowBandTest(int, char *[])
 
   // Split the band
   std::vector<RegionType> regions = band->SplitBand(10);
-  //  RegionType region;
-  using regionitType = std::vector<RegionType>::const_iterator;
-  regionitType       regionsit = regions.begin();
-  const regionitType regionsitend = regions.end();
+  auto                    regionsit = regions.begin();
+  const auto              regionsitend = regions.end();
   std::cout << "Number of regions: " << regions.size() << std::endl;
   for (unsigned int i = 0; regionsit != regionsitend; ++regionsit)
   {

--- a/Modules/Numerics/Optimizers/src/itkInitializationBiasedParticleSwarmOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkInitializationBiasedParticleSwarmOptimizer.cxx
@@ -48,7 +48,7 @@ InitializationBiasedParticleSwarmOptimizer::UpdateSwarm()
     Statistics::MersenneTwisterRandomVariateGenerator::GetInstance();
   ParametersType initialPosition = GetInitialPosition();
 
-  const unsigned int n = static_cast<unsigned int>((GetCostFunction())->GetNumberOfParameters());
+  const auto n = static_cast<unsigned int>((GetCostFunction())->GetNumberOfParameters());
   // linear decrease in the weight of the initial parameter values
   const double initializationCoefficient =
     this->m_InitializationCoefficient *

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizer.cxx
@@ -49,7 +49,7 @@ ParticleSwarmOptimizer::UpdateSwarm()
   const itk::Statistics::MersenneTwisterRandomVariateGenerator::Pointer randomGenerator =
     Statistics::MersenneTwisterRandomVariateGenerator::GetInstance();
 
-  const unsigned int n = static_cast<unsigned int>((GetCostFunction())->GetNumberOfParameters());
+  const auto n = static_cast<unsigned int>((GetCostFunction())->GetNumberOfParameters());
 
   for (unsigned int j = 0; j < m_NumberOfParticles; ++j)
   {

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
@@ -62,8 +62,8 @@ ParticleSwarmOptimizerBase::SetInitialSwarm(const SwarmType & initialSwarm)
   this->m_Particles.clear();
   if (!initialSwarm.empty())
   {
-    const SwarmType::const_iterator initialSwarm_END = initialSwarm.end();
-    const unsigned int              n = initialSwarm[0].m_CurrentParameters.GetSize();
+    const auto         initialSwarm_END = initialSwarm.end();
+    const unsigned int n = initialSwarm[0].m_CurrentParameters.GetSize();
     // check that the dimensions of the swarm data are consistent
     for (auto it = initialSwarm.begin(); it != initialSwarm_END; ++it)
     {
@@ -152,9 +152,9 @@ ParticleSwarmOptimizerBase::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Maximal number of iterations: " << this->m_MaximalNumberOfIterations << '\n';
   os << indent << "Number of generations with minimal improvement: ";
   os << this->m_NumberOfGenerationsWithMinimalImprovement << '\n';
-  const ParameterBoundsType::const_iterator end = this->m_ParameterBounds.end();
+  const auto end = this->m_ParameterBounds.end();
   os << indent << "Parameter bounds: [";
-  for (ParameterBoundsType::const_iterator it = this->m_ParameterBounds.begin(); it != end; ++it)
+  for (auto it = this->m_ParameterBounds.begin(); it != end; ++it)
   {
     os << " [" << it->first << ", " << it->second << ']';
   }
@@ -179,9 +179,9 @@ ParticleSwarmOptimizerBase::PrintSelf(std::ostream & os, Indent indent) const
 void
 ParticleSwarmOptimizerBase::PrintSwarm(std::ostream & os, Indent indent) const
 {
-  const std::vector<ParticleData>::const_iterator end = this->m_Particles.end();
+  const auto end = this->m_Particles.end();
   os << indent << "[\n";
-  for (std::vector<ParticleData>::const_iterator it = this->m_Particles.begin(); it != end; ++it)
+  for (auto it = this->m_Particles.begin(); it != end; ++it)
   {
     const ParticleData & p = *it;
     os << indent;
@@ -222,7 +222,7 @@ ParticleSwarmOptimizerBase::StartOptimization()
   InvokeEvent(StartEvent());
 
   // run the simulation
-  const unsigned int n = static_cast<unsigned int>((GetCostFunction())->GetNumberOfParameters());
+  const auto n = static_cast<unsigned int>((GetCostFunction())->GetNumberOfParameters());
   for (this->m_IterationIndex = 1; m_IterationIndex < m_MaximalNumberOfIterations && !converged; ++m_IterationIndex)
   {
 
@@ -298,7 +298,7 @@ ParticleSwarmOptimizerBase::ValidateSettings()
   }
   // if we got here it is safe to get the number of parameters the cost
   // function expects
-  const unsigned int n = static_cast<unsigned int>((GetCostFunction())->GetNumberOfParameters());
+  const auto n = static_cast<unsigned int>((GetCostFunction())->GetNumberOfParameters());
 
   // check that the number of parameters match
   ParametersType initialPosition = GetInitialPosition();
@@ -342,8 +342,8 @@ ParticleSwarmOptimizerBase::ValidateSettings()
     {
       itkExceptionMacro("cost function and particle data dimensions mismatch");
     }
-    const std::vector<ParticleData>::iterator end = this->m_Particles.end();
-    for (std::vector<ParticleData>::iterator it = this->m_Particles.begin(); it != end; ++it)
+    const auto end = this->m_Particles.end();
+    for (auto it = this->m_Particles.begin(); it != end; ++it)
     {
       ParticleData & p = (*it);
       for (unsigned int i = 0; i < n; ++i)

--- a/Modules/Numerics/Optimizers/test/itkRegularStepGradientDescentOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkRegularStepGradientDescentOptimizerTest.cxx
@@ -157,7 +157,7 @@ itkRegularStepGradientDescentOptimizerTest(int, char *[])
   itkOptimizer->SetMinimumStepLength(minimumStepLength);
   ITK_TEST_SET_GET_VALUE(minimumStepLength, itkOptimizer->GetMinimumStepLength());
 
-  const itk::SizeValueType numberOfIterations = static_cast<itk::SizeValueType>(900);
+  const auto numberOfIterations = static_cast<itk::SizeValueType>(900);
   itkOptimizer->SetNumberOfIterations(numberOfIterations);
   ITK_TEST_SET_GET_VALUE(numberOfIterations, itkOptimizer->GetNumberOfIterations());
 

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -620,8 +620,8 @@ Histogram<TMeasurement, TFrequencyContainer>::Quantile(unsigned int dimension, d
 
     const double binProportion = f_n / totalFrequency;
 
-    const double min = static_cast<double>(this->GetBinMin(dimension, n - 1));
-    const double max = static_cast<double>(this->GetBinMax(dimension, n - 1));
+    const auto   min = static_cast<double>(this->GetBinMin(dimension, n - 1));
+    const auto   max = static_cast<double>(this->GetBinMax(dimension, n - 1));
     const double interval = max - min;
     return min + ((p - p_n_prev) / binProportion) * interval;
   }
@@ -641,8 +641,8 @@ Histogram<TMeasurement, TFrequencyContainer>::Quantile(unsigned int dimension, d
     } while (m < size && p_n > p);
 
     const double binProportion = f_n / totalFrequency;
-    const double min = static_cast<double>(this->GetBinMin(dimension, n + 1));
-    const double max = static_cast<double>(this->GetBinMax(dimension, n + 1));
+    const auto   min = static_cast<double>(this->GetBinMin(dimension, n + 1));
+    const auto   max = static_cast<double>(this->GetBinMax(dimension, n + 1));
     const double interval = max - min;
     return max - ((p_n_prev - p) / binProportion) * interval;
   }

--- a/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.hxx
@@ -116,7 +116,7 @@ HistogramToTextureFeaturesFilter<THistogram>::GenerateData()
   }
   const double log2 = std::log(2.0);
 
-  typename RelativeFrequencyContainerType::const_iterator rFreqIterator = m_RelativeFrequencyContainer.begin();
+  auto rFreqIterator = m_RelativeFrequencyContainer.begin();
 
   for (HistogramIterator hit = inputHistogram->Begin(); hit != inputHistogram->End(); ++hit)
   {
@@ -186,7 +186,7 @@ HistogramToTextureFeaturesFilter<THistogram>::ComputeMeansAndVariances(double & 
   const auto                                  marginalSums = std::make_unique<double[]>(binsPerAxis);
   pixelMean = 0;
 
-  typename RelativeFrequencyContainerType::const_iterator rFreqIterator = m_RelativeFrequencyContainer.begin();
+  auto rFreqIterator = m_RelativeFrequencyContainer.begin();
 
   // Ok, now do the first pass through the histogram to get the marginal sums
   // and compute the pixel mean

--- a/Modules/Numerics/Statistics/include/itkImageClassifierFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageClassifierFilter.hxx
@@ -169,7 +169,7 @@ ImageClassifierFilter<TSample, TInputImage, TOutputImage>::GenerateData()
       discriminantScores[i] = membershipFunctionsWeightsArray[i] * membershipFunctions[i]->Evaluate(measurements);
     }
 
-    const unsigned int classIndex = static_cast<unsigned int>(m_DecisionRule->Evaluate(discriminantScores));
+    const auto classIndex = static_cast<unsigned int>(m_DecisionRule->Evaluate(discriminantScores));
 
     auto value = static_cast<OutputPixelType>(classLabels[classIndex]);
     outItr.Set(value);

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
@@ -112,7 +112,7 @@ ScalarImageToRunLengthFeaturesFilter<TImage, THistogramFrequencyContainer>::Full
 {
   const size_t numOffsets = this->m_Offsets->size();
   const size_t numFeatures = this->m_RequestedFeatures->size();
-  double **    features = new double *[numOffsets];
+  auto **      features = new double *[numOffsets];
   for (size_t i = 0; i < numOffsets; ++i)
   {
     features[i] = new double[numFeatures];

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
@@ -189,7 +189,7 @@ ScalarImageToRunLengthMatrixFilter<TImageType, THistogramFrequencyContainer>::Ge
       const MeasurementType centerBinMax = this->GetOutput()->GetBinMaxFromValue(0, centerPixelIntensity);
       const MeasurementType lastBinMax = this->GetOutput()->GetDimensionMaxs(0)[this->GetOutput()->GetSize(0) - 1];
 
-      PixelType pixelIntensity(PixelType{});
+      auto      pixelIntensity(PixelType{});
       IndexType index = centerIndex + offset;
       IndexType lastGoodIndex = centerIndex;
       bool      runLengthSegmentAlreadyVisited = false;

--- a/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
@@ -112,7 +112,7 @@ ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMa
 {
   const size_t numOffsets = m_Offsets->size();
   const size_t numFeatures = m_RequestedFeatures->size();
-  double **    features = new double *[numOffsets];
+  auto **      features = new double *[numOffsets];
   for (size_t i = 0; i < numOffsets; ++i)
   {
     features[i] = new double[numFeatures];

--- a/Modules/Numerics/Statistics/src/itkMaximumRatioDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkMaximumRatioDecisionRule.cxx
@@ -61,8 +61,8 @@ MaximumRatioDecisionRule::SetPriorProbabilities(const PriorProbabilityVectorType
   }
   else
   {
-    PriorProbabilityVectorType::const_iterator pit = p.begin();
-    for (PriorProbabilityVectorType::const_iterator it = m_PriorProbabilities.begin(); pit != p.end(); ++pit, ++it)
+    auto pit = p.begin();
+    for (auto it = m_PriorProbabilities.begin(); pit != p.end(); ++pit, ++it)
     {
       if (itk::Math::abs(*pit - *it) > itk::Math::eps)
       {

--- a/Modules/Numerics/Statistics/src/itkTDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkTDistribution.cxx
@@ -123,10 +123,10 @@ TDistribution::CDF(double x, SizeValueType degreesOfFreedom)
   //           = 0.5 + 0.5 * (1 - Ix(v/2. 1/2))
   //           = 1 - 0.5 * Ix(v/2, 1/2)
 
-  const double dof = static_cast<double>(degreesOfFreedom);
-  double       bx = dof / (dof + (x * x));
-  double       pin = dof / 2.0;
-  double       qin = 0.5;
+  const auto dof = static_cast<double>(degreesOfFreedom);
+  double     bx = dof / (dof + (x * x));
+  double     pin = dof / 2.0;
+  double     qin = 0.5;
 
   if (x >= 0.0)
   {
@@ -162,7 +162,7 @@ TDistribution::InverseCDF(double p, SizeValueType degreesOfFreedom)
   }
 
   // Based on Abramowitz and Stegun 26.7.5
-  const double dof = static_cast<double>(degreesOfFreedom);
+  const auto   dof = static_cast<double>(degreesOfFreedom);
   const double dof2 = dof * dof;
   const double dof3 = dof * dof2;
   const double dof4 = dof * dof3;

--- a/Modules/Numerics/Statistics/test/itkChiSquareDistributionTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkChiSquareDistributionTest.cxx
@@ -68,7 +68,7 @@ itkChiSquareDistributionTest(int, char *[])
 
   for (int i = 0; i <= 5; ++i)
   {
-    const double x = static_cast<double>(i);
+    const auto x = static_cast<double>(i);
 
     const double value = distributionFunction->EvaluateCDF(x);
 
@@ -160,7 +160,7 @@ itkChiSquareDistributionTest(int, char *[])
   distributionFunction->SetDegreesOfFreedom(11);
   for (int i = 0; i <= 10; ++i)
   {
-    const double x = static_cast<double>(2 * i);
+    const auto x = static_cast<double>(2 * i);
 
     const double value = distributionFunction->EvaluateCDF(x);
 
@@ -242,7 +242,7 @@ itkChiSquareDistributionTest(int, char *[])
   distributionFunction->SetDegreesOfFreedom(100);
   for (int i = 0; i <= 5; ++i)
   {
-    const double x = static_cast<double>(50 + 20 * i);
+    const auto x = static_cast<double>(50 + 20 * i);
 
     const double value = distributionFunction->EvaluateCDF(x);
 
@@ -323,7 +323,7 @@ itkChiSquareDistributionTest(int, char *[])
 
   for (int i = 0; i <= 5; ++i)
   {
-    const double x = static_cast<double>(50 + 20 * i);
+    const auto x = static_cast<double>(50 + 20 * i);
 
     const double value = distributionFunction->EvaluateCDF(x, params);
 
@@ -405,7 +405,7 @@ itkChiSquareDistributionTest(int, char *[])
 
   for (int i = 0; i <= 5; ++i)
   {
-    const double x = static_cast<double>(50 + 20 * i);
+    const auto x = static_cast<double>(50 + 20 * i);
     last_x = x;
     const double value = distributionFunction->EvaluateCDF(x, static_cast<long>(params[0]));
 

--- a/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceListSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceListSampleFilterTest.cxx
@@ -206,7 +206,7 @@ itkScalarImageToCooccurrenceListSampleFilterTest(int, char *[])
   val[1] = 8;
   baselineVectorList.emplace_back(val);
 
-  std::vector<MeasurementVectorType>::const_iterator it = baselineVectorList.begin();
+  auto it = baselineVectorList.begin();
 
   while (s_iter != sample->End())
   {

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -471,8 +471,8 @@ ImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImageRegion(FixedImage
   {
     randIter.ReinitializeSeed(m_RandomSeed++);
   }
-  typename FixedImageSampleContainer::iterator             iter;
-  const typename FixedImageSampleContainer::const_iterator end = samples.end();
+  typename FixedImageSampleContainer::iterator iter;
+  const auto                                   end = samples.end();
 
   if (m_FixedImageMask.IsNotNull() || m_UseFixedImageSamplesIntensityThreshold)
   {
@@ -581,8 +581,8 @@ ImageToImageMetric<TFixedImage, TMovingImage>::SampleFullFixedImageRegion(FixedI
 
   regionIter.GoToBegin();
 
-  typename FixedImageSampleContainer::iterator             iter;
-  const typename FixedImageSampleContainer::const_iterator end = samples.end();
+  typename FixedImageSampleContainer::iterator iter;
+  const auto                                   end = samples.end();
 
   if (m_FixedImageMask.IsNotNull() || m_UseFixedImageSamplesIntensityThreshold)
   {
@@ -731,9 +731,9 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PreComputeTransformValues()
   MovingImagePointType           mappedPoint;
 
   // Declare iterators for iteration over the sample container
-  typename FixedImageSampleContainer::const_iterator       fiter;
-  const typename FixedImageSampleContainer::const_iterator fend = m_FixedImageSamples.end();
-  SizeValueType                                            counter = 0;
+  typename FixedImageSampleContainer::const_iterator fiter;
+  const auto                                         fend = m_FixedImageSamples.end();
+  SizeValueType                                      counter = 0;
 
   for (fiter = m_FixedImageSamples.begin(); fiter != fend; ++fiter, counter++)
   {

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
@@ -122,8 +122,8 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
   // Set a pointSet from the input landmarks.
   auto pointSet = PointSetType::New();
 
-  PointsContainerConstIterator fixedIt = this->m_FixedLandmarks.begin();
-  PointsContainerConstIterator movingIt = this->m_MovingLandmarks.begin();
+  auto fixedIt = this->m_FixedLandmarks.begin();
+  auto movingIt = this->m_MovingLandmarks.begin();
   for (size_t i = 0; fixedIt != this->m_FixedLandmarks.end(); ++i, ++fixedIt, ++movingIt)
   {
     pointSet->SetPoint(static_cast<typename PointSetType::PointIdentifier>(i), (*fixedIt));
@@ -233,7 +233,7 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
   // q
   // dim+1=4 * numberOfLandmarks matrix
   vnl_matrix<ParametersValueType> q(ImageDimension + 1, numberOfLandmarks, 0.0F);
-  PointsContainerConstIterator    fixedIt = this->m_FixedLandmarks.begin();
+  auto                            fixedIt = this->m_FixedLandmarks.begin();
   for (unsigned int i = 0; fixedIt != this->m_FixedLandmarks.end(); ++i, ++fixedIt)
   {
     for (unsigned int dim = 0; dim < ImageDimension; ++dim)
@@ -247,7 +247,7 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
   // p
   // dim=3 * numberOfLandmarks matrix
   vnl_matrix<ParametersValueType> p(ImageDimension, numberOfLandmarks, 0.0F);
-  PointsContainerConstIterator    movingIt = this->m_MovingLandmarks.begin();
+  auto                            movingIt = this->m_MovingLandmarks.begin();
   for (unsigned int i = 0; movingIt != this->m_MovingLandmarks.end(); ++i, ++movingIt)
   {
     for (unsigned int dim = 0; dim < ImageDimension; ++dim)
@@ -387,8 +387,8 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
   {
     itk::Matrix<ParametersValueType, ImageDimension, ImageDimension> M;
 
-    PointsContainerConstIterator fixedItr = this->m_FixedLandmarks.begin();
-    PointsContainerConstIterator movingItr = this->m_MovingLandmarks.begin();
+    auto fixedItr = this->m_FixedLandmarks.begin();
+    auto movingItr = this->m_MovingLandmarks.begin();
 
     VectorType fixedCentered;
     VectorType movingCentered;
@@ -522,8 +522,8 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
   {
     itk::Matrix<ParametersValueType, ImageDimension, ImageDimension> M;
 
-    PointsContainerConstIterator fixedItr = this->m_FixedLandmarks.begin();
-    PointsContainerConstIterator movingItr = this->m_MovingLandmarks.begin();
+    auto fixedItr = this->m_FixedLandmarks.begin();
+    auto movingItr = this->m_MovingLandmarks.begin();
 
     VectorType fixedCentered;
     VectorType movingCentered;
@@ -643,8 +643,8 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
   transform->SetIdentity();
 
   // Compute the centroids.
-  PointType                    fixedCentroid{};
-  PointsContainerConstIterator fixedItr = this->m_FixedLandmarks.begin();
+  PointType fixedCentroid{};
+  auto      fixedItr = this->m_FixedLandmarks.begin();
   while (fixedItr != this->m_FixedLandmarks.end())
   {
     fixedCentroid[0] += (*fixedItr)[0];
@@ -655,8 +655,8 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
   fixedCentroid[0] /= this->m_FixedLandmarks.size();
   fixedCentroid[1] /= this->m_FixedLandmarks.size();
 
-  PointsContainerConstIterator movingItr = this->m_MovingLandmarks.begin();
-  PointType                    movingCentroid{};
+  auto      movingItr = this->m_MovingLandmarks.begin();
+  PointType movingCentroid{};
   while (movingItr != this->m_MovingLandmarks.end())
   {
     movingCentroid[0] += (*movingItr)[0];
@@ -767,8 +767,8 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Comput
   const LandmarkPointContainer inputLandmarks) -> PointType3D
 {
   // Compute the centroids.
-  PointType3D                  centroid{};
-  PointsContainerConstIterator fixedItr = inputLandmarks.begin();
+  PointType3D centroid{};
+  auto        fixedItr = inputLandmarks.begin();
   while (fixedItr != inputLandmarks.end())
   {
     centroid[0] += (*fixedItr)[0];

--- a/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
@@ -64,8 +64,8 @@ MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::GetNonconstValue(
   m_ThreadCounts.resize(this->GetNumberOfWorkUnits());
 
   {
-    typename std::vector<MeasureType>::iterator mIt = m_ThreadMatches.begin();
-    for (std::vector<SizeValueType>::iterator cIt = m_ThreadCounts.begin(); mIt != m_ThreadMatches.end(); ++mIt, ++cIt)
+    auto mIt = m_ThreadMatches.begin();
+    for (auto cIt = m_ThreadCounts.begin(); mIt != m_ThreadMatches.end(); ++mIt, ++cIt)
     {
       *mIt = MeasureType{};
       *cIt = 0;
@@ -87,8 +87,8 @@ MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::GetNonconstValue(
   //
   //
   {
-    typename std::vector<MeasureType>::iterator mIt = m_ThreadMatches.begin();
-    for (std::vector<SizeValueType>::iterator cIt = m_ThreadCounts.begin(); mIt != m_ThreadMatches.end(); ++mIt, ++cIt)
+    auto mIt = m_ThreadMatches.begin();
+    for (auto cIt = m_ThreadCounts.begin(); mIt != m_ThreadMatches.end(); ++mIt, ++cIt)
     {
       measure += *mIt;
       this->m_NumberOfPixelsCounted += *cIt;
@@ -230,7 +230,7 @@ MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::ThreaderCallback(
   const ThreadIdType workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
   const ThreadIdType workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
 
-  ThreadStruct * str = (ThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
+  auto * str = (ThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
 
   // execute the actual method with appropriate computation region
   // first find out how many pieces extent can be split into.

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -323,7 +323,7 @@ void
 MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::ComputeFixedImageParzenWindowIndices(
   FixedImageSampleContainer & samples)
 {
-  const typename FixedImageSampleContainer::const_iterator end = samples.end();
+  const auto end = samples.end();
   for (auto iter = samples.begin(); iter != end; ++iter)
   {
     // Determine parzen window arguments (see eqn 6 of Mattes paper [2]).

--- a/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.hxx
@@ -99,8 +99,8 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImage
   randIter.SetNumberOfSamples(m_NumberOfSpatialSamples);
   randIter.GoToBegin();
 
-  typename SpatialSampleContainer::iterator             iter;
-  const typename SpatialSampleContainer::const_iterator end = samples.end();
+  typename SpatialSampleContainer::iterator iter;
+  const auto                                end = samples.end();
 
   bool allOutside = true;
 
@@ -201,10 +201,10 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const P
   SumType dSumMoving;
   SumType dSumJoint;
 
-  typename SpatialSampleContainer::const_iterator       aiter;
-  const typename SpatialSampleContainer::const_iterator aend = m_SampleA.end();
-  typename SpatialSampleContainer::const_iterator       biter;
-  const typename SpatialSampleContainer::const_iterator bend = m_SampleB.end();
+  typename SpatialSampleContainer::const_iterator aiter;
+  const auto                                      aend = m_SampleA.end();
+  typename SpatialSampleContainer::const_iterator biter;
+  const auto                                      bend = m_SampleB.end();
   for (biter = m_SampleB.begin(); biter != bend; ++biter)
   {
     dSumFixed.ResetToZero();
@@ -293,10 +293,10 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDeriv
   SumType dDenominatorMoving;
   SumType dDenominatorJoint;
 
-  typename SpatialSampleContainer::iterator             aiter;
-  const typename SpatialSampleContainer::const_iterator aend = m_SampleA.end();
-  typename SpatialSampleContainer::iterator             biter;
-  const typename SpatialSampleContainer::const_iterator bend = m_SampleB.end();
+  typename SpatialSampleContainer::iterator aiter;
+  const auto                                aend = m_SampleA.end();
+  typename SpatialSampleContainer::iterator biter;
+  const auto                                bend = m_SampleB.end();
 
   // precalculate all the image derivatives for sample A
   using DerivativeContainer = std::vector<DerivativeType>;

--- a/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.hxx
@@ -218,7 +218,7 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateO
   }
 
   // find the index for this output
-  const unsigned int refLevel = static_cast<unsigned int>(refOutputPtr->GetSourceOutputIndex());
+  const auto refLevel = static_cast<unsigned int>(refOutputPtr->GetSourceOutputIndex());
 
   using OutputPixelType = typename TOutputImage::PixelType;
   using OperatorType = GaussianOperator<OutputPixelType, ImageDimension>;

--- a/Modules/Registration/Common/test/itkLandmarkBasedTransformInitializerTest.cxx
+++ b/Modules/Registration/Common/test/itkLandmarkBasedTransformInitializerTest.cxx
@@ -156,8 +156,8 @@ ExecuteAndExamine(typename TransformInitializerType::Pointer                init
   // LandmarkBasedTransformInitializer, they should coincide exactly with the moving
   // landmarks. Note that we specified 4 landmarks, although three non-collinear
   // landmarks is sufficient to guarantee a solution.
-  typename TransformInitializerType::PointsContainerConstIterator fitr = fixedLandmarks.begin();
-  typename TransformInitializerType::PointsContainerConstIterator mitr = movingLandmarks.begin();
+  auto fitr = fixedLandmarks.begin();
+  auto mitr = movingLandmarks.begin();
 
   using OutputVectorType = typename TransformInitializerType::OutputVectorType;
   OutputVectorType                               error;

--- a/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.hxx
@@ -58,7 +58,7 @@ typename ExpectationBasedPointSetToPointSetMetricv4<TFixedPointSet, TMovingPoint
   NeighborsIdentifierType neighborhood;
   this->m_MovingTransformedPointsLocator->FindClosestNPoints(point, this->m_EvaluationKNeighborhood, neighborhood);
 
-  for (NeighborsIterator it = neighborhood.begin(); it != neighborhood.end(); ++it)
+  for (auto it = neighborhood.begin(); it != neighborhood.end(); ++it)
   {
     const PointType   neighbor = this->m_MovingTransformedPointSet->GetPoint(*it);
     const MeasureType distance = point.SquaredEuclideanDistanceTo(neighbor);
@@ -90,7 +90,7 @@ ExpectationBasedPointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInt
 
   this->m_MovingTransformedPointsLocator->FindClosestNPoints(point, this->m_EvaluationKNeighborhood, neighborhood);
 
-  for (NeighborsIterator it = neighborhood.begin(); it != neighborhood.end(); ++it)
+  for (auto it = neighborhood.begin(); it != neighborhood.end(); ++it)
   {
     const PointType   neighbor = this->m_MovingTransformedPointSet->GetPoint(*it);
     const MeasureType distance = point.SquaredEuclideanDistanceTo(neighbor);
@@ -104,7 +104,7 @@ ExpectationBasedPointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInt
     return;
   }
 
-  for (NeighborsIterator it = neighborhood.begin(); it != neighborhood.end(); ++it)
+  for (auto it = neighborhood.begin(); it != neighborhood.end(); ++it)
   {
     const PointType  neighbor = this->m_MovingTransformedPointSet->GetPoint(*it);
     const VectorType neighborVector = neighbor.GetVectorFromOrigin();

--- a/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
@@ -146,13 +146,13 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::Allocate()
 
     // Set the initial and final codebook size
 
-    const SizeValueType initCodebookSize = (SizeValueType)1;
+    const auto initCodebookSize = (SizeValueType)1;
     m_Codebook.set_size(initCodebookSize, m_VectorDimension);
 
     // Initialize m_Codebook to 0 (it now has only one row)
     m_Codebook.fill(0);
   }
-  const SizeValueType finalCodebookSize = (SizeValueType)m_NumberOfCodewords;
+  const auto finalCodebookSize = (SizeValueType)m_NumberOfCodewords;
 
   // Allocate scratch memory for the centroid, codebook histogram
   // and the codebook distortion
@@ -442,7 +442,7 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::NearestNeighborSear
 
       for (unsigned int j = 0; j < m_VectorDimension; ++j)
       {
-        const double diff = static_cast<double>(inputImagePixelVector[j] - m_Codebook[i][j]);
+        const auto diff = static_cast<double>(inputImagePixelVector[j] - m_Codebook[i][j]);
         tempdistortion += diff * diff;
 
         if (tempdistortion > bestdistortion)

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.hxx
@@ -231,7 +231,7 @@ ConnectedComponentImageFilter<TInputImage, TOutputImage, TMaskImage>::ThreadedWr
 
   for (SizeValueType thisIdx = workUnitData.firstLine; thisIdx <= workUnitData.lastLine; ++thisIdx)
   {
-    for (LineEncodingConstIterator cIt = this->m_LineMap[thisIdx].begin(); cIt != this->m_LineMap[thisIdx].end(); ++cIt)
+    for (auto cIt = this->m_LineMap[thisIdx].begin(); cIt != this->m_LineMap[thisIdx].end(); ++cIt)
     {
       const SizeValueType   Ilab = this->LookupSet(cIt->label);
       const OutputPixelType lab = this->m_Consecutive[Ilab];

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
@@ -382,12 +382,12 @@ DeformableSimplexMesh3DGradientConstraintForceFilter<TInputMesh, TOutputMesh>::C
 
   double            max = 0;
   GradientIndexType coord2{};
-  for (auto & it : m_Positive)
+  for (auto & imgVoxel : m_Positive)
   {
     GradientIndexType coord3;
-    coord3[0] = static_cast<GradientIndexValueType>(it->GetX());
-    coord3[1] = static_cast<GradientIndexValueType>(it->GetY());
-    coord3[2] = static_cast<GradientIndexValueType>(it->GetZ());
+    coord3[0] = static_cast<GradientIndexValueType>(imgVoxel->GetX());
+    coord3[1] = static_cast<GradientIndexValueType>(imgVoxel->GetY());
+    coord3[2] = static_cast<GradientIndexValueType>(imgVoxel->GetZ());
 
     const GradientType & gradient3 = gradientImage->GetPixel(coord3);
 

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
@@ -270,7 +270,7 @@ DeformableSimplexMesh3DGradientConstraintForceFilter<TInputMesh, TOutputMesh>::C
     pos[2] = data->pos[2];
 
     m_StartVoxel = new ImageVoxel(vpos, pos, static_cast<double>(m_Image->GetPixel(index)), 0.0, 0);
-    ImageVoxel * current = new ImageVoxel(vpos, pos, static_cast<double>(m_Image->GetPixel(index)), 0.0, 0);
+    auto * current = new ImageVoxel(vpos, pos, static_cast<double>(m_Image->GetPixel(index)), 0.0, 0);
     m_Positive.push_back(current);
 
     // scan normal side

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
@@ -740,7 +740,7 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::ResolveRegions()
 
   UnsignedIntVectorType remapLabelsVec(m_InitialNumberOfRegions, 0);
 
-  UnsignedIntVectorType::iterator uniqueLabelsVecIterator = uniqueLabelsVec.begin();
+  auto uniqueLabelsVecIterator = uniqueLabelsVec.begin();
 
   RegionLabelType newLabelValue = 1;
 

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationRegion.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationRegion.cxx
@@ -286,8 +286,8 @@ KLMSegmentationRegion::SpliceRegionBorders(Self * region)
 
   // Initialize the region iterators
 
-  RegionBorderVectorConstIterator       thisRegionBordersIt = thisRegionBorder.begin();
-  const RegionBorderVectorConstIterator endOfThisRegionBorders = thisRegionBorder.end();
+  auto       thisRegionBordersIt = thisRegionBorder.begin();
+  const auto endOfThisRegionBorders = thisRegionBorder.end();
 
   auto thatRegionBordersIt = region->GetRegionBorderConstItBegin();
   auto endOfThatRegionBorders = region->GetRegionBorderConstItEnd();

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunctionWithRefitTerm.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunctionWithRefitTerm.hxx
@@ -80,7 +80,7 @@ LevelSetFunctionWithRefitTerm<TImageType, TSparseImageType>::ComputeCurvature(
     stride[j] = neighborhood.GetStride(j);
     indicator[j] = one << j;
   }
-  ScalarValueType curvature = ScalarValueType{};
+  auto curvature = ScalarValueType{};
 
   for (unsigned int counterN = 0; counterN < m_NumVertex; ++counterN)
   {

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -228,7 +228,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::Initialize()
   typename BFCType::FaceListType faceList = faceCalculator(m_StatusImage, m_StatusImage->GetRequestedRegion(), sz);
 
   // skip the first (nonboundary) region
-  for (typename BFCType::FaceListType::iterator fit = ++faceList.begin(); fit != faceList.end(); ++fit)
+  for (auto fit = ++faceList.begin(); fit != faceList.end(); ++fit)
   {
     statusIt = ImageRegionIterator<StatusImageType>(m_StatusImage, *fit);
     for (statusIt.GoToBegin(); !statusIt.IsAtEnd(); ++statusIt)
@@ -394,12 +394,11 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ConstructActi
             const StatusType layer_number = (value < m_ValueZero) ? 1 : 2;
 
             statusIt.SetPixel(m_NeighborList.GetArrayIndex(i), layer_number, bounds_status);
-            if (bounds_status) // In bounds
-            {
-              node = m_LayerNodeStore->Borrow();
-              node->m_Index = offset_index;
-              m_Layers[layer_number]->PushFront(node);
-            } // else do nothing.
+
+            node = m_LayerNodeStore->Borrow();
+            node->m_Index = offset_index;
+            m_Layers[layer_number]->PushFront(node);
+            // else do nothing.
           }
         }
       }

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
@@ -97,7 +97,7 @@ SparseFieldFourthOrderLevelSetImageFilter<TInputImage, TOutputImage>::ComputeCur
     indicator[j] = one << j;
   }
 
-  ValueType curvature = ValueType{};
+  auto curvature = ValueType{};
 
   for (unsigned int counter = 0; counter < m_NumVertex; ++counter)
   {

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -302,10 +302,10 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::UpdateActiveLayerValu
     statusIt.NeedToUseBoundaryConditionOff();
   }
 
-  unsigned int                              counter = 0;
-  ValueType                                 rms_change_accumulator = m_ValueZero;
-  typename LayerType::Iterator              layerIt = m_Layers[0]->Begin();
-  typename UpdateBufferType::const_iterator updateIt = m_UpdateBuffer.begin();
+  unsigned int                 counter = 0;
+  ValueType                    rms_change_accumulator = m_ValueZero;
+  typename LayerType::Iterator layerIt = m_Layers[0]->Begin();
+  auto                         updateIt = m_UpdateBuffer.begin();
   while (layerIt != m_Layers[0]->End())
   {
     outputIt.SetLocation(layerIt->m_Value);
@@ -957,7 +957,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::PropagateLayerValues(
     statusIt.NeedToUseBoundaryConditionOff();
   }
 
-  ValueType        value = ValueType{};
+  auto             value = ValueType{};
   const StatusType past_end = static_cast<StatusType>(m_Layers.size()) - 1;
 
   auto toIt = m_Layers[to]->Begin();

--- a/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.hxx
@@ -232,8 +232,8 @@ BinaryImageToLevelSetImageAdaptor<TInput,
     const LevelSetLabelObjectPointer ZeroSet = LevelSetLabelObjectType::New();
     ZeroSet->SetLabel(LevelSetType::ZeroLayer());
 
-    LevelSetLayerConstIterator       nodeIt = layer0.begin();
-    const LevelSetLayerConstIterator nodeEnd = layer0.end();
+    auto       nodeIt = layer0.begin();
+    const auto nodeEnd = layer0.end();
 
     while (nodeIt != nodeEnd)
     {
@@ -441,8 +441,8 @@ BinaryImageToLevelSetImageAdaptor<TInput, ShiSparseLevelSetImage<TInput::ImageDi
   const LevelSetLabelObjectPointer ObjectMinus1 = LevelSetLabelObjectType::New();
   ObjectMinus1->SetLabel(LevelSetType::MinusOneLayer());
 
-  LevelSetLayerConstIterator nodeIt = layerMinus1.begin();
-  LevelSetLayerConstIterator nodeEnd = layerMinus1.end();
+  auto nodeIt = layerMinus1.begin();
+  auto nodeEnd = layerMinus1.end();
 
   while (nodeIt != nodeEnd)
   {

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainer.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainer.h
@@ -143,8 +143,8 @@ public:
   void
   CopyInformationAndAllocate(const Self * iOther, const bool iAllocate)
   {
-    LevelSetContainerType              internalContainer = iOther->GetContainer();
-    LevelSetContainerConstIteratorType it = internalContainer.begin();
+    LevelSetContainerType internalContainer = iOther->GetContainer();
+    auto                  it = internalContainer.begin();
 
     LevelSetContainerType newContainer;
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermContainer.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermContainer.hxx
@@ -101,8 +101,8 @@ LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::AddTerm(const Te
 
     RequiredDataType termRequiredData = iTerm->GetRequiredData();
 
-    typename RequiredDataType::const_iterator       dIt = termRequiredData.begin();
-    const typename RequiredDataType::const_iterator dEnd = termRequiredData.end();
+    auto       dIt = termRequiredData.begin();
+    const auto dEnd = termRequiredData.end();
 
     while (dIt != dEnd)
     {
@@ -377,8 +377,8 @@ void
 LevelSetEquationTermContainer<TInputImage, TLevelSetContainer>::ComputeRequiredData(const LevelSetInputIndexType & iP,
                                                                                     LevelSetDataType & ioData)
 {
-  typename RequiredDataType::const_iterator       dIt = m_RequiredData.begin();
-  const typename RequiredDataType::const_iterator dEnd = m_RequiredData.end();
+  auto       dIt = m_RequiredData.begin();
+  const auto dEnd = m_RequiredData.end();
 
   auto tIt = m_Container.begin();
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionComputeIterationThreader.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionComputeIterationThreader.hxx
@@ -215,7 +215,7 @@ LevelSetEvolutionComputeIterationThreader<
   const ThreadIdType numberOfWorkUnits = this->GetNumberOfWorkUnitsUsed();
   for (ThreadIdType ii = 0; ii < numberOfWorkUnits; ++ii)
   {
-    typename std::vector<NodePairType>::const_iterator pairIt = this->m_NodePairsPerThread[ii].begin();
+    auto pairIt = this->m_NodePairsPerThread[ii].begin();
     while (pairIt != this->m_NodePairsPerThread[ii].end())
     {
       levelSetLayerUpdateBuffer->insert(*pairIt);

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetSparseImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetSparseImage.hxx
@@ -117,7 +117,7 @@ template <typename TOutput, unsigned int VDimension>
 void
 LevelSetSparseImage<TOutput, VDimension>::SetLayer(LayerIdType value, const LayerType & layer)
 {
-  const LayerMapIterator it = m_Layers.find(value);
+  const auto it = m_Layers.find(value);
   if (it != m_Layers.end())
   {
     it->second = layer;

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateWhitakerSparseLevelSet.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateWhitakerSparseLevelSet.hxx
@@ -577,8 +577,8 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
   LevelSetLayerType & outputLayerMinus2 = this->m_OutputLevelSet->GetLayer(LevelSetType::MinusTwoLayer());
   LevelSetLayerType & layerMinus1 = this->m_TempLevelSet->GetLayer(LevelSetType::MinusOneLayer());
 
-  auto                        nodeIt = outputLayerMinus2.begin();
-  const LevelSetLayerIterator nodeEnd = outputLayerMinus2.end();
+  auto       nodeIt = outputLayerMinus2.begin();
+  const auto nodeEnd = outputLayerMinus2.end();
 
   while (nodeIt != nodeEnd)
   {
@@ -603,7 +603,7 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
         }
         const LevelSetInputType neighborIndex = neighIt.GetIndex(it.GetNeighborhoodOffset());
 
-        const LevelSetLayerIterator phiIt = this->m_TempPhi.find(neighborIndex);
+        const auto phiIt = this->m_TempPhi.find(neighborIndex);
         itkAssertInDebugAndIgnoreInReleaseMacro(phiIt != this->m_TempPhi.end());
 
         max = std::max(max, phiIt->second);
@@ -612,7 +612,7 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
 
     if (thereIsAPointWithLabelEqualToMinus1)
     {
-      const LevelSetLayerIterator phiIt = this->m_TempPhi.find(currentIndex);
+      const auto phiIt = this->m_TempPhi.find(currentIndex);
 
       max = max - 1.;
 
@@ -681,8 +681,8 @@ UpdateWhitakerSparseLevelSet<VDimension, TLevelSetValueType, TEquationContainer>
   LevelSetLayerType & outputLayerPlus2 = this->m_OutputLevelSet->GetLayer(LevelSetType::PlusTwoLayer());
   LevelSetLayerType & layerPlusOne = this->m_TempLevelSet->GetLayer(LevelSetType::PlusOneLayer());
 
-  auto                        nodeIt = outputLayerPlus2.begin();
-  const LevelSetLayerIterator nodeEnd = outputLayerPlus2.end();
+  auto       nodeIt = outputLayerPlus2.begin();
+  const auto nodeEnd = outputLayerPlus2.end();
 
   while (nodeIt != nodeEnd)
   {

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainMapImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainMapImageFilterTest.cxx
@@ -77,9 +77,9 @@ itkLevelSetDomainMapImageFilterTest(int, char *[])
   OutputImageType::IndexType out_index;
   OutputImageType::PixelType out_id;
 
-  const DomainMapType                 domainMap = filter->GetDomainMap();
-  DomainMapType::const_iterator       mapIt;
-  const DomainMapType::const_iterator mapEnd = domainMap.end();
+  const DomainMapType           domainMap = filter->GetDomainMap();
+  DomainMapType::const_iterator mapIt;
+  const auto                    mapEnd = domainMap.end();
   while (!it.IsAtEnd())
   {
     out_index = it.GetIndex();

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageTest.cxx
@@ -111,9 +111,9 @@ itkMultiLevelSetDenseImageTest(int, char *[])
   CacheImageType::PixelType out_id;
 
   using DomainMapType = DomainMapImageFilterType::DomainMapType;
-  const DomainMapType                 domainMap = filter->GetDomainMap();
-  DomainMapType::const_iterator       mapIt;
-  const DomainMapType::const_iterator mapEnd = domainMap.end();
+  const DomainMapType           domainMap = filter->GetDomainMap();
+  DomainMapType::const_iterator mapIt;
+  const auto                    mapEnd = domainMap.end();
   while (!it.IsAtEnd())
   {
     out_index = it.GetIndex();

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
@@ -154,9 +154,9 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
 
     InputRealType sumOfSquares{};
 
-    typename SeedsContainerType::const_iterator       si = m_Seeds.begin();
-    const typename SeedsContainerType::const_iterator li = m_Seeds.end();
-    SizeValueType                                     num = 0;
+    auto          si = m_Seeds.begin();
+    const auto    li = m_Seeds.end();
+    SizeValueType num = 0;
     while (si != li)
     {
       if (region.IsInside(*si))
@@ -196,9 +196,9 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
     InputRealType sum{};
     InputRealType sumOfSquares{};
 
-    typename SeedsContainerType::const_iterator       si = m_Seeds.begin();
-    const typename SeedsContainerType::const_iterator li = m_Seeds.end();
-    SizeValueType                                     num = 0;
+    auto          si = m_Seeds.begin();
+    const auto    li = m_Seeds.end();
+    SizeValueType num = 0;
     while (si != li)
     {
       if (region.IsInside(*si))
@@ -228,8 +228,8 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Find the highest and lowest seed intensity.
   InputRealType lowestSeedIntensity = itk::NumericTraits<InputImagePixelType>::max();
   InputRealType highestSeedIntensity = itk::NumericTraits<InputImagePixelType>::NonpositiveMin();
-  typename SeedsContainerType::const_iterator       si = m_Seeds.begin();
-  const typename SeedsContainerType::const_iterator li = m_Seeds.end();
+  auto          si = m_Seeds.begin();
+  const auto    li = m_Seeds.end();
   while (si != li)
   {
     if (region.IsInside(*si))
@@ -299,9 +299,9 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
     secondFunction->SetInputImage(outputImage);
     secondFunction->ThresholdBetween(m_ReplaceValue, m_ReplaceValue);
 
-    typename NumericTraits<typename InputImageType::PixelType>::RealType sum = InputRealType{};
-    typename NumericTraits<typename InputImageType::PixelType>::RealType sumOfSquares = InputRealType{};
-    typename TOutputImage::SizeValueType                                 numberOfSamples = 0;
+    auto                                 sum = InputRealType{};
+    auto                                 sumOfSquares = InputRealType{};
+    typename TOutputImage::SizeValueType numberOfSamples = 0;
 
     SecondIteratorType sit(inputImage, secondFunction, m_Seeds);
     sit.GoToBegin();

--- a/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
@@ -235,9 +235,9 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
       // Find the sum of the intensities in m_Seeds2.  If the second
       // seeds are not included, the sum should be zero.  Otherwise,
       // it will be other than zero.
-      InputRealType                                     seedIntensitySum{};
-      typename SeedsContainerType::const_iterator       si = m_Seeds2.begin();
-      const typename SeedsContainerType::const_iterator li = m_Seeds2.end();
+      InputRealType seedIntensitySum{};
+      auto          si = m_Seeds2.begin();
+      const auto    li = m_Seeds2.end();
       while (si != li)
       {
         const auto value = static_cast<InputRealType>(outputImage->GetPixel(*si));
@@ -300,9 +300,9 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
       // Find the sum of the intensities in m_Seeds2.  If the second
       // seeds are not included, the sum should be zero.  Otherwise,
       // it will be other than zero.
-      InputRealType                                     seedIntensitySum{};
-      typename SeedsContainerType::const_iterator       si = m_Seeds2.begin();
-      const typename SeedsContainerType::const_iterator li = m_Seeds2.end();
+      InputRealType seedIntensitySum{};
+      auto          si = m_Seeds2.begin();
+      const auto    li = m_Seeds2.end();
       while (si != li)
       {
         const auto value = static_cast<InputRealType>(outputImage->GetPixel(*si));
@@ -358,18 +358,18 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Find the sum of the intensities in m_Seeds2.  If the second
   // seeds are not included, the sum should be zero.  Otherwise,
   // it will be other than zero.
-  InputRealType                                     seed1IntensitySum{};
-  InputRealType                                     seed2IntensitySum{};
-  typename SeedsContainerType::const_iterator       si1 = m_Seeds1.begin();
-  const typename SeedsContainerType::const_iterator li1 = m_Seeds1.end();
+  InputRealType seed1IntensitySum{};
+  InputRealType seed2IntensitySum{};
+  auto          si1 = m_Seeds1.begin();
+  const auto    li1 = m_Seeds1.end();
   while (si1 != li1)
   {
     const auto value = static_cast<InputRealType>(outputImage->GetPixel(*si1));
     seed1IntensitySum += value;
     ++si1;
   }
-  typename SeedsContainerType::const_iterator       si2 = m_Seeds2.begin();
-  const typename SeedsContainerType::const_iterator li2 = m_Seeds2.end();
+  auto       si2 = m_Seeds2.begin();
+  const auto li2 = m_Seeds2.end();
   while (si2 != li2)
   {
     const auto value = static_cast<InputRealType>(outputImage->GetPixel(*si2));

--- a/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
@@ -160,9 +160,9 @@ VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   using MeanFunctionVectorType = typename VectorMeanImageFunctionType::OutputType;
   using CovarianceFunctionMatrixType = typename CovarianceImageFunctionType::OutputType;
 
-  typename SeedsContainerType::const_iterator si = m_Seeds.begin();
-  typename SeedsContainerType::const_iterator li = m_Seeds.end();
-  SizeValueType                               seed_cnt = 0;
+  auto          si = m_Seeds.begin();
+  auto          li = m_Seeds.end();
+  SizeValueType seed_cnt = 0;
   while (si != li)
   {
     if (region.IsInside(*si))

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
@@ -633,8 +633,7 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::GenerateData()
     for (unsigned int i = 0; i < m_UpdateClusterPerThread.size(); ++i)
     {
       UpdateClusterMap & clusterMap = m_UpdateClusterPerThread[i];
-      for (typename UpdateClusterMap::const_iterator clusterIter = clusterMap.begin(); clusterIter != clusterMap.end();
-           ++clusterIter)
+      for (auto clusterIter = clusterMap.begin(); clusterIter != clusterMap.end(); ++clusterIter)
       {
         const size_t clusterIdx = clusterIter->first;
         clusterCount[clusterIdx] += clusterIter->second.count;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.hxx
@@ -158,7 +158,7 @@ VoronoiPartitioningImageFilter<TInputImage, TOutputImage>::TestHomogeneity(Index
 
   for (SizeValueType i = 0; i < num; ++i)
   {
-    const double getp = static_cast<double>(inputImage->GetPixel(Plist[i]));
+    const auto getp = static_cast<double>(inputImage->GetPixel(Plist[i]));
     addp = addp + getp;
     addpp = addpp + getp * getp;
   }

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
@@ -377,7 +377,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
 {
   auto eitend = m_WorkingVD->EdgeEnd();
 
-  for (EdgeIterator eit = m_WorkingVD->EdgeBegin(); eit != eitend; ++eit)
+  for (auto eit = m_WorkingVD->EdgeBegin(); eit != eitend; ++eit)
   {
     Point<int, 2> seeds = m_WorkingVD->GetSeedsIDAroundEdge(&*eit);
     if (((m_Label[seeds[0]] == 2) || (m_Label[seeds[1]] == 2)) && (m_NumberOfPixels[seeds[0]] > m_MinRegion) &&
@@ -531,8 +531,8 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
   {
     if (m_Label[i] == 2)
     {
-      const NeighborIdIterator nitend = m_WorkingVD->NeighborIdsEnd(i);
-      for (NeighborIdIterator nit = m_WorkingVD->NeighborIdsBegin(i); nit != nitend; ++nit)
+      const auto nitend = m_WorkingVD->NeighborIdsEnd(i);
+      for (auto nit = m_WorkingVD->NeighborIdsBegin(i); nit != nitend; ++nit)
       {
         if (((*nit) > i) && (m_Label[*nit] == 2))
         {
@@ -876,7 +876,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
       x2 = save;
       y1 = y2;
     }
-    float curr = static_cast<float>(y1);
+    auto curr = static_cast<float>(y1);
     if (dx == 0)
     {
       dx = 1;
@@ -899,7 +899,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
       y1 = y2;
       y2 = save;
     }
-    float curr = static_cast<float>(x1);
+    auto curr = static_cast<float>(x1);
     if (dy == 0)
     {
       dy = 1;
@@ -996,7 +996,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
       y1 = y2;
       y2 = save;
     }
-    float curr = static_cast<float>(y1);
+    auto curr = static_cast<float>(y1);
     if (dx == 0)
     {
       dx = 1;
@@ -1021,7 +1021,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
       y1 = y2;
       y2 = save;
     }
-    float curr = static_cast<float>(x1);
+    auto curr = static_cast<float>(x1);
     if (dy == 0)
     {
       dy = 1;

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
@@ -124,7 +124,7 @@ SegmentTreeGenerator<TScalar>::MergeEquivalencies()
 
   segTable->PruneEdgeLists(threshold);
 
-  for (typename EquivalencyTableType::Iterator it = eqTable->Begin(); it != eqTable->End(); ++it)
+  for (auto it = eqTable->Begin(); it != eqTable->End(); ++it)
   {
     MergeSegments(segTable, m_MergedSegmentsTable, it->first, it->second); // Merge first INTO second.
     // deletes first
@@ -152,8 +152,7 @@ SegmentTreeGenerator<TScalar>::CompileMergeList(SegmentTableTypePointer segments
 
   segments->PruneEdgeLists(threshold);
 
-  for (typename SegmentTableType::Iterator segment_ptr = segments->Begin(); segment_ptr != segments->End();
-       ++segment_ptr)
+  for (auto segment_ptr = segments->Begin(); segment_ptr != segments->End(); ++segment_ptr)
   {
     const IdentifierType labelFROM = segment_ptr->first;
 
@@ -454,8 +453,8 @@ SegmentTreeGenerator<TScalar>::MergeSegments(SegmentTableTypePointer           s
   // but rather will be resolved later through the one-way
   // equivalency table.
 
-  typename SegmentTableType::edge_list_t::iterator edgeTOi = to_seg->edge_list.begin();
-  typename SegmentTableType::edge_list_t::iterator edgeFROMi = from_seg->edge_list.begin();
+  auto edgeTOi = to_seg->edge_list.begin();
+  auto edgeFROMi = from_seg->edge_list.begin();
   while (edgeTOi != to_seg->edge_list.end() && edgeFROMi != from_seg->edge_list.end())
   {
     // Recursively resolve the labels we are seeing
@@ -468,7 +467,7 @@ SegmentTreeGenerator<TScalar>::MergeSegments(SegmentTableTypePointer           s
     // growing exponentially in size as segments merge.
     if (seen_table.find(labelTO) != seen_table.end() || labelTO == FROM)
     {
-      typename SegmentTableType::edge_list_t::iterator edgeTEMPi = edgeTOi;
+      auto edgeTEMPi = edgeTOi;
       ++edgeTEMPi;
       to_seg->edge_list.erase(edgeTOi);
       edgeTOi = edgeTEMPi;
@@ -530,7 +529,7 @@ SegmentTreeGenerator<TScalar>::MergeSegments(SegmentTableTypePointer           s
     const IdentifierType labelTO = eqT->RecursiveLookup(edgeTOi->label);
     if (seen_table.find(labelTO) != seen_table.end() || labelTO == FROM)
     {
-      typename SegmentTableType::edge_list_t::iterator edgeTEMPi = edgeTOi;
+      auto edgeTEMPi = edgeTOi;
       ++edgeTEMPi;
       to_seg->edge_list.erase(edgeTOi);
       edgeTOi = edgeTEMPi;

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
@@ -354,12 +354,12 @@ Segmenter<TInputImage>::CollectBoundaryInformation(flat_region_table_t & flatReg
         faceIt.Value().label = labelIt.Get();
 
         // Is this a flat region that flows out?
-        const typename flat_region_table_t::iterator flrt_it = flatRegions.find(labelIt.Get());
+        const auto flrt_it = flatRegions.find(labelIt.Get());
         if (faceIt.Get().flow != NULL_FLOW && flrt_it != flatRegions.end())
         {
           // Have we already entered this
           // flat region into the boundary?
-          const typename BoundaryType::flat_hash_t::iterator flats_it = flats->find(labelIt.Get());
+          const auto flats_it = flats->find(labelIt.Get());
           if (flats_it == flats->end()) // NO
           {
             typename BoundaryType::flat_region_t flr;
@@ -761,7 +761,7 @@ Segmenter<TInputImage>::LabelMinima(InputImageTypePointer                img,
   // boundary values for the flat regions.
   for (searchIt.GoToBegin(), labelIt.GoToBegin(); !searchIt.IsAtEnd(); ++searchIt, ++labelIt)
   {
-    const typename flat_region_table_t::iterator flatPtr = flatRegions.find(labelIt.GetPixel(nCenter));
+    const auto flatPtr = flatRegions.find(labelIt.GetPixel(nCenter));
     if (flatPtr != flatRegions.end()) // If we are in a flat region
     {                                 // Search the connectivity neighborhood
                                       // for lesser boundary pixels.
@@ -873,8 +873,7 @@ Segmenter<TInputImage>::DescendFlatRegions(flat_region_table_t & flatRegionTable
   // relabeled to reflect these equivalencies.
   auto equivalentLabels = EquivalencyTable::New();
 
-  for (typename flat_region_table_t::const_iterator region = flatRegionTable.begin(); region != flatRegionTable.end();
-       ++region)
+  for (auto region = flatRegionTable.begin(); region != flatRegionTable.end(); ++region)
   {
     if ((region->second.bounds_min < region->second.value) && (!region->second.is_on_boundary))
     {
@@ -914,7 +913,7 @@ Segmenter<TInputImage>::UpdateSegmentTable(InputImageTypePointer input, ImageReg
     // and update its minimum value if necessary.
 
     typename SegmentTableType::segment_t * segment_ptr = segments->Lookup(segment_label);
-    typename edge_table_hash_t::iterator   edge_table_entry_ptr = edgeHash.find(segment_label);
+    auto                                   edge_table_entry_ptr = edgeHash.find(segment_label);
     const edge_table_t                     tempEdgeTable;
     if (segment_ptr == nullptr) // This segment not yet identified.
     {                           // So add it to the table.
@@ -953,7 +952,7 @@ Segmenter<TInputImage>::UpdateSegmentTable(InputImageTypePointer input, ImageReg
         }
         // adjacent pixels
 
-        const typename edge_table_t::iterator edge_ptr = edge_table_entry_ptr->second.find(labelIt.GetPixel(nPos));
+        const auto edge_ptr = edge_table_entry_ptr->second.find(labelIt.GetPixel(nPos));
         if (edge_ptr == edge_table_entry_ptr->second.end())
         { // This edge has not been identified yet.
           using ValueType = typename edge_table_t::value_type;
@@ -971,9 +970,7 @@ Segmenter<TInputImage>::UpdateSegmentTable(InputImageTypePointer input, ImageReg
   // Copy all of the edge tables into the edge lists of the
   // segment table.
   //
-  for (typename edge_table_hash_t::iterator edge_table_entry_ptr = edgeHash.begin();
-       edge_table_entry_ptr != edgeHash.end();
-       ++edge_table_entry_ptr)
+  for (auto edge_table_entry_ptr = edgeHash.begin(); edge_table_entry_ptr != edgeHash.end(); ++edge_table_entry_ptr)
   {
     // Lookup the corresponding segment entry
     typename SegmentTableType::segment_t * segment_ptr = segments->Lookup(edge_table_entry_ptr->first);
@@ -983,10 +980,10 @@ Segmenter<TInputImage>::UpdateSegmentTable(InputImageTypePointer input, ImageReg
     }
 
     // Copy into the segment list
-    const IdentifierType listsz = static_cast<IdentifierType>(edge_table_entry_ptr->second.size());
+    const auto listsz = static_cast<IdentifierType>(edge_table_entry_ptr->second.size());
     segment_ptr->edge_list.resize(listsz);
-    typename edge_table_t::iterator                  edge_ptr = edge_table_entry_ptr->second.begin();
-    typename SegmentTableType::edge_list_t::iterator list_ptr = segment_ptr->edge_list.begin();
+    auto edge_ptr = edge_table_entry_ptr->second.begin();
+    auto list_ptr = segment_ptr->edge_list.begin();
     while (edge_ptr != edge_table_entry_ptr->second.end())
     {
       list_ptr->label = edge_ptr->first;
@@ -1087,10 +1084,10 @@ Segmenter<TInputImage>::MergeFlatRegions(flat_region_table_t & regions, Equivale
   // format with its Flatten() method.
   eqTable->Flatten();
 
-  for (EquivalencyTable::ConstIterator it = eqTable->Begin(); it != eqTable->End(); ++it)
+  for (auto it = eqTable->Begin(); it != eqTable->End(); ++it)
   {
-    const typename flat_region_table_t::iterator a = regions.find(it->first);
-    const typename flat_region_table_t::iterator b = regions.find(it->second);
+    const auto a = regions.find(it->first);
+    const auto b = regions.find(it->second);
     if ((a == regions.end()) || (b == regions.end()))
     {
       itkGenericExceptionMacro("MergeFlatRegions:: An unexpected and fatal error has occurred.");
@@ -1283,7 +1280,7 @@ Segmenter<TInputImage>::GenerateOutputRequestedRegion(DataObject * output)
 {
   // Only the Image output need to be propagated through.
   // No choice but to use RTTI here.
-  ImageBase<ImageDimension> * imgData = dynamic_cast<ImageBase<ImageDimension> *>(output);
+  auto * imgData = dynamic_cast<ImageBase<ImageDimension> *>(output);
 
   if (imgData)
   {
@@ -1293,7 +1290,7 @@ Segmenter<TInputImage>::GenerateOutputRequestedRegion(DataObject * output)
 
       if (this->GetOutput(idx) && this->GetOutput(idx) != output)
       {
-        ImageBase<ImageDimension> * op = dynamic_cast<ImageBase<ImageDimension> *>(this->GetOutput(idx));
+        auto * op = dynamic_cast<ImageBase<ImageDimension> *>(this->GetOutput(idx));
 
         if (op)
         {

--- a/Modules/Video/Core/include/itkVideoSource.hxx
+++ b/Modules/Video/Core/include/itkVideoSource.hxx
@@ -342,7 +342,7 @@ VideoSource<TOutputVideoStream>::ThreaderCallback(void * arg)
   const int workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
   const int threadCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
 
-  ThreadStruct * str = (ThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
+  auto * str = (ThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
 
   // execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.


### PR DESCRIPTION
This check is responsible for using the auto type specifier for variable declarations to improve code readability and maintainability.

The auto type specifier will only be introduced in situations where the variable type matches the type of the initializer expression. In other words auto should deduce the same type that was originally spelled in the source

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)