### PR TITLE
STYLE: Remove redundant idoms for setting origin/spacing

### DIFF
--- a/Examples/RegistrationITKv4/IterativeClosestPoint3.cxx
+++ b/Examples/RegistrationITKv4/IterativeClosestPoint3.cxx
@@ -216,10 +216,6 @@ main(int argc, char * argv[])
   auto pointsToImageFilter = PointsToImageFilterType::New();
 
   pointsToImageFilter->SetInput(fixedPointSet);
-
-  auto spacing = itk::MakeFilled<BinaryImageType::SpacingType>(1.0);
-
-  BinaryImageType::PointType origin{};
   // Software Guide : EndCodeSnippet
 
   // Software Guide : BeginLatex
@@ -230,8 +226,6 @@ main(int argc, char * argv[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  pointsToImageFilter->SetSpacing(spacing);
-  pointsToImageFilter->SetOrigin(origin);
   pointsToImageFilter->Update();
   const BinaryImageType::Pointer binaryImage =
     pointsToImageFilter->GetOutput();

--- a/Modules/Core/Common/test/itkImageTest.cxx
+++ b/Modules/Core/Common/test/itkImageTest.cxx
@@ -61,15 +61,12 @@ itkImageTest(int, char *[])
   image->GetSource();
   image->DisconnectPipeline();
 
-  auto                 spacing = itk::MakeFilled<Image::SpacingType>(1.0);
-  auto                 origin = itk::MakeFilled<Image::PointType>(1.0);
+
   Image::DirectionType direction;
   direction[0][0] = .5;
   direction[0][1] = .7;
   direction[1][0] = .7;
   direction[1][1] = .5;
-  image->SetSpacing(spacing);
-  image->SetOrigin(origin);
   image->SetDirection(direction);
 
   double dspacing[Image::ImageDimension] = { 2.0, 2.0 };
@@ -113,16 +110,17 @@ itkImageTest(int, char *[])
   }
 
   std::cout << "Test GetSmallestRegionContainingRegion." << std::endl;
+  // reset image spacing default values
+  auto spacing = itk::MakeFilled<Image::SpacingType>(1.0);
   image->SetSpacing(spacing);
-  origin.Fill(1.2);
+  auto origin = itk::MakeFilled<Image::PointType>(1.2);
   image->SetOrigin(origin);
   direction.SetIdentity();
   image->SetDirection(direction);
-  Image::RegionType      region;
+
   const Image::IndexType index{};
   auto                   size = Image::SizeType::Filled(4);
-  region.SetIndex(index);
-  region.SetSize(size);
+  Image::RegionType      region{ index, size };
   image->SetRegions(region);
 
   auto                   imageRef = Image::New();
@@ -154,23 +152,19 @@ itkImageTest(int, char *[])
   }
 
   using Image3D = itk::Image<float, 3>;
-  auto                     volume = Image3D::New();
-  auto                     spacingVol = itk::MakeFilled<Image3D::SpacingType>(1);
-  const Image3D::PointType originVol{};
-  Image3D::DirectionType   directionVol;
+  auto volume = Image3D::New();
+
+  Image3D::DirectionType directionVol;
   directionVol.SetIdentity();
-  volume->SetSpacing(spacingVol);
-  volume->SetOrigin(originVol);
   volume->SetDirection(directionVol);
 
-  Image3D::RegionType      cuboid;
+
   const Image3D::IndexType indexCuboid{};
   Image3D::SizeType        sizeCuboid;
   sizeCuboid[0] = 1;
   sizeCuboid[1] = 2;
   sizeCuboid[2] = 3;
-  cuboid.SetIndex(indexCuboid);
-  cuboid.SetSize(sizeCuboid);
+  Image3D::RegionType cuboid{ indexCuboid, sizeCuboid };
   volume->SetRegions(cuboid);
 
   using ProjectionTransformType = TestTransform<Image3D::ImageDimension>;

--- a/Modules/Core/Common/test/itkImageVectorOptimizerParametersHelperTest.cxx
+++ b/Modules/Core/Common/test/itkImageVectorOptimizerParametersHelperTest.cxx
@@ -92,12 +92,6 @@ itkImageVectorOptimizerParametersHelperTest(int, char *[])
   imageOfVectors->SetRegions(region);
   imageOfVectors->Allocate();
 
-  const ImageVectorType::PointType origin{};
-  auto                             spacing = itk::MakeFilled<ImageVectorType::SpacingType>(1.0);
-
-  imageOfVectors->SetOrigin(origin);
-  imageOfVectors->SetSpacing(spacing);
-
   ValueType             vectorinitvalues[VectorDimension] = { 0.0, 0.1, 0.2, 0.3 };
   const VectorPixelType vectorvalues(vectorinitvalues);
 

