### PR TITLE
Emplace back method

### DIFF
--- a/Examples/RegistrationITKv4/DeformableRegistration6.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration6.cxx
@@ -324,7 +324,7 @@ main(int argc, char * argv[])
     bsplineAdaptor->SetRequiredTransformDomainPhysicalDimensions(
       fixedPhysicalDimensions);
 
-    adaptors.push_back(bsplineAdaptor);
+    adaptors.emplace_back(bsplineAdaptor);
   }
 
   registration->SetTransformParametersAdaptorsPerLevel(adaptors);

--- a/Examples/Statistics/BayesianPluginClassifier.cxx
+++ b/Examples/Statistics/BayesianPluginClassifier.cxx
@@ -327,7 +327,7 @@ main(int, char *[])
     membershipFunction->SetMean(covarianceEstimators[i]->GetMean());
     membershipFunction->SetCovariance(
       covarianceEstimators[i]->GetCovarianceMatrix());
-    membershipFunctionVector.push_back(membershipFunction);
+    membershipFunctionVector.emplace_back(membershipFunction);
   }
   membershipFunctionVectorObject->Set(membershipFunctionVector);
   classifier->SetMembershipFunctions(membershipFunctionVectorObject);

--- a/Examples/Statistics/KdTreeBasedKMeansClustering.cxx
+++ b/Examples/Statistics/KdTreeBasedKMeansClustering.cxx
@@ -370,7 +370,7 @@ main()
       centroid[j] = estimatedMeans[index++];
     }
     membershipFunction->SetCentroid(centroid);
-    membershipFunctionVector.push_back(membershipFunction);
+    membershipFunctionVector.emplace_back(membershipFunction);
   }
   classifier->SetMembershipFunctions(membershipFunctionVectorObject);
 

--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -674,7 +674,7 @@ ProcessObject::GetOutputs()
     // only include the primary if it's required or set
     if (output.first != m_IndexedOutputs[0]->first || output.second.IsNotNull())
     {
-      res.push_back(output.second.GetPointer());
+      res.emplace_back(output.second.GetPointer());
     }
   }
   return res;
@@ -967,7 +967,7 @@ ProcessObject::GetInputs()
     // only include the primary if it's required or set
     if (input.first != m_IndexedInputs[0]->first || input.second.IsNotNull() || this->IsRequiredInputName(input.first))
     {
-      res.push_back(input.second.GetPointer());
+      res.emplace_back(input.second.GetPointer());
     }
   }
   return res;

--- a/Modules/Core/Common/src/itkThreadLogger.cxx
+++ b/Modules/Core/Common/src/itkThreadLogger.cxx
@@ -91,7 +91,7 @@ ThreadLogger::AddLogOutput(OutputType * output)
 {
   const std::lock_guard<std::mutex> lockGuard(m_Mutex);
   this->m_OperationQ.push(ADD_LOG_OUTPUT);
-  this->m_OutputQ.push(output);
+  this->m_OutputQ.emplace(output);
 }
 
 void

