### PR TITLE
ENH: Remove the `ITK_USE_CONCEPT_CHECKING` option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -494,11 +494,11 @@ option(
 mark_as_advanced(ITK_USE_64BITS_IDS)
 
 # ITK turn on concept checking
-option(
-  ITK_USE_CONCEPT_CHECKING
-  "Turn on concept checking to give helpful errors at compile time if a type cannot be used as a template parameter."
-  ON)
-mark_as_advanced(ITK_USE_CONCEPT_CHECKING)
+if(ITK_USE_CONCEPT_CHECKING)
+  message(
+    WARNING
+      "Ignoring ITK_USE_CONCEPT_CHECKING, as concept checking is performed unconditionally. This variable is no longer used")
+endif()
 if(ITK_USE_STRICT_CONCEPT_CHECKING)
   message(
     WARNING

--- a/Modules/Bridge/VTK/include/itkVTKImageExport.h
+++ b/Modules/Bridge/VTK/include/itkVTKImageExport.h
@@ -73,9 +73,8 @@ public:
   /** The type of the input image. */
   using InputImageType = TInputImage;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   itkConceptMacro(ImageDimensionCheck, (Concept::SameDimensionOrMinusOneOrTwo<3, Self::InputImageDimension>));
-#endif
+
   /** Set the input image of this image exporter. */
   using Superclass::SetInput;
   void

--- a/Modules/Core/Common/include/itkCompensatedSummation.h
+++ b/Modules/Core/Common/include/itkCompensatedSummation.h
@@ -124,10 +124,8 @@ private:
   AccumulateType m_Sum{};
   AccumulateType m_Compensation{};
 
-// Maybe support more types in the future with template specialization.
-#ifdef ITK_USE_CONCEPT_CHECKING
+  // Maybe support more types in the future with template specialization.
   itkConceptMacro(OnlyDefinedForFloatingPointTypes, (itk::Concept::IsFloatingPoint<TFloat>));
-#endif // ITK_USE_CONCEPT_CHECKING
 };
 
 void ITKCommon_EXPORT

--- a/Modules/Core/Common/include/itkExtractImageFilter.h
+++ b/Modules/Core/Common/include/itkExtractImageFilter.h
@@ -259,12 +259,7 @@ public:
   void
   SetExtractionRegion(InputImageRegionType extractRegion);
   itkGetConstMacro(ExtractionRegion, InputImageRegionType);
-
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputCovertibleToOutputCheck, (Concept::Convertible<InputImagePixelType, OutputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   ExtractImageFilter();

--- a/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.h
+++ b/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.h
@@ -81,12 +81,8 @@ public:
   OutputType
   Evaluate(const InputType & position) const override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(DimensionShouldBe3, (Concept::SameDimension<VDimension, 3u>));
   itkConceptMacro(PointDimensionShouldBe3, (Concept::SameDimension<InputType::Dimension, 3u>));
-  // End concept checking
-#endif
 
 protected:
   FiniteCylinderSpatialFunction();

--- a/Modules/Core/Common/include/itkHeavisideStepFunctionBase.h
+++ b/Modules/Core/Common/include/itkHeavisideStepFunctionBase.h
@@ -73,11 +73,9 @@ public:
   virtual OutputType
   EvaluateDerivative(const InputType & input) const = 0;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   itkConceptMacro(DoubleConvertibleToInputCheck, (Concept::Convertible<double, TInput>));
 
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, TOutput>));
-#endif // ITK_USE_CONCEPT_CHECKING
 
 protected:
   HeavisideStepFunctionBase()

--- a/Modules/Core/Common/include/itkKernelFunctionBase.h
+++ b/Modules/Core/Common/include/itkKernelFunctionBase.h
@@ -58,11 +58,7 @@ public:
   TRealValueType
   Evaluate(const TRealValueType & u) const override = 0;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(TRealValueTypeIsFloatingPointCheck, (Concept::IsFloatingPoint<TRealValueType>));
-  // End concept checking
-#endif
 
 protected:
   KernelFunctionBase() = default;

--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -212,10 +212,8 @@ template <typename TReturn, typename TInput>
 inline TReturn
 CastWithRangeCheck(TInput x)
 {
-#ifdef ITK_USE_CONCEPT_CHECKING
   itkConceptMacro(OnlyDefinedForIntegerTypes1, (itk::Concept::IsInteger<TReturn>));
   itkConceptMacro(OnlyDefinedForIntegerTypes2, (itk::Concept::IsInteger<TInput>));
-#endif // ITK_USE_CONCEPT_CHECKING
 
   auto ret = static_cast<TReturn>(x);
   if constexpr (sizeof(TReturn) > sizeof(TInput) &&

--- a/Modules/Core/Common/include/itkSobelOperator.h
+++ b/Modules/Core/Common/include/itkSobelOperator.h
@@ -120,11 +120,7 @@ public:
   // virtual void CreateToRadius(const unsigned long);
 
 protected:
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SignedOutputPixelType, (Concept::Signed<typename NumericTraits<TPixel>::ValueType>));
-  // End concept checking
-#endif
 
   /** Type alias support for coefficient vector type.*/
   using typename Superclass::CoefficientVector;

--- a/Modules/Core/Common/include/itkStreamingImageFilter.h
+++ b/Modules/Core/Common/include/itkStreamingImageFilter.h
@@ -105,12 +105,8 @@ public:
   void
   PropagateRequestedRegion(DataObject * output) override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputImagePixelType, OutputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   StreamingImageFilter();

--- a/Modules/Core/Common/src/itkConfigure.h.in
+++ b/Modules/Core/Common/src/itkConfigure.h.in
@@ -73,7 +73,6 @@
 #cmakedefine ITK_LEGACY_REMOVE
 #cmakedefine ITK_LEGACY_SILENT
 #cmakedefine ITK_FUTURE_LEGACY_REMOVE
-#cmakedefine ITK_USE_CONCEPT_CHECKING
 #cmakedefine ITK_USE_FFTWF
 #cmakedefine ITK_USE_FFTWD
 #cmakedefine ITK_USE_CUFFTW

--- a/Modules/Core/Common/test/itkSimpleFilterWatcherTest.cxx
+++ b/Modules/Core/Common/test/itkSimpleFilterWatcherTest.cxx
@@ -70,12 +70,9 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(TanHelperImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage::PixelType, double>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
+
 protected:
   TanHelperImageFilter() = default;
   ~TanHelperImageFilter() override = default;

--- a/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.h
+++ b/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.h
@@ -102,14 +102,10 @@ public:
   /** The container type for the update buffer. */
   using UpdateBufferType = OutputImageType;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputTimesDoubleCheck, (Concept::MultiplyOperator<PixelType, double>));
   itkConceptMacro(OutputAdditiveOperatorsCheck, (Concept::AdditiveOperators<PixelType>));
   itkConceptMacro(OutputAdditiveAndAssignOperatorsCheck, (Concept::AdditiveAndAssignOperators<PixelType>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<typename TInputImage::PixelType, PixelType>));
-  // End concept checking
-#endif
 
 protected:
   DenseFiniteDifferenceImageFilter() { m_UpdateBuffer = UpdateBufferType::New(); }

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.h
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.h
@@ -222,11 +222,7 @@ public:
     this->SetIsInitialized(true);
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputPixelIsFloatingPointCheck, (Concept::IsFloatingPoint<OutputPixelValueType>));
-  // End concept checking
-#endif
 
 protected:
   FiniteDifferenceImageFilter();

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUDenseFiniteDifferenceImageFilter.h
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUDenseFiniteDifferenceImageFilter.h
@@ -87,13 +87,9 @@ public:
   /** The container type for the update buffer. */
   using UpdateBufferType = OutputImageType;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputTimesDoubleCheck, (Concept::MultiplyOperator<PixelType, double>));
   itkConceptMacro(OutputAdditiveOperatorsCheck, (Concept::AdditiveOperators<PixelType>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<typename TInputImage::PixelType, PixelType>));
-  // End concept checking
-#endif
 
   /** Get OpenCL Kernel source as a string, creates a GetOpenCLSource method */
   itkGetOpenCLSourceFromKernelMacro(GPUDenseFiniteDifferenceImageFilterKernel);

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h
@@ -128,11 +128,7 @@ public:
   itkGetConstReferenceMacro(State, GPUFiniteDifferenceFilterEnum);
 #endif
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputPixelIsFloatingPointCheck, (Concept::IsFloatingPoint<OutputPixelValueType>));
-  // End concept checking
-#endif
 
   /** Methods to get timers */
   itkGetConstReferenceMacro(InitTime, TimeProbe);

--- a/Modules/Core/ImageAdaptors/include/itkComplexConjugateImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkComplexConjugateImageAdaptor.h
@@ -80,13 +80,9 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ComplexConjugateImageAdaptor);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking. */
   itkConceptMacro(InputConvertibleToComplex,
                   (Concept::Convertible<std::complex<typename NumericTraits<typename TImage::PixelType>::ValueType>,
                                         typename TImage::PixelType>));
-  // End concept checking. */
-#endif
 
 protected:
   ComplexConjugateImageAdaptor() = default;

--- a/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.h
@@ -119,14 +119,10 @@ public:
   itkGetConstMacro(NumberOfPoles, unsigned int);
 
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(DimensionCheck, (Concept::SameDimension<ImageDimension, OutputImageDimension>));
   itkConceptMacro(InputConvertibleToOutputCheck,
                   (Concept::Convertible<typename TInputImage::PixelType, typename TOutputImage::PixelType>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   BSplineDecompositionImageFilter();

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.h
@@ -425,11 +425,6 @@ public:
   PointIdentifier
   Splice(QEPrimal * a, QEPrimal * b);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-  // End concept checking
-#endif
-
   // for reusability of a mesh in the MeshToMesh filter
   void
   ClearFreePointAndCellIndexesLists()

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.h
@@ -53,11 +53,6 @@ public:
 
   using ValueArrayType = ValueType[Self::PointDimension];
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-  // End concept checking
-#endif
-
 public:
   QuadEdgeMeshPoint() = default;
   QuadEdgeMeshPoint(const Self &) = default;

--- a/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.h
@@ -254,11 +254,7 @@ public:
   const TInputImage *
   GetInput() const;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputCovertibleToOutputCheck, (Concept::Convertible<InputImagePixelType, OutputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   ExtractSliceImageFilter();

--- a/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.h
@@ -83,14 +83,10 @@ public:
   const TInputImage *
   GetInput() const;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputPixelType>));
   itkConceptMacro(RealTypeMultiplyOperatorCheck, (Concept::MultiplyOperator<RealType>));
   itkConceptMacro(RealTypeAdditiveOperatorsCheck, (Concept::AdditiveOperators<RealType>));
-  // End concept checking
-#endif
 
 protected:
   StretchIntensityImageFilter();

--- a/Modules/Core/Transform/include/itkTransformGeometryImageFilter.h
+++ b/Modules/Core/Transform/include/itkTransformGeometryImageFilter.h
@@ -131,10 +131,8 @@ public:
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputImagePixelType, OutputImagePixelType>));
-#endif
 
   /** Transform type alias */
   using TransformType = Transform<double, InputImageDimension, OutputImageDimension>;

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkCurvatureAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkCurvatureAnisotropicDiffusionImageFilter.h
@@ -79,11 +79,7 @@ public:
   /** Extract superclass image dimension. */
   static constexpr unsigned int ImageDimension = Superclass::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   CurvatureAnisotropicDiffusionImageFilter()

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkGradientAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkGradientAnisotropicDiffusionImageFilter.h
@@ -72,11 +72,7 @@ public:
   /** Extract information from the superclass. */
   static constexpr unsigned int ImageDimension = Superclass::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(UpdateBufferHasNumericTraitsCheck, (Concept::HasNumericTraits<typename UpdateBufferType::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   GradientAnisotropicDiffusionImageFilter()

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureAnisotropicDiffusionImageFilter.h
@@ -89,13 +89,9 @@ public:
   /** Determine the image dimension. */
   static constexpr unsigned int ImageDimension = Superclass::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<typename TInputImage::PixelType::ValueType>));
   itkConceptMacro(OutputHasNumericTraitsCheck,
                   (Concept::HasNumericTraits<typename TOutputImage::PixelType::ValueType>));
-  // End concept checking
-#endif
 
 protected:
   VectorCurvatureAnisotropicDiffusionImageFilter()

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientAnisotropicDiffusionImageFilter.h
@@ -82,13 +82,9 @@ public:
   /** Determine the image dimension from the  superclass. */
   static constexpr unsigned int ImageDimension = Superclass::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<typename TInputImage::PixelType::ValueType>));
   itkConceptMacro(OutputHasNumericTraitsCheck,
                   (Concept::HasNumericTraits<typename TOutputImage::PixelType::ValueType>));
-  // End concept checking
-#endif
 
 protected:
   VectorGradientAnisotropicDiffusionImageFilter()

--- a/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.h
+++ b/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.h
@@ -154,12 +154,8 @@ public:
     return this->GetNumberOfIterations();
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<typename TInputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   AntiAliasBinaryImageFilter();

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.h
@@ -112,15 +112,11 @@ public:
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
   itkConceptMacro(SameTypeCheck, (Concept::SameType<PixelType, typename TOutputImage::PixelType>));
   itkConceptMacro(AdditiveOperatorsCheck, (Concept::AdditiveOperators<PixelType>));
   itkConceptMacro(IntConvertibleToPixelTypeCheck, (Concept::Convertible<int, PixelType>));
   itkConceptMacro(PixelLessThanIntCheck, (Concept::LessThanComparable<PixelType, int>));
-  // End concept checking
-#endif
 
 protected:
   BinaryPruningImageFilter();

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.h
@@ -114,15 +114,11 @@ public:
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
   itkConceptMacro(InputAdditiveOperatorsCheck, (Concept::AdditiveOperators<PixelType>));
   itkConceptMacro(InputConvertibleToIntCheck, (Concept::Convertible<PixelType, int>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, PixelType>));
   itkConceptMacro(SameTypeCheck, (Concept::SameType<PixelType, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   BinaryThinningImageFilter();

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkDilateObjectMorphologyImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkDilateObjectMorphologyImageFilter.h
@@ -80,11 +80,7 @@ public:
   /** Type of the pixels in the Kernel. */
   using KernelPixelType = typename TKernel::PixelType;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(KernelGreaterThanComparableCheck, (Concept::GreaterThanComparable<KernelPixelType>));
-  // End concept checking
-#endif
 
 protected:
   DilateObjectMorphologyImageFilter();

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkErodeObjectMorphologyImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkErodeObjectMorphologyImageFilter.h
@@ -101,11 +101,7 @@ public:
   /** Type of the pixels in the Kernel. */
   using KernelPixelType = typename TKernel::PixelType;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(KernelGreaterThanComparableCheck, (Concept::GreaterThanComparable<KernelPixelType>));
-  // End concept checking
-#endif
 
 protected:
   ErodeObjectMorphologyImageFilter();

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.h
@@ -171,8 +171,6 @@ public:
    * an object's boundary. */
   itkGetConstMacro(UseBoundaryCondition, bool);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck1, (Concept::SameDimension<ImageDimension, OutputImageDimension>));
   itkConceptMacro(SameDimensionCheck2, (Concept::SameDimension<ImageDimension, KernelDimension>));
   itkConceptMacro(OutputInputEqualityComparableCheck,
@@ -181,8 +179,6 @@ public:
   itkConceptMacro(IntConvertibleToOutputCheck, (Concept::Convertible<int, typename TOutputImage::PixelType>));
   itkConceptMacro(InputEqualityComparable, (Concept::EqualityComparable<PixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<PixelType>));
-  // End concept checking
-#endif
 
 protected:
   ObjectMorphologyImageFilter();

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.h
@@ -216,11 +216,7 @@ public:
   /** Get the maximum number of overlapping pixels. */
   itkGetMacro(MaximumNumberOfOverlappingPixels, SizeValueType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputPixelTypeIsFloatingPointCheck, (Concept::IsFloatingPoint<OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   MaskedFFTNormalizedCorrelationImageFilter()

--- a/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.h
@@ -125,15 +125,11 @@ public:
     this->SetOperator(t);
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, MaskImageDimension>));
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputPixelType>));
   itkConceptMacro(OperatorHasNumericTraitsCheck, (Concept::HasNumericTraits<OperatorValueType>));
   // This filter can only operate on data types that are signed.
   itkConceptMacro(SignedOutputPixelType, (Concept::Signed<OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   NormalizedCorrelationImageFilter() = default;

--- a/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowImageFilter.h
+++ b/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowImageFilter.h
@@ -111,12 +111,8 @@ public:
   itkSetMacro(Threshold, double);
   itkGetConstMacro(Threshold, double);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToOutputCheck,
                   (Concept::Convertible<typename TInputImage::PixelType, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
 protected:

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.h
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.h
@@ -140,8 +140,6 @@ public:
   /** Get the timestep parameter. */
   itkGetConstMacro(TimeStep, TimeStepType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, PixelType>));
   itkConceptMacro(OutputConvertibleToDoubleCheck, (Concept::Convertible<PixelType, double>));
   itkConceptMacro(OutputDivisionOperatorsCheck, (Concept::DivisionOperators<PixelType>));
@@ -149,8 +147,6 @@ public:
   itkConceptMacro(IntOutputMultiplyOperatorCheck, (Concept::MultiplyOperator<int, PixelType, PixelType>));
   itkConceptMacro(OutputLessThanDoubleCheck, (Concept::LessThanComparable<PixelType, double>));
   itkConceptMacro(OutputDoubleAdditiveOperatorsCheck, (Concept::AdditiveOperators<PixelType, double>));
-  // End concept checking
-#endif
 
 protected:
   CurvatureFlowImageFilter();

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowImageFilter.h
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowImageFilter.h
@@ -116,8 +116,6 @@ public:
   itkSetMacro(StencilRadius, RadiusValueType);
   itkGetConstMacro(StencilRadius, RadiusValueType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(UnsignedLongConvertibleToOutputCheck,
                   (Concept::Convertible<unsigned long, typename TOutputImage::PixelType>));
   itkConceptMacro(OutputLessThanComparableCheck, (Concept::LessThanComparable<typename TOutputImage::PixelType>));
@@ -129,8 +127,6 @@ public:
                   (Concept::GreaterThanComparable<typename TOutputImage::PixelType, unsigned long>));
   itkConceptMacro(UnsignedLongOutputAditiveOperatorsCheck,
                   (Concept::AdditiveOperators<unsigned long, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   MinMaxCurvatureFlowImageFilter();

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.h
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.h
@@ -280,8 +280,6 @@ public:
 #endif
   itkGetConstReferenceMacro(BValue, TTensorPixelType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(ReferenceEqualityComparableCheck, (Concept::EqualityComparable<ReferencePixelType>));
   itkConceptMacro(TensorEqualityComparableCheck, (Concept::EqualityComparable<TensorPixelType>));
   itkConceptMacro(GradientConvertibleToDoubleCheck, (Concept::Convertible<GradientPixelType, double>));
@@ -293,8 +291,6 @@ public:
 
   itkConceptMacro(ReferenceOStreamWritableCheck, (Concept::OStreamWritable<ReferencePixelType>));
   itkConceptMacro(TensorOStreamWritableCheck, (Concept::OStreamWritable<TensorPixelType>));
-  // End concept checking
-#endif
 
 protected:
   DiffusionTensor3DReconstructionImageFilter();

--- a/Modules/Filtering/DiffusionTensorImage/include/itkTensorFractionalAnisotropyImageFilter.h
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkTensorFractionalAnisotropyImageFilter.h
@@ -102,11 +102,7 @@ public:
     this->Superclass::PrintSelf(os, indent);
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputValueType>));
-  // End concept checking
-#endif
 
 protected:
   TensorFractionalAnisotropyImageFilter() = default;

--- a/Modules/Filtering/DiffusionTensorImage/include/itkTensorRelativeAnisotropyImageFilter.h
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkTensorRelativeAnisotropyImageFilter.h
@@ -102,11 +102,7 @@ public:
     this->Superclass::PrintSelf(os, indent);
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputValueType>));
-  // End concept checking
-#endif
 
 protected:
   TensorRelativeAnisotropyImageFilter() = default;

--- a/Modules/Filtering/DisplacementField/include/itkExponentialDisplacementFieldImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkExponentialDisplacementFieldImageFilter.h
@@ -114,14 +114,10 @@ public:
   static constexpr unsigned int PixelDimension = InputPixelType::Dimension;
   static constexpr unsigned int OutputPixelDimension = OutputPixelType::Dimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<typename OutputPixelType::ValueType>));
   itkConceptMacro(SameDimensionCheck1, (Concept::SameDimension<ImageDimension, OutputImageDimension>));
   itkConceptMacro(SameDimensionCheck2, (Concept::SameDimension<ImageDimension, PixelDimension>));
   itkConceptMacro(SameDimensionCheck3, (Concept::SameDimension<ImageDimension, OutputPixelDimension>));
