### PR TITLE
COMP: Type matching for complex pixel data types

### DIFF
--- a/Modules/Filtering/ImageCompose/include/itkComposeImageFilter.hxx
+++ b/Modules/Filtering/ImageCompose/include/itkComposeImageFilter.hxx
@@ -132,7 +132,10 @@ ComposeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(const
       if constexpr (std::is_same<OutputPixelType,
                                  std::complex<typename NumericTraits<OutputPixelType>::ValueType>>::value)
       {
-        oit.Set({ inputItContainer[0].Get(), inputItContainer[1].Get() });
+        using ValueType = typename NumericTraits<OutputPixelType>::ValueType;
+        const OutputPixelType current_pixel = OutputPixelType{ static_cast<ValueType>(inputItContainer[0].Get()),
+                                                               static_cast<ValueType>(inputItContainer[1].Get()) };
+        oit.Set(current_pixel);
         ++(inputItContainer[0]);
         ++(inputItContainer[1]);
       }


### PR DESCRIPTION
Modules/Filtering/ImageCompose/include/itkComposeImageFilter.hxx:135:19: error: non-constant-expression cannot be narrowed from type 'PixelType' (aka 'unsigned char') to 'float' in initializer list [-Wc++11-narrowing]
  135 |         oit.Set({ inputItContainer[0].Get(), inputItContainer[1].Get() });
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~

Identified when building SphinxExamples remote module.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

<!-- **Thanks for contributing to ITK!** -->
