### PR TITLE
BUG: -1 was being returned in a function that returns bool

### DIFF
--- a/Modules/Core/Common/include/itkHexahedronCell.hxx
+++ b/Modules/Core/Common/include/itkHexahedronCell.hxx
@@ -452,7 +452,7 @@ HexahedronCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
     else if ((itk::Math::abs(pcoords[0]) > ITK_DIVERGED) || (itk::Math::abs(pcoords[1]) > ITK_DIVERGED) ||
              (itk::Math::abs(pcoords[2]) > ITK_DIVERGED))
     {
-      return -1;
+      return false;
     }
 
     //  if not converged, repeat

--- a/Modules/Core/Common/include/itkQuadrilateralCell.hxx
+++ b/Modules/Core/Common/include/itkQuadrilateralCell.hxx
@@ -373,7 +373,7 @@ QuadrilateralCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
     // Test for bad divergence (S.Hirschberg 11.12.2001)
     else if ((itk::Math::abs(pcoords[0]) > ITK_DIVERGED) || (itk::Math::abs(pcoords[1]) > ITK_DIVERGED))
     {
-      return -1;
+      return false;
     }
 
     //  if not converged, repeat


### PR DESCRIPTION
Found by cppcheck.

The nearby comment occurs elsewhere in the codebase, and there it was changed to `return false` so I did the same here.
