### PR TITLE
DOC: Retain Modules page, which was renamed into Topics

### DIFF
--- a/Documentation/Doxygen/DoxygenLayout.xml
+++ b/Documentation/Doxygen/DoxygenLayout.xml
@@ -4,6 +4,7 @@
   <navindex>
     <tab type="mainpage" visible="yes" title=""/>
     <tab type="pages" visible="yes" title="" intro=""/>
+    <tab type="topics" visible="yes" title="" intro=""/>
     <tab type="modules" visible="yes" title="" intro=""/>
     <tab type="namespaces" visible="yes" title="">
       <tab type="namespacelist" visible="yes" title="" intro=""/>


### PR DESCRIPTION
With the newer versions of doxygen (i.e. 1.9.8 and newer) the old modules pages is missing. As of doxygen 1.9.8 the modules have been renamed to topics to prevent confusion with C++ modules. Closes #5212.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Updated API documentation (or API not changed)
