### PR TITLE
BUG: Initialize miscellaneous local variables

### DIFF
--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
@@ -283,9 +283,9 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::DynamicThreadedG
 
   // iterator for the output image
   ImageRegionIteratorWithIndex<OutputImageType> outputIt(outputPtr, outputRegionForThread);
-  IndexType                                     index;
-  PointType                                     point;
-  DisplacementType                              displacement;
+  IndexType                                     index{};
+  PointType                                     point{};
+  DisplacementType                              displacement{};
   NumericTraits<DisplacementType>::SetLength(displacement, ImageDimension);
   static_assert(PointType::Dimension == ImageDimension, "ERROR: Point type and ImageDimension must be the same!");
   if (this->m_DefFieldSameInformation)

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
@@ -171,7 +171,7 @@ ESMDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Co
   const FloatOffsetType &  itkNotUsed(offset)) -> PixelType
 {
   auto *    globalData = (GlobalDataStruct *)gd;
-  PixelType update;
+  PixelType update{};
   IndexType FirstIndex = this->GetFixedImage()->GetLargestPossibleRegion().GetIndex();
   IndexType LastIndex = this->GetFixedImage()->GetLargestPossibleRegion().GetIndex() +
                         this->GetFixedImage()->GetLargestPossibleRegion().GetSize();
@@ -190,7 +190,6 @@ ESMDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Co
 
   if (movingPixValue == NumericTraits<MovingPixelType>::max())
   {
-    update.Fill(0.0);
     return update;
   }
 
@@ -324,7 +323,7 @@ ESMDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Co
   }
   else if (this->m_UseGradientType == GradientEnum::MappedMoving)
   {
-    PointType mappedPoint;
+    PointType mappedPoint{};
     this->GetFixedImage()->TransformIndexToPhysicalPoint(index, mappedPoint);
     for (unsigned int j = 0; j < ImageDimension; ++j)
     {
@@ -352,11 +351,7 @@ ESMDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Co
   const double usedGradientTimes2SquaredMagnitude = usedGradientTimes2.GetSquaredNorm();
 
   const double speedValue = fixedValue - movingValue;
-  if (itk::Math::abs(speedValue) < m_IntensityDifferenceThreshold)
-  {
-    update.Fill(0.0);
-  }
-  else
+  if (itk::Math::abs(speedValue) >= m_IntensityDifferenceThreshold)
   {
     double denom;
     if (m_Normalizer > 0.0)
@@ -370,11 +365,7 @@ ESMDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Co
       denom = usedGradientTimes2SquaredMagnitude;
     }
 
-    if (denom < m_DenominatorThreshold)
-    {
-      update.Fill(0.0);
-    }
-    else
+    if (denom >= m_DenominatorThreshold)
     {
       const double factor = 2.0 * speedValue / denom;
 


### PR DESCRIPTION
Initialize miscellaneous local variables to avoid undefined behavior.

Fixes:
```
Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx:308:18:
warning: iteration 2 invokes undefined behavior [-Waggressive-loop-optimizations]
  308 |         point[j] += displacement[j];
      |                  ^
```

and
```
Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx:338:18:
warning: iteration 2 invokes undefined behavior [-Waggressive-loop-optimizations]
  338 |         point[j] += displacement[j];
      |
```

and
```
Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx:331:22:
warning: iteration 2 invokes undefined behavior [-Waggressive-loop-optimizations]
  331 |       mappedPoint[j] += it.GetCenterPixel()[j];
      |
```

and
```
Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx:383:19:
warning: iteration 2 invokes undefined behavior [-Waggressive-loop-optimizations]
  383 |         update[j] = factor * usedGradientTimes2[j];
      |
```

raised for example in:
https://open.cdash.org/viewBuildError.php?type=1&buildid=10154210

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes]