### PR TITLE
update remote modules ITKv6 support

### DIFF
--- a/CMake/ITKConfig.cmake.in
+++ b/CMake/ITKConfig.cmake.in
@@ -115,6 +115,9 @@ set(ITK_USE_GPU "@ITK_USE_GPU@")
 set(ITK_WRAPPING "@ITK_WRAPPING@")
 # ITK_WRAP_DOC is disabled by default.
 
+# expose C++ standard used to build ITK for supporting external packages
+set(ITK_CXX_STANDARD CMAKE_CXX_STANDARD)
+
 if( NOT DEFINED ITK_WRAP_PYTHON)
   set(ITK_WRAP_PYTHON "@ITK_WRAP_PYTHON@")
 endif()

--- a/Modules/Remote/AdaptiveDenoising.remote.cmake
+++ b/Modules/Remote/AdaptiveDenoising.remote.cmake
@@ -57,5 +57,5 @@ itk_fetch_module(
   "
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/ntustison/ITKAdaptiveDenoising.git
-  GIT_TAG 9a7adca1a822589c66a176a9e093d8a9f1c222c2
+  GIT_TAG 853934c352f83cb1e8f87e3051e1b8e75dbb41fe
   )

--- a/Modules/Remote/AnalyzeObjectLabelMap.remote.cmake
+++ b/Modules/Remote/AnalyzeObjectLabelMap.remote.cmake
@@ -50,5 +50,5 @@ itk_fetch_module(
   "AnalyzeObjectLabelMap plugin for ITK. From Insight Journal article with handle: https://doi.org/10.54294/w2jytv"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/itkAnalyzeObjectMap.git
-  GIT_TAG 513b909271f6e90251d633e25c28d8b5f4becf37
+  GIT_TAG 7efc30114bb4f2985aaf2c5d261a5beebbf6e8ad
   )

--- a/Modules/Remote/AnisotropicDiffusionLBR.remote.cmake
+++ b/Modules/Remote/AnisotropicDiffusionLBR.remote.cmake
@@ -64,5 +64,5 @@ itk_fetch_module(
   "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKAnisotropicDiffusionLBR.git
-  GIT_TAG 1e4a4e9bac1f40058dd57abc7a49443d9ac6376b
+  GIT_TAG 4dbdfe9dd209c0f266a821d1cc2c2135c8057bf9
   )

--- a/Modules/Remote/BSplineGradient.remote.cmake
+++ b/Modules/Remote/BSplineGradient.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "Approximate an image's gradient from a b-spline fit to its intensity."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKBSplineGradient.git
-  GIT_TAG 73dcf827d76bbf2a36d08784d421b234fb630c80
+  GIT_TAG 6fbfee127c2c76b0fc9db08d70ba401b36f178e9
   )

--- a/Modules/Remote/BoneEnhancement.remote.cmake
+++ b/Modules/Remote/BoneEnhancement.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "Various filters for enhancing cortical bones in quantitative computed tomography."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKBoneEnhancement.git
-  GIT_TAG d6f6649c9ba0c96612d6868d161ea7c13dd34603
+  GIT_TAG 092a61644e419ca610b42d17e4d2767323ca42fa
   )

--- a/Modules/Remote/BoneMorphometry.remote.cmake
+++ b/Modules/Remote/BoneMorphometry.remote.cmake
@@ -52,5 +52,5 @@ itk_fetch_module(
   "
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKBoneMorphometry.git
-  GIT_TAG 47b8f352fb2cb7204d7a8b332847da438f268b35
+  GIT_TAG de22b4bc89eae43241cf8efe60f95af6e891b9ac
   )

--- a/Modules/Remote/Cleaver.remote.cmake
+++ b/Modules/Remote/Cleaver.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "ITK module wrapping Cleaver functionalities used for MultiMaterial Tetrahedral Meshing."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/SCIInstitute/ITKCleaver.git
-  GIT_TAG 249b2710c093a8f62c5e0cdbab728eebaba5b693
+  GIT_TAG eb4512278b0b5e0ddfc7b521b7d449bcdb72eeb3
   )

--- a/Modules/Remote/Cuberille.remote.cmake
+++ b/Modules/Remote/Cuberille.remote.cmake
@@ -68,5 +68,5 @@ And the related:
 "
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKCuberille.git
-  GIT_TAG 3b35bb2f3d8fb5ac5b1bece93f2cbd61f9208952
+  GIT_TAG 84364b1ce2f63b57f068820a300a63521e595eb1
   )

