### PR TITLE
STYLE: Use itk::ReadImage and itk::WriteImage in Example/Statistics-Correction

### DIFF
--- a/Examples/Statistics/BayesianClassifier.cxx
+++ b/Examples/Statistics/BayesianClassifier.cxx
@@ -67,15 +67,21 @@ main(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  // input parameters
-  const char * membershipImageFileName = argv[1];
-  const char * labelMapImageFileName = argv[2];
 
   // setup reader
   constexpr unsigned int Dimension = 2;
   using InputPixelType = float;
   using InputImageType = itk::VectorImage<InputPixelType, Dimension>;
-  const auto input = itk::ReadImage<InputImageType>(membershipImageFileName);
+  ImageType::Pointer input;
+  try
+  {
+    input = itk::ReadImage<ImageType>(argv[1]);
+  }
+  catch (const itk::ExceptionObject & excp)
+  {
+    std::cerr << excp << std::endl;
+    return EXIT_FAILURE;
+  }
 
   using LabelType = unsigned char;
   using PriorType = float;
@@ -132,7 +138,7 @@ main(int argc, char * argv[])
   //
   try
   {
-    itk::WriteImage(rescaler->GetOutput(), labelMapImageFileName);
+    itk::WriteImage(rescaler->GetOutput(), argv[2]);
   }
   catch (const itk::ExceptionObject & excp)
   {

--- a/Examples/Statistics/BayesianClassifierInitializer.cxx
+++ b/Examples/Statistics/BayesianClassifierInitializer.cxx
@@ -166,12 +166,15 @@ main(int argc, char * argv[])
     rescaler->SetInput(extractedComponentImage);
     rescaler->SetOutputMinimum(0);
     rescaler->SetOutputMaximum(255);
-    using ExtractedComponentWriterType =
-      itk::ImageFileWriter<OutputImageType>;
-    auto rescaledImageWriter = ExtractedComponentWriterType::New();
-    rescaledImageWriter->SetInput(rescaler->GetOutput());
-    rescaledImageWriter->SetFileName(argv[5]);
-    rescaledImageWriter->Update();
+    try
+    {
+      itk::WriteImage(rescaler->GetOutput(), argv[5]);
+    }
+    catch (const itk::ExceptionObject & excp)
+    {
+      std::cerr << excp << std::endl;
+      return EXIT_FAILURE;
+    }
   }
 
   return EXIT_SUCCESS;

--- a/Examples/Statistics/ScalarImageKmeansClassifier.cxx
+++ b/Examples/Statistics/ScalarImageKmeansClassifier.cxx
@@ -70,7 +70,17 @@ main(int argc, char * argv[])
   constexpr unsigned int Dimension = 2;
 
   using ImageType = itk::Image<PixelType, Dimension>;
-  const auto input = itk::ReadImage<ImageType>(inputImageFileName);
+  ImageType::Pointer input;
+  try
+  {
+    input = itk::ReadImage<ImageType>(argv[1]);
+  }
+  catch (const itk::ExceptionObject & excp)
+  {
+    std::cerr << excp << std::endl;
+    return EXIT_FAILURE;
+  }
+  
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Statistics/ScalarImageMarkovRandomField1.cxx
+++ b/Examples/Statistics/ScalarImageMarkovRandomField1.cxx
@@ -117,8 +117,16 @@ main(int argc, char * argv[])
   constexpr unsigned int Dimension = 2;
 
   using ImageType = itk::Image<PixelType, Dimension>;
-
-  const auto input = itk::ReadImage<ImageType>(inputImageFileName);
+  ImageType::Pointer input;
+  try
+  {
+    input = itk::ReadImage<ImageType>(inputImageFileName);
+  }
+  catch (const itk::ExceptionObject & excp)
+  {
+    std::cerr << excp << std::endl;
+    return EXIT_FAILURE;
+  }
   // Software Guide : EndCodeSnippet
 
 
@@ -420,23 +428,12 @@ main(int argc, char * argv[])
   intensityRescaler->SetOutputMaximum(255);
   intensityRescaler->SetInput(mrfFilter->GetOutput());
 
-  // Software Guide : BeginCodeSnippet
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-
-  auto writer = WriterType::New();
-
-  writer->SetInput(intensityRescaler->GetOutput());
-
-  writer->SetFileName(outputImageFileName);
-  // Software Guide : EndCodeSnippet
-
-
   // Software Guide : BeginLatex
   //
   // We are now ready for triggering the execution of the pipeline. This is
-  // done by simply invoking the \code{Update()} method in the writer. This
-  // call will propagate the update request to the reader and then to the MRF
-  // filter.
+  // done by simply invoking the \code{WriteImage()} function. This call will
+  // propagate the update request to the MRF filter and writes the  processed
+  // image to the specified file.
   //
   // Software Guide : EndLatex
 
@@ -444,12 +441,10 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   try
   {
-    writer->Update();
+    itk::WriteImage(intensityRescaler->GetOutput(), outputImageFileName);
   }
   catch (const itk::ExceptionObject & excp)
   {
-    std::cerr << "Problem encountered while writing ";
-    std::cerr << " image file : " << argv[2] << std::endl;
     std::cerr << excp << std::endl;
     return EXIT_FAILURE;
   }


### PR DESCRIPTION
This commit addresses the review comments related to issue #2802.In this commit Examples related to statistics has been changed to use itk::ReadImage and itk::WriteImage.