### PR TITLE
STYLE: Move empty member functions from .hxx to .h

### DIFF
--- a/Modules/Core/Common/include/itkImageBase.h
+++ b/Modules/Core/Common/include/itkImageBase.h
@@ -249,7 +249,8 @@ public:
    *
    */
   virtual void
-  Allocate(bool initialize = false);
+  Allocate(bool itkNotUsed(initialize) = false)
+  {}
 
   /** Allocates the pixel buffer of the image, zero-initializing its pixels. `AllocateInitialized()` is equivalent to
    * `Allocate(true)`. It is just intended to make the code more readable. */

--- a/Modules/Core/Common/include/itkImageBase.hxx
+++ b/Modules/Core/Common/include/itkImageBase.hxx
@@ -37,13 +37,6 @@
 
 namespace itk
 {
-
-template <unsigned int VImageDimension>
-void
-ImageBase<VImageDimension>::Allocate(bool)
-{}
-
-
 template <unsigned int VImageDimension>
 void
 ImageBase<VImageDimension>::Initialize()

--- a/Modules/Numerics/FEM/include/itkFEMSolver.h
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.h
@@ -141,7 +141,8 @@ public:
    * \param dt New time step.
    */
   virtual void
-  SetTimeStep(Float dt);
+  SetTimeStep(Float itkNotUsed(dt))
+  {}
 
   /** Returns the Solution for the specified nodal point. */
   Float

--- a/Modules/Numerics/FEM/include/itkFEMSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.hxx
@@ -108,11 +108,6 @@ Solver<VDimension>::GetTimeStep() const -> Float
 }
 
 template <unsigned int VDimension>
-void
-Solver<VDimension>::SetTimeStep(Float itkNotUsed(dt))
-{}
-
-template <unsigned int VDimension>
 auto
 Solver<VDimension>::GetSolution(unsigned int i, unsigned int which) -> Float
 {

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.h
@@ -118,13 +118,15 @@ public:
 
   /** \todo to be documented. */
   void
-  Initialize(const LevelSetInputIndexType &) override;
+  Initialize(const LevelSetInputIndexType &) override
+  {}
 
   /** Supply updates at pixels to keep the term parameters always updated */
   void
-  UpdatePixel(const LevelSetInputIndexType & iP,
-              const LevelSetOutputRealType & oldValue,
-              const LevelSetOutputRealType & newValue) override;
+  UpdatePixel(const LevelSetInputIndexType & itkNotUsed(iP),
+              const LevelSetOutputRealType & itkNotUsed(oldValue),
+              const LevelSetOutputRealType & itkNotUsed(newValue)) override
+  {}
 
 protected:
   LevelSetEquationAdvectionTerm();

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.hxx
@@ -119,19 +119,6 @@ LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::GenerateAdvectionImag
 }
 
 template <typename TInput, typename TLevelSetContainer>
-void
-LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::Initialize(const LevelSetInputIndexType &)
-{}
-
-template <typename TInput, typename TLevelSetContainer>
-void
-LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::UpdatePixel(
-  const LevelSetInputIndexType & itkNotUsed(iP),
-  const LevelSetOutputRealType & itkNotUsed(oldValue),
-  const LevelSetOutputRealType & itkNotUsed(newValue))
-{}
-
-template <typename TInput, typename TLevelSetContainer>
 auto
 LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::AdvectionSpeed(const LevelSetInputIndexType & iP) const
   -> VectorType

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationBinaryMaskTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationBinaryMaskTerm.h
@@ -94,13 +94,15 @@ public:
 
   /** Initialize term parameters in the dense case by computing for each pixel location */
   void
-  Initialize(const LevelSetInputIndexType & iP) override;
+  Initialize(const LevelSetInputIndexType & itkNotUsed(iP)) override
+  {}
 
   /** Supply updates at pixels to keep the term parameters always updated */
   void
