### PR TITLE
COMP: Fix error in Windows Python CI build

### DIFF
--- a/Modules/Core/Common/CMakeLists.txt
+++ b/Modules/Core/Common/CMakeLists.txt
@@ -133,6 +133,7 @@ configure_file(src/itkConfigurePrivate.h.in itkConfigurePrivate.h)
 
 if(ITK_WRAP_PYTHON)
   set(ITKCommon_SYSTEM_INCLUDE_DIRS "${Python3_INCLUDE_DIRS}")
+  set(ITKCommon_SYSTEM_LIBRARY_DIRS "${Python3_LIBRARY_DIRS}")
 endif()
 set(ITKCommon_INCLUDE_DIRS ${ITKCommon_BINARY_DIR})
 set(ITKCommon_LIBRARIES ITKCommon)

--- a/Modules/Core/Common/include/itkPyCommand.h
+++ b/Modules/Core/Common/include/itkPyCommand.h
@@ -39,9 +39,10 @@ namespace itk
  *
  * This class was contributed by Charl P. Botha <cpbotha |AT| ieee.org>
  *
+ * \ingroup ITKSystemObjects
  * \ingroup ITKCommon
  */
-class PyCommand : public Command
+class ITKCommon_EXPORT PyCommand : public Command
 {
 public:
   ///! Standard "Self" typedef.


### PR DESCRIPTION
This is a follow-up to commit 4cbe24cb4a45d689cadd56d554b8ccf3584a5ca6, PR #5030.

The error message was:
```log
FAILED: Wrapping/Generators/Python/itk/ITKCommon-6.0.dll lib/ITKCommon-6.0.lib C:\Windows\system32\cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_dll --msvc-ver=1929 --intdir=Modules\Core\Common\src\CMakeFiles\ITKCommon.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\mt.exe --manifests  -- C:\PROGRA~2\MICROS~2\2019\ENTERP~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\ITKCommon.rsp  /out:Wrapping\Generators\Python\itk\ITKCommon-6.0.dll /implib:lib\ITKCommon-6.0.lib /pdb:Wrapping\Generators\Python\itk\ITKCommon-6.0.pdb /dll /version:1.0 /machine:x64  /INCREMENTAL:NO && cd ." LINK: command "C:\PROGRA~2\MICROS~2\2019\ENTERP~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\ITKCommon.rsp /out:Wrapping\Generators\Python\itk\ITKCommon-6.0.dll /implib:lib\ITKCommon-6.0.lib /pdb:Wrapping\Generators\Python\itk\ITKCommon-6.0.pdb /dll /version:1.0 /machine:x64 /INCREMENTAL:NO /MANIFEST:EMBED,ID=2" failed (exit code 1104) with the following output: LINK : fatal error LNK1104: cannot open file 'python311.lib'
```
Closes #5075.


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
