### PR TITLE
DOC: Fix `defgroup` command in Doxygen `Modules` file

### DIFF
--- a/Documentation/Doxygen/Modules.dox
+++ b/Documentation/Doxygen/Modules.dox
@@ -139,7 +139,7 @@
 
 
 /**
- \ defgroup ImageEnhancement Image Enhancement Filters
+  \defgroup ImageEnhancement Image Enhancement Filters
   \ingroup ImageFilters
 
   Image enhancement filters process an image to enhance the appearance


### PR DESCRIPTION
Fix `defgroup` command in Doxygen `Modules` file: do not allow any whitespace between the backward slash and `defgroup`.

The affected group, `ImageEnhancement` is not being displayed in the list of modules/groups and no filter is currently being attributed the affected group, despite some filters, e.g. `itk::ConvertLabelMapFilter`, being within that group.

Reported by: albert-github <albert.tests@gmail.com>

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)