-  // End concept checking
-#endif
 
 protected:
   ExponentialDisplacementFieldImageFilter();

--- a/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.h
@@ -169,11 +169,7 @@ public:
   ModifiedTimeType
   GetMTime() const override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputPixelComponentType>));
-  // End concept checking
-#endif
 
 protected:
   InverseDisplacementFieldImageFilter();

--- a/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.h
@@ -103,14 +103,10 @@ public:
   itkSetMacro(StopValue, double);
   itkGetConstMacro(StopValue, double);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputImageValueType>));
 
   itkConceptMacro(SameDimensionCheck,
                   (Concept::SameDimension<TInputImage::ImageDimension, TOutputImage::ImageDimension>));
-  // End concept checking
-#endif
 
 protected:
   IterativeInverseDisplacementFieldImageFilter();

--- a/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.h
@@ -150,12 +150,8 @@ public:
   itkBooleanMacro(UseReferenceImage);
   itkGetConstMacro(UseReferenceImage, bool);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   static constexpr unsigned int PixelDimension = PixelType::Dimension;
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<ImageDimension, PixelDimension>));
-  // End concept checking
-#endif
 
 protected:
   TransformToDisplacementFieldFilter();

--- a/Modules/Filtering/DistanceMap/include/itkApproximateSignedDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkApproximateSignedDistanceMapImageFilter.h
@@ -123,11 +123,7 @@ public:
   itkSetMacro(OutsideValue, InputPixelType);
   itkGetConstMacro(OutsideValue, InputPixelType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<typename InputImageType::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   ApproximateSignedDistanceMapImageFilter();

--- a/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.h
@@ -123,11 +123,7 @@ public:
   itkGetConstMacro(UseImageSpacing, bool);
   itkBooleanMacro(UseImageSpacing);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputImage1PixelType>));
-  // End concept checking
-#endif
 
 protected:
   ContourDirectedMeanDistanceImageFilter();

--- a/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.h
@@ -129,11 +129,7 @@ public:
   itkGetConstMacro(UseImageSpacing, bool);
   itkBooleanMacro(UseImageSpacing);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputImage1PixelType>));
-  // End concept checking
-#endif
 
 protected:
   ContourMeanDistanceImageFilter();

--- a/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.h
@@ -174,17 +174,13 @@ public:
   DataObjectPointer
   MakeOutput(DataObjectPointerArraySizeType idx) override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
   static constexpr unsigned int VoronoiImageDimension = TVoronoiImage::ImageDimension;
 
-  // Begin concept checking
   itkConceptMacro(InputOutputSameDimensionCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
   itkConceptMacro(InputVoronoiSameDimensionCheck, (Concept::SameDimension<InputImageDimension, VoronoiImageDimension>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, OutputPixelType>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputPixelType, OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   DanielssonDistanceMapImageFilter();

--- a/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.h
@@ -134,11 +134,7 @@ public:
   itkGetConstMacro(DirectedHausdorffDistance, RealType);
   itkGetConstMacro(AverageHausdorffDistance, RealType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputImage1PixelType>));
-  // End concept checking
-#endif
 
 protected:
   DirectedHausdorffDistanceImageFilter();

--- a/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.h
@@ -126,8 +126,6 @@ public:
   NarrowBandPointer
   GetNarrowBand() const;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<ImageDimension, OutputImageDimension>));
   itkConceptMacro(SameTypeCheck, (Concept::SameType<PixelType, typename TOutputImage::PixelType>));
   itkConceptMacro(FloatConvertibleToPixelTypeCheck, (Concept::Convertible<float, PixelType>));
@@ -137,8 +135,6 @@ public:
   itkConceptMacro(PixelTypeFloatAdditiveOperatorsCheck, (Concept::AdditiveOperators<PixelType, float, float>));
   itkConceptMacro(FloatGreaterThanPixelTypeCheck, (Concept::GreaterThanComparable<float, PixelType>));
   itkConceptMacro(FloatLessThanPixelTypeCheck, (Concept::LessThanComparable<float, PixelType>));
-  // End concept checking
-#endif
 
 protected:
   FastChamferDistanceImageFilter();

--- a/Modules/Filtering/DistanceMap/include/itkHausdorffDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkHausdorffDistanceImageFilter.h
@@ -122,11 +122,7 @@ public:
   itkGetConstMacro(HausdorffDistance, RealType);
   itkGetConstMacro(AverageHausdorffDistance, RealType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(Input1HasNumericTraitsCheck, (Concept::HasNumericTraits<InputImage1PixelType>));
-  // End concept checking
-#endif
 
 protected:
   HausdorffDistanceImageFilter();

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.h
@@ -132,8 +132,6 @@ public:
     return m_NarrowBand;
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputPixelType>));
   itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<PixelType>));
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<ImageDimension, OutputImageDimension>));
@@ -142,8 +140,6 @@ public:
   itkConceptMacro(OutputAdditiveOperatorsCheck, (Concept::AdditiveOperators<PixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputPixelType>));
   itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<PixelType>));
-  // End concept checking
-#endif
 
 protected:
   IsoContourDistanceImageFilter();

--- a/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.h
@@ -204,14 +204,10 @@ public:
   DataObjectPointer
   MakeOutput(DataObjectPointerArraySizeType idx) override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, PixelType>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<PixelType>));
   itkConceptMacro(OutputImagePixelTypeIsFloatingPointCheck,
                   (Concept::IsFloatingPoint<typename OutputImageType::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   SignedDanielssonDistanceMapImageFilter();

--- a/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.h
@@ -153,13 +153,9 @@ public:
   itkSetMacro(BackgroundValue, InputPixelType);
   itkGetConstReferenceMacro(BackgroundValue, InputPixelType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputPixelType>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
   itkConceptMacro(OutputImagePixelTypeIsFloatingPointCheck, (Concept::IsFloatingPoint<OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   SignedMaurerDistanceMapImageFilter();

--- a/Modules/Filtering/FFT/include/itkVnlForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlForwardFFTImageFilter.h
@@ -75,11 +75,7 @@ public:
   SizeValueType
   GetSizeGreatestPrimeFactor() const override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(ImageDimensionsMatchCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
-  // End concept checking
-#endif
 
 protected:
   VnlForwardFFTImageFilter() = default;

--- a/Modules/Filtering/FFT/include/itkVnlHalfHermitianToRealInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlHalfHermitianToRealInverseFFTImageFilter.h
@@ -83,12 +83,8 @@ public:
   SizeValueType
   GetSizeGreatestPrimeFactor() const override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(PixelUnsignedIntDivisionOperatorsCheck, (Concept::DivisionOperators<OutputPixelType, unsigned int>));
   itkConceptMacro(ImageDimensionsMatchCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
-  // End concept checking
-#endif
 
 protected:
   VnlHalfHermitianToRealInverseFFTImageFilter() = default;

--- a/Modules/Filtering/FFT/include/itkVnlInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlInverseFFTImageFilter.h
@@ -79,12 +79,8 @@ public:
   SizeValueType
   GetSizeGreatestPrimeFactor() const override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(PixelUnsignedIntDivisionOperatorsCheck, (Concept::DivisionOperators<OutputPixelType, unsigned int>));
   itkConceptMacro(ImageDimensionsMatchCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
-  // End concept checking
-#endif
 
 protected:
   VnlInverseFFTImageFilter() = default;

--- a/Modules/Filtering/FFT/include/itkVnlRealToHalfHermitianForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlRealToHalfHermitianForwardFFTImageFilter.h
@@ -78,11 +78,7 @@ public:
   SizeValueType
   GetSizeGreatestPrimeFactor() const override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(ImageDimensionsMatchCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
-  // End concept checking
-#endif
 
 protected:
   VnlRealToHalfHermitianForwardFFTImageFilter() = default;

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilter.h
@@ -127,11 +127,7 @@ public:
     return m_AuxTrialValues;
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(AuxValueHasNumericTraitsCheck, (Concept::HasNumericTraits<TAuxValue>));
-  // End concept checking
-#endif
 
 protected:
   FastMarchingExtensionImageFilter();

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilterBase.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilterBase.h
@@ -119,11 +119,7 @@ public:
   itkSetObjectMacro(AuxiliaryTrialValues, AuxValueContainerType);
   itkGetModifiableObjectMacro(AuxiliaryTrialValues, AuxValueContainerType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(AuxValueHasNumericTraitsCheck, (Concept::HasNumericTraits<TAuxValue>));
-  // End concept checking
-#endif
 
 protected:
   FastMarchingExtensionImageFilterBase();

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.h
@@ -374,14 +374,10 @@ public:
   itkGetConstReferenceMacro(OverrideOutputInformation, bool);
   itkBooleanMacro(OverrideOutputInformation);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<SetDimension, SpeedImageDimension>));
   itkConceptMacro(SpeedConvertibleToDoubleCheck, (Concept::Convertible<typename TSpeedImage::PixelType, double>));
   itkConceptMacro(DoubleConvertibleToLevelSetCheck, (Concept::Convertible<double, PixelType>));
   itkConceptMacro(LevelSetOStreamWritableCheck, (Concept::OStreamWritable<PixelType>));
-  // End concept checking
-#endif
 
 protected:
   FastMarchingImageFilter();

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingTraits.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingTraits.h
@@ -92,11 +92,9 @@ public:
     Topology
   };
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   itkConceptMacro(DoubleConvertibleOutputCheck, (Concept::Convertible<double, OutputPixelType>));
 
   itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<OutputPixelType>));
-#endif
 };
 
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h
@@ -230,14 +230,10 @@ public:
    */
   itkGetConstReferenceMacro(TargetValue, double);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(LevelSetDoubleDivisionOperatorsCheck,
                   (Concept::DivisionOperators<typename TLevelSet::PixelType, double>));
   itkConceptMacro(LevelSetDoubleDivisionAndAssignOperatorsCheck,
                   (Concept::DivisionAndAssignOperators<typename TLevelSet::PixelType, double>));
-  // End concept checking
-#endif
 
 protected:
   FastMarchingUpwindGradientImageFilter();

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientAnisotropicDiffusionImageFilter.h
@@ -71,11 +71,7 @@ public:
   /** Extract information from the superclass. */
   static constexpr unsigned int ImageDimension = GPUSuperclass::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(UpdateBufferHasNumericTraitsCheck, (Concept::HasNumericTraits<typename UpdateBufferType::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   GPUGradientAnisotropicDiffusionImageFilter()

--- a/Modules/Filtering/GPUImageFilterBase/include/itkGPUNeighborhoodOperatorImageFilter.h
+++ b/Modules/Filtering/GPUImageFilterBase/include/itkGPUNeighborhoodOperatorImageFilter.h
@@ -135,7 +135,6 @@ public:
    * \sa ProcessObject::GenerateInputRequestedRegion()
   virtual void GenerateInputRequestedRegion();*/
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
   // itkConceptMacro( SameDimensionCheck,
   //                  ( Concept::SameDimension< InputImageDimension, ImageDimension > ) );
@@ -148,7 +147,6 @@ public:
   // itkConceptMacro( OperatorAdditiveOperatorsCheck,
   //                  ( Concept::AdditiveOperators< OperatorValueType > ) );
   // End concept checking
-#endif
 
 protected:
   GPUNeighborhoodOperatorImageFilter();

--- a/Modules/Filtering/ImageCompare/include/itkAbsoluteValueDifferenceImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkAbsoluteValueDifferenceImageFilter.h
@@ -104,13 +104,9 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(AbsoluteValueDifferenceImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(Input1CovertibleToDoubleCheck, (Concept::Convertible<typename TInputImage1::PixelType, double>));
   itkConceptMacro(Input2ConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage2::PixelType, double>));
   itkConceptMacro(DoubleCovertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   AbsoluteValueDifferenceImageFilter()

--- a/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.h
@@ -220,11 +220,7 @@ public:
   /** Get the number of elapsed iterations of the iterative E-M algorithm. */
   itkGetConstMacro(ElapsedIterations, unsigned int);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   STAPLEImageFilter()

--- a/Modules/Filtering/ImageCompare/include/itkSimilarityIndexImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkSimilarityIndexImageFilter.h
@@ -121,12 +121,8 @@ public:
   /** Return the computed similarity index. */
   itkGetConstMacro(SimilarityIndex, RealType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(Input1HasNumericTraitsCheck, (Concept::HasNumericTraits<InputImage1PixelType>));
   itkConceptMacro(Input2HasNumericTraitsCheck, (Concept::HasNumericTraits<InputImage2PixelType>));
-  // End concept checking
-#endif
 
 protected:
   SimilarityIndexImageFilter();

--- a/Modules/Filtering/ImageCompare/include/itkSquaredDifferenceImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkSquaredDifferenceImageFilter.h
@@ -101,13 +101,9 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(SquaredDifferenceImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(Input1ConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage1::PixelType, double>));
   itkConceptMacro(Input2ConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage2::PixelType, double>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   SquaredDifferenceImageFilter()

--- a/Modules/Filtering/ImageCompose/include/itkComposeImageFilter.h
+++ b/Modules/Filtering/ImageCompose/include/itkComposeImageFilter.h
@@ -85,12 +85,8 @@ public:
   void
   SetInput3(const InputImageType * image3);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputCovertibleToOutputCheck,
                   (Concept::Convertible<InputPixelType, typename NumericTraits<OutputPixelType>::ValueType>));
-  // End concept checking
-#endif
 
 protected:
   ComposeImageFilter();

--- a/Modules/Filtering/ImageCompose/include/itkJoinImageFilter.h
+++ b/Modules/Filtering/ImageCompose/include/itkJoinImageFilter.h
@@ -232,15 +232,11 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(JoinImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(Input1HasPixelTraitsCheck, (Concept::HasPixelTraits<typename TInputImage1::PixelType>));
   itkConceptMacro(Input2HasPixelTraitsCheck, (Concept::HasPixelTraits<typename TInputImage2::PixelType>));
   itkConceptMacro(Input1Input2HasJoinTraitsCheck,
                   (Concept::HasJoinTraits<typename PixelTraits<typename TInputImage1::PixelType>::ValueType,
                                           typename PixelTraits<typename TInputImage2::PixelType>::ValueType>));
-  // End concept checking
-#endif
 
 protected:
   JoinImageFilter() { Superclass::SetFunctor(FunctorType()); }

--- a/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.h
+++ b/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.h
@@ -85,12 +85,8 @@ public:
   itkSetMacro(Origin, double);
   itkGetConstMacro(Origin, double);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToOutputCheck,
                   (Concept::Convertible<typename TInputImage::PixelType, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   JoinSeriesImageFilter();

--- a/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.h
@@ -169,11 +169,7 @@ public:
   itkSetMacro(NumberOfRangeGaussianSamples, unsigned long);
   itkGetConstMacro(NumberOfRangeGaussianSamples, unsigned long);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   /** Constructor. */

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.h
@@ -195,15 +195,11 @@ public:
     return this->m_MultiplyImageFilter->GetOutput();
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputImagePixelType>));
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputImagePixelType>));
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<ImageDimension, OutputImageDimension>));
   itkConceptMacro(InputIsFloatingPointCheck, (Concept::IsFloatingPoint<InputImagePixelType>));
   itkConceptMacro(OutputIsFloatingPointCheck, (Concept::IsFloatingPoint<OutputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   CannyEdgeDetectionImageFilter();

--- a/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.h
@@ -80,11 +80,7 @@ public:
   itkOverrideGetNameOfClassMacro(DerivativeImageFilter);
 
   /** The output pixel type must be signed. */
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SignedOutputPixelType, (Concept::Signed<OutputPixelType>));
-  // End concept checking
-#endif
 
   /** Standard get/set macros for filter parameters. */
   itkSetMacro(Order, unsigned int);

--- a/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.h
@@ -172,11 +172,7 @@ public:
   itkGetConstMacro(NormalizeAcrossScale, bool);
   itkBooleanMacro(NormalizeAcrossScale);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   DiscreteGaussianDerivativeImageFilter()

--- a/Modules/Filtering/ImageFeature/include/itkGradientVectorFlowImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkGradientVectorFlowImageFilter.h
@@ -110,14 +110,10 @@ public:
   itkSetMacro(IterationNum, int);
   itkGetConstMacro(IterationNum, int);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<ImageDimension, OutputImageDimension>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<typename PixelType::ValueType>));
   itkConceptMacro(OutputHasNumericTraitsCheck,
                   (Concept::HasNumericTraits<typename TOutputImage::PixelType::ValueType>));
-  // End concept checking
-#endif
 
 protected:
   GradientVectorFlowImageFilter();

--- a/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.h
@@ -117,11 +117,7 @@ public:
   itkSetMacro(Alpha2, double);
   itkGetConstMacro(Alpha2, double);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   Hessian3DToVesselnessMeasureImageFilter();

--- a/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.h
@@ -134,12 +134,8 @@ public:
   void
   GenerateInputRequestedRegion() override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<PixelType>));
   itkConceptMacro(OutputHasPixelTraitsCheck, (Concept::HasPixelTraits<OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   HessianRecursiveGaussianImageFilter();

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
@@ -122,11 +122,7 @@ public:
   itkGetConstMacro(BrightObject, bool);
   itkBooleanMacro(BrightObject);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   HessianToObjectnessMeasureImageFilter();

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.h
@@ -175,15 +175,10 @@ public:
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstMacro(UseImageSpacing, bool);
 
-
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(IntConvertibleToOutputCheck, (Concept::Convertible<int, TOutputPixelType>));
   itkConceptMacro(InputGreaterThanDoubleCheck, (Concept::GreaterThanComparable<PixelType, double>));
   itkConceptMacro(OutputPlusIntCheck, (Concept::AdditiveOperators<TOutputPixelType, int>));
   itkConceptMacro(OutputDividedByIntCheck, (Concept::DivisionOperators<TOutputPixelType, int>));
-  // End concept checking
-#endif
 
 protected:
   HoughTransform2DCirclesImageFilter();

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.h
@@ -148,13 +148,9 @@ public:
   itkSetMacro(Variance, double);
   itkGetConstMacro(Variance, double);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(IntConvertibleToOutputCheck, (Concept::Convertible<int, TOutputPixelType>));
   itkConceptMacro(InputGreaterThanFloatCheck, (Concept::GreaterThanComparable<PixelType, float>));
   itkConceptMacro(OutputPlusIntCheck, (Concept::AdditiveOperators<TOutputPixelType, int>));
-  // End concept checking
-#endif
 
 protected:
   HoughTransform2DLinesImageFilter();

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianImageFilter.h
@@ -113,13 +113,9 @@ public:
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstMacro(UseImageSpacing, bool);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, ImageDimension>));
   itkConceptMacro(InputPixelTypeIsFloatingPointCheck, (Concept::IsFloatingPoint<InputPixelType>));
   itkConceptMacro(OutputPixelTypeIsFloatingPointCheck, (Concept::IsFloatingPoint<OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   LaplacianImageFilter() { m_UseImageSpacing = true; }

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.h
@@ -90,11 +90,7 @@ public:
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstMacro(UseImageSpacing, bool);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, ImageDimension>));
-  // End concept checking
-#endif
 
 protected:
   LaplacianSharpeningImageFilter() { m_UseImageSpacing = true; }

--- a/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.h
@@ -133,13 +133,9 @@ public:
   itkSetClampMacro(SelectFraction, double, 0, 1);
   itkGetMacro(SelectFraction, double);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(ImageDimensionShouldBe3, (Concept::SameDimension<TImage::ImageDimension, 3u>));
   itkConceptMacro(MaskDimensionShouldBe3, (Concept::SameDimension<TMask::ImageDimension, 3u>));
   itkConceptMacro(PointDimensionShouldBe3, (Concept::SameDimension<TFeatures::PointType::PointDimension, 3u>));
-  // End concept checking
-#endif
 
 protected:
   MaskFeaturePointSelectionFilter();

--- a/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.h
@@ -117,12 +117,8 @@ public:
    * pixel in the output image. */
   itkGetConstReferenceMacro(OutputBackgroundValue, OutputPixelType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   SimpleContourExtractorImageFilter();

--- a/Modules/Filtering/ImageFeature/include/itkSobelEdgeDetectionImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkSobelEdgeDetectionImageFilter.h
@@ -104,13 +104,9 @@ public:
   void
   GenerateInputRequestedRegion() override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, ImageDimension>));
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputPixelType>));
   itkConceptMacro(OutputPixelIsFloatingPointCheck, (Concept::IsFloatingPoint<OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   SobelEdgeDetectionImageFilter() = default;

--- a/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.h
@@ -100,11 +100,9 @@ public:
    */
   itkNewMacro(Self);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, ImageDimension>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputPixelType>));
   itkConceptMacro(InternalTypeIsFloatingPoint, (Concept::IsFloatingPoint<TInternalPrecision>));
