### PR TITLE
STYLE: Prefer compile-time constexpr

### DIFF
--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
@@ -46,7 +46,7 @@ public:
 
 private:
   /** Equal to \f$ \frac{\pi}{2 m} \f$ */
-  static const double m_Factor;
+  static constexpr double m_Factor = itk::Math::pi / (2 * VRadius);
 };
 
 /**
@@ -68,7 +68,7 @@ public:
 
 private:
   /** Equal to \f$ \frac{\pi}{m} \f$ */
-  static const double m_Factor;
+  static constexpr double m_Factor = itk::Math::pi / VRadius;
 };
 
 /**
@@ -90,7 +90,7 @@ public:
 
 private:
   /** Equal to \f$ \frac{1}{m^2} \f$ */
-  static const double m_Factor;
+  static constexpr double m_Factor = 1.0 / (VRadius * VRadius);
 };
 
 /**
@@ -112,14 +112,14 @@ public:
     if (A == 0.0)
     {
       return static_cast<TOutput>(1.0);
-    }
+    } // namespace Function
     const double z = m_Factor * A;
     return static_cast<TOutput>(std::sin(z) / z);
-  }
+  } // namespace itk
 
 private:
   /** Equal to \f$ \frac{\pi}{m} \f$ */
-  static const double m_Factor;
+  static constexpr double m_Factor = itk::Math::pi / VRadius;
 };
 
 /**
@@ -141,10 +141,10 @@ public:
 
 private:
   /** Equal to \f$ \frac{\pi}{m} \f$ */
-  static const double m_Factor1;
+  static constexpr double m_Factor1 = itk::Math::pi / VRadius;
 
   /** Equal to \f$ \frac{2 \pi}{m} \f$  */
-  static const double m_Factor2;
+  static constexpr double m_Factor2 = 2.0 * itk::Math::pi / VRadius;
 };
 } // namespace Function
 

--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
@@ -345,11 +345,10 @@ private:
   unsigned int m_WeightOffsetTable[m_OffsetTableSize][ImageDimension]{};
 
   /** The sinc function */
-  inline double
-  Sinc(double x) const
+  static double
+  Sinc(const double x)
   {
     const double px = Math::pi * x;
-
     return (x == 0.0) ? 1.0 : std::sin(px) / px;
   }
 };

--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
@@ -25,6 +25,7 @@
 
 namespace itk
 {
+// clang-format off
 namespace Function
 {
 /**
@@ -41,12 +42,10 @@ public:
   inline TOutput
   operator()(const TInput & A) const
   {
-    return static_cast<TOutput>(std::cos(A * m_Factor));
+    /** Equal to \f$ \frac{\pi}{2 m} \f$ */
+    static constexpr double factor = Math::pi / (2 * VRadius);
+    return static_cast<TOutput>(std::cos(A * factor));
   }
-
-private:
-  /** Equal to \f$ \frac{\pi}{2 m} \f$ */
-  static constexpr double m_Factor = itk::Math::pi / (2 * VRadius);
 };
 
 /**
@@ -63,12 +62,10 @@ public:
   inline TOutput
   operator()(const TInput & A) const
   {
-    return static_cast<TOutput>(0.54 + 0.46 * std::cos(A * m_Factor));
+    /** Equal to \f$ \frac{\pi}{m} \f$ */
+    static constexpr double factor = Math::pi / VRadius;
+    return static_cast<TOutput>(0.54 + 0.46 * std::cos(A * factor));
   }
-
-private:
-  /** Equal to \f$ \frac{\pi}{m} \f$ */
-  static constexpr double m_Factor = itk::Math::pi / VRadius;
 };
 
 /**
@@ -85,12 +82,10 @@ public:
   inline TOutput
   operator()(const TInput & A) const
   {
-    return static_cast<TOutput>(1.0 - A * m_Factor * A);
+    /** Equal to \f$ \frac{1}{m^2} \f$ */
+    static constexpr double factor = 1.0 / (VRadius * VRadius);
+    return static_cast<TOutput>(1.0 - A * factor * A);
   }