-  UpdatePixel(const LevelSetInputIndexType & iP,
-              const LevelSetOutputRealType & oldValue,
-              const LevelSetOutputRealType & newValue) override;
+  UpdatePixel(const LevelSetInputIndexType & itkNotUsed(iP),
+              const LevelSetOutputRealType & itkNotUsed(oldValue),
+              const LevelSetOutputRealType & itkNotUsed(newValue)) override
+  {}
 
 protected:
   LevelSetEquationBinaryMaskTerm();

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationBinaryMaskTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationBinaryMaskTerm.hxx
@@ -39,20 +39,6 @@ LevelSetEquationBinaryMaskTerm<TInput, TLevelSetContainer>::InitializeParameters
 
 
 template <typename TInput, typename TLevelSetContainer>
-void
-LevelSetEquationBinaryMaskTerm<TInput, TLevelSetContainer>::Initialize(const LevelSetInputIndexType & itkNotUsed(index))
-{}
-
-
-template <typename TInput, typename TLevelSetContainer>
-void
-LevelSetEquationBinaryMaskTerm<TInput, TLevelSetContainer>::UpdatePixel(
-  const LevelSetInputIndexType & itkNotUsed(index),
-  const LevelSetOutputRealType & itkNotUsed(oldValue),
-  const LevelSetOutputRealType & itkNotUsed(newValue))
-{}
-
-template <typename TInput, typename TLevelSetContainer>
 auto
 LevelSetEquationBinaryMaskTerm<TInput, TLevelSetContainer>::Value(const LevelSetInputIndexType & index)
   -> LevelSetOutputRealType

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.h
@@ -117,13 +117,15 @@ public:
 
   /** Initialize term parameters in the dense case by computing for each pixel location */
   void
-  Initialize(const LevelSetInputIndexType &) override;
+  Initialize(const LevelSetInputIndexType &) override
+  {}
 
   /** Supply updates at pixels to keep the term parameters always updated */
   void
-  UpdatePixel(const LevelSetInputIndexType & iP,
-              const LevelSetOutputRealType & oldValue,
-              const LevelSetOutputRealType & newValue) override;
+  UpdatePixel(const LevelSetInputIndexType & itkNotUsed(iP),
+              const LevelSetOutputRealType & itkNotUsed(oldValue),
+              const LevelSetOutputRealType & itkNotUsed(newValue)) override
+  {}
 
 protected:
   LevelSetEquationCurvatureTerm();

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.hxx
@@ -77,19 +77,6 @@ LevelSetEquationCurvatureTerm<TInput, TLevelSetContainer, TCurvatureImage>::Init
 }
 
 template <typename TInput, typename TLevelSetContainer, typename TCurvatureImage>
-void
-LevelSetEquationCurvatureTerm<TInput, TLevelSetContainer, TCurvatureImage>::Initialize(const LevelSetInputIndexType &)
-{}
-
-template <typename TInput, typename TLevelSetContainer, typename TCurvatureImage>
-void
-LevelSetEquationCurvatureTerm<TInput, TLevelSetContainer, TCurvatureImage>::UpdatePixel(
-  const LevelSetInputIndexType & itkNotUsed(iP),
-  const LevelSetOutputRealType & itkNotUsed(oldValue),
-  const LevelSetOutputRealType & itkNotUsed(newValue))
-{}
-
-template <typename TInput, typename TLevelSetContainer, typename TCurvatureImage>
 auto
 LevelSetEquationCurvatureTerm<TInput, TLevelSetContainer, TCurvatureImage>::Value(const LevelSetInputIndexType & iP)
   -> LevelSetOutputRealType

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationLaplacianTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationLaplacianTerm.h
@@ -101,13 +101,15 @@ public:
 
   /** \todo to be documented. */
   void
-  Initialize(const LevelSetInputIndexType &) override;
+  Initialize(const LevelSetInputIndexType &) override
+  {}
 
   /** Supply updates at pixels to keep the term parameters always updated */
   void