--- a/Modules/Core/Common/test/itkImageRandomConstIteratorWithIndexGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomConstIteratorWithIndexGTest.cxx
@@ -64,7 +64,7 @@ TEST(ImageRandomConstIteratorWithIndex, IsDeterministicWhenGlobalRandomSeedsAreR
 
       while (!iterator.IsAtEnd())
       {
-        samples.push_back({ iterator.Get(), iterator.GetIndex() });
+        samples.emplace_back(iterator.Get(), iterator.GetIndex());
         ++iterator;
       }
       return samples;

--- a/Modules/Core/Common/test/itkLoggerThreadWrapperTest.cxx
+++ b/Modules/Core/Common/test/itkLoggerThreadWrapperTest.cxx
@@ -148,7 +148,7 @@ create_threaded_data2(int num_threads, itk::LoggerBase * logger)
   ThreadDataVec threadData;
   for (int ii = 0; ii < num_threads; ++ii)
   {
-    threadData.push_back(ThreadDataStruct());
+    threadData.emplace_back();
     threadData[ii].logger = logger;
   }
   return threadData;

--- a/Modules/Core/Common/test/itkObjectFactoryTest3.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryTest3.cxx
@@ -151,9 +151,9 @@ itkObjectFactoryTest3(int, char *[])
   itk::ObjectFactoryBase::RegisterFactory(factory2);
   itk::ObjectFactoryBase::RegisterFactory(factory3);
 
-  descriptionList.push_back("factory1");
-  descriptionList.push_back("factory2");
-  descriptionList.push_back("factory3");
+  descriptionList.emplace_back("factory1");
+  descriptionList.emplace_back("factory2");
+  descriptionList.emplace_back("factory3");
 
   int result = ListRegisteredFactories("TryA", descriptionList);
 
@@ -171,10 +171,10 @@ itkObjectFactoryTest3(int, char *[])
   itk::ObjectFactoryBase::RegisterFactory(factory3);
   itk::ObjectFactoryBase::RegisterFactory(factory4, itk::ObjectFactoryBase::InsertionPositionEnum::INSERT_AT_FRONT);
 
-  descriptionList.push_back("factory4");
-  descriptionList.push_back("factory1");
-  descriptionList.push_back("factory2");
-  descriptionList.push_back("factory3");
+  descriptionList.emplace_back("factory4");
+  descriptionList.emplace_back("factory1");
+  descriptionList.emplace_back("factory2");
+  descriptionList.emplace_back("factory3");
 
   result = ListRegisteredFactories("TryB", descriptionList);
 
@@ -185,7 +185,7 @@ itkObjectFactoryTest3(int, char *[])
 
 
   itk::ObjectFactoryBase::RegisterFactory(factory5, itk::ObjectFactoryBase::InsertionPositionEnum::INSERT_AT_BACK);
-  descriptionList.push_back("factory5");
+  descriptionList.emplace_back("factory5");
 
   result = ListRegisteredFactories("TryC", descriptionList);
 
@@ -198,12 +198,12 @@ itkObjectFactoryTest3(int, char *[])
   itk::ObjectFactoryBase::RegisterFactory(
     factory6, itk::ObjectFactoryBase::InsertionPositionEnum::INSERT_AT_POSITION, 3);
   descriptionList.clear();
-  descriptionList.push_back("factory4"); // position 0
-  descriptionList.push_back("factory1"); // position 1
-  descriptionList.push_back("factory2"); // position 2
-  descriptionList.push_back("factory6"); // position 3
-  descriptionList.push_back("factory3"); // position 4
-  descriptionList.push_back("factory5"); // position 5
+  descriptionList.emplace_back("factory4"); // position 0
+  descriptionList.emplace_back("factory1"); // position 1
+  descriptionList.emplace_back("factory2"); // position 2
+  descriptionList.emplace_back("factory6"); // position 3
+  descriptionList.emplace_back("factory3"); // position 4
+  descriptionList.emplace_back("factory5"); // position 5
 
   result = ListRegisteredFactories("TryD", descriptionList);
 
@@ -214,7 +214,7 @@ itkObjectFactoryTest3(int, char *[])
 
 
   itk::ObjectFactoryBase::RegisterFactory(factory7, itk::ObjectFactoryBase::InsertionPositionEnum::INSERT_AT_BACK);
-  descriptionList.push_back("factory7");
+  descriptionList.emplace_back("factory7");
 
   result = ListRegisteredFactories("TryE", descriptionList);
 

--- a/Modules/Core/Common/test/itkThreadLoggerTest.cxx
+++ b/Modules/Core/Common/test/itkThreadLoggerTest.cxx
@@ -79,7 +79,7 @@ create_threaded_data(int num_threads, itk::LoggerBase * logger)
   ThreadDataVec threadData;
   for (int ii = 0; ii < num_threads; ++ii)
   {
-    threadData.push_back(ThreadDataStruct());
+    threadData.emplace_back();
     threadData[ii].logger = logger;
   }
   return threadData;

--- a/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
@@ -304,7 +304,7 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::PolygonToImageRaster(
         if (extent[2] <= y && y <= extent[3])
         {
           const int zyidx = (z - extent[4]) * zInc + (y - extent[2]);
-          zymatrix[zyidx].push_back(Point1D(X, sign));
+          zymatrix[zyidx].emplace_back(X, sign);
         }
       }
     }

--- a/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
@@ -200,9 +200,9 @@ itkDTITubeSpatialObjectTest(int, char *[])
   tubeNet1->AddChild(tube3);
 
   // testing the GetChildren() function...
-  childrenList.push_back(tube1);
-  childrenList.push_back(tube2);
-  childrenList.push_back(tube3);
+  childrenList.emplace_back(tube1);
+  childrenList.emplace_back(tube2);
+  childrenList.emplace_back(tube3);
 
   returnedList = tubeNet1->GetChildren();
 

--- a/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
@@ -211,9 +211,9 @@ itkTubeSpatialObjectTest(int, char *[])
   tubeNet1->AddChild(tube3);
 
   // testing the GetChildren() function...