-
-private:
-  /** Equal to \f$ \frac{1}{m^2} \f$ */
-  static constexpr double m_Factor = 1.0 / (VRadius * VRadius);
 };
 
 /**
@@ -113,13 +108,11 @@ public:
     {
       return static_cast<TOutput>(1.0);
     } // namespace Function
-    const double z = m_Factor * A;
+    /** Equal to \f$ \frac{\pi}{m} \f$ */
+    static constexpr double factor = Math::pi / VRadius;
+    const double z = factor * A;
     return static_cast<TOutput>(std::sin(z) / z);
   } // namespace itk
-
-private:
-  /** Equal to \f$ \frac{\pi}{m} \f$ */
-  static constexpr double m_Factor = itk::Math::pi / VRadius;
 };
 
 /**
@@ -136,17 +129,16 @@ public:
   inline TOutput
   operator()(const TInput & A) const
   {
-    return static_cast<TOutput>(0.42 + 0.5 * std::cos(A * m_Factor1) + 0.08 * std::cos(A * m_Factor2));
+    /** Equal to \f$ \frac{\pi}{m} \f$ */
+    static constexpr double factor1 = Math::pi / VRadius;
+
+    /** Equal to \f$ \frac{2 \pi}{m} \f$  */
+    static constexpr double factor2 = 2.0 * Math::pi / VRadius;
+    return static_cast<TOutput>(0.42 + 0.5 * std::cos(A * factor1) + 0.08 * std::cos(A * factor2));
   }
-
-private:
-  /** Equal to \f$ \frac{\pi}{m} \f$ */
-  static constexpr double m_Factor1 = itk::Math::pi / VRadius;
-
-  /** Equal to \f$ \frac{2 \pi}{m} \f$  */
-  static constexpr double m_Factor2 = 2.0 * itk::Math::pi / VRadius;
 };
 } // namespace Function
+// clang-format on
 
 /**
  * \class WindowedSincInterpolateImageFunction
@@ -356,7 +348,7 @@ private:
   inline double
   Sinc(double x) const
   {
-    const double px = itk::Math::pi * x;
+    const double px = Math::pi * x;
 
     return (x == 0.0) ? 1.0 : std::sin(px) / px;
   }

--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
@@ -23,29 +23,6 @@
 
 namespace itk
 {
-
-// Constant definitions for functions
-namespace Function
-{
-template <unsigned int VRadius, typename TInput, typename TOutput>
-const double CosineWindowFunction<VRadius, TInput, TOutput>::m_Factor = itk::Math::pi / (2 * VRadius);
-
-template <unsigned int VRadius, typename TInput, typename TOutput>
-const double HammingWindowFunction<VRadius, TInput, TOutput>::m_Factor = itk::Math::pi / VRadius;
-
-template <unsigned int VRadius, typename TInput, typename TOutput>
-const double WelchWindowFunction<VRadius, TInput, TOutput>::m_Factor = 1.0 / (VRadius * VRadius);
-
-template <unsigned int VRadius, typename TInput, typename TOutput>
-const double LanczosWindowFunction<VRadius, TInput, TOutput>::m_Factor = itk::Math::pi / VRadius;
-
-template <unsigned int VRadius, typename TInput, typename TOutput>
-const double BlackmanWindowFunction<VRadius, TInput, TOutput>::m_Factor1 = itk::Math::pi / VRadius;
-
-template <unsigned int VRadius, typename TInput, typename TOutput>
-const double BlackmanWindowFunction<VRadius, TInput, TOutput>::m_Factor2 = 2.0 * itk::Math::pi / VRadius;
-} // end namespace Function
-
 template <typename TInputImage,
           unsigned int VRadius,
           typename TWindowFunction,


### PR DESCRIPTION
The values of m_Factor* are known at compile-
time, so compute them only at compile-time.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
