### PR TITLE
PERF: Prefer compiletime computation of scale factor

### DIFF
--- a/Modules/Core/Common/include/itkGaussianKernelFunction.h
+++ b/Modules/Core/Common/include/itkGaussianKernelFunction.h
@@ -59,22 +59,18 @@ public:
   TRealValueType
   Evaluate(const TRealValueType & u) const override
   {
-    return (std::exp(TRealValueType{ -0.5 } * itk::Math::sqr(u)) * m_Factor);
+    constexpr auto negHalf = TRealValueType{ -0.5 };
+    return std::exp(negHalf * itk::Math::sqr(u)) * Math::one_over_sqrt2pi;
   }
 
 protected:
-  GaussianKernelFunction()
-    : m_Factor(TRealValueType{ 1.0 } / std::sqrt(TRealValueType{ 2.0 * itk::Math::pi }))
-  {}
+  GaussianKernelFunction() {}
   ~GaussianKernelFunction() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override
   {
     Superclass::PrintSelf(os, indent);
   }
-
-private:
-  const TRealValueType m_Factor{};
 };
 } // end namespace itk
 


### PR DESCRIPTION
The ivar m_Factor was a constant that did not require state to be saved.  The computation can be done at compile time, thus saving runtime computations.

Move m_Factor from an ivar to a constexpr in the one place it is used.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)