### PR TITLE
DOC: Fix incorrect `BibTeX` citation keys

### DIFF
--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
@@ -76,7 +76,7 @@ extern ITKCommon_EXPORT std::ostream &
  *
  * References:
  * The Gaussian kernel contained in this operator was described in
- * \cite lindeberg1999.
+ * \cite lindeberg1991.
  *
  * \author Ivan Macia, Vicomtech, Spain, https://www.vicomtech.org/en
  *

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.h
@@ -125,7 +125,7 @@ namespace itk
  * type. You will get a compilation error if the pixel type of the
  * output image is not float or double.
  *
- * For algorithmic details see \cite padfield 2012 and \cite padfield2010.
+ * For algorithmic details see \cite padfield2012 and \cite padfield2010.
  *
  * \author: Dirk Padfield, GE Global Research, padfield\@research.ge.com
  * \ingroup ITKConvolution

--- a/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.h
@@ -44,7 +44,7 @@ namespace itk
  *        up/down sample an image by a factor of 2.
  *
  * This class defines N-Dimension B-Spline transformation.
- * It is based on \cite unser199, \cite unser1993 and \cite unser1993a.
+ * It is based on \cite unser1999, \cite unser1993 and \cite unser1993a.
  * Code obtained from bigwww.epfl.ch by Philippe Thevenaz
  *
  * Limitations:  Spline order for the l2 pyramid must be between 0 and 3.


### PR DESCRIPTION
Fix incorrect `BibTeX` citation keys.

Fixes:
```
.../ITK/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.h:47:
 warning: \cite command to 'unser199' does not have an associated number

.../ITK/Modules/Core/Common/include/itkGaussianDerivativeOperator.h:80:
 warning: \cite command to 'lindeberg1999' does not have an associated number

.../ITK/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.h:128:
 warning: \cite command to 'padfield' does not have an associated number
```

Reported by: albert-github <albert.tests@gmail.com>

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

Fixes #5202.