-#endif
 
   using GaussianType =
     SmoothingRecursiveGaussianImageFilter<TInputImage, Image<TInternalPrecision, TOutputImage::ImageDimension>>;

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingBasedEdgeDetectionImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingBasedEdgeDetectionImageFilter.h
@@ -141,15 +141,11 @@ public:
     m_MaximumError.Fill(v);
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<OutputImagePixelType>));
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<ImageDimension, OutputImageDimension>));
   itkConceptMacro(SameTypeCheck, (Concept::SameType<InputImagePixelType, OutputImagePixelType>));
   itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<OutputImagePixelType>));
   itkConceptMacro(PixelTypeIsFloatingPointCheck, (Concept::IsFloatingPoint<InputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   ZeroCrossingBasedEdgeDetectionImageFilter();

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.h
@@ -114,14 +114,10 @@ public:
   itkSetMacro(BackgroundValue, OutputImagePixelType);
   itkGetConstMacro(BackgroundValue, OutputImagePixelType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<OutputImagePixelType>));
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<ImageDimension, OutputImageDimension>));
   itkConceptMacro(InputComparableCheck, (Concept::Comparable<InputImagePixelType>));
   itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<OutputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   ZeroCrossingImageFilter();

--- a/Modules/Filtering/ImageFilterBase/include/itkBinaryFunctorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkBinaryFunctorImageFilter.h
@@ -171,14 +171,10 @@ public:
   static constexpr unsigned int InputImage2Dimension = TInputImage2::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck1,
                   (Concept::SameDimension<Self::InputImage1Dimension, Self::InputImage2Dimension>));
   itkConceptMacro(SameDimensionCheck2,
                   (Concept::SameDimension<Self::InputImage1Dimension, Self::OutputImageDimension>));
-  // End concept checking
-#endif
 
 protected:
   BinaryFunctorImageFilter();

--- a/Modules/Filtering/ImageFilterBase/include/itkBinaryGeneratorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkBinaryGeneratorImageFilter.h
@@ -215,14 +215,10 @@ public:
   static constexpr unsigned int InputImage2Dimension = TInputImage2::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck1,
                   (Concept::SameDimension<Self::InputImage1Dimension, Self::InputImage2Dimension>));
   itkConceptMacro(SameDimensionCheck2,
                   (Concept::SameDimension<Self::InputImage1Dimension, Self::OutputImageDimension>));
-  // End concept checking
-#endif
 
 protected:
   BinaryGeneratorImageFilter();

--- a/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.h
@@ -134,16 +134,12 @@ public:
   /** Turn on and off the UseDefaultValue flag. */
   itkBooleanMacro(UseDefaultValue);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<OutputPixelType>));
   itkConceptMacro(SameDimensionCheck1, (Concept::SameDimension<InputImageDimension, ImageDimension>));
   itkConceptMacro(SameDimensionCheck2, (Concept::SameDimension<InputImageDimension, MaskImageDimension>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputPixelType, OutputPixelType>));
   itkConceptMacro(OperatorConvertibleToOutputCheck, (Concept::Convertible<OperatorValueType, OutputPixelType>));
   itkConceptMacro(OutputOStreamWritable, (Concept::OStreamWritable<OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   MaskNeighborhoodOperatorImageFilter()

--- a/Modules/Filtering/ImageFilterBase/include/itkNeighborhoodOperatorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkNeighborhoodOperatorImageFilter.h
@@ -143,15 +143,11 @@ public:
   void
   GenerateInputRequestedRegion() override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, ImageDimension>));
   itkConceptMacro(OperatorConvertibleToOutputCheck, (Concept::Convertible<OperatorValueType, OutputPixelType>));
   itkConceptMacro(InputConvertibleToOperatorCheck, (Concept::Convertible<InputPixelValueType, OperatorValueType>));
   itkConceptMacro(OperatorMultiplyOperatorCheck, (Concept::MultiplyOperator<OperatorValueType>));
   itkConceptMacro(OperatorAdditiveOperatorsCheck, (Concept::AdditiveOperators<OperatorValueType>));
-  // End concept checking
-#endif
 
 protected:
   NeighborhoodOperatorImageFilter()

--- a/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.h
@@ -83,11 +83,7 @@ public:
 
   using InputSizeType = typename InputImageType::SizeType;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   NoiseImageFilter();

--- a/Modules/Filtering/ImageFilterBase/include/itkTernaryFunctorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkTernaryFunctorImageFilter.h
@@ -130,13 +130,9 @@ public:
   static constexpr unsigned int Input3ImageDimension = TInputImage3::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck1, (Concept::SameDimension<Input1ImageDimension, Input2ImageDimension>));
   itkConceptMacro(SameDimensionCheck2, (Concept::SameDimension<Input1ImageDimension, Input3ImageDimension>));
   itkConceptMacro(SameDimensionCheck3, (Concept::SameDimension<Input1ImageDimension, OutputImageDimension>));
-  // End concept checking
-#endif
 
 protected:
   TernaryFunctorImageFilter();

--- a/Modules/Filtering/ImageFilterBase/include/itkTernaryGeneratorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkTernaryGeneratorImageFilter.h
@@ -231,13 +231,9 @@ public:
   static constexpr unsigned int Input3ImageDimension = TInputImage3::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck1, (Concept::SameDimension<Input1ImageDimension, Input2ImageDimension>));
   itkConceptMacro(SameDimensionCheck2, (Concept::SameDimension<Input1ImageDimension, Input3ImageDimension>));
   itkConceptMacro(SameDimensionCheck3, (Concept::SameDimension<Input1ImageDimension, OutputImageDimension>));
-  // End concept checking
-#endif
 
 protected:
   TernaryGeneratorImageFilter();

--- a/Modules/Filtering/ImageFilterBase/include/itkVectorNeighborhoodOperatorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkVectorNeighborhoodOperatorImageFilter.h
@@ -126,13 +126,9 @@ public:
   void
   GenerateInputRequestedRegion() override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<typename TInputImage::PixelType::ValueType>));
   itkConceptMacro(OutputHasNumericTraitsCheck,
                   (Concept::HasNumericTraits<typename TOutputImage::PixelType::ValueType>));
-  // End concept checking
-#endif
 
 protected:
   VectorNeighborhoodOperatorImageFilter()

--- a/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.h
+++ b/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.h
@@ -87,9 +87,7 @@ public:
 
   static constexpr unsigned int ImageDimension = TImageType::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   itkConceptMacro(ImageTypeHasNumericTraitsCheck, (Concept::HasNumericTraits<typename TImageType::PixelType>));
-#endif
 
   /** Frequency Iterator types */
   using FrequencyIteratorType = TFrequencyIterator;

--- a/Modules/Filtering/ImageFusion/include/itkLabelOverlayImageFilter.h
+++ b/Modules/Filtering/ImageFusion/include/itkLabelOverlayImageFilter.h
@@ -101,13 +101,9 @@ public:
   itkSetMacro(BackgroundValue, LabelPixelType);
   itkGetConstReferenceMacro(BackgroundValue, LabelPixelType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputPixelShouldHaveValueType, (Concept::HasValueType<OutputPixelType>));
   itkConceptMacro(OutputPixelShouldHaveBracketOperator,
                   (Concept::BracketOperator<OutputPixelType, unsigned int, typename OutputPixelType::ValueType>));
-  // End concept checking
-#endif
 
   /** Empty the color LUT container. */
   void

--- a/Modules/Filtering/ImageGradient/include/itkDifferenceOfGaussiansGradientImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkDifferenceOfGaussiansGradientImageFilter.h
@@ -78,11 +78,7 @@ public:
   itkGetConstMacro(Width, unsigned int);
   itkSetMacro(Width, unsigned int);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(DataTypeHasNumericTraitsCheck, (Concept::HasNumericTraits<TDataType>));
-  // End concept checking
-#endif
 
 protected:
   DifferenceOfGaussiansGradientImageFilter();

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
@@ -142,12 +142,8 @@ public:
   void
   OverrideBoundaryCondition(ImageBoundaryCondition<TInputImage> * boundaryCondition);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputPixelType, OutputValueType>));
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputValueType>));
-  // End concept checking
-#endif
 
   /** The UseImageDirection flag determines whether image derivatives are
    * computed with respect to the image grid or with respect to the physical

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.h
@@ -114,11 +114,7 @@ public:
   }
 #endif
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   GradientMagnitudeImageFilter();

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.h
@@ -128,11 +128,7 @@ public:
   void
   SetNumberOfWorkUnits(ThreadIdType nb) override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<PixelType>));
-  // End concept checking
-#endif
 
 protected:
   GradientMagnitudeRecursiveGaussianImageFilter();

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.h
@@ -171,13 +171,9 @@ public:
   itkGetConstMacro(UseImageDirection, bool);
   itkBooleanMacro(UseImageDirection);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   // Does not seem to work with wrappings, disabled
   // itkConceptMacro( InputHasNumericTraitsCheck,
   //                 ( Concept::HasNumericTraits< PixelType > ) );
-  // End concept checking
-#endif
 
 protected:
   GradientRecursiveGaussianImageFilter();

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
@@ -273,13 +273,9 @@ public:
   static int
   CubicSolver(const double *, double *);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, ImageDimension>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<typename InputPixelType::ValueType>));
   itkConceptMacro(RealTypeHasNumericTraitsCheck, (Concept::HasNumericTraits<RealType>));
-  // End concept checking
-#endif
 
 protected:
   VectorGradientMagnitudeImageFilter();

--- a/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.h
@@ -126,11 +126,7 @@ public:
   void
   GenerateInputRequestedRegion() override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   void

--- a/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.h
@@ -121,11 +121,7 @@ public:
   void
   GenerateInputRequestedRegion() override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   void

--- a/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.h
@@ -115,13 +115,9 @@ public:
   GenerateInputRequestedRegion() override;
 
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  /** Begin concept checking */
   itkConceptMacro(InputConvertibleToOutputCheck,
                   (Concept::Convertible<typename TInputImage::PixelType, typename TOutputImage::PixelType>));
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<ImageDimension, OutputImageDimension>));
-  /** End concept checking */
-#endif
 
 protected:
   BinShrinkImageFilter();

--- a/Modules/Filtering/ImageGrid/include/itkConstantPadImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkConstantPadImageFilter.h
@@ -97,14 +97,10 @@ public:
     return m_InternalBoundaryCondition.GetConstant();
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<OutputImagePixelType>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputImagePixelType, OutputImagePixelType>));
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<ImageDimension, OutputImageDimension>));
   itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<OutputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   ConstantPadImageFilter();

--- a/Modules/Filtering/ImageGrid/include/itkCropImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkCropImageFilter.h
@@ -90,12 +90,8 @@ public:
     this->SetLowerBoundaryCropSize(s);
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputImagePixelType, OutputImagePixelType>));
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
-  // End concept checking
-#endif
 
 protected:
   CropImageFilter()

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImageFilter.h
@@ -115,11 +115,7 @@ public:
   void
   AfterThreadedGenerateData() override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   InterpolateImageFilter();

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.h
@@ -154,11 +154,7 @@ public:
   void
   GenerateInputRequestedRegion() override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<typename TInputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   InterpolateImagePointsFilter();

--- a/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.h
@@ -97,11 +97,7 @@ public:
   itkGetMacro(DecayBase, double);
   itkSetClampMacro(DecayBase, double, NumericTraits<double>::min(), 1.0);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputImagePixelType, OutputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   MirrorPadImageFilter() = default;

--- a/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.h
@@ -196,13 +196,9 @@ public:
   void
   GenerateOutputInformation() override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToOutput, (Concept::Convertible<InputImagePixelType, OutputImagePixelType>));
   itkConceptMacro(SameDimension, (Concept::SameDimension<Self::InputImageDimension, Self::OutputImageDimension>));
   itkConceptMacro(DimensionShouldBe3, (Concept::SameDimension<Self::InputImageDimension, 3>));
-  // End concept checking
-#endif
 
 protected:
   OrientImageFilter();

--- a/Modules/Filtering/ImageGrid/include/itkRegionOfInterestImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkRegionOfInterestImageFilter.h
@@ -86,12 +86,8 @@ public:
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<ImageDimension, OutputImageDimension>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputImagePixelType, OutputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   RegionOfInterestImageFilter();

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
@@ -270,11 +270,7 @@ public:
   itkBooleanMacro(UseReferenceImage);
   itkGetConstMacro(UseReferenceImage, bool);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<PixelComponentType>));
-  // End concept checking
-#endif
 
 protected:
   ResampleImageFilter();

--- a/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.h
@@ -131,13 +131,9 @@ public:
   void
   GenerateInputRequestedRegion() override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToOutputCheck,
                   (Concept::Convertible<typename TInputImage::PixelType, typename TOutputImage::PixelType>));
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<ImageDimension, OutputImageDimension>));
-  // End concept checking
-#endif
 
 protected:
   ShrinkImageFilter();

--- a/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.h
@@ -115,13 +115,9 @@ public:
   SetStep(int step);
 
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  /** Begin concept checking */
   itkConceptMacro(InputConvertibleToOutputCheck,
                   (Concept::Convertible<typename TInputImage::PixelType, typename TOutputImage::PixelType>));
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<ImageDimension, OutputImageDimension>));
-  /** End concept checking */
-#endif
 
 protected:
   SliceImageFilter();

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.h
@@ -118,13 +118,9 @@ public:
    * input image. */
   itkGetConstMacro(DefaultPixelValue, OutputPixelType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<OutputPixelType>));
   itkConceptMacro(SameTypeCheck, (Concept::SameType<InputPixelType, OutputPixelType>));
   itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   TileImageFilter();

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
@@ -224,15 +224,11 @@ public:
   void
   AfterThreadedGenerateData() override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck1, (Concept::SameDimension<ImageDimension, InputImageDimension>));
   itkConceptMacro(SameDimensionCheck2, (Concept::SameDimension<ImageDimension, DisplacementFieldDimension>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<typename TInputImage::InternalPixelType>));
   itkConceptMacro(DisplacementFieldHasNumericTraitsCheck,
                   (Concept::HasNumericTraits<typename TDisplacementField::PixelType::ValueType>));
-  // End concept checking
-#endif
 
 protected:
   WarpImageFilter();