--- a/Modules/Remote/FPFH.remote.cmake
+++ b/Modules/Remote/FPFH.remote.cmake
@@ -52,5 +52,5 @@ https://github.com/InsightSoftwareConsortium/ITKFPFH
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKFPFH.git
-  GIT_TAG fc59b2e17b0417b7d4385d2b38280232eae4d449
+  GIT_TAG ce05a8a818da2b0bad926936e78c93522349c348
   )

--- a/Modules/Remote/FastBilateral.remote.cmake
+++ b/Modules/Remote/FastBilateral.remote.cmake
@@ -50,5 +50,5 @@ Insight Journal article:
 https://doi.org/10.54294/noo5vc"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKFastBilateral.git
-  GIT_TAG e37be230b50c6934b0c260c2ffec8092bf54f498
+  GIT_TAG 5aa9ad04a7d27c521634bc74d09986511055c4e0
   )

--- a/Modules/Remote/FixedPointInverseDisplacementField.remote.cmake
+++ b/Modules/Remote/FixedPointInverseDisplacementField.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "Computes the inverse of a displacement field."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKFixedPointInverseDisplacementField.git
-  GIT_TAG 6f158a7e921b02f6315311ef2e79e280a0eb83a0
+  GIT_TAG 7ad650a3abadb7a99ce139e14fab50151cdaa71d
   )

--- a/Modules/Remote/GenericLabelInterpolator.remote.cmake
+++ b/Modules/Remote/GenericLabelInterpolator.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "A generic interpolator for multi-label images."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKGenericLabelInterpolator.git
-  GIT_TAG ebf2436469ccf82c08fab54b7446f699ad0eae01
+  GIT_TAG 57b4ab6364daf746cc039b0629e6b733cb66b145
   )

--- a/Modules/Remote/GrowCut.remote.cmake
+++ b/Modules/Remote/GrowCut.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "ITKGrowCut segments a 3D image from user-provided foreground and background seeds."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKGrowCut.git
-  GIT_TAG da8597a31ae47b5a9d549ef095a32aa3bdb0d6bc
+  GIT_TAG 3d4ac3b76e99b3e0d72bf1ee5ab202cab399f725
   )

--- a/Modules/Remote/HASI.remote.cmake
+++ b/Modules/Remote/HASI.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "High-throughput Applications for Skeletal Imaging."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/KitwareMedical/HASI.git
-  GIT_TAG c736a15b2f076b36f80723af23638fb7e854b63b
+  GIT_TAG fdedee90433d2aef8b2a79ffc6dde704a2881f9e
   )

--- a/Modules/Remote/IOFDF.remote.cmake
+++ b/Modules/Remote/IOFDF.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "FDFImageIO plugin for ITK. Authors Gleen Pierce/Nick Tustison/Kent Williams"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKIOFDF.git
-  GIT_TAG 1570924e00090dccf31493f9274202455a51add4
+  GIT_TAG ec1f4e60174b0c43674bd2b57e30d0247de9ce0a
   )

--- a/Modules/Remote/IOMeshMZ3.remote.cmake
+++ b/Modules/Remote/IOMeshMZ3.remote.cmake
@@ -48,5 +48,5 @@ itk_fetch_module(
   mesh file format. https://github.com/neurolabusc/surf-ice/tree/master/mz3"
   MODULE_COMPLIANCE_LEVEL 4
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKIOMeshMZ3.git
-  GIT_TAG ea3cf602e47a361039b7ecad6a56f1ed04b2c181
+  GIT_TAG f3ee0a68f59bae46951cd1e453afd83fc2ab11ae
   )

--- a/Modules/Remote/IOMeshSWC.remote.cmake
+++ b/Modules/Remote/IOMeshSWC.remote.cmake
@@ -47,6 +47,6 @@ itk_fetch_module(
   "Read meshes from SWC files, a format for representing neuron morphology."
   MODULE_COMPLIANCE_LEVEL 4
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKIOMeshSWC.git
-  GIT_TAG 6cc788b6f677d95e0e23080d0457fede2ade2e97
+  GIT_TAG 457f94a89eb09de2fd61e2fec33511f5ff8553f4
   )
 mark_as_advanced(FORCE Module_IOMeshSWC)

--- a/Modules/Remote/IOOpenSlide.remote.cmake
+++ b/Modules/Remote/IOOpenSlide.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "ITK ImageIO for OpenSlide library supported file formats. These are generally TIFF-based microscopy formats."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKIOOpenSlide.git
-  GIT_TAG 2d7af237f872dd6f8171d2d09b843bc3cbe694a2
+  GIT_TAG db9eb2e4b6025337d72009b643d1700d51c36fe5
   )

