### PR TITLE
DOC: Update maintenance branch for 5.4 series

### DIFF
--- a/Documentation/docs/contributing/index.md
+++ b/Documentation/docs/contributing/index.md
@@ -372,10 +372,7 @@ branches:
   * `release`: Maintenance of latest release
   * `release-3.20`: Maintenance of the ITKv3 series
   * `release-4.13`: Maintenance of the ITKv4 series
-  * `5.4`: Maintenance of the ITKv5 series.
-    - The naming convention changed to support ReadTheDocs rendering of
-      versions on docs.itk.org
-    - Future releases, `6.0`, `6.1`, etc. should use this convention.
+  * `release-5.4`: Maintenance of the ITKv5 series.
   * `nightly-master`: Follows master, updated at 01:00 UTC for nightly dashboard build consistency.
   * `hooks`: Local commit hooks (place in `.git/hooks`)
   * `dashboard`: Dashboard script (setup a CDash client)


### PR DESCRIPTION
Someone deleted the `5.4` branch from the repository. And it had not been updated in the last seven months, but a `release-5.4` branch was created and has been updated. In prior section, our documentation references `release-5.4` as the maintenance branch.

We had anticipated using the `5.4` to present stable builds of the documentation in ReadTheDocs -- their versioning recognizes `5.4` but not `release-5.4`. However, we can also build versions of the tags and present that in ReadTheDocs. And, this allows use to used tagged subproject, like `itkdoxygen`, and RTD will provide unified search over the tags. With the tags, and the `release` builds, the `X.X` RTD versions are redundant.
