### PR TITLE
Move empty member function definitions from "itk*.hxx" to "itk*.h"

### DIFF
--- a/Modules/Core/Common/include/itkMapContainer.h
+++ b/Modules/Core/Common/include/itkMapContainer.h
@@ -461,7 +461,8 @@ public:
    * memory usage.
    */
   void
-  Squeeze();
+  Squeeze()
+  {}
 
   /**
    * Tell the container to release any memory it may have allocated and

--- a/Modules/Core/Common/include/itkMapContainer.hxx
+++ b/Modules/Core/Common/include/itkMapContainer.hxx
@@ -227,16 +227,6 @@ MapContainer<TElementIdentifier, TElement>::Reserve(ElementIdentifier sz)
 }
 
 /**
- * Tell the container to try to minimize its memory usage for storage of
- * the current number of elements.  This is NOT guaranteed to decrease
- * memory usage.
- */
-template <typename TElementIdentifier, typename TElement>
-void
-MapContainer<TElementIdentifier, TElement>::Squeeze()
-{}
-
-/**
  * Tell the container to release any memory it may have allocated and
  * return itself to its initial state.
  */

--- a/Modules/Core/Common/include/itkPyImageFilter.h
+++ b/Modules/Core/Common/include/itkPyImageFilter.h
@@ -102,7 +102,7 @@ public:
   }
 
 protected:
-  PyImageFilter();
+  PyImageFilter() = default;
   ~PyImageFilter() override;
 
   void

--- a/Modules/Core/Common/include/itkPyImageFilter.hxx
+++ b/Modules/Core/Common/include/itkPyImageFilter.hxx
@@ -24,10 +24,6 @@ namespace itk
 {
 
 template <class TInputImage, class TOutputImage>
-PyImageFilter<TInputImage, TOutputImage>::PyImageFilter()
-{}
-
-template <class TInputImage, class TOutputImage>
 PyImageFilter<TInputImage, TOutputImage>::~PyImageFilter()
 {
   if (this->m_GenerateDataCallable)

--- a/Modules/Core/Common/include/itkVectorContainer.h
+++ b/Modules/Core/Common/include/itkVectorContainer.h
@@ -549,7 +549,8 @@ public:
    * with other containers in the toolkit.
    */
   void
-  Squeeze();
+  Squeeze()
+  {}
 
   /**
    * Clear the elements. The final size will be zero.

--- a/Modules/Core/Common/include/itkVectorContainer.hxx
+++ b/Modules/Core/Common/include/itkVectorContainer.hxx
@@ -178,11 +178,6 @@ VectorContainer<TElementIdentifier, TElement>::Reserve(ElementIdentifier sz)
 {
   this->CreateIndex(sz - 1);
 }
-
-template <typename TElementIdentifier, typename TElement>
-void
-VectorContainer<TElementIdentifier, TElement>::Squeeze()
-{}
 } // namespace itk::detail
 
 #endif

--- a/Modules/Core/Mesh/include/itkImageToMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkImageToMeshFilter.h
@@ -87,9 +87,10 @@ public:
   OutputMeshType *
   GetOutput();
 
-  /** Prepare the output */
+  /** Prepare the output. This is a void implementation to prevent the ProcessObject version to be called. */
   void
-  GenerateOutputInformation() override;
+  GenerateOutputInformation() override
+  {}
 
 protected:
   ImageToMeshFilter();

--- a/Modules/Core/Mesh/include/itkImageToMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkImageToMeshFilter.hxx
@@ -78,15 +78,6 @@ ImageToMeshFilter<TInputImage, TOutputMesh>::GetOutput() -> OutputMeshType *
   return dynamic_cast<OutputMeshType *>(this->ProcessObject::GetOutput(0));
 }
 
-/**
- * copy information from first input to all outputs
- * This is a void implementation to prevent the
- * ProcessObject version to be called
- */
-template <typename TInputImage, typename TOutputMesh>
-void
-ImageToMeshFilter<TInputImage, TOutputMesh>::GenerateOutputInformation()
-{}
 } // end namespace itk
 
 #endif

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.h
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.h
@@ -431,7 +431,8 @@ protected:
   ThreadedApplyUpdate(const InputImageRegionType & regionToProcess, const int itkNotUsed(threadId));
 
   void