--- a/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
@@ -36,7 +36,6 @@ itkRayCastInterpolateImageFunctionTest(int itkNotUsed(argc), char * itkNotUsed(a
 
   using IndexType = ImageType::IndexType;
   using PointType = ImageType::PointType;
-  using SpacingType = ImageType::SpacingType;
   using SizeType = ImageType::SizeType;
   using RegionType = ImageType::RegionType;
 
@@ -53,14 +52,6 @@ itkRayCastInterpolateImageFunctionTest(int itkNotUsed(argc), char * itkNotUsed(a
   region.SetSize(size);
   image->SetRegions(region);
   image->Allocate();
-
-  const PointType origin{};
-
-  auto spacing = itk::MakeFilled<SpacingType>(1.0);
-
-  /* Set origin and spacing of physical coordinates */
-  image->SetOrigin(origin);
-  image->SetSpacing(spacing);
 
   /* Initialize the image contents */
   IndexType index;

--- a/Modules/Filtering/DisplacementField/test/itkInverseDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkInverseDisplacementFieldImageFilterTest.cxx
@@ -58,25 +58,17 @@ itkInverseDisplacementFieldImageFilterTest(int argc, char * argv[])
   // Creating an input displacement field
   auto field = DisplacementFieldType::New();
 
-  auto spacing = itk::MakeFilled<DisplacementFieldType::SpacingType>(1.0);
-
-  const DisplacementFieldType::PointType origin{};
-
-  DisplacementFieldType::RegionType region;
-  DisplacementFieldType::SizeType   size;
-  DisplacementFieldType::IndexType  start;
-
+  DisplacementFieldType::SizeType size;
   size[0] = 128;
   size[1] = 128;
 
+  DisplacementFieldType::IndexType start;
   start[0] = 0;
   start[1] = 0;
 
+  DisplacementFieldType::RegionType region{ start, size };
   region.SetSize(size);
   region.SetIndex(start);
-
-  field->SetOrigin(origin);
-  field->SetSpacing(spacing);
   field->SetRegions(region);
   field->Allocate();
 
@@ -98,13 +90,6 @@ itkInverseDisplacementFieldImageFilterTest(int argc, char * argv[])
   // Since the tested transform is upsampling by a factor of two, the
   // size of the inverse field should be twice the size of the input
   // field. All other geometry parameters are the same.
-  filter->SetOutputSpacing(spacing);
-  ITK_TEST_SET_GET_VALUE(spacing, filter->GetOutputSpacing());
-
-  // Keep the origin
-  filter->SetOutputOrigin(origin);
-  ITK_TEST_SET_GET_VALUE(origin, filter->GetOutputOrigin());
-
   // Set the size
   DisplacementFieldType::SizeType invFieldSize;
   invFieldSize[0] = size[0] * 2;
@@ -160,6 +145,16 @@ itkInverseDisplacementFieldImageFilterTest(int argc, char * argv[])
     }
     ++it;
   }
+
+  // Test non-default values
+  auto spacing = itk::MakeFilled<DisplacementFieldType::SpacingType>(9876.0);
+  filter->SetOutputSpacing(spacing);
+  ITK_TEST_SET_GET_VALUE(spacing, filter->GetOutputSpacing());
+
+  // Keep the origin
+  const auto origin = itk::MakeFilled<DisplacementFieldType::PointType>(1234.0);
+  filter->SetOutputOrigin(origin);
+  ITK_TEST_SET_GET_VALUE(origin, filter->GetOutputOrigin());
 
 
   std::cout << "Test finished" << std::endl;

--- a/Modules/Filtering/DisplacementField/test/itkIterativeInverseDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkIterativeInverseDisplacementFieldImageFilterTest.cxx
@@ -62,26 +62,15 @@ itkIterativeInverseDisplacementFieldImageFilterTest(int argc, char * argv[])
   // Creating an input displacement field
   auto field = DisplacementFieldType::New();
 
-  auto spacing = itk::MakeFilled<DisplacementFieldType::SpacingType>(1.0);
-
-  const DisplacementFieldType::PointType origin{};
-
-  DisplacementFieldType::RegionType region;
-  DisplacementFieldType::SizeType   size;
-  DisplacementFieldType::IndexType  start;
-
+  DisplacementFieldType::SizeType size;
   size[0] = 128;
   size[1] = 128;
 
+  DisplacementFieldType::IndexType start;
   start[0] = 0;
   start[1] = 0;
 
-  region.SetSize(size);
-  region.SetIndex(start);
-
-
-  field->SetOrigin(origin);
-  field->SetSpacing(spacing);
+  DisplacementFieldType::RegionType region{ start, size };
   field->SetRegions(region);
   field->Allocate();
 

--- a/Modules/Filtering/DisplacementField/test/itkLandmarkDisplacementFieldSourceTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkLandmarkDisplacementFieldSourceTest.cxx
@@ -53,23 +53,14 @@ itkLandmarkDisplacementFieldSourceTest(int argc, char * argv[])
 
   const itk::SimpleFilterWatcher watcher(filter);
 
-  auto spacing = itk::MakeFilled<DisplacementFieldType::SpacingType>(1.0);
 
-  const DisplacementFieldType::PointType origin{};
-
-  DisplacementFieldType::RegionType region;
-  DisplacementFieldType::SizeType   size;
-  DisplacementFieldType::IndexType  start;
-
+  DisplacementFieldType::SizeType size;
   size[0] = 128;
   size[1] = 128;
-
+  DisplacementFieldType::IndexType start;
   start[0] = 0;
   start[1] = 0;
-
-  region.SetSize(size);
-  region.SetIndex(start);
-
+  DisplacementFieldType::RegionType    region{ start, size };
   DisplacementFieldType::DirectionType direction;
   direction.SetIdentity();
 
@@ -77,11 +68,21 @@ itkLandmarkDisplacementFieldSourceTest(int argc, char * argv[])
   filter->SetKernelTransform(kernelTransform);
   ITK_TEST_SET_GET_VALUE(kernelTransform, filter->GetKernelTransform());
 
-  filter->SetOutputSpacing(spacing);
-  ITK_TEST_SET_GET_VALUE(spacing, filter->GetOutputSpacing());
+  // Test default values
+  auto spacingDefault = itk::MakeFilled<DisplacementFieldType::SpacingType>(1.0);
+  ITK_TEST_SET_GET_VALUE(spacingDefault, filter->GetOutputSpacing());
 
-  filter->SetOutputOrigin(origin);
-  ITK_TEST_SET_GET_VALUE(origin, filter->GetOutputOrigin());
+  const DisplacementFieldType::PointType originDefault{};
+  ITK_TEST_SET_GET_VALUE(originDefault, filter->GetOutputOrigin());
+
+  // Test non-default values
+  auto spacingNonDefault = itk::MakeFilled<DisplacementFieldType::SpacingType>(9876.0);
+  filter->SetOutputSpacing(spacingNonDefault);
+  ITK_TEST_SET_GET_VALUE(spacingNonDefault, filter->GetOutputSpacing());
+
+  const auto originNonDefault = itk::MakeFilled<DisplacementFieldType::PointType>(1235.0);
+  filter->SetOutputOrigin(originNonDefault);
+  ITK_TEST_SET_GET_VALUE(originNonDefault, filter->GetOutputOrigin());
 
   filter->SetOutputRegion(region);
   ITK_TEST_SET_GET_VALUE(region, filter->GetOutputRegion());
@@ -97,15 +98,14 @@ itkLandmarkDisplacementFieldSourceTest(int argc, char * argv[])
   auto sourceLandmarks = LandmarkContainerType::New();
   auto targetLandmarks = LandmarkContainerType::New();
 
-  LandmarkPointType sourcePoint;
-  LandmarkPointType targetPoint;
-
   std::ifstream pointsFile;
   pointsFile.open(argv[1]);
 
   unsigned int pointId = 0;
 
+  LandmarkPointType sourcePoint;
   pointsFile >> sourcePoint;
+  LandmarkPointType targetPoint;
   pointsFile >> targetPoint;
 
   while (!pointsFile.fail())

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseTest.cxx
@@ -51,7 +51,7 @@ FastMarchingImageFilterBaseTestFunction()
   fastMarchingFilter->SetOutputRegion(outputRegion);
   ITK_TEST_SET_GET_VALUE(outputRegion, fastMarchingFilter->GetOutputRegion());
 
-  auto outputSpacing = itk::MakeFilled<typename FastMarchingImageFilterType::OutputSpacingType>(1.0);
+  auto outputSpacing = itk::MakeFilled<typename FastMarchingImageFilterType::OutputSpacingType>(9876.0);
   fastMarchingFilter->SetOutputSpacing(outputSpacing);
   ITK_TEST_SET_GET_VALUE(outputSpacing, fastMarchingFilter->GetOutputSpacing());
 
@@ -60,7 +60,7 @@ FastMarchingImageFilterBaseTestFunction()
   fastMarchingFilter->SetOutputDirection(outputDirection);
   ITK_TEST_SET_GET_VALUE(outputDirection, fastMarchingFilter->GetOutputDirection());
 
-  const typename FastMarchingImageFilterType::OutputPointType outputOrigin{};
+  const auto outputOrigin = itk::MakeFilled<typename FastMarchingImageFilterType::OutputPointType>(1234.0);
   fastMarchingFilter->SetOutputOrigin(outputOrigin);
   ITK_TEST_SET_GET_VALUE(outputOrigin, fastMarchingFilter->GetOutputOrigin());
 

--- a/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFilterTest.cxx
@@ -46,10 +46,7 @@ BSpline(int argc, char * argv[])
   }
 
   // Reconstruction of the scalar field from the control points
-
-  const typename ScalarFieldType::PointType origin{};
-  auto                                      size = ScalarFieldType::SizeType::Filled(100);
-  auto                                      spacing = itk::MakeFilled<typename ScalarFieldType::SpacingType>(1.0);
+  auto size = ScalarFieldType::SizeType::Filled(100);
 
   using BSplinerType = itk::BSplineControlPointImageFilter<ScalarFieldType, ScalarFieldType>;
   auto bspliner = BSplinerType::New();
@@ -67,12 +64,6 @@ BSpline(int argc, char * argv[])
 
   bspliner->SetSize(size);
   ITK_TEST_SET_GET_VALUE(size, bspliner->GetSize());
-
-  bspliner->SetOrigin(origin);
-  ITK_TEST_SET_GET_VALUE(origin, bspliner->GetOrigin());
-
-  bspliner->SetSpacing(spacing);
-  ITK_TEST_SET_GET_VALUE(spacing, bspliner->GetSpacing());
 
   const typename BSplinerType::DirectionType direction = reader->GetOutput()->GetDirection();
   bspliner->SetDirection(direction);
@@ -109,8 +100,6 @@ BSpline(int argc, char * argv[])
   bspliner2->SetInput(refinedControlPointLattice);
   bspliner2->SetSplineOrder(3);
   bspliner2->SetSize(size);
-  bspliner2->SetOrigin(origin);
-  bspliner2->SetSpacing(spacing);
   bspliner2->SetDirection(reader->GetOutput()->GetDirection());
 
   try
@@ -128,6 +117,15 @@ BSpline(int argc, char * argv[])
   writer2->SetFileName(argv[4]);
   writer2->SetInput(bspliner2->GetOutput());
   writer2->Update();
+
+  // Test non-default value setting
+  const auto originNonDefault = itk::MakeFilled<typename ScalarFieldType::PointType>(1234.0);
+  bspliner->SetOrigin(originNonDefault);
+  ITK_TEST_SET_GET_VALUE(originNonDefault, bspliner->GetOrigin());
+
+  auto spacingNonDefault = itk::MakeFilled<typename ScalarFieldType::SpacingType>(9875.0);
+  bspliner->SetSpacing(spacingNonDefault);
+  ITK_TEST_SET_GET_VALUE(spacingNonDefault, bspliner->GetSpacing());
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest.cxx
@@ -91,15 +91,6 @@ itkResampleImageTest(int, char *[])
   resample->SetOutputStartIndex(index);
   ITK_TEST_SET_GET_VALUE(index, resample->GetOutputStartIndex());
 
-  const ImageType::PointType origin{};
-  resample->SetOutputOrigin(origin);
-  ITK_TEST_SET_GET_VALUE(origin, resample->GetOutputOrigin());
-
-  auto spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
-  resample->SetOutputSpacing(spacing);
-  ITK_TEST_SET_GET_VALUE(spacing, resample->GetOutputSpacing());
-
-
   // Run the resampling filter
   resample->Update();
 
@@ -124,6 +115,15 @@ itkResampleImageTest(int, char *[])
       passed = false;
     }
   }
