### PR TITLE
COMP: Limit the 3D specialized function compilation

### DIFF
--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
@@ -114,33 +114,39 @@ LevelSetFunction<TImageType>::ComputeMinimalCurvature(const NeighborhoodType & i
 
 template <typename TImageType>
 auto
-LevelSetFunction<TImageType>::Compute3DMinimalCurvature(const NeighborhoodType & neighborhood,
-                                                        const FloatOffsetType &  offset,
-                                                        GlobalDataStruct *       gd) -> ScalarValueType
+LevelSetFunction<TImageType>::Compute3DMinimalCurvature(const NeighborhoodType &            neighborhood,
+                                                        const FloatOffsetType &             offset,
+                                                        [[maybe_unused]] GlobalDataStruct * gd) -> ScalarValueType
 {
-  const ScalarValueType mean_curve = this->ComputeMeanCurvature(neighborhood, offset, gd);
-
-  int                   i0 = 0;
-  int                   i1 = 1;
-  int                   i2 = 2;
-  const ScalarValueType gauss_curve =
-    (2 *
-       (gd->m_dx[i0] * gd->m_dx[i1] * (gd->m_dxy[i2][i0] * gd->m_dxy[i1][i2] - gd->m_dxy[i0][i1] * gd->m_dxy[i2][i2]) +
-        gd->m_dx[i1] * gd->m_dx[i2] * (gd->m_dxy[i2][i0] * gd->m_dxy[i0][i1] - gd->m_dxy[i1][i2] * gd->m_dxy[i0][i0]) +
-        gd->m_dx[i0] * gd->m_dx[i2] * (gd->m_dxy[i1][i2] * gd->m_dxy[i0][i1] - gd->m_dxy[i2][i0] * gd->m_dxy[i1][i1])) +
-     gd->m_dx[i0] * gd->m_dx[i0] * (gd->m_dxy[i1][i1] * gd->m_dxy[i2][i2] - gd->m_dxy[i1][i2] * gd->m_dxy[i1][i2]) +
-     gd->m_dx[i1] * gd->m_dx[i1] * (gd->m_dxy[i0][i0] * gd->m_dxy[i2][i2] - gd->m_dxy[i2][i0] * gd->m_dxy[i2][i0]) +
-     gd->m_dx[i2] * gd->m_dx[i2] * (gd->m_dxy[i1][i1] * gd->m_dxy[i0][i0] - gd->m_dxy[i0][i1] * gd->m_dxy[i0][i1])) /
-    (gd->m_dx[i0] * gd->m_dx[i0] + gd->m_dx[i1] * gd->m_dx[i1] + gd->m_dx[i2] * gd->m_dx[i2]);
-
-  ScalarValueType discriminant = mean_curve * mean_curve - gauss_curve;
-
-  if (discriminant < 0.0)
+  if constexpr (ImageDimension == 3)
   {
-    discriminant = 0.0;
+    const ScalarValueType mean_curve = this->ComputeMeanCurvature(neighborhood, offset, gd);
+
+    constexpr int         i0 = 0;
+    constexpr int         i1 = 1;
+    constexpr int         i2 = 2;
+    const ScalarValueType gauss_curve =
+      (2 * (gd->m_dx[i0] * gd->m_dx[i1] *
+              (gd->m_dxy[i2][i0] * gd->m_dxy[i1][i2] - gd->m_dxy[i0][i1] * gd->m_dxy[i2][i2]) +
+            gd->m_dx[i1] * gd->m_dx[i2] *
+              (gd->m_dxy[i2][i0] * gd->m_dxy[i0][i1] - gd->m_dxy[i1][i2] * gd->m_dxy[i0][i0]) +
+            gd->m_dx[i0] * gd->m_dx[i2] *
+              (gd->m_dxy[i1][i2] * gd->m_dxy[i0][i1] - gd->m_dxy[i2][i0] * gd->m_dxy[i1][i1])) +
+       gd->m_dx[i0] * gd->m_dx[i0] * (gd->m_dxy[i1][i1] * gd->m_dxy[i2][i2] - gd->m_dxy[i1][i2] * gd->m_dxy[i1][i2]) +
+       gd->m_dx[i1] * gd->m_dx[i1] * (gd->m_dxy[i0][i0] * gd->m_dxy[i2][i2] - gd->m_dxy[i2][i0] * gd->m_dxy[i2][i0]) +
+       gd->m_dx[i2] * gd->m_dx[i2] * (gd->m_dxy[i1][i1] * gd->m_dxy[i0][i0] - gd->m_dxy[i0][i1] * gd->m_dxy[i0][i1])) /
+      (gd->m_dx[i0] * gd->m_dx[i0] + gd->m_dx[i1] * gd->m_dx[i1] + gd->m_dx[i2] * gd->m_dx[i2]);
+
+    ScalarValueType discriminant = mean_curve * mean_curve - gauss_curve;
+
+    if (discriminant < 0.0)
+    {
+      discriminant = 0.0;
+    }
+    discriminant = std::sqrt(discriminant);
+    return (mean_curve - discriminant);
   }
-  discriminant = std::sqrt(discriminant);
-  return (mean_curve - discriminant);
+  itkExceptionMacro(<< "This function should only be called for 3D images.");
 }
 
 template <typename TImageType>


### PR DESCRIPTION
Use if constexpr to limit the compilation of code in cases where array index access would fall outside
data structures in cases that should never be used.

Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx:138:83: warning: array index 2 is past the end of the array (that has type 'ScalarValueType[2]' (aka 'float[2]')) [-Warray-bounds]
  138 |       (gd->m_dx[i0] * gd->m_dx[i0] + gd->m_dx[i1] * gd->m_dx[i1] + gd->m_dx[i2] * gd->m_dx[i2]);
      |
## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
