### PR TITLE
BUG: Consistency of enforcing m_ShrinkFactors > 1

### DIFF
--- a/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
@@ -98,7 +98,14 @@ ShrinkImageFilter<TInputImage, TOutputImage>::SetShrinkFactor(unsigned int i, un
   }
 
   this->Modified();
-  m_ShrinkFactors[i] = factor;
+  if (m_ShrinkFactors[i] < 1)
+  {
+    m_ShrinkFactors[i] = 1;
+  }
+  else
+  {
+    m_ShrinkFactors[i] = factor;
+  }
 }
 
 


### PR DESCRIPTION
The behavior of setting individual m_ShrinkFactor elements should be the same as setting from an array of shrinkFactors.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