+
+  // Test non-default values
+  const auto origin = itk::MakeFilled<ImageType::PointType>(1234.0);
+  resample->SetOutputOrigin(origin);
+  ITK_TEST_SET_GET_VALUE(origin, resample->GetOutputOrigin());
+
+  auto spacing = itk::MakeFilled<ImageType::SpacingType>(9876.0);
+  resample->SetOutputSpacing(spacing);
+  ITK_TEST_SET_GET_VALUE(spacing, resample->GetOutputSpacing());
 
   // Report success or failure
   if (!passed)

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
@@ -96,24 +96,14 @@ itkResampleImageTest7(int, char *[])
   resample->SetOutputStartIndex(index);
   ITK_TEST_SET_GET_VALUE(index, resample->GetOutputStartIndex());
 
-  const ImageType::PointType origin{};
-  resample->SetOutputOrigin(origin);
-  ITK_TEST_SET_GET_VALUE(origin, resample->GetOutputOrigin());
-
-  auto spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
-  resample->SetOutputSpacing(spacing);
-  ITK_TEST_SET_GET_VALUE(spacing, resample->GetOutputSpacing());
-
   using StreamerType = itk::StreamingImageFilter<ImageType, ImageType>;
   auto streamer = StreamerType::New();
 
   std::cout << "Test with normal AffineTransform." << std::endl;
   streamer->SetInput(resample->GetOutput());
 
