### PR TITLE
COMP: Fix compile error due to missing itk:: prefix for MakeFilled

### DIFF
--- a/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
@@ -133,13 +133,6 @@ itkImageFunctionTest(int, char *[])
 
   image->SetRegions(region);
   image->Allocate();
-
-  auto origin = MakeFilled<ImageType::PointType>(0.0);
-  auto spacing = MakeFilled<ImageType::SpacingType>(1.0);
-
-  image->SetOrigin(origin);
-  image->SetSpacing(spacing);
-
   image->Print(std::cout);
 
   auto function = FunctionType::New();


### PR DESCRIPTION
Sample error message:

`T:\Dashboard\ITK\Modules\Nonunit\Review\test\itkImageFunctionTest.cxx(137,17): error C2065: 'MakeFilled': undeclared identifier [T:\Dashboard\ITK-build\Modules\Nonunit\Review\test\ITKReviewTestDriver.vcxproj]`


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