--- a/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
@@ -210,14 +210,10 @@ public:
   void
   BeforeThreadedGenerateData() override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<typename TInputImage::PixelType::ValueType>));
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<ValueType>));
   itkConceptMacro(DisplacementFieldHasNumericTraitsCheck,
                   (Concept::HasNumericTraits<typename TDisplacementField::PixelType::ValueType>));
-  // End concept checking
-#endif
 
 protected:
   WarpVectorImageFilter();

--- a/Modules/Filtering/ImageGrid/include/itkWrapPadImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWrapPadImageFilter.h
@@ -91,11 +91,7 @@ public:
   /** ImageDimension enumeration. */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputImagePixelType, OutputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   WrapPadImageFilter();

--- a/Modules/Filtering/ImageGrid/include/itkZeroFluxNeumannPadImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkZeroFluxNeumannPadImageFilter.h
@@ -97,14 +97,10 @@ public:
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<OutputImagePixelType>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputImagePixelType, OutputImagePixelType>));
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<ImageDimension, OutputImageDimension>));
   itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<OutputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   ZeroFluxNeumannPadImageFilter();

--- a/Modules/Filtering/ImageIntensity/include/itkAbsImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAbsImageFilter.h
@@ -85,12 +85,8 @@ public:
   using OutputPixelType = typename TOutputImage::PixelType;
 
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(ConvertibleCheck, (Concept::Convertible<InputPixelType, OutputPixelType>));
   itkConceptMacro(InputGreaterThanIntCheck, (Concept::GreaterThanComparable<InputPixelType, InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   AbsImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkAcosImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAcosImageFilter.h
@@ -93,12 +93,8 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(AcosImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputCovertibleToDoubleCheck, (Concept::Convertible<typename TInputImage::PixelType, double>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   AcosImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkAddImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAddImageFilter.h
@@ -101,14 +101,10 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(AddImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(Input1Input2OutputAdditiveOperatorsCheck,
                   (Concept::AdditiveOperators<typename TInputImage1::PixelType,
                                               typename TInputImage2::PixelType,
                                               typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   AddImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkAndImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAndImageFilter.h
@@ -72,14 +72,10 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(AndImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(Input1Input2OutputBitwiseOperatorsCheck,
                   (Concept::BitwiseOperators<typename TInputImage1::PixelType,
                                              typename TInputImage2::PixelType,
                                              typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   AndImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkAsinImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAsinImageFilter.h
@@ -92,12 +92,8 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(AsinImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage::PixelType, double>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   AsinImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkAtan2ImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAtan2ImageFilter.h
@@ -94,13 +94,9 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(Atan2ImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(Input1ConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage1::PixelType, double>));
   itkConceptMacro(Input2ConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage2::PixelType, double>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   Atan2ImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkAtanImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAtanImageFilter.h
@@ -88,12 +88,8 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(AtanImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage::PixelType, double>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   AtanImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkBinaryMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkBinaryMagnitudeImageFilter.h
@@ -99,13 +99,9 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(BinaryMagnitudeImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(Input1ConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage1::PixelType, double>));
   itkConceptMacro(Input2ConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage2::PixelType, double>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   BinaryMagnitudeImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkBoundedReciprocalImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkBoundedReciprocalImageFilter.h
@@ -82,12 +82,8 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(BoundedReciprocalImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage::PixelType, double>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   BoundedReciprocalImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkClampImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkClampImageFilter.h
@@ -75,12 +75,10 @@ public:
   OutputType
   operator()(const InputType & A) const;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputType, OutputType>));
   itkConceptMacro(InputConvertibleToDoubleCheck, (Concept::Convertible<InputType, double>));
   itkConceptMacro(DoubleLessThanComparableToOutputCheck, (Concept::LessThanComparable<double, OutputType>));
   itkConceptMacro(DoubleGreaterThanComparableToOutputCheck, (Concept::GreaterThanComparable<double, OutputType>));
-#endif
 
 private:
   OutputType m_LowerBound;

--- a/Modules/Filtering/ImageIntensity/include/itkComplexToImaginaryImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkComplexToImaginaryImageFilter.h
@@ -76,11 +76,7 @@ public:
   using OutputPixelType = typename TOutputImage::PixelType;
   using InputPixelValueType = typename NumericTraits<InputPixelType>::ValueType;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputPixelValueType, OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   ComplexToImaginaryImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkComplexToModulusImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkComplexToModulusImageFilter.h
@@ -74,11 +74,7 @@ public:
   using OutputPixelType = typename TOutputImage::PixelType;
   using InputPixelValueType = typename NumericTraits<InputPixelType>::ValueType;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputMultiplyOperatorCheck, (Concept::MultiplyOperator<InputPixelValueType>));
-  // End concept checking
-#endif
 
 protected:
   ComplexToModulusImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkComplexToPhaseImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkComplexToPhaseImageFilter.h
@@ -75,11 +75,7 @@ public:
   using OutputPixelType = typename TOutputImage::PixelType;
   using InputPixelValueType = typename NumericTraits<InputPixelType>::ValueType;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputPixelValueType, OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   ComplexToPhaseImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkComplexToRealImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkComplexToRealImageFilter.h
@@ -75,11 +75,7 @@ public:
   using OutputPixelType = typename TOutputImage::PixelType;
   using InputPixelValueType = typename NumericTraits<InputPixelType>::ValueType;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputPixelValueType, OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   ComplexToRealImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkConstrainedValueAdditionImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkConstrainedValueAdditionImageFilter.h
@@ -109,14 +109,10 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ConstrainedValueAdditionImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(Input1ConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage1::PixelType, double>));
   itkConceptMacro(Input2ConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage2::PixelType, double>));
   itkConceptMacro(DoubleConvertibleToOutputCastCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
   itkConceptMacro(DoubleLessThanOutputCheck, (Concept::LessThanComparable<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   ConstrainedValueAdditionImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkConstrainedValueDifferenceImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkConstrainedValueDifferenceImageFilter.h
@@ -103,15 +103,11 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ConstrainedValueDifferenceImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(Input1ConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage1::PixelType, double>));
   itkConceptMacro(Input2ConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage2::PixelType, double>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
   itkConceptMacro(DoubleGreaterThanOutputCheck,
                   (Concept::GreaterThanComparable<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   ConstrainedValueDifferenceImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkCosImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkCosImageFilter.h
@@ -90,12 +90,8 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(CosImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage::PixelType, double>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   CosImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkDivideImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkDivideImageFilter.h
@@ -77,15 +77,11 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(DivideImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(IntConvertibleToInput2Check, (Concept::Convertible<int, typename TInputImage2::PixelType>));
   itkConceptMacro(Input1Input2OutputDivisionOperatorsCheck,
                   (Concept::DivisionOperators<typename TInputImage1::PixelType,
                                               typename TInputImage2::PixelType,
                                               typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   DivideImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkEdgePotentialImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkEdgePotentialImageFilter.h
@@ -78,11 +78,7 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(EdgePotentialImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<typename TInputImage::PixelType::ValueType>));
-  // End concept checking
-#endif
 
 protected:
   EdgePotentialImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkExpImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkExpImageFilter.h
@@ -80,12 +80,8 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ExpImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage::PixelType, double>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   ExpImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkExpNegativeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkExpNegativeImageFilter.h
@@ -125,12 +125,8 @@ public:
     return this->GetFunctor().GetFactor();
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage::PixelType, double>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   ExpNegativeImageFilter() = default;

--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.h
@@ -170,8 +170,6 @@ public:
   itkGetModifiableObjectMacro(SourceHistogram, HistogramType);
   itkGetModifiableObjectMacro(OutputHistogram, HistogramType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputPixelType>));
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<ImageDimension, OutputImageDimension>));
   itkConceptMacro(DoubleConvertibleToInputCheck, (Concept::Convertible<double, InputPixelType>));
@@ -179,8 +177,6 @@ public:
   itkConceptMacro(InputConvertibleToDoubleCheck, (Concept::Convertible<InputPixelType, double>));
   itkConceptMacro(OutputConvertibleToDoubleCheck, (Concept::Convertible<OutputPixelType, double>));
   itkConceptMacro(SameTypeCheck, (Concept::SameType<InputPixelType, OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   HistogramMatchingImageFilter();

--- a/Modules/Filtering/ImageIntensity/include/itkIntensityWindowingImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkIntensityWindowingImageFilter.h
@@ -208,11 +208,7 @@ public:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   IntensityWindowingImageFilter();

--- a/Modules/Filtering/ImageIntensity/include/itkInvertIntensityImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkInvertIntensityImageFilter.h
@@ -125,11 +125,7 @@ public:
   void
   BeforeThreadedGenerateData() override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   InvertIntensityImageFilter();

--- a/Modules/Filtering/ImageIntensity/include/itkLog10ImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkLog10ImageFilter.h
@@ -79,12 +79,8 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(Log10ImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage::PixelType, double>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   Log10ImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkLogImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkLogImageFilter.h
@@ -77,12 +77,8 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(LogImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage::PixelType, double>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   LogImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkMagnitudeAndPhaseToComplexImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMagnitudeAndPhaseToComplexImageFilter.h
@@ -106,13 +106,9 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(MagnitudeAndPhaseToComplexImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(Input1ConvertibleToDoubleCheck, (Concept::Convertible<InputPixel1Type, double>));
   itkConceptMacro(Input2ConvertibleToDoubleCheck, (Concept::Convertible<InputPixel2Type, double>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   MagnitudeAndPhaseToComplexImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkMaskImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskImageFilter.h
@@ -218,13 +218,9 @@ public:
     return this->GetFunctor().GetMaskingValue();
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(MaskEqualityComparableCheck, (Concept::EqualityComparable<typename TMaskImage::PixelType>));
   itkConceptMacro(InputConvertibleToOutputCheck,
                   (Concept::Convertible<typename TInputImage::PixelType, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   MaskImageFilter() = default;

--- a/Modules/Filtering/ImageIntensity/include/itkMaskNegatedImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskNegatedImageFilter.h
@@ -216,13 +216,9 @@ public:
     return static_cast<const MaskImageType *>(this->ProcessObject::GetInput(1));
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(MaskEqualityComparableCheck, (Concept::EqualityComparable<typename TMaskImage::PixelType>));
   itkConceptMacro(InputConvertibleToOutputCheck,
                   (Concept::Convertible<typename TInputImage::PixelType, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   MaskNegatedImageFilter() = default;

--- a/Modules/Filtering/ImageIntensity/include/itkMatrixIndexSelectionImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMatrixIndexSelectionImageFilter.h
@@ -120,11 +120,7 @@ public:
     return this->GetFunctor().GetIndices(i, j);
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<typename TInputImage::PixelType::ValueType>));
-  // End concept checking
-#endif
 
 protected:
   MatrixIndexSelectionImageFilter() = default;

--- a/Modules/Filtering/ImageIntensity/include/itkMaximumImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaximumImageFilter.h
@@ -95,16 +95,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(MaximumImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(Input1ConvertibleToOutputCheck,
                   (Concept::Convertible<typename TInputImage1::PixelType, typename TOutputImage::PixelType>));
   itkConceptMacro(Input2ConvertibleToOutputCheck,
                   (Concept::Convertible<typename TInputImage2::PixelType, typename TOutputImage::PixelType>));
   itkConceptMacro(Input1GreaterThanInput2Check,
                   (Concept::GreaterThanComparable<typename TInputImage1::PixelType, typename TInputImage2::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   MaximumImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkMinimumImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMinimumImageFilter.h
@@ -89,16 +89,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(MinimumImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(Input1ConvertibleToInput2Check,
                   (Concept::Convertible<typename TInputImage1::PixelType, typename TInputImage2::PixelType>));
   itkConceptMacro(Input2ConvertibleToOutputCheck,
                   (Concept::Convertible<typename TInputImage2::PixelType, typename TOutputImage::PixelType>));
   itkConceptMacro(Input1LessThanInput2Check,
                   (Concept::LessThanComparable<typename TInputImage1::PixelType, typename TInputImage2::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   MinimumImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkModulusImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkModulusImageFilter.h
@@ -78,11 +78,7 @@ public:
   }
 
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   ModulusImageFilter();

--- a/Modules/Filtering/ImageIntensity/include/itkMultiplyImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMultiplyImageFilter.h
@@ -61,14 +61,10 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(MultiplyImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(Input1Input2OutputMultiplyOperatorCheck,
                   (Concept::MultiplyOperator<typename TInputImage1::PixelType,
                                              typename TInputImage2::PixelType,
                                              typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   MultiplyImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkNaryAddImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNaryAddImageFilter.h
@@ -116,13 +116,9 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(NaryAddImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToOutputCheck,
                   (Concept::Convertible<typename TInputImage::PixelType, typename TOutputImage::PixelType>));
   itkConceptMacro(InputHasZeroCheck, (Concept::HasZero<typename TInputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   NaryAddImageFilter() = default;

--- a/Modules/Filtering/ImageIntensity/include/itkNaryFunctorImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNaryFunctorImageFilter.h
@@ -98,12 +98,8 @@ public:
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
   itkConceptMacro(OutputHasZeroCheck, (Concept::HasZero<OutputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   NaryFunctorImageFilter();

--- a/Modules/Filtering/ImageIntensity/include/itkNaryMaximumImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNaryMaximumImageFilter.h
@@ -121,14 +121,10 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(NaryMaximumImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToOutputCheck,
                   (Concept::Convertible<typename TInputImage::PixelType, typename TOutputImage::PixelType>));
   itkConceptMacro(InputLessThanComparableCheck, (Concept::LessThanComparable<typename TInputImage::PixelType>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<typename TInputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   NaryMaximumImageFilter() = default;

--- a/Modules/Filtering/ImageIntensity/include/itkNormalizeToConstantImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNormalizeToConstantImageFilter.h
@@ -96,12 +96,8 @@ public:
   itkSetMacro(Constant, RealType);
   itkGetConstMacro(Constant, RealType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasPixelTraitsCheck, (Concept::HasPixelTraits<InputImagePixelType>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   NormalizeToConstantImageFilter();

--- a/Modules/Filtering/ImageIntensity/include/itkNotImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNotImageFilter.h
@@ -116,13 +116,9 @@ public:
   }
 
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<typename TInputImage::PixelType, bool>));
   itkConceptMacro(OutputConvertibleToOutputCheck, (Concept::Convertible<bool, typename TOutputImage::PixelType>));
   itkConceptMacro(InputNotOperatorCheck, (Concept::NotOperator<typename TInputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   NotImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkOrImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkOrImageFilter.h
@@ -73,14 +73,10 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(OrImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(Input1Input2OutputBitwiseOperatorsCheck,
                   (Concept::BitwiseOperators<typename TInputImage1::PixelType,
                                              typename TInputImage2::PixelType,
                                              typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   OrImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.h
@@ -90,14 +90,10 @@ public:
   void
   SetInput2(const PolylineType * input);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<NDimensions, NOutputDimensions>));
   itkConceptMacro(IntConvertibleOutputCheck, (Concept::Convertible<int, OutputImagePixelType>));
   itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<OutputImagePixelType>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputImagePixelType, OutputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   PolylineMask2DImageFilter();

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.h
@@ -116,11 +116,7 @@ public:
   ProjPlanePointType
   TransformProjectPoint(PointType inputPoint);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(VectorHasNumericTraitsCheck, (Concept::HasNumericTraits<typename VectorType::ValueType>));
-  // End concept checking
-#endif
 
 protected:
   PolylineMaskImageFilter();

--- a/Modules/Filtering/ImageIntensity/include/itkPowImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkPowImageFilter.h
@@ -111,11 +111,6 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(PowImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-  // End concept checking
-#endif
-
 protected:
   PowImageFilter()
   {

--- a/Modules/Filtering/ImageIntensity/include/itkRGBToLuminanceImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkRGBToLuminanceImageFilter.h
@@ -78,12 +78,8 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(RGBToLuminanceImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck,
                   (Concept::HasNumericTraits<typename TInputImage::PixelType::ComponentType>));
-  // End concept checking
-#endif
 
 protected:
   RGBToLuminanceImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkRescaleIntensityImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkRescaleIntensityImageFilter.h
@@ -183,14 +183,10 @@ public:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputPixelType>));
   itkConceptMacro(RealTypeMultiplyOperatorCheck, (Concept::MultiplyOperator<RealType>));
   itkConceptMacro(RealTypeAdditiveOperatorsCheck, (Concept::AdditiveOperators<RealType>));
-  // End concept checking
-#endif
 
 protected:
   RescaleIntensityImageFilter();

--- a/Modules/Filtering/ImageIntensity/include/itkShiftScaleImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkShiftScaleImageFilter.h
@@ -94,13 +94,9 @@ public:
   itkGetConstMacro(UnderflowCount, SizeValueType);
   itkGetConstMacro(OverflowCount, SizeValueType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputImagePixelType>));
   itkConceptMacro(InputPlusRealTypeCheck, (Concept::AdditiveOperators<InputImagePixelType, RealType, RealType>));
   itkConceptMacro(RealTypeMultiplyOperatorCheck, (Concept::MultiplyOperator<RealType>));
-  // End concept checking
-#endif
 
 protected:
   ShiftScaleImageFilter() = default;

--- a/Modules/Filtering/ImageIntensity/include/itkSigmoidImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSigmoidImageFilter.h
@@ -234,16 +234,12 @@ public:
     return this->GetFunctor().GetOutputMaximum();
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage::PixelType, double>));
   itkConceptMacro(OutputAdditiveOperatorsCheck, (Concept::AdditiveOperators<OutputPixelType>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, OutputPixelType>));
   itkConceptMacro(OutputTimesDoubleCheck, (Concept::MultiplyOperator<OutputPixelType, double>));
   itkConceptMacro(OutputDoubleAdditiveOperatorsCheck,
                   (Concept::AdditiveOperators<OutputPixelType, OutputPixelType, double>));
-  // End concept checking
-#endif
 
 protected:
   SigmoidImageFilter() = default;

--- a/Modules/Filtering/ImageIntensity/include/itkSinImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSinImageFilter.h
@@ -82,12 +82,8 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(SinImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage::PixelType, double>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   SinImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkSqrtImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSqrtImageFilter.h
@@ -79,12 +79,8 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(SqrtImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage::PixelType, double>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   SqrtImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkSquareImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSquareImageFilter.h
@@ -77,13 +77,9 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(SquareImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<typename TInputImage::PixelType>));
   itkConceptMacro(RealTypeMultiplyOperatorCheck,
                   (Concept::MultiplyOperator<typename NumericTraits<typename TInputImage::PixelType>::RealType>));
-  // End concept checking
-#endif
 
 protected:
   SquareImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkSubtractImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSubtractImageFilter.h
@@ -85,14 +85,10 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(SubtractImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(Input1Input2OutputAdditiveOperatorsCheck,
                   (Concept::AdditiveOperators<typename TInputImage1::PixelType,
                                               typename TInputImage2::PixelType,
                                               typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   SubtractImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkSymmetricEigenAnalysisImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSymmetricEigenAnalysisImageFilter.h
@@ -284,11 +284,7 @@ public:
     return this->GetFunctor().GetDimension();
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputValueType>));
-  // End concept checking
-#endif
 
 protected:
   SymmetricEigenAnalysisImageFilter() { this->SetDimension(TInputImage::ImageDimension); }
@@ -374,11 +370,7 @@ public:
     return this->GetFunctor().GetDimension();
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputValueType>));
-  // End concept checking
-#endif
 
 protected:
   SymmetricEigenAnalysisFixedDimensionImageFilter() = default;

--- a/Modules/Filtering/ImageIntensity/include/itkTanImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkTanImageFilter.h
@@ -79,12 +79,8 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(TanImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage::PixelType, double>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   TanImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.h
@@ -157,12 +157,8 @@ public:
   void
   GenerateInputRequestedRegion() override;
 
-#  ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputValueType>));
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputValueType>));
-  // End concept checking
-#  endif
 
 protected:
   VectorExpandImageFilter();

--- a/Modules/Filtering/ImageIntensity/include/itkVectorIndexSelectionCastImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorIndexSelectionCastImageFilter.h
@@ -126,11 +126,7 @@ public:
     return this->GetFunctor().GetIndex();
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<typename TInputImage::PixelType::ValueType>));
-  // End concept checking
-#endif
 
 protected:
   VectorIndexSelectionCastImageFilter() = default;

--- a/Modules/Filtering/ImageIntensity/include/itkVectorMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorMagnitudeImageFilter.h
@@ -83,11 +83,7 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(VectorMagnitudeImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<typename TInputImage::PixelType::ValueType>));
-  // End concept checking
-#endif
 
 protected:
   VectorMagnitudeImageFilter()

--- a/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.h
@@ -148,12 +148,8 @@ public:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputValueType>));
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputValueType>));
-  // End concept checking
-#endif
 
 protected:
   VectorRescaleIntensityImageFilter();

--- a/Modules/Filtering/ImageIntensity/include/itkWeightedAddImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkWeightedAddImageFilter.h
@@ -154,15 +154,11 @@ public:
     return this->GetFunctor().GetAlpha();
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(Input1HasNumericTraitsCheck, (Concept::HasNumericTraits<typename TInputImage1::PixelType>));
   itkConceptMacro(Input1RealTypeMultiplyCheck,
                   (Concept::MultiplyOperator<typename TInputImage1::PixelType, RealType, RealType>));
   itkConceptMacro(Input2RealTypeMultiplyCheck,
                   (Concept::MultiplyOperator<typename TInputImage2::PixelType, RealType, RealType>));
-  // End concept checking
-#endif
 
 protected:
   WeightedAddImageFilter() = default;

--- a/Modules/Filtering/ImageIntensity/include/itkXorImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkXorImageFilter.h
@@ -73,14 +73,10 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(XorImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(Input1Input2OutputBitwiseOperatorsCheck,
                   (Concept::BitwiseOperators<typename TInputImage1::PixelType,
                                              typename TInputImage2::PixelType,
                                              typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   XorImageFilter()

--- a/Modules/Filtering/ImageLabel/include/itkChangeLabelImageFilter.h
+++ b/Modules/Filtering/ImageLabel/include/itkChangeLabelImageFilter.h
@@ -150,12 +150,8 @@ public:
   void
   ClearChangeMap();
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputPixelType, OutputPixelType>));
   itkConceptMacro(PixelTypeComparable, (Concept::Comparable<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   ChangeLabelImageFilter() = default;

--- a/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
+++ b/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
@@ -94,10 +94,7 @@ public:
   using OutputOffsetType = typename TOutputImage::OffsetType;
   using OutputImagePixelType = typename TOutputImage::PixelType;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Concept checking -- input and output dimensions must be the same
   itkConceptMacro(SameDimension, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
-#endif
 
   using EnclosingFilter = ImageToImageFilter<TInputImage, TOutputImage>;
 

--- a/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.h
+++ b/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.h
@@ -91,12 +91,8 @@ public:
   itkGetConstMacro(StandardDeviation, double);
   itkSetMacro(StandardDeviation, double);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  /** Begin concept checking */
   itkConceptMacro(InputConvertibleToOutputCheck,
                   (Concept::Convertible<typename TInputImage::PixelType, typename TOutputImage::PixelType>));
-  /** End concept checking */
-#endif
 
 protected:
   AdditiveGaussianNoiseImageFilter();

--- a/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.h
+++ b/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.h
@@ -111,12 +111,8 @@ public:
   itkGetConstMacro(PepperValue, OutputImagePixelType);
 
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  /** Begin concept checking */
   itkConceptMacro(InputConvertibleToOutputCheck,
                   (Concept::Convertible<typename TInputImage::PixelType, typename TOutputImage::PixelType>));
-  /** End concept checking */
-#endif
 
 protected:
   SaltAndPepperNoiseImageFilter();

--- a/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.h
+++ b/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.h
@@ -128,12 +128,8 @@ public:
   itkGetConstMacro(Scale, double);
   itkSetMacro(Scale, double);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  /** Begin concept checking */
   itkConceptMacro(InputConvertibleToOutputCheck,
                   (Concept::Convertible<typename TInputImage::PixelType, typename TOutputImage::PixelType>));
-  /** End concept checking */
-#endif
 
 protected:
   ShotNoiseImageFilter();

--- a/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.h
+++ b/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.h
@@ -87,12 +87,8 @@ public:
   itkGetConstMacro(StandardDeviation, double);
   itkSetMacro(StandardDeviation, double);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  /** Begin concept checking */
   itkConceptMacro(InputConvertibleToOutputCheck,
                   (Concept::Convertible<typename TInputImage::PixelType, typename TOutputImage::PixelType>));
-  /** End concept checking */
-#endif
 
 protected:
   SpeckleNoiseImageFilter();

--- a/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.h
@@ -85,11 +85,7 @@ public:
 
   /** Input and output images must be the same dimension, or the output's
       dimension must be one less than that of the input. */
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(ImageDimensionCheck, (Concept::SameDimension<Self::InputImageDimension, Self::OutputImageDimension>));
-  // End concept checking
-#endif
 
   /** Set the direction in which to accumulate the data.  It must be
    * set before the update of the filter. Defaults to the last

--- a/Modules/Filtering/ImageStatistics/include/itkBinaryProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkBinaryProjectionImageFilter.h
@@ -143,12 +143,8 @@ public:
    * NumericTraits<PixelType>::NonpositiveMin(). */
   itkGetConstMacro(BackgroundValue, OutputPixelType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputPixelTypeGreaterThanComparable, (Concept::EqualityComparable<InputPixelType>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   BinaryProjectionImageFilter()

--- a/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.h
@@ -187,11 +187,7 @@ public:
   /** Get the false discovery rate for the specified individual label. */
   RealType GetFalseDiscoveryRate(LabelType) const;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(Input1HasNumericTraitsCheck, (Concept::HasNumericTraits<LabelType>));
-  // End concept checking
-#endif
 
 protected:
   LabelOverlapMeasuresImageFilter();

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.h
@@ -377,12 +377,7 @@ public:
     return Superclass::GetNumberOfStreamDivisions();
   }
 
-
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<PixelType>));
-  // End concept checking
-#endif
 
 protected:
   LabelStatisticsImageFilter();

--- a/Modules/Filtering/ImageStatistics/include/itkMaximumProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkMaximumProjectionImageFilter.h
@@ -99,12 +99,8 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputPixelTypeGreaterThanComparable, (Concept::GreaterThanComparable<InputPixelType>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   MaximumProjectionImageFilter() = default;

--- a/Modules/Filtering/ImageStatistics/include/itkMeanProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkMeanProjectionImageFilter.h
@@ -109,14 +109,10 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputPixelToOutputPixelTypeGreaterAdditiveOperatorCheck,
                   (Concept::AdditiveOperators<OutputPixelType, InputPixelType, OutputPixelType>));
 
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   MeanProjectionImageFilter() = default;

--- a/Modules/Filtering/ImageStatistics/include/itkMedianProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkMedianProjectionImageFilter.h
@@ -100,11 +100,6 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-  // End concept checking
-#endif
-
 protected:
   MedianProjectionImageFilter() = default;
   ~MedianProjectionImageFilter() override = default;

--- a/Modules/Filtering/ImageStatistics/include/itkMinimumMaximumImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkMinimumMaximumImageFilter.h
@@ -109,13 +109,9 @@ public:
     return Superclass::GetNumberOfStreamDivisions();
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(LessThanComparableCheck, (Concept::LessThanComparable<PixelType>));
   itkConceptMacro(GreaterThanComparableCheck, (Concept::GreaterThanComparable<PixelType>));
   itkConceptMacro(OStreamWritableCheck, (Concept::OStreamWritable<PixelType>));
-  // End concept checking
-#endif
 
 protected:
   MinimumMaximumImageFilter();

--- a/Modules/Filtering/ImageStatistics/include/itkMinimumProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkMinimumProjectionImageFilter.h
@@ -98,12 +98,8 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputPixelTypeGreaterThanComparable, (Concept::LessThanComparable<InputPixelType>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   MinimumProjectionImageFilter() = default;

--- a/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.h
@@ -89,12 +89,8 @@ public:
 
   /** Input and output images must be the same dimension, or the output's
       dimension must be one less than that of the input. */
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(ImageDimensionCheck,
                   (Concept::SameDimensionOrMinusOne<Self::InputImageDimension, Self::OutputImageDimension>));
-  // End concept checking
-#endif
 
   /** Set/Get the direction in which to accumulate the data.  It must be set
    * before the update of the filter. Defaults to the last dimension. */

--- a/Modules/Filtering/ImageStatistics/include/itkStandardDeviationProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkStandardDeviationProjectionImageFilter.h
@@ -129,16 +129,11 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputPixelToOutputPixelTypeGreaterAdditiveOperatorCheck,
                   (Concept::AdditiveOperators<TAccumulate, InputPixelType, TAccumulate>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
 
   itkConceptMacro(AccumulateHasNumericTraitsCheck, (Concept::HasNumericTraits<TAccumulate>));
-
-  // End concept checking
-#endif
 
 protected:
   StandardDeviationProjectionImageFilter() = default;

--- a/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.h
@@ -131,11 +131,7 @@ public:
   DataObjectPointer
   MakeOutput(const DataObjectIdentifierType & name) override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<PixelType>));
-  // End concept checking
-#endif
 
 protected:
   StatisticsImageFilter();

--- a/Modules/Filtering/ImageStatistics/include/itkSumProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkSumProjectionImageFilter.h
@@ -106,13 +106,9 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputPixelToOutputPixelTypeGreaterAdditiveOperatorCheck,
                   (Concept::AdditiveOperators<OutputPixelType, InputPixelType, OutputPixelType>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   SumProjectionImageFilter() = default;

--- a/Modules/Filtering/LabelMap/include/itkAggregateLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAggregateLabelMapFilter.h
@@ -69,16 +69,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(AggregateLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-/*  itkConceptMacro(InputEqualityComparableCheck,
+  /*itkConceptMacro(InputEqualityComparableCheck,
     (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck,
     (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck,
     (Concept::OStreamWritable<InputImagePixelType>));*/
-// End concept checking
-#endif
 
 protected:
   AggregateLabelMapFilter() = default;

--- a/Modules/Filtering/LabelMap/include/itkAttributeKeepNObjectsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeKeepNObjectsLabelMapFilter.h
@@ -73,16 +73,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(AttributeKeepNObjectsLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-  /*  itkConceptMacro(InputEqualityComparableCheck,
+  /*itkConceptMacro(InputEqualityComparableCheck,
       (Concept::EqualityComparable<InputImagePixelType>));
     itkConceptMacro(IntConvertibleToInputCheck,
       (Concept::Convertible<int, InputImagePixelType>));
     itkConceptMacro(InputOStreamWritableCheck,
       (Concept::OStreamWritable<InputImagePixelType>));*/
-  // End concept checking
-#endif
 
   /**
    * Set/Get the ordering of the objects. By default, the ones with the

--- a/Modules/Filtering/LabelMap/include/itkAttributeOpeningLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeOpeningLabelMapFilter.h
@@ -75,16 +75,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(AttributeOpeningLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   /*  itkConceptMacro(InputEqualityComparableCheck,
       (Concept::EqualityComparable<InputImagePixelType>));
     itkConceptMacro(IntConvertibleToInputCheck,
       (Concept::Convertible<int, InputImagePixelType>));
     itkConceptMacro(InputOStreamWritableCheck,
       (Concept::OStreamWritable<InputImagePixelType>));*/
-  // End concept checking
-#endif
 
   /**
    * Set/Get the threshold used to keep or remove the objects.

--- a/Modules/Filtering/LabelMap/include/itkAttributePositionLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributePositionLabelMapFilter.h
@@ -75,16 +75,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(AttributePositionLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   /*  itkConceptMacro(InputEqualityComparableCheck,
       (Concept::EqualityComparable<InputImagePixelType>));
     itkConceptMacro(IntConvertibleToInputCheck,
       (Concept::Convertible<int, InputImagePixelType>));
     itkConceptMacro(InputOStreamWritableCheck,
       (Concept::OStreamWritable<InputImagePixelType>));*/
-  // End concept checking
-#endif
 
 protected:
   AttributePositionLabelMapFilter() = default;

--- a/Modules/Filtering/LabelMap/include/itkAttributeRelabelLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeRelabelLabelMapFilter.h
@@ -74,16 +74,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(AttributeRelabelLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   /*  itkConceptMacro(InputEqualityComparableCheck,
       (Concept::EqualityComparable<InputImagePixelType>));
     itkConceptMacro(IntConvertibleToInputCheck,
       (Concept::Convertible<int, InputImagePixelType>));
     itkConceptMacro(InputOStreamWritableCheck,
       (Concept::OStreamWritable<InputImagePixelType>));*/
-  // End concept checking
-#endif
 
   /**
    * Set/Get the order of labeling of the objects. By default, the objects with

--- a/Modules/Filtering/LabelMap/include/itkAttributeSelectionLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeSelectionLabelMapFilter.h
@@ -83,16 +83,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(AttributeSelectionLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   /*  itkConceptMacro(InputEqualityComparableCheck,
       (Concept::EqualityComparable<InputImagePixelType>));
     itkConceptMacro(IntConvertibleToInputCheck,
       (Concept::Convertible<int, InputImagePixelType>));
     itkConceptMacro(InputOStreamWritableCheck,
       (Concept::OStreamWritable<InputImagePixelType>));*/
-  // End concept checking
-#endif
 
   /**
    * Set/Get the threshold used to keep or remove the objects.

--- a/Modules/Filtering/LabelMap/include/itkAttributeUniqueLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeUniqueLabelMapFilter.h
@@ -79,16 +79,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(AttributeUniqueLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   /*  itkConceptMacro(InputEqualityComparableCheck,
       (Concept::EqualityComparable<InputImagePixelType>));
     itkConceptMacro(IntConvertibleToInputCheck,
       (Concept::Convertible<int, InputImagePixelType>));
     itkConceptMacro(InputOStreamWritableCheck,
       (Concept::OStreamWritable<InputImagePixelType>));*/
-  // End concept checking
-#endif
 
   /**
    * Set/Get the order of labeling of the objects. By default, the objects with

--- a/Modules/Filtering/LabelMap/include/itkBinaryFillholeImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryFillholeImageFilter.h
@@ -86,11 +86,7 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
   /** Set the value in the image to consider as "foreground". Defaults to
    * maximum value of InputPixelType. */

--- a/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.h
@@ -86,11 +86,7 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
   /** Set the value in the image to consider as "foreground". Defaults to
    * maximum value of InputPixelType. */

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToShapeLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToShapeLabelMapFilter.h
@@ -108,13 +108,9 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
   /**
    * Set/Get the value used as "background" in the output image.

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToStatisticsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToStatisticsLabelMapFilter.h
@@ -94,13 +94,9 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
   /**
    * Set/Get the value used as "background" in the output image.

--- a/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByDilationImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByDilationImageFilter.h
@@ -105,13 +105,9 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
   /**
    * Set/Get the value used as "background" in the output image.

--- a/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByErosionImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByErosionImageFilter.h
@@ -105,13 +105,9 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
   /**
    * Set/Get the value used as "background" in the output image.

--- a/Modules/Filtering/LabelMap/include/itkBinaryReconstructionLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryReconstructionLabelMapFilter.h
@@ -80,16 +80,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(BinaryReconstructionLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   /*  itkConceptMacro(InputEqualityComparableCheck,
       (Concept::EqualityComparable<PixelType>));
     itkConceptMacro(IntConvertibleToInputCheck,
       (Concept::Convertible<int, PixelType>));
     itkConceptMacro(InputOStreamWritableCheck,
       (Concept::OStreamWritable<PixelType>));*/
-  // End concept checking
-#endif
 
   /** Set/Get the marker image */
   itkSetInputMacro(MarkerImage, MarkerImageType);

--- a/Modules/Filtering/LabelMap/include/itkBinaryShapeKeepNObjectsImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryShapeKeepNObjectsImageFilter.h
@@ -99,13 +99,9 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
   /**
    * Set/Get the value used as "background" in the output image.

--- a/Modules/Filtering/LabelMap/include/itkBinaryShapeOpeningImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryShapeOpeningImageFilter.h
@@ -99,13 +99,9 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
   /**
    * Set/Get the value used as "background" in the output image.

--- a/Modules/Filtering/LabelMap/include/itkBinaryStatisticsKeepNObjectsImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryStatisticsKeepNObjectsImageFilter.h
@@ -102,13 +102,9 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
   /**
    * Set/Get the value used as "background" in the output image.

--- a/Modules/Filtering/LabelMap/include/itkBinaryStatisticsOpeningImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryStatisticsOpeningImageFilter.h
@@ -106,13 +106,9 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
   /**
    * Set/Get the value used as "background" in the output image.

--- a/Modules/Filtering/LabelMap/include/itkChangeLabelLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkChangeLabelLabelMapFilter.h
@@ -77,16 +77,12 @@ public:
   using ChangeMapType = typename std::map<PixelType, PixelType>;
   using ChangeMapIterator = typename ChangeMapType::const_iterator;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-/*  itkConceptMacro(InputEqualityComparableCheck,
+  /*itkConceptMacro(InputEqualityComparableCheck,
     (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck,
     (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck,
     (Concept::OStreamWritable<InputImagePixelType>));*/
-// End concept checking
-#endif
 
   /**
    */

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToLabelMapFilter.h
@@ -90,9 +90,7 @@ public:
   itkSetMacro(BackgroundValue, OutputImagePixelType);
   itkGetConstMacro(BackgroundValue, OutputImagePixelType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
-#endif
 
 protected:
   LabelImageToLabelMapFilter();

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToShapeLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToShapeLabelMapFilter.h
@@ -87,13 +87,9 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(LabelImageToShapeLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
   /**
    * Set/Get the value used as "background" in the output image.

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToStatisticsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToStatisticsLabelMapFilter.h
@@ -85,13 +85,9 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(LabelImageToStatisticsLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
   /**
    * Set/Get the value used as "background" in the output image.

--- a/Modules/Filtering/LabelMap/include/itkLabelMapToLabelImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapToLabelImageFilter.h
@@ -79,9 +79,7 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(LabelMapToLabelImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
-#endif
 
 protected:
   LabelMapToLabelImageFilter() = default;

--- a/Modules/Filtering/LabelMap/include/itkLabelSelectionLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelSelectionLabelMapFilter.h
@@ -88,16 +88,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(LabelSelectionLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   /*  itkConceptMacro(InputEqualityComparableCheck,
       (Concept::EqualityComparable<InputImagePixelType>));
     itkConceptMacro(IntConvertibleToInputCheck,
       (Concept::Convertible<int, InputImagePixelType>));
     itkConceptMacro(InputOStreamWritableCheck,
       (Concept::OStreamWritable<InputImagePixelType>));*/
-  // End concept checking
-#endif
 
   const AttributeSetType &
   GetLabelSet() const

--- a/Modules/Filtering/LabelMap/include/itkLabelShapeKeepNObjectsImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelShapeKeepNObjectsImageFilter.h
@@ -91,13 +91,9 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(LabelShapeKeepNObjectsImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
   /**
    * Set/Get the value used as "background" in the output image.

--- a/Modules/Filtering/LabelMap/include/itkLabelShapeOpeningImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelShapeOpeningImageFilter.h
@@ -87,13 +87,9 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(LabelShapeOpeningImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
   /**
    * Set/Get the value used as "background" in the output image.

--- a/Modules/Filtering/LabelMap/include/itkLabelStatisticsKeepNObjectsImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelStatisticsKeepNObjectsImageFilter.h
@@ -90,13 +90,9 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(LabelStatisticsKeepNObjectsImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
   /**
    * Set/Get the value used as "background" in the output image.

--- a/Modules/Filtering/LabelMap/include/itkLabelStatisticsOpeningImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelStatisticsOpeningImageFilter.h
@@ -90,13 +90,9 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(LabelStatisticsOpeningImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
   /**
    * Set/Get the value used as "background" in the output image.

--- a/Modules/Filtering/LabelMap/include/itkLabelUniqueLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelUniqueLabelMapFilter.h
@@ -77,16 +77,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(LabelUniqueLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   /*  itkConceptMacro(InputEqualityComparableCheck,
       (Concept::EqualityComparable<InputImagePixelType>));
     itkConceptMacro(IntConvertibleToInputCheck,
       (Concept::Convertible<int, InputImagePixelType>));
     itkConceptMacro(InputOStreamWritableCheck,
       (Concept::OStreamWritable<InputImagePixelType>));*/
-  // End concept checking
-#endif
 
 protected:
   LabelUniqueLabelMapFilter() = default;

--- a/Modules/Filtering/LabelMap/include/itkMergeLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkMergeLabelMapFilter.h
@@ -132,16 +132,12 @@ public:
   using MethodChoice = ChoiceMethodEnum;
 #endif
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-/*  itkConceptMacro(InputEqualityComparableCheck,
+  /*itkConceptMacro(InputEqualityComparableCheck,
     (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck,
     (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck,
     (Concept::OStreamWritable<InputImagePixelType>));*/
-// End concept checking
-#endif
 
 #ifdef STRICT
 #  undef STRICT

--- a/Modules/Filtering/LabelMap/include/itkRelabelLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkRelabelLabelMapFilter.h
@@ -75,16 +75,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(RelabelLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-/*  itkConceptMacro(InputEqualityComparableCheck,
+  /*itkConceptMacro(InputEqualityComparableCheck,
     (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck,
     (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck,
     (Concept::OStreamWritable<InputImagePixelType>));*/
-// End concept checking
-#endif
 
 protected:
   RelabelLabelMapFilter() { this->SetReverseOrdering(true); }

--- a/Modules/Filtering/LabelMap/include/itkShapeKeepNObjectsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeKeepNObjectsLabelMapFilter.h
@@ -71,16 +71,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ShapeKeepNObjectsLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-/*  itkConceptMacro(InputEqualityComparableCheck,
+  /*itkConceptMacro(InputEqualityComparableCheck,
     (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck,
     (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck,
     (Concept::OStreamWritable<InputImagePixelType>));*/
-// End concept checking
-#endif
 
   /**
    * Set/Get the ordering of the objects. By default, the ones with the

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.h
@@ -88,16 +88,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ShapeLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-/*  itkConceptMacro(InputEqualityComparableCheck,
+  /*itkConceptMacro(InputEqualityComparableCheck,
     (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck,
     (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck,
     (Concept::OStreamWritable<InputImagePixelType>));*/
-// End concept checking
-#endif
 
   /**
    * Set/Get whether the maximum Feret diameter should be computed or not.

--- a/Modules/Filtering/LabelMap/include/itkShapeOpeningLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeOpeningLabelMapFilter.h
@@ -76,16 +76,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ShapeOpeningLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-/*  itkConceptMacro(InputEqualityComparableCheck,
+  /*itkConceptMacro(InputEqualityComparableCheck,
     (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck,
     (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck,
     (Concept::OStreamWritable<InputImagePixelType>));*/
-// End concept checking
-#endif
 
   /**
    * Set/Get the threshold used to keep or remove the objects.

--- a/Modules/Filtering/LabelMap/include/itkShapePositionLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapePositionLabelMapFilter.h
@@ -66,16 +66,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ShapePositionLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   /*  itkConceptMacro(InputEqualityComparableCheck,
       (Concept::EqualityComparable<InputImagePixelType>));
     itkConceptMacro(IntConvertibleToInputCheck,
       (Concept::Convertible<int, InputImagePixelType>));
     itkConceptMacro(InputOStreamWritableCheck,
       (Concept::OStreamWritable<InputImagePixelType>));*/
-  // End concept checking
-#endif
 
   /**
    * Set/Get the attribute to use to get the object position. The default

--- a/Modules/Filtering/LabelMap/include/itkShapeRelabelImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeRelabelImageFilter.h
@@ -86,13 +86,9 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ShapeRelabelImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
   /**
    * Set/Get the value used as "background" in the output image.

--- a/Modules/Filtering/LabelMap/include/itkShapeRelabelLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeRelabelLabelMapFilter.h
@@ -73,16 +73,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ShapeRelabelLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-/*  itkConceptMacro(InputEqualityComparableCheck,
+  /*itkConceptMacro(InputEqualityComparableCheck,
     (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck,
     (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck,
     (Concept::OStreamWritable<InputImagePixelType>));*/
-// End concept checking
-#endif
 
   /**
    * Set/Get the order of labeling of the objects. By default, the objects with

--- a/Modules/Filtering/LabelMap/include/itkShapeUniqueLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeUniqueLabelMapFilter.h
@@ -72,16 +72,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ShapeUniqueLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-/*  itkConceptMacro(InputEqualityComparableCheck,
+  /*itkConceptMacro(InputEqualityComparableCheck,
     (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck,
     (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck,
     (Concept::OStreamWritable<InputImagePixelType>));*/
-// End concept checking
-#endif
 
   /**
    * Set/Get the ordering of the objects. By default, the objects with

--- a/Modules/Filtering/LabelMap/include/itkShiftScaleLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShiftScaleLabelMapFilter.h
@@ -68,16 +68,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ShiftScaleLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-/*  itkConceptMacro(InputEqualityComparableCheck,
+  /*itkConceptMacro(InputEqualityComparableCheck,
     (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck,
     (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck,
     (Concept::OStreamWritable<InputImagePixelType>));*/
-// End concept checking
-#endif
 
   itkSetMacro(Shift, double);
   itkGetConstReferenceMacro(Shift, double);

--- a/Modules/Filtering/LabelMap/include/itkStatisticsKeepNObjectsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsKeepNObjectsLabelMapFilter.h
@@ -72,16 +72,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(StatisticsKeepNObjectsLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-/*  itkConceptMacro(InputEqualityComparableCheck,
+  /*itkConceptMacro(InputEqualityComparableCheck,
     (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck,
     (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck,
     (Concept::OStreamWritable<InputImagePixelType>));*/
-// End concept checking
-#endif
 
 protected:
   StatisticsKeepNObjectsLabelMapFilter();

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.h
@@ -75,16 +75,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(StatisticsLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-/*  itkConceptMacro(InputEqualityComparableCheck,
+  /*itkConceptMacro(InputEqualityComparableCheck,
     (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck,
     (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck,
     (Concept::OStreamWritable<InputImagePixelType>));*/
-// End concept checking
-#endif
 
   /** Set the feature image */
   void

--- a/Modules/Filtering/LabelMap/include/itkStatisticsOpeningLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsOpeningLabelMapFilter.h
@@ -72,16 +72,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(StatisticsOpeningLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-/*  itkConceptMacro(InputEqualityComparableCheck,
+  /*itkConceptMacro(InputEqualityComparableCheck,
     (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck,
     (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck,
     (Concept::OStreamWritable<InputImagePixelType>));*/
-// End concept checking
-#endif
 
 protected:
   StatisticsOpeningLabelMapFilter();

--- a/Modules/Filtering/LabelMap/include/itkStatisticsPositionLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsPositionLabelMapFilter.h
@@ -70,16 +70,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(StatisticsPositionLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   /*  itkConceptMacro(InputEqualityComparableCheck,
       (Concept::EqualityComparable<InputImagePixelType>));
     itkConceptMacro(IntConvertibleToInputCheck,
       (Concept::Convertible<int, InputImagePixelType>));
     itkConceptMacro(InputOStreamWritableCheck,
       (Concept::OStreamWritable<InputImagePixelType>));*/
-  // End concept checking
-#endif
 
 protected:
   StatisticsPositionLabelMapFilter();

--- a/Modules/Filtering/LabelMap/include/itkStatisticsRelabelImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsRelabelImageFilter.h
@@ -89,13 +89,9 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(StatisticsRelabelImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
   /**
    * Set/Get the value used as "background" in the output image.

--- a/Modules/Filtering/LabelMap/include/itkStatisticsRelabelLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsRelabelLabelMapFilter.h
@@ -71,16 +71,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(StatisticsRelabelLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-/*  itkConceptMacro(InputEqualityComparableCheck,
+  /*itkConceptMacro(InputEqualityComparableCheck,
     (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck,
     (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck,
     (Concept::OStreamWritable<InputImagePixelType>));*/
-// End concept checking
-#endif
 
 protected:
   StatisticsRelabelLabelMapFilter();

--- a/Modules/Filtering/LabelMap/include/itkStatisticsUniqueLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsUniqueLabelMapFilter.h
@@ -69,16 +69,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(StatisticsUniqueLabelMapFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-/*  itkConceptMacro(InputEqualityComparableCheck,
+  /*itkConceptMacro(InputEqualityComparableCheck,
     (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck,
     (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck,
     (Concept::OStreamWritable<InputImagePixelType>));*/
-// End concept checking
-#endif
 
 protected:
   StatisticsUniqueLabelMapFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkBasicDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBasicDilateImageFilter.h
@@ -85,15 +85,11 @@ public:
   /** Type of the pixels in the Kernel. */
   using KernelPixelType = typename TKernel::PixelType;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<PixelType, typename TOutputImage::PixelType>));
   itkConceptMacro(SameDimensionCheck1, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
   itkConceptMacro(SameDimensionCheck2, (Concept::SameDimension<InputImageDimension, KernelDimension>));
   itkConceptMacro(InputGreaterThanComparableCheck, (Concept::GreaterThanComparable<PixelType>));
   itkConceptMacro(KernelGreaterThanComparableCheck, (Concept::GreaterThanComparable<KernelPixelType>));
-  // End concept checking
-#endif
 
 protected:
   BasicDilateImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkBasicErodeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBasicErodeImageFilter.h
@@ -83,15 +83,11 @@ public:
   /** Type of the pixels in the Kernel. */
   using KernelPixelType = typename TKernel::PixelType;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<PixelType, typename TOutputImage::PixelType>));
   itkConceptMacro(SameDimensionCheck1, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
   itkConceptMacro(SameDimensionCheck2, (Concept::SameDimension<InputImageDimension, KernelDimension>));
   itkConceptMacro(InputLessThanComparableCheck, (Concept::LessThanComparable<PixelType>));
   itkConceptMacro(KernelGreaterThanComparableCheck, (Concept::GreaterThanComparable<KernelPixelType>));
-  // End concept checking
-#endif
 
 protected:
   BasicErodeImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkClosingByReconstructionImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkClosingByReconstructionImageFilter.h
@@ -110,11 +110,7 @@ public:
   itkGetConstReferenceMacro(PreserveIntensities, bool);
   itkBooleanMacro(PreserveIntensities);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputImagePixelType, OutputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   ClosingByReconstructionImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.h
@@ -116,14 +116,10 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<OutputPixelType>));
   itkConceptMacro(InputComparableCheck, (Concept::Comparable<InputPixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputPixelType>));
   itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   DoubleThresholdImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.h
@@ -90,13 +90,9 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputImagePixelType, OutputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   GrayscaleConnectedClosingImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.h
@@ -91,13 +91,9 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputImagePixelType, OutputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   GrayscaleConnectedOpeningImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.h
@@ -96,11 +96,7 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   GrayscaleFillholeImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionDilateImageFilter.h
@@ -88,8 +88,6 @@ public:
   /** Type of the pixels in the Kernel. */
   using KernelPixelType = typename TKernel::PixelType;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck1, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
   itkConceptMacro(SameDimensionCheck2, (Concept::SameDimension<InputImageDimension, KernelDimension>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<PixelType, typename TOutputImage::PixelType>));
@@ -97,8 +95,6 @@ public:
   itkConceptMacro(InputAdditiveOperatorsCheck, (Concept::AdditiveOperators<PixelType>));
   itkConceptMacro(InputGreaterThanComparableCheck, (Concept::GreaterThanComparable<PixelType>));
   itkConceptMacro(KernelGreaterThanComparableCheck, (Concept::GreaterThanComparable<KernelPixelType>));
-  // End concept checking
-#endif
 
 protected:
   GrayscaleFunctionDilateImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionErodeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionErodeImageFilter.h
@@ -88,8 +88,6 @@ public:
   /** Type of the pixels in the Kernel. */
   using KernelPixelType = typename TKernel::PixelType;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck1, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
   itkConceptMacro(SameDimensionCheck2, (Concept::SameDimension<InputImageDimension, KernelDimension>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<PixelType, typename TOutputImage::PixelType>));
@@ -97,8 +95,6 @@ public:
   itkConceptMacro(InputAdditiveOperatorsCheck, (Concept::AdditiveOperators<PixelType>));
   itkConceptMacro(InputLessThanComparableCheck, (Concept::LessThanComparable<PixelType>));
   itkConceptMacro(KernelGreaterThanComparableCheck, (Concept::GreaterThanComparable<KernelPixelType>));
-  // End concept checking
-#endif
 
 protected:
   GrayscaleFunctionErodeImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.h
@@ -139,13 +139,9 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<MarkerImageDimension, OutputImageDimension>));
   itkConceptMacro(InputComparableCheck, (Concept::Comparable<MarkerImagePixelType>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<MarkerImagePixelType, OutputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   GrayscaleGeodesicDilateImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.h
@@ -140,13 +140,9 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<MarkerImageDimension, OutputImageDimension>));
   itkConceptMacro(InputComparableCheck, (Concept::Comparable<MarkerImagePixelType>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<MarkerImagePixelType, OutputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   GrayscaleGeodesicErodeImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.h
@@ -110,11 +110,7 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   GrayscaleGrindPeakImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.h
@@ -92,13 +92,9 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   HConcaveImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.h
@@ -92,13 +92,9 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   HConvexImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.h
@@ -104,13 +104,9 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   HMaximaImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.h
@@ -102,13 +102,9 @@ public:
   itkGetConstReferenceMacro(FullyConnected, bool);
   itkBooleanMacro(FullyConnected);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   HMinimaImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkOpeningByReconstructionImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkOpeningByReconstructionImageFilter.h
@@ -112,11 +112,7 @@ public:
   itkGetConstReferenceMacro(PreserveIntensities, bool);
   itkBooleanMacro(PreserveIntensities);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   OpeningByReconstructionImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.h
@@ -116,12 +116,8 @@ public:
   itkGetConstMacro(FlatIsMaxima, bool);
   itkBooleanMacro(FlatIsMaxima);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasPixelTraitsCheck, (Concept::HasPixelTraits<InputImagePixelType>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   RegionalMaximaImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.h
@@ -114,12 +114,8 @@ public:
   itkGetConstMacro(FlatIsMinima, bool);
   itkBooleanMacro(FlatIsMinima);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasPixelTraitsCheck, (Concept::HasPixelTraits<InputImagePixelType>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   RegionalMinimaImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.h
@@ -129,12 +129,8 @@ public:
    */
   itkGetConstMacro(Flat, bool);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasPixelTraitsCheck, (Concept::HasPixelTraits<InputImagePixelType>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   ValuedRegionalExtremaImageFilter();

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalMaximaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalMaximaImageFilter.h
@@ -83,13 +83,9 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ValuedRegionalMaximaImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputPixelTypeComparable, (Concept::GreaterThanComparable<InputImagePixelType>));
   itkConceptMacro(InputHasPixelTraitsCheck, (Concept::HasPixelTraits<InputImagePixelType>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   ValuedRegionalMaximaImageFilter()

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalMinimaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalMinimaImageFilter.h
@@ -79,13 +79,9 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ValuedRegionalMinimaImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputPixelTypeComparable, (Concept::LessThanComparable<InputImagePixelType>));
   itkConceptMacro(InputHasPixelTraitsCheck, (Concept::HasPixelTraits<InputImagePixelType>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   ValuedRegionalMinimaImageFilter() { this->SetMarkerValue(NumericTraits<typename TOutputImage::PixelType>::max()); }

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.h
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.h
@@ -185,14 +185,10 @@ public:
   itkSetMacro(ContourValue, InputRealType);
   itkGetConstReferenceMacro(ContourValue, InputRealType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(DimensionShouldBe2, (Concept::SameDimension<Self::InputImageDimension, 2>));
   itkConceptMacro(InputPixelTypeComparable, (Concept::Comparable<InputPixelType>));
   itkConceptMacro(InputHasPixelTraitsCheck, (Concept::HasPixelTraits<InputPixelType>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   ContourExtractor2DImageFilter();

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteCurvatureQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteCurvatureQuadEdgeMeshFilter.h
@@ -63,11 +63,7 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(DiscreteCurvatureQuadEdgeMeshFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputIsFloatingPointCheck, (Concept::IsFloatingPoint<OutputCurvatureType>));
-  // End concept checking
-#endif
 
 protected:
   DiscreteCurvatureQuadEdgeMeshFilter()

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteCurvatureTensorQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteCurvatureTensorQuadEdgeMeshFilter.h
@@ -47,12 +47,8 @@ public:
   /** New macro for creation of through a Smart Pointer   */
   itkNewMacro(Self);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-//  itkConceptMacro( OutputIsFloatingPointCheck,
-//                   ( Concept::IsFloatingPoint< OutputCurvatureType > ) );
-// End concept checking
-#endif
+  // itkConceptMacro( OutputIsFloatingPointCheck,
+  //                  ( Concept::IsFloatingPoint< OutputCurvatureType > ) );
 
 protected:
   DiscreteCurvatureTensorQuadEdgeMeshFilter() = default;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteGaussianCurvatureQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteGaussianCurvatureQuadEdgeMeshFilter.h
@@ -69,11 +69,7 @@ public:
   /** New macro for creation of through a Smart Pointer   */
   itkNewMacro(Self);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputIsFloatingPointCheck, (Concept::IsFloatingPoint<OutputCurvatureType>));
-  // End concept checking
-#endif
 
 protected:
   DiscreteGaussianCurvatureQuadEdgeMeshFilter() = default;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteMaximumCurvatureQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteMaximumCurvatureQuadEdgeMeshFilter.h
@@ -65,11 +65,7 @@ public:
   /** New macro for creation of through a Smart Pointer   */
   itkNewMacro(Self);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputIsFloatingPointCheck, (Concept::IsFloatingPoint<OutputCurvatureType>));
-  // End concept checking
-#endif
 
 protected:
   DiscreteMaximumCurvatureQuadEdgeMeshFilter() = default;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteMeanCurvatureQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteMeanCurvatureQuadEdgeMeshFilter.h
@@ -70,11 +70,7 @@ public:
 
   using CoefficientType = ConformalMatrixCoefficients<OutputMeshType>;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputIsFloatingPointCheck, (Concept::IsFloatingPoint<OutputCurvatureType>));
-  // End concept checking
-#endif
 
 protected:
   DiscreteMeanCurvatureQuadEdgeMeshFilter() = default;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteMinimumCurvatureQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteMinimumCurvatureQuadEdgeMeshFilter.h
@@ -65,11 +65,7 @@ public:
   /** New macro for creation of through a Smart Pointer   */
   itkNewMacro(Self);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputIsFloatingPointCheck, (Concept::IsFloatingPoint<OutputCurvatureType>));
-  // End concept checking
-#endif
 
 protected:
   DiscreteMinimumCurvatureQuadEdgeMeshFilter() = default;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscretePrincipalCurvaturesQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscretePrincipalCurvaturesQuadEdgeMeshFilter.h
@@ -64,11 +64,7 @@ public:
 
   using CoefficientType = ConformalMatrixCoefficients<OutputMeshType>;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputIsFloatingPointCheck, (Concept::IsFloatingPoint<OutputCurvatureType>));
-  // End concept checking
-#endif
 
 protected:
   DiscretePrincipalCurvaturesQuadEdgeMeshFilter()

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.h
@@ -193,10 +193,8 @@ public:
   itkSetEnumMacro(AreaComputationType, AreaEnum);
   itkGetMacro(AreaComputationType, AreaEnum);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   itkConceptMacro(SameDimensionCheck1, (Concept::SameDimension<InputPointDimension, OutputPointDimension>));
   itkConceptMacro(SameDimensionCheck2, (Concept::SameDimension<InputPointDimension, 3>));
-#endif
 
 protected:
   /** Default constructor*/

--- a/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.h
@@ -92,13 +92,9 @@ public:
   void
   GenerateInputRequestedRegion() override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<Self::NDimensions, Self::NOutputDimensions>));
   itkConceptMacro(InputConvertibleToDoubleCheck, (Concept::Convertible<typename TInputImage::PixelType, double>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, PixelType>));
-  // End concept checking
-#endif
 
 protected:
   BinomialBlurImageFilter();

--- a/Modules/Filtering/Smoothing/include/itkBoxMeanImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkBoxMeanImageFilter.h
@@ -71,12 +71,7 @@ public:
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimension, (Concept::SameDimension<Self::InputImageDimension, Self::OutputImageDimension>));
-
-  // End concept checking
-#endif
 
 protected:
   BoxMeanImageFilter();

--- a/Modules/Filtering/Smoothing/include/itkBoxSigmaImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkBoxSigmaImageFilter.h
@@ -69,12 +69,7 @@ public:
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimension, (Concept::SameDimension<Self::InputImageDimension, Self::OutputImageDimension>));
-
-  // End concept checking
-#endif
 
 protected:
   BoxSigmaImageFilter();

--- a/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.h
@@ -319,13 +319,7 @@ public:
   itkLegacyMacro(unsigned int GetInternalNumberOfStreamDivisions() const;)
   itkLegacyMacro(void SetInternalNumberOfStreamDivisions(unsigned int);)
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputPixelValueType>));
-
-  // End concept checking
-#endif
 
 protected:
   DiscreteGaussianImageFilter()

--- a/Modules/Filtering/Smoothing/include/itkMeanImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkMeanImageFilter.h
@@ -84,11 +84,7 @@ public:
 
   using InputSizeType = typename InputImageType::SizeType;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   MeanImageFilter();

--- a/Modules/Filtering/Smoothing/include/itkMedianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkMedianImageFilter.h
@@ -84,13 +84,9 @@ public:
 
   using InputSizeType = typename InputImageType::SizeType;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputPixelType, OutputPixelType>));
   itkConceptMacro(InputLessThanComparableCheck, (Concept::LessThanComparable<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   MedianImageFilter();

--- a/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.h
@@ -138,13 +138,9 @@ public:
   bool
   CanRunInPlace() const override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   // This concept does not work with variable length vector images
   // itkConceptMacro( InputHasNumericTraitsCheck,
   //( Concept::HasNumericTraits< PixelType > ) );
-  // End concept checking
-#endif
 
 protected:
   SmoothingRecursiveGaussianImageFilter();

--- a/Modules/Filtering/Thresholding/include/itkBinaryThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkBinaryThresholdImageFilter.h
@@ -208,14 +208,10 @@ public:
   virtual const InputPixelObjectType *
   GetLowerThresholdInput() const;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<OutputPixelType>));
   itkConceptMacro(InputPixelTypeComparable, (Concept::Comparable<InputPixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputPixelType>));
   itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   BinaryThresholdImageFilter();

--- a/Modules/Filtering/Thresholding/include/itkBinaryThresholdProjectionImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkBinaryThresholdProjectionImageFilter.h
@@ -140,12 +140,8 @@ public:
   itkSetMacro(ThresholdValue, InputPixelType);
   itkGetConstMacro(ThresholdValue, InputPixelType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputPixelTypeGreaterThanComparable, (Concept::GreaterThanComparable<InputPixelType>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   BinaryThresholdProjectionImageFilter()

--- a/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.h
@@ -181,13 +181,9 @@ public:
   itkSetObjectMacro(Calculator, CalculatorType);
   itkGetModifiableObjectMacro(Calculator, CalculatorType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<OutputPixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputPixelType>));
   itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   HistogramThresholdImageFilter();

--- a/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageFilter.h
@@ -107,12 +107,8 @@ public:
   itkSetMacro(NumberOfIterations, unsigned int);
   itkGetConstMacro(NumberOfIterations, unsigned int);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputComparableCheck, (Concept::Comparable<OutputPixelType>));
   itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<OutputPixelType>));
-  // End concept checking
-#endif
 
   /** Set the mask image */
   void

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.h
@@ -130,12 +130,8 @@ public:
     return m_Thresholds;
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputComparableCheck, (Concept::Comparable<OutputPixelType>));
   itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   OtsuMultipleThresholdsImageFilter();

--- a/Modules/Filtering/Thresholding/include/itkThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkThresholdImageFilter.h
@@ -89,12 +89,8 @@ public:
   using PixelType = typename TImage::PixelType;
 
   /** The pixel type must support comparison operators. */
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(PixelTypeComparableCheck, (Concept::Comparable<PixelType>));
   itkConceptMacro(PixelTypeOStreamWritableCheck, (Concept::OStreamWritable<PixelType>));
-  // End concept checking
-#endif
 
   /** Set the "outside" pixel value. The default value
    * PixelType{}. */

--- a/Modules/Filtering/Thresholding/include/itkThresholdLabelerImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkThresholdLabelerImageFilter.h
@@ -144,13 +144,9 @@ public:
   using RealThresholdVector = std::vector<RealThresholdType>;
 
   /** The input and output pixel types must support comparison operators. */
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(PixelTypeComparable, (Concept::Comparable<InputPixelType>));
   itkConceptMacro(OutputPixelTypeComparable, (Concept::Comparable<OutputPixelType>));
   itkConceptMacro(OutputPixelTypeOStreamWritable, (Concept::OStreamWritable<OutputPixelType>));
-  // End concept checking
-#endif
 
   /** Set the vector of thresholds. */
   void

--- a/Modules/Nonunit/Review/include/itkGridForwardWarpImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkGridForwardWarpImageFilter.h
@@ -105,13 +105,9 @@ public:
   /** Get the foreground value */
   itkGetConstMacro(ForegroundValue, PixelType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<ImageDimension, DisplacementFieldDimension>));
   itkConceptMacro(DisplacementFieldHasNumericTraitsCheck,
                   (Concept::HasNumericTraits<typename TDisplacementField::PixelType::ValueType>));
-  // End concept checking
-#endif
 
 protected:
   GridForwardWarpImageFilter();

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
@@ -489,11 +489,7 @@ public:
   TIntensityImage *
   GetOrientedIntensityImage(LabelPixelType label) const;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<PixelType>));
-  // End concept checking
-#endif
 
 protected:
   LabelGeometryImageFilter();

--- a/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.h
@@ -170,13 +170,9 @@ public:
   void
   SetFunctionCount(const IdCellType & n);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputTimesDoubleCheck, (Concept::MultiplyOperator<OutputPixelType, double>));
   itkConceptMacro(OutputAdditiveOperatorsCheck, (Concept::AdditiveOperators<OutputPixelType>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<FeaturePixelType, OutputPixelType>));
-  // End concept checking
-#endif
 
   itkSetMacro(ReinitializeCounter, unsigned int);
   itkGetMacro(ReinitializeCounter, unsigned int);

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.h
@@ -304,13 +304,9 @@ public:
     }
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<typename TOutputImage::PixelType>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
   itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   MultiphaseSparseFiniteDifferenceImageFilter();

--- a/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdImageFilter.h
@@ -111,12 +111,8 @@ public:
   itkSetMacro(Pow, double);
   itkGetConstMacro(Pow, double);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputComparableCheck, (Concept::Comparable<OutputPixelType>));
   itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<OutputPixelType>));
-  // End concept checking
-#endif
 
   /** Set the gradient image */
   void

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseDenseLevelSetImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseDenseLevelSetImageFilter.h
@@ -107,11 +107,7 @@ public:
   using ROIFilterType = RegionOfInterestImageFilter<FeatureImageType, FeatureImageType>;
   using ROIFilterPointer = typename ROIFilterType::Pointer;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputPixelType>));
-  // End concept checking
-#endif
 
   /** Set/Get the feature image to be used for speed function of the level set
    *  equation.  Equivalent to calling Set/GetInput(1, ..) */

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseSparseLevelSetImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseSparseLevelSetImageFilter.h
@@ -117,11 +117,7 @@ public:
   using ROIFilterType = RegionOfInterestImageFilter<FeatureImageType, FeatureImageType>;
   using ROIFilterPointer = typename ROIFilterType::Pointer;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputPixelType>));
-  // End concept checking
-#endif
 
   /** Set/Get the feature image to be used for speed function of the level set
    *  equation.  Equivalent to calling Set/GetInput(1, ..) */

--- a/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.h
+++ b/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.h
@@ -127,11 +127,7 @@ public:
   DataObject::Pointer
   MakeOutput(DataObjectPointerArraySizeType idx) override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(VectorComponentHasNumericTraitsCheck, (Concept::HasNumericTraits<VectorComponentType>));
-  // End concept checking
-#endif
 
 protected:
   EigenAnalysis2DImageFilter();

--- a/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.h
+++ b/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.h
@@ -82,12 +82,8 @@ public:
   using ElementBaseType = itk::fem::Element;
   using ElementBasePointerType = itk::fem::Element::ConstPointer;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-//  itkConceptMacro(SameDimensionOrMinusOne,
-//    (Concept::SameDimensionOrMinusOne<VDimension, 3>));
-// End concept checking
-#endif
+  // itkConceptMacro(SameDimensionOrMinusOne,
+  //   (Concept::SameDimensionOrMinusOne<VDimension, 3>));
 
   /**Get/Set the number of voxels/pixels in each dimension used
    *during the mesh generation

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.h
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.h
@@ -213,12 +213,8 @@ public:
   itkGetConstMacro(UseShrinkImageFilter, bool);
   itkBooleanMacro(UseShrinkImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<ImageDimension, OutputImageDimension>));
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   MultiResolutionPyramidImageFilter();

--- a/Modules/Registration/FEM/include/itkPhysicsBasedNonRigidRegistrationMethod.h
+++ b/Modules/Registration/FEM/include/itkPhysicsBasedNonRigidRegistrationMethod.h
@@ -142,8 +142,6 @@ public:
   /** get FEMFilter */
   itkGetConstObjectMacro(FEMFilter, FEMFilterType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   /* Currently only the 3D implementation is available due to a narrow
      definition of the filter in the original proposal
      and lack of available resources. */
@@ -153,8 +151,6 @@ public:
   itkConceptMacro(MeshDimensionShouldBe3, (Concept::SameDimension<TMesh::PointType::PointDimension, 3u>));
   itkConceptMacro(DeformationFieldImageDimensionShouldBe3,
                   (Concept::SameDimension<TDeformationField::ImageDimension, 3u>));
-  // End concept checking
-#endif
 
 protected:
   PhysicsBasedNonRigidRegistrationMethod();

--- a/Modules/Registration/Metricsv4/include/itkDefaultImageToImageMetricTraitsv4.h
+++ b/Modules/Registration/Metricsv4/include/itkDefaultImageToImageMetricTraitsv4.h
@@ -106,13 +106,11 @@ public:
   using DefaultMovingImageGradientCalculator =
     CentralDifferenceImageFunction<MovingImageType, CoordinateRepresentationType>;
 
-/** Only floating-point images are currently supported. To support integer images,
- * several small changes must be made to use an internal floating-point type for
- * computations rather than the image pixel type itself. */
-#ifdef ITK_USE_CONCEPT_CHECKING
+  /** Only floating-point images are currently supported. To support integer images,
+   * several small changes must be made to use an internal floating-point type for
+   * computations rather than the image pixel type itself. */
   itkConceptMacro(OnlyDefinedForFloatingPointTypes0, (itk::Concept::IsFloatingPoint<FixedRealType>));
   itkConceptMacro(OnlyDefinedForFloatingPointTypes1, (itk::Concept::IsFloatingPoint<MovingRealType>));
-#endif // ITK_USE_CONCEPT_CHECKING
 };
 } // end namespace itk
 

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
@@ -865,14 +865,12 @@ private:
   /** Flag to know if derivative should be calculated */
   mutable bool m_ComputeDerivative{};
 
-/** Only floating-point images are currently supported. To support integer images,
- * several small changes must be made */
-#ifdef ITK_USE_CONCEPT_CHECKING
+  /** Only floating-point images are currently supported. To support integer images,
+   * several small changes must be made */
   using FixedImagePixelValueType = typename PixelTraits<FixedImagePixelType>::ValueType;
   using MovingImagePixelValueType = typename PixelTraits<MovingImagePixelType>::ValueType;
   itkConceptMacro(OnlyDefinedForFloatingPointTypes0, (itk::Concept::IsFloatingPoint<FixedImagePixelValueType>));
   itkConceptMacro(OnlyDefinedForFloatingPointTypes1, (itk::Concept::IsFloatingPoint<MovingImagePixelValueType>));
-#endif // ITK_USE_CONCEPT_CHECKING
 };
 } // namespace itk
 

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.h
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.h
@@ -179,8 +179,6 @@ public:
   DataObjectPointer
   MakeOutput(DataObjectPointerArraySizeType idx) override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(UnsignedIntConvertibleToLabelsCheck, (Concept::Convertible<unsigned int, TLabelsType>));
   itkConceptMacro(PosteriorsAdditiveOperatorsCheck, (Concept::AdditiveOperators<TPosteriorsPrecisionType>));
   itkConceptMacro(IntConvertibleToPosteriorsCheck, (Concept::Convertible<int, TPosteriorsPrecisionType>));
@@ -190,8 +188,6 @@ public:
   itkConceptMacro(
     InputPriorsPosteriorsMultiplyOperatorCheck,
     (Concept::MultiplyOperator<typename InputPixelType::ValueType, PriorsPixelType, PosteriorsPixelType>));
-  // End concept checking
-#endif
 
 protected:
   BayesianClassifierImageFilter();

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.h
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.h
@@ -141,15 +141,11 @@ public:
   void
   GenerateOutputInformation() override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputMultiplyOperatorCheck, (Concept::MultiplyOperator<InputPixelType>));
   itkConceptMacro(DoubleConvertibleToProbabilityCheck, (Concept::Convertible<double, TProbabilityPrecisionType>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
   itkConceptMacro(ProbabilityHasNumericTraitsCheck, (Concept::HasNumericTraits<TProbabilityPrecisionType>));
   itkConceptMacro(DoublePlusInputCheck, (Concept::AdditiveOperators<double, InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   BayesianClassifierInitializationImageFilter();

--- a/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.h
+++ b/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.h
@@ -144,11 +144,7 @@ public:
   /** Get the region over which the statistics will be computed */
   itkGetConstReferenceMacro(ImageRegion, ImageRegionType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   ScalarImageKmeansImageFilter();

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.h
@@ -137,8 +137,6 @@ public:
     this->Modified();
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, ImageDimension>));
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputPixelType>));
   itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<OutputPixelType>));
@@ -147,8 +145,6 @@ public:
   itkConceptMacro(OutputConvertibleToLongCheck, (Concept::Convertible<OutputPixelType, long>));
   itkConceptMacro(UnsignedLongConvertibleToOutputCheck, (Concept::Convertible<unsigned long, OutputPixelType>));
   itkConceptMacro(OutputIncrementDecrementOperatorsCheck, (Concept::IncrementDecrementOperators<OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   ConnectedComponentFunctorImageFilter() = default;

--- a/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.h
@@ -97,16 +97,12 @@ public:
     m_Seeds.push_front(seed);
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, ImageDimension>));
   itkConceptMacro(IntConvertibleToOutputCheck, (Concept::Convertible<int, OutputPixelType>));
   itkConceptMacro(UnsignedShortConvertibleToOutputCheck, (Concept::Convertible<unsigned short, OutputPixelType>));
   itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<OutputPixelType>));
   itkConceptMacro(UnsignedCharConvertibleToOutputCheck, (Concept::Convertible<unsigned char, OutputPixelType>));
   itkConceptMacro(OutputIncrementDecrementOperatorsCheck, (Concept::IncrementDecrementOperators<OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   HardConnectedComponentImageFilter() = default;

--- a/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.h
@@ -231,15 +231,11 @@ public:
     return 0;
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputPixelType>));
   itkConceptMacro(UnsignedLongConvertibleToInputCheck, (Concept::Convertible<LabelType, InputPixelType>));
   itkConceptMacro(OutputLongConvertibleToUnsignedLongCheck, (Concept::Convertible<OutputPixelType, LabelType>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputPixelType, OutputPixelType>));
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, ImageDimension>));
-  // End concept checking
-#endif
 
 protected:
   RelabelComponentImageFilter();

--- a/Modules/Segmentation/ConnectedComponents/include/itkScalarConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkScalarConnectedComponentImageFilter.h
@@ -138,15 +138,11 @@ public:
     return (this->GetFunctor().GetDistanceThreshold());
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputPixelType>));
   itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<typename TOutputImage::PixelType>));
   itkConceptMacro(MaskEqualityComparableCheck, (Concept::EqualityComparable<typename TMaskImage::PixelType>));
   itkConceptMacro(OutputIncrementDecrementOperatorsCheck,
                   (Concept::IncrementDecrementOperators<typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   ScalarConnectedComponentImageFilter() = default;

--- a/Modules/Segmentation/ConnectedComponents/include/itkVectorConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkVectorConnectedComponentImageFilter.h
@@ -141,12 +141,8 @@ public:
     return (this->GetFunctor().GetDistanceThreshold());
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputValueHasNumericTraitsCheck, (Concept::HasNumericTraits<InputValueType>));
   itkConceptMacro(InputValyeTypeIsFloatingCheck, (Concept::IsFloatingPoint<InputValueType>));
-  // End concept checking
-#endif
 
 protected:
   VectorConnectedComponentImageFilter() = default;

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.h
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.h
@@ -285,17 +285,13 @@ public:
   void
   PrintAlgorithmBorderStats();
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<typename InputImagePixelType::ValueType>));
   itkConceptMacro(SameDimension, (Concept::SameDimension<Self::InputImageDimension, Self::OutputImageDimension>));
-#  if defined(THIS_CONCEPT_FAILS_ON_GCC)
+#if defined(THIS_CONCEPT_FAILS_ON_GCC)
   /** The input pixel type must be the same as that of the output image. */
   itkConceptMacro(SameVectorDimension,
                   (Concept::SameDimension<Self::InputImageVectorDimension, Self::OutputImageVectorDimension>));
-#  endif
-  // End concept checking
-#endif
+#endif // end THIS_CONCEPT_FAILS_ON_GCC
 
 protected:
   KLMRegionGrowImageFilter();

--- a/Modules/Segmentation/LabelVoting/include/itkBinaryMedianImageFilter.h
+++ b/Modules/Segmentation/LabelVoting/include/itkBinaryMedianImageFilter.h
@@ -106,15 +106,11 @@ public:
   void
   GenerateInputRequestedRegion() override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<typename TInputImage::PixelType>));
   itkConceptMacro(InputConvertibleToOutputCheck,
                   (Concept::Convertible<typename TInputImage::PixelType, typename TOutputImage::PixelType>));
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<typename TInputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   BinaryMedianImageFilter();

--- a/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.h
+++ b/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.h
@@ -144,8 +144,6 @@ public:
     }
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputPixelType, OutputPixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputPixelType>));
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, ImageDimension>));
@@ -154,8 +152,6 @@ public:
   itkConceptMacro(InputPlusIntCheck, (Concept::AdditiveOperators<InputPixelType, int>));
   itkConceptMacro(InputIncrementDecrementOperatorsCheck, (Concept::IncrementDecrementOperators<InputPixelType>));
   itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   LabelVotingImageFilter();

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryHoleFillingImageFilter.h
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryHoleFillingImageFilter.h
@@ -86,12 +86,8 @@ public:
   /** Returns the number of pixels that changed when the filter was executed. */
   itkGetConstReferenceMacro(NumberOfPixelsChanged, SizeValueType);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputPixelType>));
   itkConceptMacro(UnsignedIntConvertibleToInputCheck, (Concept::Convertible<unsigned int, InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   VotingBinaryHoleFillingImageFilter();

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.h
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.h
@@ -106,15 +106,11 @@ public:
   void
   GenerateInputRequestedRegion() override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputPixelType>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputPixelType>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputPixelType, OutputPixelType>));
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   VotingBinaryImageFilter();

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryIterativeHoleFillingImageFilter.h
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryIterativeHoleFillingImageFilter.h
@@ -127,12 +127,8 @@ public:
   /** Returns the number of pixels that changed when the filter was executed. */
   itkGetConstReferenceMacro(NumberOfPixelsChanged, unsigned int);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputPixelType>));
   itkConceptMacro(InputOStreamWritableeCheck, (Concept::OStreamWritable<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   VotingBinaryIterativeHoleFillingImageFilter();

--- a/Modules/Segmentation/LevelSets/include/itkCannySegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkCannySegmentationLevelSetImageFilter.h
@@ -191,11 +191,7 @@ public:
     return this->m_CannyFunction->GetCannyImage();
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<TOutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   ~CannySegmentationLevelSetImageFilter() override = default;

--- a/Modules/Segmentation/LevelSets/include/itkCollidingFrontsImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkCollidingFrontsImageFilter.h
@@ -151,11 +151,7 @@ public:
   itkGetConstMacro(StopOnTargets, bool);
   itkBooleanMacro(StopOnTargets);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   CollidingFrontsImageFilter();

--- a/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetImageFilter.h
@@ -140,11 +140,7 @@ public:
     return m_CurvesFunction->GetDerivativeSigma();
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<TOutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   ~CurvesLevelSetImageFilter() override = default;

--- a/Modules/Segmentation/LevelSets/include/itkExtensionVelocitiesImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkExtensionVelocitiesImageFilter.h
@@ -99,12 +99,8 @@ public:
   AuxImageType *
   GetOutputVelocityImage(unsigned int idx = 0);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(AuxValueHasNumericTraitsCheck, (Concept::HasNumericTraits<TAuxValue>));
   itkConceptMacro(LevelSetOStreamWritableCheck, (Concept::OStreamWritable<PixelType>));
-  // End concept checking
-#endif
 
 protected:
   ExtensionVelocitiesImageFilter();

--- a/Modules/Segmentation/LevelSets/include/itkNarrowBandCurvesLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkNarrowBandCurvesLevelSetImageFilter.h
@@ -145,11 +145,7 @@ public:
     return m_CurvesFunction->GetDerivativeSigma();
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<TOutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   ~NarrowBandCurvesLevelSetImageFilter() override = default;

--- a/Modules/Segmentation/LevelSets/include/itkNarrowBandLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkNarrowBandLevelSetImageFilter.h
@@ -373,11 +373,7 @@ public:
                     "error value will not be set or used.");
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   ~NarrowBandLevelSetImageFilter() override = default;

--- a/Modules/Segmentation/LevelSets/include/itkNarrowBandThresholdSegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkNarrowBandThresholdSegmentationLevelSetImageFilter.h
@@ -203,11 +203,7 @@ public:
     return m_ThresholdFunction->GetSmoothingConductance();
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<TOutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   ~NarrowBandThresholdSegmentationLevelSetImageFilter() override = default;

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.h
@@ -337,13 +337,9 @@ public:
     return m_Data[ThreadNum].m_Layers[0];
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<PixelType>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, PixelType>));
   itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<PixelType>));
