### PR TITLE
STYLE: performance-noexcept-swap clang-tidy

### DIFF
--- a/Modules/Core/Common/include/itkCovariantVector.h
+++ b/Modules/Core/Common/include/itkCovariantVector.h
@@ -289,7 +289,7 @@ CrossProduct(CovariantVector<int, 3>, const Vector<int, 3> &, const Vector<int, 
 
 template <typename T, unsigned int VVectorDimension>
 inline void
-swap(CovariantVector<T, VVectorDimension> & a, CovariantVector<T, VVectorDimension> & b)
+swap(CovariantVector<T, VVectorDimension> & a, CovariantVector<T, VVectorDimension> & b) noexcept
 {
   a.swap(b);
 }

--- a/Modules/Core/Common/include/itkDiffusionTensor3D.h
+++ b/Modules/Core/Common/include/itkDiffusionTensor3D.h
@@ -164,7 +164,7 @@ public:
 
 template <typename T>
 inline void
-swap(DiffusionTensor3D<T> & a, DiffusionTensor3D<T> & b)
+swap(DiffusionTensor3D<T> & a, DiffusionTensor3D<T> & b) noexcept
 {
   a.swap(b);
 }

--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -443,7 +443,7 @@ public:
   Fill(const ValueType &);
 
   void
-  swap(FixedArray & other)
+  swap(FixedArray & other) noexcept
   {
     std::swap(m_InternalArray, other.m_InternalArray);
   }
@@ -468,7 +468,7 @@ operator<<(std::ostream & os, const FixedArray<TValue, VLength> & arr);
 
 template <typename TValue, unsigned int VLength>
 inline void
-swap(FixedArray<TValue, VLength> & a, FixedArray<TValue, VLength> & b)
+swap(FixedArray<TValue, VLength> & a, FixedArray<TValue, VLength> & b) noexcept
 {
   a.swap(b);
 }

--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -344,7 +344,7 @@ public:
   }
 
   void
-  swap(Index & other)
+  swap(Index & other) noexcept
   {
     std::swap(m_InternalArray, other.m_InternalArray);
   }
@@ -585,7 +585,7 @@ operator>=(const Index<VDimension> & one, const Index<VDimension> & two)
 // Specialized algorithms [6.2.2.2].
 template <unsigned int VDimension>
 inline void
-swap(Index<VDimension> & one, Index<VDimension> & two)
+swap(Index<VDimension> & one, Index<VDimension> & two) noexcept
 {
   std::swap(one.m_InternalArray, two.m_InternalArray);
 }

--- a/Modules/Core/Common/include/itkMatrix.h
+++ b/Modules/Core/Common/include/itkMatrix.h
@@ -383,7 +383,7 @@ public:
   }
 
   void
-  swap(Self & other)
+  swap(Self & other) noexcept
   {
     // allow for augment dependent look up
     using std::swap;
@@ -420,7 +420,7 @@ operator<<(std::ostream & os, const Matrix<T, VRows, VColumns> & v)
 
 template <typename T, unsigned int VRows, unsigned int VColumns>
 inline void
-swap(const Matrix<T, VRows, VColumns> & a, const Matrix<T, VRows, VColumns> & b)
+swap(const Matrix<T, VRows, VColumns> & a, const Matrix<T, VRows, VColumns> & b) noexcept
 {
   a.swap(b);
 }

--- a/Modules/Core/Common/include/itkMetaDataDictionary.h
+++ b/Modules/Core/Common/include/itkMetaDataDictionary.h
@@ -182,7 +182,7 @@ private:
 };
 
 inline void
-swap(MetaDataDictionary & a, MetaDataDictionary & b)
+swap(MetaDataDictionary & a, MetaDataDictionary & b) noexcept
 {
   a.Swap(b);
 }

--- a/Modules/Core/Common/include/itkOffset.h
+++ b/Modules/Core/Common/include/itkOffset.h
@@ -294,7 +294,7 @@ public:
   }
 
   void
-  swap(Offset & other)
+  swap(Offset & other) noexcept
   {
     std::swap(m_InternalArray, other.m_InternalArray);
   }
