### PR TITLE
Reduce indentation after return

### DIFF
--- a/Examples/RegistrationITKv4/ImageRegistrationHistogramPlotter.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistrationHistogramPlotter.cxx
@@ -147,10 +147,7 @@ public:
       {
         return static_cast<OutputPixelType>(255);
       }
-      else
-      {
-        return itk::Math::Round<OutputPixelType>(-(30.0 * std::log(A)));
-      }
+      return itk::Math::Round<OutputPixelType>(-(30.0 * std::log(A)));
     }
     else
     {

--- a/Examples/Statistics/WeightedSampleStatistics.cxx
+++ b/Examples/Statistics/WeightedSampleStatistics.cxx
@@ -84,10 +84,8 @@ public:
     {
       return 0.5;
     }
-    else
-    {
-      return 0.01;
-    }
+
+    return 0.01;
   }
 
 protected:

--- a/Modules/Bridge/VTK/src/itkVTKImageExportBase.cxx
+++ b/Modules/Bridge/VTK/src/itkVTKImageExportBase.cxx
@@ -159,10 +159,8 @@ VTKImageExportBase::PipelineModifiedCallback()
     m_LastPipelineMTime = pipelineMTime;
     return 1;
   }
-  else
-  {
-    return 0;
-  }
+
+  return 0;
 }
 
 /**

--- a/Modules/Core/Common/include/itkBSplineDerivativeKernelFunction.h
+++ b/Modules/Core/Common/include/itkBSplineDerivativeKernelFunction.h
@@ -109,7 +109,7 @@ private:
     {
       return TRealValueType{ 0.5 };
     }
-    else if ((u > TRealValueType{ -1.0 }) && (u < TRealValueType{ 0.0 }))
+    if ((u > TRealValueType{ -1.0 }) && (u < TRealValueType{ 0.0 }))
     {
       return TRealValueType{ 1.0 };
     }
@@ -139,7 +139,7 @@ private:
     {
       return (TRealValueType{ -2.0 } * u);
     }
-    else if ((u >= TRealValueType{ 0.5 }) && (u < TRealValueType{ 1.5 }))
+    if ((u >= TRealValueType{ 0.5 }) && (u < TRealValueType{ 1.5 }))
     {
       return (TRealValueType{ -1.5 } + u);
     }
@@ -161,7 +161,7 @@ private:
     {
       return (TRealValueType{ -2.0 } * u + TRealValueType{ 1.5 } * u * u);
     }
-    else if ((u > TRealValueType{ -1.0 }) && (u < TRealValueType{ 0.0 }))
+    if ((u > TRealValueType{ -1.0 }) && (u < TRealValueType{ 0.0 }))
     {
       return (TRealValueType{ -2.0 } * u - TRealValueType{ 1.5 } * u * u);
     }

--- a/Modules/Core/Common/include/itkBSplineKernelFunction.h
+++ b/Modules/Core/Common/include/itkBSplineKernelFunction.h
@@ -103,7 +103,7 @@ private:
     {
       return TRealValueType{ 1.0 };
     }
-    else if (Math::ExactlyEquals(absValue, TRealValueType{ 0.5 }))
+    if (Math::ExactlyEquals(absValue, TRealValueType{ 0.5 }))
     {
       return TRealValueType{ 0.5 };
     }
@@ -122,10 +122,8 @@ private:
     {
       return TRealValueType{ 1.0 } - absValue;
     }
-    else
-    {
-      return TRealValueType{ 0.0 };
-    }
+
+    return TRealValueType{ 0.0 };
   }
 
   /** Second order spline. */
@@ -138,7 +136,7 @@ private:
       const TRealValueType sqrValue = itk::Math::sqr(absValue);
       return TRealValueType{ 0.75 } - sqrValue;
     }
-    else if (absValue < TRealValueType{ 1.5 })
+    if (absValue < TRealValueType{ 1.5 })
     {
       const TRealValueType sqrValue = itk::Math::sqr(absValue);
       // NOTE: 1.0/8.0 == 0.125
@@ -162,7 +160,7 @@ private:
       return (TRealValueType{ 4.0 } - TRealValueType{ 6.0 } * sqrValue + TRealValueType{ 3.0 } * sqrValue * absValue) /
              TRealValueType{ 6.0 };
     }
-    else if (absValue < TRealValueType{ 2.0 })
+    if (absValue < TRealValueType{ 2.0 })
     {
       const TRealValueType sqrValue = itk::Math::sqr(absValue);
       return (TRealValueType{ 8.0 } - TRealValueType{ 12.0 } * absValue + TRealValueType{ 6.0 } * sqrValue -

--- a/Modules/Core/Common/include/itkColorTable.hxx
+++ b/Modules/Core/Common/include/itkColorTable.hxx
@@ -281,12 +281,10 @@ ColorTable<TComponent>::GetColor(unsigned int c)
   {
     return m_Color[c];
   }
-  else
-  {
-    RGBPixel<TComponent> pixel;
-    pixel.Set(0, 0, 0);
-    return pixel;
-  }
+
+  RGBPixel<TComponent> pixel;
+  pixel.Set(0, 0, 0);
+  return pixel;
 }
 
 template <typename TComponent>
@@ -329,10 +327,8 @@ ColorTable<TComponent>::GetColorName(unsigned int c)
   {
     return m_ColorName[c];
   }
-  else
-  {
-    return "";
-  }
+
+  return "";
 }
 
 template <typename TComponent>

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
@@ -55,7 +55,7 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::IndexInBounds(const Neigh
   {
     return true;
   }
-  else if (this->InBounds()) // Is this whole neighborhood in bounds?
+  if (this->InBounds()) // Is this whole neighborhood in bounds?
   {
     return true;
   }
@@ -108,7 +108,7 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::IndexInBounds(const Neigh
   {
     return true;
   }
-  else if (this->InBounds()) // Is this whole neighborhood in bounds?
+  if (this->InBounds()) // Is this whole neighborhood in bounds?
   {
     return true;
   }
@@ -162,21 +162,19 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::GetPixel(NeighborIndexTyp
     IsInBounds = true;
     return (m_NeighborhoodAccessorFunctor.Get(this->operator[](n)));
   }
+
+  OffsetType offset;
+  OffsetType internalIndex;
+  const bool flag = this->IndexInBounds(n, internalIndex, offset);
+  if (flag)
+  {
+    IsInBounds = true;
+    return (m_NeighborhoodAccessorFunctor.Get(this->operator[](n)));
+  }
   else
   {
-    OffsetType offset;
-    OffsetType internalIndex;
-    const bool flag = this->IndexInBounds(n, internalIndex, offset);
-    if (flag)
-    {
-      IsInBounds = true;
-      return (m_NeighborhoodAccessorFunctor.Get(this->operator[](n)));
-    }
-    else
-    {
-      IsInBounds = false;
-      return (m_NeighborhoodAccessorFunctor.BoundaryCondition(internalIndex, offset, this, this->m_BoundaryCondition));
-    }
+    IsInBounds = false;
+    return (m_NeighborhoodAccessorFunctor.BoundaryCondition(internalIndex, offset, this, this->m_BoundaryCondition));
   }
 }
 

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
@@ -57,7 +57,7 @@ ConstNeighborhoodIteratorWithOnlyIndex<TImage>::IndexInBounds(const NeighborInde
   {
     return true;
   }
-  else if (this->InBounds()) // Is this whole neighborhood in bounds?
+  if (this->InBounds()) // Is this whole neighborhood in bounds?
   {
     return true;
   }

--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
@@ -179,10 +179,8 @@ public:
       {
         return true;
       }
-      else
-      {
-        return false;
-      }
+
+      return false;
     }
 
     void

--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
@@ -92,18 +92,17 @@ ConstShapedNeighborhoodIterator<TImage, TBoundaryCondition>::DeactivateIndex(Nei
   {
     return;
   }
-  else
+
+  while (n != *it)
   {
-    while (n != *it)
+    ++it;
+    if (it == m_ActiveIndexList.end())
     {
-      ++it;
-      if (it == m_ActiveIndexList.end())
-      {
-        return;
-      }
+      return;
     }
-    m_ActiveIndexList.erase(it);
   }
+  m_ActiveIndexList.erase(it);
+
 
   // Did we just deactivate the index at the center of the neighborhood?
   if (n == this->GetCenterNeighborhoodIndex())

--- a/Modules/Core/Common/include/itkEquivalencyTable.h
+++ b/Modules/Core/Common/include/itkEquivalencyTable.h
@@ -98,10 +98,8 @@ public:
     {
       return a;
     }
-    else
-    {
-      return result->second;
-    }
+
+    return result->second;
   }
 
   /** Lookup an equivalency in the table by recursing through all
@@ -120,10 +118,8 @@ public:
     {
       return false;
     }
-    else
-    {
-      return true;
-    }
+
+    return true;
   }
 
   /** Erases the entry with key a.  */

--- a/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.hxx
@@ -106,10 +106,8 @@ FiniteCylinderSpatialFunction<VDimension, TInput>::Evaluate(const InputType & po
   {
     return 1;
   }
-  else
-  {
-    return 0;
-  }
+
+  return 0;
 }
 
 template <unsigned int VDimension, typename TInput>

--- a/Modules/Core/Common/include/itkFrustumSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkFrustumSpatialFunction.hxx
@@ -77,7 +77,7 @@ FrustumSpatialFunction<VDimension, TInput>::Evaluate(const InputType & position)
 
     return 1;
   }
-  else if (m_RotationPlane == RotationPlaneEnum::RotateInYZPlane)
+  if (m_RotationPlane == RotationPlaneEnum::RotateInYZPlane)
   {
     const double dx = relativePosition[0];
     const double dy = relativePosition[1];

--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
@@ -219,10 +219,8 @@ GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::ModifiedBesselI1(dou
   {
     return -accumulator;
   }
-  else
-  {
-    return accumulator;
-  }
+
+  return accumulator;
 }
 
 template <typename TPixel, unsigned int VDimension, typename TAllocator>
@@ -242,36 +240,34 @@ GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::ModifiedBesselI(int 
   {
     return 0.0;
   }
+
+  const double toy = 2.0 / itk::Math::abs(y);
+  double       qip = accumulator = 0.0;
+  double       qi = 1.0;
+  for (int j = 2 * (n + static_cast<int>(DIGITS * std::sqrt(static_cast<double>(n)))); j > 0; j--)
+  {
+    const double qim = qip + j * toy * qi;
+    qip = qi;
+    qi = qim;
+    if (itk::Math::abs(qi) > 1.0e10)
+    {
+      accumulator *= 1.0e-10;
+      qi *= 1.0e-10;
+      qip *= 1.0e-10;
+    }
+    if (j == n)
+    {
+      accumulator = qip;
+    }
+  }
+  accumulator *= ModifiedBesselI0(y) / qi;
+  if (y < 0.0 && (n & 1))
+  {
+    return -accumulator;
+  }
   else
   {
-    const double toy = 2.0 / itk::Math::abs(y);
-    double       qip = accumulator = 0.0;
-    double       qi = 1.0;
-    for (int j = 2 * (n + static_cast<int>(DIGITS * std::sqrt(static_cast<double>(n)))); j > 0; j--)
-    {
-      const double qim = qip + j * toy * qi;
-      qip = qi;
-      qi = qim;
-      if (itk::Math::abs(qi) > 1.0e10)
-      {
-        accumulator *= 1.0e-10;
-        qi *= 1.0e-10;
-        qip *= 1.0e-10;
-      }
-      if (j == n)
-      {
-        accumulator = qip;
-      }
-    }
-    accumulator *= ModifiedBesselI0(y) / qi;
-    if (y < 0.0 && (n & 1))
-    {
-      return -accumulator;
-    }
-    else
-    {
-      return accumulator;
-    }
+    return accumulator;
   }
 }
 

--- a/Modules/Core/Common/include/itkGaussianOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianOperator.hxx
@@ -129,10 +129,8 @@ GaussianOperator<TPixel, VDimension, TAllocator>::ModifiedBesselI1(double y)
   {
     return -accumulator;
   }
-  else
-  {
-    return accumulator;
-  }
+
+  return accumulator;
 }
 
 template <typename TPixel, unsigned int VDimension, typename TAllocator>
@@ -152,40 +150,38 @@ GaussianOperator<TPixel, VDimension, TAllocator>::ModifiedBesselI(int n, double 
   {
     return 0.0;
   }
+
+  const double toy = 2.0 / itk::Math::abs(y);
+  double       qip = 0.0;
+  double       accumulator = 0.0;
+  double       qi = 1.0;
+
+  for (int j = 2 * (n + static_cast<int>(std::sqrt(ACCURACY * n))); j > 0; j--)
+  {
+    const double qim = qip + j * toy * qi;
+    qip = qi;
+    qi = qim;
+    if (itk::Math::abs(qi) > 1.0e10)
+    {
+      accumulator *= 1.0e-10;
+      qi *= 1.0e-10;
+      qip *= 1.0e-10;
+    }
+    if (j == n)
+    {
+      accumulator = qip;
+    }
+  }
+
+  accumulator *= ModifiedBesselI0(y) / qi;
+
+  if (y < 0.0 && (n & 1))
+  {
+    return -accumulator;
+  }
   else
   {
-    const double toy = 2.0 / itk::Math::abs(y);
-    double       qip = 0.0;
-    double       accumulator = 0.0;
-    double       qi = 1.0;
-
-    for (int j = 2 * (n + static_cast<int>(std::sqrt(ACCURACY * n))); j > 0; j--)
-    {
-      const double qim = qip + j * toy * qi;
-      qip = qi;
-      qi = qim;
-      if (itk::Math::abs(qi) > 1.0e10)
-      {
-        accumulator *= 1.0e-10;
-        qi *= 1.0e-10;
-        qip *= 1.0e-10;
-      }
-      if (j == n)
-      {
-        accumulator = qip;
-      }
-    }
-
-    accumulator *= ModifiedBesselI0(y) / qi;
-
-    if (y < 0.0 && (n & 1))
-    {
-      return -accumulator;
-    }
-    else
-    {
-      return accumulator;
-    }
+    return accumulator;
   }
 }
 } // end namespace itk

--- a/Modules/Core/Common/include/itkHexahedronCell.hxx
+++ b/Modules/Core/Common/include/itkHexahedronCell.hxx
@@ -496,38 +496,36 @@ HexahedronCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
     }
     return true;
   }
-  else
-  {
-    CoordinateType pc[CellDimension3D];
-    if (closestPoint)
-    {
-      for (unsigned int i = 0; i < CellDimension3D; ++i) // only approximate, not really true
-                                                         // for warped hexa
-      {
-        if (pcoords[i] < 0.0)
-        {
-          pc[i] = 0.0;
-        }
-        else if (pcoords[i] > 1.0)
-        {
-          pc[i] = 1.0;
-        }
-        else
-        {
-          pc[i] = pcoords[i];
-        }
-      }
-      CoordinateType w[Self::NumberOfPoints];
-      this->EvaluateLocation(subId, points, pc, closestPoint, (InterpolationWeightType *)w);
 
-      *dist2 = 0;
-      for (unsigned int i = 0; i < Self::PointDimension3D; ++i)
+  CoordinateType pc[CellDimension3D];
+  if (closestPoint)
+  {
+    for (unsigned int i = 0; i < CellDimension3D; ++i) // only approximate, not really true
+                                                       // for warped hexa
+    {
+      if (pcoords[i] < 0.0)
       {
-        *dist2 += (closestPoint[i] - x[i]) * (closestPoint[i] - x[i]);
+        pc[i] = 0.0;
+      }
+      else if (pcoords[i] > 1.0)
+      {
+        pc[i] = 1.0;
+      }
+      else
+      {
+        pc[i] = pcoords[i];
       }
     }
-    return false;
+    CoordinateType w[Self::NumberOfPoints];
+    this->EvaluateLocation(subId, points, pc, closestPoint, (InterpolationWeightType *)w);
+
+    *dist2 = 0;
+    for (unsigned int i = 0; i < Self::PointDimension3D; ++i)
+    {
+      *dist2 += (closestPoint[i] - x[i]) * (closestPoint[i] - x[i]);
+    }
   }
+  return false;
 }
 
 /** Compute iso-parametric interpolation functions */

--- a/Modules/Core/Common/include/itkImageBufferRange.h
+++ b/Modules/Core/Common/include/itkImageBufferRange.h
@@ -681,10 +681,8 @@ MakeImageBufferRange(TImage * const image)
   {
     return {};
   }
-  else
-  {
-    return ImageBufferRange<TImage>{ *image };
-  }
+
+  return ImageBufferRange<TImage>{ *image };
 }
 
 

--- a/Modules/Core/Common/include/itkImageLinearConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageLinearConstIteratorWithIndex.h
@@ -262,11 +262,9 @@ ImageLinearConstIteratorWithIndex<TImage>::NextLine()
       this->m_Remaining = true;
       break;
     }
-    else
-    {
-      this->m_Position -= this->m_OffsetTable[n] * (this->m_Region.GetSize()[n] - 1);
-      this->m_PositionIndex[n] = this->m_BeginIndex[n];
-    }
+
+    this->m_Position -= this->m_OffsetTable[n] * (this->m_Region.GetSize()[n] - 1);
+    this->m_PositionIndex[n] = this->m_BeginIndex[n];
   }
 }
 
@@ -298,11 +296,9 @@ ImageLinearConstIteratorWithIndex<TImage>::PreviousLine()
       this->m_Remaining = true;
       break;
     }
-    else
-    {
-      this->m_Position += this->m_OffsetTable[n] * (this->m_Region.GetSize()[n] - 1);
-      this->m_PositionIndex[n] = this->m_EndIndex[n] - 1;
-    }
+
+    this->m_Position += this->m_OffsetTable[n] * (this->m_Region.GetSize()[n] - 1);
+    this->m_PositionIndex[n] = this->m_EndIndex[n] - 1;
   }
 }
 } // end namespace itk

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.h
@@ -58,10 +58,8 @@ public:
     {
       return m_Value < b.m_Value;
     }
-    else
-    {
-      return m_Priority < b.m_Priority;
-    }
+
+    return m_Priority < b.m_Priority;
   }
 };
 
@@ -104,10 +102,8 @@ public:
       ostrm << "Error: RandomPermuation does not have " << i << " elements" << std::endl;
       throw std::runtime_error(ostrm.str());
     }
-    else
-    {
-      m_Permutation[i].m_Priority = priority;
-    }
+
+    m_Permutation[i].m_Priority = priority;
   }
 
   void

--- a/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.hxx
@@ -38,11 +38,9 @@ ImageRegionConstIteratorWithIndex<TImage>::operator++()
       this->m_Remaining = true;
       break;
     }
-    else
-    {
-      this->m_Position -= this->m_OffsetTable[in] * (static_cast<OffsetValueType>(this->m_Region.GetSize()[in]) - 1);
-      this->m_PositionIndex[in] = this->m_BeginIndex[in];
-    }
+
+    this->m_Position -= this->m_OffsetTable[in] * (static_cast<OffsetValueType>(this->m_Region.GetSize()[in]) - 1);
+    this->m_PositionIndex[in] = this->m_BeginIndex[in];
   }
 
   if (!this->m_Remaining) // It will not advance here otherwise
@@ -70,11 +68,9 @@ ImageRegionConstIteratorWithIndex<TImage>::operator--()
       this->m_Remaining = true;
       break;
     }
-    else
-    {
-      this->m_Position += this->m_OffsetTable[in] * (static_cast<OffsetValueType>(this->m_Region.GetSize()[in]) - 1);
-      this->m_PositionIndex[in] = this->m_EndIndex[in] - 1;
-    }
+
+    this->m_Position += this->m_OffsetTable[in] * (static_cast<OffsetValueType>(this->m_Region.GetSize()[in]) - 1);
+    this->m_PositionIndex[in] = this->m_EndIndex[in] - 1;
   }
 
   if (!this->m_Remaining) // It will not advance here otherwise

--- a/Modules/Core/Common/include/itkImageRegionConstIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRegionConstIteratorWithOnlyIndex.hxx
@@ -37,10 +37,8 @@ ImageRegionConstIteratorWithOnlyIndex<TImage>::operator++()
       this->m_Remaining = true;
       break;
     }
-    else
-    {
-      this->m_PositionIndex[in] = this->m_BeginIndex[in];
-    }
+
+    this->m_PositionIndex[in] = this->m_BeginIndex[in];
   }
 
   return *this;
@@ -62,10 +60,8 @@ ImageRegionConstIteratorWithOnlyIndex<TImage>::operator--()
       this->m_Remaining = true;
       break;
     }
-    else
-    {
-      this->m_PositionIndex[in] = this->m_EndIndex[in] - 1;
-    }
+
+    this->m_PositionIndex[in] = this->m_EndIndex[in] - 1;
   }
 
   return *this;

--- a/Modules/Core/Common/include/itkImageSliceConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageSliceConstIteratorWithIndex.hxx
@@ -92,11 +92,9 @@ ImageSliceConstIteratorWithIndex<TImage>::NextSlice()
       this->m_Remaining = true;
       break;
     }
-    else
-    {
-      this->m_Position -= this->m_OffsetTable[n + 1] - this->m_OffsetTable[n];
-      this->m_PositionIndex[n] = this->m_BeginIndex[n];
-    }
+
+    this->m_Position -= this->m_OffsetTable[n + 1] - this->m_OffsetTable[n];
+    this->m_PositionIndex[n] = this->m_BeginIndex[n];
   }
 }
 
@@ -127,11 +125,9 @@ ImageSliceConstIteratorWithIndex<TImage>::PreviousSlice()
       this->m_Remaining = true;
       break;
     }
-    else
-    {
-      this->m_Position += this->m_OffsetTable[n + 1] - this->m_OffsetTable[n];
-      this->m_PositionIndex[n] = this->m_EndIndex[n] - 1;
-    }
+
+    this->m_Position += this->m_OffsetTable[n + 1] - this->m_OffsetTable[n];
+    this->m_PositionIndex[n] = this->m_EndIndex[n] - 1;
   }
 }
 

--- a/Modules/Core/Common/include/itkImageVectorOptimizerParametersHelper.hxx
+++ b/Modules/Core/Common/include/itkImageVectorOptimizerParametersHelper.hxx
@@ -57,25 +57,23 @@ ImageVectorOptimizerParametersHelper<TValue, VVectorDimension, VImageDimension>:
     m_ParameterImage = nullptr;
     return;
   }
-  else
+
+  auto * image = dynamic_cast<ParameterImageType *>(object);
+  if (image == nullptr)
   {
-    auto * image = dynamic_cast<ParameterImageType *>(object);
-    if (image == nullptr)
-    {
-      itkGenericExceptionMacro("ImageVectorOptimizerParametersHelper::SetParametersObject: object is "
-                               "not of proper image type. Expected VectorImage, received "
-                               << object->GetNameOfClass());
-    }
-    m_ParameterImage = image;
-    // The PixelContainer for Image<Vector> points to type Vector, so we have
-    // to determine the number of raw elements of type TValue in the buffer
-    // and cast a pointer to it for assignment to the Array data pointer.
-    const typename CommonContainerType::SizeValueType sz = image->GetPixelContainer()->Size() * VVectorDimension;
-    auto * valuePointer = reinterpret_cast<TValue *>(image->GetPixelContainer()->GetBufferPointer());
-    // Set the Array's pointer to the image data buffer. By default it will
-    // not manage the memory.
-    container->SetData(valuePointer, sz, false);
+    itkGenericExceptionMacro("ImageVectorOptimizerParametersHelper::SetParametersObject: object is "
+                             "not of proper image type. Expected VectorImage, received "
+                             << object->GetNameOfClass());
   }
+  m_ParameterImage = image;
+  // The PixelContainer for Image<Vector> points to type Vector, so we have
+  // to determine the number of raw elements of type TValue in the buffer
+  // and cast a pointer to it for assignment to the Array data pointer.
+  const typename CommonContainerType::SizeValueType sz = image->GetPixelContainer()->Size() * VVectorDimension;
+  auto * valuePointer = reinterpret_cast<TValue *>(image->GetPixelContainer()->GetBufferPointer());
+  // Set the Array's pointer to the image data buffer. By default it will
+  // not manage the memory.
+  container->SetData(valuePointer, sz, false);
 }
 
 } // namespace itk

--- a/Modules/Core/Common/include/itkNeighborhoodAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodAlgorithm.hxx
@@ -173,12 +173,10 @@ ImageBoundaryFacesCalculator<TImage>::operator()(const TImage * img, RegionType 
   {
     return FaceListType{};
   }
-  else
-  {
-    FaceListType faceList = std::move(result.m_BoundaryFaces);
-    faceList.push_front(result.m_NonBoundaryRegion);
-    return faceList;
-  }
+
+  FaceListType faceList = std::move(result.m_BoundaryFaces);
+  faceList.push_front(result.m_NonBoundaryRegion);
+  return faceList;
 }
 
 

--- a/Modules/Core/Common/include/itkOctree.hxx
+++ b/Modules/Core/Common/include/itkOctree.hxx
@@ -180,44 +180,42 @@ Octree<TPixel, ColorTableSize, MappingFunctionType>::maskToOctree(const TPixel *
   {
     return nodeArray[0];
   }
-  else
-  {
-    auto * q = new OctreeNodeBranch(this);
 
-    {
-      OctreeNode * newbranch = q->GetLeaf(OctreeNode::LeafIdentifierEnum::ZERO);
-      newbranch->SetBranch(nodeArray[static_cast<uint8_t>(OctreeNode::LeafIdentifierEnum::ZERO)]);
-    }
-    {
-      OctreeNode * newbranch = q->GetLeaf(OctreeNode::LeafIdentifierEnum::ONE);
-      newbranch->SetBranch(nodeArray[static_cast<uint8_t>(OctreeNode::LeafIdentifierEnum::ONE)]);
-    }
-    {
-      OctreeNode * newbranch = q->GetLeaf(OctreeNode::LeafIdentifierEnum::TWO);
-      newbranch->SetBranch(nodeArray[static_cast<uint8_t>(OctreeNode::LeafIdentifierEnum::TWO)]);
-    }
-    {
-      OctreeNode * newbranch = q->GetLeaf(OctreeNode::LeafIdentifierEnum::THREE);
-      newbranch->SetBranch(nodeArray[static_cast<uint8_t>(OctreeNode::LeafIdentifierEnum::THREE)]);
-    }
-    {
-      OctreeNode * newbranch = q->GetLeaf(OctreeNode::LeafIdentifierEnum::FOUR);
-      newbranch->SetBranch(nodeArray[static_cast<uint8_t>(OctreeNode::LeafIdentifierEnum::FOUR)]);
-    }
-    {
-      OctreeNode * newbranch = q->GetLeaf(OctreeNode::LeafIdentifierEnum::FIVE);
-      newbranch->SetBranch(nodeArray[static_cast<uint8_t>(OctreeNode::LeafIdentifierEnum::FIVE)]);
-    }
-    {
-      OctreeNode * newbranch = q->GetLeaf(OctreeNode::LeafIdentifierEnum::SIX);
-      newbranch->SetBranch(nodeArray[static_cast<uint8_t>(OctreeNode::LeafIdentifierEnum::SIX)]);
-    }
-    {
-      OctreeNode * newbranch = q->GetLeaf(OctreeNode::LeafIdentifierEnum::SEVEN);
-      newbranch->SetBranch(nodeArray[static_cast<uint8_t>(OctreeNode::LeafIdentifierEnum::SEVEN)]);
-    }
-    return (q);
+  auto * q = new OctreeNodeBranch(this);
+
+  {
+    OctreeNode * newbranch = q->GetLeaf(OctreeNode::LeafIdentifierEnum::ZERO);
+    newbranch->SetBranch(nodeArray[static_cast<uint8_t>(OctreeNode::LeafIdentifierEnum::ZERO)]);
   }
+  {
+    OctreeNode * newbranch = q->GetLeaf(OctreeNode::LeafIdentifierEnum::ONE);
+    newbranch->SetBranch(nodeArray[static_cast<uint8_t>(OctreeNode::LeafIdentifierEnum::ONE)]);
+  }
+  {
+    OctreeNode * newbranch = q->GetLeaf(OctreeNode::LeafIdentifierEnum::TWO);
+    newbranch->SetBranch(nodeArray[static_cast<uint8_t>(OctreeNode::LeafIdentifierEnum::TWO)]);
+  }
+  {
+    OctreeNode * newbranch = q->GetLeaf(OctreeNode::LeafIdentifierEnum::THREE);
+    newbranch->SetBranch(nodeArray[static_cast<uint8_t>(OctreeNode::LeafIdentifierEnum::THREE)]);
+  }
+  {
+    OctreeNode * newbranch = q->GetLeaf(OctreeNode::LeafIdentifierEnum::FOUR);
+    newbranch->SetBranch(nodeArray[static_cast<uint8_t>(OctreeNode::LeafIdentifierEnum::FOUR)]);
+  }
+  {
+    OctreeNode * newbranch = q->GetLeaf(OctreeNode::LeafIdentifierEnum::FIVE);
+    newbranch->SetBranch(nodeArray[static_cast<uint8_t>(OctreeNode::LeafIdentifierEnum::FIVE)]);
+  }
+  {
+    OctreeNode * newbranch = q->GetLeaf(OctreeNode::LeafIdentifierEnum::SIX);
+    newbranch->SetBranch(nodeArray[static_cast<uint8_t>(OctreeNode::LeafIdentifierEnum::SIX)]);
+  }
+  {
+    OctreeNode * newbranch = q->GetLeaf(OctreeNode::LeafIdentifierEnum::SEVEN);
+    newbranch->SetBranch(nodeArray[static_cast<uint8_t>(OctreeNode::LeafIdentifierEnum::SEVEN)]);
+  }
+  return (q);
 }
 
 template <typename TPixel, unsigned int ColorTableSize, typename MappingFunctionType>

--- a/Modules/Core/Common/include/itkPolyLineCell.hxx
+++ b/Modules/Core/Common/include/itkPolyLineCell.hxx
@@ -207,10 +207,8 @@ PolyLineCell<TCellInterface>::PointIdsEnd() -> PointIdIterator
   {
     return &m_PointIds.back() + 1;
   }
-  else
-  {
-    return nullptr;
-  }
+
+  return nullptr;
 }
 
 /**
@@ -226,10 +224,8 @@ PolyLineCell<TCellInterface>::PointIdsEnd() const -> PointIdConstIterator
   {
     return &m_PointIds.back() + 1;
   }
-  else
-  {
-    return nullptr;
-  }
+
+  return nullptr;
 }
 
 /**

--- a/Modules/Core/Common/include/itkPolygonCell.hxx
+++ b/Modules/Core/Common/include/itkPolygonCell.hxx
@@ -278,10 +278,8 @@ PolygonCell<TCellInterface>::PointIdsBegin() -> PointIdIterator
   {
     return &m_PointIds.front();
   }
-  else
-  {
-    return nullptr;
-  }
+
+  return nullptr;
 }
 
 /**
@@ -297,10 +295,8 @@ PolygonCell<TCellInterface>::PointIdsBegin() const -> PointIdConstIterator
   {
     return &m_PointIds.front();
   }
-  else
-  {
-    return nullptr;
-  }
+
+  return nullptr;
 }
 
 /**
@@ -315,10 +311,8 @@ PolygonCell<TCellInterface>::PointIdsEnd() -> PointIdIterator
   {
     return &m_PointIds.back() + 1;
   }
-  else
-  {
-    return nullptr;
-  }
+
+  return nullptr;
 }
 
 /**
@@ -334,10 +328,8 @@ PolygonCell<TCellInterface>::PointIdsEnd() const -> PointIdConstIterator
   {
     return &m_PointIds.back() + 1;
   }
-  else
-  {
-    return nullptr;
-  }
+
+  return nullptr;
 }
 
 /**

--- a/Modules/Core/Common/include/itkQuadrilateralCell.hxx
+++ b/Modules/Core/Common/include/itkQuadrilateralCell.hxx
@@ -411,37 +411,35 @@ QuadrilateralCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
     }
     return true;
   }
-  else
-  {
-    CoordinateType pc[CellDimension];
-    CoordinateType w[NumberOfPoints];
-    if (closestPoint)
-    {
-      for (unsigned int i = 0; i < CellDimension; ++i) // only approximate ??
-      {
-        if (pcoords[i] < 0.0)
-        {
-          pc[i] = 0.0;
-        }
-        else if (pcoords[i] > 1.0)
-        {
-          pc[i] = 1.0;
-        }
-        else
-        {
-          pc[i] = pcoords[i];
-        }
-      }
-      this->EvaluateLocation(subId, points, pc, closestPoint, (InterpolationWeightType *)w);
 
-      *dist2 = 0;
-      for (unsigned int i = 0; i < CellDimension; ++i)
+  CoordinateType pc[CellDimension];
+  CoordinateType w[NumberOfPoints];
+  if (closestPoint)
+  {
+    for (unsigned int i = 0; i < CellDimension; ++i) // only approximate ??
+    {
+      if (pcoords[i] < 0.0)
       {
-        *dist2 += (closestPoint[i] - x[i]) * (closestPoint[i] - x[i]);
+        pc[i] = 0.0;
+      }
+      else if (pcoords[i] > 1.0)
+      {
+        pc[i] = 1.0;
+      }
+      else
+      {
+        pc[i] = pcoords[i];
       }
     }
-    return false;
+    this->EvaluateLocation(subId, points, pc, closestPoint, (InterpolationWeightType *)w);
+
+    *dist2 = 0;
+    for (unsigned int i = 0; i < CellDimension; ++i)
+    {
+      *dist2 += (closestPoint[i] - x[i]) * (closestPoint[i] - x[i]);
+    }
   }
+  return false;
 }
 
 /** Compute iso-parametric interpolation functions */

--- a/Modules/Core/Common/include/itkSinRegularizedHeavisideStepFunction.hxx
+++ b/Modules/Core/Common/include/itkSinRegularizedHeavisideStepFunction.hxx
@@ -30,19 +30,17 @@ SinRegularizedHeavisideStepFunction<TInput, TOutput>::Evaluate(const InputType &
   {
     return NumericTraits<OutputType>::OneValue();
   }
+
+  if (static_cast<RealType>(input) <= -this->GetEpsilon())
+  {
+    return OutputType{};
+  }
   else
   {
-    if (static_cast<RealType>(input) <= -this->GetEpsilon())
-    {
-      return OutputType{};
-    }
-    else
-    {
-      const RealType angleFactor = 0.5 * itk::Math::pi * this->GetOneOverEpsilon();
-      const RealType angle = input * angleFactor;
+    const RealType angleFactor = 0.5 * itk::Math::pi * this->GetOneOverEpsilon();
+    const RealType angle = input * angleFactor;
 
-      return static_cast<OutputType>(0.5 * (1.0 + std::sin(angle)));
-    }
+    return static_cast<OutputType>(0.5 * (1.0 + std::sin(angle)));
   }
 }
 
@@ -54,13 +52,11 @@ SinRegularizedHeavisideStepFunction<TInput, TOutput>::EvaluateDerivative(const I
   {
     return OutputType{};
   }
-  else
-  {
-    const RealType angleFactor = 0.5 * itk::Math::pi * this->GetOneOverEpsilon();
-    const RealType angle = input * angleFactor;
 
-    return static_cast<OutputType>(0.5 * angleFactor * std::cos(angle));
-  }
+  const RealType angleFactor = 0.5 * itk::Math::pi * this->GetOneOverEpsilon();
+  const RealType angle = input * angleFactor;
+
+  return static_cast<OutputType>(0.5 * angleFactor * std::cos(angle));
 }
 
 } // namespace itk

--- a/Modules/Core/Common/include/itkSparseFieldLayer.h
+++ b/Modules/Core/Common/include/itkSparseFieldLayer.h
@@ -62,10 +62,8 @@ public:
     {
       return true;
     }
-    else
-    {
-      return false;
-    }
+
+    return false;
   }
 
   ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(ConstSparseFieldLayerIterator);
@@ -296,10 +294,8 @@ public:
     {
       return true;
     }
-    else
-    {
-      return false;
-    }
+
+    return false;
   }
 
   /** Returns the number of elements in the list. Size() executes in constant

--- a/Modules/Core/Common/include/itkSpatialOrientationAdapter.h
+++ b/Modules/Core/Common/include/itkSpatialOrientationAdapter.h
@@ -51,7 +51,7 @@ Max3(double x, double y, double z)
   {
     return 0;
   }
-  else if ((absY > obliquityThresholdCosineValue) && (absY > absX) && (absY > absZ))
+  if ((absY > obliquityThresholdCosineValue) && (absY > absX) && (absY > absZ))
   {
     return 1;
   }

--- a/Modules/Core/Common/include/itkSphereSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkSphereSpatialFunction.hxx
@@ -38,10 +38,8 @@ SphereSpatialFunction<VImageDimension, TInput>::Evaluate(const InputType & posit
   {
     return 1;
   }
-  else
-  {
-    return 0; // outside the sphere
-  }
+
+  return 0; // outside the sphere
 }
 
 template <unsigned int VImageDimension, typename TInput>

--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.hxx
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.hxx
@@ -31,10 +31,8 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValues(const
   {
     return ComputeEigenValuesWithEigenLibrary(A, D);
   }
-  else
-  {
-    return ComputeEigenValuesLegacy(A, D);
-  }
+
+  return ComputeEigenValuesLegacy(A, D);
 }
 
 template <typename TMatrix, typename TVector, typename TEigenMatrix>
@@ -47,10 +45,8 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesAndVec
   {
     return ComputeEigenValuesAndVectorsWithEigenLibrary(A, EigenValues, EigenVectors);
   }
-  else
-  {
-    return ComputeEigenValuesAndVectorsLegacy(A, EigenValues, EigenVectors);
-  }
+
+  return ComputeEigenValuesAndVectorsLegacy(A, EigenValues, EigenVectors);
 }
 
 template <typename TMatrix, typename TVector, typename TEigenMatrix>

--- a/Modules/Core/Common/include/itkTorusInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkTorusInteriorExteriorSpatialFunction.hxx
@@ -35,10 +35,8 @@ TorusInteriorExteriorSpatialFunction<VDimension, TInput>::Evaluate(const InputTy
   {
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 template <unsigned int VDimension, typename TInput>

--- a/Modules/Core/Common/include/itkTriangleCell.hxx
+++ b/Modules/Core/Common/include/itkTriangleCell.hxx
@@ -351,10 +351,8 @@ TriangleCell<TCellInterface>::ComputeCircumCenter(PointsContainer * iPoints) -> 
 
     return oP;
   }
-  else
-  {
-    return p[0];
-  }
+
+  return p[0];
 }
 
 template <typename TCellInterface>
@@ -461,134 +459,133 @@ TriangleCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
 
     return true;
   }
-  else
+
+  if (closestPoint)
   {
-    if (closestPoint)
+    double lt; // parameter along the line (not used)
+    if (b1 < 0.0 && b2 < 0.0)
     {
-      double lt; // parameter along the line (not used)
-      if (b1 < 0.0 && b2 < 0.0)
+      dist2Point = 0;
+      for (unsigned int i = 0; i < PointDimension; ++i)
       {
-        dist2Point = 0;
-        for (unsigned int i = 0; i < PointDimension; ++i)
-        {
-          dist2Point += (x[i] - pt3[i]) * (x[i] - pt3[i]);
-        }
-        dist2Line1 = this->DistanceToLine(x, pt1, pt3, lt, closestPoint1);
-        dist2Line2 = this->DistanceToLine(x, pt3, pt2, lt, closestPoint2);
-        if (dist2Point < dist2Line1)
-        {
-          *minDist2 = dist2Point;
-          closest = pt3;
-        }
-        else
-        {
-          *minDist2 = dist2Line1;
-          closest = closestPoint1;
-        }
-        if (dist2Line2 < *minDist2)
-        {
-          *minDist2 = dist2Line2;
-          closest = closestPoint2;
-        }
-        unsigned int i = 0;
-        for (; i < PointDimension; ++i)
-        {
-          closestPoint[i] = closest[i];
-        }
-        for (; i < 3; ++i)
-        {
-          closestPoint[i] = 0.;
-        }
+        dist2Point += (x[i] - pt3[i]) * (x[i] - pt3[i]);
       }
-      else if (b2 < 0.0 && b3 < 0.0)
+      dist2Line1 = this->DistanceToLine(x, pt1, pt3, lt, closestPoint1);
+      dist2Line2 = this->DistanceToLine(x, pt3, pt2, lt, closestPoint2);
+      if (dist2Point < dist2Line1)
       {
-        dist2Point = 0;
-        for (unsigned int i = 0; i < PointDimension; ++i)
-        {
-          dist2Point += (x[i] - pt1[i]) * (x[i] - pt1[i]);
-        }
-        dist2Line1 = this->DistanceToLine(x, pt1, pt3, lt, closestPoint1);
-        dist2Line2 = this->DistanceToLine(x, pt1, pt2, lt, closestPoint2);
-        if (dist2Point < dist2Line1)
-        {
-          *minDist2 = dist2Point;
-          closest = pt1;
-        }
-        else
-        {
-          *minDist2 = dist2Line1;
-          closest = closestPoint1;
-        }
-        if (dist2Line2 < *minDist2)
-        {
-          *minDist2 = dist2Line2;
-          closest = closestPoint2;
-        }
-        unsigned int i = 0;
-        for (; i < PointDimension; ++i)
-        {
-          closestPoint[i] = closest[i];
-        }
-        for (; i < 3; ++i)
-        {
-          closestPoint[i] = 0.;
-        }
+        *minDist2 = dist2Point;
+        closest = pt3;
       }
-      else if (b1 < 0.0 && b3 < 0.0)
+      else
       {
-        dist2Point = 0;
-        for (unsigned int i = 0; i < PointDimension; ++i)
-        {
-          dist2Point += (x[i] - pt2[i]) * (x[i] - pt2[i]);
-        }
-        dist2Line1 = this->DistanceToLine(x, pt2, pt3, lt, closestPoint1);
-        dist2Line2 = this->DistanceToLine(x, pt1, pt2, lt, closestPoint2);
-        if (dist2Point < dist2Line1)
-        {
-          *minDist2 = dist2Point;
-          closest = pt2;
-        }
-        else
-        {
-          *minDist2 = dist2Line1;
-          closest = closestPoint1;
-        }
-        if (dist2Line2 < *minDist2)
-        {
-          *minDist2 = dist2Line2;
-          closest = closestPoint2;
-        }
-        unsigned int i = 0;
-        for (; i < PointDimension; ++i)
-        {
-          closestPoint[i] = closest[i];
-        }
-        for (; i < 3; ++i)
-        {
-          closestPoint[i] = 0.;
-        }
+        *minDist2 = dist2Line1;
+        closest = closestPoint1;
       }
-      else if (b1 < 0.0)
+      if (dist2Line2 < *minDist2)
       {
-        *minDist2 = this->DistanceToLine(x, pt2, pt3, lt, closestPoint);
+        *minDist2 = dist2Line2;
+        closest = closestPoint2;
       }
-      else if (b2 < 0.0)
+      unsigned int i = 0;
+      for (; i < PointDimension; ++i)
       {
-        *minDist2 = this->DistanceToLine(x, pt1, pt3, lt, closestPoint);
+        closestPoint[i] = closest[i];
       }
-      else if (b3 < 0.0)
+      for (; i < 3; ++i)
       {
-        *minDist2 = this->DistanceToLine(x, pt1, pt2, lt, closestPoint);
+        closestPoint[i] = 0.;
       }
     }
-    if (pcoord)
+    else if (b2 < 0.0 && b3 < 0.0)
     {
-      pcoord[0] = b1;
-      pcoord[1] = b2;
-      pcoord[2] = b3;
+      dist2Point = 0;
+      for (unsigned int i = 0; i < PointDimension; ++i)
+      {
+        dist2Point += (x[i] - pt1[i]) * (x[i] - pt1[i]);
+      }
+      dist2Line1 = this->DistanceToLine(x, pt1, pt3, lt, closestPoint1);
+      dist2Line2 = this->DistanceToLine(x, pt1, pt2, lt, closestPoint2);
+      if (dist2Point < dist2Line1)
+      {
+        *minDist2 = dist2Point;
+        closest = pt1;
+      }
+      else
+      {
+        *minDist2 = dist2Line1;
+        closest = closestPoint1;
+      }
+      if (dist2Line2 < *minDist2)
+      {
+        *minDist2 = dist2Line2;
+        closest = closestPoint2;
+      }
+      unsigned int i = 0;
+      for (; i < PointDimension; ++i)
+      {
+        closestPoint[i] = closest[i];
+      }
+      for (; i < 3; ++i)
+      {
+        closestPoint[i] = 0.;
+      }
     }
-    // Just fall through to default return false;
+    else if (b1 < 0.0 && b3 < 0.0)
+    {
+      dist2Point = 0;
+      for (unsigned int i = 0; i < PointDimension; ++i)
+      {
+        dist2Point += (x[i] - pt2[i]) * (x[i] - pt2[i]);
+      }
+      dist2Line1 = this->DistanceToLine(x, pt2, pt3, lt, closestPoint1);
+      dist2Line2 = this->DistanceToLine(x, pt1, pt2, lt, closestPoint2);
+      if (dist2Point < dist2Line1)
+      {
+        *minDist2 = dist2Point;
+        closest = pt2;
+      }
+      else
+      {
+        *minDist2 = dist2Line1;
+        closest = closestPoint1;
+      }
+      if (dist2Line2 < *minDist2)
+      {
+        *minDist2 = dist2Line2;
+        closest = closestPoint2;
+      }
+      unsigned int i = 0;
+      for (; i < PointDimension; ++i)
+      {
+        closestPoint[i] = closest[i];
+      }
+      for (; i < 3; ++i)
+      {
+        closestPoint[i] = 0.;
+      }
+    }
+    else if (b1 < 0.0)
+    {
+      *minDist2 = this->DistanceToLine(x, pt2, pt3, lt, closestPoint);
+    }
+    else if (b2 < 0.0)
+    {
+      *minDist2 = this->DistanceToLine(x, pt1, pt3, lt, closestPoint);
+    }
+    else if (b3 < 0.0)
+    {
+      *minDist2 = this->DistanceToLine(x, pt1, pt2, lt, closestPoint);
+    }
   }
+  if (pcoord)
+  {
+    pcoord[0] = b1;
+    pcoord[1] = b2;
+    pcoord[2] = b3;
+  }
+  // Just fall through to default return false;
+
   return false; // Default case that should never be reached.
 }
 } // end namespace itk

--- a/Modules/Core/Common/include/itkTriangleHelper.hxx
+++ b/Modules/Core/Common/include/itkTriangleHelper.hxx
@@ -34,22 +34,20 @@ TriangleHelper<TPoint>::IsObtuse(const PointType & iA, const PointType & iB, con
   {
     return true;
   }
+
+  if (v02 * v12 < 0.0)
+  {
+    return true;
+  }
   else
   {
-    if (v02 * v12 < 0.0)
+    if (v01 * -v12 < 0.0)
     {
       return true;
     }
     else
     {
-      if (v01 * -v12 < 0.0)
-      {
-        return true;
-      }
-      else
-      {
-        return false;
-      }
+      return false;
     }
   }
 }
@@ -235,18 +233,16 @@ TriangleHelper<TPoint>::ComputeMixedArea(const PointType & iP1, const PointType 
 
     return 0.125 * (sq_d02 * cot_theta_210 + sq_d01 * cot_theta_021);
   }
+
+  auto area = static_cast<CoordinateType>(TriangleType::ComputeArea(iP1, iP2, iP3));
+
+  if ((iP2 - iP1) * (iP3 - iP1) < CoordinateType{})
+  {
+    return 0.5 * area;
+  }
   else
   {
-    auto area = static_cast<CoordinateType>(TriangleType::ComputeArea(iP1, iP2, iP3));
-
-    if ((iP2 - iP1) * (iP3 - iP1) < CoordinateType{})
-    {
-      return 0.5 * area;
-    }
-    else
-    {
-      return 0.25 * area;
-    }
+    return 0.25 * area;
   }
 }
 } // namespace itk

--- a/Modules/Core/Common/include/itkValarrayImageContainer.h
+++ b/Modules/Core/Common/include/itkValarrayImageContainer.h
@@ -112,10 +112,8 @@ public:
     {
       return &(this->ValarrayType::operator[](0));
     }
-    else
-    {
-      return nullptr;
-    }
+
+    return nullptr;
   }
 
   /** Get the number of elements currently stored in the container. */

--- a/Modules/Core/Common/include/itkVertexCell.hxx
+++ b/Modules/Core/Common/include/itkVertexCell.hxx
@@ -174,14 +174,12 @@ VertexCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
     }
     return true;
   }
-  else
+
+  if (pcoord)
   {
-    if (pcoord)
-    {
-      pcoord[0] = -10.0;
-    }
-    return false;
+    pcoord[0] = -10.0;
   }
+  return false;
 }
 } // end namespace itk
 

--- a/Modules/Core/Common/src/itkBuildInformation.cxx.in
+++ b/Modules/Core/Common/src/itkBuildInformation.cxx.in
@@ -87,7 +87,7 @@ BuildInformation::GetValue(const MapKeyType & key)
   {
     return it->second.m_Value;
   }
-  return {""};
+  return {};;
 }
 
 const BuildInformation::MapValueDescriptionType
@@ -100,7 +100,7 @@ BuildInformation::GetDescription(const MapKeyType & key)
   {
     return it->second.m_Description;
   }
-  return {""};
+  return {};;
 }
 
 const std::vector<  BuildInformation::MapKeyType >

--- a/Modules/Core/Common/src/itkDataObject.cxx
+++ b/Modules/Core/Common/src/itkDataObject.cxx
@@ -215,11 +215,9 @@ DataObject::DisconnectSource(ProcessObject * arg, const DataObjectIdentifierType
     this->Modified();
     return true;
   }
-  else
-  {
-    itkDebugMacro("could not disconnect source  " << arg << ", source output name " << name);
-    return false;
-  }
+
+  itkDebugMacro("could not disconnect source  " << arg << ", source output name " << name);
+  return false;
 }
 
 bool
@@ -234,12 +232,10 @@ DataObject::ConnectSource(ProcessObject * arg, const DataObjectIdentifierType & 
     this->Modified();
     return true;
   }
-  else
-  {
-    itkDebugMacro("could not connect source  " << arg << ", source output name " << name);
 
-    return false;
-  }
+  itkDebugMacro("could not connect source  " << arg << ", source output name " << name);
+
+  return false;
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Core/Common/src/itkEquivalencyTable.cxx
+++ b/Modules/Core/Common/src/itkEquivalencyTable.cxx
@@ -26,7 +26,7 @@ EquivalencyTable::Add(unsigned long a, unsigned long b)
   {
     return false;
   }
-  else if (a < b)
+  if (a < b)
   { // swap a, b
     const unsigned long temp = a;
     a = b;
@@ -40,10 +40,8 @@ EquivalencyTable::Add(unsigned long a, unsigned long b)
     {
       return false;
     }
-    else
-    {
-      return (this->Add((*(result.first)).second, b));
-    }
+
+    return (this->Add((*(result.first)).second, b));
   }
   else
   {
@@ -58,7 +56,7 @@ EquivalencyTable::AddAndFlatten(unsigned long a, unsigned long b)
   {
     return false;
   }
-  else if (a < b)
+  if (a < b)
   { // swap a, b
     const unsigned long temp = a;
     a = b;
@@ -74,10 +72,8 @@ EquivalencyTable::AddAndFlatten(unsigned long a, unsigned long b)
     {
       return false;
     }
-    else
-    {
-      return (this->Add((*(result.first)).second, bFlattened));
-    }
+
+    return (this->Add((*(result.first)).second, bFlattened));
   }
   else
   {

--- a/Modules/Core/Common/src/itkExceptionObject.cxx
+++ b/Modules/Core/Common/src/itkExceptionObject.cxx
@@ -91,12 +91,10 @@ ExceptionObject::operator==(const ExceptionObject & orig) const
   {
     return true;
   }
-  else
-  {
-    return (thisData != nullptr) && (origData != nullptr) && thisData->m_Location == origData->m_Location &&
-           thisData->m_Description == origData->m_Description && thisData->m_File == origData->m_File &&
-           thisData->m_Line == origData->m_Line;
-  }
+
+  return (thisData != nullptr) && (origData != nullptr) && thisData->m_Location == origData->m_Location &&
+         thisData->m_Description == origData->m_Description && thisData->m_File == origData->m_File &&
+         thisData->m_Line == origData->m_Line;
 }
 
 void

--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -199,7 +199,7 @@ MultiThreaderBase::ThreaderTypeFromString(std::string threaderString)
   {
     return ThreaderEnum::Platform;
   }
-  else if (threaderString == "POOL")
+  if (threaderString == "POOL")
   {
     return ThreaderEnum::Pool;
   }

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -588,11 +588,9 @@ ObjectFactoryBase::RegisterFactory(ObjectFactoryBase * factory, InsertionPositio
         m_PimplGlobals->m_RegisteredFactories.insert(fitr, factory);
         break;
       }
-      else
-      {
-        itkGenericExceptionMacro("Position" << position << " is outside range. \
+
+      itkGenericExceptionMacro("Position" << position << " is outside range. \
           Only " << numberOfFactories << " factories are registered");
-      }
     }
   }
   factory->Register();

--- a/Modules/Core/Common/src/itkOctreeNode.cxx
+++ b/Modules/Core/Common/src/itkOctreeNode.cxx
@@ -95,10 +95,8 @@ OctreeNode::IsNodeColored() const
 
     return this->m_Branch >= first && this->m_Branch <= last;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 void

--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -1053,10 +1053,8 @@ ProcessObject::MakeNameFromIndex(DataObjectPointerArraySizeType idx) const
   {
     return { globalIndexNames[idx] };
   }
-  else
-  {
-    return '_' + std::to_string(idx);
-  }
+
+  return '_' + std::to_string(idx);
 }
 
 

--- a/Modules/Core/Common/test/itkCMakeConfigurationTest.cxx
+++ b/Modules/Core/Common/test/itkCMakeConfigurationTest.cxx
@@ -49,10 +49,9 @@ itkCMakeInformationPrintFile(const char * name, std::ostream & os)
     os << " does not exist.\n";
     return;
   }
-  else
-  {
-    os << " has " << fs.st_size << " bytes";
-  }
+
+  os << " has " << fs.st_size << " bytes";
+
 
   const std::ifstream fin(name);
   if (fin)

--- a/Modules/Core/Common/test/itkFilterDispatchTest.cxx
+++ b/Modules/Core/Common/test/itkFilterDispatchTest.cxx
@@ -255,9 +255,7 @@ itkFilterDispatchTest(int, char *[])
     std::cout << "The test has passed." << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "The test has failed." << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "The test has failed." << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Core/Common/test/itkGaussianDerivativeOperatorTest.cxx
+++ b/Modules/Core/Common/test/itkGaussianDerivativeOperatorTest.cxx
@@ -118,7 +118,7 @@ itkGaussianDerivativeOperatorTest(int argc, char * argv[])
     std::cout << "Test finished." << std::endl;
     return EXIT_SUCCESS;
   }
-  else if (argc > 1)
+  if (argc > 1)
   {
     std::cerr << "Missing Parameters." << std::endl;
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " [variance error width order spacing]"
@@ -177,8 +177,6 @@ itkGaussianDerivativeOperatorTest(int argc, char * argv[])
   {
     return EXIT_SUCCESS;
   }
-  else
-  {
-    return EXIT_FAILURE;
-  }
+
+  return EXIT_FAILURE;
 }

--- a/Modules/Core/Common/test/itkImageRegionTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionTest.cxx
@@ -350,9 +350,7 @@ itkImageRegionTest(int, char *[])
     std::cout << "ImageRegion test passed." << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "ImageRegion test failed." << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "ImageRegion test failed." << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Core/Common/test/itkImportImageTest.cxx
+++ b/Modules/Core/Common/test/itkImportImageTest.cxx
@@ -121,9 +121,7 @@ itkImportImageTest(int, char *[])
     std::cout << "ImportImageFilter test passed." << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "ImportImageFilter test failed." << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "ImportImageFilter test failed." << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Core/Common/test/itkIteratorTests.cxx
+++ b/Modules/Core/Common/test/itkIteratorTests.cxx
@@ -172,9 +172,7 @@ itkIteratorTests(int, char *[])
     std::cout << "Iterator tests passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Iterator tests failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Iterator tests failed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Core/Common/test/itkLightObjectTest.cxx
+++ b/Modules/Core/Common/test/itkLightObjectTest.cxx
@@ -51,11 +51,10 @@ itkLightObjectTest(int, char *[])
       std::cout << "Test FAILED !" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cout << "After assignment to another SmartPointer" << std::endl;
-      std::cout << "reference count is:  " << counts2 << std::endl;
-    }
+
+    std::cout << "After assignment to another SmartPointer" << std::endl;
+    std::cout << "reference count is:  " << counts2 << std::endl;
+
   } // terminate the scope for the SmartPointer. Reference count should
     // decrement at this point.
 
@@ -66,11 +65,10 @@ itkLightObjectTest(int, char *[])
     std::cout << "Test FAILED !" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "After destroying one SmartPointer" << std::endl;
-    std::cout << "reference count is:  " << counts3 << std::endl;
-  }
+
+  std::cout << "After destroying one SmartPointer" << std::endl;
+  std::cout << "reference count is:  " << counts3 << std::endl;
+
 
   std::cout << "Test PASSED !" << std::endl;
 

--- a/Modules/Core/Common/test/itkMathCastWithRangeCheckTest.cxx
+++ b/Modules/Core/Common/test/itkMathCastWithRangeCheckTest.cxx
@@ -158,8 +158,6 @@ itkMathCastWithRangeCheckTest(int, char *[])
   {
     return EXIT_SUCCESS;
   }
-  else
-  {
-    return EXIT_FAILURE;
-  }
+
+  return EXIT_FAILURE;
 }

--- a/Modules/Core/Common/test/itkMathRoundTest.cxx
+++ b/Modules/Core/Common/test/itkMathRoundTest.cxx
@@ -198,9 +198,7 @@ itkMathRoundTest(int, char *[])
   {
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "Test passed" << std::endl;
-    return EXIT_SUCCESS;
-  }
+
+  std::cout << "Test passed" << std::endl;
+  return EXIT_SUCCESS;
 }

--- a/Modules/Core/Common/test/itkMathRoundTest2.cxx
+++ b/Modules/Core/Common/test/itkMathRoundTest2.cxx
@@ -133,9 +133,7 @@ itkMathRoundTest2(int, char *[])
   {
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "Test passed" << std::endl;
-    return EXIT_SUCCESS;
-  }
+
+  std::cout << "Test passed" << std::endl;
+  return EXIT_SUCCESS;
 }

--- a/Modules/Core/Common/test/itkMultiThreaderTypeFromEnvironmentTest.cxx
+++ b/Modules/Core/Common/test/itkMultiThreaderTypeFromEnvironmentTest.cxx
@@ -92,8 +92,6 @@ itkMultiThreaderTypeFromEnvironmentTest(int argc, char * argv[])
     std::cout << "Test PASSED!" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    return EXIT_FAILURE;
-  }
+
+  return EXIT_FAILURE;
 }

--- a/Modules/Core/Common/test/itkPhasedArray3DSpecialCoordinatesImageTest.cxx
+++ b/Modules/Core/Common/test/itkPhasedArray3DSpecialCoordinatesImageTest.cxx
@@ -103,9 +103,7 @@ itkPhasedArray3DSpecialCoordinatesImageTest(int, char *[])
     std::cout << "PhasedArray3DSpecialCoordinatesImage tests passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "PhasedArray3DSpecialCoordinatesImage tests failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "PhasedArray3DSpecialCoordinatesImage tests failed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Core/Common/test/itkSTLThreadTest.cxx
+++ b/Modules/Core/Common/test/itkSTLThreadTest.cxx
@@ -196,11 +196,9 @@ Thread(int tnum)
     // Success.
     return EXIT_FAILURE;
   }
-  else
-  {
-    // Failure.
-    return EXIT_SUCCESS;
-  }
+
+  // Failure.
+  return EXIT_SUCCESS;
 }
 
 } // namespace itkSTLThreadTestImpl

--- a/Modules/Core/Common/test/itkSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkSpatialFunctionTest.cxx
@@ -61,8 +61,6 @@ itkSpatialFunctionTest(int, char *[])
   {
     return EXIT_SUCCESS;
   }
-  else
-  {
-    return EXIT_FAILURE;
-  }
+
+  return EXIT_FAILURE;
 }

--- a/Modules/Core/Common/test/itkStreamingImageFilterTest.cxx
+++ b/Modules/Core/Common/test/itkStreamingImageFilterTest.cxx
@@ -142,9 +142,7 @@ itkStreamingImageFilterTest(int, char *[])
     std::cout << "ImageStreamingFilter test passed." << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "ImageStreaming Filter test failed." << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "ImageStreaming Filter test failed." << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Core/Common/test/itkVectorTest.cxx
+++ b/Modules/Core/Common/test/itkVectorTest.cxx
@@ -241,9 +241,7 @@ itkVectorTest(int, char *[])
     std::cout << "Vector test passed." << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Vector test failed." << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Vector test failed." << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.hxx
@@ -145,21 +145,19 @@ FiniteDifferenceImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRe
     inputPtr->SetRequestedRegion(inputRequestedRegion);
     return;
   }
-  else
-  {
-    // Couldn't crop the region (requested region is outside the largest
-    // possible region).  Throw an exception.
 
-    // store what we tried to request (prior to trying to crop)
-    inputPtr->SetRequestedRegion(inputRequestedRegion);
+  // Couldn't crop the region (requested region is outside the largest
+  // possible region).  Throw an exception.
 
-    // build an exception
-    InvalidRequestedRegionError e(__FILE__, __LINE__);
-    e.SetLocation(ITK_LOCATION);
-    e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
-    e.SetDataObject(inputPtr);
-    throw e;
-  }
+  // store what we tried to request (prior to trying to crop)
+  inputPtr->SetRequestedRegion(inputRequestedRegion);
+
+  // build an exception
+  InvalidRequestedRegionError e(__FILE__, __LINE__);
+  e.SetLocation(ITK_LOCATION);
+  e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
+  e.SetDataObject(inputPtr);
+  throw e;
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -225,7 +223,7 @@ FiniteDifferenceImageFilter<TInputImage, TOutputImage>::Halt()
   {
     return true;
   }
-  else if (this->GetElapsedIterations() == 0)
+  if (this->GetElapsedIterations() == 0)
   {
     return false;
   }

--- a/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
@@ -171,7 +171,7 @@ private:
     {
       return (static_cast<OutputType>(val00));
     }
-    else if (distance1 <= 0.) // if they have the same "y"
+    if (distance1 <= 0.) // if they have the same "y"
     {
       ++basei[0]; // then interpolate across "x"
       if (basei[0] > this->m_EndIndex[0])
@@ -256,7 +256,7 @@ private:
 
         return static_cast<OutputType>(val000 + (val100 - val000) * distance0);
       }
-      else if (distance0 <= 0.) // interpolate across "y"
+      if (distance0 <= 0.) // interpolate across "y"
       {
         ++basei[1];
         if (basei[1] > this->m_EndIndex[1])
@@ -313,39 +313,37 @@ private:
 
           return static_cast<OutputType>(val000 + (val001 - val000) * distance2);
         }
-        else // interpolate across "xz"
+        // interpolate across "xz"
+        ++basei[0];
+        if (basei[0] > this->m_EndIndex[0]) // interpolate across "z"
         {
-          ++basei[0];
-          if (basei[0] > this->m_EndIndex[0]) // interpolate across "z"
-          {
-            --basei[0];
-            ++basei[2];
-            if (basei[2] > this->m_EndIndex[2])
-            {
-              return (static_cast<OutputType>(val000));
-            }
-            const RealType & val001 = inputImagePtr->GetPixel(basei);
-
-            return static_cast<OutputType>(val000 + (val001 - val000) * distance2);
-          }
-          const RealType & val100 = inputImagePtr->GetPixel(basei);
-
-          const RealType & valx00 = val000 + (val100 - val000) * distance0;
-
-          ++basei[2];
-          if (basei[2] > this->m_EndIndex[2]) // interpolate across "x"
-          {
-            return (static_cast<OutputType>(valx00));
-          }
-          const RealType & val101 = inputImagePtr->GetPixel(basei);
-
           --basei[0];
+          ++basei[2];
+          if (basei[2] > this->m_EndIndex[2])
+          {
+            return (static_cast<OutputType>(val000));
+          }
           const RealType & val001 = inputImagePtr->GetPixel(basei);
 
-          const RealType & valx01 = val001 + (val101 - val001) * distance0;
-
-          return static_cast<OutputType>(valx00 + (valx01 - valx00) * distance2);
+          return static_cast<OutputType>(val000 + (val001 - val000) * distance2);
         }
+        const RealType & val100 = inputImagePtr->GetPixel(basei);
+
+        const RealType & valx00 = val000 + (val100 - val000) * distance0;
+
+        ++basei[2];
+        if (basei[2] > this->m_EndIndex[2]) // interpolate across "x"
+        {
+          return (static_cast<OutputType>(valx00));
+        }
+        const RealType & val101 = inputImagePtr->GetPixel(basei);
+
+        --basei[0];
+        const RealType & val001 = inputImagePtr->GetPixel(basei);
+
+        const RealType & valx01 = val001 + (val101 - val001) * distance0;
+
+        return static_cast<OutputType>(valx00 + (valx01 - valx00) * distance2);
       }
       else if (distance0 <= 0.) // interpolate across "yz"
       {

--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
@@ -111,10 +111,8 @@ public:
                        m_VoxelIncrement[1] * spacing[1] * m_VoxelIncrement[1] * spacing[1] +
                        m_VoxelIncrement[2] * spacing[2] * m_VoxelIncrement[2] * spacing[2]);
     }
-    else
-    {
-      return 0.;
-    }
+
+    return 0.;
   }
 
   /// Set the initial zero state of the object
@@ -655,10 +653,8 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::CalcRa
   {
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 /* -----------------------------------------------------------------------

--- a/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
@@ -677,11 +677,9 @@ itkBSplineInterpolateImageFunctionTest(int itkNotUsed(argc), char * itkNotUsed(a
 
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "All tests successfully passed" << std::endl;
-    return EXIT_SUCCESS;
-  }
+
+  std::cout << "All tests successfully passed" << std::endl;
+  return EXIT_SUCCESS;
 }
 
 void

--- a/Modules/Core/ImageFunction/test/itkBinaryThresholdImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBinaryThresholdImageFunctionTest.cxx
@@ -128,9 +128,8 @@ itkBinaryThresholdImageFunctionTest(int, char *[])
     std::cout << "Failed!" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "Passed!" << std::endl;
-  }
+
+  std::cout << "Passed!" << std::endl;
+
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/ImageFunction/test/itkImageAdaptorInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkImageAdaptorInterpolateImageFunctionTest.cxx
@@ -330,10 +330,9 @@ itkImageAdaptorInterpolateImageFunctionTest(int, char *[])
     std::cout << "*** Some test failed" << std::endl;
     return flag;
   }
-  else
-  {
-    std::cout << "All tests successfully passed" << std::endl;
-  }
+
+  std::cout << "All tests successfully passed" << std::endl;
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/ImageFunction/test/itkInterpolateTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkInterpolateTest.cxx
@@ -367,10 +367,9 @@ itkInterpolateTest(int, char *[])
     std::cout << "*** Some test failed" << std::endl;
     return flag;
   }
-  else
-  {
-    std::cout << "All tests successfully passed" << std::endl;
-  }
+
+  std::cout << "All tests successfully passed" << std::endl;
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/ImageFunction/test/itkRGBInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkRGBInterpolateImageFunctionTest.cxx
@@ -341,10 +341,9 @@ itkRGBInterpolateImageFunctionTest(int, char *[])
     std::cout << "*** Some test failed" << std::endl;
     return flag;
   }
-  else
-  {
-    std::cout << "All tests successfully passed" << std::endl;
-  }
+
+  std::cout << "All tests successfully passed" << std::endl;
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/ImageFunction/test/itkVectorInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkVectorInterpolateImageFunctionTest.cxx
@@ -344,10 +344,9 @@ itkVectorInterpolateImageFunctionTest(int, char *[])
     std::cout << "*** Some test failed" << std::endl;
     return flag;
   }
-  else
-  {
-    std::cout << "All tests successfully passed" << std::endl;
-  }
+
+  std::cout << "All tests successfully passed" << std::endl;
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/ImageFunction/test/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunctionTest.cxx
@@ -363,10 +363,9 @@ itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunctionTest(int, char 
     std::cout << "*** Some test failed" << std::endl;
     return flag;
   }
-  else
-  {
-    std::cout << "All tests successfully passed" << std::endl;
-  }
+
+  std::cout << "All tests successfully passed" << std::endl;
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
@@ -2473,20 +2473,18 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddNodes(int               ind
         {
           continue;
         }
-        else
+
+        if (nodesid[i] == 9)
         {
-          if (nodesid[i] == 9)
-          {
-            globalnodesid[i] = this->SearchThroughLastRow((index % m_ImageWidth) * 13 - 3, 0, m_LastRowNum - 1);
-          }
-          if (nodesid[i] == 10)
-          {
-            globalnodesid[i] = this->SearchThroughLastRow((index % m_ImageWidth) * 13 + 22, 0, m_LastRowNum - 1);
-          }
-          if (m_PointFound != 0)
-          {
-            continue;
-          }
+          globalnodesid[i] = this->SearchThroughLastRow((index % m_ImageWidth) * 13 - 3, 0, m_LastRowNum - 1);
+        }
+        if (nodesid[i] == 10)
+        {
+          globalnodesid[i] = this->SearchThroughLastRow((index % m_ImageWidth) * 13 + 22, 0, m_LastRowNum - 1);
+        }
+        if (m_PointFound != 0)
+        {
+          continue;
         }
       }
       if ((m_LastFrameNum != 0) && ((nodesid[i] == 1) || (nodesid[i] == 2) || (nodesid[i] == 3) || (nodesid[i] == 4)))
@@ -2497,22 +2495,20 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddNodes(int               ind
         {
           continue;
         }
-        else
+
+        if (nodesid[i] == 4)
         {
-          if (nodesid[i] == 4)
-          {
-            globalnodesid[i] =
-              this->SearchThroughLastFrame((index % (m_ImageWidth * m_ImageHeight)) * 13 - 11, 0, m_LastFrameNum - 1);
-          }
-          if (nodesid[i] == 1)
-          {
-            globalnodesid[i] = this->SearchThroughLastFrame(
-              (index % (m_ImageWidth * m_ImageHeight) - m_ImageWidth) * 13 + 3, 0, m_LastFrameNum - 1);
-          }
-          if (m_PointFound != 0)
-          {
-            continue;
-          }
+          globalnodesid[i] =
+            this->SearchThroughLastFrame((index % (m_ImageWidth * m_ImageHeight)) * 13 - 11, 0, m_LastFrameNum - 1);
+        }
+        if (nodesid[i] == 1)
+        {
+          globalnodesid[i] = this->SearchThroughLastFrame(
+            (index % (m_ImageWidth * m_ImageHeight) - m_ImageWidth) * 13 + 3, 0, m_LastFrameNum - 1);
+        }
+        if (m_PointFound != 0)
+        {
+          continue;
         }
       }
     }
@@ -2598,16 +2594,14 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::SearchThroughLastRow(int index
       m_PointFound = 1;
       return m_LastRow[mid][1];
     }
+
+    if (lindex > m_LastRow[mid][0])
+    {
+      return this->SearchThroughLastRow(index, mid + 1, end);
+    }
     else
     {
-      if (lindex > m_LastRow[mid][0])
-      {
-        return this->SearchThroughLastRow(index, mid + 1, end);
-      }
-      else
-      {
-        return this->SearchThroughLastRow(index, start, mid);
-      }
+      return this->SearchThroughLastRow(index, start, mid);
     }
   }
   else

--- a/Modules/Core/Mesh/include/itkMesh.hxx
+++ b/Modules/Core/Mesh/include/itkMesh.hxx
@@ -492,10 +492,8 @@ Mesh<TPixelType, VDimension, TMeshTraits>::RemoveBoundaryAssignment(int         
     m_BoundaryAssignmentsContainers[dimension]->DeleteIndex(assignId);
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
@@ -536,10 +534,8 @@ Mesh<TPixelType, VDimension, TMeshTraits>::GetNumberOfCells() const -> CellIdent
   {
     return 0;
   }
-  else
-  {
-    return m_CellsContainer->Size();
-  }
+
+  return m_CellsContainer->Size();
 }
 
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>
@@ -584,11 +580,9 @@ Mesh<TPixelType, VDimension, TMeshTraits>::GetCellBoundaryFeature(int           
     {
       return true;
     }
-    else
-    {
-      boundary.Reset();
-      return false;
-    }
+
+    boundary.Reset();
+    return false;
   }
 
   /**

--- a/Modules/Core/Mesh/include/itkSimplexMesh.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMesh.hxx
@@ -273,54 +273,52 @@ SimplexMesh<TPixelType, VDimension, TMeshTraits>::GetNeighbors(PointIdentifier  
 
     return list;
   }
+
+  IndexArray neighborArray = GetNeighbors(idx);
+
+  auto foundIt1 = std::find(list->begin(), list->end(), neighborArray[0]);
+  auto foundIt2 = std::find(list->begin(), list->end(), neighborArray[1]);
+  auto foundIt3 = std::find(list->begin(), list->end(), neighborArray[2]);
+  auto endIt = list->end();
+  bool found1 = false;
+  if (foundIt1 != endIt)
+  {
+    found1 = true;
+  }
+  bool found2 = false;
+  if (foundIt2 != endIt)
+  {
+    found2 = true;
+  }
+  bool found3 = false;
+  if (foundIt3 != endIt)
+  {
+    found3 = true;
+  }
+
+  if (!found1)
+  {
+    list->push_back(neighborArray[0]);
+  }
+  if (!found2)
+  {
+    list->push_back(neighborArray[1]);
+  }
+  if (!found3)
+  {
+    list->push_back(neighborArray[2]);
+  }
+
+  if (radius == 0)
+  {
+    return list;
+  }
   else
   {
-    IndexArray neighborArray = GetNeighbors(idx);
-
-    auto foundIt1 = std::find(list->begin(), list->end(), neighborArray[0]);
-    auto foundIt2 = std::find(list->begin(), list->end(), neighborArray[1]);
-    auto foundIt3 = std::find(list->begin(), list->end(), neighborArray[2]);
-    auto endIt = list->end();
-    bool found1 = false;
-    if (foundIt1 != endIt)
-    {
-      found1 = true;
-    }
-    bool found2 = false;
-    if (foundIt2 != endIt)
-    {
-      found2 = true;
-    }
-    bool found3 = false;
-    if (foundIt3 != endIt)
-    {
-      found3 = true;
-    }
-
-    if (!found1)
-    {
-      list->push_back(neighborArray[0]);
-    }
-    if (!found2)
-    {
-      list->push_back(neighborArray[1]);
-    }
-    if (!found3)
-    {
-      list->push_back(neighborArray[2]);
-    }
-
-    if (radius == 0)
-    {
-      return list;
-    }
-    else
-    {
-      list = GetNeighbors(neighborArray[0], radius - 1, list);
-      list = GetNeighbors(neighborArray[1], radius - 1, list);
-      list = GetNeighbors(neighborArray[2], radius - 1, list);
-      return list;
-    }
+    list = GetNeighbors(neighborArray[0], radius - 1, list);
+    list = GetNeighbors(neighborArray[1], radius - 1, list);
+    list = GetNeighbors(neighborArray[2], radius - 1, list);
+    return list;
   }
 }
 

--- a/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
@@ -119,10 +119,8 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::ComparePoints2D(Point
   {
     return (a[0] < b[0]);
   }
-  else
-  {
-    return (a[1] < b[1]);
-  }
+
+  return (a[1] < b[1]);
 }
 
 template <typename TInputMesh, typename TOutputImage>
@@ -413,10 +411,9 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::RasterizeTriangles()
       {
         continue; // this is a peripheral point in the zy projection plane
       }
-      else
-      {
-        std::sort(xlist.begin(), xlist.end(), ComparePoints1D);
-      }
+
+      std::sort(xlist.begin(), xlist.end(), ComparePoints1D);
+
       // get the first entry
       double lastx = xlist[0].m_X;
       int    lastSign = xlist[0].m_Sign;

--- a/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
@@ -338,7 +338,7 @@ TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::CreateCells()
             wrongIdx = compare.first;
             break;
           }
-          else if (compare.second == lastIdx && compare.first != wrongIdx)
+          if (compare.second == lastIdx && compare.first != wrongIdx)
           {
             tmpMap->InsertElement(compare.second, compare.first);
             lastIdx = compare.first;
@@ -387,10 +387,9 @@ TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::CreateCells()
       {
         break;
       }
-      else
-      {
-        nextIdx = newIdx;
-      }
+
+      nextIdx = newIdx;
+
       ++featureId;
     }
     ++points;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
@@ -416,10 +416,9 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::FindFirstUnusedPointIndex() -> PointI
         m_FreePointIndexes.pop();
         return (pid);
       }
-      else
-      {
-        m_FreePointIndexes.pop();
-      }
+
+      m_FreePointIndexes.pop();
+
     } while (!m_FreePointIndexes.empty());
   }
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.hxx
@@ -278,10 +278,8 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::ProcessIsolatedFace
   {
     return temp;
   }
-  else
-  {
-    return this->m_Mesh->FindEdge(org);
-  }
+
+  return this->m_Mesh->FindEdge(org);
 }
 
 template <typename TMesh, typename TQEType>
@@ -567,25 +565,23 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::IsEdgeLinkingTwoDif
   {
     return false;
   }
+
+  t = e->GetSym();
+  e_it = t;
+  bool dest_border;
+  do
+  {
+    dest_border = e_it->IsAtBorder();
+    e_it = e_it->GetOnext();
+  } while ((e_it != t) && (!dest_border));
+
+  if (!dest_border)
+  {
+    return false;
+  }
   else
   {
-    t = e->GetSym();
-    e_it = t;
-    bool dest_border;
-    do
-    {
-      dest_border = e_it->IsAtBorder();
-      e_it = e_it->GetOnext();
-    } while ((e_it != t) && (!dest_border));
-
-    if (!dest_border)
-    {
-      return false;
-    }
-    else
-    {
-      return true;
-    }
+    return true;
   }
 }
 

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.hxx
@@ -99,21 +99,19 @@ QuadEdgeMeshFrontBaseIterator<TMesh, TQE>::operator++()
     {
       continue;
     }
-    else
-    {
-      // Mark the destination as visited:
-      m_IsPointVisited->SetElement(oEdge->GetDestination(), true);
 
-      // Compute the Cost of the new OriginType:
-      const CoordinateType oCost = this->GetCost(oEdge) + fit->m_Cost;
+    // Mark the destination as visited:
+    m_IsPointVisited->SetElement(oEdge->GetDestination(), true);
 
-      // Push the Sym() on the front:
-      m_Front->push_back(FrontAtom(oEdge->GetSym(), oCost));
+    // Compute the Cost of the new OriginType:
+    const CoordinateType oCost = this->GetCost(oEdge) + fit->m_Cost;
 
-      // We still want to handle oEdge
-      m_CurrentEdge = oEdge;
-      return (*this);
-    }
+    // Push the Sym() on the front:
+    m_Front->push_back(FrontAtom(oEdge->GetSym(), oCost));
+
+    // We still want to handle oEdge
+    m_CurrentEdge = oEdge;
+    return (*this);
   }
 
   // All the edge->Origin() neighbours were already visited. Remove

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.h
@@ -207,10 +207,8 @@ public:
     {
       return (static_cast<PointIdIterator>(nullptr));
     }
-    else
-    {
-      return &m_PointIds.front();
-    }
+
+    return &m_PointIds.front();
   }
 
   PointIdIterator
@@ -221,10 +219,8 @@ public:
     {
       return (static_cast<PointIdIterator>(nullptr));
     }
-    else
-    {
-      return &m_PointIds.back() + 1;
-    }
+
+    return &m_PointIds.back() + 1;
   }
 
   PointIdConstIterator
@@ -236,10 +232,8 @@ public:
     {
       return (static_cast<PointIdIterator>(nullptr));
     }
-    else
-    {
-      return &m_PointIds.front();
-    }
+
+    return &m_PointIds.front();
   }
 
   PointIdConstIterator
@@ -250,10 +244,8 @@ public:
     {
       return (static_cast<PointIdIterator>(nullptr));
     }
-    else
-    {
-      return &m_PointIds.back() + 1;
-    }
+
+    return &m_PointIds.back() + 1;
   }
 
   /** QuadEdge internal flavor of cell API */

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.hxx
@@ -135,10 +135,8 @@ QuadEdgeMeshPolygonCell<TCellInterface>::GetNumberOfPoints() const
   {
     return n;
   }
-  else
-  {
-    return 0;
-  }
+
+  return 0;
 }
 
 // ---------------------------------------------------------------------

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
@@ -64,7 +64,7 @@ DTITubeSpatialObjectPoint<TPointDimension>::TranslateEnumToChar(DTITubeSpatialOb
       // Just fall through.
       break;
   }
-  return { "" };
+  return {};
 }
 
 template <unsigned int TPointDimension>

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -159,10 +159,8 @@ SpatialObject<TDimension>::IsInsideInObjectSpace(const PointType &   point,
   {
     return Self::IsInsideChildrenInObjectSpace(point, depth - 1, name);
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 template <unsigned int TDimension>
@@ -219,16 +217,14 @@ SpatialObject<TDimension>::IsEvaluableAtInObjectSpace(const PointType &   point,
   {
     return true;
   }
+
+  if (depth > 0)
+  {
+    return IsEvaluableAtChildrenInObjectSpace(point, depth - 1, name);
+  }
   else
   {
-    if (depth > 0)
-    {
-      return IsEvaluableAtChildrenInObjectSpace(point, depth - 1, name);
-    }
-    else
-    {
-      return false;
-    }
+    return false;
   }
 }
 
@@ -274,11 +270,9 @@ SpatialObject<TDimension>::ValueAtInObjectSpace(const PointType &   point,
       value = m_DefaultInsideValue;
       return true;
     }
-    else
-    {
-      value = m_DefaultOutsideValue;
-      return true;
-    }
+
+    value = m_DefaultOutsideValue;
+    return true;
   }
   else
   {
@@ -445,10 +439,8 @@ SpatialObject<TDimension>::RemoveChild(Self * pointer)
 
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 template <unsigned int TDimension>

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
@@ -90,10 +90,8 @@ SpatialObjectPoint<TPointDimension>::GetTagScalarValue(const std::string & tag, 
     value = iter->second;
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 template <unsigned int TPointDimension>

--- a/Modules/Core/SpatialObjects/src/itkSpatialObjectProperty.cxx
+++ b/Modules/Core/SpatialObjects/src/itkSpatialObjectProperty.cxx
@@ -113,10 +113,8 @@ SpatialObjectProperty::GetTagScalarValue(const std::string & tag, double & value
     value = it->second;
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 bool
@@ -128,10 +126,8 @@ SpatialObjectProperty::GetTagStringValue(const std::string & tag, std::string & 
     value = it->second;
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 

--- a/Modules/Core/SpatialObjects/test/itkBlobSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkBlobSpatialObjectTest.cxx
@@ -77,10 +77,9 @@ itkBlobSpatialObjectTest(int, char *[])
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
 
   // Point consistency
   std::cout << "Point consistency: ";

--- a/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
@@ -88,10 +88,9 @@ itkDTITubeSpatialObjectTest(int, char *[])
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
 
   TubeType::CovariantVectorType derivative;
 
@@ -113,10 +112,9 @@ itkDTITubeSpatialObjectTest(int, char *[])
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
 
   std::cout << "itkTubeSpatialObjectTest ";
   if (passed)
@@ -169,10 +167,9 @@ itkDTITubeSpatialObjectTest(int, char *[])
     std::cout << "[FAILED] [" << nbChildren << "!= 3]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
 
   // testing the RemoveChild() function...
   std::cout << "Removing 1" << std::endl;
@@ -190,10 +187,9 @@ itkDTITubeSpatialObjectTest(int, char *[])
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
 
   tubeNet1->AddChild(tube1);
   tubeNet1->AddChild(tube2);
@@ -232,10 +228,9 @@ itkDTITubeSpatialObjectTest(int, char *[])
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
 
   tubeNet1->RemoveChild(tube1);
   tubeNet1->RemoveChild(tube2);
@@ -277,10 +272,9 @@ itkDTITubeSpatialObjectTest(int, char *[])
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
 
   tubeNet1->Update();
 
@@ -290,10 +284,9 @@ itkDTITubeSpatialObjectTest(int, char *[])
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
 
   auto translation = itk::MakeFilled<Vector>(10);
   tubeNet1->GetModifiableObjectToParentTransform()->Translate(translation, false);
@@ -323,10 +316,9 @@ itkDTITubeSpatialObjectTest(int, char *[])
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
 
   std::cout << "DerivativeAt()...";
   try

--- a/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
@@ -107,10 +107,9 @@ itkImageSpatialObjectTest(int, char *[])
     std::cerr << " differs from " << returnedValue << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
 
   ImageSpatialObject::DerivativeVectorType derivative;
   imageSO->DerivativeAtInWorldSpace(q, 1, derivative);
@@ -148,10 +147,8 @@ itkImageSpatialObjectTest(int, char *[])
     std::cerr << " by more than " << epsilon << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
 
 
   imageSO->DerivativeAtInWorldSpace(q, 1, derivative);
@@ -172,10 +169,8 @@ itkImageSpatialObjectTest(int, char *[])
     std::cerr << " by more than " << epsilon << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
 
 
   std::cout << "Test finished." << std::endl;

--- a/Modules/Core/SpatialObjects/test/itkLandmarkSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkLandmarkSpatialObjectTest.cxx
@@ -71,10 +71,9 @@ itkLandmarkSpatialObjectTest(int, char *[])
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
 
   // Point consistency
   std::cout << "Point consistency: ";

--- a/Modules/Core/SpatialObjects/test/itkLineSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkLineSpatialObjectTest.cxx
@@ -74,10 +74,8 @@ itkLineSpatialObjectTest(int, char *[])
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
 
 
   // Point consistency

--- a/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
@@ -69,10 +69,9 @@ itkSurfaceSpatialObjectTest(int, char *[])
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
 
   // Point consistency
   std::cout << "Point consistency: ";

--- a/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
@@ -99,10 +99,9 @@ itkTubeSpatialObjectTest(int, char *[])
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
 
   TubeType::CovariantVectorType derivative;
 
@@ -124,10 +123,9 @@ itkTubeSpatialObjectTest(int, char *[])
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
 
   std::cout << "itkTubeSpatialObjectTest ";
   if (passed)
@@ -180,10 +178,9 @@ itkTubeSpatialObjectTest(int, char *[])
     std::cout << "[FAILED] [" << nbChildren << "!= 3]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
 
   // testing the RemoveChild() function...
   std::cout << "Removing 1" << std::endl;
@@ -201,10 +198,9 @@ itkTubeSpatialObjectTest(int, char *[])
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
 
   tubeNet1->AddChild(tube1);
   tubeNet1->AddChild(tube2);
@@ -243,10 +239,9 @@ itkTubeSpatialObjectTest(int, char *[])
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
 
   tubeNet1->RemoveChild(tube1);
   tubeNet1->RemoveChild(tube2);
@@ -288,10 +283,9 @@ itkTubeSpatialObjectTest(int, char *[])
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
 
   tubeNet1->Update();
 
@@ -301,10 +295,9 @@ itkTubeSpatialObjectTest(int, char *[])
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
   auto translation = itk::MakeFilled<Vector>(10);
   tubeNet1->GetModifiableObjectToParentTransform()->Translate(translation, false);
   tubeNet1->Update();
@@ -333,10 +326,9 @@ itkTubeSpatialObjectTest(int, char *[])
     std::cout << "[FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
 
   std::cout << "DerivativeAt()...";
   try

--- a/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.hxx
@@ -56,7 +56,7 @@ PipelineMonitorImageFilter<TImageType>::VerifyInputFilterExecutedStreaming(int e
   {
     return true;
   }
-  else if (expectedNumber < 0 && static_cast<unsigned int>(-expectedNumber) <= this->GetNumberOfUpdates())
+  if (expectedNumber < 0 && static_cast<unsigned int>(-expectedNumber) <= this->GetNumberOfUpdates())
   {
     return true;
   }

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -49,10 +49,8 @@ CompositeTransform<TParametersValueType, VDimension>::GetTransformCategory() con
   {
     return Self::TransformCategoryEnum::DisplacementField;
   }
-  else
-  {
-    return Self::TransformCategoryEnum::UnknownTransformCategory;
-  }
+
+  return Self::TransformCategoryEnum::UnknownTransformCategory;
 }
 
 
@@ -422,11 +420,9 @@ CompositeTransform<TParametersValueType, VDimension>::GetInverse(Self * inverse)
       inverse->ClearTransformQueue();
       return false;
     }
-    else
-    {
-      /* Push to front to reverse the transform order */
-      inverse->PushFrontTransform(inverseTransform);
-    }
+
+    /* Push to front to reverse the transform order */
+    inverse->PushFrontTransform(inverseTransform);
   }
 
   /* Copy the optimization flags */

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
@@ -538,10 +538,8 @@ protected:
     {
       return true;
     }
-    else
-    {
-      return false;
-    }
+
+    return false;
   }
 
   virtual void

--- a/Modules/Core/Transform/include/itkMultiTransform.hxx
+++ b/Modules/Core/Transform/include/itkMultiTransform.hxx
@@ -316,11 +316,9 @@ MultiTransform<TParametersValueType, VDimension, VSubDimensions>::GetInverse(Sel
       inverse->ClearTransformQueue();
       return false;
     }
-    else
-    {
-      /* Add to end of queue to preserve transform order */
-      inverse->PushBackTransform(inverseTransform);
-    }
+
+    /* Add to end of queue to preserve transform order */
+    inverse->PushBackTransform(inverseTransform);
   }
 
   return true;

--- a/Modules/Core/Transform/test/itkCenteredEuler3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkCenteredEuler3DTransformTest.cxx
@@ -122,10 +122,9 @@ itkCenteredEuler3DTransformTest(int, char *[])
     std::cerr << "Reported Result is     : " << r << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
 
   std::cout << "Testing Translation:";
 
@@ -155,10 +154,9 @@ itkCenteredEuler3DTransformTest(int, char *[])
     std::cerr << "Reported Result is     : " << r << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
 
   // Testing Parameters
   std::cout << "Testing Set/Get Parameters: ";

--- a/Modules/Core/Transform/test/itkCenteredRigid2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkCenteredRigid2DTransformTest.cxx
@@ -88,10 +88,9 @@ itkCenteredRigid2DTransformTest(int, char *[])
     std::cerr << "Reported Result is     : " << r << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
 
   std::cout << "Testing Translation:";
 
@@ -120,10 +119,9 @@ itkCenteredRigid2DTransformTest(int, char *[])
     std::cerr << "Reported Result is     : " << r << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
 
   {
     std::cout << "Testing Inverse:";
@@ -173,10 +171,9 @@ itkCenteredRigid2DTransformTest(int, char *[])
       std::cerr << "Reported Result is     : " << p3 << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cout << " [ PASSED ] " << std::endl;
-    }
+
+    std::cout << " [ PASSED ] " << std::endl;
+
 
     // Get inverse transform and transform point p2 to obtain point p3
     const CenteredRigidTransformType::Pointer inversebis =
@@ -207,10 +204,8 @@ itkCenteredRigid2DTransformTest(int, char *[])
       std::cerr << "Reported Result is     : " << p3 << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cout << " [ PASSED ] " << std::endl;
-    }
+
+    std::cout << " [ PASSED ] " << std::endl;
   }
 
   {

--- a/Modules/Core/Transform/test/itkComposeScaleSkewVersor3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkComposeScaleSkewVersor3DTransformTest.cxx
@@ -156,10 +156,8 @@ itkComposeScaleSkewVersor3DTransformTest(int, char *[])
         std::cerr << "Reported Result is   : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::Point " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::Point " << std::endl;
     }
 
     {
@@ -186,10 +184,8 @@ itkComposeScaleSkewVersor3DTransformTest(int, char *[])
         std::cerr << "Reported Result is    : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::Vector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::Vector " << std::endl;
     }
 
     {
@@ -216,10 +212,8 @@ itkComposeScaleSkewVersor3DTransformTest(int, char *[])
         std::cerr << "Reported Result is              : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::CovariantVector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::CovariantVector " << std::endl;
     }
 
     {
@@ -249,10 +243,8 @@ itkComposeScaleSkewVersor3DTransformTest(int, char *[])
         std::cerr << "Reported Result is        : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an vnl_Vector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an vnl_Vector " << std::endl;
     }
   }
 
@@ -291,10 +283,9 @@ itkComposeScaleSkewVersor3DTransformTest(int, char *[])
       std::cerr << "The center point was not invariant to rotation " << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cout << "Ok center is invariant to rotation." << std::endl;
-    }
+
+    std::cout << "Ok center is invariant to rotation." << std::endl;
+
 
     const unsigned int np = transform->GetNumberOfParameters();
 

--- a/Modules/Core/Transform/test/itkEuler2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkEuler2DTransformTest.cxx
@@ -103,10 +103,9 @@ itkEuler2DTransformTest(int, char *[])
     std::cerr << "Reported Result is     : " << r << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
 
   std::cout << "Testing Translation:";
 
@@ -135,10 +134,9 @@ itkEuler2DTransformTest(int, char *[])
     std::cerr << "Reported Result is     : " << r << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
 
   // Testing Parameters
   std::cout << "Testing Parameters: ";

--- a/Modules/Core/Transform/test/itkEuler3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkEuler3DTransformTest.cxx
@@ -122,10 +122,9 @@ itkEuler3DTransformTest(int, char *[])
     std::cerr << "Reported Result is     : " << r << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
 
   std::cout << "Testing Rotation Change from ZXY to ZYX consistency:";
 
@@ -155,10 +154,9 @@ itkEuler3DTransformTest(int, char *[])
               << "operations performed in reverse order." << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
 
   std::cout << "Testing Translation:";
 
@@ -188,10 +186,9 @@ itkEuler3DTransformTest(int, char *[])
     std::cerr << "Reported Result is     : " << r << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
 
   // Testing Parameters
   std::cout << "Testing Set/Get Parameters: ";

--- a/Modules/Core/Transform/test/itkFixedCenterOfRotationAffineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkFixedCenterOfRotationAffineTransformTest.cxx
@@ -59,10 +59,9 @@ itkFixedCenterOfRotationAffineTransformTest(int, char *[])
     std::cout << "[FAILURE]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[SUCCESS]" << std::endl;
-  }
+
+  std::cout << "[SUCCESS]" << std::endl;
+
 
   /* Create and show a simple 2D transform from given parameters */
   matrix2[0][0] = 1.0;
@@ -91,10 +90,9 @@ itkFixedCenterOfRotationAffineTransformTest(int, char *[])
     std::cout << "[FAILURE]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[SUCCESS]" << std::endl;
-  }
+
+  std::cout << "[SUCCESS]" << std::endl;
+
 
   /** Test set matrix after setting components */
   double scale1[2];
@@ -129,10 +127,9 @@ itkFixedCenterOfRotationAffineTransformTest(int, char *[])
     std::cout << "[FAILURE]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[SUCCESS]" << std::endl;
-  }
+
+  std::cout << "[SUCCESS]" << std::endl;
+
 
   /** Try scaling */
   std::cout << "Testing scaling: ";
@@ -147,10 +144,9 @@ itkFixedCenterOfRotationAffineTransformTest(int, char *[])
     std::cout << "[FAILURE]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[SUCCESS]" << std::endl;
-  }
+
+  std::cout << "[SUCCESS]" << std::endl;
+
 
   /** Test the parameters */
   std::cout << "Setting/Getting parameters: ";
@@ -182,10 +178,9 @@ itkFixedCenterOfRotationAffineTransformTest(int, char *[])
     std::cout << "[FAILURE]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[SUCCESS]" << std::endl;
-  }
+
+  std::cout << "[SUCCESS]" << std::endl;
+
 
   /** Testing point transformation */
   std::cout << "Transforming Point: ";
@@ -218,10 +213,9 @@ itkFixedCenterOfRotationAffineTransformTest(int, char *[])
     std::cout << "[FAILURE]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[SUCCESS]" << std::endl;
-  }
+
+  std::cout << "[SUCCESS]" << std::endl;
+
 
   std::cout << "Done!" << std::endl;
 

--- a/Modules/Core/Transform/test/itkIdentityTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkIdentityTransformTest.cxx
@@ -54,10 +54,9 @@ itkIdentityTransformTest(int, char *[])
     std::cerr << "Error Transforming Point" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
 
   // Test TransformVector
   std::cout << "Testing TransformVector: ";
@@ -79,10 +78,9 @@ itkIdentityTransformTest(int, char *[])
     std::cerr << "Error with TransformVector itk::Vector" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
 
   // Test TransformVector vnl_vector
   std::cout << "Testing TransformVector (vnl): ";
@@ -104,10 +102,9 @@ itkIdentityTransformTest(int, char *[])
     std::cerr << "Error with TransformVector vnlVector" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
 
   // Test TransformCovariantVector
   std::cout << "Testing TransformCovariantVector: ";
@@ -129,10 +126,9 @@ itkIdentityTransformTest(int, char *[])
     std::cerr << "Error with TransformVector CovariantVector" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
 
   const IdentityTransformType::ParametersType params(0);
   transform->SetParameters(params);
@@ -151,10 +147,9 @@ itkIdentityTransformTest(int, char *[])
     std::cerr << "Error with Jacobian: " << jacobian << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
 
   IdentityTransformType::JacobianPositionType jacobianWrtPos;
   transform->ComputeJacobianWithRespectToPosition(p, jacobianWrtPos);

--- a/Modules/Core/Transform/test/itkQuaternionRigidTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkQuaternionRigidTransformTest.cxx
@@ -105,10 +105,8 @@ itkQuaternionRigidTransformTest(int, char *[])
         std::cerr << "Reported Result is     : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an itk::Point " << std::endl;
-      }
+
+      std::cout << "Ok translating an itk::Point " << std::endl;
     }
 
     {
@@ -131,10 +129,8 @@ itkQuaternionRigidTransformTest(int, char *[])
         std::cerr << "Reported Result is      : " << q << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an itk::Vector " << std::endl;
-      }
+
+      std::cout << "Ok translating an itk::Vector " << std::endl;
     }
 
     {
@@ -157,10 +153,8 @@ itkQuaternionRigidTransformTest(int, char *[])
         std::cerr << "Reported Result is      : " << q << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an itk::CovariantVector " << std::endl;
-      }
+
+      std::cout << "Ok translating an itk::CovariantVector " << std::endl;
     }
 
     {
@@ -185,10 +179,8 @@ itkQuaternionRigidTransformTest(int, char *[])
         std::cerr << "Reported Result is      : " << q << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an vnl_Vector " << std::endl;
-      }
+
+      std::cout << "Ok translating an vnl_Vector " << std::endl;
     }
   }
 
@@ -290,10 +282,8 @@ itkQuaternionRigidTransformTest(int, char *[])
         std::cerr << "Reported Result is     : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an itk::Point " << std::endl;
-      }
+
+      std::cout << "Ok translating an itk::Point " << std::endl;
     }
 
     {
@@ -323,10 +313,8 @@ itkQuaternionRigidTransformTest(int, char *[])
         std::cerr << "Reported Result is     : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::Vector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::Vector " << std::endl;
     }
 
     {
@@ -356,10 +344,8 @@ itkQuaternionRigidTransformTest(int, char *[])
         std::cerr << "Reported Result is             : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an itk::CovariantVector " << std::endl;
-      }
+
+      std::cout << "Ok translating an itk::CovariantVector " << std::endl;
     }
 
     {
@@ -392,10 +378,8 @@ itkQuaternionRigidTransformTest(int, char *[])
         std::cerr << "Reported Result is           : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an vnl_Vector " << std::endl;
-      }
+
+      std::cout << "Ok translating an vnl_Vector " << std::endl;
     }
   }
 
@@ -481,10 +465,9 @@ itkQuaternionRigidTransformTest(int, char *[])
         std::cerr << " [ FAILED ] " << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << " [ PASSED ] compute inverse transform" << std::endl;
-      }
+
+      std::cout << " [ PASSED ] compute inverse transform" << std::endl;
+
       pOut = inverseQuaternionRigid->TransformPoint(quaternionRigid->TransformPoint(pInit));
     }
     // pOut should equate pInit
@@ -629,10 +612,8 @@ itkQuaternionRigidTransformTest(int, char *[])
         std::cerr << "Reported Result is     : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an itk::Point " << std::endl;
-      }
+
+      std::cout << "Ok translating an itk::Point " << std::endl;
     }
 
     {
@@ -662,10 +643,8 @@ itkQuaternionRigidTransformTest(int, char *[])
         std::cerr << "Reported Result is     : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::Vector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::Vector " << std::endl;
     }
 
     {
@@ -695,10 +674,8 @@ itkQuaternionRigidTransformTest(int, char *[])
         std::cerr << "Reported Result is             : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an itk::CovariantVector " << std::endl;
-      }
+
+      std::cout << "Ok translating an itk::CovariantVector " << std::endl;
     }
 
     {
@@ -731,10 +708,8 @@ itkQuaternionRigidTransformTest(int, char *[])
         std::cerr << "Reported Result is           : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an vnl_Vector " << std::endl;
-      }
+
+      std::cout << "Ok translating an vnl_Vector " << std::endl;
     }
   }
 

--- a/Modules/Core/Transform/test/itkRigid2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkRigid2DTransformTest.cxx
@@ -143,10 +143,8 @@ itkRigid2DTransformTest(int, char *[])
         std::cerr << "Reported Result is     : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an itk::Point " << std::endl;
-      }
+
+      std::cout << "Ok translating an itk::Point " << std::endl;
     }
 
     {
@@ -168,10 +166,8 @@ itkRigid2DTransformTest(int, char *[])
         std::cerr << "Reported Result is      : " << q << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an itk::Vector " << std::endl;
-      }
+
+      std::cout << "Ok translating an itk::Vector " << std::endl;
     }
 
     {
@@ -193,10 +189,8 @@ itkRigid2DTransformTest(int, char *[])
         std::cerr << "Reported Result is      : " << q << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an itk::CovariantVector " << std::endl;
-      }
+
+      std::cout << "Ok translating an itk::CovariantVector " << std::endl;
     }
 
 
@@ -220,10 +214,8 @@ itkRigid2DTransformTest(int, char *[])
         std::cerr << "Reported Result is      : " << q << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an vnl_Vector " << std::endl;
-      }
+
+      std::cout << "Ok translating an vnl_Vector " << std::endl;
     }
   }
 
@@ -354,10 +346,8 @@ itkRigid2DTransformTest(int, char *[])
         std::cerr << "Reported Result is     : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an itk::Point " << std::endl;
-      }
+
+      std::cout << "Ok translating an itk::Point " << std::endl;
     }
 
     {
@@ -385,10 +375,8 @@ itkRigid2DTransformTest(int, char *[])
         std::cerr << "Reported Result is     : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::Vector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::Vector " << std::endl;
     }
 
     {
@@ -417,10 +405,8 @@ itkRigid2DTransformTest(int, char *[])
         std::cerr << "Reported Result is             : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an itk::CovariantVector " << std::endl;
-      }
+
+      std::cout << "Ok translating an itk::CovariantVector " << std::endl;
     }
 
 
@@ -452,10 +438,8 @@ itkRigid2DTransformTest(int, char *[])
         std::cerr << "Reported Result is           : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an vnl_Vector " << std::endl;
-      }
+
+      std::cout << "Ok translating an vnl_Vector " << std::endl;
     }
 
     {

--- a/Modules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx
@@ -151,10 +151,8 @@ itkRigid3DPerspectiveTransformTest(int, char *[])
         std::cerr << "Reported Result is     : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an itk::Point " << std::endl;
-      }
+
+      std::cout << "Ok translating an itk::Point " << std::endl;
     }
   }
 
@@ -207,10 +205,8 @@ itkRigid3DPerspectiveTransformTest(int, char *[])
         std::cerr << "Reported Result is     : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::Point " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::Point " << std::endl;
     }
   }
 

--- a/Modules/Core/Transform/test/itkRigid3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkRigid3DTransformTest.cxx
@@ -107,15 +107,14 @@ TestSettingTranslation()
   {
     return true;
   }
-  else
-  {
-    std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
-    std::cout << "r1\n" << r1 << std::endl;
-    std::cout << "r2\n" << r2 << std::endl;
-    std::cout << "r3\n" << r3 << std::endl;
-    std::cout << p1 << '\n' << p2 << '\n' << p3 << std::endl;
-    std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
-  }
+
+  std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
+  std::cout << "r1\n" << r1 << std::endl;
+  std::cout << "r2\n" << r2 << std::endl;
+  std::cout << "r3\n" << r3 << std::endl;
+  std::cout << p1 << '\n' << p2 << '\n' << p3 << std::endl;
+  std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
+
 
   return false;
 }
@@ -203,10 +202,8 @@ itkRigid3DTransformTest(int, char *[])
         std::cerr << "Reported Result is     : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an itk::Point " << std::endl;
-      }
+
+      std::cout << "Ok translating an itk::Point " << std::endl;
     }
 
     {
@@ -229,10 +226,8 @@ itkRigid3DTransformTest(int, char *[])
         std::cerr << "Reported Result is      : " << q << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an itk::Vector " << std::endl;
-      }
+
+      std::cout << "Ok translating an itk::Vector " << std::endl;
     }
 
     {
@@ -255,10 +250,8 @@ itkRigid3DTransformTest(int, char *[])
         std::cerr << "Reported Result is      : " << q << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an itk::CovariantVector " << std::endl;
-      }
+
+      std::cout << "Ok translating an itk::CovariantVector " << std::endl;
     }
 
     {
@@ -283,10 +276,8 @@ itkRigid3DTransformTest(int, char *[])
         std::cerr << "Reported Result is      : " << q << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an vnl_Vector " << std::endl;
-      }
+
+      std::cout << "Ok translating an vnl_Vector " << std::endl;
     }
   }
 
@@ -383,10 +374,8 @@ itkRigid3DTransformTest(int, char *[])
         std::cerr << "Reported Result is     : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an itk::Point " << std::endl;
-      }
+
+      std::cout << "Ok translating an itk::Point " << std::endl;
     }
 
     {
@@ -416,10 +405,8 @@ itkRigid3DTransformTest(int, char *[])
         std::cerr << "Reported Result is     : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::Vector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::Vector " << std::endl;
     }
 
     {
@@ -450,10 +437,8 @@ itkRigid3DTransformTest(int, char *[])
         std::cerr << "Reported Result is             : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an itk::CovariantVector " << std::endl;
-      }
+
+      std::cout << "Ok translating an itk::CovariantVector " << std::endl;
     }
 
     {
@@ -486,10 +471,8 @@ itkRigid3DTransformTest(int, char *[])
         std::cerr << "Reported Result is           : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok translating an vnl_Vector " << std::endl;
-      }
+
+      std::cout << "Ok translating an vnl_Vector " << std::endl;
     }
 
     {

--- a/Modules/Core/Transform/test/itkScaleLogarithmicTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkScaleLogarithmicTransformTest.cxx
@@ -118,10 +118,8 @@ itkScaleLogarithmicTransformTest(int, char *[])
         std::cerr << "Reported Result is  : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Successful scaling an itk::Point " << std::endl;
-      }
+
+      std::cout << "Successful scaling an itk::Point " << std::endl;
     }
 
     {
@@ -148,10 +146,8 @@ itkScaleLogarithmicTransformTest(int, char *[])
         std::cerr << "Reported Result is      : " << q << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Successful scaling an itk::Vector " << std::endl;
-      }
+
+      std::cout << "Successful scaling an itk::Vector " << std::endl;
     }
 
     {
@@ -178,10 +174,8 @@ itkScaleLogarithmicTransformTest(int, char *[])
         std::cerr << "Reported Result is      : " << q << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Successful scaling an itk::CovariantVector " << std::endl;
-      }
+
+      std::cout << "Successful scaling an itk::CovariantVector " << std::endl;
     }
 
     {
@@ -210,10 +204,8 @@ itkScaleLogarithmicTransformTest(int, char *[])
         std::cerr << "Reported Result is      : " << q << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Successful scaling an vnl_Vector " << std::endl;
-      }
+
+      std::cout << "Successful scaling an vnl_Vector " << std::endl;
     }
 
 
@@ -235,10 +227,8 @@ itkScaleLogarithmicTransformTest(int, char *[])
         std::cerr << "but GetCenter() returned : " << c2 << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Successful SetCenter() / GetCenter() " << std::endl;
-      }
+
+      std::cout << "Successful SetCenter() / GetCenter() " << std::endl;
     }
 
 
@@ -270,10 +260,8 @@ itkScaleLogarithmicTransformTest(int, char *[])
         std::cerr << "but GetParameters() returned : " << p2 << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Successful SetParameters() / GetParameters() " << std::endl;
-      }
+
+      std::cout << "Successful SetParameters() / GetParameters() " << std::endl;
     }
   }
 

--- a/Modules/Core/Transform/test/itkScaleSkewVersor3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkScaleSkewVersor3DTransformTest.cxx
@@ -159,10 +159,8 @@ itkScaleSkewVersor3DTransformTest(int, char *[])
         std::cerr << "Reported Result is   : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::Point " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::Point " << std::endl;
     }
 
     {
@@ -189,10 +187,8 @@ itkScaleSkewVersor3DTransformTest(int, char *[])
         std::cerr << "Reported Result is    : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::Vector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::Vector " << std::endl;
     }
 
     {
@@ -219,10 +215,8 @@ itkScaleSkewVersor3DTransformTest(int, char *[])
         std::cerr << "Reported Result is              : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::CovariantVector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::CovariantVector " << std::endl;
     }
 
     {
@@ -252,10 +246,8 @@ itkScaleSkewVersor3DTransformTest(int, char *[])
         std::cerr << "Reported Result is        : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an vnl_Vector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an vnl_Vector " << std::endl;
     }
   }
 
@@ -294,10 +286,9 @@ itkScaleSkewVersor3DTransformTest(int, char *[])
       std::cerr << "The center point was not invariant to rotation " << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cout << "Ok center is invariant to rotation." << std::endl;
-    }
+
+    std::cout << "Ok center is invariant to rotation." << std::endl;
+
 
     const unsigned int np = transform->GetNumberOfParameters();
 

--- a/Modules/Core/Transform/test/itkScaleTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkScaleTransformTest.cxx
@@ -121,10 +121,8 @@ itkScaleTransformTest(int, char *[])
         std::cerr << "Reported Result is  : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok scaling an itk::Point " << std::endl;
-      }
+
+      std::cout << "Ok scaling an itk::Point " << std::endl;
     }
 
     {
@@ -151,10 +149,8 @@ itkScaleTransformTest(int, char *[])
         std::cerr << "Reported Result is      : " << q << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok scaling an itk::Vector " << std::endl;
-      }
+
+      std::cout << "Ok scaling an itk::Vector " << std::endl;
     }
 
     {
@@ -181,10 +177,8 @@ itkScaleTransformTest(int, char *[])
         std::cerr << "Reported Result is      : " << q << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok scaling an itk::CovariantVector " << std::endl;
-      }
+
+      std::cout << "Ok scaling an itk::CovariantVector " << std::endl;
     }
 
     {
@@ -213,10 +207,8 @@ itkScaleTransformTest(int, char *[])
         std::cerr << "Reported Result is      : " << q << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok scaling an vnl_Vector " << std::endl;
-      }
+
+      std::cout << "Ok scaling an vnl_Vector " << std::endl;
     }
 
 
@@ -238,10 +230,8 @@ itkScaleTransformTest(int, char *[])
         std::cerr << "but GetCenter() returned : " << c2 << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok SetCenter() / GetCenter() " << std::endl;
-      }
+
+      std::cout << "Ok SetCenter() / GetCenter() " << std::endl;
     }
   }
 

--- a/Modules/Core/Transform/test/itkScaleVersor3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkScaleVersor3DTransformTest.cxx
@@ -172,10 +172,8 @@ itkScaleVersor3DTransformTest(int, char *[])
         std::cerr << "Reported Result is   : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::Point " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::Point " << std::endl;
     }
 
     {
@@ -202,10 +200,8 @@ itkScaleVersor3DTransformTest(int, char *[])
         std::cerr << "Reported Result is    : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::Vector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::Vector " << std::endl;
     }
 
     {
@@ -232,10 +228,8 @@ itkScaleVersor3DTransformTest(int, char *[])
         std::cerr << "Reported Result is              : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::CovariantVector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::CovariantVector " << std::endl;
     }
 
     {
@@ -265,10 +259,8 @@ itkScaleVersor3DTransformTest(int, char *[])
         std::cerr << "Reported Result is        : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an vnl_Vector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an vnl_Vector " << std::endl;
     }
   }
 
@@ -307,10 +299,9 @@ itkScaleVersor3DTransformTest(int, char *[])
       std::cerr << "The center point was not invariant to rotation " << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cout << "Ok center is invariant to rotation." << std::endl;
-    }
+
+    std::cout << "Ok center is invariant to rotation." << std::endl;
+
 
     const unsigned int np = transform->GetNumberOfParameters();
 

--- a/Modules/Core/Transform/test/itkSimilarity2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkSimilarity2DTransformTest.cxx
@@ -78,10 +78,9 @@ itkSimilarity2DTransformTest(int, char *[])
     std::cerr << "Error with Identity transform" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
 
   // Test SetAngle/GetAngle
   auto transform1 = SimilarityTransformType::New();
@@ -99,10 +98,9 @@ itkSimilarity2DTransformTest(int, char *[])
     std::cerr << "transform2->GetAngle: " << transform2->GetAngle() << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
 
   transform1->SetIdentity();
   transform1->SetAngle(-angle1);
@@ -115,10 +113,9 @@ itkSimilarity2DTransformTest(int, char *[])
     std::cerr << "transform2->GetAngle: " << transform2->GetAngle() << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
   // Test the Set/Get Parameters
   std::cout << "Testing Set/GetParameters():" << std::endl;
   SimilarityTransformType::ParametersType params(6);
@@ -150,10 +147,9 @@ itkSimilarity2DTransformTest(int, char *[])
     std::cerr << "Output:" << outputParams << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
 
   // 15 degrees in radians
   transform->SetCenter({}); // Explicitly reset center to default values
@@ -186,10 +182,9 @@ itkSimilarity2DTransformTest(int, char *[])
     std::cerr << "Reported Result is     : " << r << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
 
   std::cout << "Testing Translation:";
 
@@ -218,10 +213,9 @@ itkSimilarity2DTransformTest(int, char *[])
     std::cerr << "Reported Result is     : " << r << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
 
   // Testing the Jacobian
   std::cout << "Testing Jacobian:";
@@ -238,10 +232,9 @@ itkSimilarity2DTransformTest(int, char *[])
     std::cerr << "Error with Jacobian: " << jacobian0 << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [ PASSED ] " << std::endl;
-  }
+
+  std::cout << " [ PASSED ] " << std::endl;
+
 
   {
     // Test instantiation, inverse computation, back transform etc.

--- a/Modules/Core/Transform/test/itkSimilarity3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkSimilarity3DTransformTest.cxx
@@ -161,10 +161,8 @@ itkSimilarity3DTransformTest(int, char *[])
         std::cout << "Reported Result is   : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::Point " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::Point " << std::endl;
     }
 
     {
@@ -191,10 +189,8 @@ itkSimilarity3DTransformTest(int, char *[])
         std::cout << "Reported Result is    : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::Vector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::Vector " << std::endl;
     }
     {
       // Translate an itk::CovariantVector
@@ -220,10 +216,8 @@ itkSimilarity3DTransformTest(int, char *[])
         std::cout << "Reported Result is              : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::CovariantVector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::CovariantVector " << std::endl;
     }
 
     {
@@ -253,10 +247,8 @@ itkSimilarity3DTransformTest(int, char *[])
         std::cout << "Reported Result is        : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an vnl_Vector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an vnl_Vector " << std::endl;
     }
   }
   /**  Exercise the SetCenter method  */
@@ -294,10 +286,9 @@ itkSimilarity3DTransformTest(int, char *[])
       std::cout << "The center point was not invariant to rotation " << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cout << "Ok center is invariant to rotation." << std::endl;
-    }
+
+    std::cout << "Ok center is invariant to rotation." << std::endl;
+
 
     const unsigned int np = transform->GetNumberOfParameters();
 

--- a/Modules/Core/Transform/test/itkTransformsSetParametersTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformsSetParametersTest.cxx
@@ -82,11 +82,9 @@ TestKernelTransform(const char * name, KernelType *)
     std::cout << "PASS" << std::endl;
     return 0;
   }
-  else
-  {
-    std::cout << "FAIL" << std::endl;
-    return 1;
-  }
+
+  std::cout << "FAIL" << std::endl;
+  return 1;
 }
 
 // Main Program

--- a/Modules/Core/Transform/test/itkVersorRigid3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkVersorRigid3DTransformTest.cxx
@@ -153,10 +153,8 @@ itkVersorRigid3DTransformTest(int, char *[])
         std::cerr << "Reported Result is   : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::Point " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::Point " << std::endl;
     }
 
     {
@@ -183,10 +181,8 @@ itkVersorRigid3DTransformTest(int, char *[])
         std::cerr << "Reported Result is    : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::Vector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::Vector " << std::endl;
     }
 
     {
@@ -213,10 +209,8 @@ itkVersorRigid3DTransformTest(int, char *[])
         std::cerr << "Reported Result is              : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::CovariantVector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::CovariantVector " << std::endl;
     }
 
     {
@@ -246,10 +240,8 @@ itkVersorRigid3DTransformTest(int, char *[])
         std::cerr << "Reported Result is        : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an vnl_Vector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an vnl_Vector " << std::endl;
     }
   }
 
@@ -288,10 +280,9 @@ itkVersorRigid3DTransformTest(int, char *[])
       std::cerr << "The center point was not invariant to rotation " << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cout << "Ok center is invariant to rotation." << std::endl;
-    }
+
+    std::cout << "Ok center is invariant to rotation." << std::endl;
+
 
     const unsigned int np = transform->GetNumberOfParameters();
 

--- a/Modules/Core/Transform/test/itkVersorTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkVersorTransformTest.cxx
@@ -150,10 +150,8 @@ itkVersorTransformTest(int, char *[])
         std::cerr << "Reported Result is   : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::Point " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::Point " << std::endl;
     }
 
     {
@@ -180,10 +178,8 @@ itkVersorTransformTest(int, char *[])
         std::cerr << "Reported Result is    : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::Vector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::Vector " << std::endl;
     }
 
     {
@@ -210,10 +206,8 @@ itkVersorTransformTest(int, char *[])
         std::cerr << "Reported Result is              : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an itk::CovariantVector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an itk::CovariantVector " << std::endl;
     }
 
     {
@@ -243,10 +237,8 @@ itkVersorTransformTest(int, char *[])
         std::cerr << "Reported Result is        : " << r << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "Ok rotating an vnl_Vector " << std::endl;
-      }
+
+      std::cout << "Ok rotating an vnl_Vector " << std::endl;
     }
   }
 
@@ -285,10 +277,9 @@ itkVersorTransformTest(int, char *[])
       std::cerr << "The center point was not invariant to rotation " << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cout << "Ok center is invariant to rotation." << std::endl;
-    }
+
+    std::cout << "Ok center is invariant to rotation." << std::endl;
+
 
     const unsigned int np = transform->GetNumberOfParameters();
 

--- a/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.hxx
+++ b/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.hxx
@@ -70,10 +70,8 @@ AntiAliasBinaryImageFilter<TInputImage, TOutputImage>::CalculateUpdateValue(cons
   {
     return (std::max(new_value, this->GetValueZero()));
   }
-  else
-  {
-    return (std::min(new_value, this->GetValueZero()));
-  }
+
+  return (std::min(new_value, this->GetValueZero()));
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/BiasCorrection/include/itkCompositeValleyFunction.h
+++ b/Modules/Filtering/BiasCorrection/include/itkCompositeValleyFunction.h
@@ -154,10 +154,8 @@ public:
     {
       return this->Evaluate(x);
     }
-    else
-    {
-      return GetCachedValue(x);
-    }
+
+    return GetCachedValue(x);
   }
 
   /** Evaluate the function at point x.  */

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
@@ -70,21 +70,19 @@ ObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::GenerateInputRe
     inputPtr->SetRequestedRegion(inputRequestedRegion);
     return;
   }
-  else
-  {
-    // Couldn't crop the region (requested region is outside the largest
-    // possible region).  Throw an exception.
 
-    // store what we tried to request (prior to trying to crop)
-    inputPtr->SetRequestedRegion(inputRequestedRegion);
+  // Couldn't crop the region (requested region is outside the largest
+  // possible region).  Throw an exception.
 
-    // build an exception
-    InvalidRequestedRegionError e(__FILE__, __LINE__);
-    e.SetLocation(ITK_LOCATION);
-    e.SetDescription("Requested region is outside largest possible region.");
-    e.SetDataObject(inputPtr);
-    throw e;
-  }
+  // store what we tried to request (prior to trying to crop)
+  inputPtr->SetRequestedRegion(inputRequestedRegion);
+
+  // build an exception
+  InvalidRequestedRegionError e(__FILE__, __LINE__);
+  e.SetLocation(ITK_LOCATION);
+  e.SetDescription("Requested region is outside largest possible region.");
+  e.SetDataObject(inputPtr);
+  throw e;
 }
 
 template <typename TInputImage, typename TOutputImage, typename TKernel>

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterStreamingTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterStreamingTest.cxx
@@ -165,14 +165,12 @@ itkConvolutionImageFilterStreamingTest(int argc, char * argv[])
 
     return doConvolutionImageFilterStreamingTest<FrequencyConvolutionType>(argc, argv);
   }
-  else // spatial
-  {
-    using SpatialConvolutionType = itk::ConvolutionImageFilter<ImageType>;
+  // spatial
+  using SpatialConvolutionType = itk::ConvolutionImageFilter<ImageType>;
 
-    // Do a quick filter sanity check before the test
-    auto convoluter = SpatialConvolutionType::New();
-    ITK_EXERCISE_BASIC_OBJECT_METHODS(convoluter, ConvolutionImageFilter, ConvolutionImageFilterBase);
+  // Do a quick filter sanity check before the test
+  auto convoluter = SpatialConvolutionType::New();
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(convoluter, ConvolutionImageFilter, ConvolutionImageFilterBase);
 
-    return doConvolutionImageFilterStreamingTest<SpatialConvolutionType>(argc, argv);
-  }
+  return doConvolutionImageFilterStreamingTest<SpatialConvolutionType>(argc, argv);
 }

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterSubregionTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterSubregionTest.cxx
@@ -154,14 +154,12 @@ itkConvolutionImageFilterSubregionTest(int argc, char * argv[])
 
     return doConvolutionImageFilterSubregionTest<FrequencyConvolutionType>(argc, argv);
   }
-  else // spatial
-  {
-    using SpatialConvolutionType = itk::ConvolutionImageFilter<ImageType>;
+  // spatial
+  using SpatialConvolutionType = itk::ConvolutionImageFilter<ImageType>;
 
-    // Do a quick filter sanity check before the test
-    auto convoluter = SpatialConvolutionType::New();
-    ITK_EXERCISE_BASIC_OBJECT_METHODS(convoluter, ConvolutionImageFilter, ConvolutionImageFilterBase);
+  // Do a quick filter sanity check before the test
+  auto convoluter = SpatialConvolutionType::New();
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(convoluter, ConvolutionImageFilter, ConvolutionImageFilterBase);
 
-    return doConvolutionImageFilterSubregionTest<SpatialConvolutionType>(argc, argv);
-  }
+  return doConvolutionImageFilterSubregionTest<SpatialConvolutionType>(argc, argv);
 }

--- a/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowFunction.hxx
@@ -51,10 +51,8 @@ BinaryMinMaxCurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType 
   {
     return (std::min(update, PixelType{}));
   }
-  else
-  {
-    return (std::max(update, PixelType{}));
-  }
+
+  return (std::max(update, PixelType{}));
 }
 } // end namespace itk
 

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.h
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.h
@@ -167,10 +167,8 @@ protected:
     {
       return true;
     }
-    else
-    {
-      return false;
-    }
+
+    return false;
   }
 
   /** Initialize the state of filter and equation before each iteration.

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
@@ -413,10 +413,8 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,
   {
     return (std::max(update, PixelType{}));
   }
-  else
-  {
-    return (std::min(update, PixelType{}));
-  }
+
+  return (std::min(update, PixelType{}));
 }
 } // end namespace itk
 

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.hxx
@@ -241,10 +241,8 @@ PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::Halt()
   {
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.h
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.h
@@ -368,10 +368,8 @@ protected:
     {
       return this->AddExponentialMapUpdate(a, b);
     }
-    else
-    {
-      return this->AddEuclideanUpdate(a, b);
-    }
+
+    return this->AddEuclideanUpdate(a, b);
   }
 
   template <typename RealT>

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -92,11 +92,9 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::GetThreadData(int thr
   {
     return m_ThreadData[threadId];
   }
-  else
-  {
-    itkExceptionMacro("Invalid thread id " << threadId << " or GetThreadData called before m_ThreadData (size="
-                                           << m_ThreadData.size() << ") was initialized.");
-  }
+
+  itkExceptionMacro("Invalid thread id " << threadId << " or GetThreadData called before m_ThreadData (size="
+                                         << m_ThreadData.size() << ") was initialized.");
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -182,21 +180,19 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::GenerateInputRequeste
     inputPtr->SetRequestedRegion(inputRequestedRegion);
     return;
   }
-  else
-  {
-    // Couldn't crop the region (requested region is outside the largest
-    // possible region). Throw an exception.
 
-    // Store what we tried to request (prior to trying to crop)
-    inputPtr->SetRequestedRegion(inputRequestedRegion);
+  // Couldn't crop the region (requested region is outside the largest
+  // possible region). Throw an exception.
 
-    // Build an exception
-    InvalidRequestedRegionError e(__FILE__, __LINE__);
-    e.SetLocation(ITK_LOCATION);
-    e.SetDescription("Requested region is (at least partially) outside the largest possible region");
-    e.SetDataObject(inputPtr);
-    throw e;
-  }
+  // Store what we tried to request (prior to trying to crop)
+  inputPtr->SetRequestedRegion(inputRequestedRegion);
+
+  // Build an exception
+  InvalidRequestedRegionError e(__FILE__, __LINE__);
+  e.SetLocation(ITK_LOCATION);
+  e.SetDescription("Requested region is (at least partially) outside the largest possible region");
+  e.SetDataObject(inputPtr);
+  throw e;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterDefaultTest.cxx
+++ b/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterDefaultTest.cxx
@@ -116,7 +116,7 @@ itkPatchBasedDenoisingImageFilterDefaultTest(int argc, char * argv[])
   {
     return doDenoising<OneComponent2DImage>(inFileName, outFileName);
   }
-  else if (numDimensions == 3)
+  if (numDimensions == 3)
   {
     return doDenoising<OneComponent3DImage>(inFileName, outFileName);
   }

--- a/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterTest.cxx
+++ b/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterTest.cxx
@@ -483,7 +483,7 @@ itkPatchBasedDenoisingImageFilterTest(int argc, char * argv[])
                                               kernelBandwidthMultFactor,
                                               noiseModel, noiseModelFidelityWeight );
     }*/
-  else if (numComponents == 3 && numDimensions == 2)
+  if (numComponents == 3 && numDimensions == 2)
   {
     return doDenoising<ThreeComponent2DImage>(inFileName,
                                               outFileName,

--- a/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
@@ -74,18 +74,16 @@ ConstantVelocityFieldTransform<TParametersValueType, VDimension>::GetInverse(Sel
   {
     return false;
   }
-  else
-  {
-    inverse->SetFixedParameters(this->GetFixedParameters());
-    inverse->SetUpperTimeBound(this->GetLowerTimeBound());
-    inverse->SetLowerTimeBound(this->GetUpperTimeBound());
-    inverse->SetDisplacementField(this->m_InverseDisplacementField);
-    inverse->SetInverseDisplacementField(this->m_DisplacementField);
-    inverse->SetInterpolator(this->m_Interpolator);
-    inverse->SetConstantVelocityField(this->m_ConstantVelocityField);
-    inverse->SetConstantVelocityFieldInterpolator(this->m_ConstantVelocityFieldInterpolator);
-    return true;
-  }
+
+  inverse->SetFixedParameters(this->GetFixedParameters());
+  inverse->SetUpperTimeBound(this->GetLowerTimeBound());
+  inverse->SetLowerTimeBound(this->GetUpperTimeBound());
+  inverse->SetDisplacementField(this->m_InverseDisplacementField);
+  inverse->SetInverseDisplacementField(this->m_DisplacementField);
+  inverse->SetInterpolator(this->m_Interpolator);
+  inverse->SetConstantVelocityField(this->m_ConstantVelocityField);
+  inverse->SetConstantVelocityFieldInterpolator(this->m_ConstantVelocityFieldInterpolator);
+  return true;
 }
 
 template <typename TParametersValueType, unsigned int VDimension>

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
@@ -117,21 +117,19 @@ DisplacementFieldJacobianDeterminantFilter<TInputImage, TRealType, TOutputImage>
     inputPtr->SetRequestedRegion(inputRequestedRegion);
     return;
   }
-  else
-  {
-    // Couldn't crop the region (requested region is outside the largest
-    // possible region).  Throw an exception.
 
-    // store what we tried to request (prior to trying to crop)
-    inputPtr->SetRequestedRegion(inputRequestedRegion);
+  // Couldn't crop the region (requested region is outside the largest
+  // possible region).  Throw an exception.
 
-    // build an exception
-    InvalidRequestedRegionError e(__FILE__, __LINE__);
-    e.SetLocation(ITK_LOCATION);
-    e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
-    e.SetDataObject(inputPtr);
-    throw e;
-  }
+  // store what we tried to request (prior to trying to crop)
+  inputPtr->SetRequestedRegion(inputRequestedRegion);
+
+  // build an exception
+  InvalidRequestedRegionError e(__FILE__, __LINE__);
+  e.SetLocation(ITK_LOCATION);
+  e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
+  e.SetDataObject(inputPtr);
+  throw e;
 }
 
 template <typename TInputImage, typename TRealType, typename TOutputImage>

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -109,16 +109,14 @@ DisplacementFieldTransform<TParametersValueType, VDimension>::GetInverse(Self * 
   {
     return false;
   }
-  else
-  {
-    inverse->SetFixedParameters(this->GetFixedParameters());
-    inverse->SetDisplacementField(this->m_InverseDisplacementField);
-    inverse->SetInverseDisplacementField(this->m_DisplacementField);
-    inverse->SetInterpolator(this->m_InverseInterpolator);
-    inverse->SetInverseInterpolator(this->m_Interpolator);
 
-    return true;
-  }
+  inverse->SetFixedParameters(this->GetFixedParameters());
+  inverse->SetDisplacementField(this->m_InverseDisplacementField);
+  inverse->SetInverseDisplacementField(this->m_DisplacementField);
+  inverse->SetInterpolator(this->m_InverseInterpolator);
+  inverse->SetInverseInterpolator(this->m_Interpolator);
+
+  return true;
 }
 
 template <typename TParametersValueType, unsigned int VDimension>

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
@@ -72,18 +72,16 @@ VelocityFieldTransform<TParametersValueType, VDimension>::GetInverse(Self * inve
   {
     return false;
   }
-  else
-  {
-    inverse->SetFixedParameters(this->GetFixedParameters());
-    inverse->SetUpperTimeBound(this->m_LowerTimeBound);
-    inverse->SetLowerTimeBound(this->m_UpperTimeBound);
-    inverse->SetDisplacementField(this->m_InverseDisplacementField);
-    inverse->SetInverseDisplacementField(this->m_DisplacementField);
-    inverse->SetInterpolator(this->m_Interpolator);
-    inverse->SetVelocityField(this->m_VelocityField);
-    inverse->SetVelocityFieldInterpolator(this->m_VelocityFieldInterpolator);
-    return true;
-  }
+
+  inverse->SetFixedParameters(this->GetFixedParameters());
+  inverse->SetUpperTimeBound(this->m_LowerTimeBound);
+  inverse->SetLowerTimeBound(this->m_UpperTimeBound);
+  inverse->SetDisplacementField(this->m_InverseDisplacementField);
+  inverse->SetInverseDisplacementField(this->m_DisplacementField);
+  inverse->SetInterpolator(this->m_Interpolator);
+  inverse->SetVelocityField(this->m_VelocityField);
+  inverse->SetVelocityFieldInterpolator(this->m_VelocityFieldInterpolator);
+  return true;
 }
 
 template <typename TParametersValueType, unsigned int VDimension>

--- a/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
@@ -46,13 +46,12 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Make
   {
     return VoronoiImageType::New().GetPointer();
   }
-  else
+
+  if (idx == 2)
   {
-    if (idx == 2)
-    {
-      return VectorImageType::New().GetPointer();
-    }
+    return VectorImageType::New().GetPointer();
   }
+
   return Superclass::MakeOutput(idx);
 }
 

--- a/Modules/Filtering/DistanceMap/include/itkReflectiveImageRegionConstIterator.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkReflectiveImageRegionConstIterator.hxx
@@ -141,14 +141,12 @@ ReflectiveImageRegionConstIterator<TImage>::operator++()
         this->m_Remaining = true;
         break;
       }
-      else
-      {
-        this->m_PositionIndex[in] = this->m_EndIndex[in] - m_EndOffset[in] - 1;
-        this->m_Position -= (this->m_EndOffset[in]) * (this->m_OffsetTable[in]);
-        m_IsFirstPass[in] = false;
-        this->m_Remaining = true;
-        break;
-      }
+
+      this->m_PositionIndex[in] = this->m_EndIndex[in] - m_EndOffset[in] - 1;
+      this->m_Position -= (this->m_EndOffset[in]) * (this->m_OffsetTable[in]);
+      m_IsFirstPass[in] = false;
+      this->m_Remaining = true;
+      break;
     }
     else
     {
@@ -159,12 +157,10 @@ ReflectiveImageRegionConstIterator<TImage>::operator++()
         this->m_Remaining = true;
         break;
       }
-      else
-      {
-        this->m_PositionIndex[in] = this->m_BeginIndex[in] + m_BeginOffset[in];
-        this->m_Position += (this->m_BeginOffset[in]) * (this->m_OffsetTable[in]);
-        m_IsFirstPass[in] = true;
-      }
+
+      this->m_PositionIndex[in] = this->m_BeginIndex[in] + m_BeginOffset[in];
+      this->m_Position += (this->m_BeginOffset[in]) * (this->m_OffsetTable[in]);
+      m_IsFirstPass[in] = true;
     }
   }
 

--- a/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.h
@@ -30,10 +30,8 @@ template <typename InputPixelType>
 class ITK_TEMPLATE_EXPORT InvertIntensityFunctor{ public: InputPixelType operator()(InputPixelType input)
                                                     const { if (input){ return InputPixelType {};
 }
-else
-{
-  return NumericTraits<InputPixelType>::OneValue();
-}
+
+return NumericTraits<InputPixelType>::OneValue();
 } // namespace itk
 }
 ;

--- a/Modules/Filtering/DistanceMap/test/itkFastChamferDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkFastChamferDistanceImageFilterTest.cxx
@@ -41,10 +41,8 @@ SimpleSignedDistance(const TPoint & p)
     {
       return radius;
     }
-    else
-    {
-      return -radius;
-    }
+
+    return -radius;
   }
   else
   {

--- a/Modules/Filtering/FFT/test/itkComplexToComplex1DFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkComplexToComplex1DFFTImageFilterTest.cxx
@@ -113,7 +113,7 @@ itkComplexToComplex1DFFTImageFilterTest(int argc, char * argv[])
 
     return doTest<FFTInverseType>(argv[1], argv[2], argv[3]);
   }
-  else if (backend == 1)
+  if (backend == 1)
   {
     using FFTInverseType = itk::VnlComplexToComplex1DFFTImageFilter<ComplexImageType, ComplexImageType>;
     return doTest<FFTInverseType>(argv[1], argv[2], argv[3]);

--- a/Modules/Filtering/FFT/test/itkFFT1DImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFT1DImageFilterTest.cxx
@@ -118,7 +118,7 @@ itkFFT1DImageFilterTest(int argc, char * argv[])
     }
     return doTest<FFTForwardType, FFTInverseType>(argv[1], argv[2]);
   }
-  else if (backend == 1) // Vnl backend
+  if (backend == 1) // Vnl backend
   {
     // Verify object factory returns expected type
     using VnlForwardType = itk::VnlForward1DFFTImageFilter<ImageType, ComplexImageType>;

--- a/Modules/Filtering/FFT/test/itkForward1DFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkForward1DFFTImageFilterTest.cxx
@@ -109,7 +109,7 @@ itkForward1DFFTImageFilterTest(int argc, char * argv[])
 
     return doTest<FFTForwardType>(argv[1], argv[2]);
   }
-  else if (backend == 1)
+  if (backend == 1)
   {
     using FFTForwardType = itk::VnlForward1DFFTImageFilter<ImageType, ComplexImageType>;
 

--- a/Modules/Filtering/FFT/test/itkInverse1DFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkInverse1DFFTImageFilterTest.cxx
@@ -106,7 +106,7 @@ itkInverse1DFFTImageFilterTest(int argc, char * argv[])
 
     return doTest<FFTInverseType>(argv[1], argv[2], argv[3]);
   }
-  else if (backend == 1)
+  if (backend == 1)
   {
     using FFTInverseType = itk::VnlInverse1DFFTImageFilter<ComplexImageType, ImageType>;
 

--- a/Modules/Filtering/FFT/test/itkVnlComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkVnlComplexToComplexFFTImageFilterTest.cxx
@@ -109,7 +109,7 @@ itkVnlComplexToComplexFFTImageFilterTest(int argc, char * argv[])
     }
     return EXIT_SUCCESS;
   }
-  else if (pixelTypeString.compare("double") == 0)
+  if (pixelTypeString.compare("double") == 0)
   {
     switch (dimension)
     {

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -371,18 +371,16 @@ FastMarchingImageFilterBase<TInput, TOutput>::CheckTopology(OutputImageType * oI
             this->m_LabelImage->SetPixel(iNode, Traits::Topology);
             return false;
           }
-          else
-          {
-            ItC.GoToBegin();
 
-            while (!ItC.IsAtEnd())
+          ItC.GoToBegin();
+
+          while (!ItC.IsAtEnd())
+          {
+            if (ItC.GetCenterPixel() == otherLabel)
             {
-              if (ItC.GetCenterPixel() == otherLabel)
-              {
-                ItC.SetCenterPixel(minLabel);
-              }
-              ++ItC;
+              ItC.SetCenterPixel(minLabel);
             }
+            ++ItC;
           }
         }
       }
@@ -856,10 +854,8 @@ FastMarchingImageFilterBase<TInput, TOutput>::IsCriticalC2Configuration3D(const 
       {
         return 1;
       }
-      else
-      {
-        return 2;
-      }
+
+      return 2;
     }
   }
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingQuadEdgeMeshFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingQuadEdgeMeshFilterBase.hxx
@@ -70,10 +70,8 @@ FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::GetLabelValueForGivenNode(c
   {
     return it->second;
   }
-  else
-  {
-    return Traits::Far;
-  }
+
+  return Traits::Far;
 }
 
 template <typename TInput, typename TOutput>
@@ -276,31 +274,29 @@ FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::Solve(OutputMeshType *     
     {
       return ComputeUpdate(iVal1, iVal2, norm2, sq_norm2, norm1, sq_norm1, dot, iF);
     }
+
+    OutputVectorRealType      sq_norm3;
+    OutputVectorRealType      norm3;
+    OutputVectorRealType      dot1;
+    OutputVectorRealType      dot2;
+    OutputPointIdentifierType new_id;
+
+    const bool unfolded =
+      UnfoldTriangle(oMesh, iId, iCurrentPoint, iId1, iP1, iId2, iP2, norm3, sq_norm3, dot1, dot2, new_id);
+
+    if (unfolded)
+    {
+      const OutputVectorRealType t_sq_norm3 = norm3 * norm3;
+
+      auto                       val3 = static_cast<OutputVectorRealType>(this->GetOutputValue(oMesh, new_id));
+      const OutputVectorRealType t1 = ComputeUpdate(iVal1, val3, norm3, t_sq_norm3, norm1, sq_norm1, dot1, iF);
+      const OutputVectorRealType t2 = ComputeUpdate(iVal2, val3, norm3, t_sq_norm3, norm2, sq_norm2, dot2, iF);
+
+      return std::min(t1, t2);
+    }
     else
     {
-      OutputVectorRealType      sq_norm3;
-      OutputVectorRealType      norm3;
-      OutputVectorRealType      dot1;
-      OutputVectorRealType      dot2;
-      OutputPointIdentifierType new_id;
-
-      const bool unfolded =
-        UnfoldTriangle(oMesh, iId, iCurrentPoint, iId1, iP1, iId2, iP2, norm3, sq_norm3, dot1, dot2, new_id);
-
-      if (unfolded)
-      {
-        const OutputVectorRealType t_sq_norm3 = norm3 * norm3;
-
-        auto                       val3 = static_cast<OutputVectorRealType>(this->GetOutputValue(oMesh, new_id));
-        const OutputVectorRealType t1 = ComputeUpdate(iVal1, val3, norm3, t_sq_norm3, norm1, sq_norm1, dot1, iF);
-        const OutputVectorRealType t2 = ComputeUpdate(iVal2, val3, norm3, t_sq_norm3, norm2, sq_norm2, dot2, iF);
-
-        return std::min(t1, t2);
-      }
-      else
-      {
-        return ComputeUpdate(iVal1, iVal2, norm2, sq_norm2, norm1, sq_norm1, dot, iF);
-      }
+      return ComputeUpdate(iVal1, iVal2, norm2, sq_norm2, norm1, sq_norm1, dot, iF);
     }
   }
 
@@ -370,10 +366,8 @@ FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::ComputeUpdate(const OutputV
   {
     return t + iVal1;
   }
-  else
-  {
-    return std::min(iNorm2 * iF + iVal1, iNorm1 * iF + iVal2);
-  }
+
+  return std::min(iNorm2 * iF + iVal1, iNorm1 * iF + iVal2);
 }
 
 template <typename TInput, typename TOutput>

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h
@@ -273,10 +273,8 @@ protected:
     {
       return false;
     }
-    else
-    {
-      return true;
-    }
+
+    return true;
   }
 
   /** Check that the conditions to set the target reached mode are satisfied.

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest1.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest1.cxx
@@ -209,9 +209,7 @@ itkFastMarchingImageFilterRealTest1(int itkNotUsed(argc), char * itkNotUsed(argv
     std::cout << "Test passed!" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Test failed!" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test failed!" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest2.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest2.cxx
@@ -247,9 +247,7 @@ itkFastMarchingImageFilterRealTest2(int itkNotUsed(argc), char * itkNotUsed(argv
     std::cout << "Test passed!" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Test failed!" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test failed!" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealWithNumberOfElementsTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealWithNumberOfElementsTest.cxx
@@ -165,8 +165,6 @@ itkFastMarchingImageFilterRealWithNumberOfElementsTest(int, char *[])
   {
     return EXIT_SUCCESS;
   }
-  else
-  {
-    return EXIT_FAILURE;
-  }
+
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingQuadEdgeMeshFilterBaseTest2.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingQuadEdgeMeshFilterBaseTest2.cxx
@@ -160,8 +160,6 @@ itkFastMarchingQuadEdgeMeshFilterBaseTest2(int, char *[])
   {
     return EXIT_FAILURE;
   }
-  else
-  {
-    return EXIT_SUCCESS;
-  }
+
+  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingQuadEdgeMeshFilterBaseTest4.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingQuadEdgeMeshFilterBaseTest4.cxx
@@ -162,8 +162,6 @@ itkFastMarchingQuadEdgeMeshFilterBaseTest4(int, char *[])
   {
     return EXIT_FAILURE;
   }
-  else
-  {
-    return EXIT_SUCCESS;
-  }
+
+  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
@@ -252,9 +252,7 @@ itkFastMarchingTest(int argc, char * argv[])
     std::cout << "Fast Marching test passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Fast Marching test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Fast Marching test failed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingTest2.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingTest2.cxx
@@ -218,9 +218,7 @@ itkFastMarchingTest2(int, char *[])
     std::cout << "Fast Marching test passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Fast Marching test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Fast Marching test failed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientBaseTest.cxx
@@ -239,9 +239,7 @@ itkFastMarchingUpwindGradientBaseTest(int, char *[])
     std::cout << "Fast Marching Upwind Gradient test passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Fast Marching Upwind Gradient test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Fast Marching Upwind Gradient test failed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientTest.cxx
@@ -397,9 +397,7 @@ itkFastMarchingUpwindGradientTest(int, char *[])
     std::cout << "Fast Marching Upwind Gradient test passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Fast Marching Upwind Gradient test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Fast Marching Upwind Gradient test failed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
@@ -103,21 +103,19 @@ BilateralImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
     inputPtr->SetRequestedRegion(inputRequestedRegion);
     return;
   }
-  else
-  {
-    // Couldn't crop the region (requested region is outside the largest
-    // possible region).  Throw an exception.
 
-    // store what we tried to request (prior to trying to crop)
-    inputPtr->SetRequestedRegion(inputRequestedRegion);
+  // Couldn't crop the region (requested region is outside the largest
+  // possible region).  Throw an exception.
 
-    // build an exception
-    InvalidRequestedRegionError e(__FILE__, __LINE__);
-    e.SetLocation(ITK_LOCATION);
-    e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
-    e.SetDataObject(inputPtr);
-    throw e;
-  }
+  // store what we tried to request (prior to trying to crop)
+  inputPtr->SetRequestedRegion(inputRequestedRegion);
+
+  // build an exception
+  InvalidRequestedRegionError e(__FILE__, __LINE__);
+  e.SetLocation(ITK_LOCATION);
+  e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
+  e.SetDataObject(inputPtr);
+  throw e;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.hxx
@@ -60,21 +60,19 @@ DerivativeImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
     inputPtr->SetRequestedRegion(inputRequestedRegion);
     return;
   }
-  else
-  {
-    // Couldn't crop the region (requested region is outside the largest
-    // possible region).  Throw an exception.
 
-    // store what we tried to request (prior to trying to crop)
-    inputPtr->SetRequestedRegion(inputRequestedRegion);
+  // Couldn't crop the region (requested region is outside the largest
+  // possible region).  Throw an exception.
 
-    // build an exception
-    InvalidRequestedRegionError e(__FILE__, __LINE__);
-    e.SetLocation(ITK_LOCATION);
-    e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
-    e.SetDataObject(inputPtr);
-    throw e;
-  }
+  // store what we tried to request (prior to trying to crop)
+  inputPtr->SetRequestedRegion(inputRequestedRegion);
+
+  // build an exception
+  InvalidRequestedRegionError e(__FILE__, __LINE__);
+  e.SetLocation(ITK_LOCATION);
+  e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
+  e.SetDataObject(inputPtr);
+  throw e;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.hxx
@@ -79,21 +79,19 @@ DiscreteGaussianDerivativeImageFilter<TInputImage, TOutputImage>::GenerateInputR
     inputPtr->SetRequestedRegion(inputRequestedRegion);
     return;
   }
-  else
-  {
-    // Couldn't crop the region (requested region is outside the largest
-    // possible region).  Throw an exception.
 
-    // store what we tried to request (prior to trying to crop)
-    inputPtr->SetRequestedRegion(inputRequestedRegion);
+  // Couldn't crop the region (requested region is outside the largest
+  // possible region).  Throw an exception.
 
-    // build an exception
-    InvalidRequestedRegionError e(__FILE__, __LINE__);
-    e.SetLocation(ITK_LOCATION);
-    e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
-    e.SetDataObject(inputPtr);
-    throw e;
-  }
+  // store what we tried to request (prior to trying to crop)
+  inputPtr->SetRequestedRegion(inputRequestedRegion);
+
+  // build an exception
+  InvalidRequestedRegionError e(__FILE__, __LINE__);
+  e.SetLocation(ITK_LOCATION);
+  e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
+  e.SetDataObject(inputPtr);
+  throw e;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianImageFilter.hxx
@@ -66,21 +66,19 @@ LaplacianImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
     inputPtr->SetRequestedRegion(inputRequestedRegion);
     return;
   }
-  else
-  {
-    // Couldn't crop the region (requested region is outside the largest
-    // possible region).  Throw an exception.
 
-    // store what we tried to request (prior to trying to crop)
-    inputPtr->SetRequestedRegion(inputRequestedRegion);
+  // Couldn't crop the region (requested region is outside the largest
+  // possible region).  Throw an exception.
 
-    // build an exception
-    InvalidRequestedRegionError e(__FILE__, __LINE__);
-    e.SetLocation(ITK_LOCATION);
-    e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
-    e.SetDataObject(inputPtr);
-    throw e;
-  }
+  // store what we tried to request (prior to trying to crop)
+  inputPtr->SetRequestedRegion(inputRequestedRegion);
+
+  // build an exception
+  InvalidRequestedRegionError e(__FILE__, __LINE__);
+  e.SetLocation(ITK_LOCATION);
+  e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
+  e.SetDataObject(inputPtr);
+  throw e;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageFeature/include/itkSobelEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkSobelEdgeDetectionImageFilter.hxx
@@ -59,21 +59,19 @@ SobelEdgeDetectionImageFilter<TInputImage, TOutputImage>::GenerateInputRequested
     inputPtr->SetRequestedRegion(inputRequestedRegion);
     return;
   }
-  else
-  {
-    // Couldn't crop the region (requested region is outside the largest
-    // possible region).  Throw an exception.
 
-    // store what we tried to request (prior to trying to crop)
-    inputPtr->SetRequestedRegion(inputRequestedRegion);
+  // Couldn't crop the region (requested region is outside the largest
+  // possible region).  Throw an exception.
 
-    // build an exception
-    InvalidRequestedRegionError e(__FILE__, __LINE__);
-    e.SetLocation(ITK_LOCATION);
-    e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
-    e.SetDataObject(inputPtr);
-    throw e;
-  }
+  // store what we tried to request (prior to trying to crop)
+  inputPtr->SetRequestedRegion(inputRequestedRegion);
+
+  // build an exception
+  InvalidRequestedRegionError e(__FILE__, __LINE__);
+  e.SetLocation(ITK_LOCATION);
+  e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
+  e.SetDataObject(inputPtr);
+  throw e;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.h
@@ -223,7 +223,7 @@ private:
         {
           return itk::NumericTraits<OutPixelType>::NonpositiveMin();
         }
-        else if (result > itk::NumericTraits<OutPixelType>::max())
+        if (result > itk::NumericTraits<OutPixelType>::max())
         {
           return itk::NumericTraits<OutPixelType>::max();
         }

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
@@ -69,21 +69,19 @@ ZeroCrossingImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion
     inputPtr->SetRequestedRegion(inputRequestedRegion);
     return;
   }
-  else
-  {
-    // Couldn't crop the region (requested region is outside the largest
-    // possible region).  Throw an exception.
 
-    // store what we tried to request (prior to trying to crop)
-    inputPtr->SetRequestedRegion(inputRequestedRegion);
+  // Couldn't crop the region (requested region is outside the largest
+  // possible region).  Throw an exception.
 
-    // build an exception
-    InvalidRequestedRegionError e(__FILE__, __LINE__);
-    e.SetLocation(ITK_LOCATION);
-    e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
-    e.SetDataObject(inputPtr);
-    throw e;
-  }
+  // store what we tried to request (prior to trying to crop)
+  inputPtr->SetRequestedRegion(inputRequestedRegion);
+
+  // build an exception
+  InvalidRequestedRegionError e(__FILE__, __LINE__);
+  e.SetLocation(ITK_LOCATION);
+  e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
+  e.SetDataObject(inputPtr);
+  throw e;
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -146,7 +144,7 @@ ZeroCrossingImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
             it.Set(m_ForegroundValue);
             break;
           }
-          else if (Math::ExactlyEquals(abs_this_one, abs_that) && i >= ImageDimension)
+          if (Math::ExactlyEquals(abs_this_one, abs_that) && i >= ImageDimension)
           {
             it.Set(m_ForegroundValue);
             break;

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
@@ -566,9 +566,7 @@ itkHoughTransform2DCirclesImageTest(int, char *[])
     std::cout << "Test succeeded!" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Test FAILED!" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test FAILED!" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DLinesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DLinesImageTest.cxx
@@ -357,9 +357,7 @@ itkHoughTransform2DLinesImageTest(int, char *[])
     std::cout << "Test succeeded!" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Test FAILED!" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test FAILED!" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/ImageFilterBase/include/itkBoxImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkBoxImageFilter.hxx
@@ -75,23 +75,21 @@ BoxImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
     inputPtr->SetRequestedRegion(inputRequestedRegion);
     return;
   }
-  else
-  {
-    // Couldn't crop the region (requested region is outside the largest
-    // possible region).  Throw an exception.
 
-    // store what we tried to request (prior to trying to crop)
-    inputPtr->SetRequestedRegion(inputRequestedRegion);
+  // Couldn't crop the region (requested region is outside the largest
+  // possible region).  Throw an exception.
 
-    // build an exception
-    InvalidRequestedRegionError e(__FILE__, __LINE__);
-    std::ostringstream          msg;
-    msg << static_cast<const char *>(this->GetNameOfClass()) << "::GenerateInputRequestedRegion()";
-    e.SetLocation(msg.str().c_str());
-    e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
-    e.SetDataObject(inputPtr);
-    throw e;
-  }
+  // store what we tried to request (prior to trying to crop)
+  inputPtr->SetRequestedRegion(inputRequestedRegion);
+
+  // build an exception
+  InvalidRequestedRegionError e(__FILE__, __LINE__);
+  std::ostringstream          msg;
+  msg << static_cast<const char *>(this->GetNameOfClass()) << "::GenerateInputRequestedRegion()";
+  e.SetLocation(msg.str().c_str());
+  e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
+  e.SetDataObject(inputPtr);
+  throw e;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilterBase.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilterBase.h
@@ -184,7 +184,7 @@ private:
       {
         return true;
       }
-      else if (m_Count < dc.m_Count)
+      if (m_Count < dc.m_Count)
       {
         return false;
       }

--- a/Modules/Filtering/ImageFilterBase/include/itkNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNeighborhoodOperatorImageFilter.hxx
@@ -56,21 +56,19 @@ NeighborhoodOperatorImageFilter<TInputImage, TOutputImage, TOperatorValueType>::
     inputPtr->SetRequestedRegion(inputRequestedRegion);
     return;
   }
-  else
-  {
-    // Couldn't crop the region (requested region is outside the largest
-    // possible region).  Throw an exception.
 
-    // store what we tried to request (prior to trying to crop)
-    inputPtr->SetRequestedRegion(inputRequestedRegion);
+  // Couldn't crop the region (requested region is outside the largest
+  // possible region).  Throw an exception.
 
-    // build an exception
-    InvalidRequestedRegionError e(__FILE__, __LINE__);
-    e.SetLocation(ITK_LOCATION);
-    e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
-    e.SetDataObject(inputPtr);
-    throw e;
-  }
+  // store what we tried to request (prior to trying to crop)
+  inputPtr->SetRequestedRegion(inputRequestedRegion);
+
+  // build an exception
+  InvalidRequestedRegionError e(__FILE__, __LINE__);
+  e.SetLocation(ITK_LOCATION);
+  e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
+  e.SetDataObject(inputPtr);
+  throw e;
 }
 
 template <typename TInputImage, typename TOutputImage, typename TOperatorValueType>

--- a/Modules/Filtering/ImageFilterBase/include/itkVectorNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkVectorNeighborhoodOperatorImageFilter.hxx
@@ -55,21 +55,19 @@ VectorNeighborhoodOperatorImageFilter<TInputImage, TOutputImage>::GenerateInputR
     inputPtr->SetRequestedRegion(inputRequestedRegion);
     return;
   }
-  else
-  {
-    // Couldn't crop the region (requested region is outside the largest
-    // possible region).  Throw an exception.
 
-    // store what we tried to request (prior to trying to crop)
-    inputPtr->SetRequestedRegion(inputRequestedRegion);
+  // Couldn't crop the region (requested region is outside the largest
+  // possible region).  Throw an exception.
 
-    // build an exception
-    InvalidRequestedRegionError e(__FILE__, __LINE__);
-    e.SetLocation(ITK_LOCATION);
-    e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
-    e.SetDataObject(inputPtr);
-    throw e;
-  }
+  // store what we tried to request (prior to trying to crop)
+  inputPtr->SetRequestedRegion(inputRequestedRegion);
+
+  // build an exception
+  InvalidRequestedRegionError e(__FILE__, __LINE__);
+  e.SetLocation(ITK_LOCATION);
+  e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
+  e.SetDataObject(inputPtr);
+  throw e;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.hxx
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.hxx
@@ -173,10 +173,8 @@ FrequencyBandImageFilter<TImageType, TFrequencyIterator>::BandPass(FrequencyIter
       {
         return;
       }
-      else
-      {
-        freqIt.Set(PixelType{});
-      }
+
+      freqIt.Set(PixelType{});
     }
   }
 
@@ -189,10 +187,8 @@ FrequencyBandImageFilter<TImageType, TFrequencyIterator>::BandPass(FrequencyIter
       {
         return;
       }
-      else
-      {
-        freqIt.Set(PixelType{});
-      }
+
+      freqIt.Set(PixelType{});
     }
   }
 }

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyBandImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyBandImageFilterTest.cxx
@@ -336,9 +336,7 @@ itkFrequencyBandImageFilterTest(int argc, char * argv[])
     std::cout << "Test PASSED!" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Test FAILED!" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test FAILED!" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyIteratorsGTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyIteratorsGTest.cxx
@@ -139,10 +139,8 @@ compareImages(ImageType * imageToTest, ImageType * knownImage, double difference
     std::cerr << "Unequal images, with " << numberOfDiffPixels << " unequal pixels" << std::endl;
     return false;
   }
-  else
-  {
-    return true;
-  }
+
+  return true;
 }
 
 template <typename ImageType, typename ForwardFFTType, typename InverseFFTType, typename FrequencyIteratorType>

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
@@ -75,21 +75,19 @@ GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputIm
     inputPtr->SetRequestedRegion(inputRequestedRegion);
     return;
   }
-  else
-  {
-    // Couldn't crop the region (requested region is outside the largest
-    // possible region).  Throw an exception.
 
-    // store what we tried to request (prior to trying to crop)
-    inputPtr->SetRequestedRegion(inputRequestedRegion);
+  // Couldn't crop the region (requested region is outside the largest
+  // possible region).  Throw an exception.
 
-    // build an exception
-    InvalidRequestedRegionError e(__FILE__, __LINE__);
-    e.SetLocation(ITK_LOCATION);
-    e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
-    e.SetDataObject(inputPtr);
-    throw e;
-  }
+  // store what we tried to request (prior to trying to crop)
+  inputPtr->SetRequestedRegion(inputRequestedRegion);
+
+  // build an exception
+  InvalidRequestedRegionError e(__FILE__, __LINE__);
+  e.SetLocation(ITK_LOCATION);
+  e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
+  e.SetDataObject(inputPtr);
+  throw e;
 }
 
 template <typename TInputImage, typename TOperatorValueType, typename TOutputValueType, typename TOutputImageType>

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
@@ -76,21 +76,19 @@ GradientMagnitudeImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedR
     inputPtr->SetRequestedRegion(inputRequestedRegion);
     return;
   }
-  else
-  {
-    // Couldn't crop the region (requested region is outside the largest
-    // possible region).  Throw an exception.
 
-    // store what we tried to request (prior to trying to crop)
-    inputPtr->SetRequestedRegion(inputRequestedRegion);
+  // Couldn't crop the region (requested region is outside the largest
+  // possible region).  Throw an exception.
 
-    // build an exception
-    InvalidRequestedRegionError e(__FILE__, __LINE__);
-    e.SetLocation(ITK_LOCATION);
-    e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
-    e.SetDataObject(inputPtr);
-    throw e;
-  }
+  // store what we tried to request (prior to trying to crop)
+  inputPtr->SetRequestedRegion(inputRequestedRegion);
+
+  // build an exception
+  InvalidRequestedRegionError e(__FILE__, __LINE__);
+  e.SetLocation(ITK_LOCATION);
+  e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
+  e.SetDataObject(inputPtr);
+  throw e;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
@@ -111,21 +111,19 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::Genera
     inputPtr->SetRequestedRegion(inputRequestedRegion);
     return;
   }
-  else
-  {
-    // Couldn't crop the region (requested region is outside the largest
-    // possible region).  Throw an exception.
 
-    // store what we tried to request (prior to trying to crop)
-    inputPtr->SetRequestedRegion(inputRequestedRegion);
+  // Couldn't crop the region (requested region is outside the largest
+  // possible region).  Throw an exception.
 
-    // build an exception
-    InvalidRequestedRegionError e(__FILE__, __LINE__);
-    e.SetLocation(ITK_LOCATION);
-    e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
-    e.SetDataObject(inputPtr);
-    throw e;
-  }
+  // store what we tried to request (prior to trying to crop)
+  inputPtr->SetRequestedRegion(inputRequestedRegion);
+
+  // build an exception
+  InvalidRequestedRegionError e(__FILE__, __LINE__);
+  e.SetLocation(ITK_LOCATION);
+  e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
+  e.SetDataObject(inputPtr);
+  throw e;
 }
 
 template <typename TInputImage, typename TRealType, typename TOutputImage>

--- a/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest2.cxx
@@ -129,7 +129,7 @@ itkGradientImageFilterTest2(int argc, char * argv[])
   {
     return DoIt<itk::Image<float, 2>>(infname, outfname);
   }
-  else if (dimension == 3)
+  if (dimension == 3)
     return DoIt<itk::Image<float, 3>>(infname, outfname);
 
   return EXIT_FAILURE;

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -376,10 +376,8 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::SplitRe
   {
     return this->GetNumberOfWorkUnits();
   }
-  else // we split on the output region for reconstruction
-  {
-    return Superclass::SplitRequestedRegion(i, num, splitRegion);
-  }
+  // we split on the output region for reconstruction
+  return Superclass::SplitRequestedRegion(i, num, splitRegion);
 }
 
 template <typename TInputPointSet, typename TOutputImage>

--- a/Modules/Filtering/ImageGrid/include/itkCoxDeBoorBSplineKernelFunction.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkCoxDeBoorBSplineKernelFunction.hxx
@@ -166,10 +166,8 @@ CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::Evaluate(const TRe
   {
     return PolynomialType(this->m_BSplineShapeFunctions.get_row(which)).evaluate(absValue);
   }
-  else
-  {
-    return TRealValueType{ 0.0 };
-  }
+
+  return TRealValueType{ 0.0 };
 }
 
 template <unsigned int VSplineOrder, typename TRealValueType>
@@ -208,10 +206,8 @@ CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::EvaluateNthDerivat
     {
       return -der;
     }
-    else
-    {
-      return der;
-    }
+
+    return der;
   }
   else
   {

--- a/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.hxx
@@ -129,7 +129,7 @@ OrientImageFilter<TInputImage, TOutputImage>::DeterminePermutationsAndFlips(
             // Axis i is already in place
             continue;
           }
-          else if (AnatomicalOrientation::SameOrientationAxes(fixed_codes[i], moving_codes[j]))
+          if (AnatomicalOrientation::SameOrientationAxes(fixed_codes[i], moving_codes[j]))
           {
             // The cyclic permutation (i j) applies. Therefore, the remainder
             // is (k), i.e., stationary

--- a/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.hxx
@@ -82,7 +82,7 @@ PermuteAxesImageFilter<TImage>::SetOrder(const PermuteOrderArrayType & order)
       err.SetDescription("Order indices is out of range");
       throw err;
     }
-    else if (used[order[j]])
+    if (used[order[j]])
     {
       ExceptionObject err(__FILE__, __LINE__);
       err.SetLocation(ITK_LOCATION);

--- a/Modules/Filtering/ImageGrid/test/itkBSplineResampleImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineResampleImageFilterTest.cxx
@@ -704,9 +704,7 @@ itkBSplineResampleImageFilterTest(int itkNotUsed(argc), char * itkNotUsed(argv)[
 
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "All tests successfully passed" << std::endl;
-    return EXIT_SUCCESS;
-  }
+
+  std::cout << "All tests successfully passed" << std::endl;
+  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageGrid/test/itkBinShrinkImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBinShrinkImageFilterTest2.cxx
@@ -113,8 +113,6 @@ itkBinShrinkImageFilterTest2(int, char *[])
   {
     return EXIT_SUCCESS;
   }
-  else
-  {
-    return EXIT_FAILURE;
-  }
+
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/ImageGrid/test/itkInterpolateImagePointsFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkInterpolateImagePointsFilterTest.cxx
@@ -301,11 +301,9 @@ itkInterpolateImagePointsFilterTest(int, char *[])
     std::cout << "\n*** " << testStatus << " tests failed" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "\nAll tests successfully passed\n" << std::endl;
-    return EXIT_SUCCESS;
-  }
+
+  std::cout << "\nAll tests successfully passed\n" << std::endl;
+  return EXIT_SUCCESS;
 }
 
 void

--- a/Modules/Filtering/ImageGrid/test/itkShrinkImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkShrinkImageTest.cxx
@@ -217,10 +217,8 @@ itkShrinkImageTest(int, char *[])
     std::cout << std::flush;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "ShrinkImageFilter test failed." << std::endl;
-    std::cout << std::flush;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "ShrinkImageFilter test failed." << std::endl;
+  std::cout << std::flush;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/ImageIntensity/include/itkArithmeticOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkArithmeticOpsFunctors.h
@@ -148,10 +148,8 @@ public:
     {
       return (TOutput)(A / B);
     }
-    else
-    {
-      return NumericTraits<TOutput>::max(static_cast<TOutput>(A));
-    }
+
+    return NumericTraits<TOutput>::max(static_cast<TOutput>(A));
   }
 };
 
@@ -221,10 +219,8 @@ public:
     {
       return static_cast<TOutput>(A % B);
     }
-    else
-    {
-      return NumericTraits<TOutput>::max(static_cast<TOutput>(A));
-    }
+
+    return NumericTraits<TOutput>::max(static_cast<TOutput>(A));
   }
 };
 
@@ -303,10 +299,8 @@ public:
       {
         return NumericTraits<TOutput>::max(A);
       }
-      else
-      {
-        return NumericTraits<TOutput>::NonpositiveMin(A);
-      }
+
+      return NumericTraits<TOutput>::NonpositiveMin(A);
     }
     return static_cast<TOutput>(temp);
   }

--- a/Modules/Filtering/ImageIntensity/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
@@ -211,12 +211,10 @@ DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::Evaluate(c
     this->ConvertPointToNearestIndex(point, index);
     return this->EvaluateAtIndex(index);
   }
-  else
-  {
-    ContinuousIndexType cindex;
-    this->ConvertPointToContinuousIndex(point, cindex);
-    return this->EvaluateAtContinuousIndex(cindex);
-  }
+
+  ContinuousIndexType cindex;
+  this->ConvertPointToContinuousIndex(point, cindex);
+  return this->EvaluateAtContinuousIndex(cindex);
 }
 
 /** Evaluate the function at specified ContinuousIndex position.*/
@@ -231,65 +229,63 @@ DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::EvaluateAt
     this->ConvertContinuousIndexToNearestIndex(cindex, index);
     return this->EvaluateAtIndex(index);
   }
-  else
+
+  using NumberOfNeighborsType = unsigned int;
+
+  constexpr NumberOfNeighborsType neighbors = 1 << ImageDimension2;
+
+  // Compute base index = closet index below point
+  // Compute distance from point to base index
+  IndexType baseIndex;
+  double    distance[ImageDimension2];
+  for (unsigned int dim = 0; dim < ImageDimension2; ++dim)
   {
-    using NumberOfNeighborsType = unsigned int;
+    baseIndex[dim] = Math::Floor<IndexValueType>(cindex[dim]);
+    distance[dim] = cindex[dim] - static_cast<double>(baseIndex[dim]);
+  }
 
-    constexpr NumberOfNeighborsType neighbors = 1 << ImageDimension2;
+  // Interpolated value is the weighted sum of each of the surrounding
+  // neighbors. The weight for each neighbor is the fraction overlap
+  // of the neighbor pixel with respect to a pixel centered on point.
+  TOutput value{};
+  TOutput totalOverlap{};
 
-    // Compute base index = closet index below point
-    // Compute distance from point to base index
-    IndexType baseIndex;
-    double    distance[ImageDimension2];
+  for (NumberOfNeighborsType counter = 0; counter < neighbors; ++counter)
+  {
+    double                overlap = 1.0;   // fraction overlap
+    NumberOfNeighborsType upper = counter; // each bit indicates upper/lower neighbour
+    IndexType             neighIndex;
+
+    // get neighbor index and overlap fraction
     for (unsigned int dim = 0; dim < ImageDimension2; ++dim)
     {
-      baseIndex[dim] = Math::Floor<IndexValueType>(cindex[dim]);
-      distance[dim] = cindex[dim] - static_cast<double>(baseIndex[dim]);
+      if (upper & 1)
+      {
+        neighIndex[dim] = baseIndex[dim] + 1;
+        overlap *= distance[dim];
+      }
+      else
+      {
+        neighIndex[dim] = baseIndex[dim];
+        overlap *= 1.0 - distance[dim];
+      }
+      upper >>= 1;
     }
 
-    // Interpolated value is the weighted sum of each of the surrounding
-    // neighbors. The weight for each neighbor is the fraction overlap
-    // of the neighbor pixel with respect to a pixel centered on point.
-    TOutput value{};
-    TOutput totalOverlap{};
-
-    for (NumberOfNeighborsType counter = 0; counter < neighbors; ++counter)
+    // get neighbor value only if overlap is not zero
+    if (overlap)
     {
-      double                overlap = 1.0;   // fraction overlap
-      NumberOfNeighborsType upper = counter; // each bit indicates upper/lower neighbour
-      IndexType             neighIndex;
-
-      // get neighbor index and overlap fraction
-      for (unsigned int dim = 0; dim < ImageDimension2; ++dim)
-      {
-        if (upper & 1)
-        {
-          neighIndex[dim] = baseIndex[dim] + 1;
-          overlap *= distance[dim];
-        }
-        else
-        {
-          neighIndex[dim] = baseIndex[dim];
-          overlap *= 1.0 - distance[dim];
-        }
-        upper >>= 1;
-      }
-
-      // get neighbor value only if overlap is not zero
-      if (overlap)
-      {
-        value += overlap * static_cast<TOutput>(this->EvaluateAtIndex(neighIndex));
-        totalOverlap += overlap;
-      }
-
-      if (totalOverlap == 1.0)
-      {
-        // finished
-        break;
-      }
+      value += overlap * static_cast<TOutput>(this->EvaluateAtIndex(neighIndex));
+      totalOverlap += overlap;
     }
-    return (static_cast<OutputType>(value));
+
+    if (totalOverlap == 1.0)
+    {
+      // finished
+      break;
+    }
   }
+  return (static_cast<OutputType>(value));
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageIntensity/include/itkLogicOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkLogicOpsFunctors.h
@@ -365,10 +365,8 @@ public:
     {
       return static_cast<TOutput>(B);
     }
-    else
-    {
-      return static_cast<TOutput>(C);
-    }
+
+    return static_cast<TOutput>(C);
   }
 };
 

--- a/Modules/Filtering/ImageIntensity/include/itkMaskImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskImageFilter.h
@@ -56,10 +56,8 @@ public:
     {
       return static_cast<TOutput>(A);
     }
-    else
-    {
-      return m_OutsideValue;
-    }
+
+    return m_OutsideValue;
   }
 
   /** Method to explicitly set the outside value of the mask */

--- a/Modules/Filtering/ImageIntensity/include/itkMaskNegatedImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskNegatedImageFilter.h
@@ -53,10 +53,8 @@ public:
     {
       return m_OutsideValue;
     }
-    else
-    {
-      return static_cast<TOutput>(A);
-    }
+
+    return static_cast<TOutput>(A);
   }
 
   /** Method to explicitly set the outside value of the mask */

--- a/Modules/Filtering/ImageIntensity/include/itkMaximumImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaximumImageFilter.h
@@ -48,10 +48,8 @@ public:
     {
       return static_cast<TOutput>(A);
     }
-    else
-    {
-      return static_cast<TOutput>(B);
-    }
+
+    return static_cast<TOutput>(B);
   }
 };
 } // namespace Functor

--- a/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest.cxx
@@ -194,9 +194,6 @@ itkAdaptImageFilterTest(int, char *[])
     std::cout << "AdaptImageFilterTest passed." << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cerr << "AdaptImageFilterTest failed." << std::endl;
-    return EXIT_FAILURE;
-  }
+  std::cerr << "AdaptImageFilterTest failed." << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest2.cxx
@@ -191,9 +191,6 @@ itkAdaptImageFilterTest2(int, char *[])
     std::cout << "AdaptImageFilterTest2 passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "AdaptImageFilterTest2 passed" << std::endl;
-    return EXIT_FAILURE;
-  }
+  std::cout << "AdaptImageFilterTest2 passed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/ImageIntensity/test/itkEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkEqualTest.cxx
@@ -179,10 +179,8 @@ itkEqualTest(int, char *[])
     {
       return (EXIT_FAILURE);
     }
-    else
-    {
-      std::cout << "Step 1 passed" << std::endl;
-    }
+
+    std::cout << "Step 1 passed" << std::endl;
   }
 
   {
@@ -209,10 +207,8 @@ itkEqualTest(int, char *[])
     {
       return (EXIT_FAILURE);
     }
-    else
-    {
-      std::cout << "Step 2 passed " << std::endl;
-    }
+
+    std::cout << "Step 2 passed " << std::endl;
   }
   // Now try testing with constant : 3 == Im2
   {
@@ -238,10 +234,8 @@ itkEqualTest(int, char *[])
     {
       return (EXIT_FAILURE);
     }
-    else
-    {
-      std::cout << "Step 3 passed" << std::endl;
-    }
+
+    std::cout << "Step 3 passed" << std::endl;
   }
 
   {

--- a/Modules/Filtering/ImageIntensity/test/itkGreaterEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkGreaterEqualTest.cxx
@@ -134,10 +134,8 @@ itkGreaterEqualTest(int, char *[])
     {
       return (EXIT_FAILURE);
     }
-    else
-    {
-      std::cout << "Step 1 passed" << std::endl;
-    }
+
+    std::cout << "Step 1 passed" << std::endl;
   }
 
   {
@@ -165,10 +163,8 @@ itkGreaterEqualTest(int, char *[])
     {
       return (EXIT_FAILURE);
     }
-    else
-    {
-      std::cout << "Step 2 passed " << std::endl;
-    }
+
+    std::cout << "Step 2 passed " << std::endl;
   }
   // Now try testing with constant : 3 != Im2
   {
@@ -194,10 +190,8 @@ itkGreaterEqualTest(int, char *[])
     {
       return (EXIT_FAILURE);
     }
-    else
-    {
-      std::cout << "Step 3 passed" << std::endl;
-    }
+
+    std::cout << "Step 3 passed" << std::endl;
   }
   // All objects should be automatically destroyed at this point
   return EXIT_SUCCESS;

--- a/Modules/Filtering/ImageIntensity/test/itkGreaterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkGreaterTest.cxx
@@ -133,10 +133,8 @@ itkGreaterTest(int, char *[])
     {
       return (EXIT_FAILURE);
     }
-    else
-    {
-      std::cout << "Step 1 passed" << std::endl;
-    }
+
+    std::cout << "Step 1 passed" << std::endl;
   }
 
   {
@@ -164,10 +162,8 @@ itkGreaterTest(int, char *[])
     {
       return (EXIT_FAILURE);
     }
-    else
-    {
-      std::cout << "Step 2 passed " << std::endl;
-    }
+
+    std::cout << "Step 2 passed " << std::endl;
   }
   // Now try testing with constant : 3 != Im2
   {
@@ -191,10 +187,8 @@ itkGreaterTest(int, char *[])
     {
       return (EXIT_FAILURE);
     }
-    else
-    {
-      std::cout << "Step 3 passed" << std::endl;
-    }
+
+    std::cout << "Step 3 passed" << std::endl;
   }
   // All objects should be automatically destroyed at this point
   return EXIT_SUCCESS;

--- a/Modules/Filtering/ImageIntensity/test/itkLessEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkLessEqualTest.cxx
@@ -135,10 +135,8 @@ itkLessEqualTest(int, char *[])
     {
       return (EXIT_FAILURE);
     }
-    else
-    {
-      std::cout << "Step 1 passed" << std::endl;
-    }
+
+    std::cout << "Step 1 passed" << std::endl;
   }
 
   {
@@ -165,10 +163,8 @@ itkLessEqualTest(int, char *[])
     {
       return (EXIT_FAILURE);
     }
-    else
-    {
-      std::cout << "Step 2 passed " << std::endl;
-    }
+
+    std::cout << "Step 2 passed " << std::endl;
   }
   // Now try testing with constant : 3 != Im2
   {
@@ -192,10 +188,8 @@ itkLessEqualTest(int, char *[])
     {
       return (EXIT_FAILURE);
     }
-    else
-    {
-      std::cout << "Step 3 passed" << std::endl;
-    }
+
+    std::cout << "Step 3 passed" << std::endl;
   }
   // All objects should be automatically destroyed at this point
   return EXIT_SUCCESS;

--- a/Modules/Filtering/ImageIntensity/test/itkLessTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkLessTest.cxx
@@ -132,10 +132,8 @@ itkLessTest(int, char *[])
     {
       return (EXIT_FAILURE);
     }
-    else
-    {
-      std::cout << "Step 1 passed" << std::endl;
-    }
+
+    std::cout << "Step 1 passed" << std::endl;
   }
 
   {
@@ -162,10 +160,8 @@ itkLessTest(int, char *[])
     {
       return (EXIT_FAILURE);
     }
-    else
-    {
-      std::cout << "Step 2 passed " << std::endl;
-    }
+
+    std::cout << "Step 2 passed " << std::endl;
   }
   // Now try testing with constant : 3 != Im2
   {
@@ -189,10 +185,8 @@ itkLessTest(int, char *[])
     {
       return (EXIT_FAILURE);
     }
-    else
-    {
-      std::cout << "Step 3 passed" << std::endl;
-    }
+
+    std::cout << "Step 3 passed" << std::endl;
   }
   // All objects should be automatically destroyed at this point
   return EXIT_SUCCESS;

--- a/Modules/Filtering/ImageIntensity/test/itkNotEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNotEqualTest.cxx
@@ -135,10 +135,8 @@ itkNotEqualTest(int, char *[])
     {
       return (EXIT_FAILURE);
     }
-    else
-    {
-      std::cout << "Step 1 passed" << std::endl;
-    }
+
+    std::cout << "Step 1 passed" << std::endl;
   }
   {
     // Create a logic Filter
@@ -164,10 +162,8 @@ itkNotEqualTest(int, char *[])
     {
       return (EXIT_FAILURE);
     }
-    else
-    {
-      std::cout << "Step 2 passed " << std::endl;
-    }
+
+    std::cout << "Step 2 passed " << std::endl;
   }
   {
     // Now try testing with constant : 3 != Im2
@@ -191,10 +187,8 @@ itkNotEqualTest(int, char *[])
     {
       return (EXIT_FAILURE);
     }
-    else
-    {
-      std::cout << "Step 3 passed" << std::endl;
-    }
+
+    std::cout << "Step 3 passed" << std::endl;
   }
   // All objects should be automatically destroyed at this point
   return EXIT_SUCCESS;

--- a/Modules/Filtering/ImageIntensity/test/itkRGBToVectorAdaptImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkRGBToVectorAdaptImageFilterTest.cxx
@@ -138,9 +138,7 @@ itkRGBToVectorAdaptImageFilterTest(int, char *[])
     std::cout << "AdaptImageFilterTest passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "AdaptImageFilterTest passed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "AdaptImageFilterTest passed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/ImageIntensity/test/itkSymmetricEigenAnalysisImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSymmetricEigenAnalysisImageFilterTest.cxx
@@ -372,8 +372,6 @@ itkSymmetricEigenAnalysisImageFilterTest(int argc, char * argv[])
   {
     return EXIT_SUCCESS;
   }
-  else
-  {
-    return EXIT_FAILURE;
-  }
+
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/ImageLabel/test/itkChangeLabelImageFilterTest.cxx
+++ b/Modules/Filtering/ImageLabel/test/itkChangeLabelImageFilterTest.cxx
@@ -178,9 +178,7 @@ itkChangeLabelImageFilterTest(int, char *[])
     std::cout << "Test passed. " << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Test failed. " << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test failed. " << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.hxx
@@ -50,7 +50,7 @@ NoiseBaseImageFilter<TInputImage, TOutputImage>::ClampCast(const double value) -
   {
     return NumericTraits<OutputImagePixelType>::max();
   }
-  else if (value <= static_cast<double>(NumericTraits<OutputImagePixelType>::NonpositiveMin()))
+  if (value <= static_cast<double>(NumericTraits<OutputImagePixelType>::NonpositiveMin()))
   {
     return NumericTraits<OutputImagePixelType>::NonpositiveMin();
   }

--- a/Modules/Filtering/ImageSources/include/itkGaborKernelFunction.h
+++ b/Modules/Filtering/ImageSources/include/itkGaborKernelFunction.h
@@ -76,10 +76,8 @@ public:
     {
       return envelope * std::sin(phase);
     }
-    else
-    {
-      return envelope * std::cos(phase);
-    }
+
+    return envelope * std::cos(phase);
   }
 
   /** Set/Get the standard deviation of the Gaussian envelope. */

--- a/Modules/Filtering/ImageStatistics/include/itkBinaryProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkBinaryProjectionImageFilter.h
@@ -75,10 +75,8 @@ public:
     {
       return (TOutputPixel)m_ForegroundValue;
     }
-    else
-    {
-      return m_BackgroundValue;
-    }
+
+    return m_BackgroundValue;
   }
 
   bool m_IsForeground;

--- a/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.hxx
@@ -161,10 +161,8 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetTotalOverlap() const -> RealTyp
   {
     return NumericTraits<RealType>::max();
   }
-  else
-  {
-    return (numerator / denominator);
-  }
+
+  return (numerator / denominator);
 }
 
 template <typename TLabelImage>
@@ -212,10 +210,8 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetUnionOverlap() const -> RealTyp
   {
     return NumericTraits<RealType>::max();
   }
-  else
-  {
-    return (numerator / denominator);
-  }
+
+  return (numerator / denominator);
 }
 
 template <typename TLabelImage>
@@ -279,10 +275,8 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetVolumeSimilarity() const -> Rea
   {
     return NumericTraits<RealType>::max();
   }
-  else
-  {
-    return (2.0 * numerator / denominator);
-  }
+
+  return (2.0 * numerator / denominator);
 }
 
 template <typename TLabelImage>
@@ -322,10 +316,8 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalseNegativeError() const -> R
   {
     return NumericTraits<RealType>::max();
   }
-  else
-  {
-    return (numerator / denominator);
-  }
+
+  return (numerator / denominator);
 }
 
 template <typename TLabelImage>
@@ -377,10 +369,8 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalsePositiveError() const -> R
   {
     return NumericTraits<RealType>::max();
   }
-  else
-  {
-    return (numerator / denominator);
-  }
+
+  return (numerator / denominator);
 }
 
 template <typename TLabelImage>
@@ -433,10 +423,8 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalseDiscoveryRate() const -> R
   {
     return NumericTraits<RealType>::max();
   }
-  else
-  {
-    return (numerator / denominator);
-  }
+
+  return (numerator / denominator);
 }
 
 template <typename TLabelImage>

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
@@ -277,10 +277,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMinimum(LabelPixelType 
     // label does not exist, return a default value
     return NumericTraits<PixelType>::max();
   }
-  else
-  {
-    return mapIt->second.m_Minimum;
-  }
+
+  return mapIt->second.m_Minimum;
 }
 
 template <typename TInputImage, typename TLabelImage>
@@ -293,10 +291,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMaximum(LabelPixelType 
     // label does not exist, return a default value
     return NumericTraits<PixelType>::NonpositiveMin();
   }
-  else
-  {
-    return mapIt->second.m_Maximum;
-  }
+
+  return mapIt->second.m_Maximum;
 }
 
 template <typename TInputImage, typename TLabelImage>
@@ -309,10 +305,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMean(LabelPixelType lab
     // label does not exist, return a default value
     return PixelType{};
   }
-  else
-  {
-    return mapIt->second.m_Mean;
-  }
+
+  return mapIt->second.m_Mean;
 }
 
 template <typename TInputImage, typename TLabelImage>
@@ -325,10 +319,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetSum(LabelPixelType labe
     // label does not exist, return a default value
     return PixelType{};
   }
-  else
-  {
-    return mapIt->second.m_Sum;
-  }
+
+  return mapIt->second.m_Sum;
 }
 
 template <typename TInputImage, typename TLabelImage>
@@ -341,10 +333,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetSigma(LabelPixelType la
     // label does not exist, return a default value
     return PixelType{};
   }
-  else
-  {
-    return mapIt->second.m_Sigma;
-  }
+
+  return mapIt->second.m_Sigma;
 }
 
 template <typename TInputImage, typename TLabelImage>
@@ -357,10 +347,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetVariance(LabelPixelType
     // label does not exist, return a default value
     return PixelType{};
   }
-  else
-  {
-    return mapIt->second.m_Variance;
-  }
+
+  return mapIt->second.m_Variance;
 }
 
 template <typename TInputImage, typename TLabelImage>
@@ -374,10 +362,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetBoundingBox(LabelPixelT
     // label does not exist, return a default value
     return emptyBox;
   }
-  else
-  {
-    return mapIt->second.m_BoundingBox;
-  }
+
+  return mapIt->second.m_BoundingBox;
 }
 
 template <typename TInputImage, typename TLabelImage>
@@ -392,21 +378,19 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetRegion(LabelPixelType l
     // label does not exist, return a default value
     return emptyRegion;
   }
-  else
+
+  BoundingBoxType bbox = this->GetBoundingBox(label);
+  IndexType       index;
+  SizeType        size;
+
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
-    BoundingBoxType bbox = this->GetBoundingBox(label);
-    IndexType       index;
-    SizeType        size;
-
-    for (unsigned int i = 0; i < ImageDimension; ++i)
-    {
-      index[i] = bbox[2 * i];
-      size[i] = bbox[2 * i + 1] - bbox[2 * i] + 1;
-    }
-    const RegionType region(index, size);
-
-    return region;
+    index[i] = bbox[2 * i];
+    size[i] = bbox[2 * i + 1] - bbox[2 * i] + 1;
   }
+  const RegionType region(index, size);
+
+  return region;
 }
 
 template <typename TInputImage, typename TLabelImage>
@@ -419,10 +403,8 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetCount(LabelPixelType la
     // label does not exist, return a default value
     return 0;
   }
-  else
-  {
-    return mapIt->second.m_Count;
-  }
+
+  return mapIt->second.m_Count;
 }
 
 template <typename TInputImage, typename TLabelImage>
@@ -436,30 +418,28 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetMedian(LabelPixelType l
     // label does not exist OR histograms not enabled, return the default value
     return median;
   }
-  else
+
+  typename HistogramType::SizeValueType bin = 0;
+
+  typename HistogramType::IndexType index;
+  index.SetSize(1);
+  RealType total = 0;
+
+  // count bins until just over half the distribution is counted
+  while (total <= (mapIt->second.m_Count / 2) && (bin < m_NumBins[0]))
   {
-    typename HistogramType::SizeValueType bin = 0;
-
-    typename HistogramType::IndexType index;
-    index.SetSize(1);
-    RealType total = 0;
-
-    // count bins until just over half the distribution is counted
-    while (total <= (mapIt->second.m_Count / 2) && (bin < m_NumBins[0]))
-    {
-      index[0] = bin;
-      total += mapIt->second.m_Histogram->GetFrequency(index);
-      ++bin;
-    }
-    --bin;
     index[0] = bin;
-
-    // return center of bin range
-    const RealType lowRange = mapIt->second.m_Histogram->GetBinMin(0, bin);
-    const RealType highRange = mapIt->second.m_Histogram->GetBinMax(0, bin);
-    median = lowRange + (highRange - lowRange) / 2;
-    return median;
+    total += mapIt->second.m_Histogram->GetFrequency(index);
+    ++bin;
   }
+  --bin;
+  index[0] = bin;
+
+  // return center of bin range
+  const RealType lowRange = mapIt->second.m_Histogram->GetBinMin(0, bin);
+  const RealType highRange = mapIt->second.m_Histogram->GetBinMax(0, bin);
+  median = lowRange + (highRange - lowRange) / 2;
+  return median;
 }
 
 template <typename TInputImage, typename TLabelImage>
@@ -472,11 +452,9 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::GetHistogram(LabelPixelTyp
     // label does not exist, return a default value
     return nullptr;
   }
-  else
-  {
-    // this will be zero if histograms have not been enabled
-    return mapIt->second.m_Histogram;
-  }
+
+  // this will be zero if histograms have not been enabled
+  return mapIt->second.m_Histogram;
 }
 
 template <typename TImage, typename TLabelImage>

--- a/Modules/Filtering/ImageStatistics/test/itkMinimumMaximumImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkMinimumMaximumImageFilterTest.cxx
@@ -125,9 +125,7 @@ itkMinimumMaximumImageFilterTest(int argc, char * argv[])
     std::cout << "*** Some tests failed" << std::endl;
     return flag;
   }
-  else
-  {
-    std::cout << "All tests successfully passed" << std::endl;
-    return EXIT_SUCCESS;
-  }
+
+  std::cout << "All tests successfully passed" << std::endl;
+  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageStatistics/test/itkProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkProjectionImageFilterTest.cxx
@@ -60,10 +60,8 @@ public:
     {
       return 100;
     }
-    else
-    {
-      return 0;
-    }
+
+    return 0;
   }
 
   bool m_IsForeground{ false };

--- a/Modules/Filtering/LabelMap/include/itkAttributeUniqueLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeUniqueLabelMapFilter.h
@@ -137,7 +137,7 @@ private:
         {
           return true;
         }
-        else if (lla.line.GetIndex()[i] < llb.line.GetIndex()[i])
+        if (lla.line.GetIndex()[i] < llb.line.GetIndex()[i])
         {
           return false;
         }

--- a/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
@@ -122,7 +122,7 @@ LabelObject<TLabel, VImageDimension>::RemoveIndex(const IndexType & idx)
         it->SetLength(orgLineLength - 1);
         return true;
       }
-      else if (orgLineIndex[0] + static_cast<IndexValueType>(orgLineLength) - 1 == idx[0])
+      if (orgLineIndex[0] + static_cast<IndexValueType>(orgLineLength) - 1 == idx[0])
       {
         // decrease the length by one
         it->SetLength(orgLineLength - 1);

--- a/Modules/Filtering/LabelMap/include/itkLabelObjectLineComparator.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelObjectLineComparator.h
@@ -53,7 +53,7 @@ public:
       {
         return true;
       }
-      else if (idx1[i] > idx2[i])
+      if (idx1[i] > idx2[i])
       {
         return false;
       }

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
@@ -167,7 +167,7 @@ public:
     {
       return NUMBER_OF_PIXELS;
     }
-    else if (s == "PhysicalSize")
+    if (s == "PhysicalSize")
     {
       return PHYSICAL_SIZE;
     }

--- a/Modules/Filtering/LabelMap/include/itkShapeUniqueLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeUniqueLabelMapFilter.h
@@ -354,7 +354,7 @@ private:
         {
           return true;
         }
-        else if (lla.line.GetIndex()[i] < llb.line.GetIndex()[i])
+        if (lla.line.GetIndex()[i] < llb.line.GetIndex()[i])
         {
           return false;
         }

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelObject.h
@@ -104,7 +104,7 @@ public:
     {
       return MINIMUM;
     }
-    else if (s == "Maximum")
+    if (s == "Maximum")
     {
       return MAXIMUM;
     }

--- a/Modules/Filtering/LabelMap/src/itkGeometryUtilities.cxx
+++ b/Modules/Filtering/LabelMap/src/itkGeometryUtilities.cxx
@@ -50,10 +50,8 @@ GeometryUtilities::GammaN2p1(const long n)
   {
     return Factorial(n / 2);
   }
-  else
-  {
-    return std::sqrt(itk::Math::pi) * DoubleFactorial(n) / std::pow(2, (n + 1) / 2.0);
-  }
+
+  return std::sqrt(itk::Math::pi) * DoubleFactorial(n) / std::pow(2, (n + 1) / 2.0);
 }
 
 double

--- a/Modules/Filtering/LabelMap/test/itkLabelImageToLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelImageToLabelMapFilterTest.cxx
@@ -125,7 +125,7 @@ itkLabelImageToLabelMapFilterTest(int, char *[])
           itkAssertOrThrowMacro((val == 3), "Error in Label Image (foreground).");
           continue;
         }
-        else if (ctrJ == 7)
+        if (ctrJ == 7)
         {
           itkAssertOrThrowMacro((val == 5), "Error in Label Image (foreground).");
         }

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateLine.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateLine.hxx
@@ -221,19 +221,17 @@ AnchorErodeDilateLine<TInputPix, TCompare>::StartLine(std::vector<TInputPix> & b
     inLeftP = currentP;
     return (true);
   }
-  else
+
+  // Now we need a histogram
+  // Initialise it
+  ++outLeftP;
+  ++inLeftP;
+  for (int aux = inLeftP; aux <= currentP; ++aux)
   {
-    // Now we need a histogram
-    // Initialise it
-    ++outLeftP;
-    ++inLeftP;
-    for (int aux = inLeftP; aux <= currentP; ++aux)
-    {
-      histo.AddPixel(inbuffer[aux]);
-    }
-    Extreme = histo.GetValue();
-    buffer[outLeftP] = Extreme;
+    histo.AddPixel(inbuffer[aux]);
   }
+  Extreme = histo.GetValue();
+  buffer[outLeftP] = Extreme;
 
   while (currentP < inRightP)
   {
@@ -247,17 +245,15 @@ AnchorErodeDilateLine<TInputPix, TCompare>::StartLine(std::vector<TInputPix> & b
       inLeftP = currentP;
       return (true);
     }
-    else
-    {
-      // update histogram
-      histo.AddPixel(inbuffer[currentP]);
-      histo.RemovePixel(inbuffer[inLeftP]);
-      // find extreme
-      Extreme = histo.GetValue();
-      ++inLeftP;
-      ++outLeftP;
-      buffer[outLeftP] = Extreme;
-    }
+
+    // update histogram
+    histo.AddPixel(inbuffer[currentP]);
+    histo.RemovePixel(inbuffer[inLeftP]);
+    // find extreme
+    Extreme = histo.GetValue();
+    ++inLeftP;
+    ++outLeftP;
+    buffer[outLeftP] = Extreme;
   }
   return (false);
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseLine.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseLine.hxx
@@ -165,24 +165,23 @@ AnchorOpenCloseLine<TInputPix, TCompare>::StartLine(std::vector<InputImagePixelT
     outLeftP = currentP;
     return (true);
   }
-  else
+
+  // Now we need a histogram
+  // Initialise it
+  ++outLeftP;
+  for (unsigned int aux = outLeftP; aux <= currentP; ++aux)
   {
-    // Now we need a histogram
-    // Initialise it
-    ++outLeftP;
-    for (unsigned int aux = outLeftP; aux <= currentP; ++aux)
-    {
-      histo.AddPixel(buffer[aux]);
-    }
-    // find the minimum value. The version
-    // in the paper assumes integer pixel types and initializes the
-    // search to the current extreme. Hopefully the latter is an
-    // optimization step.
-    Extreme = histo.GetValue();
-    histo.RemovePixel(buffer[outLeftP]);
-    buffer[outLeftP] = Extreme;
-    histo.AddPixel(Extreme);
+    histo.AddPixel(buffer[aux]);
   }
+  // find the minimum value. The version
+  // in the paper assumes integer pixel types and initializes the
+  // search to the current extreme. Hopefully the latter is an
+  // optimization step.
+  Extreme = histo.GetValue();
+  histo.RemovePixel(buffer[outLeftP]);
+  buffer[outLeftP] = Extreme;
+  histo.AddPixel(Extreme);
+
 
   while (currentP < outRightP)
   {
@@ -198,17 +197,15 @@ AnchorOpenCloseLine<TInputPix, TCompare>::StartLine(std::vector<InputImagePixelT
       outLeftP = currentP;
       return (true);
     }
-    else
-    {
-      /* histogram update */
-      histo.AddPixel(buffer[currentP]);
-      histo.RemovePixel(buffer[outLeftP]);
-      Extreme = histo.GetValue();
-      ++outLeftP;
-      histo.RemovePixel(buffer[outLeftP]);
-      buffer[outLeftP] = Extreme;
-      histo.AddPixel(Extreme);
-    }
+
+    /* histogram update */
+    histo.AddPixel(buffer[currentP]);
+    histo.RemovePixel(buffer[outLeftP]);
+    Extreme = histo.GetValue();
+    ++outLeftP;
+    histo.RemovePixel(buffer[outLeftP]);
+    buffer[outLeftP] = Extreme;
+    histo.AddPixel(Extreme);
   }
   // Finish the line
   while (outLeftP < outRightP)

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
@@ -118,22 +118,20 @@ GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::GenerateInputRequ
       markerPtr->SetRequestedRegion(markerRequestedRegion);
       return;
     }
-    else
-    {
-      // Couldn't crop the region (requested region is outside the largest
-      // possible region).  Throw an exception.
 
-      // store what we tried to request (prior to trying to crop)
-      markerPtr->SetRequestedRegion(markerRequestedRegion);
+    // Couldn't crop the region (requested region is outside the largest
+    // possible region).  Throw an exception.
 
-      // build an exception
-      InvalidRequestedRegionError e(__FILE__, __LINE__);
-      e.SetLocation(ITK_LOCATION);
-      e.SetDescription(
-        "Requested region for the marker image is (at least partially) outside the largest possible region.");
-      e.SetDataObject(markerPtr);
-      throw e;
-    }
+    // store what we tried to request (prior to trying to crop)
+    markerPtr->SetRequestedRegion(markerRequestedRegion);
+
+    // build an exception
+    InvalidRequestedRegionError e(__FILE__, __LINE__);
+    e.SetLocation(ITK_LOCATION);
+    e.SetDescription(
+      "Requested region for the marker image is (at least partially) outside the largest possible region.");
+    e.SetDataObject(markerPtr);
+    throw e;
   }
   else
   {

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
@@ -118,22 +118,20 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::GenerateInputReque
       markerPtr->SetRequestedRegion(markerRequestedRegion);
       return;
     }
-    else
-    {
-      // Couldn't crop the region (requested region is outside the largest
-      // possible region).  Throw an exception.
 
-      // store what we tried to request (prior to trying to crop)
-      markerPtr->SetRequestedRegion(markerRequestedRegion);
+    // Couldn't crop the region (requested region is outside the largest
+    // possible region).  Throw an exception.
 
-      // build an exception
-      InvalidRequestedRegionError e(__FILE__, __LINE__);
-      e.SetLocation(ITK_LOCATION);
-      e.SetDescription(
-        "Requested region for the marker image is (at least partially) outside the largest possible region.");
-      e.SetDataObject(markerPtr);
-      throw e;
-    }
+    // store what we tried to request (prior to trying to crop)
+    markerPtr->SetRequestedRegion(markerRequestedRegion);
+
+    // build an exception
+    InvalidRequestedRegionError e(__FILE__, __LINE__);
+    e.SetLocation(ITK_LOCATION);
+    e.SetDescription(
+      "Requested region for the marker image is (at least partially) outside the largest possible region.");
+    e.SetDataObject(markerPtr);
+    throw e;
   }
   else
   {

--- a/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramMorphologicalGradientImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramMorphologicalGradientImageFilter.h
@@ -177,10 +177,8 @@ public:
     {
       return m_Max - m_Min;
     }
-    else
-    {
-      return TInputPixel{};
-    }
+
+    return TInputPixel{};
   }
 
   static bool

--- a/Modules/Filtering/MathematicalMorphology/include/itkSharedMorphologyUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkSharedMorphologyUtilities.hxx
@@ -206,10 +206,8 @@ ComputeStartEnd(const typename TImage::IndexType  StartIndex,
         {
           break;
         }
-        else
-        {
-          --sPos;
-        }
+
+        --sPos;
       }
     }
     else
@@ -239,10 +237,8 @@ ComputeStartEnd(const typename TImage::IndexType  StartIndex,
         {
           break;
         }
-        else
-        {
-          ++ePos;
-        }
+
+        ++ePos;
       }
     }
     else

--- a/Modules/Filtering/MathematicalMorphology/test/itkRegionalMaximaImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkRegionalMaximaImageFilterTest.cxx
@@ -137,7 +137,7 @@ itkRegionalMaximaImageFilterTest(int argc, char * argv[])
     return RegionalMaximaImageFilterTestHelper<Image2DType, Image2DType>(
       inputImageFile, outputImageFile, outputImageFile2, fullyConnected, flatIsMaxima);
   }
-  else if (dimension == 3)
+  if (dimension == 3)
   {
     using Image3DType = itk::Image<PixelType, 3>;
     return RegionalMaximaImageFilterTestHelper<Image3DType, Image3DType>(

--- a/Modules/Filtering/MathematicalMorphology/test/itkRegionalMinimaImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkRegionalMinimaImageFilterTest.cxx
@@ -137,7 +137,7 @@ itkRegionalMinimaImageFilterTest(int argc, char * argv[])
     return RegionalMinimaImageFilterTestHelper<Image2DType, Image2DType>(
       inputImageFile, outputImageFile, outputImageFile2, fullyConnected, flatIsMinima);
   }
-  else if (dimension == 3)
+  if (dimension == 3)
   {
     using Image3DType = itk::Image<PixelType, 3>;
     return RegionalMinimaImageFilterTestHelper<Image3DType, Image3DType>(

--- a/Modules/Filtering/Path/include/itkChainCodePath.hxx
+++ b/Modules/Filtering/Path/include/itkChainCodePath.hxx
@@ -79,10 +79,8 @@ ChainCodePath<VDimension>::IncrementInput(InputType & input) const -> OffsetType
   {
     return m_Chain[input++];
   }
-  else
-  {
-    return this->GetZeroOffset();
-  }
+
+  return this->GetZeroOffset();
 }
 
 template <unsigned int VDimension>

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
@@ -658,21 +658,19 @@ ContourExtractor2DImageFilter<TInputImage>::GenerateInputRequestedRegion()
       input->SetRequestedRegion(requestedRegion);
       return;
     }
-    else
-    {
-      // Couldn't crop the region (requested region is outside the largest
-      // possible region).  Throw an exception.
 
-      // store what we tried to request (prior to trying to crop)
-      input->SetRequestedRegion(requestedRegion);
+    // Couldn't crop the region (requested region is outside the largest
+    // possible region).  Throw an exception.
 
-      // build an exception
-      InvalidRequestedRegionError e(__FILE__, __LINE__);
-      e.SetLocation(ITK_LOCATION);
-      e.SetDescription("Requested region is outside the largest possible region.");
-      e.SetDataObject(input);
-      throw e;
-    }
+    // store what we tried to request (prior to trying to crop)
+    input->SetRequestedRegion(requestedRegion);
+
+    // build an exception
+    InvalidRequestedRegionError e(__FILE__, __LINE__);
+    e.SetLocation(ITK_LOCATION);
+    e.SetDescription("Requested region is outside the largest possible region.");
+    e.SetDataObject(input);
+    throw e;
   }
   else
   {

--- a/Modules/Filtering/Path/include/itkHilbertPath.hxx
+++ b/Modules/Filtering/Path/include/itkHilbertPath.hxx
@@ -155,10 +155,8 @@ HilbertPath<TIndexValue, VDimension>::SetBit(const PathIndexType x,
   {
     return (x | (1 << (width - i - 1)));
   }
-  else
-  {
-    return (x & ~(1 << (width - i - 1)));
-  }
+
+  return (x & ~(1 << (width - i - 1)));
 }
 
 template <typename TIndexValue, unsigned int VDimension>
@@ -215,7 +213,7 @@ HilbertPath<TIndexValue, VDimension>::GetDirection(const PathIndexType x, const 
   {
     return 0;
   }
-  else if (x % 2 == 0)
+  if (x % 2 == 0)
   {
     return (this->GetTrailingSetBits(x - 1, n) % n);
   }
@@ -233,10 +231,8 @@ HilbertPath<TIndexValue, VDimension>::GetEntry(const PathIndexType x) -> PathInd
   {
     return 0;
   }
-  else
-  {
-    return (this->GetGrayCode(2 * static_cast<PathIndexType>((x - 1) / 2)));
-  }
+
+  return (this->GetGrayCode(2 * static_cast<PathIndexType>((x - 1) / 2)));
 }
 
 template <typename TIndexValue, unsigned int VDimension>

--- a/Modules/Filtering/Path/src/itkChainCodePath2D.cxx
+++ b/Modules/Filtering/Path/src/itkChainCodePath2D.cxx
@@ -47,10 +47,8 @@ ChainCodePath2D::IncrementInput(InputType & input) const
   {
     return DecodeOffset(m_Chain2D[input++]);
   }
-  else
-  {
-    return this->GetZeroOffset();
-  }
+
+  return this->GetZeroOffset();
 }
 
 std::string

--- a/Modules/Filtering/Path/test/itkChainCodePath2DTest.cxx
+++ b/Modules/Filtering/Path/test/itkChainCodePath2DTest.cxx
@@ -100,9 +100,7 @@ itkChainCodePath2DTest(int, char *[])
     std::cout << "Test passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test failed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/Path/test/itkChainCodePathTest.cxx
+++ b/Modules/Filtering/Path/test/itkChainCodePathTest.cxx
@@ -117,9 +117,7 @@ itkChainCodePathTest(int, char *[])
     std::cout << "Test passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test failed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/Path/test/itkChainCodeToFourierSeriesPathFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkChainCodeToFourierSeriesPathFilterTest.cxx
@@ -99,9 +99,7 @@ itkChainCodeToFourierSeriesPathFilterTest(int, char *[])
     std::cout << "Test passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test failed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/Path/test/itkFourierSeriesPathTest.cxx
+++ b/Modules/Filtering/Path/test/itkFourierSeriesPathTest.cxx
@@ -92,9 +92,7 @@ itkFourierSeriesPathTest(int, char *[])
     std::cout << "Test passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test failed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/Path/test/itkOrthogonallyCorrected2DParametricPathTest.cxx
+++ b/Modules/Filtering/Path/test/itkOrthogonallyCorrected2DParametricPathTest.cxx
@@ -96,9 +96,7 @@ itkOrthogonallyCorrected2DParametricPathTest(int, char *[])
     std::cout << "Test passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test failed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/Path/test/itkPathFunctionsTest.cxx
+++ b/Modules/Filtering/Path/test/itkPathFunctionsTest.cxx
@@ -139,9 +139,7 @@ itkPathFunctionsTest(int, char *[])
     std::cout << "Test passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test failed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/Path/test/itkPathIteratorTest.cxx
+++ b/Modules/Filtering/Path/test/itkPathIteratorTest.cxx
@@ -132,9 +132,7 @@ itkPathIteratorTest(int, char *[])
     std::cout << "Test passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test failed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/Path/test/itkPathToChainCodePathFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkPathToChainCodePathFilterTest.cxx
@@ -97,9 +97,7 @@ itkPathToChainCodePathFilterTest(int, char *[])
     std::cout << "Test passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test failed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/Path/test/itkPolyLineParametricPathTest.cxx
+++ b/Modules/Filtering/Path/test/itkPolyLineParametricPathTest.cxx
@@ -111,9 +111,7 @@ itkPolyLineParametricPathTest(int, char *[])
     std::cout << "Test passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test failed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.hxx
@@ -405,16 +405,15 @@ EdgeDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::CheckQEProcessing
           itkDebugMacro("RemoveSamosa");
           return 1;
         } // end if( OriginOrderIsTwo && DestinationOrderIsTwo )
-        else
-        {
-          // two triangles share three points and two edges
-          // the last edge is duplicated = two edge cells
-          // having the same points. It is a valid manifold case
-          // but you have to decimate it the right way.
-          // from the top the drawing of that case looks like an Eye
-          itkDebugMacro("RemoveEye");
-          return 2;
-        } // end else if( OriginOrderIsTwo && DestinationOrderIsTwo )
+
+        // two triangles share three points and two edges
+        // the last edge is duplicated = two edge cells
+        // having the same points. It is a valid manifold case
+        // but you have to decimate it the right way.
+        // from the top the drawing of that case looks like an Eye
+        itkDebugMacro("RemoveEye");
+        return 2;
+        // end else if( OriginOrderIsTwo && DestinationOrderIsTwo )
       } // end if( OriginOrderIsTwo || DestinationOrderIsTwo )
       else // if( OriginOrderIsTwo || DestinationOrderIsTwo )
       {
@@ -424,10 +423,9 @@ EdgeDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::CheckQEProcessing
           itkDebugMacro("NumberOfCommonVerticesIn0Ring( ) > 2");
           return 3;
         } // end if( NumberOfCommonVerticesIn0Ring( ) > 2 )
-        else
-        {
-          return 0;
-        }
+
+        return 0;
+
       } // end else if( OriginOrderIsTwo || DestinationOrderIsTwo )
     } // end if( LeftIsTriangle && RightIsTriangle )
     else // if( LeftIsTriangle && RightIsTriangle )
@@ -437,17 +435,16 @@ EdgeDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::CheckQEProcessing
         itkDebugMacro("NumberOfCommonVerticesIn0Ring( ) > 1");
         return 4;
       } // end if( NumberOfCommonVerticesIn0Ring( ) > 1 )
-      else // if( NumberOfCommonVerticesIn0Ring( ) > 1 )
+      // if( NumberOfCommonVerticesIn0Ring( ) > 1 )
+      if (RightIsTriangle)
       {
-        if (RightIsTriangle)
-        {
-          return 5;
-        }
-        else
-        {
-          return 6;
-        }
-      } // end else if( NumberOfCommonVerticesIn0Ring( ) > 1 )
+        return 5;
+      }
+      else
+      {
+        return 6;
+      }
+      // end else if( NumberOfCommonVerticesIn0Ring( ) > 1 )
     } // end else if( LeftIsTriangle && RightIsTriangle )
   } // end if( LeftIsTriangle || RightIsTriangle )
   else // if( LeftIsTriangle || RightIsTriangle )
@@ -456,10 +453,9 @@ EdgeDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::CheckQEProcessing
     {
       return 7;
     }
-    else
-    {
-      return 0;
-    }
+
+    return 0;
+
   } // end if( LeftIsTriangle || RightIsTriangle )
 
   //   return 0;
@@ -568,10 +564,8 @@ EdgeDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::IsCriterionSatisf
   {
     return true;
   }
-  else
-  {
-    return this->m_Criterion->is_satisfied(this->GetOutput(), 0, m_Priority.second);
-  }
+
+  return this->m_Criterion->is_satisfied(this->GetOutput(), 0, m_Priority.second);
 }
 } // namespace itk
 #endif

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
@@ -91,10 +91,8 @@ LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::
     {
       return OutputCoordinateType{};
     }
-    else
-    {
-      return (1. / (2. * area));
-    }
+
+    return (1. / (2. * area));
   }
   else
   {
@@ -157,10 +155,8 @@ LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::
     oV(it->second);
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 template <typename TInputMesh, typename TOutputMesh, typename TSolverTraits>

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.hxx
@@ -128,90 +128,88 @@ NormalQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::Weight(const OutputPointIdent
   {
     return static_cast<OutputVertexNormalComponentType>(1.0);
   }
-  else
+
+
+  auto * poly = dynamic_cast<OutputPolygonType *>(outputMesh->GetCells()->GetElement(iCId));
+  if (poly != nullptr) // this test should be removed...
   {
-
-    auto * poly = dynamic_cast<OutputPolygonType *>(outputMesh->GetCells()->GetElement(iCId));
-    if (poly != nullptr) // this test should be removed...
+    // this test should be removed...
+    if (poly->GetNumberOfPoints() == 3)
     {
-      // this test should be removed...
-      if (poly->GetNumberOfPoints() == 3)
+      OutputQEType *  edge = poly->GetEdgeRingEntry();
+      OutputQEType *  temp = edge;
+      OutputPointType pt[3];
+      int             internal_id(0);
+      int             k(0);
+      do
       {
-        OutputQEType *  edge = poly->GetEdgeRingEntry();
-        OutputQEType *  temp = edge;
-        OutputPointType pt[3];
-        int             internal_id(0);
-        int             k(0);
-        do
+        pt[k] = outputMesh->GetPoint(temp->GetOrigin());
+        if (temp->GetOrigin() == iPId)
         {
-          pt[k] = outputMesh->GetPoint(temp->GetOrigin());
-          if (temp->GetOrigin() == iPId)
-          {
-            internal_id = k;
-          }
-
-          temp = temp->GetLnext();
-          ++k;
-        } while (temp != edge);
-
-        switch (m_Weight)
-        {
-          default:
-          case WeightEnum::GOURAUD:
-          {
-            return static_cast<OutputVertexNormalComponentType>(1.);
-          }
-          case WeightEnum::THURMER:
-          {
-            // this implementation may be included inside itkTriangle
-            OutputVectorType u;
-            OutputVectorType v;
-            switch (internal_id)
-            {
-              case 0:
-                u = pt[1] - pt[0];
-                v = pt[2] - pt[0];
-                break;
-              case 1:
-                u = pt[0] - pt[1];
-                v = pt[2] - pt[1];
-                break;
-              case 2:
-                u = pt[0] - pt[2];
-                v = pt[1] - pt[2];
-                break;
-            }
-            typename OutputVectorType::RealValueType norm_u = u.GetNorm();
-            if (norm_u > itk::Math::eps)
-            {
-              norm_u = 1. / norm_u;
-              u *= norm_u;
-            }
-
-            typename OutputVectorType::RealValueType norm_v = v.GetNorm();
-            if (norm_v > itk::Math::eps)
-            {
-              norm_v = 1. / norm_v;
-              v *= norm_v;
-            }
-            return static_cast<OutputVertexNormalComponentType>(std::acos(u * v));
-          }
-          case WeightEnum::AREA:
-          {
-            return static_cast<OutputVertexNormalComponentType>(TriangleType::ComputeArea(pt[0], pt[1], pt[2]));
-          }
+          internal_id = k;
         }
-      }
-      else
+
+        temp = temp->GetLnext();
+        ++k;
+      } while (temp != edge);
+
+      switch (m_Weight)
       {
-        std::cout << "Input should be a triangular mesh!!!" << std::endl;
-        return static_cast<OutputVertexNormalComponentType>(0.);
+        default:
+        case WeightEnum::GOURAUD:
+        {
+          return static_cast<OutputVertexNormalComponentType>(1.);
+        }
+        case WeightEnum::THURMER:
+        {
+          // this implementation may be included inside itkTriangle
+          OutputVectorType u;
+          OutputVectorType v;
+          switch (internal_id)
+          {
+            case 0:
+              u = pt[1] - pt[0];
+              v = pt[2] - pt[0];
+              break;
+            case 1:
+              u = pt[0] - pt[1];
+              v = pt[2] - pt[1];
+              break;
+            case 2:
+              u = pt[0] - pt[2];
+              v = pt[1] - pt[2];
+              break;
+          }
+          typename OutputVectorType::RealValueType norm_u = u.GetNorm();
+          if (norm_u > itk::Math::eps)
+          {
+            norm_u = 1. / norm_u;
+            u *= norm_u;
+          }
+
+          typename OutputVectorType::RealValueType norm_v = v.GetNorm();
+          if (norm_v > itk::Math::eps)
+          {
+            norm_v = 1. / norm_v;
+            v *= norm_v;
+          }
+          return static_cast<OutputVertexNormalComponentType>(std::acos(u * v));
+        }
+        case WeightEnum::AREA:
+        {
+          return static_cast<OutputVertexNormalComponentType>(TriangleType::ComputeArea(pt[0], pt[1], pt[2]));
+        }
       }
     }
     else
     {
+      std::cout << "Input should be a triangular mesh!!!" << std::endl;
       return static_cast<OutputVertexNormalComponentType>(0.);
     }
+  }
+  else
+  {
+    return static_cast<OutputVertexNormalComponentType>(0.);
   }
 }
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkNormalQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkNormalQuadEdgeMeshFilterTest.cxx
@@ -62,22 +62,21 @@ itkNormalQuadEdgeMeshFilterTest(int argc, char * argv[])
     std::cout << "   * 2:  AREA" << std::endl;
     return EXIT_FAILURE;
   }
-  else
+
+  switch (param)
   {
-    switch (param)
-    {
-      default:
-      case 0:
-        weight_type = NormalFilterType::WeightEnum::GOURAUD;
-        break;
-      case 1:
-        weight_type = NormalFilterType::WeightEnum::THURMER;
-        break;
-      case 2:
-        weight_type = NormalFilterType::WeightEnum::AREA;
-        break;
-    }
+    default:
+    case 0:
+      weight_type = NormalFilterType::WeightEnum::GOURAUD;
+      break;
+    case 1:
+      weight_type = NormalFilterType::WeightEnum::THURMER;
+      break;
+    case 2:
+      weight_type = NormalFilterType::WeightEnum::AREA;
+      break;
   }
+
 
   auto reader = ReaderType::New();
   reader->SetFileName(argv[1]);

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkParameterizationQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkParameterizationQuadEdgeMeshFilterTest.cxx
@@ -170,7 +170,7 @@ itkParameterizationQuadEdgeMeshFilterTest(int argc, char * argv[])
     return ParameterizationQuadEdgeMeshFilterTest<IterativeSolverTraits>(
       argv[1], std::stoi(argv[2]), std::stoi(argv[3]), argv[5]);
   }
-  else if (std::stoi(argv[4]) == 1)
+  if (std::stoi(argv[4]) == 1)
   {
     return ParameterizationQuadEdgeMeshFilterTest<LUSolverTraits>(
       argv[1], std::stoi(argv[2]), std::stoi(argv[3]), argv[5]);

--- a/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.hxx
@@ -100,10 +100,8 @@ DiscreteGaussianImageFilter<TInputImage, TOutputImage>::GetKernelVarianceArray()
     }
     return adjustedVariance;
   }
-  else
-  {
-    return this->GetVariance();
-  }
+
+  return this->GetVariance();
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterTest.cxx
@@ -250,10 +250,9 @@ itkRecursiveGaussianImageFilterTest(int, char *[])
         std::cerr << "Central pixel at sigma = " << sigmaB << " = " << valueB << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "PASSED !" << std::endl;
-      }
+
+      std::cout << "PASSED !" << std::endl;
+
 
     } // end of test for normalization across scales
 
@@ -299,10 +298,9 @@ itkRecursiveGaussianImageFilterTest(int, char *[])
         std::cout << "error: " << error << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "PASSED !" << std::endl;
-      }
+
+      std::cout << "PASSED !" << std::endl;
+
 
     } // end of test for normalization
 
@@ -357,10 +355,8 @@ itkRecursiveGaussianImageFilterTest(int, char *[])
         std::cerr << " : " << derivativeUpperBound << " ] " << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "PASSED !" << std::endl;
-      }
+
+      std::cout << "PASSED !" << std::endl;
 
 
       // Now do the similar testing between First Derivative and Second
@@ -400,10 +396,8 @@ itkRecursiveGaussianImageFilterTest(int, char *[])
         std::cerr << " : " << secondDerivativeUpperBound << " ] " << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cout << "PASSED !" << std::endl;
-      }
+
+      std::cout << "PASSED !" << std::endl;
 
 
     } // end of test for normalization among derivatives

--- a/Modules/Filtering/Thresholding/include/itkBinaryThresholdProjectionImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkBinaryThresholdProjectionImageFilter.h
@@ -78,10 +78,8 @@ public:
     {
       return m_ForegroundValue;
     }
-    else
-    {
-      return m_BackgroundValue;
-    }
+
+    return m_BackgroundValue;
   }
 
   bool m_IsForeground;

--- a/Modules/Filtering/Thresholding/include/itkKittlerIllingworthThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkKittlerIllingworthThresholdCalculator.hxx
@@ -209,21 +209,19 @@ KittlerIllingworthThresholdCalculator<THistogram, TOutput>::GenerateData()
         threshold = Tprev;
         break;
       }
+
+      typename HistogramType::MeasurementVectorType v(1);
+      typename HistogramType::IndexType             idx;
+      v[0] = temp;
+      const bool status = histogram->GetIndex(v, idx);
+      itkAssertInDebugAndIgnoreInReleaseMacro(status);
+      if (status)
+      {
+        threshold = Math::Floor<IndexValueType>(static_cast<double>(idx[0]));
+      }
       else
       {
-        typename HistogramType::MeasurementVectorType v(1);
-        typename HistogramType::IndexType             idx;
-        v[0] = temp;
-        const bool status = histogram->GetIndex(v, idx);
-        itkAssertInDebugAndIgnoreInReleaseMacro(status);
-        if (status)
-        {
-          threshold = Math::Floor<IndexValueType>(static_cast<double>(idx[0]));
-        }
-        else
-        {
-          itkExceptionMacro("KittlerIllingworthThresholdCalculator failed to lookup threshold");
-        }
+        itkExceptionMacro("KittlerIllingworthThresholdCalculator failed to lookup threshold");
       }
     }
   }

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.hxx
@@ -118,14 +118,12 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::IncrementThresholds(InstanceI
       // Exit the for loop if a threshold has been incremented
       break;
     }
-    else // If this threshold can't be incremented
+    // If this threshold can't be incremented
+    // If it's the lowest threshold
+    if (j == 0)
     {
-      // If it's the lowest threshold
-      if (j == 0)
-      {
-        // We couldn't increment because we're done
-        return false;
-      }
+      // We couldn't increment because we're done
+      return false;
     }
   }
   // We incremented

--- a/Modules/IO/BMP/src/itkBMPImageIO.cxx
+++ b/Modules/IO/BMP/src/itkBMPImageIO.cxx
@@ -203,7 +203,7 @@ BMPImageIO::Read(void * buffer)
           posLine = 0;
           continue;
         }
-        else if (byte2 == 1)
+        if (byte2 == 1)
         {
           // End of bitmap data
           break;
@@ -691,14 +691,12 @@ BMPImageIO::GetColorPaletteEntry(const unsigned char entry) const
   {
     return m_ColorPalette[entry];
   }
-  else
-  {
-    RGBPixelType p;
-    p.SetRed(0);
-    p.SetGreen(0);
-    p.SetBlue(0);
-    return p;
-  }
+
+  RGBPixelType p;
+  p.SetRed(0);
+  p.SetGreen(0);
+  p.SetBlue(0);
+  return p;
 }
 
 void

--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
@@ -185,7 +185,7 @@ ReadJCAMPDX(const std::string & filename, MetaDataDictionary & dict)
       // Comment line
       continue;
     }
-    else if (line.substr(0, 5) == "##END")
+    if (line.substr(0, 5) == "##END")
     {
       // There should be one comment line after this line in the file
       continue;
@@ -599,10 +599,8 @@ Bruker2dseqImageIO::Read(void * buffer)
       {
         break;
       }
-      else
-      {
-        sizeToSwap *= std::stoi(i[0].c_str());
-      }
+
+      sizeToSwap *= std::stoi(i[0].c_str());
     }
     if (sizeToSwap > 1)
     {

--- a/Modules/IO/CSV/include/itkCSVFileReaderBase.h
+++ b/Modules/IO/CSV/include/itkCSVFileReaderBase.h
@@ -149,10 +149,8 @@ public:
     {
       return std::numeric_limits<TData>::quiet_NaN();
     }
-    else
-    {
-      return value;
-    }
+
+    return value;
   }
 
   /** This method must be defined in derived classes to parse the entire

--- a/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
@@ -111,7 +111,7 @@ GetH5TypeSpecialize(float, H5::PredType::NATIVE_FLOAT) GetH5TypeSpecialize(doubl
   {
     return IOComponentEnum::UCHAR;
   }
-  else if (type == H5::PredType::NATIVE_CHAR)
+  if (type == H5::PredType::NATIVE_CHAR)
   {
     return IOComponentEnum::CHAR;
   }

--- a/Modules/IO/IPL/src/itkIPLFileNameList.cxx
+++ b/Modules/IO/IPL/src/itkIPLFileNameList.cxx
@@ -43,7 +43,7 @@ private:
     {
       return true;
     }
-    else if (echoNumDiff > 0)
+    if (echoNumDiff > 0)
     {
       return false;
     }

--- a/Modules/IO/ImageBase/include/itkInternationalizationIOHelpers.h
+++ b/Modules/IO/ImageBase/include/itkInternationalizationIOHelpers.h
@@ -171,10 +171,9 @@ I18nOpenForWriting(const std::string & str, const bool append = false)
   {
     return I18nOpen(str, O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
   }
-  else
-  {
-    return I18nOpen(str, O_WRONLY | O_CREAT | O_APPEND, S_IRUSR | S_IWUSR);
-  }
+
+  return I18nOpen(str, O_WRONLY | O_CREAT | O_APPEND, S_IRUSR | S_IWUSR);
+
 #else
   if (!append)
   {

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -463,7 +463,7 @@ ImageIOBase::GetComponentTypeFromString(const std::string & typeString)
   {
     return IOComponentEnum::UCHAR;
   }
-  else if (typeString.compare("char") == 0)
+  if (typeString.compare("char") == 0)
   {
     return IOComponentEnum::CHAR;
   }
@@ -556,7 +556,7 @@ ImageIOBase::GetPixelTypeFromString(const std::string & pixelString)
   {
     return IOPixelEnum::SCALAR;
   }
-  else if (pixelString.compare("vector") == 0)
+  if (pixelString.compare("vector") == 0)
   {
     return IOPixelEnum::VECTOR;
   }

--- a/Modules/IO/ImageBase/src/itkStreamingImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkStreamingImageIOBase.cxx
@@ -256,7 +256,7 @@ StreamingImageIOBase::GetActualNumberOfSplitsForWriting(unsigned int          nu
     // fall back to super classses non-streaming implementation
     return ImageIOBase::GetActualNumberOfSplitsForWriting(numberOfRequestedSplits, pasteRegion, largestPossibleRegion);
   }
-  else if (!itksys::SystemTools::FileExists(m_FileName.c_str()))
+  if (!itksys::SystemTools::FileExists(m_FileName.c_str()))
   {
     // file doesn't exits so we don't have potential problems
   }
@@ -366,10 +366,9 @@ StreamingImageIOBase::GenerateStreamableReadRegionFromRequestedRegion(const Imag
   {
     return ImageIOBase::GenerateStreamableReadRegionFromRequestedRegion(requestedRegion);
   }
-  else
-  {
-    streamableRegion = requestedRegion;
-  }
+
+  streamableRegion = requestedRegion;
+
 
   return streamableRegion;
 }

--- a/Modules/IO/ImageBase/test/itkImageFileWriterStreamingPastingCompressingTest1.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterStreamingPastingCompressingTest1.cxx
@@ -181,13 +181,11 @@ ActualTest(std::string inputFileName,
       std::cout << "TEST PASSED" << std::endl;
       return EXIT_SUCCESS;
     }
-    else
-    {
-      std::cout << "UnExpected ExceptionObject caught !" << std::endl;
-      std::cout << err << std::endl;
-      std::cout << "TEST FAILED" << std::endl;
-      return EXIT_FAILURE;
-    }
+
+    std::cout << "UnExpected ExceptionObject caught !" << std::endl;
+    std::cout << err << std::endl;
+    std::cout << "TEST FAILED" << std::endl;
+    return EXIT_FAILURE;
   }
 
   if (expectException == 1)

--- a/Modules/IO/ImageBase/test/itkLargeImageWriteReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkLargeImageWriteReadTest.cxx
@@ -180,16 +180,14 @@ itkLargeImageWriteReadTest(int argc, char * argv[])
 
     return ActualTest<ImageType>(filename, size);
   }
-  else
-  {
-    constexpr unsigned int Dimension = 3;
 
-    using PixelType = unsigned short;
-    using ImageType = itk::Image<PixelType, Dimension>;
+  constexpr unsigned int Dimension = 3;
 
-    auto size = ImageType::SizeType::Filled(atol(argv[2]));
-    size[2] = atol(argv[3]);
+  using PixelType = unsigned short;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-    return ActualTest<ImageType>(filename, size);
-  }
+  auto size = ImageType::SizeType::Filled(atol(argv[2]));
+  size[2] = atol(argv[3]);
+
+  return ActualTest<ImageType>(filename, size);
 }

--- a/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
+++ b/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
@@ -1030,14 +1030,13 @@ JPEG2000ImageIO::GenerateStreamableReadRegionFromRequestedRegion(const ImageIORe
   {
     return ImageIOBase::GenerateStreamableReadRegionFromRequestedRegion(requestedRegion);
   }
-  else
-  {
-    // Compute the required set of tiles that fully contain the requested region
-    streamableRegion = requestedRegion;
 
-    this->ComputeRegionInTileBoundaries(0, this->m_Internal->m_TileWidth, streamableRegion);
-    this->ComputeRegionInTileBoundaries(1, this->m_Internal->m_TileHeight, streamableRegion);
-  }
+  // Compute the required set of tiles that fully contain the requested region
+  streamableRegion = requestedRegion;
+
+  this->ComputeRegionInTileBoundaries(0, this->m_Internal->m_TileWidth, streamableRegion);
+  this->ComputeRegionInTileBoundaries(1, this->m_Internal->m_TileHeight, streamableRegion);
+
 
   itkDebugMacro("Streamable region = " << streamableRegion);
 

--- a/Modules/IO/MRC/src/itkMRCImageIOPrivate.h
+++ b/Modules/IO/MRC/src/itkMRCImageIOPrivate.h
@@ -73,7 +73,7 @@ min_max_element(TInputIter first, TInputIter last)
       }
       break;
     }
-    else if (*first < *prev)
+    if (*first < *prev)
     {
       if (*first < *(result.first))
       {

--- a/Modules/IO/MeshGifti/src/itkGiftiMeshIO.cxx
+++ b/Modules/IO/MeshGifti/src/itkGiftiMeshIO.cxx
@@ -108,10 +108,8 @@ GiftiMeshIO::GetLabelColorTable()
   {
     return colorMap;
   }
-  else
-  {
-    return nullptr;
-  }
+
+  return nullptr;
 }
 
 GiftiMeshIO::LabelNameContainerPointer
@@ -122,10 +120,8 @@ GiftiMeshIO::GetLabelNameTable()
   {
     return labelMap;
   }
-  else
-  {
-    return nullptr;
-  }
+
+  return nullptr;
 }
 
 void

--- a/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
+++ b/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
@@ -166,10 +166,8 @@ VTKPolyDataMeshIO::CanReadFile(const char * fileName)
   {
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 bool

--- a/Modules/IO/Meta/test/itkLargeMetaImageWriteReadTest.cxx
+++ b/Modules/IO/Meta/test/itkLargeMetaImageWriteReadTest.cxx
@@ -174,16 +174,14 @@ itkLargeMetaImageWriteReadTest(int argc, char * argv[])
 
     return ActualTest<ImageType>(filename, size);
   }
-  else
-  {
-    constexpr unsigned int Dimension = 3;
 
-    using PixelType = unsigned short;
-    using ImageType = itk::Image<PixelType, Dimension>;
+  constexpr unsigned int Dimension = 3;
 
-    auto size = ImageType::SizeType::Filled(atol(argv[2]));
-    size[2] = atol(argv[3]);
+  using PixelType = unsigned short;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-    return ActualTest<ImageType>(filename, size);
-  }
+  auto size = ImageType::SizeType::Filled(atol(argv[2]));
+  size[2] = atol(argv[3]);
+
+  return ActualTest<ImageType>(filename, size);
 }

--- a/Modules/IO/Meta/test/testMetaCommand.cxx
+++ b/Modules/IO/Meta/test/testMetaCommand.cxx
@@ -80,10 +80,8 @@ testMetaCommand(int argc, char * argv[])
       std::cout << "Expected parse failure that did not occur, so test failed" << std::endl;
       return 1;
     }
-    else
-    {
-      return (command.GetValueAsInt("SumOfValues") - SumValue);
-    }
+
+    return (command.GetValueAsInt("SumOfValues") - SumValue);
   }
   else
   {

--- a/Modules/IO/Meta/test/testMetaImage.cxx
+++ b/Modules/IO/Meta/test/testMetaImage.cxx
@@ -227,10 +227,9 @@ testMetaImage(int, char *[])
     std::cout << "MET_ImageModalityToString: FAIL" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "Modality  = " << modality << std::endl;
-  }
+
+  std::cout << "Modality  = " << modality << std::endl;
+
 
   // Testing Append function
   std::cout << "Testing Append:";

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest12.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest12.cxx
@@ -115,11 +115,9 @@ itkNiftiImageIOTest12(int argc, char * argv[])
       std::cerr << origPhysLocationIndexThree << " != " << readPhysLocationIndexThree << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cout << "Index location [3,3,3] represents same physical space:" << std::endl;
-      std::cerr << origPhysLocationIndexThree << " != " << readPhysLocationIndexThree << std::endl;
-    }
+
+    std::cout << "Index location [3,3,3] represents same physical space:" << std::endl;
+    std::cerr << origPhysLocationIndexThree << " != " << readPhysLocationIndexThree << std::endl;
   }
   catch (const itk::ExceptionObject & e)
   {

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest2.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest2.cxx
@@ -67,8 +67,6 @@ itkNiftiImageIOTest2(int argc, char * argv[])
   {
     return test_success;
   }
-  else
-  {
-    return !test_success;
-  }
+
+  return !test_success;
 }

--- a/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
+++ b/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
@@ -55,10 +55,8 @@ NrrdImageIO::SupportsDimension(unsigned long dim)
   {
     return dim <= NRRD_DIM_MAX;
   }
-  else
-  {
-    return dim <= NRRD_DIM_MAX - 1;
-  }
+
+  return dim <= NRRD_DIM_MAX - 1;
 }
 
 void

--- a/Modules/IO/NRRD/test/itkNrrdComplexImageReadTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdComplexImageReadTest.cxx
@@ -112,8 +112,6 @@ itkNrrdComplexImageReadTest(int argc, char * argv[])
     std::cout << "failure because err == " << err << "> " << thresh << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    return EXIT_SUCCESS;
-  }
+
+  return EXIT_SUCCESS;
 }

--- a/Modules/IO/NRRD/test/itkNrrdCovariantVectorImageReadTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdCovariantVectorImageReadTest.cxx
@@ -84,8 +84,6 @@ itkNrrdCovariantVectorImageReadTest(int argc, char * argv[])
     std::cout << "test FAILED because values not as expected\n";
     return EXIT_FAILURE;
   }
-  else
-  {
-    return EXIT_SUCCESS;
-  }
+
+  return EXIT_SUCCESS;
 }

--- a/Modules/IO/NRRD/test/itkNrrdDiffusionTensor3DImageReadTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdDiffusionTensor3DImageReadTest.cxx
@@ -122,8 +122,6 @@ itkNrrdDiffusionTensor3DImageReadTest(int argc, char * argv[])
     std::cout << "failure because err == " << err << "> " << thresh << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    return EXIT_SUCCESS;
-  }
+
+  return EXIT_SUCCESS;
 }

--- a/Modules/IO/NRRD/test/itkNrrdVectorImageReadTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdVectorImageReadTest.cxx
@@ -86,8 +86,6 @@ itkNrrdVectorImageReadTest(int argc, char * argv[])
     std::cout << "test FAILED because values not as expected\n";
     return EXIT_FAILURE;
   }
-  else
-  {
-    return EXIT_SUCCESS;
-  }
+
+  return EXIT_SUCCESS;
 }

--- a/Modules/IO/PNG/test/itkPNGImageIOTest2.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTest2.cxx
@@ -37,10 +37,8 @@ CompareExtensions(itk::ImageIOBase::ArrayOfExtensionsType & a1, itk::ImageIOBase
   {
     return EXIT_SUCCESS;
   }
-  else
-  {
-    return EXIT_FAILURE;
-  }
+
+  return EXIT_FAILURE;
 }
 } // end anonymous namespace
 

--- a/Modules/IO/RAW/test/itkRawImageIOTest4.cxx
+++ b/Modules/IO/RAW/test/itkRawImageIOTest4.cxx
@@ -203,10 +203,9 @@ itkRawImageIOTest4(int argc, char * argv[])
     std::cerr << "Reading Raw BigEndian FAILED !!" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "Reading Raw BigEndian PASSED !!" << std::endl << std::endl;
-  }
+
+  std::cout << "Reading Raw BigEndian PASSED !!" << std::endl << std::endl;
+
 
   std::cout << "Testing read of Little Endian File" << std::endl;
   fileIsBigEndian = false;
@@ -216,10 +215,9 @@ itkRawImageIOTest4(int argc, char * argv[])
     std::cerr << "Reading Raw LittleEndian FAILED !!" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "Reading Raw LittleEndian PASSED !!" << std::endl << std::endl;
-  }
+
+  std::cout << "Reading Raw LittleEndian PASSED !!" << std::endl << std::endl;
+
 
   std::cout << "Test PASSED !!" << std::endl << std::endl;
 

--- a/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
+++ b/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
@@ -165,7 +165,7 @@ public:
   static std::string
   ZeroValue()
   {
-    return { "" };
+    return {};
   }
 };
 

--- a/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
@@ -372,10 +372,9 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
     std::cout << tubeN1->GetNumberOfChildren() << " instead of 9 [FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
+
+  std::cout << "[PASSED]" << std::endl;
+
 
   std::cout << "Testing Writing SceneSpatialObject: " << std::endl;
 
@@ -435,10 +434,9 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
     std::cout << "No Scene : [FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [PASSED]" << std::endl;
-  }
+
+  std::cout << " [PASSED]" << std::endl;
+
 
   std::cout << "Testing Number of children:";
   if (myScene->GetNumberOfChildren(1) != 12)
@@ -447,10 +445,9 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
     std::cout << " [FAILED]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << " [PASSED]" << std::endl;
-  }
+
+  std::cout << " [PASSED]" << std::endl;
+
 
   std::cout << "Testing CenterLine Position:";
 

--- a/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
+++ b/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
@@ -95,10 +95,8 @@ StimulateImageIO::CanReadFile(const char * filename)
   {
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 void

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -132,11 +132,10 @@ TIFFImageIO::GetFormat()
           m_ImageFormat = TIFFImageIO::PALETTE_GRAYSCALE;
           return m_ImageFormat;
         }
-        else
-        { // if not expanding read grayscale palette as palette
-          m_ImageFormat = TIFFImageIO::PALETTE_RGB;
-          return m_ImageFormat;
-        }
+
+        // if not expanding read grayscale palette as palette
+        m_ImageFormat = TIFFImageIO::PALETTE_RGB;
+        return m_ImageFormat;
       }
   }
   m_ImageFormat = TIFFImageIO::OTHER;

--- a/Modules/IO/TIFF/test/itkLargeTIFFImageWriteReadTest.cxx
+++ b/Modules/IO/TIFF/test/itkLargeTIFFImageWriteReadTest.cxx
@@ -171,16 +171,14 @@ itkLargeTIFFImageWriteReadTest(int argc, char * argv[])
 
     return itkLargeTIFFImageWriteReadTestHelper<ImageType>(filename, size);
   }
-  else
-  {
-    constexpr unsigned int Dimension = 3;
 
-    using PixelType = unsigned short;
-    using ImageType = itk::Image<PixelType, Dimension>;
+  constexpr unsigned int Dimension = 3;
 
-    auto size = ImageType::SizeType::Filled(atol(argv[2]));
-    size[2] = atol(argv[3]);
+  using PixelType = unsigned short;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-    return itkLargeTIFFImageWriteReadTestHelper<ImageType>(filename, size);
-  }
+  auto size = ImageType::SizeType::Filled(atol(argv[2]));
+  size[2] = atol(argv[3]);
+
+  return itkLargeTIFFImageWriteReadTestHelper<ImageType>(filename, size);
 }

--- a/Modules/IO/TIFF/test/itkTIFFImageIOTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOTest.cxx
@@ -110,7 +110,7 @@ itkTIFFImageIOTest(int argc, char * argv[])
               << "[pixeltype: 1:RBG<char>(default); 2:RBG<ushort>; 3:short; 4:float; 5:ushort]" << std::endl;
     return EXIT_FAILURE;
   }
-  else if (argc == 4)
+  if (argc == 4)
   {
     dimension = std::stoi(argv[3]);
   }
@@ -125,7 +125,7 @@ itkTIFFImageIOTest(int argc, char * argv[])
     using PixelType = itk::RGBPixel<unsigned char>;
     return itkTIFFImageIOTestHelper<itk::Image<PixelType, 2>>(argc, argv);
   }
-  else if (dimension == 2 && pixelType == 2)
+  if (dimension == 2 && pixelType == 2)
   {
     using PixelType = itk::RGBPixel<unsigned short>;
     return itkTIFFImageIOTestHelper<itk::Image<PixelType, 2>>(argc, argv);

--- a/Modules/IO/TIFF/test/itkTIFFImageIOTestPalette.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOTestPalette.cxx
@@ -230,10 +230,8 @@ itkTIFFImageIOTestPalette(int argc, char * argv[])
       std::cerr << "Palette not written as it was read at position [" << i << "]." << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cout << "Read and written palette are equal" << std::endl;
-    }
+
+    std::cout << "Read and written palette are equal" << std::endl;
   }
 
   // Exercise other methods

--- a/Modules/IO/TransformBase/src/itkTransformFileReader.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformFileReader.cxx
@@ -49,11 +49,9 @@ struct KernelTransformHelper
       kernelTransform->ComputeWMatrix();
       return 0;
     }
-    else
-    {
-      // try one less dimension
-      return KernelTransformHelper<TParameterType, Dimension - 1>::InitializeWMatrix(transform);
-    }
+
+    // try one less dimension
+    return KernelTransformHelper<TParameterType, Dimension - 1>::InitializeWMatrix(transform);
   }
 };
 

--- a/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
+++ b/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
@@ -103,7 +103,7 @@ HDF5TransformIOTemplate<TParametersValueType>::GetH5TypeFromString() const
   {
     return H5::PredType::NATIVE_DOUBLE;
   }
-  else if (!NameParametersValueTypeString.compare(std::string("float")))
+  if (!NameParametersValueTypeString.compare(std::string("float")))
   {
     return H5::PredType::NATIVE_FLOAT;
   }

--- a/Modules/IO/TransformHDF5/test/itkIOTransformHDF5Test.cxx
+++ b/Modules/IO/TransformHDF5/test/itkIOTransformHDF5Test.cxx
@@ -394,7 +394,7 @@ itkIOTransformHDF5Test(int argc, char * argv[])
       const int result2 = oneTest<double>("Transforms_double.hdf5", "TransformsBad_double.hdf5", false);
       return (!(result1 == EXIT_SUCCESS && result2 == EXIT_SUCCESS));
     }
-    else if (testType == "compressed")
+    if (testType == "compressed")
     {
       const int result1 = oneTest<float>("Transforms_float_compressed.h5", "TransformsBad_float_compressed.h5", true);
       const int result2 =

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -100,10 +100,8 @@ VTKImageIO::CanReadFile(const char * filename)
   {
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 
@@ -157,7 +155,7 @@ VTKImageIO::GetComponentTypeAsString(IOComponentEnum t)
   {
     return "vtktypeuint64";
   }
-  else if (t == IOComponentEnum::LONGLONG)
+  if (t == IOComponentEnum::LONGLONG)
   {
     return "vtktypeint64";
   }

--- a/Modules/IO/XML/src/itkDOMNode.cxx
+++ b/Modules/IO/XML/src/itkDOMNode.cxx
@@ -58,10 +58,8 @@ DOMNode::GetAttribute(const std::string & key) const
   {
     return "";
   }
-  else
-  {
-    return i->second;
-  }
+
+  return i->second;
 }
 
 /** Check whether has an attribute. */
@@ -315,10 +313,8 @@ DOMNode::GetChild(IdentifierType i)
   {
     return nullptr;
   }
-  else
-  {
-    return (DOMNode *)this->m_Children[i];
-  }
+
+  return (DOMNode *)this->m_Children[i];
 }
 
 /** Retrieve a child by index (return nullptr if out of range). */
@@ -409,10 +405,8 @@ DOMNode::GetSibling(OffsetType i)
   {
     return nullptr;
   }
-  else
-  {
-    return parent->GetChild(j);
-  }
+
+  return parent->GetChild(j);
 }
 
 /** Retrieve an older or younger sibling by distance (return nullptr if no such sibling). */
@@ -434,10 +428,8 @@ DOMNode::GetRoot()
   {
     return this;
   }
-  else
-  {
-    return node->GetRoot();
-  }
+
+  return node->GetRoot();
 }
 
 /** Return the root node. */
@@ -596,10 +588,8 @@ DOMNode::Find(const std::string & path)
   {
     return node;
   }
-  else
-  {
-    return node->Find(rpath);
-  }
+
+  return node->Find(rpath);
 }
 
 /**

--- a/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.hxx
+++ b/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.hxx
@@ -80,16 +80,14 @@ EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::Ge
   {
     return eigenVector;
   }
-  else
-  {
-    itkWarningMacro(
 
-      << "EigenAnalysis2DImageFilter::GetMaxEigenVector(): dynamic_cast has failed. A reinterpret_cast is being "
-         "attempted."
-      << std::endl
-      << "Type name is: " << typeid(*this->GetOutput(2)).name());
-    return reinterpret_cast<EigenVectorImageType *>(this->ProcessObject::GetOutput(2));
-  }
+  itkWarningMacro(
+
+    << "EigenAnalysis2DImageFilter::GetMaxEigenVector(): dynamic_cast has failed. A reinterpret_cast is being "
+       "attempted."
+    << std::endl
+    << "Type name is: " << typeid(*this->GetOutput(2)).name());
+  return reinterpret_cast<EigenVectorImageType *>(this->ProcessObject::GetOutput(2));
 }
 
 template <typename TInputImage, typename TEigenValueImage, typename TEigenVectorImage>

--- a/Modules/Numerics/NarrowBand/test/itkNarrowBandImageFilterBaseTest.cxx
+++ b/Modules/Numerics/NarrowBand/test/itkNarrowBandImageFilterBaseTest.cxx
@@ -63,10 +63,8 @@ protected:
     {
       return true;
     }
-    else
-    {
-      return false;
-    }
+
+    return false;
   }
 
   void

--- a/Modules/Numerics/Optimizers/src/itkLBFGSBOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLBFGSBOptimizer.cxx
@@ -368,10 +368,8 @@ LBFGSBOptimizerHelper::report_iter()
   {
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 std::string

--- a/Modules/Numerics/Optimizers/src/itkLBFGSOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLBFGSOptimizer.cxx
@@ -315,6 +315,6 @@ LBFGSOptimizer::GetStopConditionDescription() const
     return m_StopConditionDescription.str();
   }
 
-  return { "" };
+  return {};
 }
 } // end namespace itk

--- a/Modules/Numerics/Optimizers/src/itkLBFGSOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLBFGSOptimizer.cxx
@@ -314,9 +314,7 @@ LBFGSOptimizer::GetStopConditionDescription() const
     }
     return m_StopConditionDescription.str();
   }
-  else
-  {
-    return { "" };
-  }
+
+  return { "" };
 }
 } // end namespace itk

--- a/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearVnlOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearVnlOptimizer.cxx
@@ -94,10 +94,8 @@ MultipleValuedNonLinearVnlOptimizer::GetUseCostFunctionGradient() const
   {
     return m_CostFunctionAdaptor->GetUseGradient();
   }
-  else
-  {
-    return m_UseGradient;
-  }
+
+  return m_UseGradient;
 }
 
 /** The purpose of this method is to get around the lack of iteration reporting

--- a/Modules/Numerics/Optimizers/test/itkAmoebaOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkAmoebaOptimizerTest.cxx
@@ -390,10 +390,8 @@ AmoebaTest1()
     std::cerr << "[TEST 1 FAILURE]\n";
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "succeeded\n";
-  }
+
+  std::cout << "succeeded\n";
 
   // Set now the function to maximize
   //
@@ -465,10 +463,7 @@ AmoebaTest1()
       std::cerr << "[TEST 1 FAILURE]\n";
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cout << "succeeded\n";
-    }
+    std::cout << "succeeded\n";
   }
   std::cout << "[TEST 1 SUCCESS]\n";
   return EXIT_SUCCESS;

--- a/Modules/Numerics/Optimizers/test/itkConjugateGradientOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkConjugateGradientOptimizerTest.cxx
@@ -264,10 +264,9 @@ itkConjugateGradientOptimizerTest(int, char *[])
     std::cout << "[FAILURE]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[SUCCESS]" << std::endl;
-  }
+
+  std::cout << "[SUCCESS]" << std::endl;
+
 
   std::cout << "Test passed." << std::endl;
   return EXIT_SUCCESS;

--- a/Modules/Numerics/Optimizers/test/itkCumulativeGaussianOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkCumulativeGaussianOptimizerTest.cxx
@@ -117,16 +117,14 @@ itkCumulativeGaussianOptimizerTest(int, char *[])
     std::cout << "[TEST DONE]" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cerr << std::endl << "Test Failed with a Fit Error of " << optimizer->GetFitError() << std::endl << std::endl;
 
-    // Print out the resulting parameters.
-    std::cerr << "Fitted mean = " << optimizer->GetComputedMean() << std::endl;
-    std::cerr << "Fitted standard deviation = " << optimizer->GetComputedStandardDeviation() << std::endl;
-    std::cerr << "Fitted upper asymptote = " << optimizer->GetUpperAsymptote() << std::endl;
-    std::cerr << "Fitted lower asymptote = " << optimizer->GetLowerAsymptote() << std::endl;
+  std::cerr << std::endl << "Test Failed with a Fit Error of " << optimizer->GetFitError() << std::endl << std::endl;
 
-    return EXIT_FAILURE;
-  }
+  // Print out the resulting parameters.
+  std::cerr << "Fitted mean = " << optimizer->GetComputedMean() << std::endl;
+  std::cerr << "Fitted standard deviation = " << optimizer->GetComputedStandardDeviation() << std::endl;
+  std::cerr << "Fitted upper asymptote = " << optimizer->GetUpperAsymptote() << std::endl;
+  std::cerr << "Fitted lower asymptote = " << optimizer->GetLowerAsymptote() << std::endl;
+
+  return EXIT_FAILURE;
 }

--- a/Modules/Numerics/Optimizers/test/itkLBFGSOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkLBFGSOptimizerTest.cxx
@@ -242,10 +242,9 @@ itkLBFGSOptimizerTest(int, char *[])
     std::cout << "[FAILURE]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[SUCCESS]" << std::endl;
-  }
+
+  std::cout << "[SUCCESS]" << std::endl;
+
 
   std::cout << "Test passed." << std::endl;
   return EXIT_SUCCESS;

--- a/Modules/Numerics/Optimizers/test/itkLevenbergMarquardtOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkLevenbergMarquardtOptimizerTest.cxx
@@ -397,10 +397,9 @@ itkRunLevenbergMarquardOptimization(bool   useGradient,
     std::cout << "[FAILURE]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[SUCCESS]" << std::endl;
-  }
+
+  std::cout << "[SUCCESS]" << std::endl;
+
 
   std::cout << "Test passed." << std::endl;
   return EXIT_SUCCESS;

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
@@ -174,10 +174,8 @@ GradientDescentLineSearchOptimizerv4Template<TInternalComputationValueType>::Gol
     {
       return this->GoldenSectionSearch(b, x, c, metricx);
     }
-    else
-    {
-      return this->GoldenSectionSearch(a, x, b, metricx);
-    }
+
+    return this->GoldenSectionSearch(a, x, b, metricx);
   }
   else
   {
@@ -185,7 +183,7 @@ GradientDescentLineSearchOptimizerv4Template<TInternalComputationValueType>::Gol
     {
       return this->GoldenSectionSearch(a, b, x, metricb);
     }
-    else if (metricx == NumericTraits<TInternalComputationValueType>::max())
+    if (metricx == NumericTraits<TInternalComputationValueType>::max())
     {
       // Keep the lower bounds when metricx and metricb are both max,
       // likely due to no valid sample points, from too large of a

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerBasev4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerBasev4.hxx
@@ -35,10 +35,8 @@ LBFGSOptimizerBaseHelperv4<TInternalVnlOptimizerType>::report_iter()
   {
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 } // namespace itk

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
@@ -189,10 +189,8 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
   {
     return this->m_VirtualImage->TransformPhysicalPointToIndex(point, index);
   }
-  else
-  {
-    itkExceptionMacro("m_VirtualImage is undefined. Cannot transform.");
-  }
+
+  itkExceptionMacro("m_VirtualImage is undefined. Cannot transform.");
 }
 
 template <unsigned int TFixedDimension,
@@ -270,10 +268,8 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
   {
     return this->GetTimeStamp();
   }
-  else
-  {
-    return this->GetVirtualImage()->GetTimeStamp();
-  }
+
+  return this->GetVirtualImage()->GetTimeStamp();
 }
 
 template <unsigned int TFixedDimension,
@@ -331,10 +327,8 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
     }
     return this->ComputeParameterOffsetFromVirtualIndex(index, numberOfLocalParameters);
   }
-  else
-  {
-    itkExceptionMacro("m_VirtualImage is undefined. Cannot calculate offset.");
-  }
+
+  itkExceptionMacro("m_VirtualImage is undefined. Cannot calculate offset.");
 }
 
 template <unsigned int TFixedDimension,
@@ -351,10 +345,8 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
     const OffsetValueType offset = this->m_VirtualImage->ComputeOffset(index) * numberOfLocalParameters;
     return offset;
   }
-  else
-  {
-    itkExceptionMacro("m_VirtualImage is undefined. Cannot calculate offset.");
-  }
+
+  itkExceptionMacro("m_VirtualImage is undefined. Cannot calculate offset.");
 }
 
 template <unsigned int TFixedDimension,
@@ -370,11 +362,9 @@ typename ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, 
   {
     return this->m_VirtualImage->GetSpacing();
   }
-  else
-  {
-    auto spacing = MakeFilled<VirtualSpacingType>(NumericTraits<typename VirtualSpacingType::ValueType>::OneValue());
-    return spacing;
-  }
+
+  auto spacing = MakeFilled<VirtualSpacingType>(NumericTraits<typename VirtualSpacingType::ValueType>::OneValue());
+  return spacing;
 }
 
 template <unsigned int TFixedDimension,
@@ -390,12 +380,10 @@ typename ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, 
   {
     return this->m_VirtualImage->GetDirection();
   }
-  else
-  {
-    auto direction =
-      MakeFilled<VirtualDirectionType>(NumericTraits<typename VirtualDirectionType::ValueType>::OneValue());
-    return direction;
-  }
+
+  auto direction =
+    MakeFilled<VirtualDirectionType>(NumericTraits<typename VirtualDirectionType::ValueType>::OneValue());
+  return direction;
 }
 
 template <unsigned int TFixedDimension,
@@ -410,11 +398,9 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
   {
     return this->m_VirtualImage->GetOrigin();
   }
-  else
-  {
-    VirtualOriginType origin{};
-    return origin;
-  }
+
+  VirtualOriginType origin{};
+  return origin;
 }
 
 template <unsigned int TFixedDimension,
@@ -429,10 +415,8 @@ const typename ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualI
   {
     return this->m_VirtualImage->GetBufferedRegion();
   }
-  else
-  {
-    itkExceptionMacro("m_VirtualImage is undefined. Cannot return region. ");
-  }
+
+  itkExceptionMacro("m_VirtualImage is undefined. Cannot return region. ");
 }
 
 template <unsigned int TFixedDimension,

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
@@ -95,10 +95,8 @@ RegistrationParameterScalesEstimator<TMetric>::GetTransform()
   {
     return this->m_Metric->GetMovingTransform();
   }
-  else
-  {
-    return this->m_Metric->GetFixedTransform();
-  }
+
+  return this->m_Metric->GetFixedTransform();
 }
 
 template <typename TMetric>
@@ -109,10 +107,8 @@ RegistrationParameterScalesEstimator<TMetric>::GetDimension()
   {
     return MovingDimension;
   }
-  else
-  {
-    return FixedDimension;
-  }
+
+  return FixedDimension;
 }
 
 template <typename TMetric>
@@ -124,8 +120,8 @@ RegistrationParameterScalesEstimator<TMetric>::IsDisplacementFieldTransform()
   {
     return true;
   }
-  else if (!this->m_TransformForward && this->m_Metric->GetFixedTransform()->GetTransformCategory() ==
-                                          FixedTransformType::TransformCategoryEnum::DisplacementField)
+  if (!this->m_TransformForward && this->m_Metric->GetFixedTransform()->GetTransformCategory() ==
+                                     FixedTransformType::TransformCategoryEnum::DisplacementField)
   {
     return true;
   }
@@ -213,10 +209,8 @@ RegistrationParameterScalesEstimator<TMetric>::TransformHasLocalSupportForScales
   {
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 template <typename TMetric>
@@ -227,10 +221,8 @@ RegistrationParameterScalesEstimator<TMetric>::GetNumberOfLocalParameters()
   {
     return this->m_Metric->GetMovingTransform()->GetNumberOfLocalParameters();
   }
-  else
-  {
-    return this->m_Metric->GetFixedTransform()->GetNumberOfLocalParameters();
-  }
+
+  return this->m_Metric->GetFixedTransform()->GetNumberOfLocalParameters();
 }
 
 template <typename TMetric>
@@ -409,10 +401,8 @@ RegistrationParameterScalesEstimator<TMetric>::CheckGeneralAffineTransform()
   {
     return this->CheckGeneralAffineTransformTemplated<MovingTransformType>();
   }
-  else
-  {
-    return this->CheckGeneralAffineTransformTemplated<FixedTransformType>();
-  }
+
+  return this->CheckGeneralAffineTransformTemplated<FixedTransformType>();
 }
 
 template <typename TMetric>

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.hxx
@@ -147,14 +147,12 @@ RegistrationParameterScalesFromShiftBase<TMetric>::EstimateStepScale(const Param
   {
     return FloatType{};
   }
-  else
-  {
-    const FloatType factor = this->m_SmallParameterVariation / maxStep;
-    ParametersType  smallStep(step.size());
-    // Use a small step to have a linear approximation.
-    smallStep = step * factor;
-    return this->ComputeMaximumVoxelShift(smallStep) / factor;
-  }
+
+  const FloatType factor = this->m_SmallParameterVariation / maxStep;
+  ParametersType  smallStep(step.size());
+  // Use a small step to have a linear approximation.
+  smallStep = step * factor;
+  return this->ComputeMaximumVoxelShift(smallStep) / factor;
 }
 
 /**

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4Base.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4Base.cxx
@@ -213,7 +213,7 @@ LBFGSOptimizerBasev4<TInternalVnlOptimizerType>::GetStopConditionDescription() c
     return m_StopConditionDescription.str();
   }
 
-  return { "" };
+  return {};
 }
 
 template class ITKOptimizersv4_EXPORT LBFGSOptimizerBasev4<vnl_lbfgs>;

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4Base.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4Base.cxx
@@ -212,10 +212,8 @@ LBFGSOptimizerBasev4<TInternalVnlOptimizerType>::GetStopConditionDescription() c
     }
     return m_StopConditionDescription.str();
   }
-  else
-  {
-    return { "" };
-  }
+
+  return { "" };
 }
 
 template class ITKOptimizersv4_EXPORT LBFGSOptimizerBasev4<vnl_lbfgs>;

--- a/Modules/Numerics/Optimizersv4/test/itkAmoebaOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAmoebaOptimizerv4Test.cxx
@@ -462,10 +462,7 @@ AmoebaTest1()
     std::cerr << "[TEST 1 FAILURE]\n";
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "succeeded\n";
-  }
+  std::cout << "succeeded\n";
 
   std::cout << "[TEST 1 SUCCESS]\n";
   return EXIT_SUCCESS;

--- a/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
@@ -220,11 +220,9 @@ itkAutoScaledGradientDescentRegistrationOnVectorTestTemplated(int         number
     std::cout << "Test FAILED." << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "Test PASSED." << std::endl;
-    return EXIT_SUCCESS;
-  }
+
+  std::cout << "Test PASSED." << std::endl;
+  return EXIT_SUCCESS;
 }
 
 int
@@ -266,8 +264,6 @@ itkAutoScaledGradientDescentRegistrationOnVectorTest(int argc, char ** const arg
   {
     return EXIT_SUCCESS;
   }
-  else
-  {
-    return EXIT_FAILURE;
-  }
+
+  return EXIT_FAILURE;
 }

--- a/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationTest.cxx
@@ -253,11 +253,9 @@ itkAutoScaledGradientDescentRegistrationTestTemplated(int         numberOfIterat
     std::cout << "Test FAILED." << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "Test PASSED." << std::endl;
-    return EXIT_SUCCESS;
-  }
+
+  std::cout << "Test PASSED." << std::endl;
+  return EXIT_SUCCESS;
 }
 
 int
@@ -330,8 +328,6 @@ itkAutoScaledGradientDescentRegistrationTest(int argc, char ** const argv)
   {
     return EXIT_SUCCESS;
   }
-  else
-  {
-    return EXIT_FAILURE;
-  }
+
+  return EXIT_FAILURE;
 }

--- a/Modules/Numerics/Optimizersv4/test/itkLBFGS2Optimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkLBFGS2Optimizerv4Test.cxx
@@ -315,10 +315,9 @@ itkLBFGS2Optimizerv4Test(int, char *[])
     std::cout << "[FAILURE]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[SUCCESS]" << std::endl;
-  }
+
+  std::cout << "[SUCCESS]" << std::endl;
+
 
   //
   // Test stopping when number of iterations reached

--- a/Modules/Numerics/Optimizersv4/test/itkLBFGSOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkLBFGSOptimizerv4Test.cxx
@@ -289,10 +289,9 @@ itkLBFGSOptimizerv4Test(int, char *[])
     std::cout << "[FAILURE]" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "[SUCCESS]" << std::endl;
-  }
+
+  std::cout << "[SUCCESS]" << std::endl;
+
 
   //
   // Test stopping when number of iterations reached

--- a/Modules/Numerics/Optimizersv4/test/itkQuasiNewtonOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkQuasiNewtonOptimizerv4Test.cxx
@@ -211,11 +211,9 @@ itkQuasiNewtonOptimizerv4TestTemplated(int         numberOfIterations,
     std::cout << "Test FAILED." << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cout << "Test PASSED." << std::endl;
-    return EXIT_SUCCESS;
-  }
+
+  std::cout << "Test PASSED." << std::endl;
+  return EXIT_SUCCESS;
 }
 
 int
@@ -258,9 +256,7 @@ itkQuasiNewtonOptimizerv4Test(int argc, char ** const argv)
     std::cout << std::endl << "Tests PASSED." << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << std::endl << "Tests FAILED." << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << std::endl << "Tests FAILED." << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesEstimatorTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesEstimatorTest.cxx
@@ -390,9 +390,7 @@ itkRegistrationParameterScalesEstimatorTest(int, char *[])
     std::cout << "Test passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test failed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromIndexShiftTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromIndexShiftTest.cxx
@@ -382,9 +382,7 @@ itkRegistrationParameterScalesFromIndexShiftTest(int, char *[])
     std::cout << "Test passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test failed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromJacobianTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromJacobianTest.cxx
@@ -340,9 +340,7 @@ itkRegistrationParameterScalesFromJacobianTest(int, char *[])
     std::cout << "Test passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test failed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftPointSetTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftPointSetTest.cxx
@@ -380,9 +380,7 @@ itkRegistrationParameterScalesFromPhysicalShiftPointSetTest(int, char *[])
     std::cout << "Test passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cerr << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cerr << "Test failed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftTest.cxx
@@ -384,9 +384,7 @@ itkRegistrationParameterScalesFromPhysicalShiftTest(int, char *[])
     std::cout << "Test passed" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Test failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test failed" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Numerics/Polynomials/include/itkMultivariateLegendrePolynomial.h
+++ b/Modules/Numerics/Polynomials/include/itkMultivariateLegendrePolynomial.h
@@ -182,7 +182,7 @@ public:
 
       return LegendreSum(norm_x, m_Degree, m_CachedXCoef);
     }
-    else if (m_Dimension == 3)
+    if (m_Dimension == 3)
     {
       if (index[2] != m_PrevZ)
       {
@@ -257,17 +257,15 @@ public:
           m_Index[dim] += 1;
           return *this;
         }
+
+        if (dim == m_Dimension - 1)
+        {
+          m_IsAtEnd = true;
+          break;
+        }
         else
         {
-          if (dim == m_Dimension - 1)
-          {
-            m_IsAtEnd = true;
-            break;
-          }
-          else
-          {
-            m_Index[dim] = 0;
-          }
+          m_Index[dim] = 0;
         }
       }
       return *this;

--- a/Modules/Numerics/Statistics/include/itkDistanceMetric.h
+++ b/Modules/Numerics/Statistics/include/itkDistanceMetric.h
@@ -105,11 +105,9 @@ public:
       {
         return;
       }
-      else
-      {
-        this->m_MeasurementVectorSize = s;
-        this->Modified();
-      }
+
+      this->m_MeasurementVectorSize = s;
+      this->Modified();
     }
     else
     {

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -266,11 +266,10 @@ Histogram<TMeasurement, TFrequencyContainer>::GetIndex(const MeasurementVectorTy
         index[dim] = (IndexValueType)0;
         continue;
       }
-      else
-      { // set an illegal value and return 0
-        index[dim] = (IndexValueType)m_Size[dim];
-        return false;
-      }
+
+      // set an illegal value and return 0
+      index[dim] = (IndexValueType)m_Size[dim];
+      return false;
     }
 
     IndexValueType end = static_cast<IndexValueType>(m_Min[dim].size()) - 1;
@@ -284,11 +283,10 @@ Histogram<TMeasurement, TFrequencyContainer>::GetIndex(const MeasurementVectorTy
         index[dim] = (IndexValueType)m_Size[dim] - 1;
         continue;
       }
-      else
-      { // set an illegal value and return 0
-        index[dim] = (IndexValueType)m_Size[dim];
-        return false;
-      }
+
+      // set an illegal value and return 0
+      index[dim] = (IndexValueType)m_Size[dim];
+      return false;
     }
 
     // Binary search for the bin where this measurement could be
@@ -617,27 +615,25 @@ Histogram<TMeasurement, TFrequencyContainer>::Quantile(unsigned int dimension, d
     const double interval = max - min;
     return min + ((p - p_n_prev) / binProportion) * interval;
   }
-  else
-  {
-    InstanceIdentifier n = size - 1;
-    InstanceIdentifier m{};
-    double             p_n = 1.0;
-    do
-    {
-      f_n = this->GetFrequency(n, dimension);
-      cumulated += f_n;
-      p_n_prev = p_n;
-      p_n = 1.0 - cumulated / totalFrequency;
-      --n;
-      ++m;
-    } while (m < size && p_n > p);
 
-    const double binProportion = f_n / totalFrequency;
-    const auto   min = static_cast<double>(this->GetBinMin(dimension, n + 1));
-    const auto   max = static_cast<double>(this->GetBinMax(dimension, n + 1));
-    const double interval = max - min;
-    return max - ((p_n_prev - p) / binProportion) * interval;
-  }
+  InstanceIdentifier n = size - 1;
+  InstanceIdentifier m{};
+  double             p_n = 1.0;
+  do
+  {
+    f_n = this->GetFrequency(n, dimension);
+    cumulated += f_n;
+    p_n_prev = p_n;
+    p_n = 1.0 - cumulated / totalFrequency;
+    --n;
+    ++m;
+  } while (m < size && p_n > p);
+
+  const double binProportion = f_n / totalFrequency;
+  const auto   min = static_cast<double>(this->GetBinMin(dimension, n + 1));
+  const auto   max = static_cast<double>(this->GetBinMax(dimension, n + 1));
+  const double interval = max - min;
+  return max - ((p_n_prev - p) / binProportion) * interval;
 }
 
 template <typename TMeasurement, typename TFrequencyContainer>

--- a/Modules/Numerics/Statistics/include/itkHistogramToEntropyImageFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToEntropyImageFilter.h
@@ -74,11 +74,9 @@ public:
       const double p = static_cast<OutputPixelType>(A) / static_cast<OutputPixelType>(m_TotalFrequency);
       return static_cast<OutputPixelType>((-1) * p * std::log(p) / std::log(2.0));
     }
-    else
-    {
-      const double p = static_cast<OutputPixelType>(A + 1) / static_cast<OutputPixelType>(m_TotalFrequency);
-      return static_cast<OutputPixelType>((-1) * p * std::log(p) / std::log(2.0));
-    }
+
+    const double p = static_cast<OutputPixelType>(A + 1) / static_cast<OutputPixelType>(m_TotalFrequency);
+    return static_cast<OutputPixelType>((-1) * p * std::log(p) / std::log(2.0));
   }
 
   void

--- a/Modules/Numerics/Statistics/include/itkHistogramToImageFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogramToImageFilter.hxx
@@ -59,11 +59,9 @@ HistogramToImageFilter<THistogram, TImage, TFunction>::SetTotalFrequency(SizeVal
   {
     return;
   }
-  else
-  {
-    this->GetFunctor().SetTotalFrequency(n);
-    this->Modified();
-  }
+
+  this->GetFunctor().SetTotalFrequency(n);
+  this->Modified();
 }
 
 template <typename THistogram, typename TImage, typename TFunction>

--- a/Modules/Numerics/Statistics/include/itkHistogramToLogProbabilityImageFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToLogProbabilityImageFilter.h
@@ -68,11 +68,10 @@ public:
       return static_cast<OutputPixelType>(
         std::log(static_cast<OutputPixelType>(A) / static_cast<OutputPixelType>(m_TotalFrequency)) / std::log(2.0));
     }
-    else
-    { // Check for Log 0. Always assume that the frequency is at least 1.
-      return static_cast<OutputPixelType>(
-        std::log(static_cast<OutputPixelType>(A + 1) / static_cast<OutputPixelType>(m_TotalFrequency)) / std::log(2.0));
-    }
+
+    // Check for Log 0. Always assume that the frequency is at least 1.
+    return static_cast<OutputPixelType>(
+      std::log(static_cast<OutputPixelType>(A + 1) / static_cast<OutputPixelType>(m_TotalFrequency)) / std::log(2.0));
   }
 
   void

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.h
@@ -127,10 +127,8 @@ public:
     {
       return Superclass::GetMeasurementVectorSize();
     }
-    else
-    {
-      return m_Image->GetNumberOfComponentsPerPixel();
-    }
+
+    return m_Image->GetNumberOfComponentsPerPixel();
   }
 
   /** method to return frequency for a specified id */

--- a/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
@@ -52,20 +52,18 @@ ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::GetMeasurementVect
   {
     return m_MeasurementVectorInternal;
   }
-  else
-  {
-    IndexType reqIndex;
-    ImageHelper<ImageType::ImageDimension, ImageType::ImageDimension>::ComputeIndex(
-      m_Region.GetIndex(), id, m_OffsetTable, reqIndex);
 
-    const OffsetType offset = reqIndex - m_NeighborIndexInternal;
+  IndexType reqIndex;
+  ImageHelper<ImageType::ImageDimension, ImageType::ImageDimension>::ComputeIndex(
+    m_Region.GetIndex(), id, m_OffsetTable, reqIndex);
 
-    m_NeighborIndexInternal = reqIndex;
-    m_MeasurementVectorInternal[0] += offset;
-    m_InstanceIdentifierInternal = id;
+  const OffsetType offset = reqIndex - m_NeighborIndexInternal;
 
-    return m_MeasurementVectorInternal;
-  }
+  m_NeighborIndexInternal = reqIndex;
+  m_MeasurementVectorInternal[0] += offset;
+  m_InstanceIdentifierInternal = id;
+
+  return m_MeasurementVectorInternal;
 }
 
 /** returns the number of measurement vectors in this container*/

--- a/Modules/Numerics/Statistics/include/itkKdTreeGenerator.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTreeGenerator.hxx
@@ -199,18 +199,16 @@ KdTreeGenerator<TSample>::GenerateTreeLoop(unsigned int            beginIndex,
       // return the pointer to empty terminal node
       return m_Tree->GetEmptyTerminalNode();
     }
-    else
+
+    auto * ptr = new KdTreeTerminalNode<TSample>();
+
+    for (unsigned int j = beginIndex; j < endIndex; ++j)
     {
-      auto * ptr = new KdTreeTerminalNode<TSample>();
-
-      for (unsigned int j = beginIndex; j < endIndex; ++j)
-      {
-        ptr->AddInstanceIdentifier(this->GetSubsample()->GetInstanceIdentifier(j));
-      }
-
-      // return a terminal node
-      return ptr;
+      ptr->AddInstanceIdentifier(this->GetSubsample()->GetInstanceIdentifier(j));
     }
+
+    // return a terminal node
+    return ptr;
   }
   else
   {

--- a/Modules/Numerics/Statistics/include/itkListSample.hxx
+++ b/Modules/Numerics/Statistics/include/itkListSample.hxx
@@ -108,10 +108,8 @@ ListSample<TMeasurementVector>::GetFrequency(InstanceIdentifier instanceId) cons
   {
     return 1;
   }
-  else
-  {
-    return 0;
-  }
+
+  return 0;
 }
 
 template <typename TMeasurementVector>

--- a/Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h
+++ b/Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h
@@ -192,7 +192,7 @@ public:
     {
       return VLength;
     }
-    else if (b->Size() != VLength)
+    if (b->Size() != VLength)
     {
       itkGenericExceptionMacro(<< errMsg);
     }
@@ -229,7 +229,7 @@ public:
     {
       return VLength;
     }
-    else if (b->Size() != VLength)
+    if (b->Size() != VLength)
     {
       itkGenericExceptionMacro(<< errMsg);
     }
@@ -262,7 +262,7 @@ public:
     {
       return VLength;
     }
-    else if (b->size() != VLength)
+    if (b->size() != VLength)
     {
       itkGenericExceptionMacro(<< errMsg);
     }
@@ -277,7 +277,7 @@ public:
     {
       return VLength;
     }
-    else if (l != VLength)
+    if (l != VLength)
     {
       itkGenericExceptionMacro(<< errMsg);
     }
@@ -292,7 +292,7 @@ public:
     {
       return VLength;
     }
-    else if (l != VLength)
+    if (l != VLength)
     {
       itkGenericExceptionMacro(<< errMsg);
     }

--- a/Modules/Numerics/Statistics/include/itkMembershipFunctionBase.h
+++ b/Modules/Numerics/Statistics/include/itkMembershipFunctionBase.h
@@ -101,11 +101,9 @@ public:
       {
         return;
       }
-      else
-      {
-        this->m_MeasurementVectorSize = s;
-        this->Modified();
-      }
+
+      this->m_MeasurementVectorSize = s;
+      this->Modified();
     }
     else
     {

--- a/Modules/Numerics/Statistics/include/itkMixtureModelComponentBase.hxx
+++ b/Modules/Numerics/Statistics/include/itkMixtureModelComponentBase.hxx
@@ -147,10 +147,8 @@ MixtureModelComponentBase<TSample>::GetWeight(unsigned int index) const
   {
     return m_Weights[index];
   }
-  else
-  {
-    itkExceptionMacro("Weight array is not allocated.");
-  }
+
+  itkExceptionMacro("Weight array is not allocated.");
 }
 
 template <typename TSample>

--- a/Modules/Numerics/Statistics/include/itkSample.h
+++ b/Modules/Numerics/Statistics/include/itkSample.h
@@ -125,19 +125,17 @@ public:
       {
         return;
       }
+
+      // If the new size is different from the current size, then
+      // only change the measurement vector size if the container is empty.
+      if (this->Size())
+      {
+        itkExceptionMacro("Attempting to change the measurement vector size of a non-empty Sample");
+      }
       else
       {
-        // If the new size is different from the current size, then
-        // only change the measurement vector size if the container is empty.
-        if (this->Size())
-        {
-          itkExceptionMacro("Attempting to change the measurement vector size of a non-empty Sample");
-        }
-        else
-        {
-          this->m_MeasurementVectorSize = s;
-          this->Modified();
-        }
+        this->m_MeasurementVectorSize = s;
+        this->Modified();
       }
     }
     else

--- a/Modules/Numerics/Statistics/include/itkSampleToHistogramFilter.h
+++ b/Modules/Numerics/Statistics/include/itkSampleToHistogramFilter.h
@@ -186,7 +186,7 @@ private:
       {
         return NumericTraits<HistogramMeasurementType>::max();
       }
-      else if (from <= fromMin)
+      if (from <= fromMin)
       {
         return NumericTraits<HistogramMeasurementType>::min();
       }

--- a/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.hxx
@@ -173,11 +173,9 @@ SpatialNeighborSubsampler<TSample, TRegion>::Search(const InstanceIdentifier & q
         someRemaining = true;
         break;
       }
-      else
-      {
-        offset -= offsetTable[dim] * (static_cast<typename RegionType::OffsetValueType>(searchSize[dim]) - 1);
-        positionIndex[dim] = searchIndex[dim];
-      }
+
+      offset -= offsetTable[dim] * (static_cast<typename RegionType::OffsetValueType>(searchSize[dim]) - 1);
+      positionIndex[dim] = searchIndex[dim];
     }
   }
 } // end Search method

--- a/Modules/Numerics/Statistics/include/itkStatisticsAlgorithm.hxx
+++ b/Modules/Numerics/Statistics/include/itkStatisticsAlgorithm.hxx
@@ -214,7 +214,7 @@ MedianOfThree(const TValue a, const TValue b, const TValue c)
     {
       return b;
     }
-    else if (a < c)
+    if (a < c)
     {
       return c;
     }

--- a/Modules/Numerics/Statistics/src/itkChiSquareDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkChiSquareDistribution.cxx
@@ -133,7 +133,7 @@ ChiSquareDistribution::InverseCDF(double p, SizeValueType degreesOfFreedom)
   {
     return 0.0;
   }
-  else if (p >= 1.0)
+  if (p >= 1.0)
   {
     return itk::NumericTraits<double>::max();
   }

--- a/Modules/Numerics/Statistics/src/itkGaussianDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkGaussianDistribution.cxx
@@ -172,11 +172,9 @@ GaussianDistribution::PDF(double x, const ParametersType & p)
   {
     return PDF(x, p[0], p[1]);
   }
-  else
-  {
-    itkGenericExceptionMacro("Invalid number of parameters to describe distribution. Expected 2 parameters, but got "
-                             << p.size() << " parameters.");
-  }
+
+  itkGenericExceptionMacro("Invalid number of parameters to describe distribution. Expected 2 parameters, but got "
+                           << p.size() << " parameters.");
 }
 
 double
@@ -222,7 +220,7 @@ GaussianDistribution::InverseCDF(double p)
   {
     return itk::NumericTraits<double>::NonpositiveMin();
   }
-  else if (p >= 1.0)
+  if (p >= 1.0)
   {
     return itk::NumericTraits<double>::max();
   }
@@ -262,7 +260,7 @@ GaussianDistribution::InverseCDF(double p, double mean, double variance)
   {
     return x;
   }
-  else if (Math::ExactlyEquals(x, itk::NumericTraits<double>::max()))
+  if (Math::ExactlyEquals(x, itk::NumericTraits<double>::max()))
   {
     return x;
   }
@@ -298,11 +296,9 @@ GaussianDistribution::EvaluatePDF(double x) const
 
     return GaussianDistribution::PDF(x, m_Parameters[0], m_Parameters[1]);
   }
-  else
-  {
-    itkGenericExceptionMacro("Invalid number of parameters to describe distribution. Expected 2 parameters, but got "
-                             << m_Parameters.size() << " parameters.");
-  }
+
+  itkGenericExceptionMacro("Invalid number of parameters to describe distribution. Expected 2 parameters, but got "
+                           << m_Parameters.size() << " parameters.");
 }
 
 double
@@ -317,11 +313,9 @@ GaussianDistribution::EvaluatePDF(double x, const ParametersType & p) const
 
     return GaussianDistribution::PDF(x, p[0], p[1]);
   }
-  else
-  {
-    itkGenericExceptionMacro("Invalid number of parameters to describe distribution. Expected 2 parameters, but got "
-                             << p.size() << " parameters.");
-  }
+
+  itkGenericExceptionMacro("Invalid number of parameters to describe distribution. Expected 2 parameters, but got "
+                           << p.size() << " parameters.");
 }
 
 double
@@ -347,11 +341,9 @@ GaussianDistribution::EvaluateCDF(double x) const
 
     return GaussianDistribution::CDF(x, m_Parameters[0], m_Parameters[1]);
   }
-  else
-  {
-    itkGenericExceptionMacro("Invalid number of parameters to describe distribution. Expected 2 parameters, but got "
-                             << m_Parameters.size() << " parameters.");
-  }
+
+  itkGenericExceptionMacro("Invalid number of parameters to describe distribution. Expected 2 parameters, but got "
+                           << m_Parameters.size() << " parameters.");
 }
 
 double
@@ -366,11 +358,9 @@ GaussianDistribution::EvaluateCDF(double x, const ParametersType & p) const
 
     return GaussianDistribution::CDF(x, p[0], p[1]);
   }
-  else
-  {
-    itkGenericExceptionMacro("Invalid number of parameters to describe distribution. Expected 2 parameters, but got "
-                             << p.size() << " parameters.");
-  }
+
+  itkGenericExceptionMacro("Invalid number of parameters to describe distribution. Expected 2 parameters, but got "
+                           << p.size() << " parameters.");
 }
 
 double
@@ -396,11 +386,9 @@ GaussianDistribution::EvaluateInverseCDF(double p) const
 
     return GaussianDistribution::InverseCDF(p, m_Parameters[0], m_Parameters[1]);
   }
-  else
-  {
-    itkGenericExceptionMacro("Invalid number of parameters to describe distribution. Expected 2 parameters, but got "
-                             << m_Parameters.size() << " parameters.");
-  }
+
+  itkGenericExceptionMacro("Invalid number of parameters to describe distribution. Expected 2 parameters, but got "
+                           << m_Parameters.size() << " parameters.");
 }
 
 double
@@ -415,11 +403,9 @@ GaussianDistribution::EvaluateInverseCDF(double p, const ParametersType & params
 
     return GaussianDistribution::InverseCDF(p, params[0], params[1]);
   }
-  else
-  {
-    itkGenericExceptionMacro("Invalid number of parameters to describe distribution. Expected 2 parameters, but got "
-                             << params.size() << " parameters.");
-  }
+
+  itkGenericExceptionMacro("Invalid number of parameters to describe distribution. Expected 2 parameters, but got "
+                           << params.size() << " parameters.");
 }
 
 double

--- a/Modules/Numerics/Statistics/src/itkNormalVariateGenerator.cxx
+++ b/Modules/Numerics/Statistics/src/itkNormalVariateGenerator.cxx
@@ -98,10 +98,8 @@ NormalVariateGenerator::GetVariate()
   {
     return m_GScale * m_Gausssave[m_Gaussfaze];
   }
-  else
-  {
-    return FastNorm();
-  }
+
+  return FastNorm();
 }
 
 /*      -----------------------------------------------------   */

--- a/Modules/Numerics/Statistics/src/itkSparseFrequencyContainer2.cxx
+++ b/Modules/Numerics/Statistics/src/itkSparseFrequencyContainer2.cxx
@@ -63,10 +63,8 @@ SparseFrequencyContainer2::GetFrequency(const InstanceIdentifier id) const
   {
     return iter->second;
   }
-  else
-  {
-    return 0;
-  }
+
+  return 0;
 }
 
 bool

--- a/Modules/Numerics/Statistics/src/itkTDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkTDistribution.cxx
@@ -132,10 +132,8 @@ TDistribution::CDF(double x, SizeValueType degreesOfFreedom)
   {
     return 1.0 - 0.5 * dbetai_(&bx, &pin, &qin);
   }
-  else
-  {
-    return 0.5 * dbetai_(&bx, &pin, &qin);
-  }
+
+  return 0.5 * dbetai_(&bx, &pin, &qin);
 }
 
 double
@@ -156,7 +154,7 @@ TDistribution::InverseCDF(double p, SizeValueType degreesOfFreedom)
   {
     return itk::NumericTraits<double>::NonpositiveMin();
   }
-  else if (p >= 1.0)
+  if (p >= 1.0)
   {
     return itk::NumericTraits<double>::max();
   }
@@ -342,10 +340,8 @@ TDistribution::GetVariance() const
 
       return dof / (dof - 2.0);
     }
-    else
-    {
-      return NumericTraits<double>::quiet_NaN();
-    }
+
+    return NumericTraits<double>::quiet_NaN();
   }
   else
   {

--- a/Modules/Numerics/Statistics/test/itkHistogramToTextureFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkHistogramToTextureFeaturesFilterTest.cxx
@@ -331,9 +331,7 @@ itkHistogramToTextureFeaturesFilterTest(int, char *[])
     std::cerr << "Test failed" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cerr << "Test succeeded" << std::endl;
-    return EXIT_SUCCESS;
-  }
+
+  std::cerr << "Test succeeded" << std::endl;
+  return EXIT_SUCCESS;
 }

--- a/Modules/Numerics/Statistics/test/itkListSampleTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkListSampleTest.cxx
@@ -86,20 +86,18 @@ itkListSampleTest(int argc, char * argv[])
     std::cerr << "FAILED" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cerr << "PASSED" << std::endl;
-  }
+
+  std::cerr << "PASSED" << std::endl;
+
   std::cerr << "Trying GetMeasurementVectorSize()...";
   if (sample->GetMeasurementVectorSize() != measurementVectorSize)
   {
     std::cerr << "GetMeasurementVectorSize() failed" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cerr << "PASSED" << std::endl;
-  }
+
+  std::cerr << "PASSED" << std::endl;
+
 
   // get and set measurements
   std::cerr << "Trying GetMeasurementVector(4)..." << std::endl;
@@ -109,10 +107,9 @@ itkListSampleTest(int argc, char * argv[])
     std::cerr << "FAILED" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cerr << "PASSED" << std::endl;
-  }
+
+  std::cerr << "PASSED" << std::endl;
+
 
   std::cerr << "Trying SetMeasurementVector(4,mv)...";
   const float tmp = mv[0];
@@ -123,10 +120,9 @@ itkListSampleTest(int argc, char * argv[])
     std::cerr << "FAILED" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cerr << "PASSED" << std::endl;
-  }
+
+  std::cerr << "PASSED" << std::endl;
+
 
   std::cerr << "Trying SetMeasurement(4,0,tmp)...";
   mv[0] = tmp;
@@ -136,10 +132,9 @@ itkListSampleTest(int argc, char * argv[])
     std::cerr << "FAILED" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cerr << "PASSED" << std::endl;
-  }
+
+  std::cerr << "PASSED" << std::endl;
+
 
   // frequency
   std::cerr << "Trying GetTotalFrequency...";
@@ -148,10 +143,9 @@ itkListSampleTest(int argc, char * argv[])
     std::cerr << "FAILED" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cerr << "PASSED" << std::endl;
-  }
+
+  std::cerr << "PASSED" << std::endl;
+
 
   //
   // iterator tests
@@ -171,10 +165,9 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "FAILED" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
+
 
     // assignment operator
     std::cerr << "Trying Iterator::assignment operator...";
@@ -185,10 +178,9 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "FAILED" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
+
 
     SampleType::InstanceIdentifier id = 0;
     while (s_iter != sample->End())
@@ -199,40 +191,36 @@ itkListSampleTest(int argc, char * argv[])
         std::cerr << "FAILED" << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cerr << "PASSED" << std::endl;
-      }
+
+      std::cerr << "PASSED" << std::endl;
+
       std::cerr << "Trying Iterator::GetInstanceIdentifier (forward)...";
       if (id != s_iter.GetInstanceIdentifier())
       {
         std::cerr << "FAILED" << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cerr << "PASSED" << std::endl;
-      }
+
+      std::cerr << "PASSED" << std::endl;
+
       std::cerr << "Trying Iterator::GetFrequency (forward)...";
       if (s_iter.GetFrequency() != 1)
       {
         std::cerr << "FAILED" << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cerr << "PASSED" << std::endl;
-      }
+
+      std::cerr << "PASSED" << std::endl;
+
       std::cerr << "Trying GetFrequency (forward)...";
       if (sample->GetFrequency(id) != 1)
       {
         std::cerr << "FAILED" << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cerr << "PASSED" << std::endl;
-      }
+
+      std::cerr << "PASSED" << std::endl;
+
       ++id;
       ++s_iter;
     }
@@ -243,10 +231,8 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "FAILED" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
   }
 
   // ConstIterator test
@@ -265,10 +251,9 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "FAILED" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
+
 
     // assignment operator
     std::cerr << "Trying Const Iterator::operator= ()...";
@@ -279,10 +264,9 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "FAILED" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
+
 
     // copy from non-const iterator
     std::cerr << "Trying Iterator::Copy Constructor (from non-const)...";
@@ -293,10 +277,9 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "FAILED" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
+
     // assignment from non-const iterator
     std::cerr << "Trying Iterator::assignment (from non-const)...";
     s2_iter = nonconst_iter;
@@ -305,10 +288,9 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "FAILED" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
+
 
     SampleType::InstanceIdentifier id = 0;
     while (s_iter != sample->End())
@@ -319,10 +301,9 @@ itkListSampleTest(int argc, char * argv[])
         std::cerr << "FAILED" << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cerr << "PASSED" << std::endl;
-      }
+
+      std::cerr << "PASSED" << std::endl;
+
 
       std::cerr << "Trying Iterator::GetInstanceIdentifier (forward)...";
       if (id != s_iter.GetInstanceIdentifier())
@@ -330,20 +311,18 @@ itkListSampleTest(int argc, char * argv[])
         std::cerr << "FAILED" << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cerr << "PASSED" << std::endl;
-      }
+
+      std::cerr << "PASSED" << std::endl;
+
       std::cerr << "Trying Iterator::GetFrequency (forward)...";
       if (s_iter.GetFrequency() != 1)
       {
         std::cerr << "FAILED" << std::endl;
         return EXIT_FAILURE;
       }
-      else
-      {
-        std::cerr << "PASSED" << std::endl;
-      }
+
+      std::cerr << "PASSED" << std::endl;
+
       ++id;
       ++s_iter;
     }
@@ -354,10 +333,8 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "FAILED" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
   }
 
 
@@ -370,10 +347,9 @@ itkListSampleTest(int argc, char * argv[])
     std::cerr << "FAILED" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cerr << "PASSED" << std::endl;
-  }
+
+  std::cerr << "PASSED" << std::endl;
+
 
   std::cerr << "Trying Resize()...";
   sample->Resize(sampleSize);
@@ -382,10 +358,8 @@ itkListSampleTest(int argc, char * argv[])
     std::cerr << "FAILED" << std::endl;
     return EXIT_FAILURE;
   }
-  else
-  {
-    std::cerr << "PASSED" << std::endl;
-  }
+
+  std::cerr << "PASSED" << std::endl;
 
 
   // Test a VariableSizeVector
@@ -502,10 +476,9 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "FAILED" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
+
 
     std::cerr << "Trying Iterator constructor from sample...";
     IteratorType iter3 = sample->Begin();
@@ -514,10 +487,9 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "FAILED" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
+
 
     std::cerr << "Trying Iterator walk...";
     unsigned int counter = 0;
@@ -532,10 +504,9 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "FAILED. counter: " << counter << " != sample->Size(): " << sample->Size() << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
+
 
     std::cerr << "Trying Iterator copy constructor...";
     const IteratorType iter4(iter2);
@@ -544,10 +515,9 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "FAILED" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
+
 
     std::cerr << "Trying Iterator operator=...";
     const IteratorType iter5 = iter2;
@@ -556,10 +526,9 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "FAILED" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
+
 
     std::cerr << "Trying Iterator Constructor with instance identifier 7...";
     IteratorType iter6(sample);
@@ -573,10 +542,8 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "FAILED" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
   }
 
   // Testing methods specific to ConstIterators
@@ -599,10 +566,9 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "ConstIterator operator==() FAILED" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
+
 
     std::cerr << "Trying ConstIterator copy constructor...";
     const ConstIteratorType iter3(iter2);
@@ -611,10 +577,9 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "FAILED" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
+
 
     std::cerr << "Trying Constructor from const container Begin() differs from non-const Begin()...";
     const SampleType * constSample = sample.GetPointer();
@@ -626,10 +591,9 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "FAILED" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
+
 
     std::cerr << "Trying ConstIterator Constructor from const container differs from non-const container...";
     const ConstIteratorType iter6(constSample);
@@ -639,10 +603,9 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "FAILED" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
+
 
     std::cerr << "Trying Constructor with instance identifier 0...";
     const ConstIteratorType iter8(sample);
@@ -651,10 +614,8 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "FAILED" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
 
 
     ConstIteratorType iter9(sample);
@@ -686,10 +647,8 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "FAILED" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
 
 
     std::cerr << "Trying Iterator walk...";
@@ -704,10 +663,8 @@ itkListSampleTest(int argc, char * argv[])
       std::cerr << "FAILED" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "PASSED" << std::endl;
-    }
+
+    std::cerr << "PASSED" << std::endl;
   }
 
   std::cerr << "Test passed." << std::endl;

--- a/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest.cxx
@@ -395,11 +395,9 @@ itkScalarImageToCooccurrenceMatrixFilterTest(int, char *[])
       std::cerr << "Test failed" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "Test succeeded" << std::endl;
-      return EXIT_SUCCESS;
-    }
+
+    std::cerr << "Test succeeded" << std::endl;
+    return EXIT_SUCCESS;
   }
   catch (const itk::ExceptionObject & err)
   {

--- a/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest2.cxx
@@ -326,11 +326,9 @@ itkScalarImageToCooccurrenceMatrixFilterTest2(int, char *[])
       std::cerr << "Test failed" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "Test succeeded" << std::endl;
-      return EXIT_SUCCESS;
-    }
+
+    std::cerr << "Test succeeded" << std::endl;
+    return EXIT_SUCCESS;
   }
   catch (const itk::ExceptionObject & err)
   {

--- a/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthFeaturesFilterTest.cxx
@@ -349,11 +349,9 @@ itkScalarImageToRunLengthFeaturesFilterTest(int, char *[])
       std::cerr << "Test failed" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "Test succeeded" << std::endl;
-      return EXIT_SUCCESS;
-    }
+
+    std::cerr << "Test succeeded" << std::endl;
+    return EXIT_SUCCESS;
   }
   catch (const itk::ExceptionObject & err)
   {

--- a/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthMatrixFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthMatrixFilterTest.cxx
@@ -259,11 +259,9 @@ itkScalarImageToRunLengthMatrixFilterTest(int, char *[])
       std::cerr << "Test failed" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "Test succeeded" << std::endl;
-      return EXIT_SUCCESS;
-    }
+
+    std::cerr << "Test succeeded" << std::endl;
+    return EXIT_SUCCESS;
   }
   catch (const itk::ExceptionObject & err)
   {

--- a/Modules/Numerics/Statistics/test/itkScalarImageToTextureFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToTextureFeaturesFilterTest.cxx
@@ -342,11 +342,9 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
       std::cerr << "Test failed" << std::endl;
       return EXIT_FAILURE;
     }
-    else
-    {
-      std::cerr << "Test succeeded" << std::endl;
-      return EXIT_SUCCESS;
-    }
+
+    std::cerr << "Test succeeded" << std::endl;
+    return EXIT_SUCCESS;
   }
   catch (const itk::ExceptionObject & err)
   {

--- a/Modules/Numerics/Statistics/test/itkWeightedMeanSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedMeanSampleFilterTest.cxx
@@ -57,10 +57,8 @@ public:
     {
       return 0.5;
     }
-    else
-    {
-      return 1.0;
-    }
+
+    return 1.0;
   }
 
 protected:

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -381,7 +381,7 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueTh
   {
     return false;
   }
-  else if (movingImageValue > this->m_MovingImageTrueMax)
+  if (movingImageValue > this->m_MovingImageTrueMax)
   {
     return false;
   }
@@ -572,7 +572,7 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAn
   {
     return false;
   }
-  else if (movingImageValue > this->m_MovingImageTrueMax)
+  if (movingImageValue > this->m_MovingImageTrueMax)
   {
     return false;
   }

--- a/Modules/Registration/Common/test/itkLandmarkBasedTransformInitializerTest.cxx
+++ b/Modules/Registration/Common/test/itkLandmarkBasedTransformInitializerTest.cxx
@@ -189,10 +189,9 @@ ExecuteAndExamine(typename TransformInitializerType::Pointer                init
     std::cout << "[FAILED]" << std::endl;
     return false;
   }
-  else
-  {
-    std::cout << " Landmark alignment using " << transform->GetNameOfClass() << " [PASSED]" << std::endl;
-  }
+
+  std::cout << " Landmark alignment using " << transform->GetNameOfClass() << " [PASSED]" << std::endl;
+
   return true;
 }
 

--- a/Modules/Registration/Metricsv4/include/itkEuclideanDistancePointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkEuclideanDistancePointSetToPointSetMetricv4.hxx
@@ -38,10 +38,8 @@ typename EuclideanDistancePointSetToPointSetMetricv4<TFixedPointSet, TMovingPoin
   {
     return distance;
   }
-  else
-  {
-    return 0;
-  }
+
+  return 0;
 }
 
 template <typename TFixedPointSet, typename TMovingPointSet, class TInternalComputationValueType>

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.hxx
@@ -570,10 +570,8 @@ ImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage, TInternalComputat
   {
     return this->m_SparseGetValueAndDerivativeThreader->GetNumberOfWorkUnitsUsed();
   }
-  else
-  {
-    return this->m_DenseGetValueAndDerivativeThreader->GetNumberOfWorkUnitsUsed();
-  }
+
+  return this->m_DenseGetValueAndDerivativeThreader->GetNumberOfWorkUnitsUsed();
 }
 
 template <typename TFixedImage,
@@ -646,11 +644,9 @@ ImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage, TInternalComputat
     // over which we're evaluating over.
     return this->m_VirtualSampledPointSet->GetNumberOfPoints();
   }
-  else
-  {
-    const typename VirtualImageType::RegionType region = this->GetVirtualRegion();
-    return region.GetNumberOfPixels();
-  }
+
+  const typename VirtualImageType::RegionType region = this->GetVirtualRegion();
+  return region.GetNumberOfPixels();
 }
 
 template <typename TFixedImage,

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationGetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationGetValueAndDerivativeThreader.hxx
@@ -117,7 +117,7 @@ JointHistogramMutualInformationGetValueAndDerivativeThreader<
   {
     return false;
   }
-  else if (movingImageValue > this->m_JointAssociate->m_MovingImageTrueMax)
+  if (movingImageValue > this->m_JointAssociate->m_MovingImageTrueMax)
   {
     return false;
   }
@@ -218,10 +218,8 @@ JointHistogramMutualInformationGetValueAndDerivativeThreader<
       this->m_ThreaderFixedImageMarginalPDFInterpolator[threadId]->Evaluate(leftpoint);
     return deriv / delta;
   }
-  else
-  {
-    return InternalComputationValueType{};
-  }
+
+  return InternalComputationValueType{};
 }
 
 template <typename TDomainPartitioner, typename TImageToImageMetric, typename TJointHistogramMetric>
@@ -265,10 +263,8 @@ JointHistogramMutualInformationGetValueAndDerivativeThreader<
       this->m_JointHistogramMIPerThreadVariables[threadId].MovingImageMarginalPDFInterpolator->Evaluate(leftpoint);
     return deriv / delta;
   }
-  else
-  {
-    return InternalComputationValueType{};
-  }
+
+  return InternalComputationValueType{};
 }
 
 template <typename TDomainPartitioner, typename TImageToImageMetric, typename TJointHistogramMetric>

--- a/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.hxx
+++ b/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.hxx
@@ -185,10 +185,8 @@ ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordinate>::GetGauss
   {
     return this->m_Gaussians[i].GetPointer();
   }
-  else
-  {
-    return nullptr;
-  }
+
+  return nullptr;
 }
 
 /**

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -239,7 +239,7 @@ MattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader<
   {
     return false;
   }
-  else if (movingImageValue > this->m_MattesAssociate->m_MovingImageTrueMax)
+  if (movingImageValue > this->m_MattesAssociate->m_MovingImageTrueMax)
   {
     return false;
   }

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4RegistrationTest.cxx
@@ -317,10 +317,8 @@ itkImageToImageMetricv4RegistrationTestRunAll(int argc, char * argv[])
   {
     return EXIT_SUCCESS;
   }
-  else
-  {
-    return EXIT_FAILURE;
-  }
+
+  return EXIT_FAILURE;
 }
 
 //////////////////////////////////////////////////////////////

--- a/Modules/Registration/Metricsv4/test/itkMultiStartImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMultiStartImageToImageMetricv4RegistrationTest.cxx
@@ -253,8 +253,6 @@ itkMultiStartImageToImageMetricv4RegistrationTest(int argc, char * argv[])
   {
     return EXIT_SUCCESS;
   }
-  else
-  {
-    return EXIT_FAILURE;
-  }
+
+  return EXIT_FAILURE;
 }

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
@@ -215,7 +215,7 @@ ESMDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Co
         warpedMovingGradient[dim] = 0.0;
         continue;
       }
-      else if (index[dim] == FirstIndex[dim])
+      if (index[dim] == FirstIndex[dim])
       {
         // compute derivative
         tmpIndex[dim] += 1;

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
@@ -530,10 +530,8 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
   {
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 template <typename TFixedImage,

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
@@ -779,10 +779,8 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
         itkDebugMacro("clone copy allocation of output transform");
         return;
       }
-      else
-      {
-        itkExceptionMacro("Unable to convert InitialTransform input to the OutputTransform type");
-      }
+
+      itkExceptionMacro("Unable to convert InitialTransform input to the OutputTransform type");
     }
   }
 
@@ -1085,10 +1083,8 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
   {
     return;
   }
-  else
-  {
-    matrixOffsetOutputTransform->SetCenter(center);
-  }
+
+  matrixOffsetOutputTransform->SetCenter(center);
 }
 
 template <typename TFixedImage, typename TMovingImage, typename TTransform, typename TVirtualImage, typename TPointSet>

--- a/Modules/Registration/RegistrationMethodsv4/test/itkQuasiNewtonOptimizerv4RegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkQuasiNewtonOptimizerv4RegistrationTest.cxx
@@ -330,7 +330,7 @@ itkQuasiNewtonOptimizerv4RegistrationTest(int argc, char * argv[])
     // using AffineTransformType = itk::Euler2DTransform<double>;
     return itkQuasiNewtonOptimizerv4RegistrationTestMain<2, AffineTransformType>(argc, argv);
   }
-  else if (Dimension == 3)
+  if (Dimension == 3)
   {
     using AffineTransformType = itk::AffineTransform<double, 3>;
     // using AffineTransformType = itk::Euler3DTransform<double>;

--- a/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.h
@@ -213,10 +213,8 @@ public:
     {
       return m_SizeOfObjectsInPixels[obj - 1];
     }
-    else
-    {
-      return 0;
-    }
+
+    return 0;
   }
 
   /** Get the size of a particular object in physical space (in units of pixel
@@ -229,10 +227,8 @@ public:
     {
       return m_SizeOfObjectsInPhysicalUnits[obj - 1];
     }
-    else
-    {
-      return 0;
-    }
+
+    return 0;
   }
 
 #ifdef ITK_USE_CONCEPT_CHECKING

--- a/Modules/Segmentation/ConnectedComponents/include/itkScalarConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkScalarConnectedComponentImageFilter.h
@@ -88,10 +88,8 @@ public:
     {
       return true;
     }
-    else
-    {
-      return false;
-    }
+
+    return false;
   }
 
 protected:

--- a/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterTest.cxx
@@ -276,9 +276,7 @@ itkRelabelComponentImageFilterTest(int argc, char * argv[])
     std::cout << "Test PASSED!" << std::endl;
     return EXIT_SUCCESS;
   }
-  else
-  {
-    std::cout << "Test FAILED!" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  std::cout << "Test FAILED!" << std::endl;
+  return EXIT_FAILURE;
 }

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
@@ -96,7 +96,7 @@ DeformableSimplexMesh3DGradientConstraintForceFilter<TInputMesh, TOutputMesh>::S
   {
     return -1;
   }
-  else if (a > 0)
+  if (a > 0)
   {
     return 1;
   }

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMSegmentationBorder.h
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMSegmentationBorder.h
@@ -59,22 +59,20 @@ public:
       {
         return (m_Pointer > rhs.m_Pointer);
       }
-      else
-      {
-        // The purpose of this comparison is to not let any one region
-        // get more borders than another region.  In the degenerate
-        // case of an image where the Lambdas are always equal to some
-        // constant C, allowing a single region to be repeatedly
-        // merged so that it gains many borders will result in
-        // pathologically slow behavior.
-        const double v1 = std::max(static_cast<double>(m_Pointer->GetRegion1()->GetRegionBorderSize()),
-                                   static_cast<double>(m_Pointer->GetRegion2()->GetRegionBorderSize()));
 
-        const double v2 = std::max(static_cast<double>(rhs.m_Pointer->GetRegion1()->GetRegionBorderSize()),
-                                   static_cast<double>(rhs.m_Pointer->GetRegion2()->GetRegionBorderSize()));
+      // The purpose of this comparison is to not let any one region
+      // get more borders than another region.  In the degenerate
+      // case of an image where the Lambdas are always equal to some
+      // constant C, allowing a single region to be repeatedly
+      // merged so that it gains many borders will result in
+      // pathologically slow behavior.
+      const double v1 = std::max(static_cast<double>(m_Pointer->GetRegion1()->GetRegionBorderSize()),
+                                 static_cast<double>(m_Pointer->GetRegion2()->GetRegionBorderSize()));
 
-        return (v1 > v2);
-      }
+      const double v2 = std::max(static_cast<double>(rhs.m_Pointer->GetRegion1()->GetRegionBorderSize()),
+                                 static_cast<double>(rhs.m_Pointer->GetRegion2()->GetRegionBorderSize()));
+
+      return (v1 > v2);
     }
     return (m_Pointer->GetLambda() > rhs.m_Pointer->GetLambda());
   }
@@ -88,22 +86,20 @@ public:
       {
         return (m_Pointer > rhs->m_Pointer);
       }
-      else
-      {
-        // The purpose of this comparison is to not let any one region
-        // get more borders than another region.  In the degenerate
-        // case of an image where the Lambdas are always equal to some
-        // constant C, allowing a single region to be repeatedly
-        // merged so that it gains many borders will result in
-        // pathologically slow behavior.
-        double v1 = std::max(static_cast<double>(m_Pointer->GetRegion1()->GetRegionBorderSize()),
-                             static_cast<double>(m_Pointer->GetRegion2()->GetRegionBorderSize()));
 
-        double v2 = std::max(static_cast<double>(rhs->m_Pointer->GetRegion1()->GetRegionBorderSize()),
-                             static_cast<double>(rhs->m_Pointer->GetRegion2()->GetRegionBorderSize()));
+      // The purpose of this comparison is to not let any one region
+      // get more borders than another region.  In the degenerate
+      // case of an image where the Lambdas are always equal to some
+      // constant C, allowing a single region to be repeatedly
+      // merged so that it gains many borders will result in
+      // pathologically slow behavior.
+      double v1 = std::max(static_cast<double>(m_Pointer->GetRegion1()->GetRegionBorderSize()),
+                           static_cast<double>(m_Pointer->GetRegion2()->GetRegionBorderSize()));
 
-        return (v1 > v2);
-      }
+      double v2 = std::max(static_cast<double>(rhs->m_Pointer->GetRegion1()->GetRegionBorderSize()),
+                           static_cast<double>(rhs->m_Pointer->GetRegion2()->GetRegionBorderSize()));
+
+      return (v1 > v2);
     }
     return (m_Pointer->GetLambda() > rhs->m_Pointer->GetLambda());
   }

--- a/Modules/Segmentation/LabelVoting/include/itkBinaryMedianImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkBinaryMedianImageFilter.hxx
@@ -69,21 +69,19 @@ BinaryMedianImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion
     inputPtr->SetRequestedRegion(inputRequestedRegion);
     return;
   }
-  else
-  {
-    // Couldn't crop the region (requested region is outside the largest
-    // possible region).  Throw an exception.
 
-    // store what we tried to request (prior to trying to crop)
-    inputPtr->SetRequestedRegion(inputRequestedRegion);
+  // Couldn't crop the region (requested region is outside the largest
+  // possible region).  Throw an exception.
 
-    // build an exception
-    InvalidRequestedRegionError e(__FILE__, __LINE__);
-    e.SetLocation(ITK_LOCATION);
-    e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
-    e.SetDataObject(inputPtr);
-    throw e;
-  }
+  // store what we tried to request (prior to trying to crop)
+  inputPtr->SetRequestedRegion(inputRequestedRegion);
+
+  // build an exception
+  InvalidRequestedRegionError e(__FILE__, __LINE__);
+  e.SetLocation(ITK_LOCATION);
+  e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
+  e.SetDataObject(inputPtr);
+  throw e;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.hxx
@@ -69,21 +69,19 @@ VotingBinaryImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion
     inputPtr->SetRequestedRegion(inputRequestedRegion);
     return;
   }
-  else
-  {
-    // Couldn't crop the region (requested region is outside the largest
-    // possible region).  Throw an exception.
 
-    // store what we tried to request (prior to trying to crop)
-    inputPtr->SetRequestedRegion(inputRequestedRegion);
+  // Couldn't crop the region (requested region is outside the largest
+  // possible region).  Throw an exception.
 
-    // build an exception
-    InvalidRequestedRegionError e(__FILE__, __LINE__);
-    e.SetLocation(ITK_LOCATION);
-    e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
-    e.SetDataObject(inputPtr);
-    throw e;
-  }
+  // store what we tried to request (prior to trying to crop)
+  inputPtr->SetRequestedRegion(inputRequestedRegion);
+
+  // build an exception
+  InvalidRequestedRegionError e(__FILE__, __LINE__);
+  e.SetLocation(ITK_LOCATION);
+  e.SetDescription("Requested region is (at least partially) outside the largest possible region.");
+  e.SetDataObject(inputPtr);
+  throw e;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Segmentation/LevelSets/include/itkAnisotropicFourthOrderLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkAnisotropicFourthOrderLevelSetImageFilter.h
@@ -126,10 +126,8 @@ protected:
     {
       return true;
     }
-    else
-    {
-      return false;
-    }
+
+    return false;
   }
 
 private:

--- a/Modules/Segmentation/LevelSets/include/itkImplicitManifoldNormalVectorFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkImplicitManifoldNormalVectorFilter.h
@@ -164,10 +164,8 @@ protected:
     {
       return true;
     }
-    else
-    {
-      return false;
-    }
+
+    return false;
   }
 
 protected:

--- a/Modules/Segmentation/LevelSets/include/itkIsotropicFourthOrderLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkIsotropicFourthOrderLevelSetImageFilter.h
@@ -122,10 +122,8 @@ protected:
     {
       return true;
     }
-    else
-    {
-      return false;
-    }
+
+    return false;
   }
 };
 } // end namespace itk

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
@@ -32,20 +32,18 @@ LevelSetFunction<TImageType>::ComputeCurvatureTerm(const NeighborhoodType & neig
   {
     return this->ComputeMeanCurvature(neighborhood, offset, gd);
   }
+
+  if constexpr (ImageDimension == 3)
+  {
+    return this->Compute3DMinimalCurvature(neighborhood, offset, gd);
+  }
+  else if constexpr (ImageDimension == 2)
+  {
+    return this->ComputeMeanCurvature(neighborhood, offset, gd);
+  }
   else
   {
-    if constexpr (ImageDimension == 3)
-    {
-      return this->Compute3DMinimalCurvature(neighborhood, offset, gd);
-    }
-    else if constexpr (ImageDimension == 2)
-    {
-      return this->ComputeMeanCurvature(neighborhood, offset, gd);
-    }
-    else
-    {
-      return this->ComputeMinimalCurvature(neighborhood, offset, gd);
-    }
+    return this->ComputeMinimalCurvature(neighborhood, offset, gd);
   }
 }
 

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetVelocityNeighborhoodExtractor.h
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetVelocityNeighborhoodExtractor.h
@@ -105,10 +105,8 @@ public:
     {
       return nullptr;
     }
-    else
-    {
-      return m_AuxImage[idx];
-    }
+
+    return m_AuxImage[idx];
   }
 
   /** Get the container of auxiliary values associated with the inside

--- a/Modules/Segmentation/LevelSets/include/itkNarrowBandLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkNarrowBandLevelSetImageFilter.h
@@ -253,10 +253,8 @@ public:
     {
       return true;
     }
-    else
-    {
-      return false;
-    }
+
+    return false;
   }
 
   /** Turn On/Off the flag which determines whether Positive or Negative speed

--- a/Modules/Segmentation/LevelSets/include/itkNormalVectorDiffusionFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkNormalVectorDiffusionFunction.h
@@ -161,10 +161,8 @@ protected:
     {
       return NumericTraits<NodeValueType>::OneValue();
     }
-    else
-    {
-      return static_cast<NodeValueType>(std::exp(m_FluxStopConstant * v));
-    }
+
+    return static_cast<NodeValueType>(std::exp(m_FluxStopConstant * v));
   }
 
 private:

--- a/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetFunction.hxx
@@ -94,10 +94,8 @@ SegmentationLevelSetFunction<TImageType, TFeatureImageType>::PropagationSpeed(co
   {
     return (static_cast<ScalarValueType>(m_Interpolator->EvaluateAtContinuousIndex(cdx)));
   }
-  else
-  {
-    return (static_cast<ScalarValueType>(m_SpeedImage->GetPixel(idx)));
-  }
+
+  return (static_cast<ScalarValueType>(m_SpeedImage->GetPixel(idx)));
 }
 
 template <typename TImageType, typename TFeatureImageType>

--- a/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.h
@@ -300,10 +300,8 @@ public:
     {
       return true;
     }
-    else
-    {
-      return false;
-    }
+
+    return false;
   }
 
   /** Turn On/Off the flag which determines whether Positive or Negative speed

--- a/Modules/Segmentation/LevelSets/include/itkUnsharpMaskLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkUnsharpMaskLevelSetImageFilter.h
@@ -115,10 +115,8 @@ protected:
     {
       return true;
     }
-    else
-    {
-      return false;
-    }
+
+    return false;
   }
 };
 } // end namespace itk

--- a/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
@@ -203,10 +203,8 @@ private:
     {
       return true;
     }
-    else
-    {
-      return false;
-    }
+
+    return false;
   }
 };
 

--- a/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
@@ -209,10 +209,8 @@ private:
     {
       return true;
     }
-    else
-    {
-      return false;
-    }
+
+    return false;
   }
 };
 

--- a/Modules/Segmentation/LevelSets/test/itkShapePriorSegmentationLevelSetFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkShapePriorSegmentationLevelSetFunctionTest.cxx
@@ -101,10 +101,8 @@ private:
     {
       return true;
     }
-    else
-    {
-      return false;
-    }
+
+    return false;
   }
 };
 

--- a/Modules/Segmentation/LevelSets/test/itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
@@ -130,10 +130,8 @@ protected:
     {
       return true;
     }
-    else
-    {
-      return false;
-    }
+
+    return false;
   }
 };
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainerBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainerBase.hxx
@@ -82,10 +82,8 @@ LevelSetContainerBase<TIdentifier, TLevelSet>::GetLevelSet(const LevelSetIdentif
   {
     return it->second;
   }
-  else
-  {
-    return nullptr;
-  }
+
+  return nullptr;
 }
 
 template <typename TIdentifier, typename TLevelSet>
@@ -100,28 +98,26 @@ LevelSetContainerBase<TIdentifier, TLevelSet>::AddLevelSet(const LevelSetIdentif
     this->Modified();
     return true;
   }
+
+  if (m_Container.empty())
+  {
+    m_Container.insert(LevelSetPairType(iId, iLevelSet));
+    this->Modified();
+    return true;
+  }
   else
   {
-    if (m_Container.empty())
+    auto it = m_Container.find(iId);
+
+    if (it != m_Container.end())
+    {
+      return false;
+    }
+    else
     {
       m_Container.insert(LevelSetPairType(iId, iLevelSet));
       this->Modified();
       return true;
-    }
-    else
-    {
-      auto it = m_Container.find(iId);
-
-      if (it != m_Container.end())
-      {
-        return false;
-      }
-      else
-      {
-        m_Container.insert(LevelSetPairType(iId, iLevelSet));
-        this->Modified();
-        return true;
-      }
     }
   }
 }
@@ -141,10 +137,8 @@ LevelSetContainerBase<TIdentifier, TLevelSet>::RemoveLevelSet(const LevelSetIden
 
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 template <typename TIdentifier, typename TLevelSet>

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.hxx
@@ -57,10 +57,8 @@ LevelSetEquationCurvatureTerm<TInput, TLevelSetContainer, TCurvatureImage>::Valu
   {
     return iData.MeanCurvature.m_Value;
   }
-  else
-  {
-    return m_CurvatureImage->GetPixel(iP) * iData.MeanCurvature.m_Value;
-  }
+
+  return m_CurvatureImage->GetPixel(iP) * iData.MeanCurvature.m_Value;
 }
 
 template <typename TInput, typename TLevelSetContainer, typename TCurvatureImage>
@@ -105,10 +103,8 @@ LevelSetEquationCurvatureTerm<TInput, TLevelSetContainer, TCurvatureImage>::Valu
   {
     return this->m_CurrentLevelSetPointer->EvaluateMeanCurvature(iP);
   }
-  else
-  {
-    return m_CurvatureImage->GetPixel(iP) * this->m_CurrentLevelSetPointer->EvaluateMeanCurvature(iP);
-  }
+
+  return m_CurvatureImage->GetPixel(iP) * this->m_CurrentLevelSetPointer->EvaluateMeanCurvature(iP);
 }
 
 } // namespace itk

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermBase.hxx
@@ -70,10 +70,8 @@ LevelSetEquationTermBase<TInputImage, TLevelSetContainer>::Evaluate(const LevelS
   {
     return this->m_Coefficient * this->Value(iP);
   }
-  else
-  {
-    return LevelSetOutputRealType{};
-  }
+
+  return LevelSetOutputRealType{};
 }
 // ----------------------------------------------------------------------------
 
@@ -88,10 +86,8 @@ LevelSetEquationTermBase<TInputImage, TLevelSetContainer>::Evaluate(const LevelS
   {
     return this->m_Coefficient * this->Value(iP, iData);
   }
-  else
-  {
-    return LevelSetOutputRealType{};
-  }
+
+  return LevelSetOutputRealType{};
 }
 // ----------------------------------------------------------------------------
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkMalcolmSparseLevelSetImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkMalcolmSparseLevelSetImage.hxx
@@ -53,17 +53,15 @@ MalcolmSparseLevelSetImage<VDimension>::Evaluate(const InputType & inputPixel) c
   {
     return MinusOneLayer();
   }
+
+  const char status = this->m_LabelMap->GetPixel(mapIndex);
+  if (status == PlusOneLayer())
+  {
+    return PlusOneLayer();
+  }
   else
   {
-    const char status = this->m_LabelMap->GetPixel(mapIndex);
-    if (status == PlusOneLayer())
-    {
-      return PlusOneLayer();
-    }
-    else
-    {
-      itkGenericExceptionMacro("status " << static_cast<int>(status) << " should be 1 or -1");
-    }
+    itkGenericExceptionMacro("status " << static_cast<int>(status) << " should be 1 or -1");
   }
 }
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkShiSparseLevelSetImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkShiSparseLevelSetImage.hxx
@@ -52,18 +52,16 @@ ShiSparseLevelSetImage<VDimension>::Evaluate(const InputType & inputIndex) const
   {
     return static_cast<OutputType>(this->MinusThreeLayer());
   }
+
+  const LayerIdType status = this->m_LabelMap->GetPixel(mapIndex);
+
+  if (status == this->PlusThreeLayer())
+  {
+    return static_cast<OutputType>(this->PlusThreeLayer());
+  }
   else
   {
-    const LayerIdType status = this->m_LabelMap->GetPixel(mapIndex);
-
-    if (status == this->PlusThreeLayer())
-    {
-      return static_cast<OutputType>(this->PlusThreeLayer());
-    }
-    else
-    {
-      itkGenericExceptionMacro("status " << static_cast<int>(status) << " should be 3 or -3");
-    }
+    itkGenericExceptionMacro("status " << static_cast<int>(status) << " should be 3 or -3");
   }
 }
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainMapImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainMapImageFilterTest.cxx
@@ -96,14 +96,12 @@ itkLevelSetDomainMapImageFilterTest(int, char *[])
         {
           return EXIT_FAILURE;
         }
-        else
+
+        for (const auto & lIt : *lout)
         {
-          for (const auto & lIt : *lout)
-          {
-            std::cout << lIt << ' ';
-          }
-          std::cout << std::endl;
+          std::cout << lIt << ' ';
         }
+        std::cout << std::endl;
       }
     }
     ++it;

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageTest.cxx
@@ -145,20 +145,18 @@ itkMultiLevelSetDenseImageTest(int, char *[])
         {
           return EXIT_FAILURE;
         }
-        else
-        {
-          for (const auto & lIt : *lout)
-          {
-            std::cout << lIt << ' ' << level_set[lIt]->Evaluate(out_index) << std::endl;
-          }
-          std::cout << std::endl;
 
-          // lout->sort();
-          if (*lout != solution)
-          {
-            std::cerr << "FAILURE!!!" << std::endl;
-            return EXIT_FAILURE;
-          }
+        for (const auto & lIt : *lout)
+        {
+          std::cout << lIt << ' ' << level_set[lIt]->Evaluate(out_index) << std::endl;
+        }
+        std::cout << std::endl;
+
+        // lout->sort();
+        if (*lout != solution)
+        {
+          std::cerr << "FAILURE!!!" << std::endl;
+          return EXIT_FAILURE;
         }
       }
     }

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
@@ -409,10 +409,8 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GibbsEnergy(unsigned int i, 
   {
     return res -= m_CliqueWeight_4;
   }
-  else
-  {
-    return res -= m_CliqueWeight_6;
-  }
+
+  return res -= m_CliqueWeight_6;
 }
 
 template <typename TInputImage, typename TClassifiedImage>

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -95,7 +95,7 @@ VoronoiDiagram2DGenerator<TCoordinate>::comp(PointType arg1, PointType arg2)
   {
     return true;
   }
-  else if (arg1[1] > arg2[1])
+  if (arg1[1] > arg2[1])
   {
     return false;
   }
@@ -201,7 +201,7 @@ VoronoiDiagram2DGenerator<TCoordinate>::Pointonbnd(int VertID)
   {
     return 1;
   }
-  else if (almostsame(currVert[1], m_Pymax))
+  if (almostsame(currVert[1], m_Pymax))
   {
     return 2;
   }
@@ -666,7 +666,7 @@ VoronoiDiagram2DGenerator<TCoordinate>::getRightReg(FortuneHalfEdge * he) -> For
   {
     return (m_BottomSite);
   }
-  else if (he->m_RorL)
+  if (he->m_RorL)
   {
     return (he->m_Edge->m_Reg[0]);
   }
@@ -684,7 +684,7 @@ VoronoiDiagram2DGenerator<TCoordinate>::getLeftReg(FortuneHalfEdge * he) -> Fort
   {
     return (m_BottomSite);
   }
-  else if (he->m_RorL)
+  if (he->m_RorL)
   {
     return (he->m_Edge->m_Reg[1]);
   }

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.hxx
@@ -82,10 +82,8 @@ VoronoiSegmentationImageFilter<TInputImage, TOutputImage, TBinaryPriorImage>::Te
   {
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 template <typename TInputImage, typename TOutputImage, typename TBinaryPriorImage>

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.hxx
@@ -276,10 +276,8 @@ MorphologicalWatershedFromMarkersImageFilter<TInputImage, TLabelImage>::Generate
               collision = true;
               break;
             }
-            else
-            {
-              marker = o;
-            }
+
+            marker = o;
           }
         }
         if (!collision)

--- a/Modules/Segmentation/Watersheds/include/itkOneWayEquivalencyTable.h
+++ b/Modules/Segmentation/Watersheds/include/itkOneWayEquivalencyTable.h
@@ -92,10 +92,8 @@ public:
     {
       return a;
     }
-    else
-    {
-      return result->second;
-    }
+
+    return result->second;
   }
 
   /** Lookup an equivalency in the table by recursing through all
@@ -114,10 +112,8 @@ public:
     {
       return false;
     }
-    else
-    {
-      return true;
-    }
+
+    return true;
   }
 
   /**  Erases the entry with key a.   */

--- a/Modules/Segmentation/Watersheds/include/itkWatershedBoundary.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedBoundary.h
@@ -151,10 +151,8 @@ public:
     {
       return m_Faces[dimension].first;
     }
-    else
-    {
-      return m_Faces[dimension].second;
-    }
+
+    return m_Faces[dimension].second;
   }
 
   void
@@ -190,10 +188,8 @@ public:
     {
       return &(m_FlatHashes[dimension].first);
     }
-    else
-    {
-      return &(m_FlatHashes[dimension].second);
-    }
+
+    return &(m_FlatHashes[dimension].second);
   }
 
   void
@@ -250,10 +246,8 @@ public:
     {
       return m_Valid[dimension].first;
     }
-    else
-    {
-      return m_Valid[dimension].second;
-    }
+
+    return m_Valid[dimension].second;
   }
 
 protected:

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.h
@@ -78,10 +78,8 @@ public:
       {
         return true;
       }
-      else
-      {
-        return false;
-      }
+
+      return false;
     }
   };
 
@@ -125,10 +123,8 @@ public:
     {
       return nullptr;
     }
-    else
-    {
-      return &(result->second);
-    }
+
+    return &(result->second);
   }
 
   /** Lookup a segment in the table.  Returns a const pointer
@@ -142,10 +138,8 @@ public:
     {
       return 0;
     }
-    else
-    {
-      return &(result->second);
-    }
+
+    return &(result->second);
   }
 
   /** Returns TRUE if the entry key is found in the table.  FALSE if the key is
@@ -157,10 +151,8 @@ public:
     {
       return false;
     }
-    else
-    {
-      return true;
-    }
+
+    return true;
   }
 
   /** Deletes an entry from the table.   */

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.hxx
@@ -65,10 +65,8 @@ SegmentTable<TScalar>::Add(IdentifierType a, const segment_t & t)
   {
     return false;
   }
-  else
-  {
-    return true;
-  }
+
+  return true;
 }
 } // end namespace watershed
 } // end namespace itk

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
@@ -704,7 +704,7 @@ Segmenter<TInputImage>::LabelMinima(InputImageTypePointer                img,
         foundFlatRegion = true;
         break;
       }
-      else if (currentValue > searchIt.GetPixel(nPos))
+      if (currentValue > searchIt.GetPixel(nPos))
       {
         foundSinglePixelMinimum = false;
       }
@@ -1201,7 +1201,7 @@ Segmenter<TInputImage>::MakeOutput(DataObjectPointerArraySizeType idx) -> DataOb
   {
     return OutputImageType::New().GetPointer();
   }
-  else if (idx == 1)
+  if (idx == 1)
   {
     return SegmentTableType::New().GetPointer();
   }

--- a/Modules/Video/Core/include/itkRingBuffer.hxx
+++ b/Modules/Video/Core/include/itkRingBuffer.hxx
@@ -160,10 +160,8 @@ RingBuffer<TElement>::GetOffsetBufferIndex(OffsetValueType offset) -> OffsetValu
   {
     return (signedHeadIndex + moddedOffset) % this->GetNumberOfBuffers();
   }
-  else
-  {
-    return (signedHeadIndex + (this->GetNumberOfBuffers() - moddedOffset)) % this->GetNumberOfBuffers();
-  }
+
+  return (signedHeadIndex + (this->GetNumberOfBuffers() - moddedOffset)) % this->GetNumberOfBuffers();
 }
 
 } // end namespace itk

--- a/Modules/Video/Core/src/itkTemporalDataObject.cxx
+++ b/Modules/Video/Core/src/itkTemporalDataObject.cxx
@@ -164,7 +164,7 @@ TemporalDataObject::GetUnbufferedRequestedTemporalRegion()
   }
 
   // Handle case with unbuffered frames at end -- TODO: FIX FOR REAL TIME!!!!!
-  else if (reqEnd > bufEnd)
+  if (reqEnd > bufEnd)
   {
     TemporalRegionType out;
     out.SetFrameStart(bufEnd + 1);

--- a/Modules/Video/IO/include/itkVideoFileWriter.hxx
+++ b/Modules/Video/IO/include/itkVideoFileWriter.hxx
@@ -282,10 +282,8 @@ VideoFileWriter<TInputVideoStream>::InitializeVideoIO()
 
       return true;
     }
-    else
-    {
-      return false;
-    }
+
+    return false;
   }
   else
   {


### PR DESCRIPTION
Reduce indentation where possible and where it makes understanding code easier.
Early exit is one of the suggested enforcements of that. Please do not use else
or else if after something that interrupts control flow - like return, break,
continue, throw.

clang-tidy readability-else-after-return

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