--- a/Modules/Remote/IOScanco.remote.cmake
+++ b/Modules/Remote/IOScanco.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "An ITK module to read and write Scanco microCT .isq files."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKIOScanco.git
-  GIT_TAG 10b80f69048e79ab3069e89635822a6851099278
+  GIT_TAG 1d9ee255289d7aaaf8b321a75842f650028e2d04
   )

--- a/Modules/Remote/IsotropicWavelets.remote.cmake
+++ b/Modules/Remote/IsotropicWavelets.remote.cmake
@@ -54,5 +54,5 @@ Cerdan, P.H. \"Steerable Isotropic Wavelets for Multiscale and Phase Analysis\".
   # Upstream repository was transferred from phcerdan to InsightSoftwareConsortium
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKIsotropicWavelets.git
-  GIT_TAG 9dc0f58fdf76842b0cb88e4898da5314292c13d5
+  GIT_TAG cf178f114a3e1ce15054bbf2aea77bda43e429c5
   )

--- a/Modules/Remote/LabelErodeDilate.remote.cmake
+++ b/Modules/Remote/LabelErodeDilate.remote.cmake
@@ -54,5 +54,5 @@ itk_fetch_module(
   #UPSTREAM_GIT_REPOSITORY
   GIT_REPOSITORY
   https://github.com/InsightSoftwareConsortium/ITKLabelErodeDilate.git
-  GIT_TAG 8adf7351a5056f091ca0b061283ebcb2ba9788a4
+  GIT_TAG 8197f1484227c3bbfae93a469b61a5ad5d7e8126
   )

--- a/Modules/Remote/LesionSizingToolkit.remote.cmake
+++ b/Modules/Remote/LesionSizingToolkit.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "Framework for determining the sizes of lesions in medical images."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/LesionSizingToolkit.git
-  GIT_TAG 67a91c0cba44b35a443f6fd6e2d46695c4f7ff9c
+  GIT_TAG 648cafff857018cc01a0514e932985f6f0b5befd
   )

--- a/Modules/Remote/MGHIO.remote.cmake
+++ b/Modules/Remote/MGHIO.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "MGHIO ImageIO plugin for ITK"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/itkMGHImageIO.git
-  GIT_TAG a3a970296f72a3fa7fa496e4370fb7d2feb9311d
+  GIT_TAG 969f1827d92ddac18339e9a4d9120fea0e2bc916
   )

--- a/Modules/Remote/MeshNoise.remote.cmake
+++ b/Modules/Remote/MeshNoise.remote.cmake
@@ -51,5 +51,5 @@ itk_fetch_module(
   "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKMeshNoise.git
-  GIT_TAG 2b2ccb53f7eb0fb03034cc89ac6793e35e2427c2
+  GIT_TAG ab1c3bdd2ebeba3bf291a186cc56b1d53ccda78f
   )

--- a/Modules/Remote/MeshToPolyData.remote.cmake
+++ b/Modules/Remote/MeshToPolyData.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "Convert an ITK Mesh to a data structure compatible with vtkPolyData."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKMeshToPolyData.git
-  GIT_TAG 45454052790b9f01bc1e1baf0e9400f68a3f1363
+  GIT_TAG 7c9812527af5e061510ed5f5709da191a50e122a
   )

--- a/Modules/Remote/MinimalPathExtraction.remote.cmake
+++ b/Modules/Remote/MinimalPathExtraction.remote.cmake
@@ -48,6 +48,6 @@ itk_fetch_module(
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction.git
-  GIT_TAG e43a18f43272bea8c9de5ded7846efbffc81f0ad
+  GIT_TAG c5ea9a1da2486df25346fe4db9115664ac5e9fd9
   )
 # Release v1.2.6

--- a/Modules/Remote/MorphologicalContourInterpolation.remote.cmake
+++ b/Modules/Remote/MorphologicalContourInterpolation.remote.cmake
@@ -58,5 +58,5 @@ This work is supported by NIH grant R01 EB014346
 'Continued development and maintenance of the ITK-SNAP 3D image segmentation software'."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/KitwareMedical/ITKMorphologicalContourInterpolation.git
-  GIT_TAG 821bf9b3ef8eaaab10391ed060dc9ca5e4d37b39
+  GIT_TAG be6ef51c784f723211ab9eeed1b588cdc6d5185b
   )

--- a/Modules/Remote/PerformanceBenchmarking.remote.cmake
+++ b/Modules/Remote/PerformanceBenchmarking.remote.cmake
@@ -59,5 +59,5 @@ For more information, see::
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKPerformanceBenchmarking.git
-  GIT_TAG 6c7c21413da6c0760b86ed28513d404bb5a347de
+  GIT_TAG 3c8e8b1abdea02365e4384ae900a2afdd039b365
   )