-  childrenList.push_back(tube1);
-  childrenList.push_back(tube2);
-  childrenList.push_back(tube3);
+  childrenList.emplace_back(tube1);
+  childrenList.emplace_back(tube2);
+  childrenList.emplace_back(tube3);
 
   returnedList = tubeNet1->GetChildren();
 

--- a/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
@@ -92,7 +92,7 @@ GDCMSeriesFileNames::GetSeriesUIDs()
       // Create its unique series ID
       const std::string id = m_SerieHelper->CreateUniqueSeriesIdentifier(file).c_str();
 
-      m_SeriesUIDs.push_back(id.c_str());
+      m_SeriesUIDs.emplace_back(id.c_str());
     }
     flist = m_SerieHelper->GetNextSingleSerieUIDFileSet();
   }

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
@@ -144,7 +144,7 @@ ImageSeriesWriter<TInputImage, TOutputImage>::GenerateNumericFileNames()
     ITK_GCC_SUPPRESS_Wformat_nonliteral
     snprintf(fileName, IOCommon::ITK_MAXPATHLEN + 1, m_SeriesFormat.c_str(), fileNumber);
     ITK_GCC_PRAGMA_POP
-    m_FileNames.push_back(fileName);
+    m_FileNames.emplace_back(fileName);
     fileNumber += this->m_IncrementIndex;
   }
 }

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -64,13 +64,13 @@ ImageIOBase::GetSupportedReadExtensions() const
 void
 ImageIOBase::AddSupportedReadExtension(const char * extension)
 {
-  this->m_SupportedReadExtensions.push_back(extension);
+  this->m_SupportedReadExtensions.emplace_back(extension);
 }
 
 void
 ImageIOBase::AddSupportedWriteExtension(const char * extension)
 {
-  this->m_SupportedWriteExtensions.push_back(extension);
+  this->m_SupportedWriteExtensions.emplace_back(extension);
 }
 
 void

--- a/Modules/IO/ImageBase/test/itkImageSeriesReaderDimensionsTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageSeriesReaderDimensionsTest.cxx
@@ -42,12 +42,12 @@ itkImageSeriesReaderDimensionsTest(int argc, char * argv[])
   using Reader5DType = itk::ImageSeriesReader<Image5DType>;
 
   Reader2DType::FileNamesContainer fname;
-  fname.push_back(argv[1]);
+  fname.emplace_back(argv[1]);
 
   Reader2DType::FileNamesContainer fnames;
   for (int i = 1; i < argc; ++i)
   {
-    fnames.push_back(argv[i]);
+    fnames.emplace_back(argv[i]);
   }
 
 

--- a/Modules/IO/ImageBase/test/itkImageSeriesReaderSamplingTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageSeriesReaderSamplingTest.cxx
@@ -37,7 +37,7 @@ itkImageSeriesReaderSamplingTest(int argc, char * argv[])
   for (int i = 1; i < argc; ++i)
   {
     std::cout << argv[i] << std::endl;
-    fnames.push_back(argv[i]);
+    fnames.emplace_back(argv[i]);
   }
 
   std::cout << "testing reading a series of 2D images to 3D with extra slices" << std::endl;

--- a/Modules/IO/ImageBase/test/itkImageSeriesReaderVectorTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageSeriesReaderVectorTest.cxx
@@ -36,7 +36,7 @@ itkImageSeriesReaderVectorTest(int argc, char * argv[])
   VectorImageSeriesReader::FileNamesContainer fnames;
   for (int i = 1; i < argc; ++i)
   {
-    fnames.push_back(argv[i]);
+    fnames.emplace_back(argv[i]);
   }
 
 

--- a/Modules/IO/MeshBase/src/itkMeshIOBase.cxx
+++ b/Modules/IO/MeshBase/src/itkMeshIOBase.cxx
@@ -44,13 +44,13 @@ MeshIOBase::GetSupportedWriteExtensions() const
 void
 MeshIOBase::AddSupportedReadExtension(const char * extension)
 {
-  this->m_SupportedReadExtensions.push_back(extension);
+  this->m_SupportedReadExtensions.emplace_back(extension);
 }
 
 void
 MeshIOBase::AddSupportedWriteExtension(const char * extension)
 {
-  this->m_SupportedWriteExtensions.push_back(extension);
+  this->m_SupportedWriteExtensions.emplace_back(extension);
 }
 
 unsigned int

--- a/Modules/IO/PNG/test/itkPNGImageIOTest2.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTest2.cxx
@@ -112,8 +112,8 @@ itkPNGImageIOTest2(int argc, char * argv[])
   // Check supported file extensions
   // Expecting ".png" and ".PNG"
   itk::ImageIOBase::ArrayOfExtensionsType expectedExtensions;
