### PR TITLE
DOC: Convert from raw in-code citations to bibtex (4/4)

### DIFF
--- a/Documentation/Doxygen/doxygen.bib
+++ b/Documentation/Doxygen/doxygen.bib
@@ -1164,6 +1164,17 @@
   url          = {https://secwww.jhuapl.edu/techdigest/Content/techdigest/pdf/V19-N04/19-04-Spall.pdf},
   institution  = {Johns Hopkins APL}
 }
+@article{spall1998a,
+  title        = {Implementation of the simultaneous perturbation algorithm for stochastic optimization},
+  author       = {Spall, James C.},
+  year         = 1998,
+  journal      = {IEEE Transactions on Aerospace and Electronic Systems},
+  volume       = 34,
+  number       = 3,
+  pages        = {817--823},
+  doi          = {10.1109/7.705889},
+  url          = {https://doi.org/10.1109/7.705889}
+}
 @inproceedings{sprengel1996,
   title        = {Thin-plate spline approximation for image registration},
   author       = {Sprengel, R. and Rohr, K. and Stiehl, H.S.},

--- a/Modules/Core/Transform/include/itkKernelTransform.h
+++ b/Modules/Core/Transform/include/itkKernelTransform.h
@@ -226,10 +226,7 @@ public:
    * spline to approximate rather than interpolate the landmarks.
    * Stiffness values are usually rather small, typically in the range
    * of 0.001 to 0.1. The approximating spline formulation is based on
-   * the short paper by R. Sprengel, K. Rohr, H. Stiehl. "Thin-Plate
-   * Spline Approximation for Image Registration". In 18th
-   * International Conference of the IEEE Engineering in Medicine and
-   * Biology Society. 1996.
+   * \cite sprengel1996.
    */
   itkSetClampMacro(Stiffness, double, 0.0, NumericTraits<double>::max());
   itkGetConstMacro(Stiffness, double);

--- a/Modules/Numerics/Optimizers/include/itkSPSAOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkSPSAOptimizer.h
@@ -118,10 +118,7 @@ public:
    * the MaximumNumberOfIterations, the Scales, and the
    * the InitialPosition before calling this method.
    *
-   * Described in:
-   * Spall, J.C. (1998), "Implementation of the Simultaneous Perturbation
-   * Algorithm for Stochastic Optimization", IEEE Trans. Aerosp. Electron.
-   * Syst. 34(3), 817-823.
+   * Described in \cite spall1998a.
    */
   virtual void
   GuessParameters(SizeValueType numberOfGradientEstimates, double initialStepSize);

--- a/Modules/Segmentation/LevelSets/include/itkShapeDetectionLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkShapeDetectionLevelSetImageFilter.h
@@ -36,7 +36,7 @@ namespace itk
  * is propagated outwards (or inwards) until it ''sticks'' to the shape boundaries.
  * This is done by using a level set speed function based on a user supplied
  * edge potential map. This approach for segmentation follows that of
- * Malladi et al (1995).
+ * Malladi et al (1995) \cite malladi1995.
  *
  * \par INPUTS
  * This filter requires two inputs.  The first input is a initial level set.

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.h
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.h
@@ -342,9 +342,7 @@ protected:
   Allocate();
 
   /** Apply MRF Classifier. In this example the images are labelled using
-   * Iterated Conditional Mode algorithm by J. Besag, "On statistical
-   * analysis of dirty pictures," J. Royal Stat. Soc. B, vol. 48,
-   * pp. 259-302, 1986. */
+   * Iterated Conditional Mode algorithm \cite besag1986.*/
   virtual void
   ApplyMRFImageFilter();
 


### PR DESCRIPTION
Fourth and final PR, converting raw inline citations with various styles to using a bibliography database and the doxygen cite command.

Bibtex file was formatted using bibtex-tidy
(https://github.com/FlamingTempura/bibtex-tidy). This tool can be used as a pre-commit hook but currently does not have an option for just performing compliance checking so not added to .pre-commit-config.yaml file.