-  UpdatePixel(const LevelSetInputIndexType & iP,
-              const LevelSetOutputRealType & oldValue,
-              const LevelSetOutputRealType & newValue) override;
+  UpdatePixel(const LevelSetInputIndexType & itkNotUsed(iP),
+              const LevelSetOutputRealType & itkNotUsed(oldValue),
+              const LevelSetOutputRealType & itkNotUsed(newValue)) override
+  {}
 
 protected:
   LevelSetEquationLaplacianTerm();

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationLaplacianTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationLaplacianTerm.hxx
@@ -37,19 +37,6 @@ LevelSetEquationLaplacianTerm<TInput, TLevelSetContainer>::InitializeParameters(
 }
 
 template <typename TInput, typename TLevelSetContainer>
-void
-LevelSetEquationLaplacianTerm<TInput, TLevelSetContainer>::Initialize(const LevelSetInputIndexType &)
-{}
-
-template <typename TInput, typename TLevelSetContainer>
-void
-LevelSetEquationLaplacianTerm<TInput, TLevelSetContainer>::UpdatePixel(
-  const LevelSetInputIndexType & itkNotUsed(iP),
-  const LevelSetOutputRealType & itkNotUsed(oldValue),
-  const LevelSetOutputRealType & itkNotUsed(newValue))
-{}
-
-template <typename TInput, typename TLevelSetContainer>
 auto
 LevelSetEquationLaplacianTerm<TInput, TLevelSetContainer>::LaplacianSpeed(
   const LevelSetInputIndexType & itkNotUsed(iP)) const -> LevelSetOutputRealType

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationOverlapPenaltyTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationOverlapPenaltyTerm.h
@@ -103,7 +103,8 @@ public:
 
   /** Initialize term parameters in the dense case by computing for each pixel location */
   void
-  Initialize(const LevelSetInputIndexType & index) override;
+  Initialize(const LevelSetInputIndexType & itkNotUsed(index)) override
+  {}
 
   /** Compute the sum of Heaviside functions in the multi-levelset cases
    *  except the current levelset */
@@ -112,9 +113,10 @@ public:
 
   /** Supply updates at pixels to keep the term parameters always updated */
   void
-  UpdatePixel(const LevelSetInputIndexType & index,
-              const LevelSetOutputRealType & oldValue,
-              const LevelSetOutputRealType & newValue) override;
+  UpdatePixel(const LevelSetInputIndexType & itkNotUsed(index),
+              const LevelSetOutputRealType & itkNotUsed(oldValue),
+              const LevelSetOutputRealType & itkNotUsed(newValue)) override
+  {}
 
 
 protected:

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationOverlapPenaltyTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationOverlapPenaltyTerm.hxx
@@ -34,25 +34,11 @@ LevelSetEquationOverlapPenaltyTerm<TInput, TLevelSetContainer>::LevelSetEquation
 
 template <typename TInput, typename TLevelSetContainer>
 void
-LevelSetEquationOverlapPenaltyTerm<TInput, TLevelSetContainer>::UpdatePixel(
-  const LevelSetInputIndexType & itkNotUsed(index),
-  const LevelSetOutputRealType & itkNotUsed(oldValue),
-  const LevelSetOutputRealType & itkNotUsed(newValue))
-{}
-
-template <typename TInput, typename TLevelSetContainer>
-void
 LevelSetEquationOverlapPenaltyTerm<TInput, TLevelSetContainer>::InitializeParameters()
 {
   this->SetUp();
 }
 
-
-template <typename TInput, typename TLevelSetContainer>
-void
-LevelSetEquationOverlapPenaltyTerm<TInput, TLevelSetContainer>::Initialize(
-  const LevelSetInputIndexType & itkNotUsed(index))
-{}
 
 template <typename TInput, typename TLevelSetContainer>
 auto

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationPropagationTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationPropagationTerm.h
@@ -111,13 +111,15 @@ public:
 
   /** \todo to be documented. */
   void
-  Initialize(const LevelSetInputIndexType &) override;
+  Initialize(const LevelSetInputIndexType &) override
+  {}
 
   /** Supply updates at pixels to keep the term parameters always updated */
   void
