### PR TITLE
ENH: Make default-constructors of RGBPixel and RGBAPixel `constexpr`

### DIFF
--- a/.github/workflows/itk_dict.txt
+++ b/.github/workflows/itk_dict.txt
@@ -226,6 +226,7 @@ Wachowiak
 Wanlin
 Wdeprecated
 Wi
+Wmaybe
 Wtautological
 Xu
 Y'CbCr

--- a/Modules/Core/Common/include/itkRGBAPixel.h
+++ b/Modules/Core/Common/include/itkRGBAPixel.h
@@ -81,7 +81,13 @@ public:
 #ifdef ITK_FUTURE_LEGACY_REMOVE
   RGBAPixel() = default;
 #else
-  RGBAPixel() { this->Fill(0); }
+  constexpr RGBAPixel()
+    : Superclass(Superclass())
+  {
+    // `: Superclass(Superclass())` is a workaround for an old compiler bug. A simple `: Superclass()` triggered
+    // warnings from GCC 9.4.0 saying: "warning: '<anonymous>' may be used uninitialized in this function
+    // [-Wmaybe-uninitialized]".
+  }
 #endif
 
   /** Pass-through constructor for the Array base class. */

--- a/Modules/Core/Common/include/itkRGBPixel.h
+++ b/Modules/Core/Common/include/itkRGBPixel.h
@@ -80,7 +80,13 @@ public:
 #ifdef ITK_FUTURE_LEGACY_REMOVE
   RGBPixel() = default;
 #else
-  RGBPixel() { this->Fill(0); }
+  constexpr RGBPixel()
+    : Superclass(Superclass())
+  {
+    // `: Superclass(Superclass())` is a workaround for an old compiler bug. A simple `: Superclass()` triggered
+    // warnings from GCC 9.4.0 saying: "warning: '<anonymous>' may be used uninitialized in this function
+    // [-Wmaybe-uninitialized]".
+  }
 #endif
 
 #if defined(ITK_LEGACY_REMOVE)

--- a/Modules/Core/Common/test/itkRGBAPixelGTest.cxx
+++ b/Modules/Core/Common/test/itkRGBAPixelGTest.cxx
@@ -22,6 +22,11 @@
 #include <gtest/gtest.h>
 
 
+static_assert(itk::RangeGTestUtilities::CheckConstexprBeginAndEndOfContainer<itk::RGBAPixel<>>() &&
+              itk::RangeGTestUtilities::CheckConstexprBeginAndEndOfContainer<itk::RGBAPixel<std::uint8_t>>() &&
+              itk::RangeGTestUtilities::CheckConstexprBeginAndEndOfContainer<itk::RGBAPixel<float>>());
+
+
 // Tests that a RGBAPixel that is "value-initialized" (by empty braces, `{}`) is zero-filled.
 TEST(RGBAPixel, ValueInitializedIsZeroFilled)
 {

--- a/Modules/Core/Common/test/itkRGBPixelGTest.cxx
+++ b/Modules/Core/Common/test/itkRGBPixelGTest.cxx
@@ -22,6 +22,11 @@
 #include <gtest/gtest.h>
 
 
+static_assert(itk::RangeGTestUtilities::CheckConstexprBeginAndEndOfContainer<itk::RGBPixel<>>() &&
+              itk::RangeGTestUtilities::CheckConstexprBeginAndEndOfContainer<itk::RGBPixel<std::uint8_t>>() &&
+              itk::RangeGTestUtilities::CheckConstexprBeginAndEndOfContainer<itk::RGBPixel<float>>());
+
+
 // Tests that a RGBPixel that is "value-initialized" (by empty braces, `{}`) is zero-filled.
 TEST(RGBPixel, ValueInitializedIsZeroFilled)
 {


### PR DESCRIPTION
Tested by means of `CheckConstexprBeginAndEndOfContainer()`. Note that these default-constructors were already `constexpr` _implicitly_, as implied by `= default`, when `ITK_FUTURE_LEGACY_REMOVE` would be enabled.