-  // End concept checking
-#endif
 
 protected:
   ParallelSparseFieldLevelSetImageFilter();

--- a/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.h
@@ -127,12 +127,8 @@ public:
     return m_OutputNarrowBand;
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(LevelSetDoubleAdditiveOperatorsCheck, (Concept::AdditiveOperators<PixelType, double>));
   itkConceptMacro(LevelSetOStreamWritableCheck, (Concept::OStreamWritable<PixelType>));
-  // End concept checking
-#endif
 
 protected:
   ReinitializeLevelSetImageFilter();

--- a/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.h
@@ -502,11 +502,7 @@ public:
   void
   GenerateAdvectionImage();
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<TOutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   ~SegmentationLevelSetImageFilter() override = default;

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.h
@@ -271,11 +271,7 @@ public:
     ++m_RefitIteration;
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<ValueType>));
-  // End concept checking
-#endif
 
 protected:
   SparseFieldFourthOrderLevelSetImageFilter();

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.h
@@ -332,13 +332,9 @@ public:
     this->SetInterpolateSurfaceLocation(false);
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<typename TOutputImage::PixelType>));
   itkConceptMacro(DoubleConvertibleToOutputCheck, (Concept::Convertible<double, typename TOutputImage::PixelType>));
   itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   SparseFieldLevelSetImageFilter();

