### PR TITLE
COMP: Fix building with ITK_USE_FLOAT_SPACE_PRECISION=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -541,6 +541,9 @@ mark_as_advanced(ITK_COMPUTER_MEMORY_SIZE)
 # spacing/direction/origin to single precision
 option(ITK_USE_FLOAT_SPACE_PRECISION "Use single precision for origin/spacing/directions in itk::Image" OFF)
 mark_as_advanced(ITK_USE_FLOAT_SPACE_PRECISION)
+if( ITK_USE_FLOAT_SPACE_PRECISION AND ITK_WRAP_PYTHON)
+  message(FATAL_ERROR "ITK_USE_FLOAT_SPACE_PRECISION=ON not supported with ITK_WRAP_PYTHON=ON")
+endif()
 
 # This flag allows to not build itkTestDrivers while still configuring all the tests and disable all
 # tests that are implemented in the `test` folder in each ITK module. It does not disable tests

--- a/Examples/DataRepresentation/Image/Image4.cxx
+++ b/Examples/DataRepresentation/Image/Image4.cxx
@@ -453,7 +453,8 @@ main(int, char *[])
     image->GetDirection();
   const ImageType::PointType & ImageOrigin = image->GetOrigin();
 
-  using VectorType = itk::Vector<double, Dimension>;
+  using VectorType =
+    itk::Vector<ImageType::PointType::CoordinateType, Dimension>;
   VectorType LeftEyeIndexVector;
   LeftEyeIndexVector[0] = LeftEyeIndex[0];
   LeftEyeIndexVector[1] = LeftEyeIndex[1];

--- a/Modules/Core/Common/include/itkImageAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkImageAlgorithm.hxx
@@ -207,7 +207,7 @@ ImageAlgorithm::EnlargeRegionOverBox(const typename InputImageType::RegionType &
   {
     numberOfInputCorners *= 2;
   }
-  using ContinuousIndexValueType = double;
+  using ContinuousIndexValueType = ContinuousIndex<SpacePrecisionType>::ValueType;
   using ContinuousInputIndexType = ContinuousIndex<ContinuousIndexValueType, InputImageType::ImageDimension>;
   using ContinuousOutputIndexType = ContinuousIndex<ContinuousIndexValueType, OutputImageType::ImageDimension>;
 
@@ -241,7 +241,7 @@ ImageAlgorithm::EnlargeRegionOverBox(const typename InputImageType::RegionType &
 
     using InputPointType = Point<SpacePrecisionType, InputImageType::ImageDimension>;
     const InputPointType inputPoint =
-      inputImage->template TransformContinuousIndexToPhysicalPoint<SpacePrecisionType, SpacePrecisionType>(
+      inputImage->template TransformContinuousIndexToPhysicalPoint<SpacePrecisionType, ContinuousIndexValueType>(
         currentInputCornerIndex);
     using OutputPointType = Point<SpacePrecisionType, OutputImageType::ImageDimension>;
     OutputPointType outputPoint{};

--- a/Modules/Filtering/ImageSources/test/itkPhysicalPointImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkPhysicalPointImageSourceTest.cxx
@@ -100,13 +100,6 @@ itkPhysicalPointImageSourceTest(int argc, char * argv[])
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(physicalPointImageSource, PhysicalPointImageSource, GenerateImageSource);
 
-
-  double theta = 0;
-  if (argc >= 4)
-  {
-    theta = std::stod(argv[3]);
-  }
-
   int                  testStatus = EXIT_SUCCESS;
   auto                 spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
   ImageType::PointType origin{};
@@ -129,7 +122,8 @@ itkPhysicalPointImageSourceTest(int argc, char * argv[])
   }
   else
   {
-    itk::SpacePrecisionType M[] = { std::cos(theta), -std::sin(theta), std::sin(theta), std::cos(theta) };
+    const itk::SpacePrecisionType theta = (argc >= 4) ? std::stod(argv[3]) : 0;
+    itk::SpacePrecisionType       M[] = { std::cos(theta), -std::sin(theta), std::sin(theta), std::cos(theta) };
 
     direction = vnl_matrix<itk::SpacePrecisionType>(M, 2, 2);
     testStatus = itkPhysicalPointImageSourceTest<itk::VectorImage<float, ImageDimension>>(


### PR DESCRIPTION
    
Need to match precision for types used to allow building.
In a few cases double precision was assumed for values
related to spacing precision.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
