### PR TITLE
ENH: Activate standard pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,10 +20,28 @@ repos:
        Source/DataDictionary/gdcmPrivateDefaultDicts.cxx|
        Documentation/watershed.ps
        )
+   - id: check-ast
+     exclude: "\\/ThirdParty\\/"
+   - id: check-case-conflict
+   - id: check-illegal-windows-names
    - id: check-json
+     exclude: "\\/ThirdParty\\/"
+   - id: check-merge-conflict
+     exclude: "\\/ThirdParty\\/"
+     args: ['--assume-in-merge']
    - id: check-toml
+     exclude: "\\/ThirdParty\\/"
+   - id: check-vcs-permalinks
+     exclude: "\\/ThirdParty\\/"
+   - id: check-xml
+     exclude: "\\/ThirdParty\\/"
    - id: check-yaml
+     exclude: "\\/ThirdParty\\/"
    - id: check-shebang-scripts-are-executable
+     exclude: "\\/ThirdParty\\/"
+   - id: debug-statements
+     exclude: "\\/ThirdParty\\/"
+   - id: destroyed-symlinks
    - id: detect-private-key
    - id: end-of-file-fixer
      exclude: "\\.(md5|sha|sha512|svg|vtk|vtp)$|^Resources\\/[^\\/]+\\.h$|\\/ColorFiles\\/.+\\.txt$|Data\\/Input\\/.+$|\\/ThirdParty\\/|\\/Data\\/"
@@ -32,7 +50,10 @@ repos:
    - id: mixed-line-ending
      exclude: "\\.(sha|sha512|svg|vtk|vtp)$|\\/ThirdParty\\/|\\/Data\\/"
    - id: name-tests-test
+     exclude: "\\/ThirdParty\\/"
      args: ['--pytest-test-first']
+   - id: no-commit-to-branch
+     args: ['--branch','dashboard','--branch','python-builds','--branch','release','--branch','hooks','--branch', 'main','--branch','master','--pattern','release-*']
    - id: trailing-whitespace
      exclude: "\\.(sha|sha512|svg|vtk|vtp)$|\\/ThirdParty\\/|\\/Data\\/"
 - repo: https://github.com/pre-commit/mirrors-clang-format

--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -229,7 +229,7 @@ function(check_avx_flags avx_flags_var)
 endfunction()
 
 # Check for the presence of SSE2.
-# Adapted from the AVX check and https://github.com/InsightSoftwareConsortium/ITK/blob/master/Modules/ThirdParty/VNL/src/vxl/config/cmake/config/vxl_platform_tests.cxx#L164-L178
+# Adapted from the AVX check and https://github.com/InsightSoftwareConsortium/ITK/blob/4cbe24cb4a45d689cadd56d554b8ccf3584a5ca6/Modules/ThirdParty/VNL/src/vxl/config/cmake/config/vxl_platform_tests.cxx#L164-L178
 function(check_sse2_flags sse2_flags_var)
 
   # set flags to be used in check_cxx_source_runs below


### PR DESCRIPTION
Adding recently added common checks to the ITK
pre-commit checking.

Of note:
  no-commit-to-branch
     to prevent accidently adding changes to
     protected branches.
  check-merge-conflict
     to bring ghostflow errors to developers
     environment before posting as a PR.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