--- a/Modules/Segmentation/LevelSetsv4/include/itkWhitakerSparseLevelSetImage.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkWhitakerSparseLevelSetImage.h
@@ -87,13 +87,7 @@ public:
   OutputType
   Evaluate(const InputType & inputIndex) const override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
-
   itkConceptMacro(DoubleConvertible, (Concept::Convertible<OutputRealType, OutputType>));
-
-  // End concept checking
-#endif // ITK_USE_CONCEPT_CHECKING
 
   static inline LayerIdType
   MinusThreeLayer()

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.h
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.h
@@ -324,8 +324,6 @@ public:
   /* Get macro for number of iterations */
   itkGetConstReferenceMacro(NumberOfIterations, unsigned int);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(UnsignedIntConvertibleToClassifiedCheck,
                   (Concept::Convertible<unsigned int, LabelledImagePixelType>));
   itkConceptMacro(ClassifiedConvertibleToUnsignedIntCheck,
@@ -333,8 +331,6 @@ public:
   itkConceptMacro(ClassifiedConvertibleToIntCheck, (Concept::Convertible<LabelledImagePixelType, int>));
   itkConceptMacro(IntConvertibleToClassifiedCheck, (Concept::Convertible<int, LabelledImagePixelType>));
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, ClassifiedImageDimension>));
-  // End concept checking
-#endif
 
 protected:
   MRFImageFilter();

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.h
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.h
@@ -227,14 +227,10 @@ protected:
   virtual void
   ApplyGPImageFilter();
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(
     SameDimension,
     (Concept::SameDimension<Self::InputImageType::ImageDimension, Self::ClassifiedImageType::ImageDimension>));
   itkConceptMacro(DimensionShouldBe3, (Concept::SameDimension<Self::InputImageType::ImageDimension, 3>));