--- a/Modules/Remote/PhaseSymmetry.remote.cmake
+++ b/Modules/Remote/PhaseSymmetry.remote.cmake
@@ -55,5 +55,5 @@ https://doi.org/10.54294/gcb82u
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/KitwareMedical/ITKPhaseSymmetry.git
-  GIT_TAG eb791a8ae9559469ec24fe4ccb49e8b8bd6c8dd3
+  GIT_TAG edbc01415b011045b99ac20c0fea95ec78b2b7b9
   )

--- a/Modules/Remote/PolarTransform.remote.cmake
+++ b/Modules/Remote/PolarTransform.remote.cmake
@@ -55,5 +55,5 @@ For more information, see the Insight Journal article:
   "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKPolarTransform.git
-  GIT_TAG 930d44ac91d2994e4d604be67714f1ffb9cd065c
+  GIT_TAG 292d5aff2aa55f1aca22638c678f335aa4be959a
   )

--- a/Modules/Remote/PrincipalComponentsAnalysis.remote.cmake
+++ b/Modules/Remote/PrincipalComponentsAnalysis.remote.cmake
@@ -52,5 +52,5 @@ A more detailed description can be found in the Insight Journal article:
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKPrincipalComponentsAnalysis.git
-  GIT_TAG 2f8d8bffb37fca8875a674465af5e3d902432f30
+  GIT_TAG 7521b75ebbe91d52e8432782fd67ef75120a6797
   )

--- a/Modules/Remote/RLEImage.remote.cmake
+++ b/Modules/Remote/RLEImage.remote.cmake
@@ -53,5 +53,5 @@ This work is supported by NIH grant R01 EB014346
 'Continued development and maintenance of the ITK-SNAP 3D image segmentation software'."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/KitwareMedical/ITKRLEImage.git
-  GIT_TAG 3ab10cda40977e4a39f9c46f1858f2fddcda8030
+  GIT_TAG a26763f003ceac727f6e2395d277af19c07b5d34
   )

--- a/Modules/Remote/RTK.remote.cmake
+++ b/Modules/Remote/RTK.remote.cmake
@@ -42,5 +42,5 @@ itk_fetch_module(
   "Reconstruction Toolkit (RTK) https://www.openrtk.org/"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/RTKConsortium/RTK.git
-  GIT_TAG 870737fca5274f9247e7d79fd09b61233dc2d369
+  GIT_TAG 1fb003a0e052fd9fec94520c9fa39ff4339828e0
   )

--- a/Modules/Remote/SCIFIO.remote.cmake
+++ b/Modules/Remote/SCIFIO.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "SCIFIO (Bioformats) ImageIO plugin for ITK"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/scifio/scifio-imageio.git
-  GIT_TAG 1054ece893ee072bdb8124c45ce207de00af280f
+  GIT_TAG 911983a668c0d56810275df8c05cf61a6314fbda
   )

--- a/Modules/Remote/Shape.remote.cmake
+++ b/Modules/Remote/Shape.remote.cmake
@@ -49,5 +49,5 @@ itk_fetch_module(
   ITK external module for libraries originally developed in SPHARM-PDM 3D Slicer extension (https://github.com/NIRALUser/SPHARM-PDM)."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/SlicerSALT/ITKShape.git
-  GIT_TAG b5311e41f644aede86367f883e2d115d92b08e62
+  GIT_TAG 0879946ac7e78469efce3192f6e5558f6a112189
   )

--- a/Modules/Remote/SimpleITKFilters.remote.cmake
+++ b/Modules/Remote/SimpleITKFilters.remote.cmake
@@ -50,5 +50,5 @@ itk_fetch_module(
   contains a discrete hessian, and a composite filter to compute objectness."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKSimpleITKFilters.git
-  GIT_TAG 2216e1b31e9fcd52a3f4a4a24994d22a149db965
+  GIT_TAG d13acf7ae2d6056d66477de15edd641ba3b23ce9
   )

--- a/Modules/Remote/SphinxExamples.remote.cmake
+++ b/Modules/Remote/SphinxExamples.remote.cmake
@@ -51,5 +51,5 @@ itk_fetch_module(
   "This module builds the examples found at https://itk.org/ITKExamples/"
   MODULE_COMPLIANCE_LEVEL 5
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKSphinxExamples.git
-  GIT_TAG a63e366aaf3be3f10a1badf47c3180eefcec5edf
+  GIT_TAG 600e811d0e89135cdf576da50c4a3dd92c3e1414
   )

--- a/Modules/Remote/SplitComponents.remote.cmake
+++ b/Modules/Remote/SplitComponents.remote.cmake
@@ -50,5 +50,5 @@ itk::Image of, for example, itk::Vector, itk::CovariantVector, or
 itk::SymmetricSecondRankTensor. https://doi.org/10.54294/4c92vb"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKSplitComponents.git
-  GIT_TAG 539fcd8faca472c760a567c041cb53c610cd9108
+  GIT_TAG 8f456b1d9987fc24d36904c1001e699e4fed4808
   )