-  PostProcessOutput() override;
+  PostProcessOutput() override
+  {}
 
   virtual void
   SetThreadData(int threadId, const ThreadDataStruct & data);

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -2334,11 +2334,6 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ComputeGradientJointE
 
 template <typename TInputImage, typename TOutputImage>
 void
-PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::PostProcessOutput()
-{}
-
-template <typename TInputImage, typename TOutputImage>
-void
 PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);

--- a/Modules/Numerics/FEM/include/itkFEMSolver.h
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.h
@@ -382,7 +382,8 @@ protected:
 
   /** Decompose matrix using svd, qr, etc. if needed. */
   void
-  DecomposeK();
+  DecomposeK()
+  {}
 
   /** Solve for the displacement vector u. May be overridden in derived
    * classes. */

--- a/Modules/Numerics/FEM/include/itkFEMSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.hxx
@@ -519,11 +519,6 @@ Solver<VDimension>::AssembleF(int dim)
 
 template <unsigned int VDimension>
 void
-Solver<VDimension>::DecomposeK()
-{}
-
-template <unsigned int VDimension>
-void
 Solver<VDimension>::RunSolver()
 {
 

--- a/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.h
+++ b/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.h
@@ -271,7 +271,8 @@ protected:
   /** This method allows deallocation of data and further post processing
    */
   void
-  PostProcessOutput() override;
+  PostProcessOutput() override
+  {}
 
   /* This function clears all pixels from the narrow band */
   void

--- a/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.hxx
+++ b/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.hxx
@@ -283,11 +283,6 @@ NarrowBandImageFilterBase<TInputImage, TOutputImage>::ThreadedCalculateChange(co
 
 template <typename TInputImage, typename TOutputImage>
 void
-NarrowBandImageFilterBase<TInputImage, TOutputImage>::PostProcessOutput()
-{}
-
-template <typename TInputImage, typename TOutputImage>
-void
 NarrowBandImageFilterBase<TInputImage, TOutputImage>::GetSplitRegion(const size_t & i, ThreadRegionType & splitRegion)
 {
   splitRegion.first = m_RegionList[i].Begin;

--- a/Modules/Segmentation/LevelSets/include/itkBinaryMaskToNarrowBandPointSetFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkBinaryMaskToNarrowBandPointSetFilter.h
@@ -141,7 +141,8 @@ protected:
 
   /** Some type alias associated with the output mesh. */
   void
-  GenerateOutputInformation() override;
+  GenerateOutputInformation() override
+  {}
 
 private:
   DistanceFilterPointer m_DistanceFilter{};

--- a/Modules/Segmentation/LevelSets/include/itkBinaryMaskToNarrowBandPointSetFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkBinaryMaskToNarrowBandPointSetFilter.hxx
@@ -67,14 +67,6 @@ BinaryMaskToNarrowBandPointSetFilter<TInputImage, TOutputMesh>::PrintSelf(std::o
  */
 template <typename TInputImage, typename TOutputMesh>
 void
-BinaryMaskToNarrowBandPointSetFilter<TInputImage, TOutputMesh>::GenerateOutputInformation()
-{}
-
-/**
- *
- */
-template <typename TInputImage, typename TOutputMesh>
-void
 BinaryMaskToNarrowBandPointSetFilter<TInputImage, TOutputMesh>::SetInput(const InputImageType * inputImage)
 {
   // This const_cast is needed due to the lack of

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionMesh.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionMesh.h
@@ -71,7 +71,8 @@ protected:
   /** Allocate a list mesh with each node being a list of overlapping
    *  level set support at that pixel */
   void
-  AllocateListDomain();
+  AllocateListDomain()
+  {}
 
 private:
   MeshPointer  m_Mesh{};

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionMesh.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionMesh.hxx
@@ -48,11 +48,6 @@ LevelSetDomainPartitionMesh<TMesh>::PopulateListDomain()
   }
 }
 
-template <typename TMesh>
-void
-LevelSetDomainPartitionMesh<TMesh>::AllocateListDomain()
-{}
-
 } // end namespace itk
 
 #endif

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.h
@@ -109,7 +109,8 @@ public:
 
   /** \todo to be documented. */
   void
-  Update() override;
+  Update() override
+  {}
 
   /** Initialize the parameters in the terms prior to an iteration */
   void

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.hxx
@@ -125,11 +125,6 @@ LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::Initialize(const Leve
 
 template <typename TInput, typename TLevelSetContainer>
 void
-LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::Update()
-{}
-
-template <typename TInput, typename TLevelSetContainer>
-void
 LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::UpdatePixel(
   const LevelSetInputIndexType & itkNotUsed(iP),
   const LevelSetOutputRealType & itkNotUsed(oldValue),

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationBinaryMaskTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationBinaryMaskTerm.h
@@ -85,7 +85,8 @@ public:
 
   /** Update the term parameter values at end of iteration */
   void
-  Update() override;
+  Update() override
+  {}
 
   /** Initialize parameters in the terms prior to an iteration */
   void

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationBinaryMaskTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationBinaryMaskTerm.hxx
@@ -32,11 +32,6 @@ LevelSetEquationBinaryMaskTerm<TInput, TLevelSetContainer>::LevelSetEquationBina
 
 template <typename TInput, typename TLevelSetContainer>
 void
-LevelSetEquationBinaryMaskTerm<TInput, TLevelSetContainer>::Update()
-{}
-
-template <typename TInput, typename TLevelSetContainer>
-void
 LevelSetEquationBinaryMaskTerm<TInput, TLevelSetContainer>::InitializeParameters()
 {
   this->SetUp();

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.h
@@ -108,7 +108,8 @@ public:
 
   /** Update the term parameter values at end of iteration */
   void
-  Update() override;
+  Update() override
+  {}
 
   /** Initialize the parameters in the terms prior to an iteration */
   void

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.hxx
@@ -83,11 +83,6 @@ LevelSetEquationCurvatureTerm<TInput, TLevelSetContainer, TCurvatureImage>::Init
 
 template <typename TInput, typename TLevelSetContainer, typename TCurvatureImage>
 void
-LevelSetEquationCurvatureTerm<TInput, TLevelSetContainer, TCurvatureImage>::Update()
-{}
-
-template <typename TInput, typename TLevelSetContainer, typename TCurvatureImage>
-void
 LevelSetEquationCurvatureTerm<TInput, TLevelSetContainer, TCurvatureImage>::UpdatePixel(
   const LevelSetInputIndexType & itkNotUsed(iP),
   const LevelSetOutputRealType & itkNotUsed(oldValue),

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationLaplacianTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationLaplacianTerm.h
@@ -92,7 +92,8 @@ public:
 
   /** Update the term parameter values at end of iteration */
   void
-  Update() override;
+  Update() override
+  {}
 
   /** Initialize the parameters in the terms prior to an iteration */
   void

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationLaplacianTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationLaplacianTerm.hxx
@@ -43,11 +43,6 @@ LevelSetEquationLaplacianTerm<TInput, TLevelSetContainer>::Initialize(const Leve
 
 template <typename TInput, typename TLevelSetContainer>
 void
-LevelSetEquationLaplacianTerm<TInput, TLevelSetContainer>::Update()
-{}
-
-template <typename TInput, typename TLevelSetContainer>
-void
 LevelSetEquationLaplacianTerm<TInput, TLevelSetContainer>::UpdatePixel(
   const LevelSetInputIndexType & itkNotUsed(iP),
   const LevelSetOutputRealType & itkNotUsed(oldValue),

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationOverlapPenaltyTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationOverlapPenaltyTerm.h
@@ -94,7 +94,8 @@ public:
 
   /** Update the term parameter values at end of iteration */
   void
-  Update() override;
+  Update() override
+  {}
 
   /** Initialize parameters in the terms prior to an iteration */
   void

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationOverlapPenaltyTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationOverlapPenaltyTerm.hxx
@@ -34,11 +34,6 @@ LevelSetEquationOverlapPenaltyTerm<TInput, TLevelSetContainer>::LevelSetEquation
 
 template <typename TInput, typename TLevelSetContainer>
 void
-LevelSetEquationOverlapPenaltyTerm<TInput, TLevelSetContainer>::Update()
-{}
-
-template <typename TInput, typename TLevelSetContainer>
-void
 LevelSetEquationOverlapPenaltyTerm<TInput, TLevelSetContainer>::UpdatePixel(
   const LevelSetInputIndexType & itkNotUsed(index),
   const LevelSetOutputRealType & itkNotUsed(oldValue),

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationPropagationTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationPropagationTerm.h
@@ -102,7 +102,8 @@ public:
 
   /** \todo to be documented. */
   void
-  Update() override;
+  Update() override
+  {}
 
   /** Initialize the parameters in the terms prior to an iteration */
   void

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationPropagationTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationPropagationTerm.hxx
@@ -56,11 +56,6 @@ LevelSetEquationPropagationTerm<TInput, TLevelSetContainer, TPropagationImage>::
 
 template <typename TInput, typename TLevelSetContainer, typename TPropagationImage>
 void
-LevelSetEquationPropagationTerm<TInput, TLevelSetContainer, TPropagationImage>::Update()
-{}
-
-template <typename TInput, typename TLevelSetContainer, typename TPropagationImage>
-void
 LevelSetEquationPropagationTerm<TInput, TLevelSetContainer, TPropagationImage>::UpdatePixel(
   const LevelSetInputIndexType & itkNotUsed(iP),
   const LevelSetOutputRealType & itkNotUsed(oldValue),

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionBase.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionBase.h
@@ -140,16 +140,19 @@ protected:
   /** Initialize the update buffers for all level sets to hold the updates of
    *  equations in each iteration. No-op by default. */
   virtual void
-  AllocateUpdateBuffer();
+  AllocateUpdateBuffer()
+  {}
 
   /** Computer the update at each pixel and store in the update buffer. No-op by
    * default. */
   virtual void
-  ComputeIteration();
+  ComputeIteration()
+  {}
 
   /** Compute the time-step for the next iteration. No-op by default. */
   virtual void
-  ComputeTimeStepForNextIteration();
+  ComputeTimeStepForNextIteration()
+  {}
 
   virtual void
   UpdateLevelSets() = 0;

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionBase.hxx
@@ -236,20 +236,5 @@ LevelSetEvolutionBase<TEquationContainer, TLevelSet>::Evolve()
   }
 }
 
-template <typename TEquationContainer, typename TLevelSet>
-void
-LevelSetEvolutionBase<TEquationContainer, TLevelSet>::AllocateUpdateBuffer()
-{}
-
-template <typename TEquationContainer, typename TLevelSet>
-void
-LevelSetEvolutionBase<TEquationContainer, TLevelSet>::ComputeIteration()
-{}
-
-template <typename TEquationContainer, typename TLevelSet>
-void
-LevelSetEvolutionBase<TEquationContainer, TLevelSet>::ComputeTimeStepForNextIteration()
-{}
-
 } // namespace itk
 #endif // itkLevelSetEvolutionBase_hxx


### PR DESCRIPTION
Moved the member function definitions of member functions that have an empty
parameter list and an empty member function definition from their "itk*.hxx"
file to the corresponding "itk*.h" file, and into their class definition.

Defaulted the default-constructor of `PyImageFilter`.

Found by regular expression `::.+\(\)\r\n{}` in "itk*.hxx" files.

Suggested by Denis Shamonin (@dpshamonin).