-  unsigned char numStreamDiv;
-
   // Run the resampling filter without streaming, i.e. 1 StreamDivisions
-  numStreamDiv = 1; // do not split, i.e. do not stream
+  unsigned char numStreamDiv = 1; // do not split, i.e. do not stream
   streamer->SetNumberOfStreamDivisions(numStreamDiv);
   ITK_TRY_EXPECT_NO_EXCEPTION(streamer->UpdateLargestPossibleRegion());
 
@@ -157,6 +147,16 @@ itkResampleImageTest7(int, char *[])
     std::cerr << "at index [" << itNoSDI.GetIndex() << ']' << std::endl;
     return EXIT_FAILURE;
   }
+
+  // Test non default values
+  const auto origin = itk::MakeFilled<ImageType::PointType>(1234.0);
+  resample->SetOutputOrigin(origin);
+  ITK_TEST_SET_GET_VALUE(origin, resample->GetOutputOrigin());
+
+  auto spacing = itk::MakeFilled<ImageType::SpacingType>(9876.0);
+  resample->SetOutputSpacing(spacing);
+  ITK_TEST_SET_GET_VALUE(spacing, resample->GetOutputSpacing());
+
 
   std::cout << "Test passed." << std::endl;
   return EXIT_SUCCESS;

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
@@ -193,15 +193,6 @@ itkResampleImageTest8(int, char *[])
   resample->SetOutputStartIndex(outputIndex);
   ITK_TEST_SET_GET_VALUE(outputIndex, resample->GetOutputStartIndex());
 