-  expectedExtensions.push_back(".png");
-  expectedExtensions.push_back(".PNG");
+  expectedExtensions.emplace_back(".png");
+  expectedExtensions.emplace_back(".PNG");
 
   // Read extensions
   itk::ImageIOBase::ArrayOfExtensionsType readExtensions = io->GetSupportedReadExtensions();

--- a/Modules/IO/XML/src/itkDOMNode.cxx
+++ b/Modules/IO/XML/src/itkDOMNode.cxx
@@ -265,7 +265,7 @@ DOMNode::AddChildAtEnd(DOMNode * node)
   }
 
   node->m_Parent = this;
-  this->m_Children.push_back(Pointer(node));
+  this->m_Children.emplace_back(node);
 }
 
 /** Replace a child (throw exception if not able to replace). */

--- a/Modules/Numerics/Optimizers/test/itkInitializationBiasedParticleSwarmOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkInitializationBiasedParticleSwarmOptimizerTest.cxx
@@ -163,7 +163,7 @@ IBPSOTest1(typename OptimizerType::CoefficientType inertiaCoefficient,
 
   // set optimizer parameters
   OptimizerType::ParameterBoundsType bounds;
-  bounds.push_back(std::make_pair(-10, 10));
+  bounds.emplace_back(-10, 10);
   constexpr unsigned int        numberOfParticles = 10;
   constexpr unsigned int        maxIterations = 200;
   constexpr double              xTolerance = 0.1;
@@ -289,8 +289,8 @@ IBPSOTest2(typename OptimizerType::CoefficientType inertiaCoefficient,
 
   // set optimizer parameters
   OptimizerType::ParameterBoundsType bounds;
-  bounds.push_back(std::make_pair(-10, 10));
-  bounds.push_back(std::make_pair(-10, 10));
+  bounds.emplace_back(-10, 10);
+  bounds.emplace_back(-10, 10);
   constexpr unsigned int        numberOfParticles = 10;
   constexpr unsigned int        maxIterations = 200;
   constexpr double              xTolerance = 0.1;
@@ -388,8 +388,8 @@ IBPSOTest3(typename OptimizerType::CoefficientType inertiaCoefficient,
 
   // set optimizer parameters
   OptimizerType::ParameterBoundsType bounds;
-  bounds.push_back(std::make_pair(-100, 100));
-  bounds.push_back(std::make_pair(-100, 100));
+  bounds.emplace_back(-100, 100);
+  bounds.emplace_back(-100, 100);
   constexpr unsigned int        numberOfParticles = 100;
   constexpr unsigned int        maxIterations = 1000;
   constexpr double              xTolerance = 0.1;

--- a/Modules/Numerics/Optimizers/test/itkParticleSwarmOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkParticleSwarmOptimizerTest.cxx
@@ -121,7 +121,7 @@ PSOTest1()
 
   // set optimizer parameters
   OptimizerType::ParameterBoundsType bounds;
-  bounds.push_back(std::make_pair(-10, 10));
+  bounds.emplace_back(-10, 10);
   constexpr unsigned int        numberOfParticles = 10;
   constexpr unsigned int        maxIterations = 100;
   constexpr double              xTolerance = 0.1;
@@ -220,8 +220,8 @@ PSOTest2()
 
   // set optimizer parameters
   OptimizerType::ParameterBoundsType bounds;
-  bounds.push_back(std::make_pair(-10, 10));
-  bounds.push_back(std::make_pair(-10, 10));
+  bounds.emplace_back(-10, 10);
+  bounds.emplace_back(-10, 10);
   constexpr unsigned int        numberOfParticles = 10;
   constexpr unsigned int        maxIterations = 100;
   constexpr double              xTolerance = 0.1;
@@ -299,8 +299,8 @@ PSOTest3()
 
   // set optimizer parameters
   OptimizerType::ParameterBoundsType bounds;
-  bounds.push_back(std::make_pair(-100, 100));
-  bounds.push_back(std::make_pair(-100, 100));
+  bounds.emplace_back(-100, 100);
+  bounds.emplace_back(-100, 100);
   constexpr unsigned int        numberOfParticles = 100;
   constexpr unsigned int        maxIterations = 200;
   constexpr double              xTolerance = 0.1;

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNPointSetRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNPointSetRegistrationTest.cxx
@@ -200,7 +200,7 @@ itkBSplineSyNPointSetRegistrationTest(int itkNotUsed(argc), char * itkNotUsed(ar
     fieldTransformAdaptor->SetMeshSizeForTheUpdateField(newUpdateMeshSize);
     fieldTransformAdaptor->SetMeshSizeForTheTotalField(newTotalMeshSize);
 
-    adaptors.push_back(fieldTransformAdaptor);
+    adaptors.emplace_back(fieldTransformAdaptor);
   }
 
   displacementFieldRegistration->SetFixedPointSet(fixedPoints);

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSyNPointSetRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSyNPointSetRegistrationTest.cxx
@@ -187,7 +187,7 @@ itkSyNPointSetRegistrationTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
     fieldTransformAdaptor->SetRequiredOrigin(shrinkFilter->GetOutput()->GetOrigin());
     fieldTransformAdaptor->SetTransform(outputTransform);
 
-    adaptors.push_back(fieldTransformAdaptor);
+    adaptors.emplace_back(fieldTransformAdaptor);
   }
 
   displacementFieldRegistration->SetFixedPointSet(fixedPoints);

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldPointSetRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldPointSetRegistrationTest.cxx
@@ -268,7 +268,7 @@ itkTimeVaryingBSplineVelocityFieldPointSetRegistrationTest(int itkNotUsed(argc),
     fieldTransformAdaptor->SetRequiredTransformDomainOrigin(velocityFieldOrigin);
     fieldTransformAdaptor->SetRequiredTransformDomainMeshSize(transformDomainMeshSize);
 
-    adaptors.push_back(fieldTransformAdaptor);
+    adaptors.emplace_back(fieldTransformAdaptor);
   }
   velocityFieldRegistration->SetTransformParametersAdaptorsPerLevel(adaptors);
 

--- a/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest1.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest1.cxx
@@ -137,21 +137,21 @@ itkSampleClassifierFilterTest1(int, char *[])
   MembershipFunctionType::CentroidType centroid1;
   itk::NumericTraits<MembershipFunctionType::CentroidType>::SetLength(centroid1, numberOfComponents);
   membershipFunction1->SetCentroid(centroid1);
-  membershipFunctionsVector.push_back(membershipFunction1);
+  membershipFunctionsVector.emplace_back(membershipFunction1);
 
   const MembershipFunctionPointer membershipFunction2 = MembershipFunctionType::New();
   membershipFunction1->SetMeasurementVectorSize(numberOfComponents);
   MembershipFunctionType::CentroidType centroid2;
   itk::NumericTraits<MembershipFunctionType::CentroidType>::SetLength(centroid2, numberOfComponents);
   membershipFunction2->SetCentroid(centroid2);
-  membershipFunctionsVector.push_back(membershipFunction2);
+  membershipFunctionsVector.emplace_back(membershipFunction2);
 
   const MembershipFunctionPointer membershipFunction3 = MembershipFunctionType::New();
   membershipFunction3->SetMeasurementVectorSize(numberOfComponents);
   MembershipFunctionType::CentroidType centroid3;
   itk::NumericTraits<MembershipFunctionType::CentroidType>::SetLength(centroid3, numberOfComponents);
   membershipFunction3->SetCentroid(centroid3);
-  membershipFunctionsVector.push_back(membershipFunction3);
+  membershipFunctionsVector.emplace_back(membershipFunction3);
 
   try
   {

--- a/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest2.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest2.cxx
@@ -81,7 +81,7 @@ itkSampleClassifierFilterTest2(int, char *[])
   covariance1.SetIdentity();
   covariance1[0][0] = 0.5;
   membershipFunction1->SetCovariance(covariance1);
-  membershipFunctionsVector.push_back(membershipFunction1);
+  membershipFunctionsVector.emplace_back(membershipFunction1);
 
   const MembershipFunctionPointer membershipFunction2 = MembershipFunctionType::New();
   membershipFunction1->SetMeasurementVectorSize(numberOfComponents);
@@ -96,7 +96,7 @@ itkSampleClassifierFilterTest2(int, char *[])
   covariance2.SetIdentity();
   covariance2[0][0] = 0.5;
   membershipFunction2->SetCovariance(covariance2);
-  membershipFunctionsVector.push_back(membershipFunction2);
+  membershipFunctionsVector.emplace_back(membershipFunction2);
 
   // Add class labels
   ClassLabelVectorType & classLabelVector = classLabelsObject->Get();


### PR DESCRIPTION
The check flags insertions to an STL-style container done by calling the
push_back method with an explicitly-constructed temporary of the container
element type. In this case, the corresponding emplace_back method results in
less verbose and potentially more efficient code.


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
