### PR TITLE
BUG: SAGITAL_PLANE -> SAGITTAL_PLANE, though with legacy support

### DIFF
--- a/Modules/Core/Common/include/itkCommonEnums.h
+++ b/Modules/Core/Common/include/itkCommonEnums.h
@@ -212,7 +212,10 @@ public:
   enum class Octree : uint8_t
   {
     UNKNOWN_PLANE,   ///< The plane is Unknown
-    SAGITAL_PLANE,   ///< The plane is Sagittal
+    SAGITTAL_PLANE,  ///< The plane is Sagittal
+#if !defined(ITK_LEGACY_REMOVE)
+    SAGITAL_PLANE = SAGITTAL_PLANE, ///< Support misspelling
+#endif
     CORONAL_PLANE,   ///< The plane is Coronal
     TRANSVERSE_PLANE ///< The plane is Transverse
   };

--- a/Modules/Core/Common/include/itkCommonEnums.h
+++ b/Modules/Core/Common/include/itkCommonEnums.h
@@ -214,7 +214,7 @@ public:
     UNKNOWN_PLANE,   ///< The plane is Unknown
     SAGITTAL_PLANE,  ///< The plane is Sagittal
 #if !defined(ITK_LEGACY_REMOVE)
-    SAGITAL_PLANE = SAGITTAL_PLANE, ///< Support misspelling
+    SAGITAL_PLANE [[deprecated("Use SAGITTAL_PLANE instead")]] = SAGITTAL_PLANE, ///< Support misspelling
 #endif
     CORONAL_PLANE,   ///< The plane is Coronal
     TRANSVERSE_PLANE ///< The plane is Transverse

--- a/Modules/Core/Common/include/itkOctree.h
+++ b/Modules/Core/Common/include/itkOctree.h
@@ -50,6 +50,7 @@ public:
   // We need to expose the enum values at the class level
   // for backwards compatibility
   static constexpr OctreeEnum UNKNOWN_PLANE = OctreeEnum::UNKNOWN_PLANE;
+  static constexpr OctreeEnum SAGITTAL_PLANE = OctreeEnum::SAGITTAL_PLANE;
   static constexpr OctreeEnum SAGITAL_PLANE = OctreeEnum::SAGITAL_PLANE;
   static constexpr OctreeEnum CORONAL_PLANE = OctreeEnum::CORONAL_PLANE;
   static constexpr OctreeEnum TRANSVERSE_PLANE = OctreeEnum::TRANSVERSE_PLANE;
@@ -187,6 +188,7 @@ public:
    * */
 #if !defined(ITK_LEGACY_REMOVE)
   static constexpr OctreeEnum UNKNOWN_PLANE = OctreeEnum::UNKNOWN_PLANE;
+  static constexpr OctreeEnum SAGITTAL_PLANE = OctreeEnum::SAGITTAL_PLANE;
   static constexpr OctreeEnum SAGITAL_PLANE = OctreeEnum::SAGITAL_PLANE;
   static constexpr OctreeEnum CORONAL_PLANE = OctreeEnum::CORONAL_PLANE;
   static constexpr OctreeEnum TRANSVERSE_PLANE = OctreeEnum::TRANSVERSE_PLANE;

--- a/Modules/Core/Common/include/itkOctree.h
+++ b/Modules/Core/Common/include/itkOctree.h
@@ -51,7 +51,7 @@ public:
   // for backwards compatibility
   static constexpr OctreeEnum UNKNOWN_PLANE = OctreeEnum::UNKNOWN_PLANE;
   static constexpr OctreeEnum SAGITTAL_PLANE = OctreeEnum::SAGITTAL_PLANE;
-  static constexpr OctreeEnum SAGITAL_PLANE = OctreeEnum::SAGITAL_PLANE;
+  [[deprecated("Use SAGITTAL_PLANE instead")]] static constexpr OctreeEnum SAGITAL_PLANE = OctreeEnum::SAGITTAL_PLANE;
   static constexpr OctreeEnum CORONAL_PLANE = OctreeEnum::CORONAL_PLANE;
   static constexpr OctreeEnum TRANSVERSE_PLANE = OctreeEnum::TRANSVERSE_PLANE;
 #endif
@@ -189,7 +189,7 @@ public:
 #if !defined(ITK_LEGACY_REMOVE)
   static constexpr OctreeEnum UNKNOWN_PLANE = OctreeEnum::UNKNOWN_PLANE;
   static constexpr OctreeEnum SAGITTAL_PLANE = OctreeEnum::SAGITTAL_PLANE;
-  static constexpr OctreeEnum SAGITAL_PLANE = OctreeEnum::SAGITAL_PLANE;
+  [[deprecated("Use SAGITTAL_PLANE instead")]] static constexpr OctreeEnum SAGITAL_PLANE = OctreeEnum::SAGITTAL_PLANE;
   static constexpr OctreeEnum CORONAL_PLANE = OctreeEnum::CORONAL_PLANE;
   static constexpr OctreeEnum TRANSVERSE_PLANE = OctreeEnum::TRANSVERSE_PLANE;
 #endif

--- a/Modules/Core/Common/src/itkCommonEnums.cxx
+++ b/Modules/Core/Common/src/itkCommonEnums.cxx
@@ -229,8 +229,8 @@ operator<<(std::ostream & out, const OctreeEnums::Octree value)
     {
       case OctreeEnums::Octree::UNKNOWN_PLANE:
         return "itk::OctreeEnums::Octree::UNKNOWN_PLANE";
-      case OctreeEnums::Octree::SAGITAL_PLANE:
-        return "itk::OctreeEnums::Octree::SAGITAL_PLANE";
+      case OctreeEnums::Octree::SAGITTAL_PLANE:
+        return "itk::OctreeEnums::Octree::SAGITTAL_PLANE";
       case OctreeEnums::Octree::CORONAL_PLANE:
         return "itk::OctreeEnums::Octree::CORONAL_PLANE";
       case OctreeEnums::Octree::TRANSVERSE_PLANE:

--- a/Modules/Core/Common/test/itkOctreeTest.cxx
+++ b/Modules/Core/Common/test/itkOctreeTest.cxx
@@ -114,7 +114,7 @@ itkOctreeTest(int, char *[])
 
   // Test streaming enumeration for OctreeEnums::Octree elements
   const std::set<itk::OctreeEnums::Octree> allOctree{ itk::OctreeEnums::Octree::UNKNOWN_PLANE,
-                                                      itk::OctreeEnums::Octree::SAGITAL_PLANE,
+                                                      itk::OctreeEnums::Octree::SAGITTAL_PLANE,
                                                       itk::OctreeEnums::Octree::CORONAL_PLANE,
                                                       itk::OctreeEnums::Octree::TRANSVERSE_PLANE };
   for (const auto & ee : allOctree)


### PR DESCRIPTION
Closes #3923.

Replace the misspelling `SAGITAL_PLANE` with `SAGITTAL_PLANE`.

Note that both spellings are accepted if _not_ `ITK_LEGACY_REMOVE`. 

However, invocation of `std::ostream &operator<<(std::ostream & out, const OctreeEnums::Octree value)` with either spelling will output a string with the correct spelling: `"itk::OctreeEnums::Octree::SAGITTAL_PLANE"`

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)