-  const OutputImageType::PointType origin{};
-  resample->SetOutputOrigin(origin);
-  ITK_TEST_SET_GET_VALUE(origin, resample->GetOutputOrigin());
-
-  auto spacing = itk::MakeFilled<OutputImageType::SpacingType>(1.0);
-  resample->SetOutputSpacing(spacing);
-  ITK_TEST_SET_GET_VALUE(spacing, resample->GetOutputSpacing());
-
-
   // Run the resampling filter
   resample->Update();
 
@@ -226,6 +217,16 @@ itkResampleImageTest8(int, char *[])
       passed = false;
     }
   }
+
+  // Test non-default values
+  const auto origin = itk::MakeFilled<OutputImageType::PointType>(1234.0);
+  resample->SetOutputOrigin(origin);
+  ITK_TEST_SET_GET_VALUE(origin, resample->GetOutputOrigin());
+
+  auto spacing = itk::MakeFilled<OutputImageType::SpacingType>(9876.0);
+  resample->SetOutputSpacing(spacing);
+  ITK_TEST_SET_GET_VALUE(spacing, resample->GetOutputSpacing());
+
 
   // Report success or failure
   if (!passed)

--- a/Modules/Filtering/ImageSources/test/itkGridImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGridImageSourceTest.cxx
@@ -56,20 +56,13 @@ itkGridImageSourceTest(int argc, char * argv[])
 
   // Specify image parameters
   auto size = static_cast<ImageType::SizeValueType>(std::stod(argv[2]));
+
   auto imageSize = ImageType::SizeType::Filled(size);
-
-  const ImageType::PointType origin{};
-
-  auto imageSpacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
+  gridImage->SetSize(imageSize);
 
   ImageType::DirectionType direction;
   direction.SetIdentity();
-
-  gridImage->SetSize(imageSize);
-  gridImage->SetSpacing(imageSpacing);
-  gridImage->SetOrigin(origin);
   gridImage->SetDirection(direction);
-
 
   // Specify grid parameters
   const double scale = 255.0;

--- a/Modules/Filtering/ImageSources/test/itkPhysicalPointImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkPhysicalPointImageSourceTest.cxx
@@ -86,8 +86,6 @@ itkPhysicalPointImageSourceTest(int argc, char * argv[])
 
   auto size = itk::Size<ImageDimension>::Filled(64);
 
-  auto                     spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
-  ImageType::PointType     origin{};
   ImageType::DirectionType direction;
   direction.SetIdentity();
 
@@ -109,7 +107,9 @@ itkPhysicalPointImageSourceTest(int argc, char * argv[])
     theta = std::stod(argv[3]);
   }
 
