### PR TITLE
COMP: Fix clang compile error in MCI TestWithRLEImage.cxx

### DIFF
--- a/Modules/Core/Common/include/itkImageAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkImageAlgorithm.hxx
@@ -36,8 +36,8 @@ ImageAlgorithm::DispatchedCopy(const InputImageType *                       inIm
 {
   if (inRegion.GetSize()[0] == outRegion.GetSize()[0])
   {
-    itk::ImageScanlineConstIterator it(inImage, inRegion);
-    itk::ImageScanlineIterator      ot(outImage, outRegion);
+    itk::ImageScanlineConstIterator<InputImageType> it(inImage, inRegion);
+    itk::ImageScanlineIterator<OutputImageType>     ot(outImage, outRegion);
 
     while (!it.IsAtEnd())
     {


### PR DESCRIPTION
See https://github.com/KitwareMedical/ITKRLEImage/issues/65.

The error message was:
```log
[658/2516] Building CXX object Modules/Remote/MorphologicalContourInterpolation/test/CMakeFiles/MorphologicalContourInterpolationTestDriver.dir/itkMorphologicalContourInterpolationTestWithRLEImage.cxx.o FAILED: Modules/Remote/MorphologicalContourInterpolation/test/CMakeFiles/MorphologicalContourInterpolationTestDriver.dir/itkMorphologicalContourInterpolationTestWithRLEImage.cxx.o /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DEIGEN_MPL2_ONLY -IModules/ThirdParty/Eigen3/src -IModules/ThirdParty/KWSys/src -I/.../ITK/Modules/ThirdParty/VNL/src/vxl/v3p/netlib -I/.../ITK/Modules/ThirdParty/VNL/src/vxl/vcl -I/.../ITK/Modules/ThirdParty/VNL/src/vxl/core -IModules/ThirdParty/VNL/src/vxl/v3p/netlib -IModules/ThirdParty/VNL/src/vxl/vcl -IModules/ThirdParty/VNL/src/vxl/core -IModules/Core/Common -I/.../ITK/Modules/Core/Common/include -I/.../ITK/Modules/ThirdParty/DoubleConversion/src -IModules/ThirdParty/DoubleConversion/src/double-conversion -IModules/IO/ImageBase -I/.../ITK/Modules/IO/ImageBase/include -I/.../ITK/Modules/Core/TestKernel/include -I/.../ITK/Modules/Core/ImageAdaptors/include -IModules/ThirdParty/Netlib -I/.../ITK/Modules/Numerics/Statistics/include -I/.../ITK/Modules/Filtering/ImageFilterBase/include -I/.../ITK/Modules/Core/Transform/include -I/.../ITK/Modules/Core/ImageFunction/include -I/.../ITK/Modules/Filtering/ImageGrid/include -I/.../ITK/Modules/Filtering/ImageCompose/include -IModules/ThirdParty/ZLIB/src -IModules/ThirdParty/ZLIB/src/itkzlib-ng -I/.../ITK/Modules/ThirdParty/ZLIB/src -IModules/ThirdParty/MetaIO/src/MetaIO/src -I/.../ITK/Modules/ThirdParty/MetaIO/src/MetaIO/src -I/.../ITK/Modules/Core/SpatialObjects/include -I/.../ITK/Modules/Filtering/ImageStatistics/include -I/.../ITK/Modules/Filtering/Path/include -I/.../ITK/Modules/Filtering/ImageIntensity/include -I/.../ITK/Modules/Filtering/ImageLabel/include -I/.../ITK/Modules/Filtering/LabelMap/include -I/.../ITK/Modules/Filtering/Thresholding/include -I/.../ITK/Modules/Segmentation/ConnectedComponents/include -I/.../ITK/Modules/Filtering/MathematicalMorphology/include -I/.../ITK/Modules/Filtering/BinaryMathematicalMorphology/include -I/.../ITK/Modules/Core/FiniteDifference/include -I/.../ITK/Modules/Filtering/CurvatureFlow/include -I/.../ITK/Modules/Numerics/NarrowBand/include -I/.../ITK/Modules/Filtering/DistanceMap/include -I/.../ITK/Modules/Remote/MorphologicalContourInterpolation/include -I/.../ITK/Modules/Remote/RLEImage/include -I/.../ITK/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo -I/.../ITK/Modules/ThirdParty/VNL/src/vxl/core/vnl -IModules/ThirdParty/VNL/src/vxl/core/vnl -isystem /.../ITK/Modules/ThirdParty/Eigen3/src/itkeigen/.. -mtune=generic -march=corei7 -Wall -Wcast-align -Wdisabled-optimization -Wextra -Wformat=2 -Winvalid-pch -Wno-format-nonliteral -Wpointer-arith -Wshadow -Wunused -Wwrite-strings -Wno-strict-overflow -Wno-deprecated -Wno-invalid-offsetof -Wno-undefined-var-template -Woverloaded-virtual -Wctad-maybe-unsupported  -O3 -DNDEBUG -arch x86_64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk -fPIE -std=c++17 -MD -MT Modules/Remote/MorphologicalContourInterpolation/test/CMakeFiles/MorphologicalContourInterpolationTestDriver.dir/itkMorphologicalContourInterpolationTestWithRLEImage.cxx.o -MF Modules/Remote/MorphologicalContourInterpolation/test/CMakeFiles/MorphologicalContourInterpolationTestDriver.dir/itkMorphologicalContourInterpolationTestWithRLEImage.cxx.o.d -o Modules/Remote/MorphologicalContourInterpolation/test/CMakeFiles/MorphologicalContourInterpolationTestDriver.dir/itkMorphologicalContourInterpolationTestWithRLEImage.cxx.o -c /.../ITK/Modules/Remote/MorphologicalContourInterpolation/test/itkMorphologicalContourInterpolationTestWithRLEImage.cxx In file included from Modules/Remote/MorphologicalContourInterpolation/test/itkMorphologicalContourInterpolationTestWithRLEImage.cxx:20: In file included from Modules/IO/ImageBase/include/itkImageFileWriter.h:266: In file included from Modules/IO/ImageBase/include/itkImageFileWriter.hxx:33: In file included from Modules/Core/Common/include/itkImageAlgorithm.h:221:

Modules/Core/Common/include/itkImageAlgorithm.hxx:40:37: error: no viable constructor or deduction guide for deduction of template arguments of 'ImageScanlineIterator'

   40 |     itk::ImageScanlineIterator      ot(outImage, outRegion);
      |                                     ^
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

