### PR TITLE
DOC: Fix multiple group Doxygen warnings

### DIFF
--- a/Modules/Filtering/FFT/include/itkComplexToComplexFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkComplexToComplexFFTImageFilter.h
@@ -35,7 +35,6 @@ class ComplexToComplexFFTImageFilterEnums
 public:
   /**
    * \ingroup ITKFFT
-   * \ingroup FourierTransform
    * */
   enum class TransformDirection : uint8_t
   {

--- a/Modules/IO/ImageBase/include/itkIOCommon.h
+++ b/Modules/IO/ImageBase/include/itkIOCommon.h
@@ -34,7 +34,6 @@ class IOCommonEnums
 {
 public:
   /**
-   * \ingroup IOFilters
    * \ingroup ITKIOImageBase
    * enumerated constants for the different data types
    */


### PR DESCRIPTION
Fix multiple group Doxygen warnings: enum classes cannot be members of multiple groups: remove the additional grouping command, and leave the one corresponding to the most specific group.

From the Doxygen documentation:
"Note that compound entities (like classes, files and namespaces) can be put into multiple groups, but members (like variable, functions, typedefs and enums) can only be a member of one group (...)."

https://www.doxygen.nl/manual/grouping.html#topics

Fixes:
```
Warning
Modules/IO/ImageBase/include/itkIOCommon.h:42:
 warning: Member AtomicPixel found in multiple @ingroup groups!
 The member will be put in group ITKIOImageBase, and not in group IOFilters
```

and
```
Warning
Modules/Filtering/FFT/include/itkComplexToComplexFFTImageFilter.h:41:
 warning: Member TransformDirection found in multiple @ingroup groups!
 The member will be put in group FourierTransform, and not in group ITKFFT
```

raised for example in:
https://open.cdash.org/viewBuildError.php?type=1&buildid=10117138

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Updated API documentation (or API not changed)