### PR TITLE
COMP: Update KWStyle

### DIFF
--- a/Utilities/KWStyle/BuildKWStyle.cmake
+++ b/Utilities/KWStyle/BuildKWStyle.cmake
@@ -23,7 +23,7 @@ if(NOT TARGET KWStyle)
   ExternalProject_Add(
     KWStyle
     GIT_REPOSITORY "https://github.com/Kitware/KWStyle.git"
-    GIT_TAG 6971e89ec4c763601edf1d0ea0d6f71d42fbca5d
+    GIT_TAG 2b53cb522e79a4a2c0bde5a23eb3275e7ee91140
     UPDATE_COMMAND ""
     DOWNLOAD_DIR ${KWStyle_SOURCE_DIR}
     SOURCE_DIR ${KWStyle_SOURCE_DIR}


### PR DESCRIPTION
Attempting the address build warnings on Clang. Example:

```log
KWStyle/Utilities/boost/xpressive/basic_regex.hpp:200:43: note: in instantiation of member function 'boost::xpressive::regex_compiler<std::__wrap_iter<const char *>>::compile' requested here
  200 |         return regex_compiler<BidiIter>().compile(begin, flags);
      |                                           ^

KWStyle/kwsParser.cxx:575:32: note: in instantiation of member function 'boost::xpressive::basic_regex<std::__wrap_iter<const char *>>::compile' requested here

  575 |   sregex unixNewline = sregex::compile("\r?\n|\r");
      |                                ^
In file included from KWStyle/kwsParser.cxx:18:
In file included from KWStyle/Utilities/boost/xpressive/xpressive.hpp:18:
In file included from KWStyle/Utilities/boost/xpressive/xpressive_static.hpp:24:
In file included from KWStyle/Utilities/boost/xpressive/regex_primitives.hpp:22:
In file included from KWStyle/Utilities/boost/xpressive/detail/core/matchers.hpp:46:
KWStyle/Utilities/boost/xpressive/detail/core/matcher/simple_repeat_matcher.hpp:219:32: warning: definition of implicit copy constructor for 'simple_repeat_matcher<boost::xpressive::detail::shared_matchable<std::__wrap_iter<const char *>>, mpl_::bool_<true>>' is deprecated because it has a user-provided copy assignment operator [-Wdeprecated-copy-with-user-provided-copy]
  219 |         simple_repeat_matcher &operator =(simple_repeat_matcher const &);
      |                                ^
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