-  // End concept checking
-#endif
 
 private:
   using InputImageSizeType = typename TInputImage::SizeType;

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.h
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.h
@@ -141,12 +141,8 @@ public:
   virtual const SeedsContainerType &
   GetSeeds() const;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputImagePixelType>));
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   ConfidenceConnectedImageFilter();

--- a/Modules/Segmentation/RegionGrowing/include/itkConnectedThresholdImageFilter.h
+++ b/Modules/Segmentation/RegionGrowing/include/itkConnectedThresholdImageFilter.h
@@ -149,16 +149,12 @@ public:
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<OutputImagePixelType>));
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(InputConvertibleToOutputCheck, (Concept::Convertible<InputImagePixelType, OutputImagePixelType>));
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
   itkConceptMacro(IntConvertibleToInputCheck, (Concept::Convertible<int, InputImagePixelType>));
   itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<OutputImagePixelType>));
-  // End concept checking
-#endif
 
   using ConnectivityEnum = ConnectedThresholdImageFilterEnums::Connectivity;
 #if !defined(ITK_LEGACY_REMOVE)

--- a/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.h
+++ b/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.h
@@ -199,11 +199,7 @@ public:
    * threshold. */
   itkGetConstReferenceMacro(ThresholdingFailed, bool);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   IsolatedConnectedImageFilter();

