### PR TITLE
BUG: Enforce consistency between MultiResolutionPDEDeformableRegistration levels and iterations

### DIFF
--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.h
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.h
@@ -220,7 +220,7 @@ public:
   itkGetModifiableObjectMacro(FieldExpander, FieldExpanderType);
 
   /** Set number of iterations per multi-resolution levels. */
-  itkSetMacro(NumberOfIterations, NumberOfIterationsType);
+  virtual void SetNumberOfIterations(NumberOfIterationsType numberOfIterations);
   itkSetVectorMacro(NumberOfIterations, unsigned int, m_NumberOfLevels);
 
   /** Get number of iterations per multi-resolution levels. */

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
@@ -201,6 +201,33 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
                                          TRealType,
                                          TFloatImageType,
                                          TRegistrationType,
+                                         TDefaultRegistrationType>::SetNumberOfIterations(NumberOfIterationsType numberOfIterations)
+{
+  // In case numberOfIterations.GetSize() differs from this->m_numberOfLevels, first set the
+  // latter to equal the former.
+  this->SetNumberOfLevels(numberOfIterations.GetSize());
+  // Now do the requested set
+  if (this->m_NumberOfIterations != numberOfIterations)
+  {
+    this->m_NumberOfIterations = std::move(numberOfIterations);
+    this->Modified();
+  }
+}
+
+template <typename TFixedImage,
+          typename TMovingImage,
+          typename TDisplacementField,
+          typename TRealType,
+          typename TFloatImageType,
+          typename TRegistrationType,
+          typename TDefaultRegistrationType>
+void
+MultiResolutionPDEDeformableRegistration<TFixedImage,
+                                         TMovingImage,
+                                         TDisplacementField,
+                                         TRealType,
+                                         TFloatImageType,
+                                         TRegistrationType,
                                          TDefaultRegistrationType>::SetNumberOfLevels(unsigned int num)
 {
   if (m_NumberOfLevels != num)

--- a/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
@@ -24,6 +24,7 @@
 
 #include <iostream>
 #include "itkTestingMacros.h"
+#include "itkArray.h"
 
 namespace
 {
@@ -243,18 +244,28 @@ itkMultiResolutionPDEDeformableRegistrationTest(int argc, char * argv[])
 
   constexpr unsigned int numLevel = 3;
   unsigned int           numIterations[numLevel];
+  itk::Array<unsigned int> numIterationsArray;
+
+  numIterationsArray.SetSize(numLevel);
   numIterations[0] = 64;
+  numIterationsArray[0] = numIterations[0];
 
   unsigned int ilevel;
   for (ilevel = 1; ilevel < numLevel; ++ilevel)
   {
     numIterations[ilevel] = numIterations[ilevel - 1] / 2;
+    numIterationsArray[ilevel] = numIterations[ilevel];
   }
 
   registrator->SetNumberOfLevels(numLevel);
   ITK_TEST_SET_GET_VALUE(numLevel, registrator->GetNumberOfLevels());
+  registrator->SetNumberOfLevels(numLevel + 2);
+  ITK_TEST_SET_GET_VALUE(numLevel + 2, registrator->GetNumberOfLevels());
 
-  registrator->SetNumberOfIterations(numIterations);
+  registrator->SetNumberOfIterations(numIterationsArray);
+  // NumberOfLevels should now be numLevel because numIterationsArray is of size numLevel.
+  ITK_TEST_SET_GET_VALUE(numLevel, registrator->GetNumberOfLevels());
+
   RegistrationType::NumberOfIterationsType numIterationsArr;
   numIterationsArr.SetData(numIterations, numLevel);
   ITK_TEST_SET_GET_VALUE(numIterationsArr, registrator->GetNumberOfIterations());


### PR DESCRIPTION
Closes #3466.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)