-  UpdatePixel(const LevelSetInputIndexType & iP,
-              const LevelSetOutputRealType & oldValue,
-              const LevelSetOutputRealType & newValue) override;
+  UpdatePixel(const LevelSetInputIndexType & itkNotUsed(iP),
+              const LevelSetOutputRealType & itkNotUsed(oldValue),
+              const LevelSetOutputRealType & itkNotUsed(newValue)) override
+  {}
 
 protected:
   LevelSetEquationPropagationTerm();

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationPropagationTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationPropagationTerm.hxx
@@ -49,20 +49,6 @@ LevelSetEquationPropagationTerm<TInput, TLevelSetContainer, TPropagationImage>::
 }
 
 template <typename TInput, typename TLevelSetContainer, typename TPropagationImage>
-void
-LevelSetEquationPropagationTerm<TInput, TLevelSetContainer, TPropagationImage>::Initialize(
-  const LevelSetInputIndexType &)
-{}
-
-template <typename TInput, typename TLevelSetContainer, typename TPropagationImage>
-void
-LevelSetEquationPropagationTerm<TInput, TLevelSetContainer, TPropagationImage>::UpdatePixel(
-  const LevelSetInputIndexType & itkNotUsed(iP),
-  const LevelSetOutputRealType & itkNotUsed(oldValue),
-  const LevelSetOutputRealType & itkNotUsed(newValue))
-{}
-
-template <typename TInput, typename TLevelSetContainer, typename TPropagationImage>
 auto
 LevelSetEquationPropagationTerm<TInput, TLevelSetContainer, TPropagationImage>::PropagationSpeed(
   const LevelSetInputIndexType & iP) const -> LevelSetOutputRealType

--- a/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.h
@@ -154,7 +154,8 @@ protected:
 
   unsigned short m_Face{ 0 };
   void
-  GenerateOutputRequestedRegion(DataObject * output) override;
+  GenerateOutputRequestedRegion(DataObject * itkNotUsed(output)) override
+  {}
 };
 } // end namespace watershed
 } // end namespace itk

--- a/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.hxx
@@ -90,11 +90,6 @@ BoundaryResolver<TPixelType, TDimension>::GenerateData()
 // --------------------PIPELINE METHODS------------------------
 // ------------------------------------------------------------
 template <typename TPixelType, unsigned int TDimension>
-void
-BoundaryResolver<TPixelType, TDimension>::GenerateOutputRequestedRegion(DataObject *)
-{}
-
-template <typename TPixelType, unsigned int TDimension>
 typename BoundaryResolver<TPixelType, TDimension>::DataObjectPointer
 BoundaryResolver<TPixelType, TDimension>::MakeOutput(DataObjectPointerArraySizeType)
 {

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.h
@@ -219,7 +219,8 @@ protected:
 
   /** Methods required by the itk pipeline */
   void
-  GenerateOutputRequestedRegion(DataObject * output) override;
+  GenerateOutputRequestedRegion(DataObject * itkNotUsed(output)) override
+  {}
 
   void
   GenerateInputRequestedRegion() override;

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
@@ -554,11 +554,6 @@ SegmentTreeGenerator<TScalar>::MergeSegments(SegmentTableTypePointer           s
 
 template <typename TScalar>
 void
-SegmentTreeGenerator<TScalar>::GenerateOutputRequestedRegion(DataObject * itkNotUsed(output))
-{}
-
-template <typename TScalar>
-void
 SegmentTreeGenerator<TScalar>::GenerateInputRequestedRegion()
 {
   Superclass::GenerateInputRequestedRegion();


### PR DESCRIPTION
Moved the member function definitions of member functions that have an empty member function definition from their "itk*.hxx" file to the corresponding "itk*.h" file, and into their class definition.

Found by regular expression `^..[^:,].+\)\r\n{}` in "itk*.hxx" files.

- Follow-up to pull request #5198 commit b94770d8746133a441df1796e3d1628c6935adfc "STYLE: Move empty member functions with empty param list from .hxx to .h"

@dpshamonin Denis, please have a look!