### PR TITLE
DOC: Update Doxygen footer link to tarballs

### DIFF
--- a/Documentation/Doxygen/DoxygenFooter.html
+++ b/Documentation/Doxygen/DoxygenFooter.html
@@ -13,18 +13,11 @@
 <!--BEGIN !GENERATE_TREEVIEW-->
 <hr class="footer"/>
 <div class="footer" align="left">
-  <small>Tarballs of the nightly generated Doxygen documentation are available
-    for the
-    <a href="https://itk.org/files/NightlyDoxygen/InsightDoxygenDocHtml.tar.gz">html</a>,
-    <a href="https://itk.org/files/NightlyDoxygen/InsightDoxygenDocXml.tar.gz">xml</a>, and
-    <a href="https://itk.org/files/NightlyDoxygen/InsightDoxygenDocTag.gz">tag file</a>.
-  Previous versions of this documentation for version:
-    <a href="https://itk.org/Doxygen53/html/index.html">5.3</a>,
-    <a href="https://itk.org/Doxygen52/html/index.html">5.2</a>,
-    <a href="https://itk.org/Doxygen51/html/index.html">5.1</a>,
-    <a href="https://itk.org/Doxygen50/html/index.html">5.0</a>,
-    <a href="https://itk.org/Doxygen413/html/index.html">4.13</a>,
-    <a href="https://itk.org/Doxygen320/html/index.html">3.20</a>.
+  <small>Tarballs of release and nightly generated Doxygen documentation
+    are available in the
+    <a href="https://github.com/InsightSoftwareConsortium/ITKDoxygen/releases">
+      <i>InsightSoftwareConsortium/ITKDoxygen</i> GitHub Releases
+    </a>.
   </small>
 </div>
 <address class="footer"><small>


### PR DESCRIPTION
Nightly tarballs and release tarballs, for all released versions of ITK,
are now available in the ITKDoxygen GitHub Releases.