-  int testStatus = EXIT_SUCCESS;
+  int                  testStatus = EXIT_SUCCESS;
+  auto                 spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
+  ImageType::PointType origin{};
   if (std::stoi(argv[2]) == 0)
   {
     testStatus = itkPhysicalPointImageSourceTest<itk::Image<itk::Point<double, ImageDimension>, ImageDimension>>(

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
@@ -69,12 +69,11 @@ MakeNiftiImage(const char * filename)
   {
     ImageDimension = ImageType::ImageDimension
   };
-  const typename ImageType::SizeType size = { { 10, 10, 10 } };
-  auto                               spacing = itk::MakeFilled<typename ImageType::SpacingType>(1.0);
-
-  const typename ImageType::IndexType  index = { { 0, 0, 0 } };
+  const typename ImageType::SizeType   size = { { 10, 10, 10 } };
+  const typename ImageType::IndexType  index{};
   const typename ImageType::RegionType region(index, size);
   {
+    auto                              spacing = itk::MakeFilled<typename ImageType::SpacingType>(1.0);
     const typename ImageType::Pointer img =
       itk::IOTestHelper::AllocateImageFromRegionAndSpacing<ImageType>(region, spacing);
 
@@ -274,26 +273,15 @@ TestImageOfSymMats(const std::string & fname)
             << "======================== Initialized Direction" << std::endl
             << myDirection << std::endl;
 
-  typename DtiImageType::SizeType    size;
-  typename DtiImageType::IndexType   index;
-  typename DtiImageType::SpacingType spacing;
-  typename DtiImageType::PointType   origin;
-  for (unsigned int i = 0; i < VDimension; ++i)
-  {
-    size[i] = dimsize;
-    index[i] = 0;
-    spacing[i] = 1.0;
-    origin[i] = 0;
-  }
-
   //
   // swizzle up a random vector image.
-  typename DtiImageType::RegionType imageRegion;
-  imageRegion.SetSize(size);
-  imageRegion.SetIndex(index);
+  const auto                        size = itk::MakeFilled<typename DtiImageType::SizeType>(dimsize);
+  typename DtiImageType::IndexType  index{};
+  typename DtiImageType::RegionType imageRegion{ index, size };
+
+  const auto                           spacing = itk::MakeFilled<typename DtiImageType::SpacingType>(1.0);
   const typename DtiImageType::Pointer vi =
     itk::IOTestHelper::AllocateImageFromRegionAndSpacing<DtiImageType>(imageRegion, spacing);
-  vi->SetOrigin(origin);
   vi->SetDirection(myDirection);
 
   int dims[7];

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest11.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest11.cxx
@@ -49,10 +49,10 @@ itkNiftiImageIOTest11(int argc, char * argv[])
   size[1] = 1;
   size[2] = 1;
 
-  const ImageType::IndexType index{};
-  auto                       spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
-
+  const ImageType::IndexType  index{};
   const ImageType::RegionType imageRegion{ index, size };
+
+  auto                     spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
   const ImageType::Pointer im = itk::IOTestHelper::AllocateImageFromRegionAndSpacing<ImageType>(imageRegion, spacing);
   const ImageType::DirectionType dir(CORDirCosines<ImageType>());
   std::cout << "itkNiftiImageIOTest11" << std::endl;

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
@@ -70,16 +70,13 @@ TestImageOfVectors(const std::string & fname, const std::string & intentCode = "
   std::cout << "======================== Initialized Direction" << std::endl;
   std::cout << myDirection << std::endl;
 
-  auto                                      size = itk::MakeFilled<typename VectorImageType::SizeType>(dimsize);
-  auto                                      spacing = itk::MakeFilled<typename VectorImageType::SpacingType>(1.0);
-  typename VectorImageType::IndexType       index{};
-  const typename VectorImageType::PointType origin{};
-  typename VectorImageType::RegionType      imageRegion;
-  imageRegion.SetSize(size);
-  imageRegion.SetIndex(index);
+  typename VectorImageType::IndexType  index{};
+  auto                                 size = itk::MakeFilled<typename VectorImageType::SizeType>(dimsize);
+  typename VectorImageType::RegionType imageRegion{ index, size };
+  auto                                 spacing = itk::MakeFilled<typename VectorImageType::SpacingType>(1.0);
+
   const typename VectorImageType::Pointer vi =
     itk::IOTestHelper::AllocateImageFromRegionAndSpacing<VectorImageType>(imageRegion, spacing);
-  vi->SetOrigin(origin);
   vi->SetDirection(myDirection);
 
   size_t dims[7];

--- a/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
@@ -154,24 +154,14 @@ itkANTSNeighborhoodCorrelationImageToImageMetricv4Test(int, char ** const)
   auto                        size = ImageType::SizeType::Filled(imageSize);
   const ImageType::IndexType  index{};
   const ImageType::RegionType region{ index, size };
-  auto                        spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
-  const ImageType::PointType  origin{};
-  ImageType::DirectionType    direction;
-  direction.SetIdentity();
 
   /* Create simple test images. */
   auto fixedImage = ImageType::New();
   fixedImage->SetRegions(region);
-  fixedImage->SetSpacing(spacing);
-  fixedImage->SetOrigin(origin);
-  fixedImage->SetDirection(direction);
   fixedImage->Allocate();
 
   auto movingImage = ImageType::New();
   movingImage->SetRegions(region);
-  movingImage->SetSpacing(spacing);
-  movingImage->SetOrigin(origin);
-  movingImage->SetDirection(direction);
   movingImage->Allocate();
 
   /* Fill images */

--- a/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
@@ -131,24 +131,14 @@ itkCorrelationImageToImageMetricv4Test(int, char ** const)
   auto                        size = ImageType::SizeType::Filled(imageSize);
   const ImageType::IndexType  index{};
   const ImageType::RegionType region{ index, size };
-  auto                        spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
-  const ImageType::PointType  origin{};
-  ImageType::DirectionType    direction;
-  direction.SetIdentity();
 
   /* Create simple test images. */
   auto fixedImage = ImageType::New();
   fixedImage->SetRegions(region);
-  fixedImage->SetSpacing(spacing);
-  fixedImage->SetOrigin(origin);
-  fixedImage->SetDirection(direction);
   fixedImage->Allocate();
 
   auto movingImage = ImageType::New();
   movingImage->SetRegions(region);
-  movingImage->SetSpacing(spacing);
-  movingImage->SetOrigin(origin);
-  movingImage->SetDirection(direction);
   movingImage->Allocate();
 
   /* Fill images */

--- a/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
@@ -39,24 +39,15 @@ itkDemonsImageToImageMetricv4Test(int, char ** const)
   auto                        size = ImageType::SizeType::Filled(imageSize);
   const ImageType::IndexType  index{};
   const ImageType::RegionType region{ index, size };
-  auto                        spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
-  const ImageType::PointType  origin{};
-  ImageType::DirectionType    direction;
-  direction.SetIdentity();
+
 
   /* Create simple test images. */
   auto fixedImage = ImageType::New();
   fixedImage->SetRegions(region);
-  fixedImage->SetSpacing(spacing);
-  fixedImage->SetOrigin(origin);
-  fixedImage->SetDirection(direction);
   fixedImage->Allocate();
 
   auto movingImage = ImageType::New();
   movingImage->SetRegions(region);
-  movingImage->SetSpacing(spacing);
-  movingImage->SetOrigin(origin);
-  movingImage->SetDirection(direction);
   movingImage->Allocate();
 
   /* Fill images */

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
@@ -97,26 +97,19 @@ itkEuclideanDistancePointSetMetricTest2Run()
   using FieldType = typename DisplacementFieldTransformType::DisplacementFieldType;
   using RegionType = typename FieldType::RegionType;
 
-  auto spacing = itk::MakeFilled<typename FieldType::SpacingType>(1.0);
-
-  typename FieldType::DirectionType direction{};
-  for (unsigned int d = 0; d < Dimension; ++d)
-  {
-    direction[d][d] = 1.0;
-  }
-
-  const typename FieldType::PointType origin{};
-
   auto regionSize = RegionType::SizeType::Filled(static_cast<itk::SizeValueType>(pointMax + 1.0));
 
   const typename RegionType::IndexType regionIndex{};
 
   const RegionType region{ regionIndex, regionSize };
 
-  auto displacementField = FieldType::New();
-  displacementField->SetOrigin(origin);
+  auto                              displacementField = FieldType::New();
+  typename FieldType::DirectionType direction{};
+  for (unsigned int d = 0; d < Dimension; ++d)
+  {
+    direction[d][d] = 1.0;
+  }
   displacementField->SetDirection(direction);
-  displacementField->SetSpacing(spacing);
   displacementField->SetRegions(region);
   displacementField->Allocate();
   const typename DisplacementFieldTransformType::OutputVectorType zeroVector{};
@@ -131,6 +124,8 @@ itkEuclideanDistancePointSetMetricTest2Run()
   metric->SetMovingTransform(displacementTransform);
   // If we don't set this explicitly, it will still work because it will be taken from the
   // displacement field during initialization.
+  auto                                spacing = itk::MakeFilled<typename FieldType::SpacingType>(1.0);
+  const typename FieldType::PointType origin{};
   metric->SetVirtualDomain(spacing, origin, direction, region);
 
   metric->Initialize();

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
@@ -389,24 +389,15 @@ itkImageToImageMetricv4Test(int, char ** const)
   const ImageToImageMetricv4TestImageType::SizeType   size = { { imageSize, imageSize } };
   const ImageToImageMetricv4TestImageType::IndexType  index = { { 0, 0 } };
   const ImageToImageMetricv4TestImageType::RegionType region{ index, size };
-  auto spacing = itk::MakeFilled<ImageToImageMetricv4TestImageType::SpacingType>(1.0);
-  const ImageToImageMetricv4TestImageType::PointType origin{};
-  ImageToImageMetricv4TestImageType::DirectionType   direction;
-  direction.SetIdentity();
+
 
   // Create simple test images.
   auto fixedImage = ImageToImageMetricv4TestImageType::New();
   fixedImage->SetRegions(region);
-  fixedImage->SetSpacing(spacing);
-  fixedImage->SetOrigin(origin);
-  fixedImage->SetDirection(direction);
   fixedImage->Allocate();
 
   auto movingImage = ImageToImageMetricv4TestImageType::New();
   movingImage->SetRegions(region);
-  movingImage->SetSpacing(spacing);
-  movingImage->SetOrigin(origin);
-  movingImage->SetDirection(direction);
   movingImage->Allocate();
 
   // Fill images

--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
@@ -38,24 +38,14 @@ itkJointHistogramMutualInformationImageToImageMetricv4Test(int, char *[])
   auto                        size = ImageType::SizeType::Filled(imageSize);
   const ImageType::IndexType  index{};
   const ImageType::RegionType region{ index, size };
-  auto                        spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
-  const ImageType::PointType  origin{};
-  ImageType::DirectionType    direction;
-  direction.SetIdentity();
 
   /* Create simple test images. */
   auto fixedImage = ImageType::New();
   fixedImage->SetRegions(region);
-  fixedImage->SetSpacing(spacing);
-  fixedImage->SetOrigin(origin);
-  fixedImage->SetDirection(direction);
   fixedImage->Allocate();
 
   auto movingImage = ImageType::New();
   movingImage->SetRegions(region);
-  movingImage->SetSpacing(spacing);
-  movingImage->SetOrigin(origin);
-  movingImage->SetDirection(direction);
   movingImage->Allocate();
 
   /* Fill images */

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
@@ -41,24 +41,14 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest(int, char ** const)
   auto                        size = ImageType::SizeType::Filled(imageSize);
   const ImageType::IndexType  index{};
   const ImageType::RegionType region{ index, size };
-  auto                        spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
-  const ImageType::PointType  origin{};
-  ImageType::DirectionType    direction;
-  direction.SetIdentity();
 
   /* Create simple test images. */
   auto fixedImage = ImageType::New();
   fixedImage->SetRegions(region);
-  fixedImage->SetSpacing(spacing);
-  fixedImage->SetOrigin(origin);
-  fixedImage->SetDirection(direction);
   fixedImage->Allocate();
 
   auto movingImage = ImageType::New();
   movingImage->SetRegions(region);
-  movingImage->SetSpacing(spacing);
-  movingImage->SetOrigin(origin);
-  movingImage->SetDirection(direction);
   movingImage->Allocate();
 
   /* Fill images */

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest2.cxx
@@ -37,24 +37,14 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest2Run(typename TMetric::MeasureType
   auto                                 size = ImageType::SizeType::Filled(imageSize);
   const typename ImageType::IndexType  index{};
   const typename ImageType::RegionType region{ index, size };
-  auto                                 spacing = itk::MakeFilled<typename ImageType::SpacingType>(1.0);
-  const typename ImageType::PointType  origin{};
-  typename ImageType::DirectionType    direction;
-  direction.SetIdentity();
 
   /* Create simple test images. */
   auto fixedImage = ImageType::New();
   fixedImage->SetRegions(region);
-  fixedImage->SetSpacing(spacing);
-  fixedImage->SetOrigin(origin);
-  fixedImage->SetDirection(direction);
   fixedImage->Allocate();
 
   auto movingImage = ImageType::New();
   movingImage->SetRegions(region);
-  movingImage->SetSpacing(spacing);
-  movingImage->SetOrigin(origin);
-  movingImage->SetDirection(direction);
   movingImage->Allocate();
 
   /*

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
@@ -42,24 +42,14 @@ itkMeanSquaresImageToImageMetricv4SpeedTest(int argc, char * argv[])
   auto                        size = ImageType::SizeType::Filled(imageSize);
   const ImageType::IndexType  index{};
   const ImageType::RegionType region{ index, size };
-  auto                        spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
-  const ImageType::PointType  origin{};
-  ImageType::DirectionType    direction;
-  direction.SetIdentity();
 
   /* Create simple test images. */
   auto fixedImage = ImageType::New();
   fixedImage->SetRegions(region);
-  fixedImage->SetSpacing(spacing);
-  fixedImage->SetOrigin(origin);
-  fixedImage->SetDirection(direction);
   fixedImage->Allocate();
 
   auto movingImage = ImageType::New();
   movingImage->SetRegions(region);
-  movingImage->SetSpacing(spacing);
-  movingImage->SetOrigin(origin);
-  movingImage->SetDirection(direction);
   movingImage->Allocate();
 
   /* Fill images */

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4Test.cxx
@@ -37,24 +37,14 @@ itkMeanSquaresImageToImageMetricv4Test(int, char ** const)
   auto                        size = ImageType::SizeType::Filled(imageSize);
   const ImageType::IndexType  index{};
   const ImageType::RegionType region{ index, size };
-  auto                        spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
-  const ImageType::PointType  origin{};
-  ImageType::DirectionType    direction;
-  direction.SetIdentity();
 
   /* Create simple test images. */
   auto fixedImage = ImageType::New();
   fixedImage->SetRegions(region);
-  fixedImage->SetSpacing(spacing);
-  fixedImage->SetOrigin(origin);
-  fixedImage->SetDirection(direction);
   fixedImage->Allocate();
 
   auto movingImage = ImageType::New();
   movingImage->SetRegions(region);
-  movingImage->SetSpacing(spacing);
-  movingImage->SetOrigin(origin);
-  movingImage->SetDirection(direction);
   movingImage->Allocate();
 
   /* Fill images */

--- a/Modules/Registration/Metricsv4/test/itkMetricImageGradientTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMetricImageGradientTest.cxx
@@ -212,16 +212,12 @@ itkMetricImageGradientTestRunTest(unsigned int                 imageSize,
   auto                                 size = ImageType::SizeType::Filled(imageSize);
   typename ImageType::IndexType        virtualIndex{};
   const typename ImageType::RegionType region{ virtualIndex, size };
-  auto                                 spacing = itk::MakeFilled<typename ImageType::SpacingType>(1.0);
-  const typename ImageType::PointType  origin{};
   typename ImageType::DirectionType    direction;
   direction.SetIdentity();
 
   // Create simple test images.
   auto image = ImageType::New();
   image->SetRegions(region);
-  image->SetSpacing(spacing);
-  image->SetOrigin(origin);
   image->SetDirection(direction);
   image->Allocate();
 


### PR DESCRIPTION
The default origin is {0.0,...} and spacing is {1.0,...},
do not reset those values explicitly in tests.

When testing the Get/Set functions, use values other
then the default values.

Prefer initializations of regions with index and size
over explicit assignment calls of SetIndex() and SetSize()
immediately after declaration.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