--- a/Modules/Remote/Strain.remote.cmake
+++ b/Modules/Remote/Strain.remote.cmake
@@ -56,5 +56,5 @@ For more information, see:
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/KitwareMedical/ITKStrain.git
-  GIT_TAG 8257ffc718c3a70222365977e2accbc55b567a88
+  GIT_TAG 1397eb6b4ce6d0e789af8ecc2fbe6cdf889e63abge95a2db1831ce6a6eb41d0ccb08f58dd64ef883e
   )

--- a/Modules/Remote/SubdivisionQuadEdgeMeshFilter.remote.cmake
+++ b/Modules/Remote/SubdivisionQuadEdgeMeshFilter.remote.cmake
@@ -51,5 +51,5 @@ See the following Insight Journal's publication:
   https://doi.org/10.54294/vw0ke0"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/itkSubdivisionQuadEdgeMeshFilter
-  GIT_TAG bc5a615da775128e009af2520b43bf0a38f60702
+  GIT_TAG 3e3a910c42da2be4a6eb7ba512619c1bac53d01e
   )

--- a/Modules/Remote/TextureFeatures.remote.cmake
+++ b/Modules/Remote/TextureFeatures.remote.cmake
@@ -57,5 +57,5 @@ For more information, see:
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKTextureFeatures.git
-  GIT_TAG 99b5f66d72ef160faf1f46d4328a06217111101f
+  GIT_TAG 4e63c643c0c9b882b9d3f47e4cb9f886d2c259bd
   )

--- a/Modules/Remote/Thickness3D.remote.cmake
+++ b/Modules/Remote/Thickness3D.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "Tools for 3D thickness measurement"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKThickness3D.git
-  GIT_TAG 866e25fefea4318240a90632acf3a12719d0416f
+  GIT_TAG d5473939c1ddf125c09fcdb9b4ea33e337055436
   )

--- a/Modules/Remote/TotalVariation.remote.cmake
+++ b/Modules/Remote/TotalVariation.remote.cmake
@@ -52,5 +52,5 @@ https://github.com/albarji/proxTV
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKTotalVariation.git
-  GIT_TAG 0b4f9450f7c98b8db6dee5990bbd9be5d6e6c4d2
+  GIT_TAG 38c25ae8167df32f32fe7d52cb66445bbc10c471
   )

--- a/Modules/Remote/TubeTK.remote.cmake
+++ b/Modules/Remote/TubeTK.remote.cmake
@@ -49,5 +49,5 @@ itk_fetch_module(
   "http://www.tubetk.org"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKTubeTK.git
-  GIT_TAG e29408eb2fa55ec21b9a9b8197f8a61ecbb3e5d1
+  GIT_TAG 08e17b1c7780ee8b0a9d36cf049ce3f1283a62ce
   )

--- a/Modules/Remote/VkFFTBackend.remote.cmake
+++ b/Modules/Remote/VkFFTBackend.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "ITK FFT accelerated backends using the VkFFT library for Vulkan/CUDA/HIP/OpenCL compatibility."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKVkFFTBackend.git
-  GIT_TAG 0d6863b3dfa4a7505c41585023b6f91ea2a07a7f
+  GIT_TAG f3366b369cbd7824ba596bb0f1c6de625e99dc14
   )

--- a/Modules/Remote/WebAssemblyInterface.remote.cmake
+++ b/Modules/Remote/WebAssemblyInterface.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "The itk-wasm WebAssemblyInterface module provides tools to a) build C/C++ code to WebAssembly-compatible processing pipelines, b) bridge local filesystems, JavaScript/Typescript data structures, and traditional file formats, c) transfer data efficiently in and out of the WebAssembly runtime."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/itk-wasm.git
-  GIT_TAG 5babcf68be5fdfdd689dce97779d2085103c0bc1
+  GIT_TAG b10f94ee177cffc89a573e88d3097317dbcd487d
   )


### PR DESCRIPTION
COMP: Update remote module hashes for ITKv6**

Allow building remote modules with ITK_FUTURE_LEGACY_REMOVE
ITK_LEGACY_REMOVE turned ON.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [s] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