@@ -525,7 +525,7 @@ operator>=(const Offset<VDimension> & one, const Offset<VDimension> & two)
 // Specialized algorithms [6.2.2.2].
 template <unsigned int VDimension>
 inline void
-swap(Offset<VDimension> & one, Offset<VDimension> & two)
+swap(Offset<VDimension> & one, Offset<VDimension> & two) noexcept
 {
   std::swap(one.m_InternalArray, two.m_InternalArray);
 }

--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -349,7 +349,7 @@ public:
 
 template <typename TCoordinate, unsigned int VPointDimension>
 inline void
-swap(Point<TCoordinate, VPointDimension> & a, Point<TCoordinate, VPointDimension> & b)
+swap(Point<TCoordinate, VPointDimension> & a, Point<TCoordinate, VPointDimension> & b) noexcept
 {
   a.swap(b);
 }

--- a/Modules/Core/Common/include/itkRGBAPixel.h
+++ b/Modules/Core/Common/include/itkRGBAPixel.h
@@ -246,7 +246,7 @@ operator>>(std::istream & is, RGBAPixel<TComponent> & c);
 
 template <typename T>
 inline void
-swap(RGBAPixel<T> & a, RGBAPixel<T> & b)
+swap(RGBAPixel<T> & a, RGBAPixel<T> & b) noexcept
 {
   a.swap(b);
 }

--- a/Modules/Core/Common/include/itkRGBPixel.h
+++ b/Modules/Core/Common/include/itkRGBPixel.h
@@ -240,7 +240,7 @@ operator>>(std::istream & is, RGBPixel<TComponent> & c);
 
 template <typename T>
 inline void
-swap(RGBPixel<T> & a, RGBPixel<T> & b)
+swap(RGBPixel<T> & a, RGBPixel<T> & b) noexcept
 {
   a.swap(b);
 }

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -268,7 +268,7 @@ public:
   }
 
   void
-  swap(Size & other)
+  swap(Size & other) noexcept
   {
     std::swap(m_InternalArray, other.m_InternalArray);
   }
@@ -499,7 +499,7 @@ operator>=(const Size<VDimension> & one, const Size<VDimension> & two)
 // Specialized algorithms [6.2.2.2].
 template <unsigned int VDimension>
 inline void
-swap(Size<VDimension> & one, Size<VDimension> & two)
+swap(Size<VDimension> & one, Size<VDimension> & two) noexcept
 {
   std::swap(one.m_InternalArray, two.m_InternalArray);
 }

--- a/Modules/Core/Common/include/itkSymmetricSecondRankTensor.h
+++ b/Modules/Core/Common/include/itkSymmetricSecondRankTensor.h
@@ -259,7 +259,7 @@ operator>>(InputStreamType & is, SymmetricSecondRankTensor<TComponent, VDimensio
 
 template <typename T>
 inline void
-swap(SymmetricSecondRankTensor<T> & a, SymmetricSecondRankTensor<T> & b)
+swap(SymmetricSecondRankTensor<T> & a, SymmetricSecondRankTensor<T> & b) noexcept
 {
   a.swap(b);
 }

--- a/Modules/Core/Common/include/itkVector.h
+++ b/Modules/Core/Common/include/itkVector.h
@@ -324,7 +324,7 @@ ITKCommon_EXPORT Vector<int, 3>
 
 template <typename T, unsigned int VVectorDimension>
 inline void
-swap(Vector<T, VVectorDimension> & a, Vector<T, VVectorDimension> & b)
+swap(Vector<T, VVectorDimension> & a, Vector<T, VVectorDimension> & b) noexcept
 {
   a.swap(b);
 }


### PR DESCRIPTION
The check flags user-defined swap and iter_swap functions not marked with noexcept or marked with noexcept(expr) where expr evaluates to false (but is not a false literal itself).

When a swap or iter_swap function is marked as noexcept, it assures the compiler that no exceptions will be thrown during the swapping of two objects, which allows the compiler to perform certain optimizations such as omitting exception handling code.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
