### PR TITLE
DOC: Note migration guide replacing `CoordinateType` with `CoordRepType`

### DIFF
--- a/Documentation/docs/migration_guides/itk_6_migration_guide.md
+++ b/Documentation/docs/migration_guides/itk_6_migration_guide.md
@@ -107,3 +107,11 @@ the region information properties of the original PointSet object. With previous
 ITK versions, `PointSet::Clone()` did not copy any data. (It previously just
 created a default-constructed PointSet object, like `PointSet::CreateAnother()`
 does.)
+
+For the sake of code readibility, a new `CoordinateType` alias is added for
+each nested `CoordRepType` alias. The old `CoordRepType` aliases will still be
+available with ITK 6.0, but it is recommended to use `CoordinateType` instead.
+The `CoordRepType` aliases will be removed when `ITK_FUTURE_LEGACY_REMOVE` is
+enabled. Similarly, `InputCoordinateType`, `OutputCoordinateType`, and
+`ImagePointCoordinateType` replace `InputCoordRepType`, `OutputCoordRepType`,
+and `ImagePointCoordRepType`, respectively.


### PR DESCRIPTION
Added note about `CoordRepType` being replaced with `CoordinateType`.

Follow-up to:
- pull request #5006 commit a68b8f67dae4466e6e0450b0be35fb5a81eb2090 "ENH: FUTURE REMOVE `...CoordRepType` in favor of `...CoordinateType`"
- pull request #4997 commit e667fa39a6914d666ae5dd0b47202ebfb2acfd1f "ENH: Deprecate (FUTURE REMOVE) CoordRepType in favor of CoordinateType"
