### PR TITLE
BUG: Fix ExposeMetaData<std::vector<double>> im MetaImageIO

### DIFF
--- a/Modules/IO/Meta/src/itkMetaImageIO.cxx
+++ b/Modules/IO/Meta/src/itkMetaImageIO.cxx
@@ -637,7 +637,7 @@ MetaImageIO::WriteImageInformation()
       unsigned int i = 0;
       while (i < vval.size() - 1)
       {
-        strs << vval[++i] << ' ';
+        strs << vval[i++] << ' ';
       }
       strs << vval[i];
     }


### PR DESCRIPTION
Indexes were incorrectly accessed with pre-increment instead of post-increment

```cpp
#include <iostream>
#include <vector>

int main()
{
  std::vector<int> v;
  v.push_back(1);
  v.push_back(2);
  v.push_back(3);

  {
    unsigned int i = 0;
    while (i < v.size() - 1)
    {
      std::cout << v[++i] << ' '; // wrong
    }
    std::cout << v[i] << std::endl;
  }

  {
    unsigned int i = 0;
    while (i < v.size() - 1)
    {
      std::cout << v[i++] << ' ';
    }
    std::cout << v[i] << std::endl;
  }

  return 0;
}
```

```
r@deb2:~$ ./a.out 
2 3 3
1 2 3
```

Closes #5062