### PR TITLE
DOC: Convert from raw in-code citations to bibtex (3/N)

### DIFF
--- a/Documentation/Doxygen/doxygen.bib
+++ b/Documentation/Doxygen/doxygen.bib
@@ -1,3 +1,9 @@
+@book{abramowitz1972,
+  title        = {Handbook of Mathematical Functions: with Formulas, Graphs, and Mathematical Tables},
+  author       = {Milton Abramowitz and Irene A. Stegun},
+  year         = 1972,
+  publisher    = {John Wiley & Sons, New York.}
+}
 @article{alyassin1994,
   title        = {Evaluation of new algorithms for the interactive measurement of surface area and volume},
   author       = {Alyassin, Abdalmajeid M. and Lancaster, Jack L. and Downs III, J. Hunter and Fox, Peter T.},
@@ -157,6 +163,17 @@
   doi          = {10.1007/s11263-007-0052-1},
   url          = {https://doi.org/10.1007/s11263-007-0052-1}
 }
+@article{byrd1995,
+  title        = {A Limited Memory Algorithm for Bound Constrained Optimization},
+  author       = {Byrd, Richard H. and Lu, Peihuang and Nocedal, Jorge and Zhu, Ciyou},
+  year         = 1995,
+  journal      = {SIAM Journal on Scientific Computing},
+  volume       = 16,
+  number       = 5,
+  pages        = {1190--1208},
+  doi          = {10.1137/0916069},
+  url          = {https://doi.org/10.1137/0916069}
+}
 @article{canny1986,
   title        = {A Computational Approach to Edge Detection},
   author       = {John Canny},
@@ -185,6 +202,38 @@
   year         = 1995,
   publisher    = {Prentice Hall}
 }
+@inproceedings{chan1999,
+  title        = {An Active Contour Model without Edges},
+  author       = {Chan, Tony and Vese, Luminita},
+  year         = 1999,
+  booktitle    = {Scale-Space Theories in Computer Vision},
+  publisher    = {Springer Berlin Heidelberg},
+  pages        = {141--151},
+  doi          = {10.1007/3-540-48236-9_13},
+  url          = {https://doi.org/10.1007/3-540-48236-9_13}
+}
+@article{chan2001,
+  title        = {Active contours without edges},
+  author       = {Chan, Tony F. and Vese, Luminita A.},
+  year         = 2001,
+  journal      = {IEEE Transactions on Image Processing},
+  volume       = 10,
+  number       = 2,
+  pages        = {266--277},
+  doi          = {10.1109/83.902291},
+  url          = {https://doi.org/10.1109/83.902291}
+}
+@article{chu1990,
+  title        = {Use of gray value distribution of run lengths for texture analysis},
+  author       = {A. Chu and C.M. Sehgal and J.F. Greenleaf},
+  year         = 1990,
+  journal      = {Pattern Recognition Letters},
+  volume       = 11,
+  number       = 6,
+  pages        = {415--419},
+  doi          = {10.1016/0167-8655(90)90112-F},
+  url          = {https://doi.org/10.1016/0167-8655(90)90112-F}
+}
 @inproceedings{chung2002,
   title        = {Multi-modal Image Registration by Minimising Kullback-Leibler Distance},
   author       = {Chung, Albert C. S. and Wells, William M. and Norbash, Alexander and Grimson, W. Eric L.},
@@ -193,6 +242,39 @@
   pages        = {525--532},
   doi          = {10.1007/3-540-45787-9_66},
   url          = {https://doi.org/10.1007/3-540-45787-9_66}
+}
+@article{clatz2005,
+  title        = {Robust nonrigid registration to capture brain shift from intraoperative MRI},
+  author       = {Clatz, O. and Delingette, H. and Talos, I.-F. and Golby, A.J. and Kikinis, R. and Jolesz, F.A. and Ayache, N. and Warfield, S.K.},
+  year         = 2005,
+  journal      = {IEEE Transactions on Medical Imaging},
+  volume       = 24,
+  number       = 11,
+  pages        = {1417--1427},
+  doi          = {10.1109/TMI.2005.856734},
+  url          = {https://doi.org/10.1109/TMI.2005.856734}
+}
+@article{conners1980,
+  title        = {A Theoretical Comparison of Texture Algorithms},
+  author       = {Conners, Richard W. and Harlow, Charles A.},
+  year         = 1980,
+  journal      = {IEEE Transactions on Pattern Analysis and Machine Intelligence},
+  volume       = {PAMI-2},
+  number       = 3,
+  pages        = {204--222},
+  doi          = {10.1109/TPAMI.1980.4767008},
+  url          = {https://doi.org/10.1109/TPAMI.1980.4767008}
+}
+@article{conners1984,
+  title        = {Segmentation of a high-resolution urban scene using texture operators},
+  author       = {Richard W. Conners and Mohan M. Trivedi and Charles A. Harlow},
+  year         = 1984,
+  journal      = {Computer Vision, Graphics, and Image Processing},
+  volume       = 25,
+  number       = 3,
+  pages        = {273--310},
+  doi          = {10.1016/0734-189X(84)90197-X},
+  url          = {https://doi.org/10.1016/0734-189X(84)90197-X}
 }
 @article{danielsson1980,
   title        = {Euclidean distance mapping},
@@ -204,6 +286,17 @@
   pages        = {227--248},
   doi          = {10.1016/0146-664X(80)90054-4},
   url          = {https://doi.org/10.1016/0146-664X(80)90054-4}
+}
+@article{dasarathy1991,
+  title        = {Image characterizations based on joint gray level—run length distributions},
+  author       = {Belur V. Dasarathy and Edwin B. Holder},
+  year         = 1991,
+  journal      = {Pattern Recognition Letters},
+  volume       = 12,
+  number       = 8,
+  pages        = {497--502},
+  doi          = {https://doi.org/10.1016/0167-8655(91)80014-2},
+  url          = {10.1016/0167-8655(91)80014-2}
 }
 @article{davis1997,
   title        = {A physics-based coordinate transformation for {3-D} image matching},
@@ -227,6 +320,14 @@
   doi          = {10.1023/A:1008157432188},
   url          = {https://doi.org/10.1023/A:1008157432188}
 }
+@book{dennis1983,
+  title        = {Numerical Methods for Unconstrained Optimization and Nonlinear Equations},
+  author       = {Dennis, Jr. John E. and Schnabel, Robert B.},
+  year         = 1983,
+  publisher    = {Society for Industrial and Applied Mathematics (SIAM)},
+  doi          = {10.1137/1.9781611971200},
+  url          = {https://doi.org/10.1137/1.9781611971200}
+}
 @article{deriche1990,
   title        = {Fast algorithms for low-level vision},
   author       = {Rachid Deriche},
@@ -237,6 +338,17 @@
   pages        = {78--87},
   doi          = {10.1109/34.41386},
   url          = {https://doi.org/10.1109/34.41386}
+}
+@article{dufour2005,
+  title        = {Segmenting and tracking fluorescent cells in dynamic 3-D microscopy with coupled active surfaces},
+  author       = {Dufour, A. and Shinin, V. and Tajbakhsh, S. and Guillen-Aghion, N. and Olivo-Marin, J.-C. and Zimmer, C.},
+  year         = 2005,
+  journal      = {IEEE Transactions on Image Processing},
+  volume       = 14,
+  number       = 9,
+  pages        = {1396--1410},
+  doi          = {10.1109/TIP.2005.852790},
+  url          = {https://doi.org/10.1109/TIP.2005.852790}
 }
 @article{farneback2006,
   title        = {Improving Deriche-style Recursive Gaussian Filters},
@@ -278,6 +390,27 @@
   pages        = {130--137},
   doi          = {10.1007/BFb0056195},
   url          = {https://doi.org/10.1007/BFb0056195}
+}
+@inproceedings{galen2007,
+  title        = {Scalable training of L1-regularized log-linear models},
+  author       = {Andrew, Galen and Gao, Jianfeng},
+  year         = 2007,
+  booktitle    = {International Conference on Machine Learning (ICML)},
+  pages        = {33–40},
+  doi          = {10.1145/1273496.1273501},
+  url          = {https://doi.org/10.1145/1273496.1273501},
+  numpages     = 8
+}
+@article{galloway1975,
+  title        = {Texture analysis using gray level run lengths},
+  author       = {Mary M. Galloway},
+  year         = 1975,
+  journal      = {Computer Graphics and Image Processing},
+  volume       = 4,
+  number       = 2,
+  pages        = {172--179},
+  doi          = {10.1016/S0146-664X(75)80008-6},
+  url          = {https://doi.org/10.1016/S0146-664X(75)80008-6}
 }
 @book{gamma1994,
   title        = {Design Patterns: Elements of Reusable Object-Oriented Software},
@@ -338,6 +471,28 @@
   year         = 2006,
   number       = {CS-2006-07},
   institution  = {Dalhousie University}
+}
+@article{haralick1973,
+  title        = {Textural Features for Image Classification},
+  author       = {Haralick, Robert M. and Shanmugam, K. and Dinstein, Its'Hak},
+  year         = 1973,
+  journal      = {IEEE Transactions on Systems, Man, and Cybernetics},
+  volume       = {SMC-3},
+  number       = 6,
+  pages        = {610--621},
+  doi          = {10.1109/TSMC.1973.4309314},
+  url          = {https://doi.org/10.1109/TSMC.1973.4309314}
+}
+@article{haralick1979,
+  title        = {Statistical and structural approaches to texture},
+  author       = {Haralick, R.M.},
+  year         = 1979,
+  journal      = {Proceedings of the IEEE},
+  volume       = 67,
+  number       = 5,
+  pages        = {786--804},
+  doi          = {10.1109/PROC.1979.11328},
+  url          = {https://doi.org/10.1109/PROC.1979.11328}
 }
 @article{hasan2001,
   title        = {Analytical Computation of the Eigenvalues and Eigenvectors in {DT-MRI}},
@@ -427,6 +582,16 @@
   pages        = {273--285},
   doi          = {10.1016/0734-189X(85)90125-2},
   url          = {https://doi.org/10.1016/0734-189X(85)90125-2}
+}
+@inproceedings{kennedy1995,
+  title        = {Particle swarm optimization},
+  author       = {Kennedy, J. and Eberhart, R.},
+  year         = 1995,
+  booktitle    = {International Conference on Neural Networks},
+  volume       = 4,
+  pages        = {1942--1948},
+  doi          = {10.1109/ICNN.1995.488968},
+  url          = {https://doi.org/10.1109/ICNN.1995.488968}
 }
 @article{kim2011,
   title        = {Affine Transformation for Landmark Based Registration Initializer in ITK},
@@ -523,11 +688,41 @@
   doi          = {10.1016/S0167-8655(98)00057-9},
   url          = {https://doi.org/10.1016/S0167-8655(98)00057-9}
 }
+@inproceedings{li2005,
+  title        = {Level set evolution without re-initialization: a new variational formulation},
+  author       = {Chunming Li and Chenyang Xu and Changfeng Gui and Fox, M.D.},
+  year         = 2005,
+  booktitle    = {IEEE Computer Society Conference on Computer Vision and Pattern Recognition (CVPR)},
+  volume       = 1,
+  pages        = {430--436},
+  doi          = {10.1109/CVPR.2005.213},
+  url          = {https://doi.org/10.1109/CVPR.2005.213}
+}
 @phdthesis{lindeberg1991,
   title        = {Discrete Scale-Space Theory and the Scale-Space Primal Sketch},
   author       = {Tony Lindeberg},
   year         = 1991,
   school       = {Royal Institute of Technology, Stockholm, Sweden}
+}
+@article{liu1989,
+  title        = {On the limited memory BFGS method for large scale optimization},
+  author       = {Liu, Dong C. and Nocedal, Jorge},
+  year         = 1989,
+  journal      = {Mathematical Programming},
+  volume       = 45,
+  number       = 1,
+  pages        = {503--528},
+  doi          = {10.1007/BF01589116},
+  url          = {https://doi.org/10.1007/BF01589116}
+}
+@inproceedings{liu2009,
+  title        = {Real-Time Non-rigid Registration of Medical Images on a Cooperative Parallel Architecture},
+  author       = {Liu, Yixun and Fedorov, Andriy and Kikinis, Ron and Chrisochoides, Nikos},
+  year         = 2009,
+  booktitle    = {IEEE International Conference on Bioinformatics and Biomedicine},
+  pages        = {401--404},
+  doi          = {10.1109/BIBM.2009.10},
+  url          = {https://doi.org/10.1109/BIBM.2009.10}
 }
 @article{lorensen1987,
   title        = {Marching cubes: {A} high resolution {3D} surface construction algorithm},
@@ -640,6 +835,17 @@
   doi          = {10.1007/10704282_23},
   url          = {https://doi.org/10.1007/10704282_23}
 }
+@article{meijster2002,
+  title        = {A comparison of algorithms for connected set openings and closings},
+  author       = {Meijster, A. and Wilkinson, M.H.F.},
+  year         = 2002,
+  journal      = {IEEE Transactions on Pattern Analysis and Machine Intelligence},
+  volume       = 24,
+  number       = 4,
+  pages        = {484--494},
+  doi          = {10.1109/34.993556},
+  url          = {https://doi.org/10.1109/34.993556}
+}
 @article{melhem2002,
   title        = {Diffusion Tensor {MR} Imaging of the Brain and White Matter Tractography},
   author       = {Melhem, Elias R. and Mori, Susumu and Mukundan, Govind and Kraut, Michael A. and Pomper, Martin G. and van Zijl, Peter C. M.},
@@ -650,6 +856,17 @@
   pages        = {3--16},
   doi          = {10.2214/ajr.178.1.1780003},
   url          = {https://doi.org/10.2214/ajr.178.1.1780003}
+}
+@article{more1994,
+  title        = {Line search algorithms with guaranteed sufficient decrease},
+  author       = {Mor\'{e}, Jorge J. and Thuente, David J.},
+  year         = 1994,
+  journal      = {ACM Transactions on Mathematical Software},
+  volume       = 20,
+  number       = 3,
+  pages        = {286–307},
+  doi          = {10.1145/192115.192132},
+  url          = {https://doi.org/10.1145/192115.192132}
 }
 @article{ng2006,
   title        = {Automatic thresholding for defect detection},
@@ -668,6 +885,18 @@
   author       = {Nikos Nikopoulos and Ioannis Pitas},
   year         = 1997,
   booktitle    = {IEEE Workshop on Nonlinear Signal and Image Processing}
+}
+@article{nocedal1980,
+  title        = {Updating Quasi-Newton Matrices with Limited Storage},
+  author       = {Jorge Nocedal},
+  year         = 1980,
+  journal      = {Mathematics of Computation},
+  volume       = 35,
+  number       = 151,
+  pages        = {773--782},
+  doi          = {10.1090/S0025-5718-1980-0572855-7},
+  url          = {http://www.jstor.org/stable/2006193},
+  url          = {https://doi.org/10.1090/S0025-5718-1980-0572855-7}
 }
 @article{nyul2000,
   title        = {New variants of a method of {MRI} scale standardization},
@@ -926,6 +1155,14 @@
   pages        = {267--292},
   doi          = {10.1007/978-3-662-05088-0_9},
   url          = {https://doi.org/10.1007/978-3-662-05088-0_9}
+}
+@techreport{spall1998,
+  title        = {An Overview of the Simultaneous Perturbation Method for Efficient Optimization},
+  author       = {James C. Spall},
+  year         = 1998,
+  number       = {19(4)},
+  url          = {https://secwww.jhuapl.edu/techdigest/Content/techdigest/pdf/V19-N04/19-04-Spall.pdf},
+  institution  = {Johns Hopkins APL}
 }
 @inproceedings{sprengel1996,
   title        = {Thin-plate spline approximation for image registration},
@@ -1189,6 +1426,28 @@
   doi          = {10.1023/A:1007958904918},
   url          = {https://doi.org/10.1023/A:1007958904918}
 }
+@article{wachowiak2004,
+  title        = {An approach to multimodal biomedical image registration utilizing particle swarm optimization},
+  author       = {Wachowiak, M.P. and Smolikova, R. and Yufeng Zheng and Zurada, J.M. and Elmaghraby, A.S.},
+  year         = 2004,
+  journal      = {IEEE Transactions on Evolutionary Computation},
+  volume       = 8,
+  number       = 3,
+  pages        = {289--301},
+  doi          = {10.1109/TEVC.2004.826068},
+  url          = {https://doi.org/10.1109/TEVC.2004.826068}
+}
+@article{wallace1996,
+  title        = {Fast pseudorandom generators for normal and exponential variates},
+  author       = {Wallace, C. S.},
+  year         = 1996,
+  journal      = {ACM Transactions on Mathematical Software},
+  volume       = 22,
+  number       = 1,
+  pages        = {119–127},
+  doi          = {10.1145/225545.225554},
+  url          = {https://doi.org/10.1145/225545.225554}
+}
 @inproceedings{warfield2002,
   title        = {Validation of Image Segmentation and Expert Quality with an Expectation-Maximization Algorithm},
   author       = {Warfield, Simon K. and Zou, Kelly H. and Wells, William M.},
@@ -1256,6 +1515,17 @@
   pages        = {370--378},
   doi          = {10.1109/83.366472},
   url          = {https://doi.org/10.1109/83.366472}
+}
+@article{zhu1997,
+  title        = {Algorithm 778: {L-BFGS-B}: Fortran subroutines for large-scale bound-constrained optimization},
+  author       = {Zhu, Ciyou and Byrd, Richard H. and Lu, Peihuang and Nocedal, Jorge},
+  year         = 1997,
+  journal      = {ACM Transactions on Mathematical Software},
+  volume       = 23,
+  number       = 4,
+  pages        = {550–560},
+  doi          = {10.1145/279232.279236},
+  url          = {https://doi.org/10.1145/279232.279236}
 }
 @article{zijdenbos1994,
   title        = {Morphometric analysis of white matter lesions in {MR} images: method and validation},

--- a/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.h
@@ -35,9 +35,7 @@ namespace itk
  * volume) while attribute closings fill dark regions that meet the
  * attribute criteria.
  *
- * This filter is implemented using the method of Wilkinson, "A
- * comparison of algorithms for Connected set openings and Closings",
- * A. Meijster and M. H. Wilkinson, PAMI, vol 24, no. 4, April 2002.
+ * This filter is implemented using the method describe in \cite meijster2002.
  *
  * This code was contributed in the Insight Journal paper
  *

--- a/Modules/Nonunit/Review/include/itkConstrainedRegionBasedLevelSetFunctionSharedData.h
+++ b/Modules/Nonunit/Review/include/itkConstrainedRegionBasedLevelSetFunctionSharedData.h
@@ -28,11 +28,7 @@ namespace itk
  *
  * This class holds cache data used during the computation of the LevelSet updates.
  *
- * Based on the paper:
- *
- *        "An active contour model without edges"
- *         T. Chan and L. Vese.
- *         In Scale-Space Theories in Computer Vision, pages 141-151, 1999.
+ * Based on the paper \cite chan1999.
  *
  * \author Mosaliganti K., Smith B., Gelas A., Gouaillard A., Megason S.
  *

--- a/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.h
@@ -66,11 +66,7 @@ namespace itk
  * subclass it to a specific instance that supplies a function and Halt()
  * method.
  *
- * Based on the paper:
- *
- *        "An active contour model without edges"
- *         T. Chan and L. Vese.
- *         In Scale-Space Theories in Computer Vision, pages 141-151, 1999.
+ * Based on the paper \cite chan1999.
  *
  * \author Mosaliganti K., Smith B., Gelas A., Gouaillard A., Megason S.
  *

--- a/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.h
@@ -125,11 +125,7 @@ namespace itk
  * (or ThreadedHalt) method returns a true value to stop iteration.
  *
  *
- * Based on the paper:
- *
- *        "An active contour model without edges"
- *         T. Chan and L. Vese.
- *         In Scale-Space Theories in Computer Vision, pages 141-151, 1999.
+ * Based on the paper \cite chan1999.
  *
  * \author Mosaliganti K., Smith B., Gelas A., Gouaillard A., Megason S.
  *

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.h
@@ -136,20 +136,9 @@ namespace itk
  *  FiniteDifferenceFunction to use for calculations.  This is set using the
  *  method SetDifferenceFunction in the parent class.
  *
- * \par REFERENCES
- * Whitaker, Ross. A Level-Set Approach to 3D Reconstruction from Range Data.
- * International Journal of Computer Vision.  V. 29 No. 3, 203-231. 1998.
+ * For algorithmic details see \cite whitaker1998 and \sethian1996.
  *
- * \par
- * Sethian, J.A. Level Set Methods. Cambridge University Press. 1996.
- *
- *
- *
- * This code was adapted from the paper
- *
- *        "An active contour model without edges"
- *         T. Chan and L. Vese.
- *         In Scale-Space Theories in Computer Vision, pages 141-151, 1999.
+ * This code was adapted from \cite chan1999.
  *
  * \author Mosaliganti K., Smith B., Gelas A., Gouaillard A., Megason S.
  *

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.h
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.h
@@ -31,11 +31,7 @@ namespace itk
  * This class implements a level set function that computes the speed image by
  * integrating values on the image domain.
  *
- * Based on the paper:
- *
- *        "An active contour model without edges"
- *         T. Chan and L. Vese.
- *         In Scale-Space Theories in Computer Vision, pages 141-151, 1999.
+ * Based on the paper \cite chan1999.
  *
  * \author Mosaliganti K., Smith B., Gelas A., Gouaillard A., Megason S.
  *
@@ -459,12 +455,7 @@ protected:
 
   /** \brief Compute the laplacian term
       \return \f$ \Delta \phi - \div(\frac{\nabla \phi}{|\nabla \phi|}) \f$
-      For details see
-
-      \par REFERENCE
-      Li, C.M. and Xu, C.Y. and Gui, C. and Fox, M.D.
-      "Level Set Evolution without Re-Initialization: A New Variational Formulation",
-      CVPR05. 2005. pp. 430-436.
+      For details see \cite li2005.
   */
 
   /** \brief Compute the laplacian

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionData.h
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionData.h
@@ -35,11 +35,7 @@ namespace itk
  *
  * This class holds cache data used during the computation of the LevelSet updates.
  *
- * Based on the paper:
- *
- *        "An active contour model without edges"
- *         T. Chan and L. Vese.
- *         In Scale-Space Theories in Computer Vision, pages 141-151, 1999.
+ * Based on the paper \cite chan1999.
  *
  * \author Mosaliganti K., Smith B., Gelas A., Gouaillard A., Megason S.
  *

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionSharedData.h
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionSharedData.h
@@ -35,11 +35,7 @@ namespace itk
  *
  * This class holds cache data used during the computation of the LevelSet updates.
  *
- * Based on the paper:
- *
- *        "An active contour model without edges"
- *         T. Chan and L. Vese.
- *         In Scale-Space Theories in Computer Vision, pages 141-151, 1999.
+ * Based on the paper \cite chan1999.
  *
  * \author Mosaliganti K., Smith B., Gelas A., Gouaillard A., Megason S.
  *

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseDenseLevelSetImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseDenseLevelSetImageFilter.h
@@ -27,11 +27,7 @@ namespace itk
 /** \class ScalarChanAndVeseDenseLevelSetImageFilter
  * \brief Dense implementation of the Chan and Vese multiphase level set image filter.
  *
- * This code was adapted from the paper:
- *
- *        "An active contour model without edges"
- *         T. Chan and L. Vese.
- *         In Scale-Space Theories in Computer Vision, pages 141-151, 1999.
+ * This code was adapted from the paper \cite chan1999.
  *
  * \author Mosaliganti K., Smith B., Gelas A., Gouaillard A., Megason S.
  *

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseLevelSetFunction.h
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseLevelSetFunction.h
@@ -33,16 +33,7 @@ namespace itk
  *
  * \author Mosaliganti K., Smith B., Gelas A., Gouaillard A., Megason S.
  *
- * Based on the papers:
- *
- *        "An active contour model without edges"
- *         T. Chan and L. Vese.
- *         In Scale-Space Theories in Computer Vision, pages 141-151, 1999.
- *
- *         "Segmenting and Tracking Fluorescent Cells in Dynamic 3-D
- *          Microscopy With Coupled Active Surfaces"
- *          Dufour, Shinin, Tajbakhsh, Guillen-Aghion, Olivo-Marin
- *          In IEEE Transactions on Image Processing, vol. 14, No 9, Sep. 2005
+ * Based on the papers \cite chan1999 and \cite dufour2005.
  *
  *  This code was taken from the Insight Journal paper:
  *

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseLevelSetFunctionData.h
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseLevelSetFunctionData.h
@@ -28,11 +28,8 @@ namespace itk
  *
  * This class holds cache data used during the computation of the LevelSet updates.
  *
- * Based on the paper:
+ * Based on the paper \cite chan1999.
  *
- *        "An active contour model without edges"
- *         T. Chan and L. Vese.
- *         In Scale-Space Theories in Computer Vision, pages 141-151, 1999.
  *
  * \author Mosaliganti K., Smith B., Gelas A., Gouaillard A., Megason S.
  *

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseSparseLevelSetImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseSparseLevelSetImageFilter.h
@@ -27,11 +27,7 @@ namespace itk
 /** \class ScalarChanAndVeseSparseLevelSetImageFilter
  * \brief Sparse implementation of the Chan and Vese multiphase level set image filter.
  *
- * This code was adapted from the paper:
- *
- *        "An active contour model without edges"
- *         T. Chan and L. Vese.
- *         In Scale-Space Theories in Computer Vision, pages 141-151, 1999.
+ * This code was adapted from the paper \cite chan1999.
  *
  * \author Mosaliganti K., Smith B., Gelas A., Gouaillard A., Megason S.
  *

--- a/Modules/Nonunit/Review/include/itkScalarRegionBasedLevelSetFunction.h
+++ b/Modules/Nonunit/Review/include/itkScalarRegionBasedLevelSetFunction.h
@@ -33,11 +33,7 @@ namespace itk
  * integrating values on the image domain. NOTE: The convention followed is
  * inside of the level-set function is negative and outside is positive.
  *
- * Based on the paper:
- *
- *        "An active contour model without edges"
- *         T. Chan and L. Vese.
- *         In Scale-Space Theories in Computer Vision, pages 141-151, 1999.
+ * Based on the paper \cite chan2001.
  *
  * \author Mosaliganti K., Smith B., Gelas A., Gouaillard A., Megason S.
  *

--- a/Modules/Nonunit/Review/include/itkUnconstrainedRegionBasedLevelSetFunctionSharedData.h
+++ b/Modules/Nonunit/Review/include/itkUnconstrainedRegionBasedLevelSetFunctionSharedData.h
@@ -28,11 +28,8 @@ namespace itk
  *
  * This class holds cache data used during the computation of the LevelSet updates.
  *
- * Based on the paper:
+ * Based on the paper \cite chan1999.
  *
- *        "An active contour model without edges"
- *         T. Chan and L. Vese.
- *         In Scale-Space Theories in Computer Vision, pages 141-151, 1999.
  *
  * \author Mosaliganti K., Smith B., Gelas A., Gouaillard A., Megason S.
  *

--- a/Modules/Numerics/FEM/include/itkFEMRobustSolver.h
+++ b/Modules/Numerics/FEM/include/itkFEMRobustSolver.h
@@ -62,19 +62,7 @@ namespace fem
  *
  * \author Yixun Liu
  *
- * \par REFERENCE
- * O. Clatz, H. Delingette, I.-F. Talos, A. Golby, R. Kikinis, F. Jolesz,
- * N. Ayache, and S. Warfield, "Robust non-rigid registration to capture
- * brain shift from intra-operative MRI", IEEE Trans. Med. Imag., vol. 24,
- * no. 11, pp. 1417-1427, 2005.
- *
- *
- * \par REFERENCE
- * Yixun Liu, Andriy Fedorov, Ron Kikinis and Nikos Chrisochoides, "Real-time Non-rigid
- * Registration of Medical Images on a Cooperative Parallel Architecture",
- * IEEE International Conference on Bioinformatics & Biomedicine, pp. 401- 4,
- * November 2009.
- *
+ * For algorithmic details see \cite clatz2005 and \cite liu2009.
  *
  * \ingroup ITKFEM
  */

--- a/Modules/Numerics/FEM/include/itkFEMScatteredDataPointSetToImageFilter.h
+++ b/Modules/Numerics/FEM/include/itkFEMScatteredDataPointSetToImageFilter.h
@@ -106,17 +106,7 @@ namespace fem
  *
  * \author Yixun Liu
  *
- * \par REFERENCE
- * O. Clatz, H. Delingette, I.-F. Talos, A. Golby, R. Kikinis, F. Jolesz,
- * N. Ayache, and S. Warfield, "Robust non-rigid registration to capture brain
- * shift from intra-operative MRI", IEEE Trans. Med. Imag.,
- * 24(11);1417-27, 2005.
- *
- * \par REFERENCE
- * Yixun Liu, Andriy Fedorov, Ron Kikinis and Nikos Chrisochoides,
- * "Real-time Non-rigidRegistration of Medical Images on a Cooperative Parallel
- * Architecture", IEEE International Conference on Bioinformatics & Biomedicine,
- * pp. 401-404, November 2009.
+ * For algorithmic details see \cite clatz2005 and \cite liu2009.
  *
  * \sa FEMRobustSolver
  *

--- a/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.h
+++ b/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.h
@@ -61,8 +61,7 @@ namespace itk
  *  FiniteDifferenceFunction to use for calculations.  This is set using the
  *  method SetDifferenceFunction in the parent class.
  *
- * \par REFERENCES
- * Sethian, J.A. Level Set Methods. Cambridge University Press. 1996.
+ * For algorithmic details see \cite sethian1996.
  *
  * \ingroup ITKNarrowBand
  */

--- a/Modules/Numerics/Optimizers/include/itkInitializationBiasedParticleSwarmOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkInitializationBiasedParticleSwarmOptimizer.h
@@ -28,11 +28,7 @@ namespace itk
  * \brief Implementation of a biased/regularized Particle Swarm Optimization
  *        (PSO) algorithm.
  *
- * This PSO algorithm was originally described in:
- * M. P. Wachowiak, R. Smolikova, Y. Zheng, J. M. Zurada, A. S. Elmaghraby,
- * "An approach to multimodal biomedical image registration utilizing particle
- * swarm optimization", IEEE Transactions on Evolutionary Computing,
- * vol. 8(3): 289-301, 2004.
+ * This PSO algorithm was originally described in \cite wachowiak2004.
  *
  * The algorithm uses a stochastic optimization approach. Optimization
  * is performed by maintaining a swarm (flock) of

--- a/Modules/Numerics/Optimizers/include/itkLBFGSBOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkLBFGSBOptimizer.h
@@ -45,18 +45,7 @@ class ITK_FORWARD_EXPORT LBFGSBOptimizerHelper;
  *
  * See also the documentation in Numerics/lbfgsb.c
  *
- * References:
- *
- * [1] R. H. Byrd, P. Lu and J. Nocedal.
- * A Limited Memory Algorithm for Bound Constrained Optimization, (1995),
- * SIAM Journal on Scientific and Statistical Computing ,
- * 16, 5, pp. 1190-1208.
- *
- * [2] C. Zhu, R. H. Byrd and J. Nocedal.
- * L-BFGS-B: Algorithm 778: L-BFGS-B, FORTRAN routines for large scale
- * bound constrained optimization (1997),
- * ACM Transactions on Mathematical Software,
- * Vol 23, Num. 4, pp. 550 - 560.
+ * For algorithmic details see \cite byrd1995 and \cite zhu1997.
  *
  * \ingroup Numerics Optimizers
  * \ingroup ITKOptimizers

--- a/Modules/Numerics/Optimizers/include/itkLBFGSOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkLBFGSOptimizer.h
@@ -27,7 +27,8 @@ namespace itk
 {
 /** \class LBFGSOptimizer
  * \brief Wrap of the vnl_lbfgs algorithm for use in ITKv4 registration framework.
- * The vnl_lbfgs is a wrapper for the NETLIB fortran code by Nocedal [1].
+ * The vnl_lbfgs is a wrapper for the NETLIB fortran code by Nocedal
+ * [NETLIB lbfgs](http://users.iems.northwestern.edu/~nocedal/lbfgs.html).
  *
  * LBFGS is a quasi-Newton method. Quasi-Newton methods use an approximate estimate
  * of the inverse Hessian \f$ (\nabla^2 f(x) )^{-1} \f$ to scale the gradient step:
@@ -40,7 +41,7 @@ namespace itk
  * thus only the gradient of the objective function is required.
  *
  * The step size \f$ s \f$ is determined through line search with the approach
- * by More and Thuente [4]. This line search approach finds a step size such that
+ * by More and Thuente \cite more1994. This line search approach finds a step size such that
  * \f[
  * \lVert \nabla f(x + s (\nabla^2 f(x_n) )^{-1} \nabla f(x) ) \rVert
  *   \le
@@ -64,21 +65,9 @@ namespace itk
  * optimizer is unlikely to find a minima.
  *
  *
- * References:
- *
- * [1] [NETLIB lbfgs](http://users.iems.northwestern.edu/~nocedal/lbfgs.html)
- *
- * [2] Jorge Nocedal.
- * Updating Quasi-Newton Matrices with Limited Storage.
- * Mathematics of Computation, Vol. 35, No. 151, pp. 773-782, 1980.
- *
- * [3] Dong C. Liu and Jorge Nocedal.
- * On the limited memory BFGS method for large scale optimization.
- * Mathematical Programming B, Vol. 45, No. 3, pp. 503-528, 1989.
- *
- * [4] More, J. J. and D. J. Thuente.
- * Line Search Algorithms with Guaranteed Sufficient Decrease.
- * ACM Transactions on Mathematical Software 20, no. 3 (1994): 286-307.
+ * For algorithmic details see:
+ * [NETLIB lbfgs](http://users.iems.northwestern.edu/~nocedal/lbfgs.html),
+ * \cite nocedal1980, \cite liu1989, and \cite more1994.
  *
  * \ingroup Numerics Optimizers
  * \ingroup ITKOptimizers

--- a/Modules/Numerics/Optimizers/include/itkOnePlusOneEvolutionaryOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkOnePlusOneEvolutionaryOptimizer.h
@@ -52,15 +52,8 @@ namespace itk
  * by Martin Styner, Univ. of North Carolina at Chapel Hill, and his
  * colleagues.
  *
- * For more details. refer to the following articles.
- * "Parametric estimate of intensity inhomogeneities applied to MRI"
- * Martin Styner, G. Gerig, Christian Brechbuehler, Gabor Szekely,
- * IEEE TRANSACTIONS ON MEDICAL IMAGING; 19(3), pp. 153-165, 2000,
- * (https://www.cs.unc.edu/~styner/docs/tmi00.pdf)
- *
- * "Evaluation of 2D/3D bias correction with 1+1ES-optimization"
- * Martin Styner, Prof. Dr. G. Gerig (IKT, BIWI, ETH Zuerich), TR-197
- * (https://www.cs.unc.edu/~styner/docs/StynerTR97.pdf)
+ * For more details refer to the following articles \cite styner2000
+ * and \cite styner1997.
  *
  * \ingroup Numerics Optimizers
  *

--- a/Modules/Numerics/Optimizers/include/itkParticleSwarmOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkParticleSwarmOptimizer.h
@@ -26,9 +26,7 @@ namespace itk
 /** \class ParticleSwarmOptimizer
  * \brief Implementation of a Particle Swarm Optimization (PSO) algorithm.
  *
- * The PSO algorithm was originally presented in:<br>
- * J. Kennedy, R. Eberhart, "Particle Swarm Optimization",
- * Proc. IEEE Int. Neural Networks, 1995.<br>
+ * The PSO algorithm was originally presented in \cite kennedy1995.
  *
  * The algorithm uses a stochastic optimization approach. Optimization
  * is performed by maintaining a swarm (flock) of

--- a/Modules/Numerics/Optimizers/include/itkParticleSwarmOptimizerBase.h
+++ b/Modules/Numerics/Optimizers/include/itkParticleSwarmOptimizerBase.h
@@ -28,9 +28,7 @@ namespace itk
 /** \class ParticleSwarmOptimizerBase
  * \brief Abstract implementation of a Particle Swarm Optimization (PSO) algorithm.
  *
- * The PSO algorithm was originally presented in:<br>
- * J. Kennedy, R. Eberhart, "Particle Swarm Optimization",
- * Proc. IEEE Int. Neural Networks, 1995.<br>
+ * The PSO algorithm was originally presented in \cite kennedy1995.
  *
  * The algorithm is a stochastic global search optimization approach.
  * Optimization is performed by maintaining a swarm of particles that traverse

--- a/Modules/Numerics/Optimizers/include/itkSPSAOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkSPSAOptimizer.h
@@ -50,13 +50,8 @@ extern ITKOptimizers_EXPORT std::ostream &
  * \brief An optimizer based on simultaneous perturbation...
  *
  * This optimizer is an implementation of the Simultaneous
- * Perturbation Stochastic Approximation method, described in:
- *
- * - https://www.jhuapl.edu/SPSA/
- *
- * - Spall, J.C. (1998), "An Overview of the Simultaneous
- * Perturbation Method for Efficient Optimization," Johns
- * Hopkins APL Technical Digest, vol. 19, pp. 482-492
+ * Perturbation Stochastic Approximation method, described in
+ * \cite spall1998.
  *
  * \ingroup Optimizers
  * \ingroup ITKOptimizers

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.h
@@ -41,7 +41,7 @@ public:
   {
     /** The default algorithm (MoreThuente method). */
     LINESEARCH_DEFAULT = 0,
-    /** MoreThuente method proposed by More and Thuente. */
+    /** MoreThuente method proposed by More and Thuente \cite more1994. */
     LINESEARCH_MORETHUENTE = 0,
     /**
      * Backtracking method with the Armijo condition.
@@ -85,10 +85,10 @@ extern ITKOptimizersv4_EXPORT std::ostream &
 
 /**
  * \class LBFGS2Optimizerv4Template
- * \brief Wrap of the libLBFGS[1] algorithm for use in ITKv4 registration framework.
- * LibLBFGS is a translation of LBFGS code by Nocedal [2] and adds the orthantwise
- * limited-memory Quasi-Newton method [3] for optimization with L1-norm on the
- * parameters.
+ * \brief Wrap of the [libLBFGS](https://www.chokkan.org/software/liblbfgs/) algorithm for use in ITKv4 registration
+ * framework. LibLBFGS is a translation of LBFGS code by Nocedal [NETLIB
+ * lbfgs](http://users.iems.northwestern.edu/~nocedal/lbfgs.html) and adds the orthantwise limited-memory Quasi-Newton
+ * method \cite galen2007 for optimization with L1-norm on the parameters.
  *
  * LBFGS is a quasi-Newton method uses an approximate estimate of the inverse Hessian
  * \f$ (\nabla^2 f(x) )^-1 \f$ to scale the gradient step:
@@ -101,7 +101,7 @@ extern ITKOptimizersv4_EXPORT std::ostream &
  * thus only the gradient of the objective function is required.
  *
  * The step size \f$ s \f$ is determined through line search which defaults to
- * the approach by More and Thuente [4]. This line search approach finds a step
+ * the approach by More and Thuente  \cite more1994. This line search approach finds a step
  * size such that
  * \f[
  * \lVert \nabla f(x + s (\nabla^2 f(x_n) )^{-1} \nabla f(x) ) \rVert
@@ -112,7 +112,7 @@ extern ITKOptimizersv4_EXPORT std::ostream &
  * and SetGradientLineSearchAccuracy()
  *
  * Instead of the More-Tunete method, backtracking with three different
- * conditions [7] are available and can be set through SetLineSearch():
+ * conditions \cite dennis1983 are available and can be set through SetLineSearch():
  *  - LINESEARCH_BACKTRACKING_ARMIJO
  *  - LINESEARCH_BACKTRACKING_WOLFE
  *  - LINESEARCH_BACKTRACKING_STRONG_WOLFE
@@ -127,31 +127,11 @@ extern ITKOptimizersv4_EXPORT std::ostream &
  * through SetMaximumIterations() (default 0 = no maximum).
  *
  *
- * References:
- *
- * [1] [libLBFGS](https://www.chokkan.org/software/liblbfgs/)
- *
- * [2] [NETLIB lbfgs](http://users.iems.northwestern.edu/~nocedal/lbfgs.html)
- *
- * [3] Galen Andrew and Jianfeng Gao.
- * Scalable training of L1-regularized log-linear models.
- * 24th International Conference on Machine Learning, pp. 33-40, 2007.
- *
- * [4] Jorge Nocedal.
- * Updating Quasi-Newton Matrices with Limited Storage.
- * Mathematics of Computation, Vol. 35, No. 151, pp. 773-782, 1980.
- *
- * [5] Dong C. Liu and Jorge Nocedal.
- * On the limited memory BFGS method for large scale optimization.
- * Mathematical Programming B, Vol. 45, No. 3, pp. 503-528, 1989.
- *
- * [6] More, J. J. and D. J. Thuente.
- * Line Search Algorithms with Guaranteed Sufficient Decrease.
- * ACM Transactions on Mathematical Software 20, no. 3 (1994): 286-307.
- *
- * [7] John E. Dennis and Robert B. Schnabel.
- * Numerical Methods for Unconstrained Optimization and Nonlinear Equations,
- * Englewood Cliffs, 1983.
+ * For algorithmic details see
+ * [libLBFGS](https://www.chokkan.org/software/liblbfgs/), [NETLIB
+ * lbfgs](http://users.iems.northwestern.edu/~nocedal/lbfgs.html),
+ * \cite galen2007, \cite nocedal1980, \cite liu1989,
+ * \cite more1994, and \dennis1983.
  *
  * \ingroup ITKOptimizersv4
  */

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGSBOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGSBOptimizerv4.h
@@ -48,18 +48,7 @@ class ITK_FORWARD_EXPORT LBFGSBOptimizerHelperv4;
  *
  * See also the documentation in Numerics/lbfgsb.c
  *
- * References:
- *
- * [1] R. H. Byrd, P. Lu and J. Nocedal.
- * A Limited Memory Algorithm for Bound Constrained Optimization, (1995),
- * SIAM Journal on Scientific and Statistical Computing ,
- * 16, 5, pp. 1190-1208.
- *
- * [2] C. Zhu, R. H. Byrd and J. Nocedal.
- * L-BFGS-B: Algorithm 778: L-BFGS-B, FORTRAN routines for large scale
- * bound constrained optimization (1997),
- * ACM Transactions on Mathematical Software,
- * Vol 23, Num. 4, pp. 550 - 560.
+ * For algorithmic details see \cite byrd1995 and \cite zhu1997.
  *
  * \ingroup Numerics Optimizersv4
  * \ingroup ITKOptimizersv4

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerv4.h
@@ -63,22 +63,8 @@ namespace itk
  * should be set or left at one. Otherwise the Hessian approximation as well as
  * the line search will be disturbed and the optimizer is unlikely to find a minima.
  *
- *
- * References:
- *
- * [1] [NETLIB lbfgs](http://users.iems.northwestern.edu/~nocedal/lbfgs.html)
- *
- * [2] Jorge Nocedal.
- * Updating Quasi-Newton Matrices with Limited Storage.
- * Mathematics of Computation, Vol. 35, No. 151, pp. 773-782, 1980.
- *
- * [3] Dong C. Liu and Jorge Nocedal.
- * On the limited memory BFGS method for large scale optimization.
- * Mathematical Programming B, Vol. 45, No. 3, pp. 503-528, 1989.
- *
- * [4] More, J. J. and D. J. Thuente.
- * Line Search Algorithms with Guaranteed Sufficient Decrease.
- * ACM Transactions on Mathematical Software 20, no. 3 (1994): 286-307.
+ * For algorithmic details see [NETLIB lbfgs](http://users.iems.northwestern.edu/~nocedal/lbfgs.html),
+ * \cite nocedal1980, \cite liu1989 and \cite more1994.
  *
  * \ingroup ITKOptimizersv4
  */

--- a/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.h
@@ -52,15 +52,8 @@ namespace itk
  * by Martin Styner, Univ. of North Carolina at Chapel Hill, and his
  * colleagues.
  *
- * For more details. refer to the following articles.
- * "Parametric estimate of intensity inhomogeneities applied to MRI"
- * Martin Styner, G. Gerig, Christian Brechbuehler, Gabor Szekely,
- * IEEE TRANSACTIONS ON MEDICAL IMAGING; 19(3), pp. 153-165, 2000,
- * (https://www.cs.unc.edu/~styner/docs/tmi00.pdf)
- *
- * "Evaluation of 2D/3D bias correction with 1+1ES-optimization"
- * Martin Styner, Prof. Dr. G. Gerig (IKT, BIWI, ETH Zuerich), TR-197
- * (https://www.cs.unc.edu/~styner/docs/StynerTR97.pdf)
+ * For more details refer to the following articles \cite styner2000
+ * and \cite styner1997.
  *
  * \sa NormalVariateGenerator
  * \ingroup ITKOptimizersv4

--- a/Modules/Numerics/Polynomials/include/itkMultivariateLegendrePolynomial.h
+++ b/Modules/Numerics/Polynomials/include/itkMultivariateLegendrePolynomial.h
@@ -61,15 +61,7 @@ namespace itk
  * by Martin Styner, Univ. of North Carolina at Chapel Hill, and his
  * colleagues.
  *
- * \note For more details. refer to the following articles.
- * "Parametric estimate of intensity inhomogeneities applied to MRI"
- * Martin Styner, G. Gerig, Christian Brechbuehler, Gabor Szekely,
- * IEEE TRANSACTIONS ON MEDICAL IMAGING; 19(3), pp. 153-165, 2000,
- * (https://www.cs.unc.edu/~styner/docs/tmi99.pdf)
- *
- * "Evaluation of 2D/3D bias correction with 1+1ES-optimization"
- * Martin Styner, Prof. Dr. G. Gerig (IKT, BIWI, ETH Zuerich), TR-197
- * (https://www.cs.unc.edu/~styner/docs/StynerTR97.pdf)
+ * \note For more details refer to \cite styner2000 and \cite styner1997.
  * \ingroup ITKPolynomials
  */
 

--- a/Modules/Numerics/Statistics/include/itkGaussianDistribution.h
+++ b/Modules/Numerics/Statistics/include/itkGaussianDistribution.h
@@ -222,9 +222,7 @@ public:
    * Biophysics Research Institute at the Medical College of
    * Wisconsin.  This function is based off of a rational polynomial
    * approximation to the inverse Gaussian CDF which can be found in
-   * M. Abramowitz and I.A. Stegun. Handbook of Mathematical Functions
-   * with Formulas, Graphs, and Mathematical Tables.  John Wiley & Sons.
-   * New York. Equation 26.2.23. pg. 933. 1972.
+   * \cite abramowitz1972 Equation 26.2.23. pg. 933.
    *
    * Since the initial approximation only provides an estimate within
    * 4.5 E-4 of the true value, 3 Newton-Raphson iterations are used

--- a/Modules/Numerics/Statistics/include/itkHistogramToRunLengthFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToRunLengthFeaturesFilter.h
@@ -73,17 +73,8 @@ operator<<(std::ostream & out, const HistogramToRunLengthFeaturesFilterEnums::Ru
  *
  * This class is templated over the input histogram type.
  *
- * Print references:
- * M. M. Galloway. Texture analysis using gray level run lengths. Computer
- * Graphics and Image Processing, 4:172-179, 1975.
- *
- * A. Chu, C. M. Sehgal, and J. F. Greenleaf. Use of gray value distribution of
- * run lengths for texture analysis.  Pattern Recognition Letters, 11:415-420,
- * 1990.
- *
- * B. R. Dasarathy and E. B. Holder. Image characterizations based on joint
- * gray-level run-length distributions. Pattern Recognition Letters, 12:490-502,
- * 1991.
+ * For algorithmic details see \cite galloway1975, \cite chu1990 and
+ * \cite dasarathy1991.
  *
  * IJ article: https://doi.org/10.54294/ex0itu
  *

--- a/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.h
@@ -104,21 +104,8 @@ operator<<(std::ostream & out, const HistogramToTextureFeaturesFilterEnums::Text
  * http://www.cssip.uq.edu.au/meastex/www/algs/algs/algs.html
  * https://www.ucalgary.ca/~mhallbey/texture/texture_tutorial.html
  *
- * Print references:
- *
- * Haralick, R.M., K. Shanmugam and I. Dinstein. 1973.  Textural Features for
- * Image Classification. IEEE Transactions on Systems, Man and Cybernetics.
- * SMC-3(6):610-620.
- *
- * Haralick, R.M. 1979. Statistical and Structural Approaches to Texture.
- * Proceedings of the IEEE, 67:786-804.
- *
- * R.W. Conners and C.A. Harlow. A Theoretical Comparison of Texture Algorithms.
- * IEEE Transactions on Pattern Analysis and Machine Intelligence,  2:204-222, 1980.
- *
- * R.W. Conners, M.M. Trivedi, and C.A. Harlow. Segmentation of a High-Resolution
- * Urban Scene using Texture  Operators. Computer Vision, Graphics and Image
- * Processing, 25:273-310,  1984.
+ * For algorithmic details see \cite haralick1973, \cite haralick1979,
+ * \cite conners1980 and \cite conners1984.
  *
  * \sa ScalarImageToCooccurrenceMatrixFilter
  * \sa ScalarImageToTextureFeaturesFilter

--- a/Modules/Numerics/Statistics/include/itkNormalVariateGenerator.h
+++ b/Modules/Numerics/Statistics/include/itkNormalVariateGenerator.h
@@ -40,9 +40,7 @@ namespace Statistics
  *
  *  Revision date 31 May 1996
  *      This is a revised version of the algorithm described in
- *
- *      ACM Transactions on Mathematical Software, Vol 22, No 1
- *      March 1996, pp 119-127.
+ *      \cite wallace1996.
  *
  * It is somewhat faster, and uses less memory as the vector of variates is
  * updated in-situ. It has passed all the same statistical tests as described

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.h
@@ -35,10 +35,7 @@ namespace Statistics
  *
  * This filters creates a grey-level co-occurrence matrix from a N-D scalar
  * image. This is the first step in texture description a la Haralick. (See
- * Haralick, R.M., K. Shanmugam and I. Dinstein. 1973. Textural Features for
- * Image Classification. IEEE Transactions on Systems, Man and Cybernetics.
- * SMC-3(6):610-620. See also Haralick, R.M. 1979. Statistical and Structural
- * Approaches to Texture. Proceedings of the IEEE, 67:786-804.)
+ * \cite haralick1973 and \cite haralick1979.
  *
  * The basic idea is as follows:
  * Given an image and an offset (e.g. (1, -1) for a 2-d image), grey-level

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.h
@@ -70,17 +70,8 @@ namespace Statistics
  * (1) The average value of each feature.
  * (2) The standard deviation in the values of each feature.
  *
- * Print references:
- * M. M. Galloway. Texture analysis using gray level run lengths. Computer
- * Graphics and Image Processing, 4:172-179, 1975.
- *
- * A. Chu, C. M. Sehgal, and J. F. Greenleaf. Use of gray value distribution of
- * run lengths for texture analysis.  Pattern Recognition Letters, 11:415-420,
- * 1990.
- *
- * B. R. Dasarathy and E. B. Holder. Image characterizations based on joint
- * gray-level run-length distributions. Pattern Recognition Letters, 12:490-502,
- * 1991.
+ * For algorithmic details see \cite galloway1975, \cite chu1990 and
+ * \cite dasarathy1991.
  *
  * IJ article: https://doi.org/10.54294/ex0itu
  *

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.h
@@ -36,18 +36,8 @@ namespace Statistics
  *  used for image texture description.
  *
  * This filters creates a grey-level run length matrix from a N-D scalar
- * image. This is another possible texture description.  See the following
- * references.
- * M. M. Galloway. Texture analysis using gray level run lengths. Computer
- * Graphics and Image Processing, 4:172-179, 1975.
- *
- * A. Chu, C. M. Sehgal, and J. F. Greenleaf. Use of gray value distribution of
- * run lengths for texture analysis.  Pattern Recognition Letters, 11:415-420,
- * 1990.
- *
- * B. R. Dasarathy and E. B. Holder. Image characterizations based on joint
- * gray-level run-length distributions. Pattern Recognition Letters, 12:490-502,
- * 1991.
+ * image. This is another possible texture description.
+ * See \cite galloway1975, \cite chu1990 and \cite dasarathy1991.
  *
  * The basic idea is as follows:
  * Given an image and an offset (e.g. (1, -1) for a 2-d image), each element

--- a/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.h
@@ -79,20 +79,8 @@ namespace Statistics
  * Web reference:
  * http://www.fp.ucalgary.ca/mhallbey/tutorial.htm
  *
- * Print references:
- * Haralick, R.M., K. Shanmugam and I. Dinstein. 1973.  Textural Features for
- * Image Classification. IEEE Transactions on Systems, Man and Cybernetics.
- * SMC-3(6):610-620.
- *
- * Haralick, R.M. 1979. Statistical and Structural Approaches to Texture.
- * Proceedings of the IEEE, 67:786-804.
- *
- * R.W. Conners and C.A. Harlow. A Theoretical Comparison of Texture Algorithms.
- * IEEE Transactions on Pattern Analysis and Machine Intelligence,  2:204-222, 1980.
- *
- * R.W. Conners, M.M. Trivedi, and C.A. Harlow. Segmentation of a High-Resolution
- * Urban Scene using Texture  Operators. Computer Vision, Graphics and Image
- * Processing, 25:273-310,  1984.
+ * For algorithmic details see \cite haralick1973, \cite haralick1979,
+ * \cite conners1980 and \cite conners1984.
  *
  * \sa ScalarImageToCooccurrenceMatrixFilter
  * \sa HistogramToTextureFeaturesFilter


### PR DESCRIPTION
Third PR out of N, converting raw inline citations with various styles to using a bibliography database and the doxygen cite command.

Bibtex file was formatted using bibtex-tidy
(https://github.com/FlamingTempura/bibtex-tidy). This tool can be used as a pre-commit hook but currently does not have an option for just performing compliance checking so not added to .pre-commit-config.yaml file.
