### PR TITLE
DOC: Fix legacy methods `itk::Transform` Doxygen warnings

### DIFF
--- a/Modules/Core/Transform/include/itkTransform.h
+++ b/Modules/Core/Transform/include/itkTransform.h
@@ -529,9 +529,11 @@ public:
                       " is unimplemented for "
                       << this->GetNameOfClass());
   }
+
+#if !defined(ITK_LEGACY_REMOVE)
   itkLegacyMacro(virtual void ComputeJacobianWithRespectToPosition(const InputPointType & x, JacobianType & jacobian)
                    const;)
-
+#endif
 
   /** This provides the ability to get a local jacobian value
    *  in a dense/local transform, e.g. DisplacementFieldTransform. For such
@@ -540,8 +542,11 @@ public:
    *  since there is no change with respect to position. */
   virtual void
   ComputeInverseJacobianWithRespectToPosition(const InputPointType & pnt, InverseJacobianPositionType & jacobian) const;
+
+#if !defined(ITK_LEGACY_REMOVE)
   itkLegacyMacro(virtual void ComputeInverseJacobianWithRespectToPosition(const InputPointType & x,
                                                                           JacobianType &         jacobian) const;)
+#endif
 
   /** Apply this transform to an image without resampling.
    *


### PR DESCRIPTION
Fix legacy methods `itk::Transform` Doxygen warnings: protect with the `ITK_LEGACY_REMOVE` macro definition a function declared as legacy with the `itkLegacyMacro` in `itk::Transform`.

Fixes:
```
Warning
Parsing file /home/kitware/DashboModules/Core/Transform/include/itkTransform.h:535:
 warning: Illegal member name found.
```

and
```
Warning
Modules/Core/Transform/include/itkTransform.h:535:
 warning: no uniquely matching class member found for
  itk::Transform::virtual void itk::Transform< TParametersValueType, VInputDimension, VOutputDimension >::ComputeInverseJacobianWithRespectToPosition() const &
```

Raised for example in:
https://open.cdash.org/viewBuildError.php?type=1&buildid=10124761

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)