### PR TITLE
DOC: Fix miscellaneous Doxygen warnings

### DIFF
--- a/Modules/Filtering/FastMarching/include/itkFastMarchingTraits.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingTraits.h
@@ -74,7 +74,7 @@ public:
 
   using SuperclassType = TSuperclass;
 
-  /** \enum LabelEnum Fast Marching algorithm nodes types. */
+  /** \enum LabelType Fast Marching algorithm nodes types. */
   enum LabelType
   {
     /** \c Far represent far away nodes*/

--- a/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.h
@@ -45,10 +45,11 @@ namespace itk
  *
  * An AnatomicalOrientation object can be constructed unambiguously with the following syntax:
  *
- * \code
- *  AnatomicalOrientation(AnatomicalOrientation::CoordinateEnum::RightToLeft,
- *                        AnatomicalOrientation::CoordinateEnum::AnteriorToPosterior,
- *                        AnatomicalOrientation::CoordinateEnum::InferiorToSuperior);
+   \code
+       AnatomicalOrientation(AnatomicalOrientation::CoordinateEnum::RightToLeft,
+                             AnatomicalOrientation::CoordinateEnum::AnteriorToPosterior,
+                             AnatomicalOrientation::CoordinateEnum::InferiorToSuperior);
+   \endcode
  *
  *
  * The orientations were previously defined in the itk::SpatialOrientation class. However,

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
@@ -344,10 +344,12 @@ protected:
   virtual void
   LinearThreadedGenerateData(const OutputImageRegionType & outputRegionForThread);
 
+#if !defined(ITK_LEGACY_REMOVE)
   /** Cast pixel from interpolator output to PixelType. */
   itkLegacyMacro(virtual PixelType CastPixelWithBoundsChecking(const InterpolatorOutputType value,
                                                                const ComponentType          minComponent,
                                                                const ComponentType          maxComponent) const;)
+#endif
 
 private:
   static PixelComponentType


### PR DESCRIPTION
Fix miscellaneous Doxygen warnings:
- Fix the Doxygen name for the `itk::FastMarchingTraits::LabelType` enum.
- Add the missing `\endcode` tag to a code snippet in `itk::OrientImageFilter`.
- Add the `ITK_LEGACY_REMOVE` macro to a function declared as legacy with the `itkLegacyMacro` in `itk::ResampleImageFilter`.

Fixes:
```
Warning
Modules/Filtering/FastMarching/include/itkFastMarchingTraits.h:77:
 warning: Documentation for undefined enum 'LabelEnum' found.
```

and
```
Warning
Modul/.../ITK/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.h:268:
 warning: Reached end of file while still inside a (nested) comment. Nesting level 1 (probable line reference: 29)

Warning
Modules/Filtering/ImageGrid/include/itkOrientImageFilter.h:268:
 warning: File ended in the middle of a comment block! Perhaps a missing \endcode?
```

and
```
Warning
Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h:367: warning: no uniquely matching class member found for
  template < TComponent >
  static itk::ResampleImageFilter< TComponent >::itkLegacyMacro(const TComponent value)
```

raised for example in:
https://open.cdash.org/viewBuildError.php?type=1&buildid=10117138

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Updated API documentation (or API not changed)
