### PR TITLE
ENH: fixed issue 4818 with itkMemoryProbesCollecterBaseTest

### DIFF
--- a/Modules/Core/Common/test/itkMemoryProbesCollecterBaseTest.cxx
+++ b/Modules/Core/Common/test/itkMemoryProbesCollecterBaseTest.cxx
@@ -36,7 +36,7 @@ Sleep(unsigned int milliseconds)
 int
 itkMemoryProbesCollecterBaseTest(int, char *[])
 {
-  constexpr size_t bufsize = 256L * 1024L * 1024L; // 256 MiB
+  constexpr size_t bufsize = 768L * 1024L * 1024L; // 768 MiB
 
   itk::MemoryProbesCollectorBase mcollecter;
   itk::MemoryProbe               probe;


### PR DESCRIPTION
On macOS, itkMemoryProbesCollecterBaseTest would often fail with messages like:

Freeing memory should result in less memory but it is 262216kB instead of 262164kB

Just increased the amout of memory allocated in this test to make it more likely to pass.

Closes #4818.