### PR TITLE
BUG: GenerateImageSource sets Size from ReferenceImage

### DIFF
--- a/Modules/Filtering/ImageSources/include/itkGenerateImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGenerateImageSource.hxx
@@ -63,6 +63,9 @@ GenerateImageSource<TOutputImage>::GenerateOutputInformation()
       outputPtr->SetSpacing(referenceImage->GetSpacing());
       outputPtr->SetOrigin(referenceImage->GetOrigin());
       outputPtr->SetDirection(referenceImage->GetDirection());
+      this->m_Direction = referenceImage->GetDirection();
+      this->m_StartIndex = referenceImage->GetLargestPossibleRegion().GetIndex();
+      this->m_Size = referenceImage->GetLargestPossibleRegion().GetSize();
     }
     else
     {

--- a/Modules/Filtering/ImageSources/test/Baseline/itkGridImageSourceTest5.mha.cid
+++ b/Modules/Filtering/ImageSources/test/Baseline/itkGridImageSourceTest5.mha.cid
@@ -1,0 +1,1 @@
+bafkreidpb356aruiokudkoxyo47ol4nyesw3hywpfd4dbvigbixmcebmwe

--- a/Modules/Filtering/ImageSources/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageSources/test/CMakeLists.txt
@@ -4,6 +4,7 @@ set(ITKImageSourcesTests
     itkGaborImageSourceTest.cxx
     itkGaussianImageSourceTest.cxx
     itkGridImageSourceTest.cxx
+    itkGridImageSourceTest2.cxx
     itkPhysicalPointImageSourceTest.cxx)
 
 createtestdriver(ITKImageSources "${ITKImageSources-Test_LIBRARIES}" "${ITKImageSourcesTests}")
@@ -138,6 +139,18 @@ itk_add_test(
   0
   0
   0)
+itk_add_test(
+  NAME
+  itkGridImageSourceTest5
+  COMMAND
+  ITKImageSourcesTestDriver
+  --compare
+  DATA{Baseline/itkGridImageSourceTest5.mha}
+  ${ITK_TEST_OUTPUT_DIR}/itkGridImageSourceTest5.mha
+  itkGridImageSourceTest2
+  DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
+  ${ITK_TEST_OUTPUT_DIR}/itkGridImageSourceTest5.mha
+  )
 itk_add_test(
   NAME
   itkPhysicalPointImageSourceTest0

--- a/Modules/Filtering/ImageSources/test/itkGridImageSourceTest2.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGridImageSourceTest2.cxx
@@ -1,0 +1,68 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "itkGridImageSource.h"
+#include "itkImageFileReader.h"
+#include "itkImageFileWriter.h"
+#include "itkSimpleFilterWatcher.h"
+#include "itkTestingMacros.h"
+
+
+int
+itkGridImageSourceTest2(int argc, char * argv[])
+{
+  if (argc != 3)
+  {
+    std::cout << "Usage: " << itkNameOfTestExecutableMacro(argv)
+              << " inputImage"
+              << " outputImage" << std::endl;
+    return EXIT_FAILURE;
+  }
+  const char * inputImageFile = argv[1];
+  const char * outputImageFile = argv[2];
+
+
+  constexpr unsigned int ImageDimension = 3;
+  using PixelType = uint8_t;
+
+  using ImageType = itk::Image<PixelType, ImageDimension>;
+
+  // Instantiate the filter
+  using GridSourceType = itk::GridImageSource<ImageType>;
+  auto gridImage = GridSourceType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(gridImage, GridImageSource, GenerateImageSource);
+
+  ImageType::Pointer inputImage = itk::ReadImage<ImageType>(inputImageFile);
+
+  gridImage->SetReferenceImage(inputImage);
+  gridImage->UseReferenceImageOn();
+
+  itk::SimpleFilterWatcher watcher(gridImage, "GridImageSource");
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(gridImage->Update());
+
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  auto writer = WriterType::New();
+  writer->SetFileName(outputImageFile);
+  writer->SetInput(gridImage->GetOutput());
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
+  std::cout << "Test finished" << std::endl;
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
We want the same behavior as SetOutputParametersFromImage.

Without this, a crash occurs on Update().