### PR TITLE
STYLE: clang-tidy bugprone-implicit-widening-of-multiplication-result

### DIFF
--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.hxx
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.hxx
@@ -18,6 +18,8 @@
 #ifndef itkSymmetricEigenAnalysis_hxx
 #define itkSymmetricEigenAnalysis_hxx
 
+#include <cstddef>
+
 #include "itkMath.h"
 #include "itkMakeUniqueForOverwrite.h"
 
@@ -60,7 +62,7 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesLegacy
   const auto workArea1 = std::make_unique<double[]>(m_Dimension);
 
   // Copy the input matrix
-  const auto inputMatrix = make_unique_for_overwrite<double[]>(m_Dimension * m_Dimension);
+  const auto inputMatrix = make_unique_for_overwrite<double[]>(static_cast<size_t>(m_Dimension * m_Dimension));
   const auto dVector = make_unique_for_overwrite<double[]>(m_Dimension);
 
   unsigned int k = 0;
@@ -94,10 +96,10 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesAndVec
   TEigenMatrix &  EigenVectors) const
 {
   const auto workArea1 = std::make_unique<double[]>(m_Dimension);
-  const auto workArea2 = std::make_unique<double[]>(m_Dimension * m_Dimension);
+  const auto workArea2 = std::make_unique<double[]>(static_cast<size_t>(m_Dimension * m_Dimension));
 
   // Copy the input matrix
-  const auto inputMatrix = make_unique_for_overwrite<double[]>(m_Dimension * m_Dimension);
+  const auto inputMatrix = make_unique_for_overwrite<double[]>(static_cast<size_t>(m_Dimension * m_Dimension));
   const auto dVector = make_unique_for_overwrite<double[]>(m_Dimension);
 
   unsigned int k = 0;

--- a/Modules/Core/Common/src/itkImageRegionSplitterDirection.cxx
+++ b/Modules/Core/Common/src/itkImageRegionSplitterDirection.cxx
@@ -16,6 +16,8 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
+
 #include "itkImageRegionSplitterDirection.h"
 
 
@@ -88,14 +90,14 @@ ImageRegionSplitterDirection::GetSplitInternal(unsigned int   dim,
   // Split the region
   if (i < maxPieceIdUsed)
   {
-    regionIndex[splitAxis] += i * valuesPerPiece;
+    regionIndex[splitAxis] += static_cast<IndexValueType>(i * valuesPerPiece);
     regionSize[splitAxis] = valuesPerPiece;
   }
   if (i == maxPieceIdUsed)
   {
-    regionIndex[splitAxis] += i * valuesPerPiece;
+    regionIndex[splitAxis] += static_cast<IndexValueType>(i * valuesPerPiece);
     // last piece needs to process the "rest" dimension being split
-    regionSize[splitAxis] = regionSize[splitAxis] - i * valuesPerPiece;
+    regionSize[splitAxis] = regionSize[splitAxis] - static_cast<SizeValueType>(i * valuesPerPiece);
   }
 
 

--- a/Modules/Core/Common/src/itkImageRegionSplitterSlowDimension.cxx
+++ b/Modules/Core/Common/src/itkImageRegionSplitterSlowDimension.cxx
@@ -16,6 +16,8 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
+
 #include "itkImageRegionSplitterSlowDimension.h"
 
 
@@ -78,14 +80,14 @@ ImageRegionSplitterSlowDimension::GetSplitInternal(unsigned int   dim,
   // Split the region
   if (i < maxPieceIdUsed)
   {
-    regionIndex[splitAxis] += i * valuesPerPiece;
+    regionIndex[splitAxis] += static_cast<IndexValueType>(i * valuesPerPiece);
     regionSize[splitAxis] = valuesPerPiece;
   }
   if (i == maxPieceIdUsed)
   {
-    regionIndex[splitAxis] += i * valuesPerPiece;
+    regionIndex[splitAxis] += static_cast<IndexValueType>(i * valuesPerPiece);
     // last piece needs to process the "rest" dimension being split
-    regionSize[splitAxis] = regionSize[splitAxis] - i * valuesPerPiece;
+    regionSize[splitAxis] = regionSize[splitAxis] - static_cast<SizeValueType>(i * valuesPerPiece);
   }
 
   return maxPieceIdUsed + 1;

--- a/Modules/Core/Common/src/itkThreadedIndexedContainerPartitioner.cxx
+++ b/Modules/Core/Common/src/itkThreadedIndexedContainerPartitioner.cxx
@@ -15,6 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
+#include <cstddef>
+
 #include "itkThreadedIndexedContainerPartitioner.h"
 #include "itkMath.h"
 
@@ -41,12 +43,12 @@ ThreadedIndexedContainerPartitioner::PartitionDomain(const ThreadIdType threadId
   // Split the index range
   if (threadId < maxThreadIdUsed)
   {
-    subIndexRange[0] = completeIndexRange[0] + threadId * valuesPerThread;
+    subIndexRange[0] = completeIndexRange[0] + static_cast<DomainType::value_type>(threadId * valuesPerThread);
     subIndexRange[1] = subIndexRange[0] + valuesPerThread - 1;
   }
   if (threadId == maxThreadIdUsed)
   {
-    subIndexRange[0] = completeIndexRange[0] + threadId * valuesPerThread;
+    subIndexRange[0] = completeIndexRange[0] + static_cast<DomainType::value_type>(threadId * valuesPerThread);
     // last thread needs to process the "rest" of the range
     subIndexRange[1] = completeIndexRange[1];
   }

--- a/Modules/Core/Common/test/itkCompensatedSummationTest2.cxx
+++ b/Modules/Core/Common/test/itkCompensatedSummationTest2.cxx
@@ -20,6 +20,7 @@
 #include "itkDomainThreader.h"
 #include "itkThreadedIndexedContainerPartitioner.h"
 #include "itkCompensatedSummation.h"
+#include <cstddef>
 #include <iostream>
 #include <iomanip>
 
@@ -154,7 +155,7 @@ itkCompensatedSummationTest2(int, char *[])
 
   const itk::ThreadIdType maxNumberOfThreads = domainThreader->GetMultiThreader()->GetGlobalMaximumNumberOfThreads();
   domain[0] = 0;
-  domain[1] = maxNumberOfThreads * 10000;
+  domain[1] = static_cast<DomainType::value_type>(maxNumberOfThreads * 10000);
 
   /* Test with single thread. We should get the same result. */
   const itk::ThreadIdType numberOfThreads = 1;

--- a/Modules/Core/Common/test/itkImportImageTest.cxx
+++ b/Modules/Core/Common/test/itkImportImageTest.cxx
@@ -16,6 +16,7 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
 #include <iostream>
 #include "itkImageRegionIterator.h"
 #include "itkShrinkImageFilter.h"
@@ -26,7 +27,7 @@ int
 itkImportImageTest(int, char *[])
 {
   // Create a C-array to hold an image
-  auto * rawImage = new short[8 * 12];
+  auto * rawImage = new short[static_cast<unsigned long>(8 * 12)];
   for (unsigned int i = 0; i < 8 * 12; ++i)
   {
     rawImage[i] = i;
@@ -76,7 +77,7 @@ itkImportImageTest(int, char *[])
     std::cout << "import->GetOrigin(): " << originValue << std::endl;
 
     import->SetRegion(region);
-    import->SetImportPointer(rawImage, 8 * 12, true);
+    import->SetImportPointer(rawImage, static_cast<itk::SizeValueType>(8 * 12), true);
     import->Update();
     image = import->GetOutput();
   }

--- a/Modules/Core/Common/test/itkIteratorTests.cxx
+++ b/Modules/Core/Common/test/itkIteratorTests.cxx
@@ -16,6 +16,7 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
 #include <iostream>
 
 #include "itkImage.h"
@@ -58,7 +59,7 @@ itkIteratorTests(int, char *[])
   o3->Allocate();
 
   // extra variables
-  const unsigned long num = 190 * 190 * 190;
+  const unsigned long num = static_cast<const unsigned long>(190 * 190 * 190);
 
   bool passed = true;
   // memset

--- a/Modules/Core/Common/test/itkPointSetTest.cxx
+++ b/Modules/Core/Common/test/itkPointSetTest.cxx
@@ -19,6 +19,7 @@
 #include "itkPointSet.h"
 #include "vnl/vnl_sample.h"
 #include "itkTestingMacros.h"
+#include <cstddef>
 #include <iostream>
 
 /**
@@ -106,7 +107,7 @@ itkPointSetTest(int, char *[])
   pointsArray->InsertElement(0, 1.0);
   ITK_TRY_EXPECT_EXCEPTION(pset->SetPoints(pointsArray));
 
-  pointsArray->Reserve(numOfPoints * pointDimension);
+  pointsArray->Reserve(static_cast<PointsVectorContainer::ElementIdentifier>(numOfPoints * pointDimension));
 
   int index = 0;
   for (int i = 0; i < numOfPoints; ++i)

--- a/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
@@ -20,6 +20,7 @@
 
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkNumericTraits.h"
+#include <cstddef>
 #include <cstdlib>
 #include <algorithm> // For max.
 
@@ -282,7 +283,7 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::PolygonToImageRaster(
     n = static_cast<int>(xylist.size()) / 2;
     for (int k = 0; k < n; ++k)
     {
-      Point2DType & p2D1 = xylist[2 * k];
+      Point2DType & p2D1 = xylist[static_cast<std::string::size_type>(2 * k)];
       const double  X1 = p2D1[0];
       const double  Y1 = p2D1[1];
       Point2DType & p2D2 = xylist[2 * k + 1];
@@ -358,7 +359,7 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::RasterizeTriangles()
   // parallel to the x axis intersects the polydata
   const int    zInc = extent[3] - extent[2] + 1;
   const int    zSize = extent[5] - extent[4] + 1;
-  Point1DArray zymatrix(zInc * zSize);
+  Point1DArray zymatrix(static_cast<Point1DArray::size_type>(zInc * zSize));
   PointVector  coords;
 
   const CellsContainerPointer cells = input->GetCells();
@@ -458,7 +459,7 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::RasterizeTriangles()
 
       for (int i = 0; i < n; ++i)
       {
-        auto x1 = static_cast<int>(std::ceil(nlist[2 * i]));
+        auto x1 = static_cast<int>(std::ceil(nlist[static_cast<std::vector<double>::size_type>(2 * i)]));
         auto x2 = static_cast<int>(std::floor(nlist[2 * i + 1]));
 
         if (x2 < extent[0] || x1 > (extent[1]))

--- a/Modules/Core/Mesh/test/itkCellInterfaceTest.cxx
+++ b/Modules/Core/Mesh/test/itkCellInterfaceTest.cxx
@@ -16,6 +16,7 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
 #include <iostream>
 
 #include "itkMesh.h"
@@ -88,7 +89,7 @@ TestCellInterface(std::string name, TCell * aCell)
 
   using PointIdentifier = typename TCell::PointIdentifier;
 
-  auto * pointIds = new PointIdentifier[cell->GetNumberOfPoints() * 2];
+  auto * pointIds = new PointIdentifier[static_cast<unsigned long>(cell->GetNumberOfPoints() * 2)];
 
   for (unsigned int i = 0; i < cell->GetNumberOfPoints() * 2; ++i)
   {
@@ -111,7 +112,8 @@ TestCellInterface(std::string name, TCell * aCell)
   }
   std::cout << std::endl;
 
-  cell->SetPointIds(&pointIds[cell->GetNumberOfPoints()], &pointIds[cell->GetNumberOfPoints() * 2]);
+  cell->SetPointIds(&pointIds[cell->GetNumberOfPoints()],
+                    &pointIds[static_cast<size_t>(cell->GetNumberOfPoints() * 2)]);
   std::cout << "    Iterator test: PointIds for populated cell: ";
   typename TCell::PointIdIterator pxpointId = cell->PointIdsBegin();
   typename TCell::PointIdIterator pxendId = cell->PointIdsEnd();

--- a/Modules/Core/Mesh/test/itkVTKPolyDataWriterTest01.cxx
+++ b/Modules/Core/Mesh/test/itkVTKPolyDataWriterTest01.cxx
@@ -16,6 +16,8 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
+
 #include "itkVTKPolyDataWriter.h"
 #include "itkTestingMacros.h"
 
@@ -58,7 +60,7 @@ itkVTKPolyDataWriterTest01(int argc, char * argv[])
 
   for (unsigned int i = 0; i < numberOfPoints; ++i)
   {
-    point[0] = rawPoints[3 * i];
+    point[0] = rawPoints[static_cast<size_t>(3 * i)];
     point[1] = rawPoints[3 * i + 1];
     point[2] = rawPoints[3 * i + 2];
     mesh->SetPoint(i, point);
@@ -72,7 +74,7 @@ itkVTKPolyDataWriterTest01(int argc, char * argv[])
 
   for (unsigned int i = 0; i < 4; ++i)
   {
-    pointIds[0] = rawCells[3 * i];
+    pointIds[0] = rawCells[static_cast<size_t>(3 * i)];
     pointIds[1] = rawCells[3 * i + 1];
     pointIds[2] = rawCells[3 * i + 2];
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorsTestHelper.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorsTestHelper.h
@@ -18,6 +18,8 @@
 #ifndef itkQuadEdgeMeshEulerOperatorsTestHelper_h
 #define itkQuadEdgeMeshEulerOperatorsTestHelper_h
 
+#include <cstddef>
+
 #include "itkQuadEdgeMeshTopologyChecker.h"
 #include "itkQuadEdgeMeshPolygonCell.h"
 
@@ -105,7 +107,7 @@ CreateSquareQuadMesh(typename TMesh::Pointer mesh)
   {
     poly = new QEPolygonCellType(4);
     cellpointer.TakeOwnership(poly);
-    cellpointer->SetPointId(0, simpleSquareCells[4 * i]);
+    cellpointer->SetPointId(0, simpleSquareCells[static_cast<ptrdiff_t>(4 * i)]);
     cellpointer->SetPointId(1, simpleSquareCells[4 * i + 1]);
     cellpointer->SetPointId(2, simpleSquareCells[4 * i + 2]);
     cellpointer->SetPointId(3, simpleSquareCells[4 * i + 3]);
@@ -153,7 +155,7 @@ CreateSquareTriangularMesh(typename TMesh::Pointer mesh)
   {
     poly = new QEPolygonCellType(3);
     cellpointer.TakeOwnership(poly);
-    cellpointer->SetPointId(0, simpleSquareCells[3 * i]);
+    cellpointer->SetPointId(0, simpleSquareCells[static_cast<ptrdiff_t>(3 * i)]);
     cellpointer->SetPointId(1, simpleSquareCells[3 * i + 1]);
     cellpointer->SetPointId(2, simpleSquareCells[3 * i + 2]);
     mesh->SetCell(i, cellpointer);
@@ -209,7 +211,7 @@ CreateTetraedronMesh(typename TMesh::Pointer mesh)
   {
     poly = new QEPolygonCellType(3);
     cellpointer.TakeOwnership(poly);
-    cellpointer->SetPointId(0, simpleSquareCells[3 * i]);
+    cellpointer->SetPointId(0, simpleSquareCells[static_cast<ptrdiff_t>(3 * i)]);
     cellpointer->SetPointId(1, simpleSquareCells[3 * i + 1]);
     cellpointer->SetPointId(2, simpleSquareCells[3 * i + 2]);
     mesh->SetCell(i, cellpointer);
@@ -263,7 +265,7 @@ CreateSamosa(typename TMesh::Pointer mesh)
   {
     poly = new QEPolygonCellType(3);
     cellpointer.TakeOwnership(poly);
-    cellpointer->SetPointId(0, simpleSquareCells[3 * i]);
+    cellpointer->SetPointId(0, simpleSquareCells[static_cast<ptrdiff_t>(3 * i)]);
     cellpointer->SetPointId(1, simpleSquareCells[3 * i + 1]);
     cellpointer->SetPointId(2, simpleSquareCells[3 * i + 2]);
     mesh->SetCell(i, cellpointer);

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshAddFaceTest2.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshAddFaceTest2.cxx
@@ -16,6 +16,8 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
+
 #include "itkQuadEdgeMeshTopologyChecker.h"
 
 
@@ -92,7 +94,7 @@ itkQuadEdgeMeshAddFaceTest2(int, char *[])
   {
     poly = new QEPolygonCellType(3);
     cellpointer.TakeOwnership(poly);
-    cellpointer->SetPointId(0, oddConnectivityCells[3 * i]);
+    cellpointer->SetPointId(0, oddConnectivityCells[static_cast<ptrdiff_t>(3 * i)]);
     cellpointer->SetPointId(1, oddConnectivityCells[3 * i + 1]);
     cellpointer->SetPointId(2, oddConnectivityCells[3 * i + 2]);
     mesh->SetCell(i, cellpointer);

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshCellInterfaceTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshCellInterfaceTest.cxx
@@ -16,6 +16,7 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
 #include <iostream>
 
 #include "itkQuadEdgeMesh.h"
@@ -113,7 +114,7 @@ TestCellInterface(std::string name, TCell * aCell)
 
   using PointIdentifier = MeshType::PointIdentifier;
 
-  auto * pointIds = new PointIdentifier[cell->GetNumberOfPoints() * 2];
+  auto * pointIds = new PointIdentifier[static_cast<unsigned long>(cell->GetNumberOfPoints() * 2)];
   for (unsigned int i = 0; i < cell->GetNumberOfPoints() * 2; ++i)
   {
     pointIds[i] = i;
@@ -141,7 +142,8 @@ TestCellInterface(std::string name, TCell * aCell)
   }
   std::cout << std::endl;
 
-  cell->SetPointIds(&pointIds[cell->GetNumberOfPoints()], &pointIds[cell->GetNumberOfPoints() * 2]);
+  cell->SetPointIds(&pointIds[cell->GetNumberOfPoints()],
+                    &pointIds[static_cast<size_t>(cell->GetNumberOfPoints() * 2)]);
   std::cout << "    Iterator test: PointIds for populated cell: ";
   typename TCell::PointIdIterator pxpointId = cell->PointIdsBegin();
   typename TCell::PointIdIterator pxendId = cell->PointIdsEnd();

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshDeletePointAndReorderIDsTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshDeletePointAndReorderIDsTest.cxx
@@ -16,6 +16,8 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
+
 #include "itkQuadEdgeMesh.h"
 #include "itkMath.h"
 
@@ -64,7 +66,7 @@ itkQuadEdgeMeshDeletePointAndReorderIDsTest(int, char *[])
   {
     poly = new QEPolygonCellType(3);
     cellpointer.TakeOwnership(poly);
-    cellpointer->SetPointId(0, specialCells[3 * i]);
+    cellpointer->SetPointId(0, specialCells[static_cast<ptrdiff_t>(3 * i)]);
     cellpointer->SetPointId(1, specialCells[3 * i + 1]);
     cellpointer->SetPointId(2, specialCells[3 * i + 2]);
     mesh->SetCell(i, cellpointer);

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexTest.cxx
@@ -16,6 +16,8 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
+
 #include "itkQuadEdgeMeshEulerOperatorDeleteCenterVertexFunction.h"
 #include "itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.h"
 #include "itkQuadEdgeMeshEulerOperatorsTestHelper.h"
@@ -131,7 +133,7 @@ itkQuadEdgeMeshEulerOperatorDeleteCenterVertexTest(int itkNotUsed(argc), char * 
     {
       poly = new QEPolygonCellType(3);
       cellpointer.TakeOwnership(poly);
-      cellpointer->SetPointId(0, specialCells[3 * i]);
+      cellpointer->SetPointId(0, specialCells[static_cast<ptrdiff_t>(3 * i)]);
       cellpointer->SetPointId(1, specialCells[3 * i + 1]);
       cellpointer->SetPointId(2, specialCells[3 * i + 2]);
       specialmesh->SetCell(i, cellpointer);

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshFrontIteratorTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshFrontIteratorTest.cxx
@@ -28,6 +28,8 @@
  * primal and dual version of the front iterator.
  */
 
+#include <cstddef>
+
 #include "itkQuadEdgeMesh.h"
 
 int
@@ -178,7 +180,7 @@ itkQuadEdgeMeshFrontIteratorTest(int, char *[])
   {
     poly = new QEPolygonCellType(3);
     cellpointer.TakeOwnership(poly);
-    cellpointer->SetPointId(0, simpleSquareCells[3 * i]);
+    cellpointer->SetPointId(0, simpleSquareCells[static_cast<ptrdiff_t>(3 * i)]);
     cellpointer->SetPointId(1, simpleSquareCells[3 * i + 1]);
     cellpointer->SetPointId(2, simpleSquareCells[3 * i + 2]);
     mesh->SetCell(i, cellpointer);

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshTest1.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshTest1.cxx
@@ -16,6 +16,8 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
+
 #include "itkQuadEdgeMesh.h"
 
 int
@@ -124,7 +126,7 @@ itkQuadEdgeMeshTest1(int, char *[])
     {
       poly = new QEPolygonCellType(3);
       cellpointer.TakeOwnership(poly);
-      cellpointer->SetPointId(0, specialCells[3 * i]);
+      cellpointer->SetPointId(0, specialCells[static_cast<ptrdiff_t>(3 * i)]);
       cellpointer->SetPointId(1, specialCells[3 * i + 1]);
       cellpointer->SetPointId(2, specialCells[3 * i + 2]);
       mesh->SetCell(i, cellpointer);

--- a/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
+++ b/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
@@ -28,6 +28,8 @@
 #ifndef itkRandomImageSource_hxx
 #define itkRandomImageSource_hxx
 
+#include <cstddef>
+
 #include "itkImageRegionIterator.h"
 #include "itkObjectFactory.h"
 #include "itkTotalProgressReporter.h"
@@ -234,7 +236,7 @@ RandomImageSource<TOutputImage>::DynamicThreadedGenerateData(const OutputImageRe
 
   for (ImageRegionIterator<TOutputImage> it(image, outputRegionForThread); !it.IsAtEnd(); ++it)
   {
-    sample_seed = (sample_seed * 16807) % 2147483647L;
+    sample_seed = (static_cast<long>(sample_seed * 16807)) % 2147483647L;
     const double u = static_cast<double>(sample_seed) / 2147483711UL;
     const double rnd = (1.0 - u) * dMin + u * dMax;
 

--- a/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
@@ -26,6 +26,8 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
+
 #include "itkBSplineTransform.h"
 
 
@@ -86,7 +88,7 @@ itkBSplineTransformTest1()
    */
 
   ParametersType fixedParameters;
-  fixedParameters.SetSize(SpaceDimension * (SpaceDimension + 3));
+  fixedParameters.SetSize(static_cast<itk::SizeValueType>(SpaceDimension * (SpaceDimension + 3)));
 
   unsigned int fixedParametersCount = 0;
   for (unsigned int i = 0; i < SpaceDimension; ++i)

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterStreamingTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterStreamingTest.cxx
@@ -108,7 +108,8 @@ doConvolutionImageFilterStreamingTest(int argc, char * argv[])
   // two inputs (Primary and KernelImage)
   const unsigned int requestsPerStream = 2;
   // Verify ConvolutionImageFilter upstream requests
-  ITK_TEST_EXPECT_EQUAL(inputMonitor->GetOutputRequestedRegions().size(), requestsPerStream * numStreamDivisions);
+  ITK_TEST_EXPECT_EQUAL(inputMonitor->GetOutputRequestedRegions().size(),
+                        static_cast<std::size_t>(requestsPerStream * numStreamDivisions));
   ITK_TEST_EXPECT_EQUAL(inputMonitor->GetNumberOfUpdates(), numStreamDivisions);
 
   // Verify ConvolutionImageFilter downstream outputs

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -20,6 +20,8 @@
 #define itkFastMarchingImageFilterBase_hxx
 
 
+#include <cstddef>
+
 #include "itkImageRegionIterator.h"
 #include "itkConnectedComponentImageFilter.h"
 #include "itkRelabelComponentImageFilter.h"
@@ -840,12 +842,12 @@ FastMarchingImageFilterBase<TInput, TOutput>::IsCriticalC2Configuration3D(const 
   for (unsigned int i = 0; i < 4; ++i)
   {
     bool isC2 = false;
-    if (neighborhood[2 * i] == neighborhood[2 * i + 1])
+    if (neighborhood[static_cast<size_t>(2 * i)] == neighborhood[2 * i + 1])
     {
       isC2 = true;
       for (unsigned int j = 0; j < 8; ++j)
       {
-        if (neighborhood[j] == neighborhood[2 * i] && j != 2 * i && j != 2 * i + 1)
+        if (neighborhood[j] == neighborhood[static_cast<size_t>(2 * i)] && j != 2 * i && j != 2 * i + 1)
         {
           isC2 = false;
         }
@@ -853,7 +855,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::IsCriticalC2Configuration3D(const 
     }
     if (isC2)
     {
-      if (neighborhood[2 * i])
+      if (neighborhood[static_cast<size_t>(2 * i)])
       {
         return 1;
       }

--- a/Modules/Filtering/ImageGrid/test/itkBinShrinkImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBinShrinkImageFilterTest1.cxx
@@ -15,6 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
+#include <cstddef>
+
 #include "itkBinShrinkImageFilter.h"
 #include "itkShrinkImageFilter.h"
 #include "itkPipelineMonitorImageFilter.h"
@@ -184,7 +186,8 @@ itkBinShrinkImageFilterTest1(int, char *[])
                                                                  monitor2->GetOutput()->GetLargestPossibleRegion());
     for (inIt.GoToBegin(); !inIt.IsAtEnd(); ++inIt)
     {
-      if (inIt.Get() != static_cast<int>(inIt.GetIndex()[0] * factors[0] + 2) * 10)
+      if (inIt.Get() != static_cast<OutputMonitorFilterType::InputImageType::PixelType>(
+                          static_cast<int>(inIt.GetIndex()[0] * factors[0] + 2) * 10))
       {
         std::cout << "Wrong pixel value at " << inIt.GetIndex() << " of " << inIt.Get() << std::endl;
         failed = true;
@@ -254,7 +257,8 @@ itkBinShrinkImageFilterTest1(int, char *[])
                                                                  monitor2->GetOutput()->GetLargestPossibleRegion());
     for (inIt.GoToBegin(); !inIt.IsAtEnd(); ++inIt)
     {
-      if (inIt.Get() != static_cast<int>(inIt.GetIndex()[0] * factors[0] + 1) * 10)
+      if (inIt.Get() != static_cast<OutputMonitorFilterType::InputImageType::PixelType>(
+                          static_cast<int>(inIt.GetIndex()[0] * factors[0] + 1) * 10))
       {
         std::cout << "Wrong pixel value at " << inIt.GetIndex() << " of " << inIt.Get() << std::endl;
         failed = true;

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.h
@@ -23,6 +23,7 @@
 #include "itkSimpleDataObjectDecorator.h"
 #include "itkHistogram.h"
 #include "itkPrintHelper.h"
+#include <cstddef>
 #include <mutex>
 #include <unordered_map>
 #include <vector>
@@ -136,7 +137,7 @@ public:
       m_Variance = RealType{};
 
       const unsigned int imageDimension = Self::ImageDimension;
-      m_BoundingBox.resize(imageDimension * 2);
+      m_BoundingBox.resize(static_cast<BoundingBoxType::size_type>(imageDimension * 2));
       for (unsigned int i = 0; i < imageDimension * 2; i += 2)
       {
         m_BoundingBox[i] = NumericTraits<IndexValueType>::max();
@@ -163,7 +164,7 @@ public:
       m_Variance = RealType{};
 
       const unsigned int imageDimension = Self::ImageDimension;
-      m_BoundingBox.resize(imageDimension * 2);
+      m_BoundingBox.resize(static_cast<BoundingBoxType::size_type>(imageDimension * 2));
       for (unsigned int i = 0; i < imageDimension * 2; i += 2)
       {
         m_BoundingBox[i] = NumericTraits<IndexValueType>::max();

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkImageScanlineConstIterator.h"
 #include "itkTotalProgressReporter.h"
 #include <algorithm> // For min and max.
+#include <cstddef>
 
 namespace itk
 {
@@ -400,8 +401,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetRegion(LabelPixelType l
 
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
-      index[i] = bbox[2 * i];
-      size[i] = bbox[2 * i + 1] - bbox[2 * i] + 1;
+      index[i] = bbox[static_cast<BoundingBoxType::size_type>(2 * i)];
+      size[i] = bbox[2 * i + 1] - bbox[static_cast<BoundingBoxType::size_type>(2 * i)] + 1;
     }
     const RegionType region(index, size);
 

--- a/Modules/Filtering/Path/include/itkChainCodeToFourierSeriesPathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkChainCodeToFourierSeriesPathFilter.hxx
@@ -19,6 +19,7 @@
 #define itkChainCodeToFourierSeriesPathFilter_hxx
 
 #include <cmath>
+#include <cstddef>
 
 namespace itk
 {
@@ -62,7 +63,7 @@ ChainCodeToFourierSeriesPathFilter<TInputChainCodePath, TOutputFourierSeriesPath
   {
     numHarmonics = 2;
   }
-  else if (numHarmonics * 2 > numSteps)
+  else if (static_cast<size_t>(numHarmonics * 2) > numSteps)
   {
     numHarmonics = numSteps / 2;
   }

--- a/Modules/Filtering/Path/include/itkPathFunctions.h
+++ b/Modules/Filtering/Path/include/itkPathFunctions.h
@@ -21,6 +21,7 @@
 #include "itkChainCodePath.h"
 #include "itkFourierSeriesPath.h"
 #include <cmath>
+#include <cstddef>
 
 namespace itk
 {
@@ -99,7 +100,7 @@ MakeFourierSeriesPathTraceChainCode(TFourierSeriesPath &   FSPath,
   {
     numHarmonics = 2;
   }
-  else if (numHarmonics * 2 > numSteps)
+  else if (static_cast<size_t>(numHarmonics * 2) > numSteps)
   {
     numHarmonics = numSteps / 2;
   }

--- a/Modules/IO/BMP/test/itkBMPImageIOTestPalette.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTestPalette.cxx
@@ -22,6 +22,7 @@
 #include "itkImageRegionConstIterator.h"
 #include "itkMetaDataDictionary.h"
 #include "itkTestingMacros.h"
+#include <cstddef>
 #include <fstream>
 
 // Specific ImageIO test
@@ -61,7 +62,8 @@ itkBMPImageIOTestPalette(int argc, char * argv[])
 
   // Exercise exception cases
   const size_t sizeOfActualIORegion =
-    io->GetIORegion().GetNumberOfPixels() * (io->GetComponentSize() * io->GetNumberOfComponents());
+    io->GetIORegion().GetNumberOfPixels() *
+    (static_cast<itk::SizeValueType>(io->GetComponentSize() * io->GetNumberOfComponents()));
   auto * loadBuffer = new char[sizeOfActualIORegion];
 
   ITK_TRY_EXPECT_EXCEPTION(io->Read(loadBuffer));

--- a/Modules/IO/GE/src/itkGE4ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE4ImageIO.cxx
@@ -20,6 +20,7 @@
 #include "Ge4xHdr.h"
 #include "itksys/SystemTools.hxx"
 #include "itkBitCast.h"
+#include <cstddef>
 #include <iostream>
 #include <fstream>
 // From uiig library "The University of Iowa Imaging Group-UIIG"
@@ -286,7 +287,7 @@ GE4ImageIO::ReadHeader(const char * FileNameToRead)
   // find file length in line ...
   const SizeValueType file_length = itksys::SystemTools::FileLength(FileNameToRead);
 
-  hdr->offset = file_length - (hdr->imageXsize * hdr->imageYsize * 2);
+  hdr->offset = file_length - (static_cast<SizeValueType>(hdr->imageXsize * hdr->imageYsize * 2));
   return hdr;
 }
 

--- a/Modules/IO/GE/src/itkGE5ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE5ImageIO.cxx
@@ -21,6 +21,7 @@
 #include "itkMakeUniqueForOverwrite.h"
 #include "Ge5xHdr.h"
 #include <algorithm>
+#include <cstddef>
 #include <iostream>
 #include <fstream>
 
@@ -341,8 +342,8 @@ GE5ImageIO::ReadHeader(const char * FileNameToRead)
   // where to begin reading image data
   if (!pixelHdrFlag)
   {
-    curImage->offset =
-      itksys::SystemTools::FileLength(FileNameToRead) - (curImage->imageXsize * curImage->imageYsize * 2);
+    curImage->offset = itksys::SystemTools::FileLength(FileNameToRead) -
+                       (static_cast<unsigned long>(curImage->imageXsize * curImage->imageYsize * 2));
   }
 
   curImage->xFOV = hdr2Float(buffer.get() + VOff(34, 36));

--- a/Modules/IO/GE/src/itkGEAdwImageIO.cxx
+++ b/Modules/IO/GE/src/itkGEAdwImageIO.cxx
@@ -18,6 +18,7 @@
 #include "itkGEAdwImageIO.h"
 #include "itksys/SystemTools.hxx"
 
+#include <cstddef>
 #include <iostream>
 #include <fstream>
 
@@ -80,7 +81,7 @@ GEAdwImageIO::CanReadFile(const char * FileNameToRead)
     return false;
   }
 
-  imageSize = varHdrSize + GE_ADW_FIXED_HDR_LENGTH + (matrixX * matrixY * sizeof(short));
+  imageSize = varHdrSize + GE_ADW_FIXED_HDR_LENGTH + (static_cast<unsigned long>(matrixX * matrixY) * sizeof(short));
 
   if (imageSize != itksys::SystemTools::FileLength(FileNameToRead))
   {

--- a/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
+++ b/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
@@ -22,6 +22,7 @@
 #include "itkAnatomicalOrientation.h"
 #include "itkDirectory.h"
 #include "itkMetaDataObject.h"
+#include <cstddef>
 #include <iostream>
 #include <fstream>
 #include <cstring>
@@ -84,7 +85,10 @@ IPLCommonImageIO::Read(void * buffer)
     this->OpenFileForReading(f, curfilename);
 
     f.seekg((*it)->GetSliceOffset(), std::ios::beg);
-    if (!this->ReadBufferAsBinary(f, img_buffer, m_FilenameList->GetXDim() * m_FilenameList->GetYDim() * sizeof(short)))
+    if (!this->ReadBufferAsBinary(f,
+                                  img_buffer,
+                                  static_cast<unsigned long>(m_FilenameList->GetXDim() * m_FilenameList->GetYDim()) *
+                                    sizeof(short)))
     {
       f.close();
       RAISE_EXCEPTION();
@@ -94,9 +98,9 @@ IPLCommonImageIO::Read(void * buffer)
     // the FILE endian-ness, not as the name would lead you to believe.
     // So, on LittleEndian systems, SwapFromSystemToBigEndian will swap.
     // On BigEndian systems, SwapFromSystemToBigEndian will do nothing.
-    itk::ByteSwapper<short>::SwapRangeFromSystemToBigEndian(img_buffer,
-                                                            m_FilenameList->GetXDim() * m_FilenameList->GetYDim());
-    img_buffer += m_FilenameList->GetXDim() * m_FilenameList->GetYDim();
+    itk::ByteSwapper<short>::SwapRangeFromSystemToBigEndian(
+      img_buffer, static_cast<BufferSizeType>(m_FilenameList->GetXDim() * m_FilenameList->GetYDim()));
+    img_buffer += static_cast<ptrdiff_t>(m_FilenameList->GetXDim() * m_FilenameList->GetYDim());
   }
 }
 

--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -27,6 +27,7 @@
 
 #include "itksys/SystemTools.hxx"
 #include "itkMakeUniqueForOverwrite.h"
+#include <cstddef>
 #include <fstream>
 
 namespace itk
@@ -388,7 +389,8 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateData()
   // pixels to be read and the actual size of the pixels to be read
   // (as opposed to the sizes of the output)
   const size_t sizeOfActualIORegion =
-    m_ActualIORegion.GetNumberOfPixels() * (m_ImageIO->GetComponentSize() * m_ImageIO->GetNumberOfComponents());
+    m_ActualIORegion.GetNumberOfPixels() *
+    (static_cast<SizeValueType>(m_ImageIO->GetComponentSize() * m_ImageIO->GetNumberOfComponents()));
 
   const IOComponentEnum ioType = ImageIOBase::MapPixelType<typename ConvertPixelTraits::ComponentType>::CType;
   if (m_ImageIO->GetComponentType() != ioType ||

--- a/Modules/IO/ImageBase/src/itkStreamingImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkStreamingImageIOBase.cxx
@@ -15,6 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
+#include <cstddef>
+
 #include "itkStreamingImageIOBase.h"
 
 #include "itksys/SystemTools.hxx"
@@ -112,7 +114,7 @@ bool
 StreamingImageIOBase::ReadBufferAsBinary(std::istream & is, void * buffer, StreamingImageIOBase::SizeType num)
 {
   // some systems have a limit of 2GB to be read at once
-  const SizeType maxChunk = 1024 * 1024 * 1024;
+  const SizeType maxChunk = static_cast<const SizeType>(1024 * 1024 * 1024);
 
   auto bytesRemaining = static_cast<std::streamsize>(num);
 
@@ -139,7 +141,7 @@ bool
 StreamingImageIOBase::WriteBufferAsBinary(std::ostream & os, const void * buffer, StreamingImageIOBase::SizeType num)
 {
   // some systems have a limit of 2GB to be written at once
-  const SizeType maxChunk = 1024 * 1024 * 1024;
+  const SizeType maxChunk = static_cast<const SizeType>(1024 * 1024 * 1024);
 
   std::streamsize bytesRemaining = num;
 

--- a/Modules/IO/ImageBase/test/itk64bitTest.cxx
+++ b/Modules/IO/ImageBase/test/itk64bitTest.cxx
@@ -19,6 +19,7 @@
 #include "itkImageFileWriter.h"
 #include "itkImageRegionConstIterator.h"
 #include "itkNumericTraits.h"
+#include <cstddef>
 #include <iostream>
 #include "itkTestingMacros.h"
 
@@ -29,7 +30,7 @@ int
 verifyContent(ImageType::Pointer image)
 {
   itk::ImageRegionConstIterator<ImageType> it(image, image->GetBufferedRegion());
-  const unsigned long long                 imageSize = 4 * 3 * 2;
+  const unsigned long long                 imageSize = static_cast<const unsigned long long>(4 * 3 * 2);
   unsigned long long                       value = 1;
   while (!it.IsAtEnd() && value <= imageSize)
   {

--- a/Modules/IO/ImageBase/test/itkLargeImageWriteReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkLargeImageWriteReadTest.cxx
@@ -16,6 +16,8 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
+
 #include "itkImageFileWriter.h"
 #include "itkImageFileReader.h"
 #include "itkTimeProbesCollectorBase.h"
@@ -53,7 +55,7 @@ ActualTest(std::string filename, typename TImageType::SizeType size)
       numberOfPixels *= region.GetSize(i);
     }
 
-    const size_t sizeInMebiBytes = sizeof(PixelType) * numberOfPixels / (1024 * 1024);
+    const size_t sizeInMebiBytes = sizeof(PixelType) * numberOfPixels / (static_cast<unsigned long>(1024 * 1024));
 
     std::cout << "Trying to allocate an image of size " << sizeInMebiBytes << " MiB " << std::endl;
 

--- a/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
+++ b/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
@@ -25,6 +25,7 @@
 #define JPEGIO_JPEG_MESSAGES 1
 
 #if (defined JPEGIO_JPEG_MESSAGES && JPEGIO_JPEG_MESSAGES == 1)
+#  include <cstddef>
 #  include <cstdio>
 #endif
 
@@ -216,7 +217,7 @@ JPEGImageIO::Read(void * buffer)
   if (m_IsCMYK && m_CMYKtoRGB)
   {
     JSAMPROW buf1[1];
-    auto * volatile buf0 = new JSAMPLE[cinfo.output_width * 4];
+    auto * volatile buf0 = new JSAMPLE[static_cast<unsigned long>(cinfo.output_width * 4)];
     buf1[0] = buf0;
 
     while (cinfo.output_scanline < cinfo.output_height)

--- a/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
+++ b/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
@@ -16,6 +16,8 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
+
 #include "itkJPEG2000ImageIO.h"
 #include "itksys/SystemTools.hxx"
 
@@ -583,8 +585,8 @@ JPEG2000ImageIO::Read(void * buffer)
       itkDebugMacro("sizePerChannelInBytes:   " << sizePerChannelInBytes);
 
       const SizeValueType sizePerStrideXInBytes = sizePerChannelInBytes / tsizey;
-      const SizeValueType initialStrideInBytes =
-        (l_current_tile_y0 - p_start_y) * sizex * sizePerComponentInBytes * numberOfComponents;
+      const SizeValueType initialStrideInBytes = static_cast<SizeValueType>((l_current_tile_y0 - p_start_y) * sizex) *
+                                                 sizePerComponentInBytes * numberOfComponents;
       const SizeValueType priorStrideInBytes =
         (l_current_tile_x0 - p_start_x) * sizePerComponentInBytes * numberOfComponents;
       const SizeValueType postStrideInBytes =

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 #include "itkMINCImageIO.h"
 
+#include <cstddef>
 #include <cstdio>
 #include <cctype>
 #include "vnl/vnl_vector.h"
@@ -1060,12 +1061,12 @@ MINCImageIO::WriteImageInformation()
   {
     // the format should be ((+|-)(X|Y|Z|V|T))*
     // std::cout<<"Restoring original dimension order:"<<dimension_order.c_str()<<std::endl;
-    if (dimension_order.length() == (minc_dimensions * 2))
+    if (dimension_order.length() == (static_cast<std::string::size_type>(minc_dimensions * 2)))
     {
       dimorder_good = true;
       for (unsigned int i = 0; i < minc_dimensions && dimorder_good; ++i)
       {
-        const bool positive = (dimension_order[i * 2] == '+');
+        const bool positive = (dimension_order[static_cast<std::string::size_type>(i * 2)] == '+');
         int        j = 0;
         switch (dimension_order[i * 2 + 1])
         {

--- a/Modules/IO/MRC/src/itkMRCHeaderObject.cxx
+++ b/Modules/IO/MRC/src/itkMRCHeaderObject.cxx
@@ -15,6 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
+#include <cstddef>
+
 #include "itkMRCHeaderObject.h"
 #include "itkMRCImageIOPrivate.h"
 #include "itkByteSwapper.h"
@@ -153,7 +155,8 @@ MRCHeaderObject::SetExtendedHeader(const void * buffer)
   memcpy(this->m_ExtendedHeader, buffer, this->m_ExtendedHeaderSize);
 
   this->m_ExtendedFeiHeader = nullptr;
-  if (this->m_ExtendedHeaderSize == 128 * 1024 && this->m_Header.nint == 0 && this->m_Header.nreal == 32)
+  if (this->m_ExtendedHeaderSize == static_cast<SizeValueType>(128 * 1024) && this->m_Header.nint == 0 &&
+      this->m_Header.nreal == 32)
   {
     this->m_ExtendedFeiHeader = static_cast<FeiExtendedHeader *>(this->m_ExtendedHeader);
 

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
@@ -29,6 +29,7 @@
 #include "itksys/SystemTools.hxx"
 #include "itkMakeUniqueForOverwrite.h"
 
+#include <cstddef>
 #include <fstream>
 
 namespace itk
@@ -363,7 +364,8 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Re
                   << " m_MeshIO->NumberOfComponents " << m_MeshIO->GetNumberOfPointPixelComponents());
 
     const auto inputPointDataBuffer = make_unique_for_overwrite<char[]>(
-      m_MeshIO->GetNumberOfPointPixelComponents() * m_MeshIO->GetComponentSize(m_MeshIO->GetPointPixelComponentType()) *
+      static_cast<SizeValueType>(m_MeshIO->GetNumberOfPointPixelComponents() *
+                                 m_MeshIO->GetComponentSize(m_MeshIO->GetPointPixelComponentType())) *
       m_MeshIO->GetNumberOfPointPixels());
     m_MeshIO->ReadPointData(static_cast<void *>(inputPointDataBuffer.get()));
 
@@ -404,7 +406,8 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Re
                   << " m_MeshIO->NumberOfComponents " << m_MeshIO->GetNumberOfCellPixelComponents());
 
     const auto inputCellDataBuffer = make_unique_for_overwrite<char[]>(
-      m_MeshIO->GetNumberOfCellPixelComponents() * m_MeshIO->GetComponentSize(m_MeshIO->GetCellPixelComponentType()) *
+      static_cast<SizeValueType>(m_MeshIO->GetNumberOfCellPixelComponents() *
+                                 m_MeshIO->GetComponentSize(m_MeshIO->GetCellPixelComponentType())) *
       m_MeshIO->GetNumberOfCellPixels());
     m_MeshIO->ReadCellData(static_cast<void *>(inputCellDataBuffer.get()));
 

--- a/Modules/IO/MeshGifti/src/itkGiftiMeshIO.cxx
+++ b/Modules/IO/MeshGifti/src/itkGiftiMeshIO.cxx
@@ -16,6 +16,8 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
+
 #include "itkGiftiMeshIO.h"
 #include "itkMetaDataObject.h"
 
@@ -738,7 +740,8 @@ GiftiMeshIO::WriteMeshInformation()
     {
       if (colorMap)
       {
-        m_GiftiImage->labeltable.rgba = (float *)malloc(colorMap->Size() * 4 * sizeof(float));
+        m_GiftiImage->labeltable.rgba =
+          (float *)malloc(static_cast<unsigned long>(colorMap->Size() * 4) * sizeof(float));
         unsigned int kk = 0;
         for (LabelColorContainer::ConstIterator lt = colorMap->Begin(); lt != colorMap->End(); ++lt)
         {

--- a/Modules/IO/Meta/src/itkMetaImageIO.cxx
+++ b/Modules/IO/Meta/src/itkMetaImageIO.cxx
@@ -16,6 +16,8 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
+
 #include "itkMetaImageIO.h"
 #include "itkAnatomicalOrientation.h"
 #include "itkIOCommon.h"
@@ -836,7 +838,8 @@ MetaImageIO::Write(const void * buffer)
     m_MetaImage.AnatomicalOrientation(2, axisToMetOrientation.at(coordOrient.GetTertiaryTerm()));
   }
   // Propagate direction cosine information.
-  auto * transformMatrix = static_cast<double *>(malloc(numberOfDimensions * numberOfDimensions * sizeof(double)));
+  auto * transformMatrix =
+    static_cast<double *>(malloc(static_cast<unsigned long>(numberOfDimensions * numberOfDimensions) * sizeof(double)));
   if (transformMatrix)
   {
     for (unsigned int ii = 0; ii < numberOfDimensions; ++ii)

--- a/Modules/IO/Meta/test/itkLargeMetaImageWriteReadTest.cxx
+++ b/Modules/IO/Meta/test/itkLargeMetaImageWriteReadTest.cxx
@@ -16,6 +16,8 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
+
 #include "itkImageFileWriter.h"
 #include "itkImageFileReader.h"
 #include "itkTimeProbesCollectorBase.h"
@@ -59,7 +61,7 @@ ActualTest(std::string filename, typename TImageType::SizeType size)
       numberOfPixels *= region.GetSize(i);
     }
 
-    const size_t sizeInMebiBytes = sizeof(PixelType) * numberOfPixels / (1024 * 1024);
+    const size_t sizeInMebiBytes = sizeof(PixelType) * numberOfPixels / (static_cast<unsigned long>(1024 * 1024));
 
     std::cout << "Trying to allocate an image of size " << sizeInMebiBytes << " MiB " << std::endl;
 

--- a/Modules/IO/PNG/test/itkPNGImageIOTest.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTest.cxx
@@ -16,6 +16,7 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
 #include <iostream>
 #include "itkPNGImageIO.h"
 #include "itkImageFileReader.h"
@@ -55,7 +56,8 @@ itkPNGImageIOTest(int argc, char * argv[])
 
   // Exercise exception cases
   const size_t sizeOfActualIORegion =
-    io->GetIORegion().GetNumberOfPixels() * (io->GetComponentSize() * io->GetNumberOfComponents());
+    io->GetIORegion().GetNumberOfPixels() *
+    (static_cast<itk::SizeValueType>(io->GetComponentSize() * io->GetNumberOfComponents()));
   auto * loadBuffer = new char[sizeOfActualIORegion];
 
   ITK_TRY_EXPECT_EXCEPTION(io->Read(loadBuffer));

--- a/Modules/IO/PNG/test/itkPNGImageIOTest2.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTest2.cxx
@@ -16,6 +16,7 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
 #include <iostream>
 #include <algorithm>
 #include "itkPNGImageIO.h"
@@ -76,7 +77,8 @@ itkPNGImageIOTest2(int argc, char * argv[])
 
   // Exercise exception cases
   const size_t sizeOfActualIORegion =
-    io->GetIORegion().GetNumberOfPixels() * (io->GetComponentSize() * io->GetNumberOfComponents());
+    io->GetIORegion().GetNumberOfPixels() *
+    (static_cast<itk::SizeValueType>(io->GetComponentSize() * io->GetNumberOfComponents()));
   auto * loadBuffer = new char[sizeOfActualIORegion];
 
   ITK_TRY_EXPECT_EXCEPTION(io->Read(loadBuffer));

--- a/Modules/IO/PNG/test/itkPNGImageIOTestPalette.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTestPalette.cxx
@@ -16,6 +16,7 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
 #include <iostream>
 #include <algorithm>
 #include "itkPNGImageIO.h"
@@ -65,7 +66,8 @@ itkPNGImageIOTestPalette(int argc, char * argv[])
 
   // Exercise exception cases
   const size_t sizeOfActualIORegion =
-    io->GetIORegion().GetNumberOfPixels() * (io->GetComponentSize() * io->GetNumberOfComponents());
+    io->GetIORegion().GetNumberOfPixels() *
+    (static_cast<itk::SizeValueType>(io->GetComponentSize() * io->GetNumberOfComponents()));
   auto * loadBuffer = new char[sizeOfActualIORegion];
 
   ITK_TRY_EXPECT_EXCEPTION(io->Read(loadBuffer));

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -16,6 +16,8 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
+
 #include "itkTIFFImageIO.h"
 #include "itkTIFFReaderInternal.h"
 #include "itksys/SystemTools.hxx"
@@ -776,7 +778,7 @@ TIFFImageIO::InternalWrite(const void * buffer)
     {
       itkExceptionMacro("TIFFScanlineSize returned 0");
     }
-    rowsperstrip = static_cast<uint32_t>(1024 * 1024 / scanlinesize);
+    rowsperstrip = static_cast<uint32_t>(static_cast<uint64_t>(1024 * 1024) / scanlinesize);
     if (rowsperstrip < 1)
     {
       rowsperstrip = 1;

--- a/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
+++ b/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
@@ -25,6 +25,7 @@
 #include "itkCompositeTransformIOHelper.h"
 #include "itkVersion.h"
 #include "itkMakeUniqueForOverwrite.h"
+#include <cstddef>
 #include <sstream>
 
 namespace itk
@@ -132,7 +133,7 @@ HDF5TransformIOTemplate<TParametersValueType>::WriteParameters(const std::string
     // region
     const H5::DSetCreatPropList plist;
     plist.setDeflate(5); // Set intermediate compression level
-    constexpr hsize_t oneMegabyte = 1024 * 1024;
+    constexpr hsize_t oneMegabyte = static_cast<const hsize_t>(1024 * 1024);
     const hsize_t     chunksize = (dim > oneMegabyte) ? oneMegabyte : dim; // Use chunks of 1 MB if large, else use dim
     plist.setChunk(1, &chunksize);
 

--- a/Modules/Numerics/Statistics/src/itkNormalVariateGenerator.cxx
+++ b/Modules/Numerics/Statistics/src/itkNormalVariateGenerator.cxx
@@ -15,6 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
+#include <cstddef>
+
 #include "itkMath.h"
 
 #include "itkNormalVariateGenerator.h"
@@ -183,12 +185,12 @@ startpass:
       pb = pa + m_LEN;
       pc = pb + m_LEN;
       pd = pc + m_LEN;
-      p0 = m_Vec1 + 4 * m_LEN;
+      p0 = m_Vec1 + static_cast<ptrdiff_t>(4 * m_LEN);
       goto scanset;
     case 1: /*   From consec in bot to scatt in top  */
       inc = 1;
       mask = m_LMASK;
-      pa = m_Vec1 + 4 * m_LEN;
+      pa = m_Vec1 + static_cast<ptrdiff_t>(4 * m_LEN);
       pb = pa + m_LEN;
       pc = pb + m_LEN;
       pd = pc + m_LEN;
@@ -200,9 +202,9 @@ startpass:
       skew *= 2;
       stride *= 2;
       pa = m_Vec1 + 1;
-      pb = pa + 2 * m_LEN;
-      pc = pb + 2 * m_LEN;
-      pd = pc + 2 * m_LEN;
+      pb = pa + static_cast<ptrdiff_t>(2 * m_LEN);
+      pc = pb + static_cast<ptrdiff_t>(2 * m_LEN);
+      pd = pc + static_cast<ptrdiff_t>(2 * m_LEN);
       p0 = m_Vec1;
       goto scanset;
     case 3: /*  From consec in odd to scatt in even  */
@@ -211,9 +213,9 @@ startpass:
       skew *= 2;
       stride *= 2;
       pa = m_Vec1;
-      pb = pa + 2 * m_LEN;
-      pc = pb + 2 * m_LEN;
-      pd = pc + 2 * m_LEN;
+      pb = pa + static_cast<ptrdiff_t>(2 * m_LEN);
+      pc = pb + static_cast<ptrdiff_t>(2 * m_LEN);
+      pd = pc + static_cast<ptrdiff_t>(2 * m_LEN);
       p0 = m_Vec1 + 1;
       goto scanset;
   } /*   End of scan pattern cases */
@@ -237,7 +239,7 @@ scanset:
   }
 
 matrix0:
-  pa += (inc * (m_LEN - 1));
+  pa += (static_cast<ptrdiff_t>(inc * (m_LEN - 1)));
 mpass0:
   skew = (skew + stride) & mask;
   pe = p0 + skew;
@@ -279,7 +281,7 @@ mpass0:
   goto endpass;
 
 matrix1:
-  pb += (inc * (m_LEN - 1));
+  pb += (static_cast<ptrdiff_t>(inc * (m_LEN - 1)));
 mpass1:
   skew = (skew + stride) & mask;
   pe = p0 + skew;
@@ -321,7 +323,7 @@ mpass1:
   goto endpass;
 
 matrix2:
-  pc += (inc * (m_LEN - 1));
+  pc += (static_cast<ptrdiff_t>(inc * (m_LEN - 1)));
 mpass2:
   skew = (skew + stride) & mask;
   pe = p0 + skew;
@@ -363,7 +365,7 @@ mpass2:
   goto endpass;
 
 matrix3:
-  pd += (inc * (m_LEN - 1));
+  pd += (static_cast<ptrdiff_t>(inc * (m_LEN - 1)));
 mpass3:
   skew = (skew + stride) & mask;
   pe = p0 + skew;

--- a/Modules/Numerics/Statistics/test/itkSubsampleTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkSubsampleTest2.cxx
@@ -16,6 +16,8 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
+
 #include "itkListSample.h"
 #include "itkSubsample.h"
 
@@ -70,7 +72,8 @@ itkSubsampleTest2(int, char *[])
   {
     std::cout << "Measurement Vector: " << i << '\t' << subSample->GetMeasurementVector(i) << std::endl;
 
-    if (subSample->GetMeasurementVector(i) != sample->GetMeasurementVector(i * 2))
+    if (subSample->GetMeasurementVector(i) !=
+        sample->GetMeasurementVector(static_cast<SubsampleType::InstanceIdentifier>(i * 2)))
     {
       std::cerr << "Subsampling is not correctly done!" << std::endl;
       return EXIT_FAILURE;
@@ -103,7 +106,8 @@ itkSubsampleTest2(int, char *[])
   {
     std::cout << "Measurement Vector: " << i << '\t' << subSample2->GetMeasurementVector(i) << std::endl;
 
-    if (subSample2->GetMeasurementVector(i) != sample->GetMeasurementVector(i * 4))
+    if (subSample2->GetMeasurementVector(i) !=
+        sample->GetMeasurementVector(static_cast<SubsampleType::InstanceIdentifier>(i * 4)))
     {
       std::cerr << "Subsampling of a subsample is not correctly done!" << std::endl;
       return EXIT_FAILURE;

--- a/Modules/Registration/Common/include/itkBSplineTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkBSplineTransformParametersAdaptor.hxx
@@ -19,6 +19,8 @@
 #define itkBSplineTransformParametersAdaptor_hxx
 
 
+#include <cstddef>
+
 #include "itkBSplineDecompositionImageFilter.h"
 #include "itkBSplineResampleImageFunction.h"
 #include "itkResampleImageFilter.h"
@@ -108,7 +110,7 @@ BSplineTransformParametersAdaptor<TTransform>::SetRequiredFixedParameters(const 
     for (SizeValueType dj = 0; dj < SpaceDimension; ++dj)
     {
       this->m_RequiredTransformDomainDirection[di][dj] =
-        this->m_RequiredFixedParameters[3 * SpaceDimension + (di * SpaceDimension + dj)];
+        this->m_RequiredFixedParameters[static_cast<SizeValueType>(3 * SpaceDimension) + (di * SpaceDimension + dj)];
     }
   }
 
@@ -122,7 +124,8 @@ BSplineTransformParametersAdaptor<TTransform>::SetRequiredFixedParameters(const 
   // Set the physical dimensions parameters
   for (SizeValueType i = 0; i < SpaceDimension; ++i)
   {
-    const FixedParametersValueType gridSpacing = this->m_RequiredFixedParameters[2 * SpaceDimension + i];
+    const FixedParametersValueType gridSpacing =
+      this->m_RequiredFixedParameters[static_cast<SizeValueType>(2 * SpaceDimension) + i];
     this->m_RequiredTransformDomainPhysicalDimensions[i] =
       gridSpacing * static_cast<FixedParametersValueType>(this->m_RequiredTransformDomainMeshSize[i]);
   }
@@ -131,7 +134,8 @@ BSplineTransformParametersAdaptor<TTransform>::SetRequiredFixedParameters(const 
   OriginType origin;
   for (SizeValueType i = 0; i < SpaceDimension; ++i)
   {
-    const FixedParametersValueType gridSpacing = this->m_RequiredFixedParameters[2 * SpaceDimension + i];
+    const FixedParametersValueType gridSpacing =
+      this->m_RequiredFixedParameters[static_cast<SizeValueType>(2 * SpaceDimension) + i];
     origin[i] = 0.5 * gridSpacing * (TransformType::SplineOrder - 1);
   }
   origin = this->m_RequiredTransformDomainDirection * origin;
@@ -181,7 +185,8 @@ BSplineTransformParametersAdaptor<TTransform>::UpdateRequiredFixedParameters()
     const FixedParametersValueType gridSpacing =
       this->m_RequiredTransformDomainPhysicalDimensions[i] /
       static_cast<FixedParametersValueType>(this->m_RequiredTransformDomainMeshSize[i]);
-    this->m_RequiredFixedParameters[2 * SpaceDimension + i] = static_cast<FixedParametersValueType>(gridSpacing);
+    this->m_RequiredFixedParameters[static_cast<SizeValueType>(2 * SpaceDimension) + i] =
+      static_cast<FixedParametersValueType>(gridSpacing);
   }
 
   // Set the direction parameters
@@ -189,7 +194,7 @@ BSplineTransformParametersAdaptor<TTransform>::UpdateRequiredFixedParameters()
   {
     for (SizeValueType dj = 0; dj < SpaceDimension; ++dj)
     {
-      this->m_RequiredFixedParameters[3 * SpaceDimension + (di * SpaceDimension + dj)] =
+      this->m_RequiredFixedParameters[static_cast<SizeValueType>(3 * SpaceDimension) + (di * SpaceDimension + dj)] =
         static_cast<FixedParametersValueType>(this->m_RequiredTransformDomainDirection[di][dj]);
     }
   }
@@ -217,10 +222,11 @@ BSplineTransformParametersAdaptor<TTransform>::AdaptTransformParameters()
   {
     newGridSize[i] = static_cast<SizeValueType>(this->m_RequiredFixedParameters[i]);
     newGridOrigin[i] = this->m_RequiredFixedParameters[SpaceDimension + i];
-    newGridSpacing[i] = this->m_RequiredFixedParameters[2 * SpaceDimension + i];
+    newGridSpacing[i] = this->m_RequiredFixedParameters[static_cast<SizeValueType>(2 * SpaceDimension) + i];
     for (SizeValueType j = 0; j < SpaceDimension; ++j)
     {
-      newGridDirection[i][j] = this->m_RequiredFixedParameters[3 * SpaceDimension + (i * SpaceDimension + j)];
+      newGridDirection[i][j] =
+        this->m_RequiredFixedParameters[static_cast<SizeValueType>(3 * SpaceDimension) + (i * SpaceDimension + j)];
     }
   }
 

--- a/Modules/Registration/Common/include/itkConstantVelocityFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkConstantVelocityFieldTransformParametersAdaptor.hxx
@@ -19,6 +19,8 @@
 #define itkConstantVelocityFieldTransformParametersAdaptor_hxx
 
 
+#include <cstddef>
+
 #include "itkIdentityTransform.h"
 #include "itkResampleImageFilter.h"
 #include "itkLinearInterpolateImageFunction.h"
@@ -107,11 +109,13 @@ ConstantVelocityFieldTransformParametersAdaptor<TTransform>::SetRequiredSpacing(
   bool isModified = false;
   for (SizeValueType d = 0; d < ConstantVelocityFieldDimension; ++d)
   {
-    if (Math::NotExactlyEquals(this->m_RequiredFixedParameters[2 * ConstantVelocityFieldDimension + d], spacing[d]))
+    if (Math::NotExactlyEquals(
+          this->m_RequiredFixedParameters[static_cast<SizeValueType>(2 * ConstantVelocityFieldDimension) + d],
+          spacing[d]))
     {
       isModified = true;
     }
-    this->m_RequiredFixedParameters[2 * ConstantVelocityFieldDimension + d] = spacing[d];
+    this->m_RequiredFixedParameters[static_cast<SizeValueType>(2 * ConstantVelocityFieldDimension) + d] = spacing[d];
   }
 
   if (isModified)
@@ -128,7 +132,7 @@ ConstantVelocityFieldTransformParametersAdaptor<TTransform>::GetRequiredSpacing(
   SpacingType spacing;
   for (SizeValueType d = 0; d < ConstantVelocityFieldDimension; ++d)
   {
-    spacing[d] = this->m_RequiredFixedParameters[2 * ConstantVelocityFieldDimension + d];
+    spacing[d] = this->m_RequiredFixedParameters[static_cast<SizeValueType>(2 * ConstantVelocityFieldDimension) + d];
   }
   return spacing;
 }
@@ -142,14 +146,15 @@ ConstantVelocityFieldTransformParametersAdaptor<TTransform>::SetRequiredDirectio
   {
     for (SizeValueType dj = 0; dj < ConstantVelocityFieldDimension; ++dj)
     {
-      if (Math::NotExactlyEquals(this->m_RequiredFixedParameters[3 * ConstantVelocityFieldDimension +
-                                                                 (di * ConstantVelocityFieldDimension + dj)],
-                                 direction[di][dj]))
+      if (Math::NotExactlyEquals(
+            this->m_RequiredFixedParameters[static_cast<SizeValueType>(3 * ConstantVelocityFieldDimension) +
+                                            (di * ConstantVelocityFieldDimension + dj)],
+            direction[di][dj]))
       {
         isModified = true;
       }
-      this->m_RequiredFixedParameters[3 * ConstantVelocityFieldDimension + (di * ConstantVelocityFieldDimension + dj)] =
-        direction[di][dj];
+      this->m_RequiredFixedParameters[static_cast<SizeValueType>(3 * ConstantVelocityFieldDimension) +
+                                      (di * ConstantVelocityFieldDimension + dj)] = direction[di][dj];
     }
   }
 
@@ -170,8 +175,8 @@ ConstantVelocityFieldTransformParametersAdaptor<TTransform>::GetRequiredDirectio
     for (SizeValueType dj = 0; dj < ConstantVelocityFieldDimension; ++dj)
     {
       direction[di][dj] =
-        this
-          ->m_RequiredFixedParameters[3 * ConstantVelocityFieldDimension + (di * ConstantVelocityFieldDimension + dj)];
+        this->m_RequiredFixedParameters[static_cast<SizeValueType>(3 * ConstantVelocityFieldDimension) +
+                                        (di * ConstantVelocityFieldDimension + dj)];
     }
   }
   return direction;

--- a/Modules/Registration/Common/include/itkDisplacementFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkDisplacementFieldTransformParametersAdaptor.hxx
@@ -19,6 +19,8 @@
 #define itkDisplacementFieldTransformParametersAdaptor_hxx
 
 
+#include <cstddef>
+
 #include "itkIdentityTransform.h"
 #include "itkResampleImageFilter.h"
 #include "itkLinearInterpolateImageFunction.h"
@@ -107,11 +109,12 @@ DisplacementFieldTransformParametersAdaptor<TTransform>::SetRequiredSpacing(cons
   bool isModified = false;
   for (SizeValueType d = 0; d < SpaceDimension; ++d)
   {
-    if (Math::NotExactlyEquals(this->m_RequiredFixedParameters[2 * SpaceDimension + d], spacing[d]))
+    if (Math::NotExactlyEquals(this->m_RequiredFixedParameters[static_cast<SizeValueType>(2 * SpaceDimension) + d],
+                               spacing[d]))
     {
       isModified = true;
     }
-    this->m_RequiredFixedParameters[2 * SpaceDimension + d] = spacing[d];
+    this->m_RequiredFixedParameters[static_cast<SizeValueType>(2 * SpaceDimension) + d] = spacing[d];
   }
 
   if (isModified)
@@ -128,7 +131,7 @@ DisplacementFieldTransformParametersAdaptor<TTransform>::GetRequiredSpacing() co
   SpacingType spacing;
   for (SizeValueType d = 0; d < SpaceDimension; ++d)
   {
-    spacing[d] = this->m_RequiredFixedParameters[2 * SpaceDimension + d];
+    spacing[d] = this->m_RequiredFixedParameters[static_cast<SizeValueType>(2 * SpaceDimension) + d];
   }
   return spacing;
 }
@@ -142,12 +145,14 @@ DisplacementFieldTransformParametersAdaptor<TTransform>::SetRequiredDirection(co
   {
     for (SizeValueType dj = 0; dj < SpaceDimension; ++dj)
     {
-      if (Math::NotExactlyEquals(this->m_RequiredFixedParameters[3 * SpaceDimension + (di * SpaceDimension + dj)],
+      if (Math::NotExactlyEquals(this->m_RequiredFixedParameters[static_cast<SizeValueType>(3 * SpaceDimension) +
+                                                                 (di * SpaceDimension + dj)],
                                  direction[di][dj]))
       {
         isModified = true;
       }
-      this->m_RequiredFixedParameters[3 * SpaceDimension + (di * SpaceDimension + dj)] = direction[di][dj];
+      this->m_RequiredFixedParameters[static_cast<SizeValueType>(3 * SpaceDimension) + (di * SpaceDimension + dj)] =
+        direction[di][dj];
     }
   }
 
@@ -167,7 +172,8 @@ DisplacementFieldTransformParametersAdaptor<TTransform>::GetRequiredDirection() 
   {
     for (SizeValueType dj = 0; dj < SpaceDimension; ++dj)
     {
-      direction[di][dj] = this->m_RequiredFixedParameters[3 * SpaceDimension + (di * SpaceDimension + dj)];
+      direction[di][dj] =
+        this->m_RequiredFixedParameters[static_cast<SizeValueType>(3 * SpaceDimension) + (di * SpaceDimension + dj)];
     }
   }
   return direction;

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -18,6 +18,8 @@
 #ifndef itkImageToImageMetric_hxx
 #define itkImageToImageMetric_hxx
 
+#include <cstddef>
+
 #include "itkImageRandomConstIteratorWithIndex.h"
 #include "itkMath.h"
 #include "itkMakeUniqueForOverwrite.h"
@@ -1058,7 +1060,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::GetValueThread(ThreadIdType threa
 
   if (threadId == m_NumberOfWorkUnits - 1)
   {
-    chunkSize = m_NumberOfFixedImageSamples - ((m_NumberOfWorkUnits - 1) * chunkSize);
+    chunkSize = m_NumberOfFixedImageSamples - (static_cast<SizeValueType>((m_NumberOfWorkUnits - 1) * chunkSize));
   }
 
 
@@ -1157,7 +1159,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeThread(Threa
 
   if (threadId == m_NumberOfWorkUnits - 1)
   {
-    chunkSize = m_NumberOfFixedImageSamples - ((m_NumberOfWorkUnits - 1) * chunkSize);
+    chunkSize = m_NumberOfFixedImageSamples - (static_cast<SizeValueType>((m_NumberOfWorkUnits - 1) * chunkSize));
   }
 
   int numSamples = 0;

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -18,6 +18,8 @@
 #ifndef itkMattesMutualInformationImageToImageMetric_hxx
 #define itkMattesMutualInformationImageToImageMetric_hxx
 
+#include <cstddef>
+
 #include "itkImageRegionIterator.h"
 #include "itkImageIterator.h"
 #include "itkMath.h"
@@ -189,13 +191,15 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Initialize
    */
   constexpr int padding = 2; // this will pad by 2 bins
 
-  this->m_FixedImageBinSize = (this->m_FixedImageTrueMax - this->m_FixedImageTrueMin) /
-                              static_cast<PDFValueType>(this->m_NumberOfHistogramBins - 2 * padding);
+  this->m_FixedImageBinSize =
+    (this->m_FixedImageTrueMax - this->m_FixedImageTrueMin) /
+    static_cast<PDFValueType>(this->m_NumberOfHistogramBins - static_cast<SizeValueType>(2 * padding));
   this->m_FixedImageNormalizedMin =
     this->m_FixedImageTrueMin / this->m_FixedImageBinSize - static_cast<PDFValueType>(padding);
 
-  this->m_MovingImageBinSize = (this->m_MovingImageTrueMax - this->m_MovingImageTrueMin) /
-                               static_cast<PDFValueType>(this->m_NumberOfHistogramBins - 2 * padding);
+  this->m_MovingImageBinSize =
+    (this->m_MovingImageTrueMax - this->m_MovingImageTrueMin) /
+    static_cast<PDFValueType>(this->m_NumberOfHistogramBins - static_cast<SizeValueType>(2 * padding));
   this->m_MovingImageNormalizedMin =
     this->m_MovingImageTrueMin / this->m_MovingImageBinSize - static_cast<PDFValueType>(padding);
 

--- a/Modules/Registration/Common/include/itkTimeVaryingVelocityFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkTimeVaryingVelocityFieldTransformParametersAdaptor.hxx
@@ -19,6 +19,8 @@
 #define itkTimeVaryingVelocityFieldTransformParametersAdaptor_hxx
 
 
+#include <cstddef>
+
 #include "itkIdentityTransform.h"
 #include "itkResampleImageFilter.h"
 #include "itkLinearInterpolateImageFunction.h"
@@ -107,11 +109,12 @@ TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::SetRequiredSpaci
   bool isModified = false;
   for (SizeValueType d = 0; d < TotalDimension; ++d)
   {
-    if (Math::NotExactlyEquals(this->m_RequiredFixedParameters[2 * TotalDimension + d], spacing[d]))
+    if (Math::NotExactlyEquals(this->m_RequiredFixedParameters[static_cast<SizeValueType>(2 * TotalDimension) + d],
+                               spacing[d]))
     {
       isModified = true;
     }
-    this->m_RequiredFixedParameters[2 * TotalDimension + d] = spacing[d];
+    this->m_RequiredFixedParameters[static_cast<SizeValueType>(2 * TotalDimension) + d] = spacing[d];
   }
 
   if (isModified)
@@ -128,7 +131,7 @@ TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::GetRequiredSpaci
   SpacingType spacing;
   for (SizeValueType d = 0; d < TotalDimension; ++d)
   {
-    spacing[d] = this->m_RequiredFixedParameters[2 * TotalDimension + d];
+    spacing[d] = this->m_RequiredFixedParameters[static_cast<SizeValueType>(2 * TotalDimension) + d];
   }
   return spacing;
 }
@@ -142,12 +145,14 @@ TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::SetRequiredDirec
   {
     for (SizeValueType dj = 0; dj < TotalDimension; ++dj)
     {
-      if (Math::NotExactlyEquals(this->m_RequiredFixedParameters[3 * TotalDimension + (di * TotalDimension + dj)],
+      if (Math::NotExactlyEquals(this->m_RequiredFixedParameters[static_cast<SizeValueType>(3 * TotalDimension) +
+                                                                 (di * TotalDimension + dj)],
                                  direction[di][dj]))
       {
         isModified = true;
       }
-      this->m_RequiredFixedParameters[3 * TotalDimension + (di * TotalDimension + dj)] = direction[di][dj];
+      this->m_RequiredFixedParameters[static_cast<SizeValueType>(3 * TotalDimension) + (di * TotalDimension + dj)] =
+        direction[di][dj];
     }
   }
 
@@ -167,7 +172,8 @@ TimeVaryingVelocityFieldTransformParametersAdaptor<TTransform>::GetRequiredDirec
   {
     for (SizeValueType dj = 0; dj < TotalDimension; ++dj)
     {
-      direction[di][dj] = this->m_RequiredFixedParameters[3 * TotalDimension + (di * TotalDimension + dj)];
+      direction[di][dj] =
+        this->m_RequiredFixedParameters[static_cast<SizeValueType>(3 * TotalDimension) + (di * TotalDimension + dj)];
     }
   }
   return direction;

--- a/Modules/Registration/Common/test/itkCenteredVersorTransformInitializerTest.cxx
+++ b/Modules/Registration/Common/test/itkCenteredVersorTransformInitializerTest.cxx
@@ -16,6 +16,8 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
+
 #include "itkCenteredVersorTransformInitializer.h"
 
 #include "itkImageRegionIterator.h"
@@ -104,9 +106,9 @@ itkCenteredVersorTransformInitializerTest(int, char *[])
   internalIndex[1] = index[1] + 30;
   internalIndex[2] = index[2] + 10;
 
-  internalSize[0] = size[0] - 2 * 20;
-  internalSize[1] = size[1] - 2 * 30;
-  internalSize[2] = size[2] - 2 * 10;
+  internalSize[0] = size[0] - static_cast<SizeType::value_type>(2 * 20);
+  internalSize[1] = size[1] - static_cast<SizeType::value_type>(2 * 30);
+  internalSize[2] = size[2] - static_cast<SizeType::value_type>(2 * 10);
 
 
   internalRegion.SetSize(internalSize);
@@ -127,9 +129,9 @@ itkCenteredVersorTransformInitializerTest(int, char *[])
   internalIndex[1] = index[1] + 20;
   internalIndex[2] = index[2] + 30;
 
-  internalSize[0] = size[0] - 2 * 10;
-  internalSize[1] = size[1] - 2 * 20;
-  internalSize[2] = size[2] - 2 * 30;
+  internalSize[0] = size[0] - static_cast<SizeType::value_type>(2 * 10);
+  internalSize[1] = size[1] - static_cast<SizeType::value_type>(2 * 20);
+  internalSize[2] = size[2] - static_cast<SizeType::value_type>(2 * 30);
 
 
   internalRegion.SetSize(internalSize);

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
@@ -19,6 +19,7 @@
 #define itkMattesMutualInformationImageToImageMetricv4_hxx
 
 #include "itkCompensatedSummation.h"
+#include <cstddef>
 #include <mutex>
 
 namespace itk
@@ -251,13 +252,15 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
    */
   constexpr int padding = 2; // this will pad by 2 bins
 
-  this->m_FixedImageBinSize = (this->m_FixedImageTrueMax - this->m_FixedImageTrueMin) /
-                              static_cast<PDFValueType>(this->m_NumberOfHistogramBins - 2 * padding);
+  this->m_FixedImageBinSize =
+    (this->m_FixedImageTrueMax - this->m_FixedImageTrueMin) /
+    static_cast<PDFValueType>(this->m_NumberOfHistogramBins - static_cast<SizeValueType>(2 * padding));
   this->m_FixedImageNormalizedMin =
     this->m_FixedImageTrueMin / this->m_FixedImageBinSize - static_cast<PDFValueType>(padding);
 
-  this->m_MovingImageBinSize = (this->m_MovingImageTrueMax - this->m_MovingImageTrueMin) /
-                               static_cast<PDFValueType>(this->m_NumberOfHistogramBins - 2 * padding);
+  this->m_MovingImageBinSize =
+    (this->m_MovingImageTrueMax - this->m_MovingImageTrueMin) /
+    static_cast<PDFValueType>(this->m_NumberOfHistogramBins - static_cast<SizeValueType>(2 * padding));
   this->m_MovingImageNormalizedMin =
     this->m_MovingImageTrueMin / this->m_MovingImageBinSize - static_cast<PDFValueType>(padding);
 

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
@@ -17,6 +17,8 @@
  *=========================================================================*/
 
 #define ITK_LEGACY_TEST
+#include <cstddef>
+
 #include "itkImageToImageMetricv4.h"
 #include "itkTranslationTransform.h"
 #include "itkTestingMacros.h"
@@ -507,7 +509,8 @@ itkImageToImageMetricv4Test(int, char ** const)
             metric, fixedImage, movingImage, truthValue, truthDerivative);
         }
         std::cout << "* Testing with identity transforms..." << std::endl;
-        if (ImageToImageMetricv4TestRunSingleTest(metric, truthValue, truthDerivative, imageSize * imageSize, false) !=
+        if (ImageToImageMetricv4TestRunSingleTest(
+              metric, truthValue, truthDerivative, static_cast<itk::SizeValueType>(imageSize * imageSize), false) !=
             EXIT_SUCCESS)
         {
           std::cerr << "----------------------------" << std::endl
@@ -593,7 +596,8 @@ itkImageToImageMetricv4Test(int, char ** const)
   // Evaluate the metric
   std::cout << "* Testing with identity DisplacementFieldTransform for moving image..." << std::endl;
   ImageToImageMetricv4TestComputeIdentityTruthValues(metric, fixedImage, movingImage, truthValue, truthDerivative);
-  if (ImageToImageMetricv4TestRunSingleTest(metric, truthValue, truthDerivative, imageSize * imageSize, false) !=
+  if (ImageToImageMetricv4TestRunSingleTest(
+        metric, truthValue, truthDerivative, static_cast<itk::SizeValueType>(imageSize * imageSize), false) !=
       EXIT_SUCCESS)
   {
     return EXIT_FAILURE;
@@ -664,7 +668,8 @@ itkImageToImageMetricv4Test(int, char ** const)
 
   std::cout << "Testing metric output..." << std::endl;
   ImageToImageMetricv4TestComputeIdentityTruthValues(metric, fixedImage, movingImage, truthValue, truthDerivative);
-  if (ImageToImageMetricv4TestRunSingleTest(metric, truthValue, truthDerivative, imageSize * imageSize, false) !=
+  if (ImageToImageMetricv4TestRunSingleTest(
+        metric, truthValue, truthDerivative, static_cast<itk::SizeValueType>(imageSize * imageSize), false) !=
       EXIT_SUCCESS)
   {
     return EXIT_FAILURE;

--- a/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
@@ -17,6 +17,8 @@
  *=========================================================================*/
 
 // Insight classes
+#include <cstddef>
+
 #include "itkTextOutput.h"
 
 #include "itkKLMRegionGrowImageFilter.h"
@@ -1763,10 +1765,10 @@ test_regiongrowKLM4D()
 
   ImageType::SizeType imageSize;
   const int           multVal = 2;
-  imageSize[0] = 2 * multVal;
-  imageSize[1] = 3 * multVal;
-  imageSize[2] = 5 * multVal;
-  imageSize[3] = 7 * multVal;
+  imageSize[0] = static_cast<ImageType::SizeType::value_type>(2 * multVal);
+  imageSize[1] = static_cast<ImageType::SizeType::value_type>(3 * multVal);
+  imageSize[2] = static_cast<ImageType::SizeType::value_type>(5 * multVal);
+  imageSize[3] = static_cast<ImageType::SizeType::value_type>(7 * multVal);
   const unsigned int numPixels = imageSize[0] * imageSize[1] * imageSize[2] * imageSize[3];
 
   const ImageType::IndexType index{};

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageWithKdTreeTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageWithKdTreeTest.cxx
@@ -16,6 +16,8 @@
  *
  *=========================================================================*/
 
+#include <cstddef>
+
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
 #include "itkLevelSetDomainPartitionImageWithKdTree.h"
 #include "itkTestingMacros.h"
@@ -76,7 +78,7 @@ itkLevelSetDomainPartitionImageWithKdTreeTest(int, char *[])
 
   for (unsigned int i = 0; i < numberOfLevelSetFunctions; ++i)
   {
-    index[0] = 10 * i;
+    index[0] = static_cast<itk::IndexValueType>(10 * i);
     index[1] = 0;
     size.Fill(10);
 

--- a/Modules/Video/Core/test/itkRingBufferTest.cxx
+++ b/Modules/Video/Core/test/itkRingBufferTest.cxx
@@ -15,6 +15,7 @@
  *  limitations under the License.
  *
  *=========================================================================*/
+#include <cstddef>
 #include <iostream>
 
 #include "itkRingBuffer.h"
@@ -108,7 +109,7 @@ itkRingBufferTest(int, char *[])
   }
 
   // Test looping buffer offset backward
-  ringBuffer->MoveHead(-2 * static_cast<int>(ringBuffer->GetNumberOfBuffers()));
+  ringBuffer->MoveHead(static_cast<itk::OffsetValueType>(-2 * static_cast<int>(ringBuffer->GetNumberOfBuffers())));
   if (ringBuffer->GetHeadIndex() != oldHeadIndex)
   {
     // DEBUG


### PR DESCRIPTION
The check diagnoses instances where a result of a multiplication is implicitly widened, and suggests (with fix-it) to either silence the code by making widening explicit, or to perform the multiplication in a wider type, to avoid the widening afterwards.

This is fine in general, but if width * height overflows, you end up wrapping back to the beginning of base instead of processing the entire requested buffer.

Indeed, this only matters for pretty large buffers (4GB+), but that can happen very easily for example in image processing, where for that to happen you “only” need a ~269MPix image.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
