### PR TITLE
ENH: Update CMake minimum support to 3.22.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 # CMake versions greater than the ITK_NEWEST_VALIDATED_POLICIES_VERSION policies will
 # continue to generate policy warnings "CMake Warning (dev)...Policy CMP0XXX is not set:"
 #
-set(ITK_OLDEST_VALIDATED_POLICIES_VERSION "3.16.3")
+set(ITK_OLDEST_VALIDATED_POLICIES_VERSION "3.22.1")
 set(ITK_NEWEST_VALIDATED_POLICIES_VERSION "3.29.0")
 cmake_minimum_required(VERSION ${ITK_OLDEST_VALIDATED_POLICIES_VERSION}...${ITK_NEWEST_VALIDATED_POLICIES_VERSION}
                        FATAL_ERROR)


### PR DESCRIPTION
The update to HDF5 #4940, added a required CMake minimum version of 3.18. Update the top-level requirement to match.

While possible to build ITK without HDF5, this is not a common configuration. The non-minimum requirement at the top level can be considered a bug. 

Note: Ubuntu 20.04 contains cmake 2.16.3, but standard support end April 2025 ( likely before the ITK 6.0 final release).