--- a/Modules/Segmentation/RegionGrowing/include/itkNeighborhoodConnectedImageFilter.h
+++ b/Modules/Segmentation/RegionGrowing/include/itkNeighborhoodConnectedImageFilter.h
@@ -103,15 +103,11 @@ public:
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<InputImagePixelType>));
   itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<OutputImagePixelType>));
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
   itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<OutputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   NeighborhoodConnectedImageFilter();

--- a/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.h
+++ b/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.h
@@ -140,14 +140,9 @@ public:
   virtual const SeedsContainerType &
   GetSeeds() const;
 
-
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(OutputEqualityComparableCheck, (Concept::EqualityComparable<OutputImagePixelType>));
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<typename InputImagePixelType::ValueType>));
   itkConceptMacro(OutputOStreamWritableCheck, (Concept::OStreamWritable<OutputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   VectorConfidenceConnectedImageFilter();

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.h
@@ -82,12 +82,8 @@ public:
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
   itkConceptMacro(IntConvertibleToOutputCheck, (Concept::Convertible<int, OutputPixelType>));
-  // End concept checking
-#endif
 
 protected:
   VoronoiPartitioningImageFilter() = default;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.h
@@ -114,12 +114,8 @@ public:
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
   itkConceptMacro(IntConvertibleToOutputCheck, (Concept::Convertible<int, typename TOutputImage::PixelType>));
-  // End concept checking
-#endif
 
 protected:
   VoronoiSegmentationImageFilter() = default;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.h
@@ -204,13 +204,9 @@ public:
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<InputImageDimension, OutputImageDimension>));
   itkConceptMacro(IntConvertibleToOutputCheck, (Concept::Convertible<int, typename TOutputImage::PixelType>));
   itkConceptMacro(PixelDimensionCheck, (Concept::SameDimension<PixelType::Dimension, 3u>));
-  // End concept checking
-#endif
 
 protected:
   VoronoiSegmentationRGBImageFilter();

--- a/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.h
+++ b/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.h
@@ -101,12 +101,8 @@ public:
   /** Neighborhood iterator type */
   using NeighborhoodIteratorType = ConstNeighborhoodIterator<Image<float, 2>>;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(LessThanComparableCheck, (Concept::LessThanComparable<InputImagePixelType>));
   itkConceptMacro(OStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
-  // End concept checking
-#endif
 
 protected:
   TobogganImageFilter() = default;

--- a/Modules/Segmentation/Watersheds/include/itkWatershedImageFilter.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedImageFilter.h
@@ -252,14 +252,10 @@ public:
   void
   EnlargeOutputRequestedRegion(DataObject * data) override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(InputEqualityComparableCheck, (Concept::EqualityComparable<ScalarType>));
   itkConceptMacro(InputAdditiveOperatorsCheck, (Concept::AdditiveOperators<ScalarType>));
   itkConceptMacro(DoubleInputMultiplyOperatorCheck, (Concept::MultiplyOperator<double, ScalarType, ScalarType>));
   itkConceptMacro(InputLessThanComparableCheck, (Concept::LessThanComparable<ScalarType>));
-  // End concept checking
-#endif
 
 protected:
   WatershedImageFilter();

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVBasicTypeBridge.h
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVBasicTypeBridge.h
@@ -61,10 +61,7 @@ struct OpenCVBasicTypeBridge<TPoint, cv::Point_<typename TPoint::CoordinateType>
     return OpenCVDataType(iP[0], iP[1]);
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<TPoint::PointDimension, 2>));
-#endif
 };
 
 template <typename TPoint>
@@ -91,10 +88,7 @@ struct OpenCVBasicTypeBridge<TPoint, cv::Point3_<typename TPoint::CoordinateType
     return OpenCVDataType(iP[0], iP[1], iP[2]);
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
-  // Begin concept checking
   itkConceptMacro(SameDimensionCheck, (Concept::SameDimension<TPoint::PointDimension, 3>));
-#endif
 };
 
 template <>

--- a/Utilities/Doxygen/DoxygenConfig.cmake
+++ b/Utilities/Doxygen/DoxygenConfig.cmake
@@ -148,7 +148,6 @@ set(DOXYGEN_PREDEFINED
     "size_t=vcl_size_t"
     "ITK_USE_FFTWD"
     "ITK_USE_FFTWF"
-    "ITK_USE_CONCEPT_CHECKING"
     "itkMacro_h"
     "ITK_LEGACY_REMOVE"
     "ITK_FUTURE_LEGACY_REMOVE"

--- a/Wrapping/DoxygenConfig.cmake
+++ b/Wrapping/DoxygenConfig.cmake
@@ -142,7 +142,6 @@ set(DOXYGEN_PREDEFINED
     "size_t=vcl_size_t"
     "ITK_USE_FFTWD"
     "ITK_USE_FFTWF"
-    "ITK_USE_CONCEPT_CHECKING"
     "itkMacro_h"
     "ITK_LEGACY_REMOVE"
     "ITK_FUTURE_LEGACY_REMOVE"


### PR DESCRIPTION
Resolves https://github.com/InsightSoftwareConsortium/ITK/issues/3775. These changes remove the `ITK_USE_CONCEPT_CHECKING` option in favor of always performing concept checking, since this option has been enabled by default for a while now.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)


