### PR TITLE
DOC: Convert from raw in-code citations to bibtex (2/N)

### DIFF
--- a/Documentation/Doxygen/doxygen.bib
+++ b/Documentation/Doxygen/doxygen.bib
@@ -70,6 +70,17 @@
   year         = 1998,
   publisher    = {CRC Press}
 }
+@article{besag1986,
+  title        = {On the Statistical Analysis of Dirty Pictures},
+  author       = {Julian Besag},
+  year         = 1986,
+  journal      = {Journal of the Royal Statistical Society: Series B (Methodological)},
+  volume       = 48,
+  number       = 3,
+  pages        = {259--279},
+  doi          = {10.1111/j.2517-6161.1986.tb01412.x},
+  url          = {https://doi.org/10.1111/j.2517-6161.1986.tb01412.x}
+}
 @article{besl1992,
   title        = {A method for registration of {3-D} shapes},
   author       = {Besl, P.J. and McKay, Neil D.},
@@ -157,6 +168,17 @@
   doi          = {10.1109/TPAMI.1986.4767851},
   url          = {https://doi.org/10.1109/TPAMI.1986.4767851}
 }
+@article{caselles1997,
+  title        = {Geodesic Active Contours},
+  author       = {Caselles, Vicent and Kimmel, Ron and Sapiro, Guillermo},
+  year         = 1997,
+  journal      = {International Journal of Computer Vision},
+  volume       = 22,
+  number       = 1,
+  pages        = {61--79},
+  doi          = {10.1023/A:1007979827043},
+  url          = {https://doi.org/10.1023/A:1007979827043}
+}
 @book{castleman1995,
   title        = {Digital Signal Processing},
   author       = {Kenneth R. Castleman},
@@ -194,6 +216,17 @@
   doi          = {10.1109/42.585766},
   url          = {https://doi.org/10.1109/42.585766}
 }
+@article{delingette1999,
+  title        = {General Object Reconstruction Based on Simplex Meshes},
+  author       = {Delingette, Herv{\'e}},
+  year         = 1999,
+  journal      = {International Journal of Computer Vision},
+  volume       = 32,
+  number       = 2,
+  pages        = {111--146},
+  doi          = {10.1023/A:1008157432188},
+  url          = {https://doi.org/10.1023/A:1008157432188}
+}
 @article{deriche1990,
   title        = {Fast algorithms for low-level vision},
   author       = {Rachid Deriche},
@@ -226,6 +259,17 @@
   doi          = {10.1016/j.laa.2003.10.021},
   url          = {https://doi.org/10.1016/j.laa.2003.10.021}
 }
+@article{fortune1987,
+  title        = {A sweepline algorithm for {Voronoi} diagrams},
+  author       = {Fortune, Steven},
+  year         = 1987,
+  journal      = {Algorithmica},
+  volume       = 2,
+  number       = 1,
+  pages        = {153--174},
+  doi          = {10.1007/BF01840357},
+  url          = {https://doi.org/10.1007/BF01840357}
+}
 @inproceedings{frangi1998,
   title        = {Multiscale vessel enhancement filtering},
   author       = {Frangi, Alejandro F. and Niessen, Wiro J. and Vincken, Koen L. and Viergever, Max A.},
@@ -240,6 +284,14 @@
   author       = {Erich Gamma and Richard Helm and Ralph Johnson and John Vlissides},
   year         = 1994,
   publisher    = {Addison-Wesley}
+}
+@book{gersho1992,
+  title        = {Vector Quantization and Signal Compression},
+  author       = {Allen Gersho and Robert M. Gray},
+  year         = 1992,
+  publisher    = {Springer New York, NY},
+  doi          = {10.1007/978-1-4615-3626-0},
+  url          = {https://doi.org/10.1007/978-1-4615-3626-0}
 }
 @article{glasbey1993,
   title        = {An Analysis of Histogram-Based Thresholding Algorithms},
@@ -343,6 +395,17 @@
   doi          = {10.1016/0031-3203(94)E0043-K},
   url          = {https://doi.org/10.1016/0031-3203(94)E0043-K}
 }
+@article{imelinska2000,
+  title        = {Semi-automated color segmentation of anatomical tissue},
+  author       = {C. Imeli{\'n}ska and M.S. Downes and W. Yuan},
+  year         = 2000,
+  journal      = {Computerized Medical Imaging and Graphics},
+  volume       = 24,
+  number       = 3,
+  pages        = {173--180},
+  doi          = {10.1016/S0895-6111(00)00017-3},
+  url          = {https://doi.org/10.1016/S0895-6111(00)00017-3}
+}
 @article{jin2005,
   title        = {A comparison of algorithms for vertex normal computation},
   author       = {Jin, Shuangshuang and Lewis, Robert R. and West, David},
@@ -406,6 +469,17 @@
   doi          = {10.1109/42.640737},
   url          = {https://doi.org/10.1109/42.640737}
 }
+@article{koepfler1994,
+  title        = {A Multiscale Algorithm for Image Segmentation by Variational Method},
+  author       = {Koepfler, G. and Lopez, C. and Morel, J. M.},
+  year         = 1994,
+  journal      = {SIAM Journal on Numerical Analysis},
+  volume       = 31,
+  number       = 1,
+  pages        = {282--299},
+  doi          = {10.1137/0731015},
+  url          = {https://doi.org/10.1137/0731015}
+}
 @article{lee1997,
   title        = {Scattered data interpolation with multilevel B-splines},
   author       = {Lee, S. and Wolberg, G. and Shin, S.Y.},
@@ -416,6 +490,16 @@
   pages        = {228--244},
   doi          = {10.1109/2945.620490},
   url          = {https://doi.org/10.1109/2945.620490}
+}
+@inproceedings{leventon2000,
+  title        = {Statistical shape influence in geodesic active contours},
+  author       = {Leventon, M.E. and Grimson, W.E.L. and Faugeras, O.},
+  year         = 2000,
+  booktitle    = {IEEE Conference on Computer Vision and Pattern Recognition (CVPR)},
+  volume       = 1,
+  pages        = {316--323 vol.1},
+  doi          = {10.1109/CVPR.2000.855835},
+  url          = {https://doi.org/10.1109/CVPR.2000.855835}
 }
 @article{li1993,
   title        = {Minimum cross entropy thresholding},
@@ -455,6 +539,29 @@
   pages        = {163--169},
   doi          = {10.1145/37402.37422},
   url          = {https://doi.org/10.1145/37402.37422}
+}
+@article{lorigo2001,
+  title        = {{CURVES:} Curve evolution for vessel segmentation},
+  author       = {L.M. Lorigo and O.D. Faugeras and W.E.L. Grimson and R. Keriven and R. Kikinis and A. Nabavi and C.-F. Westin},
+  year         = 2001,
+  journal      = {Medical Image Analysis},
+  volume       = 5,
+  number       = 3,
+  pages        = {195--206},
+  doi          = {10.1016/S1361-8415(01)00040-8},
+  issn         = {1361-8415},
+  url          = {https://doi.org/10.1016/S1361-8415(01)00040-8}
+}
+@article{malladi1995,
+  title        = {Shape modeling with front propagation: a level set approach},
+  author       = {Malladi, Ravikanth and Sethian, James A. and Vemuri, Baba C.},
+  year         = 1995,
+  journal      = {IEEE Transactions on Pattern Analysis and Machine Intelligence},
+  volume       = 17,
+  number       = 2,
+  pages        = {158--175},
+  doi          = {10.1109/34.368173},
+  url          = {https://doi.org/10.1109/34.368173}
 }
 @article{martin1968,
   title        = {Householder's tridiagonalization of a symmetric matrix},
@@ -612,6 +719,17 @@
   doi          = {10.1007/978-3-642-59223-2},
   url          = {https://doi.org/10.1007/978-3-642-59223-2}
 }
+@article{pikaz1996,
+  title        = {Digital image thresholding, based on topological stable-state},
+  author       = {Arie Pikaz and Amir Averbuch},
+  year         = 1996,
+  journal      = {Pattern Recognition},
+  volume       = 29,
+  number       = 5,
+  pages        = {829--843},
+  doi          = {https://doi.org/10.1016/0031-3203(95)00126-3},
+  doi          = {10.1016/0031-3203(95)00126-3}
+}
 @article{pluta2009,
   title        = {Appearance and incomplete label matching for diffeomorphic template based hippocampus segmentation},
   author       = {John Pluta and Brian B. Avants and Simon Glynn and Suyash Awate and James C. Gee and John A. Detre},
@@ -656,6 +774,28 @@
   doi          = {10.1016/j.patrec.2004.07.002},
   url          = {https://doi.org/10.1016/j.patrec.2004.07.002}
 }
+@article{rohlfing2004,
+  title        = {Performance-based classifier combination in atlas-based image segmentation using expectation-maximization parameter estimation},
+  author       = {Rohlfing, T. and Russakoff, D.B. and Maurer, C.R.},
+  year         = 2004,
+  journal      = {IEEE Transactions on Medical Imaging},
+  volume       = 23,
+  number       = 8,
+  pages        = {983--994},
+  doi          = {10.1109/TMI.2004.830803},
+  url          = {https://doi.org/10.1109/TMI.2004.830803}
+}
+@article{rohlfing2005,
+  title        = {Multi-classifier framework for atlas-based image segmentation},
+  author       = {Torsten Rohlfing and Calvin R. Maurer},
+  year         = 2005,
+  journal      = {Pattern Recognition Letters},
+  volume       = 26,
+  number       = 13,
+  pages        = {2070--2079},
+  doi          = {10.1016/j.patrec.2005.03.017},
+  url          = {https://doi.org/10.1016/j.patrec.2005.03.017}
+}
 @article{sapiro1996,
   title        = {Anisotropic diffusion of multivalued images with applications to color filtering},
   author       = {Sapiro, G. and Ringach, D.L.},
@@ -666,6 +806,12 @@
   pages        = {1582--1586},
   doi          = {10.1109/83.541429},
   url          = {https://doi.org/10.1109/83.541429}
+}
+@book{sethian1996,
+  title        = {Level Set Methods Evolving Interfaces in Geometry, Fluid Mechanics, Computer Vision, and Materials Science},
+  author       = {James A. Sethian},
+  year         = 1996,
+  publisher    = {Cambridge University Press}
 }
 @inbook{sethian1999,
   title        = {Image Enhancement and Noise Removal},
@@ -770,6 +916,17 @@
   doi          = {10.1007/978-3-662-05088-0_4},
   url          = {https://doi.org/10.1007/978-3-662-05088-0_4}
 }
+@inbook{soille2004c,
+  title        = {Segmentation},
+  author       = {Soille, Pierre},
+  year         = 2004,
+  booktitle    = {Morphological Image Analysis: Principles and Applications},
+  publisher    = {Springer Berlin Heidelberg},
+  address      = {Berlin, Heidelberg},
+  pages        = {267--292},
+  doi          = {10.1007/978-3-662-05088-0_9},
+  url          = {https://doi.org/10.1007/978-3-662-05088-0_9}
+}
 @inproceedings{sprengel1996,
   title        = {Thin-plate spline approximation for image registration},
   author       = {Sprengel, R. and Rohr, K. and Stiehl, H.S.},
@@ -798,7 +955,7 @@
   publisher    = {Addison Wesley}
 }
 @techreport{styner1997,
-  title        = {Evaluation of 2D/3D bias correction with {1+1ES-optimization}},
+  title        = {Evaluation of {2D/3D} bias correction with {1+1ES-optimization}},
   author       = {Martin Styner and Guido Gerig},
   year         = 1997,
   number       = {TR-197},
@@ -970,6 +1127,14 @@
   doi          = {10.1109/79.799930},
   url          = {https://doi.org/10.1109/79.799930}
 }
+@article{urish2005,
+  title        = {Unsupervised Segmentation for Myofiber Counting in Immunofluorescent Microscopy Images},
+  author       = {Urish, Kenneth and August, Jonas and Huard, Johnny},
+  year         = 2005,
+  doi          = {10.54294/h1vbsl},
+  url          = {https://doi.org/10.54294/h1vbsl},
+  jounral      = {The Insight Journal}
+}
 @article{vemuri2003,
   title        = {Image registration via level-set motion: Applications to atlas-based segmentation},
   author       = {B.C. Vemuri and J. Ye and Y. Chen and C.M. Leonard},
@@ -1050,6 +1215,17 @@
   year         = 2002,
   booktitle    = {International Society for Magnetic Resonance in Medicine (ISMRM)},
   url          = {https://cds.ismrm.org/ismrm-2002/PDF4/1166.PDF}
+}
+@article{whitaker1998,
+  title        = {A Level-Set Approach to {3D} Reconstruction from Range Data},
+  author       = {Whitaker, Ross T.},
+  year         = 1998,
+  journal      = {International Journal of Computer Vision},
+  volume       = 29,
+  number       = 3,
+  pages        = {203--231},
+  doi          = {10.1023/A:1008036829907},
+  url          = {https://doi.org/10.1023/A:1008036829907}
 }
 @inproceedings{whitaker2000,
   title        = {Reducing Aliasing Artifacts in Iso-Surfaces of Binary Volumes},

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.h
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.h
@@ -219,15 +219,7 @@ private:
  * The multiresolution pyramid implementation is based on
  * itkMultiResolutionPyramidImageFilter (without Gaussian smoothing)
  *
- * For more details. refer to the following articles.
- * "Parametric estimate of intensity inhomogeneities applied to MRI"
- * Martin Styner, Guido Gerig, Christian Brechbuehler, Gabor Szekely,
- * IEEE TRANSACTIONS ON MEDICAL IMAGING; 19(3), pp. 153-165, 2000,
- * (https://www.cs.unc.edu/~styner/docs/tmi00.pdf)
- *
- * "Evaluation of 2D/3D bias correction with 1+1ES-optimization"
- * Martin Styner, Prof. Dr. G. Gerig (IKT, BIWI, ETH Zuerich), TR-197
- * (https://www.cs.unc.edu/~styner/docs/StynerTR97.pdf)
+ * For more details refer to \cite styner2000 and \cite styner1997.
  * \ingroup ITKBiasCorrection
  */
 template <typename TInputImage, typename TOutputImage, typename TMaskImage>

--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.h
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.h
@@ -35,7 +35,7 @@ namespace itk
  * \brief Implementation of the N4  bias field correction algorithm.
  *
  * The nonparametric nonuniform intensity normalization (N3) algorithm, as
- * introduced by Sled et al. in 1998 is a method for correcting nonuniformity
+ * introduced by Sled et al. in 1998 \cite sled1998 is a method for correcting nonuniformity
  * associated with MR images. The algorithm assumes a simple parametric model
  * (Gaussian) for the bias field and does not require tissue class segmentation.
  * In addition, there are only a couple of parameters to tune with the default

--- a/Modules/Filtering/Convolution/include/itkFFTNormalizedCorrelationImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkFFTNormalizedCorrelationImageFilter.h
@@ -84,11 +84,7 @@ namespace itk
  * type. You will get a compilation error if the pixel type of the
  * output image is not float or double.
  *
- * References:
- * 1) D. Padfield. "Masked object registration in the Fourier domain."
- * Transactions on Image Processing.
- * 2) D. Padfield. "Masked FFT registration". In Proc. Computer
- * Vision and Pattern Recognition, 2010.
+ * For algorithmic details see \cite padfield2012 and \cite padfield2010.
  *
  * \author: Dirk Padfield, GE Global Research, padfield\@research.ge.com
  * \ingroup ITKConvolution

--- a/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.h
+++ b/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.h
@@ -95,9 +95,7 @@ namespace itk
  * is a table containing all cluster centers.  The GLA produces results
  * that are equivalent to the K-means clustering algorithm.
  *
- * For more information about the algorithms, see A. Gersho and R. M. Gray,
- * {\em Vector Quantization and Signal Compression},
- * Kluwer Academic Publishers, Boston, MA, 1992.
+ * For more information about the algorithms, see \cite gersho1992.
  *
  * This object supports data handling of multiband images. The object
  * accepts the input image in vector format only, where each pixel is a

--- a/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.h
@@ -56,13 +56,7 @@ namespace itk
  * Stable State Thresholding works well on images with a large number
  * of objects to be counted.
  *
- * \par References:
- * 1) Urish KL, August J, Huard J. "Unsupervised segmentation for myofiber
- * counting in immunofluorescent microscopy images". Insight Journal.
- * ISC/NA-MIC/MICCAI Workshop on Open-Source Software (2005)
- * https://doi.org/10.54294/h1vbsl
- * 2) Pikaz A, Averbuch, A. "Digital image thresholding based on topological
- * stable-state". Pattern Recognition, 29(5): 829-843, 1996.
+ * For algorithmic details see \cite urish2005 and \cite pikaz1996.
  *
  * \par
  * Questions: email Ken Urish at ken.urish(at)gmail.com

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.h
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.h
@@ -61,7 +61,7 @@ namespace itk
  * produce more regular mesh. Higher values ( 0.3 < gamma < 0.2) will allow to move the vertices to
  * regions of higher curvature.
  *
- * This approach for segmentation follows that of Delingette et al. (1997).
+ * This approach for segmentation follows that of \cite delingette1999.
  *
  * This filter currently assumes that the spacing of the input image is 1.
  *

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.h
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.h
@@ -102,10 +102,7 @@ namespace itk
  * Appropriate padding must be performed by the user if any image which
  * are not multiples of the grid sizes are used.
  *
- * For more information about the algorithm, see G. Koepfler, C. Lopez
- * and J. M. Morel, ``A Multiscale Algorithm for Image Segmentation by
- * Variational Method,'' {\em SIAM Journal of Numerical Analysis},
- * vol. 31, pp. 282-299, 1994.
+ * For more information about the algorithm, see \cite koepfler1994.
  *
  * Algorithm details:
  *

--- a/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.h
+++ b/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.h
@@ -35,10 +35,7 @@ namespace itk
  * commonly used as a way of boosting segmentation performance.
  *
  * The use of label voting for combination of multiple segmentations is
- * described in
- *
- * T. Rohlfing and C. R. Maurer, Jr., "Multi-classifier framework for
- * atlas-based image segmentation," Pattern Recognition Letters, 2005.
+ * described in \cite rohlfing2005.
  *
  * \par INPUTS
  * All input volumes to this filter must be segmentations of an image,

--- a/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.h
+++ b/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.h
@@ -45,19 +45,10 @@ namespace itk
  * this estimated ground truth.
  *
  * The algorithm is based on the binary STAPLE algorithm by Warfield et al. as
- * published originally in
- *
- * S. Warfield, K. Zou, W. Wells, "Validation of image segmentation and expert
- * quality with an expectation-maximization algorithm" in MICCAI 2002: Fifth
- * International Conference on Medical Image Computing and Computer-Assisted
- * Intervention, Springer-Verlag, Heidelberg, Germany, 2002, pp. 298-306
+ * published originally in \cite warfield2002.
  *
  * The multi-label algorithm implemented here is described in detail in
- *
- * T. Rohlfing, D. B. Russakoff, and C. R. Maurer, Jr., "Performance-based
- * classifier combination in atlas-based image segmentation using
- * expectation-maximization parameter estimation," IEEE Transactions on
- * Medical Imaging, vol. 23, pp. 983-994, Aug. 2004.
+ * \cite rohlfing2004.
  *
  * \par INPUTS
  * All input volumes to this filter must be segmentations of an image,

--- a/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetFunction.h
@@ -46,10 +46,7 @@ namespace itk
  * from the negative gradient of the edge potential image. This term behaves like
  * a doublet attracting the contour to the edges.
  *
- * \par This implementation is based on:
- *  L. Lorigo, O. Faugeras, W.E.L. Grimson, R. Keriven, R. Kikinis, A. Nabavi,
- *  and C.-F. Westin, Curves: Curve evolution for vessel segmentation.
- *  Medical Image Analysis, 5:195-206, 2001.
+ * \par This implementation is based on \cite lorigo2001.
  *
  * \sa LevelSetFunction
  * \sa SegmentationLevelSetImageFunction

--- a/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetImageFilter.h
@@ -45,7 +45,8 @@ namespace itk
  *    the initial contour does not have to lie wholly within the shape to be segmented.
  *    The initial contour is allow to overlap the shape boundary. The extra advection term
  *    in the update equation behaves like a doublet and attracts the contour to the boundary.
- *    This approach for segmentation follows that of Lorigo et al (2001).
+ *    This approach for segmentation follows that of Lorigo et al
+ *    (2001) \cite lorigo2001.
  *
  *    \par
  *    The second input is the feature image.  For this filter, this is the edge
@@ -82,10 +83,7 @@ namespace itk
  *    zero crossings of the image correspond to the position of the level set
  *    front.
  *
- *    \par REFERENCES
- *    L. Lorigo, O. Faugeras, W.E.L. Grimson, R. Keriven, R. Kikinis, A. Nabavi,
- *    and C.-F. Westin, Curves: Curve evolution for vessel segmentation.
- *    Medical Image Analysis, 5:195-206, 2001.
+ *    For algorithmic details see \cite lorigo2001.
  *
  *   \par
  *   See SparseFieldLevelSetImageFilter and

--- a/Modules/Segmentation/LevelSets/include/itkExtensionVelocitiesImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkExtensionVelocitiesImageFilter.h
@@ -39,9 +39,7 @@ namespace itk
  * For the output, the extended velocity is only valid for a distance
  * of OutputNarrowBandwidth / 2 of either side of the level set of interest.
  *
- * Implementation of this class is based on Chapter 11 of
- * "Level Set Methods and Fast Marching Methods", J.A. Sethian,
- * Cambridge Press, Second edition, 1999.
+ * Implementation of this class is based on \cite sethian1999b.
  *
  * \ingroup LevelSetSegmentation
  * \ingroup ITKLevelSets

--- a/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourLevelSetFunction.h
@@ -60,11 +60,7 @@ namespace itk
  *
  * This term behaves like a doublet attracting the contour to the edges.
  *
- * This implementation is based on:
- * "Geodesic Active Contours",
- * V. Caselles, R. Kimmel and G. Sapiro.
- * International Journal on Computer Vision,
- * Vol 22, No. 1, pp 61-97, 1997
+ * This implementation is based on \cite caselles1997.
  *
  * \sa LevelSetFunction
  * \sa SegmentationLevelSetImageFunction

--- a/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourLevelSetImageFilter.h
@@ -87,12 +87,7 @@ namespace itk
  * See SparseFieldLevelSetImageFilter and
  * SegmentationLevelSetImageFilter for more information.
  *
- * \par REFERENCES
- * \par
- *    "Geodesic Active Contours",
- *    V. Caselles, R. Kimmel and G. Sapiro.
- *    International Journal on Computer Vision,
- *    Vol 22, No. 1, pp 61-97, 1997
+ * For algorithmic details see \cite caselles1997.
  *
  * \sa SegmentationLevelSetImageFilter
  * \sa GeodesicActiveContourLevelSetFunction

--- a/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourShapePriorLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourShapePriorLevelSetFunction.h
@@ -66,7 +66,7 @@ namespace itk
  * This term behaves like a doublet attracting the contour to the edges.
  *
  * This class extends the basic LevelSetFunction with a shape prior term
- * as developed in [1].
+ * as developed in \cite leventon2000.
  *
  * \f$ \zeta( \phi^{*} - \phi) \f$
  *
@@ -81,10 +81,6 @@ namespace itk
  * \sa SegmentationLevelSetFunction
  * \sa ShapePriorSegmentationLevelSetFunction
  * \sa ShapeSignedDistanceFunction
- *
- * \par REFERENCES
- * \par
- * [1] Leventon, M.E. et al. "Statistical Shape Influence in Geodesic Active Contours", CVPR 2000.
  *
  * \ingroup FiniteDifferenceFunctions
  * \ingroup ITKLevelSets

--- a/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourShapePriorLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourShapePriorLevelSetImageFilter.h
@@ -50,7 +50,7 @@ namespace itk
  * in the update equation behaves like a doublet and attracts the contour to the boundary.
  * The shape prior term adds robustness by incorporating aprior information about
  * the shape to be segmented.
- * This approach for segmentation follows that of Leventon et al (2000).
+ * This approach for segmentation follows that of \cite leventon2000.
  *
  * \par
  * The second input is the feature image.  For this filter, this is the edge
@@ -93,10 +93,6 @@ namespace itk
  * \par
  * See SparseFieldLevelSetImageFilter and
  * SegmentationLevelSetImageFilter for more information.
- *
- * \par REFERENCES
- * \par
- * Leventon, M.E. et al. "Statistical Shape Influence in Geodesic Active Contours", CVPR 2000.
  *
  * \sa SegmentationLevelSetImageFilter
  * \sa ShapePriorSegmentationLevelSetImageFilter

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.h
@@ -29,7 +29,7 @@ namespace itk
  * finite difference image filter.  (See FiniteDifferenceImageFilter.)
  *
  * LevelSetFunction implements a generic level set function.  This function is
- * an expanded form of the basic equation developed in [1].
+ * an expanded form of the basic equation developed in \cite sethian1996.
  *
  * \f$\phi_{t} + \alpha
  * \stackrel{\rightharpoonup}{A}(\mathbf{x})\cdot\nabla\phi + \beta
@@ -53,10 +53,6 @@ namespace itk
  * that you pass Initialize is the radius of the neighborhood needed to perform
  * the calculations.  If your subclass does not do any additional neighborhood
  * processing, then the default radius should be 1 in each direction.
- *
- * \par REFERENCES
- * \par
- * [1] Sethian, J.A. Level Set Methods. Cambridge University Press. 1996.
  *
  * \ingroup FiniteDifferenceFunctions
  * \ingroup Functions

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.h
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.h
@@ -45,9 +45,7 @@ namespace itk
  * provided, the algorithm will only search pixels within the
  * narrowband.
  *
- * Implementation of this class is based on Chapter 11 of
- * "Level Set Methods and Fast Marching Methods", J.A. Sethian,
- * Cambridge Press, Second edition, 1999.
+ * Implementation of this class is based on \cite sethian1999b.
  *
  * \ingroup LevelSetSegmentation
  *

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetVelocityNeighborhoodExtractor.h
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetVelocityNeighborhoodExtractor.h
@@ -42,9 +42,7 @@ namespace itk
  * the level set, the type of the auxiliary/velocity variables and the
  * number of auxiliary/velocity variables.
  *
- * Implementation of this class is based on Chapter 11 of
- * "Level Set Methods and Fast Marching Methods", J.A. Sethian,
- * Cambridge Press, Second edition, 1999.
+ * Implementation of this class is based on \cite sethian1999b.
  *
  * \ingroup LevelSetSegmentation
  *

--- a/Modules/Segmentation/LevelSets/include/itkNarrowBandCurvesLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkNarrowBandCurvesLevelSetImageFilter.h
@@ -45,7 +45,7 @@ namespace itk
  *    the initial contour does not have to lie wholly within the shape to be segmented.
  *    The initial contour is allow to overlap the shape boundary. The extra advection term
  *    in the update equation behaves like a doublet and attracts the contour to the boundary.
- *    This approach for segmentation follows that of Lorigo et al (2001).
+ *    This approach for segmentation follows that of \cite lorigo2001.
  *
  *    \par
  *    The second input is the feature image.  For this filter, this is the edge
@@ -81,11 +81,6 @@ namespace itk
  *    and positive values in the image are outside of the inside region.  The
  *    zero crossings of the image correspond to the position of the level set
  *    front.
- *
- *    \par REFERENCES
- *    L. Lorigo, O. Faugeras, W.E.L. Grimson, R. Keriven, R. Kikinis, A. Nabavi,
- *    and C.-F. Westin, Curves: Curve evolution for vessel segmentation.
- *    Medical Image Analysis, 5:195-206, 2001.
  *
  *   \par
  *   See NarrowBandImageFilterBase and

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.h
@@ -243,12 +243,7 @@ private:
  *  FiniteDifferenceFunction to use for calculations.  This is set using the
  *  method SetDifferenceFunction in the parent class.
  *
- * \par REFERENCES
- * Whitaker, Ross. A Level-Set Approach to 3D Reconstruction from Range Data.
- * International Journal of Computer Vision.  V. 29 No. 3, 203-231. 1998.
- *
- * \par
- * Sethian, J.A. Level Set Methods. Cambridge University Press. 1996.
+ * For algorithmic details see \cite whitaker1998 and \cite sethian1996.
  *
  * \ingroup ITKLevelSets
  */

--- a/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.h
@@ -43,9 +43,7 @@ namespace itk
  * For the output, the reinitialize level set is only valid for a distance
  * of OutputNarrowBandwidth / 2 of either side of the level set of interest.
  *
- * Implementation of this class is based on Chapter 11 of
- * "Level Set Methods and Fast Marching Methods", J.A. Sethian,
- * Cambridge Press, Second edition, 1999.
+ * Implementation of this class is based on \cite sethian1999b.
  *
  * \ingroup LevelSetSegmentation
  *

--- a/Modules/Segmentation/LevelSets/include/itkShapeDetectionLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkShapeDetectionLevelSetFunction.h
@@ -55,11 +55,7 @@ namespace itk
  *
  * Note that there is no advection term in this function.
  *
- * This implementation is based on:
- * "Shape Modeling with Front Propagation: A Level Set Approach",
- * R. Malladi, J. A. Sethian and B. C. Vermuri.
- * IEEE Trans. on Pattern Analysis and Machine Intelligence,
- * Vol 17, No. 2, pp 158-174, February 1995
+ * This implementation is based on \cite malladi1995.
  *
  * \sa LevelSetFunction
  * \sa SegmentationLevelSetImageFunction

--- a/Modules/Segmentation/LevelSets/include/itkShapeDetectionLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkShapeDetectionLevelSetImageFilter.h
@@ -88,12 +88,7 @@ namespace itk
  * See SparseFieldLevelSetImageFilter and
  * SegmentationLevelSetImageFilter for more information.
  *
- * \par REFERENCES
- * \par
- *    "Shape Modeling with Front Propagation: A Level Set Approach",
- *    R. Malladi, J. A. Sethian and B. C. Vermuri.
- *    IEEE Trans. on Pattern Analysis and Machine Intelligence,
- *    Vol 17, No. 2, pp 158-174, February 1995
+ * For algorithmic details see \cite malladi1995.
  *
  * \sa SegmentationLevelSetImageFilter
  * \sa ShapeDetectionLevelSetFunction

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunction.h
@@ -38,10 +38,7 @@ namespace itk
  *
  * \sa ShapePriorSegmentationLevelSetImageFilter
  *
- * \par REFERENCES
- * \par
- * [1] Leventon, M.E. et al. "Statistical Shape Influence in Geodesic Active Contours", CVPR 2000.
- *
+ * For algorithmic details see \cite leventon2000.
  *
  * \ingroup Numerics Optimizers
  * \ingroup ITKLevelSets

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunctionBase.h
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunctionBase.h
@@ -28,18 +28,14 @@ namespace itk
  * \brief Represents the base class of maximum aprior (MAP) cost function used
  * ShapePriorSegmentationLevelSetImageFilter to estimate the shape parameters.
  *
- * This class follows the shape and pose parameters estimation developed in [1].
+ * This class follows the shape and pose parameters estimation
+ * developed in \cite leventon2000.
  *
  * This class has two template parameters, the feature image type representing the
  * edge potential map and the pixel type used to
  * represent the output level set in the ShapePriorSegmentationLevelSetImageFilter.
  *
  * \sa ShapePriorSegmentationLevelSetImageFilter
- *
- * \par REFERENCES
- * \par
- * [1] Leventon, M.E. et al. "Statistical Shape Influence in Geodesic Active Contours", CVPR 2000.
- *
  *
  * \ingroup Numerics Optimizers
  * \ingroup ITKLevelSets

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.h
@@ -30,7 +30,7 @@ namespace itk
  * shape model.
  *
  * This class extends the basic LevelSetFunction with a shape prior term
- * as developed in [1].
+ * as developed in \cite leventon2000.
  *
  * \f$ \zeta( \phi^{*} - \phi) \f$
  *
@@ -43,10 +43,6 @@ namespace itk
  * \sa LevelSetFunction
  * \sa SegmentationLevelSetImageFunction
  * \sa ShapeSignedDistanceFunction
- *
- * \par REFERENCES
- * \par
- * [1] Leventon, M.E. et al. "Statistical Shape Influence in Geodesic Active Contours", CVPR 2000.
  *
  * \ingroup FiniteDifferenceFunctions
  * \ingroup ITKLevelSets

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetImageFilter.h
@@ -36,7 +36,7 @@ namespace itk
  * \par OVERVIEW
  * This class extends the functionality of SegmentationLevelSetImageFilter
  * with an additional statistical shape influence term in the level set evolution as
- * developed in [1].
+ * developed in \cite leventon2000.
  *
  * \par TEMPLATE PARAMETERS
  * There are two required and one optional template parameter for these
@@ -62,10 +62,6 @@ namespace itk
  *
  * \sa ShapeSignedDistanceFunction
  * \sa ShapePriorSegmentationLevelSetFunction
- *
- * \par REFERENCES
- * \par
- * [1] Leventon, M.E. et al. "Statistical Shape Influence in Geodesic Active Contours", CVPR 2000.
  *
  * \ingroup ITKLevelSets
  */

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.h
@@ -231,12 +231,7 @@ private:
  *  FiniteDifferenceFunction to use for calculations.  This is set using the
  *  method SetDifferenceFunction in the parent class.
  *
- * \par REFERENCES
- * Whitaker, Ross. A Level-Set Approach to 3D Reconstruction from Range Data.
- * International Journal of Computer Vision.  V. 29 No. 3, 203-231. 1998.
- *
- * \par
- * Sethian, J.A. Level Set Methods. Cambridge University Press. 1996.
+ * For algorithmic details see \cite whitaker1998 and \par sethian1996.
  *
  * \ingroup ITKLevelSets
  */

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.h
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.h
@@ -123,9 +123,8 @@ extern ITKMarkovRandomFieldsClassifiers_EXPORT std::ostream &
  *
  * For minimization of the MRF labeling function the MinimizeFunctional
  * virtual method is called. For our current implementation we use
- * the iterated conditional modes (ICM) algorithm described by Besag in the
- * paper "On the Statistical Analysis of Dirty Pictures" in J. Royal Stat.
- * Soc. B, Vol. 48, 1986.
+ * the iterated conditional modes (ICM) algorithm described in
+ * \cite besag1986.
  *
  * In each iteration, the algorithm visits each pixel in turn and
  * determines whether to update its classification by computing the influence

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
@@ -29,9 +29,7 @@ namespace itk
  * \brief Implement the Sweep Line Algorithm for the construction of the
  *        2D Voronoi Diagram.
  *
- * Detailed information on this method can be found in:
- * "A sweepline algorithm for Voronoi diagrams."
- * S. Fortune, Algorithmica 2, 153-174, 1987.
+ * Detailed information on this method can be found in \cite fortune1987.
  *
  * Input parameters are:
  * (1) Size of the region.

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.h
@@ -41,10 +41,7 @@ namespace itk
  * The parameters can also be automatically set by given a prior, as a binary
  * image.
  *
- * Detail information about this algorithm can be found in:
- *  " Semi-automated color segmentation of anatomical tissue,"
- *   C. Imelinska, M. Downes, and W. Yuan
- *  Computerized Medical Imaging and Graphics, Vor.24, pp 173-180, 2000.
+ * Detailed information about this algorithm can be found in \cite imelinska2000.
  *
  * \ingroup HybridSegmentation
  * \ingroup ITKVoronoi

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.h
@@ -47,10 +47,7 @@ namespace itk
  * image segmentation can be implemented by deriving image filters from this class, by
  * implementing the virtual methods
  *
- * Detailed information about this algorithm can be found in:
- *  " Semi-automated color segmentation of anatomical tissue,"
- *   C. Imelinska, M. Downes, and W. Yuan
- *  Computerized Medical Imaging and Graphics, Vor.24, pp 173-180, 2000.
+ * Detailed information about this algorithm can be found in \cite imelinska2000.
  *
  * \ingroup HybridSegmentation
  * \ingroup ITKVoronoi

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.h
@@ -41,11 +41,7 @@ namespace itk
  *
  * These parameters can also be automatically set by providing a binary image prior.
  *
- * Detailed information about this algorithm can be found in:
- *  " Semi-automated color segmentation of anatomical tissue,"
- *   C. Imelinska, M. Downes, and W. Yuan
- *  Computerized Medical Imaging and Graphics, Vol.24, pp 173-180, 2000.
- *
+ * Detailed information about this algorithm can be found in \cite imelinska2000.
  *
  * \ingroup HybridSegmentation
  * \ingroup ITKVoronoi

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.h
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.h
@@ -62,8 +62,7 @@ namespace itk
  * image.
  *
  * The morphological watershed transform algorithm is described in
- * Chapter 9.2 of Pierre Soille's book "Morphological Image Analysis:
- * Principles and Applications", Second Edition, Springer, 2003.
+ * \cite soille2004c.
  *
  * This code was contributed in the Insight Journal paper:
  * "The watershed transform in ITK - discussion and new developments"

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.h
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.h
@@ -32,9 +32,7 @@ namespace itk
  * size by passing the output of this filter to a RelabelComponentImageFilter.
  *
  * The morphological watershed transform algorithm is described in
- * Chapter 9.2 of Pierre Soille's book "Morphological Image Analysis:
- * Principles and Applications", Second Edition, Springer, 2003.
- *
+ * \cite soille2004c.
  *
  * This code was contributed in the Insight Journal paper:
  * "The watershed transform in ITK - discussion and new developments"


### PR DESCRIPTION
Second PR out of N, converting raw inline citations with various styles to using a bibliography database and the doxygen cite command.

Bibtex file was formatted using bibtex-tidy
(https://github.com/FlamingTempura/bibtex-tidy). This tool can be used as a pre-commit hook but currently does not have an option for just performing compliance checking so not added to .pre-commit-config.yaml file.
