### PR TITLE
libpng: re-import 1.6.44 using our modern import script

### DIFF
--- a/Modules/ThirdParty/PNG/UpdateFromUpstream.sh
+++ b/Modules/ThirdParty/PNG/UpdateFromUpstream.sh
@@ -1,22 +1,21 @@
 #!/usr/bin/env bash
 
-thirdparty_module_name='PNG'
+set -e
+set -x
+shopt -s dotglob
 
-upstream_git_url='git://git.code.sf.net/p/libpng/code'
-upstream_git_branch='v1.6.44' # Sept 12, 2024
-
-snapshot_author_name='LIBPNG Upstream'
-snapshot_author_email='png-mng-implement@lists.sourceforge.net'
-
-snapshot_redact_cmd=''
-snapshot_relative_path='src/itkpng'
-snapshot_paths='
-  png*.c
-  png*.h
-  arm/*
-  LICENSE
-  scripts/pnglibconf.h.prebuilt
-  '
+readonly name="png"
+readonly ownership="LIBPNG Upstream <png-mng-implement@lists.sourceforge.net>"
+readonly subtree="Modules/ThirdParty/PNG/src/itk$name"
+readonly repo="git://git.code.sf.net/p/libpng/code"
+readonly tag='v1.6.44' # Sept 12, 2024
+readonly paths="
+png*.c
+png*.h
+arm/*
+LICENSE
+scripts/pnglibconf.h.prebuilt
+"
 
 
 extract_source () {
@@ -26,5 +25,4 @@ extract_source () {
     popd
 }
 
-source "${BASH_SOURCE%/*}/../../../Utilities/Maintenance/UpdateThirdPartyFromUpstream.sh"
-update_from_upstream
+. "${BASH_SOURCE%/*}/../../../Utilities/Maintenance/update-third-party.bash"

--- a/Modules/ThirdParty/PNG/src/itkpng/.gitattributes
+++ b/Modules/ThirdParty/PNG/src/itkpng/.gitattributes
@@ -1,0 +1,1 @@
+* -whitespace


### PR DESCRIPTION
This makes no changes other than to the import script itself.  This just prepares history structure for future imports with the modern `update-third-party.bash` helper.
