### PR TITLE
STYLE: PrintSlice re-used variable name

### DIFF
--- a/Modules/Core/Common/test/itkSliceIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkSliceIteratorTest.cxx
@@ -128,12 +128,12 @@ PrintRegion(itk::SmartPointer<itk::Image<TPixelType, VDimension>> I)
 
 template <typename TContainer>
 void
-PrintSlice(TContainer s)
+PrintSlice(TContainer s_container)
 {
   std::cout << '[';
-  for (s = s.Begin(); s < s.End(); ++s)
+  for (auto iter = s_container.Begin(); iter < s_container.End(); ++iter)
   {
-    std::cout << *s << ' ';
+    std::cout << *iter << ' ';
   }
   std::cout << ']' << std::endl;
 }


### PR DESCRIPTION
The variable name s was used as an input and a loop variable. Split the names to clearly indicate the iteration variable intent.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
