### PR TITLE
STYLE: Move empty `const` member functions from .hxx to .h

### DIFF
--- a/Modules/Filtering/LabelMap/include/itkLabelObjectLine.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelObjectLine.h
@@ -97,7 +97,8 @@ protected:
   PrintHeader(std::ostream & os, Indent indent) const;
 
   virtual void
-  PrintTrailer(std::ostream & os, Indent indent) const;
+  PrintTrailer(std::ostream & itkNotUsed(os), Indent itkNotUsed(indent)) const
+  {}
 
 private:
   IndexType  m_Index{};

--- a/Modules/Filtering/LabelMap/include/itkLabelObjectLine.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelObjectLine.hxx
@@ -126,14 +126,6 @@ LabelObjectLine<VImageDimension>::PrintSelf(std::ostream & os, Indent indent) co
   os << indent << "Index: " << this->m_Index << std::endl;
   os << indent << "Length: " << this->m_Length << std::endl;
 }
-
-/**
- * Define a default print trailer for all objects.
- */
-template <unsigned int VImageDimension>
-void
-LabelObjectLine<VImageDimension>::PrintTrailer(std::ostream & itkNotUsed(os), Indent itkNotUsed(indent)) const
-{}
 } // namespace itk
 
 #endif

--- a/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.h
+++ b/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.h
@@ -90,7 +90,9 @@ public:
 
   /** Get the derivatives of the match measure. */
   void
-  GetDerivative(const TransformParametersType & parameters, DerivativeType & Derivative) const override;
+  GetDerivative(const TransformParametersType & itkNotUsed(parameters),
+                DerivativeType &                itkNotUsed(derivative)) const override
+  {}
 
   /**  Get the match measure, i.e. the value for single valued optimizers. */
   MeasureType

--- a/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.hxx
+++ b/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.hxx
@@ -130,13 +130,6 @@ EuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet, TDistanceMap>::Get
 
 template <typename TFixedPointSet, typename TMovingPointSet, typename TDistanceMap>
 void
-EuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet, TDistanceMap>::GetDerivative(
-  const TransformParametersType & itkNotUsed(parameters),
-  DerivativeType &                itkNotUsed(derivative)) const
-{}
-
-template <typename TFixedPointSet, typename TMovingPointSet, typename TDistanceMap>
-void
 EuclideanDistancePointMetric<TFixedPointSet, TMovingPointSet, TDistanceMap>::GetValueAndDerivative(
   const TransformParametersType & parameters,
   MeasureType &                   value,


### PR DESCRIPTION
Moved the member function definitions of `const`member functions that have an empty member function definition from their "itk*.hxx" file to the corresponding "itk*.h" file, and into their class definition.

Found by regular expression `^..[^:,].+\) const\r\n{}` in "itk*.hxx" files.

- Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/5198 commit b94770d8746133a441df1796e3d1628c6935adfc
"STYLE: Move empty member functions with empty param list from .hxx to .h"