### PR TITLE
STYLE: Use itk::ReadImage and itk::WriteImage in Example/Statistics

### DIFF
--- a/Examples/Statistics/BayesianClassifier.cxx
+++ b/Examples/Statistics/BayesianClassifier.cxx
@@ -67,15 +67,21 @@ main(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  // input parameters
-  const char * membershipImageFileName = argv[1];
-  const char * labelMapImageFileName = argv[2];
 
   // setup reader
   constexpr unsigned int Dimension = 2;
   using InputPixelType = float;
   using InputImageType = itk::VectorImage<InputPixelType, Dimension>;
-  const auto input = itk::ReadImage<InputImageType>(membershipImageFileName);
+  InputImageType::Pointer input;
+  try
+  {
+    input = itk::ReadImage<InputImageType>(argv[1]);
+  }
+  catch (const itk::ExceptionObject & excp)
+  {
+    std::cerr << excp << std::endl;
+    return EXIT_FAILURE;
+  }
 
   using LabelType = unsigned char;
   using PriorType = float;
@@ -132,7 +138,7 @@ main(int argc, char * argv[])
   //
   try
   {
-    itk::WriteImage(rescaler->GetOutput(), labelMapImageFileName);
+    itk::WriteImage(rescaler->GetOutput(), argv[2]);
   }
   catch (const itk::ExceptionObject & excp)
   {

--- a/Examples/Statistics/BayesianClassifier.cxx
+++ b/Examples/Statistics/BayesianClassifier.cxx
@@ -67,89 +67,70 @@ main(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-
-  // setup reader
-  constexpr unsigned int Dimension = 2;
-  using InputPixelType = float;
-  using InputImageType = itk::VectorImage<InputPixelType, Dimension>;
-  InputImageType::Pointer input;
   try
   {
-    input = itk::ReadImage<InputImageType>(argv[1]);
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+    constexpr unsigned int Dimension = 2;
+    using InputPixelType = float;
+    using InputImageType = itk::VectorImage<InputPixelType, Dimension>;
 
-  using LabelType = unsigned char;
-  using PriorType = float;
-  using PosteriorType = float;
+    auto input = itk::ReadImage<InputImageType>(argv[1]);
 
+    using LabelType = unsigned char;
+    using PriorType = float;
+    using PosteriorType = float;
 
-  using ClassifierFilterType =
-    itk::BayesianClassifierImageFilter<InputImageType,
-                                       LabelType,
-                                       PosteriorType,
-                                       PriorType>;
+    using ClassifierFilterType =
+      itk::BayesianClassifierImageFilter<InputImageType,
+                                         LabelType,
+                                         PosteriorType,
+                                         PriorType>;
 
-  auto filter = ClassifierFilterType::New();
+    auto filter = ClassifierFilterType::New();
 
+    filter->SetInput(input);
 
-  filter->SetInput(input);
+    if (argc > 3)
+    {
+      filter->SetNumberOfSmoothingIterations(std::stoi(argv[3]));
+      using ExtractedComponentImageType =
+        ClassifierFilterType::ExtractedComponentImageType;
+      using SmoothingFilterType =
+        itk::GradientAnisotropicDiffusionImageFilter<
+          ExtractedComponentImageType,
+          ExtractedComponentImageType>;
+      auto smoother = SmoothingFilterType::New();
+      smoother->SetNumberOfIterations(1);
+      smoother->SetTimeStep(0.125);
+      smoother->SetConductanceParameter(3);
+      filter->SetSmoothingFilter(smoother);
+    }
 
-  if (argv[3])
-  {
-    filter->SetNumberOfSmoothingIterations(std::stoi(argv[3]));
-    using ExtractedComponentImageType =
-      ClassifierFilterType::ExtractedComponentImageType;
-    using SmoothingFilterType = itk::GradientAnisotropicDiffusionImageFilter<
-      ExtractedComponentImageType,
-      ExtractedComponentImageType>;
-    auto smoother = SmoothingFilterType::New();
-    smoother->SetNumberOfIterations(1);
-    smoother->SetTimeStep(0.125);
-    smoother->SetConductanceParameter(3);
-    filter->SetSmoothingFilter(smoother);
-  }
+    // SET FILTER'S PRIOR PARAMETERS
+    // do nothing here to default to uniform priors
+    // otherwise set the priors to some user provided values
 
+    // Rescale the label map to the dynamic range of the datatype and write it
+    using ClassifierOutputImageType = ClassifierFilterType::OutputImageType;
+    using OutputImageType = itk::Image<unsigned char, Dimension>;
+    using RescalerType =
+      itk::RescaleIntensityImageFilter<ClassifierOutputImageType,
+                                       OutputImageType>;
+    auto rescaler = RescalerType::New();
+    rescaler->SetInput(filter->GetOutput());
+    rescaler->SetOutputMinimum(0);
+    rescaler->SetOutputMaximum(255);
 
-  // SET FILTER'S PRIOR PARAMETERS
-  // do nothing here to default to uniform priors
-  // otherwise set the priors to some user provided values
-
-  //
-  // Setup writer.. Rescale the label map to the dynamic range of the
-  // datatype and write it
-  //
-  using ClassifierOutputImageType = ClassifierFilterType::OutputImageType;
-  using OutputImageType = itk::Image<unsigned char, Dimension>;
-  using RescalerType =
-    itk::RescaleIntensityImageFilter<ClassifierOutputImageType,
-                                     OutputImageType>;
-  auto rescaler = RescalerType::New();
-  rescaler->SetInput(filter->GetOutput());
-  rescaler->SetOutputMinimum(0);
-  rescaler->SetOutputMaximum(255);
-
-  //
-  // Write labelmap to file
-  //
-  try
-  {
+    // Write labelmap to file
     itk::WriteImage(rescaler->GetOutput(), argv[2]);
+
+    // Testing print
+    filter->Print(std::cout);
+    std::cout << "Test passed." << std::endl;
   }
   catch (const itk::ExceptionObject & excp)
   {
-    std::cerr << "Exception caught: " << std::endl;
-    std::cerr << excp << std::endl;
+    std::cerr << "ITK exception caught:\n" << excp << std::endl;
     return EXIT_FAILURE;
   }
-
-  // Testing print
-  filter->Print(std::cout);
-  std::cout << "Test passed." << std::endl;
-
   return EXIT_SUCCESS;
 }

--- a/Examples/Statistics/BayesianClassifierInitializer.cxx
+++ b/Examples/Statistics/BayesianClassifierInitializer.cxx
@@ -80,101 +80,73 @@ main(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  using ImageType = itk::Image<unsigned char, Dimension>;
-  using BayesianInitializerType =
-    itk::BayesianClassifierInitializationImageFilter<ImageType>;
-  auto bayesianInitializer = BayesianInitializerType::New();
-
-  ImageType::Pointer input;
   try
   {
-    input = itk::ReadImage<ImageType>(argv[1]);
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Exception thrown " << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+    using ImageType = itk::Image<unsigned char, Dimension>;
+    using BayesianInitializerType =
+      itk::BayesianClassifierInitializationImageFilter<ImageType>;
+    auto bayesianInitializer = BayesianInitializerType::New();
 
-  bayesianInitializer->SetInput(input);
-  bayesianInitializer->SetNumberOfClasses(std::stoi(argv[3]));
+    auto input = itk::ReadImage<ImageType>(argv[1]);
 
-  // TODO add test where we specify membership functions
+    bayesianInitializer->SetInput(input);
+    bayesianInitializer->SetNumberOfClasses(std::stoi(argv[3]));
 
-  try
-  {
+    // TODO add test where we specify membership functions
+
     bayesianInitializer->Update();
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Exception thrown " << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
 
-  try
-  {
     itk::WriteImage(bayesianInitializer->GetOutput(), argv[2]);
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Exception thrown " << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
 
-  if (argv[4] && argv[5])
-  {
-    using MembershipImageType = BayesianInitializerType::OutputImageType;
-    using ExtractedComponentImageType =
-      itk::Image<MembershipImageType::InternalPixelType, Dimension>;
-    auto extractedComponentImage = ExtractedComponentImageType::New();
-    extractedComponentImage->CopyInformation(
-      bayesianInitializer->GetOutput());
-    extractedComponentImage->SetBufferedRegion(
-      bayesianInitializer->GetOutput()->GetBufferedRegion());
-    extractedComponentImage->SetRequestedRegion(
-      bayesianInitializer->GetOutput()->GetRequestedRegion());
-    extractedComponentImage->Allocate();
-    using ConstIteratorType =
-      itk::ImageRegionConstIterator<MembershipImageType>;
-    using IteratorType =
-      itk::ImageRegionIterator<ExtractedComponentImageType>;
-    ConstIteratorType cit(
-      bayesianInitializer->GetOutput(),
-      bayesianInitializer->GetOutput()->GetBufferedRegion());
-    IteratorType it(extractedComponentImage,
-                    extractedComponentImage->GetLargestPossibleRegion());
-
-    const unsigned int componentToExtract = std::stoi(argv[4]);
-    cit.GoToBegin();
-    it.GoToBegin();
-    while (!cit.IsAtEnd())
+    if (argv[4] && argv[5])
     {
-      it.Set(cit.Get()[componentToExtract]);
-      ++it;
-      ++cit;
-    }
+      using MembershipImageType = BayesianInitializerType::OutputImageType;
+      using ExtractedComponentImageType =
+        itk::Image<MembershipImageType::InternalPixelType, Dimension>;
+      auto extractedComponentImage = ExtractedComponentImageType::New();
+      extractedComponentImage->CopyInformation(
+        bayesianInitializer->GetOutput());
+      extractedComponentImage->SetBufferedRegion(
+        bayesianInitializer->GetOutput()->GetBufferedRegion());
+      extractedComponentImage->SetRequestedRegion(
+        bayesianInitializer->GetOutput()->GetRequestedRegion());
+      extractedComponentImage->Allocate();
+      using ConstIteratorType =
+        itk::ImageRegionConstIterator<MembershipImageType>;
+      using IteratorType =
+        itk::ImageRegionIterator<ExtractedComponentImageType>;
+      ConstIteratorType cit(
+        bayesianInitializer->GetOutput(),
+        bayesianInitializer->GetOutput()->GetBufferedRegion());
+      IteratorType it(extractedComponentImage,
+                      extractedComponentImage->GetLargestPossibleRegion());
 
-    // Write out the rescaled extracted component
-    using OutputImageType = itk::Image<unsigned char, Dimension>;
-    using RescalerType =
-      itk::RescaleIntensityImageFilter<ExtractedComponentImageType,
-                                       OutputImageType>;
-    auto rescaler = RescalerType::New();
-    rescaler->SetInput(extractedComponentImage);
-    rescaler->SetOutputMinimum(0);
-    rescaler->SetOutputMaximum(255);
-    try
-    {
+      const unsigned int componentToExtract = std::stoi(argv[4]);
+      cit.GoToBegin();
+      it.GoToBegin();
+      while (!cit.IsAtEnd())
+      {
+        it.Set(cit.Get()[componentToExtract]);
+        ++it;
+        ++cit;
+      }
+
+      // Write out the rescaled extracted component
+      using OutputImageType = itk::Image<unsigned char, Dimension>;
+      using RescalerType =
+        itk::RescaleIntensityImageFilter<ExtractedComponentImageType,
+                                         OutputImageType>;
+      auto rescaler = RescalerType::New();
+      rescaler->SetInput(extractedComponentImage);
+      rescaler->SetOutputMinimum(0);
+      rescaler->SetOutputMaximum(255);
       itk::WriteImage(rescaler->GetOutput(), argv[5]);
     }
-    catch (const itk::ExceptionObject & excp)
-    {
-      std::cerr << excp << std::endl;
-      return EXIT_FAILURE;
-    }
+  }
+  catch (const itk::ExceptionObject & excp)
+  {
+    std::cerr << "ITK exception caught:\n" << excp << std::endl;
+    return EXIT_FAILURE;
   }
 
   return EXIT_SUCCESS;

--- a/Examples/Statistics/BayesianClassifierInitializer.cxx
+++ b/Examples/Statistics/BayesianClassifierInitializer.cxx
@@ -166,12 +166,15 @@ main(int argc, char * argv[])
     rescaler->SetInput(extractedComponentImage);
     rescaler->SetOutputMinimum(0);
     rescaler->SetOutputMaximum(255);
-    using ExtractedComponentWriterType =
-      itk::ImageFileWriter<OutputImageType>;
-    auto rescaledImageWriter = ExtractedComponentWriterType::New();
-    rescaledImageWriter->SetInput(rescaler->GetOutput());
-    rescaledImageWriter->SetFileName(argv[5]);
-    rescaledImageWriter->Update();
+    try
+    {
+      itk::WriteImage(rescaler->GetOutput(), argv[5]);
+    }
+    catch (const itk::ExceptionObject & excp)
+    {
+      std::cerr << excp << std::endl;
+      return EXIT_FAILURE;
+    }
   }
 
   return EXIT_SUCCESS;

--- a/Examples/Statistics/ScalarImageKmeansClassifier.cxx
+++ b/Examples/Statistics/ScalarImageKmeansClassifier.cxx
@@ -55,9 +55,6 @@ main(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  const char * inputImageFileName = argv[1];
-
-
   // Software Guide : BeginLatex
   //
   // First we define the pixel type and dimension of the image that we intend
@@ -70,7 +67,17 @@ main(int argc, char * argv[])
   constexpr unsigned int Dimension = 2;
 
   using ImageType = itk::Image<PixelType, Dimension>;
-  const auto input = itk::ReadImage<ImageType>(inputImageFileName);
+  ImageType::Pointer input;
+  try
+  {
+    input = itk::ReadImage<ImageType>(argv[1]);
+  }
+  catch (const itk::ExceptionObject & excp)
+  {
+    std::cerr << excp << std::endl;
+    return EXIT_FAILURE;
+  }
+
   // Software Guide : EndCodeSnippet
 
 
@@ -149,9 +156,6 @@ main(int argc, char * argv[])
   // Software Guide : EndCodeSnippet
 
 
-  const char * outputImageFileName = argv[2];
-
-
   // Software Guide : BeginLatex
   //
   // The \doxygen{ScalarImageKmeansImageFilter} is predefined for producing an
@@ -165,7 +169,7 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   try
   {
-    itk::WriteImage(kmeansFilter->GetOutput(), outputImageFileName);
+    itk::WriteImage(kmeansFilter->GetOutput(), argv[2]);
   }
   catch (const itk::ExceptionObject & excp)
   {

--- a/Examples/Statistics/ScalarImageKmeansClassifier.cxx
+++ b/Examples/Statistics/ScalarImageKmeansClassifier.cxx
@@ -59,147 +59,132 @@ main(int argc, char * argv[])
   //
   // First we define the pixel type and dimension of the image that we intend
   // to classify. With this image type we can also read the input image.
+  // We start a try-catch block which encloses most of the code in the
+  // example.
   //
   // Software Guide : EndLatex
-
-  // Software Guide : BeginCodeSnippet
-  using PixelType = short;
-  constexpr unsigned int Dimension = 2;
-
-  using ImageType = itk::Image<PixelType, Dimension>;
-  ImageType::Pointer input;
-  try
-  {
-    input = itk::ReadImage<ImageType>(argv[1]);
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  // Software Guide : EndCodeSnippet
-
-
-  // Software Guide : BeginLatex
-  //
-  // With the \code{ImageType} we instantiate the type of the
-  // \doxygen{ScalarImageKmeansImageFilter} that will compute the K-Means
-  // model and then classify the image pixels.
-  //
-  // Software Guide : EndLatex
-
-  // Software Guide : BeginCodeSnippet
-  using KMeansFilterType = itk::ScalarImageKmeansImageFilter<ImageType>;
-
-  auto kmeansFilter = KMeansFilterType::New();
-
-  kmeansFilter->SetInput(input);
-
-  const unsigned int numberOfInitialClasses = std::stoi(argv[4]);
-  // Software Guide : EndCodeSnippet
-
-
-  // Software Guide : BeginLatex
-  //
-  // In general the classification will produce as output an image whose pixel
-  // values are integers associated to the labels of the classes. Since
-  // typically these integers will be generated in order (0,1,2,...N), the
-  // output image will tend to look very dark when displayed with naive
-  // viewers. It is therefore convenient to have the option of spreading the
-  // label values over the dynamic range of the output image pixel type. When
-  // this is done, the dynamic range of the pixels is divided by the number of
-  // classes in order to define the increment between labels. For example, an
-  // output image of 8 bits will have a dynamic range of [0:256], and when it
-  // is used for holding four classes, the non-contiguous labels will be
-  // (0,64,128,192). The selection of the mode to use is done with the method
-  // \code{SetUseNonContiguousLabels()}.
-  //
-  // Software Guide : EndLatex
-
-  // Software Guide : BeginCodeSnippet
-  const unsigned int useNonContiguousLabels = std::stoi(argv[3]);
-
-  kmeansFilter->SetUseNonContiguousLabels(useNonContiguousLabels);
-  // Software Guide : EndCodeSnippet
-
-
-  constexpr unsigned int argoffset = 5;
-
-  if (static_cast<unsigned int>(argc) < numberOfInitialClasses + argoffset)
-  {
-    std::cerr << "Error: " << std::endl;
-    std::cerr << numberOfInitialClasses << " classes has been specified ";
-    std::cerr << "but no enough means have been provided in the command ";
-    std::cerr << "line arguments " << std::endl;
-    return EXIT_FAILURE;
-  }
-
-
-  // Software Guide : BeginLatex
-  //
-  // For each one of the classes we must provide a tentative initial value for
-  // the mean of the class. Given that this is a scalar image, each one of the
-  // means is simply a scalar value. Note however that in a general case of
-  // K-Means, the input image would be a vector image and therefore the means
-  // will be vectors of the same dimension as the image pixels.
-  //
-  // Software Guide : EndLatex
-
-
-  // Software Guide : BeginCodeSnippet
-  for (unsigned int k = 0; k < numberOfInitialClasses; ++k)
-  {
-    const double userProvidedInitialMean = std::stod(argv[k + argoffset]);
-    kmeansFilter->AddClassWithInitialMean(userProvidedInitialMean);
-  }
-  // Software Guide : EndCodeSnippet
-
-
-  // Software Guide : BeginLatex
-  //
-  // The \doxygen{ScalarImageKmeansImageFilter} is predefined for producing an
-  // 8 bits scalar image as output. This output image contains labels
-  // associated to each one of the classes in the K-Means algorithm. In the
-  // following lines we write the output of the classification filter to file.
-  //
-  // Software Guide : EndLatex
-
 
   // Software Guide : BeginCodeSnippet
   try
   {
+    using PixelType = short;
+    constexpr unsigned int Dimension = 2;
+
+    using ImageType = itk::Image<PixelType, Dimension>;
+
+    auto input = itk::ReadImage<ImageType>(argv[1]);
+    // Software Guide : EndCodeSnippet
+
+    // Software Guide : BeginLatex
+    //
+    // With the \code{ImageType} we instantiate the type of the
+    // \doxygen{ScalarImageKmeansImageFilter} that will compute the K-Means
+    // model and then classify the image pixels.
+    //
+    // Software Guide : EndLatex
+
+    // Software Guide : BeginCodeSnippet
+    using KMeansFilterType = itk::ScalarImageKmeansImageFilter<ImageType>;
+
+    auto kmeansFilter = KMeansFilterType::New();
+
+    kmeansFilter->SetInput(input);
+
+    const unsigned int numberOfInitialClasses = std::stoi(argv[4]);
+    // Software Guide : EndCodeSnippet
+
+    // Software Guide : BeginLatex
+    //
+    // In general the classification will produce as output an image whose
+    // pixel values are integers associated to the labels of the classes.
+    // Since typically these integers will be generated in order (0,1,2,...N),
+    // the output image will tend to look very dark when displayed with naive
+    // viewers. It is therefore convenient to have the option of spreading the
+    // label values over the dynamic range of the output image pixel type.
+    // When this is done, the dynamic range of the pixels is divided by the
+    // number of classes in order to define the increment between labels. For
+    // example, an output image of 8 bits will have a dynamic range of
+    // [0:256], and when it is used for holding four classes, the
+    // non-contiguous labels will be (0,64,128,192). The selection of the mode
+    // to use is done with the method
+    // \code{SetUseNonContiguousLabels()}.
+    //
+    // Software Guide : EndLatex
+
+    // Software Guide : BeginCodeSnippet
+    const unsigned int useNonContiguousLabels = std::stoi(argv[3]);
+
+    kmeansFilter->SetUseNonContiguousLabels(useNonContiguousLabels);
+    // Software Guide : EndCodeSnippet
+
+    constexpr unsigned int argoffset = 5;
+
+    if (static_cast<unsigned int>(argc) < numberOfInitialClasses + argoffset)
+    {
+      std::cerr << "Error: " << std::endl;
+      std::cerr << numberOfInitialClasses << " classes has been specified ";
+      std::cerr << "but no enough means have been provided in the command ";
+      std::cerr << "line arguments " << std::endl;
+      return EXIT_FAILURE;
+    }
+
+    // Software Guide : BeginLatex
+    //
+    // For each one of the classes we must provide a tentative initial value
+    // for the mean of the class. Given that this is a scalar image, each one
+    // of the means is simply a scalar value. Note however that in a general
+    // case of K-Means, the input image would be a vector image and therefore
+    // the means will be vectors of the same dimension as the image pixels.
+    //
+    // Software Guide : EndLatex
+
+    // Software Guide : BeginCodeSnippet
+    for (unsigned int k = 0; k < numberOfInitialClasses; ++k)
+    {
+      const double userProvidedInitialMean = std::stod(argv[k + argoffset]);
+      kmeansFilter->AddClassWithInitialMean(userProvidedInitialMean);
+    }
+    // Software Guide : EndCodeSnippet
+
+    // Software Guide : BeginLatex
+    //
+    // The \doxygen{ScalarImageKmeansImageFilter} is predefined for producing
+    // an 8 bits scalar image as output. This output image contains labels
+    // associated to each one of the classes in the K-Means algorithm. The
+    // following line writes the output of the classification filter to file.
+    //
+    // Software Guide : EndLatex
+
+    // Software Guide : BeginCodeSnippet
     itk::WriteImage(kmeansFilter->GetOutput(), argv[2]);
+    // Software Guide : EndCodeSnippet
+
+    // Software Guide : BeginLatex
+    //
+    // At this point the classification is done, the labeled image is saved in
+    // a file, and we can take a look at the means that were found as a result
+    // of the model estimation performed inside the classifier filter.
+    //
+    // Software Guide : EndLatex
+
+    // Software Guide : BeginCodeSnippet
+    KMeansFilterType::ParametersType estimatedMeans =
+      kmeansFilter->GetFinalMeans();
+
+    const unsigned int numberOfClasses = estimatedMeans.Size();
+
+    for (unsigned int i = 0; i < numberOfClasses; ++i)
+    {
+      std::cout << "cluster[" << i << "] ";
+      std::cout << "    estimated mean : " << estimatedMeans[i] << std::endl;
+    }
   }
   catch (const itk::ExceptionObject & excp)
   {
-    std::cerr << "Problem encountered while writing ";
-    std::cerr << " image file : " << argv[2] << std::endl;
-    std::cerr << excp << std::endl;
+    std::cerr << "ITK exception caught:\n" << excp << std::endl;
     return EXIT_FAILURE;
   }
-  // Software Guide : EndCodeSnippet
-
-
-  // Software Guide : BeginLatex
-  //
-  // At this point the classification is done, the labeled image is saved in a
-  // file, and we can take a look at the means that were found as a result of
-  // the model estimation performed inside the classifier filter.
-  //
-  // Software Guide : EndLatex
-
-  // Software Guide : BeginCodeSnippet
-  KMeansFilterType::ParametersType estimatedMeans =
-    kmeansFilter->GetFinalMeans();
-
-  const unsigned int numberOfClasses = estimatedMeans.Size();
-
-  for (unsigned int i = 0; i < numberOfClasses; ++i)
-  {
-    std::cout << "cluster[" << i << "] ";
-    std::cout << "    estimated mean : " << estimatedMeans[i] << std::endl;
-  }
+  return EXIT_SUCCESS;
 
   // Software Guide : EndCodeSnippet
 
@@ -217,6 +202,4 @@ main(int argc, char * argv[])
   //  The means were estimated by ScalarImageKmeansModelEstimator.cxx.
   //
   //  Software Guide : EndLatex
-
-  return EXIT_SUCCESS;
 }

--- a/Examples/Statistics/ScalarImageMarkovRandomField1.cxx
+++ b/Examples/Statistics/ScalarImageMarkovRandomField1.cxx
@@ -106,356 +106,350 @@ main(int argc, char * argv[])
   //
   // First we define the pixel type and dimension of the image that we intend
   // to classify and read the input image.In this particular case we choose to
-  // use
-  // \code{short} as pixel type, which is typical for MicroMRI and CT
-  // data sets.
+  // use \code{short} as pixel type, which is typical for MicroMRI and CT data
+  // sets. We open a try block to enclose most of the code in this example.
   //
   // Software Guide : EndLatex
-
-  // Software Guide : BeginCodeSnippet
-  using PixelType = short;
-  constexpr unsigned int Dimension = 2;
-
-  using ImageType = itk::Image<PixelType, Dimension>;
-  ImageType::Pointer input;
-  try
-  {
-    input = itk::ReadImage<ImageType>(inputImageFileName);
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
-  // Software Guide : EndCodeSnippet
-
-
-  // Software Guide : BeginLatex
-  //
-  // As a second step we define the pixel type and dimension of the image of
-  // labels that provides the initial classification of the pixels from the
-  // first image. This initial labeled image can be the output of a K-Means
-  // method like the one illustrated in section \ref{sec:KMeansClassifier}.
-  //
-  // Software Guide : EndLatex
-
-  // Software Guide : BeginCodeSnippet
-  using LabelPixelType = unsigned char;
-
-  using LabelImageType = itk::Image<LabelPixelType, Dimension>;
-
-  const auto labelInput =
-    itk::ReadImage<LabelImageType>(inputLabelImageFileName);
-  // Software Guide : EndCodeSnippet
-
-
-  // Software Guide : BeginLatex
-  //
-  // Since the Markov Random Field algorithm is defined in general for images
-  // whose pixels have multiple components, that is, images of vector type, we
-  // must adapt our scalar image in order to satisfy the interface expected by
-  // the \code{MRFImageFilter}. We do this by using the
-  // \doxygen{ComposeImageFilter}. With this filter we will present our
-  // scalar image as a vector image whose vector pixels contain a single
-  // component.
-  //
-  // Software Guide : EndLatex
-
-  // Software Guide : BeginCodeSnippet
-  using ArrayPixelType = itk::FixedArray<LabelPixelType, 1>;
-
-  using ArrayImageType = itk::Image<ArrayPixelType, Dimension>;
-
-  using ScalarToArrayFilterType =
-    itk::ComposeImageFilter<ImageType, ArrayImageType>;
-
-  auto scalarToArrayFilter = ScalarToArrayFilterType::New();
-  scalarToArrayFilter->SetInput(input);
-  // Software Guide : EndCodeSnippet
-
-
-  // Software Guide : BeginLatex
-  //
-  // With the input image type \code{ImageType} and labeled image type
-  // \code{LabelImageType} we instantiate the type of the
-  // \doxygen{MRFImageFilter} that will apply the Markov Random Field
-  // algorithm in order to refine the pixel classification.
-  //
-  // Software Guide : EndLatex
-
-  // Software Guide : BeginCodeSnippet
-  using MRFFilterType = itk::MRFImageFilter<ArrayImageType, LabelImageType>;
-
-  auto mrfFilter = MRFFilterType::New();
-
-  mrfFilter->SetInput(scalarToArrayFilter->GetOutput());
-  // Software Guide : EndCodeSnippet
-
-
-  // Software Guide : BeginLatex
-  //
-  // We set now some of the parameters for the MRF filter. In particular, the
-  // number of classes to be used during the classification, the maximum
-  // number of iterations to be run in this filter and the error tolerance
-  // that will be used as a criterion for convergence.
-  //
-  // Software Guide : EndLatex
-
-  // Software Guide : BeginCodeSnippet
-  mrfFilter->SetNumberOfClasses(numberOfClasses);
-  mrfFilter->SetMaximumNumberOfIterations(numberOfIterations);
-  mrfFilter->SetErrorTolerance(1e-7);
-  // Software Guide : EndCodeSnippet
-
-
-  // Software Guide : BeginLatex
-  //
-  // The smoothing factor represents the tradeoff between fidelity to the
-  // observed image and the smoothness of the segmented image. Typical
-  // smoothing factors have values between 1~5. This factor will multiply the
-  // weights that define the influence of neighbors on the classification of a
-  // given pixel. The higher the value, the more uniform will be the regions
-  // resulting from the classification refinement.
-  //
-  // Software Guide : EndLatex
-
-  // Software Guide : BeginCodeSnippet
-  mrfFilter->SetSmoothingFactor(smoothingFactor);
-  // Software Guide : EndCodeSnippet
-
-
-  // Software Guide : BeginLatex
-  //
-  // Given that the MRF filter need to continually relabel the pixels, it
-  // needs access to a set of membership functions that will measure to what
-  // degree every pixel belongs to a particular class.  The classification is
-  // performed by the \doxygen{ImageClassifierBase} class, that is
-  // instantiated using the type of the input vector image and the type of the
-  // labeled image.
-  //
-  // Software Guide : EndLatex
-
-  // Software Guide : BeginCodeSnippet
-  using SupervisedClassifierType =
-    itk::ImageClassifierBase<ArrayImageType, LabelImageType>;
-
-  auto classifier = SupervisedClassifierType::New();
-  // Software Guide : EndCodeSnippet
-
-
-  // Software Guide : BeginLatex
-  //
-  // The classifier need a decision rule to be set by the user. Note that we
-  // must use \code{GetPointer()} in the call of the \code{SetDecisionRule()}
-  // method because we are passing a SmartPointer, and smart pointer cannot
-  // perform polymorphism, we must then extract the raw pointer that is
-  // associated to the smart pointer. This extraction is done with the
-  // GetPointer() method.
-  //
-  // Software Guide : EndLatex
-
-  // Software Guide : BeginCodeSnippet
-  using DecisionRuleType = itk::Statistics::MinimumDecisionRule;
-
-  auto classifierDecisionRule = DecisionRuleType::New();
-
-  classifier->SetDecisionRule(classifierDecisionRule);
-  // Software Guide : EndCodeSnippet
-
-
-  // Software Guide : BeginLatex
-  //
-  // We now instantiate the membership functions. In this case we use the
-  // \subdoxygen{Statistics}{DistanceToCentroidMembershipFunction} class
-  // templated over the pixel type of the vector image, that in our example
-  // happens to be a vector of dimension 1.
-  //
-  // Software Guide : EndLatex
-
-  // Software Guide : BeginCodeSnippet
-  using MembershipFunctionType =
-    itk::Statistics::DistanceToCentroidMembershipFunction<ArrayPixelType>;
-
-  using MembershipFunctionPointer = MembershipFunctionType::Pointer;
-
-
-  double                               meanDistance = 0;
-  MembershipFunctionType::CentroidType centroid(1);
-  for (unsigned int i = 0; i < numberOfClasses; ++i)
-  {
-    const MembershipFunctionPointer membershipFunction =
-      MembershipFunctionType::New();
-
-    centroid[0] = std::stod(argv[i + numberOfArgumentsBeforeMeans]);
-
-    membershipFunction->SetCentroid(centroid);
-
-    classifier->AddMembershipFunction(membershipFunction);
-    meanDistance += static_cast<double>(centroid[0]);
-  }
-  if (numberOfClasses > 0)
-  {
-    meanDistance /= numberOfClasses;
-  }
-  else
-  {
-    std::cerr << "ERROR: numberOfClasses is 0" << std::endl;
-    return EXIT_FAILURE;
-  }
-  // Software Guide : EndCodeSnippet
-
-  // Software Guide : BeginLatex
-  //
-  // We set the Smoothing factor. This factor will multiply the weights that
-  // define the influence of neighbors on the classification of a given pixel.
-  // The higher the value, the more uniform will be the regions resulting from
-  // the classification refinement.
-  //
-  // Software Guide : EndLatex
-
-  // Software Guide : BeginCodeSnippet
-  mrfFilter->SetSmoothingFactor(smoothingFactor);
-  // Software Guide : EndCodeSnippet
-
-
-  // Software Guide : BeginLatex
-  //
-  // and we set the neighborhood radius that will define the size of the
-  // clique to be used in the computation of the neighbors' influence in the
-  // classification of any given pixel. Note that despite the fact that we
-  // call this a radius, it is actually the half size of an hypercube. That
-  // is, the actual region of influence will not be circular but rather an
-  // n-dimensional box. For example, a neighborhood radius of 2 in a 3D image
-  // will result in a clique of size 5x5x5 pixels, and a radius of 1 will
-  // result in a clique of size 3x3x3 pixels.
-  //
-  // Software Guide : EndLatex
-
-  // Software Guide : BeginCodeSnippet
-  mrfFilter->SetNeighborhoodRadius(1);
-  // Software Guide : EndCodeSnippet
-
-
-  // Software Guide : BeginLatex
-  //
-  // We should now set the weights used for the neighbors. This is done by
-  // passing an array of values that contains the linear sequence of weights
-  // for the neighbors. For example, in a neighborhood of size 3x3x3, we
-  // should provide a linear array of 9 weight values. The values are packaged
-  // in a \code{std::vector} and are supposed to be \code{double}. The
-  // following lines illustrate a typical set of values for a 3x3x3
-  // neighborhood. The array is arranged and then passed to the filter by
-  // using the method \code{SetMRFNeighborhoodWeight()}.
-  //
-  // Software Guide : EndLatex
-
-  // Software Guide : BeginCodeSnippet
-  std::vector<double> weights;
-  weights.push_back(1.5);
-  weights.push_back(2.0);
-  weights.push_back(1.5);
-  weights.push_back(2.0);
-  weights.push_back(0.0); // This is the central pixel
-  weights.push_back(2.0);
-  weights.push_back(1.5);
-  weights.push_back(2.0);
-  weights.push_back(1.5);
-  // Software Guide : EndCodeSnippet
-
-
-  // Software Guide : BeginLatex
-  //
-  // We now scale weights so that the smoothing function and the image
-  // fidelity functions have comparable value. This is necessary since the
-  // label image and the input image can have different dynamic ranges. The
-  // fidelity function is usually computed using a distance function, such as
-  // the \doxygen{DistanceToCentroidMembershipFunction} or one of the other
-  // membership functions. They tend to have values in the order of the means
-  // specified.
-  //
-  // Software Guide : EndLatex
-
-  // Software Guide : BeginCodeSnippet
-  double totalWeight = 0;
-  for (const double weight : weights)
-  {
-    totalWeight += weight;
-  }
-  for (double & weight : weights)
-  {
-    weight = static_cast<double>(weight * meanDistance / (2 * totalWeight));
-  }
-
-  mrfFilter->SetMRFNeighborhoodWeight(weights);
-  // Software Guide : EndCodeSnippet
-
-
-  // Software Guide : BeginLatex
-  //
-  // Finally, the classifier class is connected to the Markov Random Fields
-  // filter.
-  //
-  // Software Guide : EndLatex
-
-  // Software Guide : BeginCodeSnippet
-  mrfFilter->SetClassifier(classifier);
-  // Software Guide : EndCodeSnippet
-
-
-  // Software Guide : BeginLatex
-  //
-  // The output image produced by the \doxygen{MRFImageFilter} has the same
-  // pixel type as the labeled input image. In the following lines we use the
-  // \code{OutputImageType} in order to instantiate the type of a
-  // \doxygen{ImageFileWriter}. Then create one, and connect it to the output
-  // of the classification filter after passing it through an intensity
-  // rescaler to rescale it to an 8 bit dynamic range
-  //
-  // Software Guide : EndLatex
-
-  // Software Guide : BeginCodeSnippet
-  using OutputImageType = MRFFilterType::OutputImageType;
-  // Software Guide : EndCodeSnippet
-
-  // Rescale outputs to the dynamic range of the display
-  using RescaledOutputImageType = itk::Image<unsigned char, Dimension>;
-  using RescalerType =
-    itk::RescaleIntensityImageFilter<OutputImageType,
-                                     RescaledOutputImageType>;
-
-  auto intensityRescaler = RescalerType::New();
-  intensityRescaler->SetOutputMinimum(0);
-  intensityRescaler->SetOutputMaximum(255);
-  intensityRescaler->SetInput(mrfFilter->GetOutput());
-
-  // Software Guide : BeginLatex
-  //
-  // We are now ready for triggering the execution of the pipeline. This is
-  // done by simply invoking the \code{WriteImage()} function. This call will
-  // propagate the update request to the MRF filter and writes the  processed
-  // image to the specified file.
-  //
-  // Software Guide : EndLatex
-
 
   // Software Guide : BeginCodeSnippet
   try
   {
+    using PixelType = short;
+    constexpr unsigned int Dimension = 2;
+
+    using ImageType = itk::Image<PixelType, Dimension>;
+    auto input = itk::ReadImage<ImageType>(inputImageFileName);
+    // Software Guide : EndCodeSnippet
+
+
+    // Software Guide : BeginLatex
+    //
+    // As a second step we define the pixel type and dimension of the image of
+    // labels that provides the initial classification of the pixels from the
+    // first image. This initial labeled image can be the output of a K-Means
+    // method like the one illustrated in section \ref{sec:KMeansClassifier}.
+    //
+    // Software Guide : EndLatex
+
+    // Software Guide : BeginCodeSnippet
+    using LabelPixelType = unsigned char;
+
+    using LabelImageType = itk::Image<LabelPixelType, Dimension>;
+
+    const auto labelInput =
+      itk::ReadImage<LabelImageType>(inputLabelImageFileName);
+    // Software Guide : EndCodeSnippet
+
+
+    // Software Guide : BeginLatex
+    //
+    // Since the Markov Random Field algorithm is defined in general for
+    // images whose pixels have multiple components, that is, images of vector
+    // type, we must adapt our scalar image in order to satisfy the interface
+    // expected by the \code{MRFImageFilter}. We do this by using the
+    // \doxygen{ComposeImageFilter}. With this filter we will present our
+    // scalar image as a vector image whose vector pixels contain a single
+    // component.
+    //
+    // Software Guide : EndLatex
+
+    // Software Guide : BeginCodeSnippet
+    using ArrayPixelType = itk::FixedArray<LabelPixelType, 1>;
+
+    using ArrayImageType = itk::Image<ArrayPixelType, Dimension>;
+
+    using ScalarToArrayFilterType =
+      itk::ComposeImageFilter<ImageType, ArrayImageType>;
+
+    auto scalarToArrayFilter = ScalarToArrayFilterType::New();
+    scalarToArrayFilter->SetInput(input);
+    // Software Guide : EndCodeSnippet
+
+
+    // Software Guide : BeginLatex
+    //
+    // With the input image type \code{ImageType} and labeled image type
+    // \code{LabelImageType} we instantiate the type of the
+    // \doxygen{MRFImageFilter} that will apply the Markov Random Field
+    // algorithm in order to refine the pixel classification.
+    //
+    // Software Guide : EndLatex
+
+    // Software Guide : BeginCodeSnippet
+    using MRFFilterType = itk::MRFImageFilter<ArrayImageType, LabelImageType>;
+
+    auto mrfFilter = MRFFilterType::New();
+
+    mrfFilter->SetInput(scalarToArrayFilter->GetOutput());
+    // Software Guide : EndCodeSnippet
+
+
+    // Software Guide : BeginLatex
+    //
+    // We set now some of the parameters for the MRF filter. In particular,
+    // the number of classes to be used during the classification, the maximum
+    // number of iterations to be run in this filter and the error tolerance
+    // that will be used as a criterion for convergence.
+    //
+    // Software Guide : EndLatex
+
+    // Software Guide : BeginCodeSnippet
+    mrfFilter->SetNumberOfClasses(numberOfClasses);
+    mrfFilter->SetMaximumNumberOfIterations(numberOfIterations);
+    mrfFilter->SetErrorTolerance(1e-7);
+    // Software Guide : EndCodeSnippet
+
+
+    // Software Guide : BeginLatex
+    //
+    // The smoothing factor represents the tradeoff between fidelity to the
+    // observed image and the smoothness of the segmented image. Typical
+    // smoothing factors have values between 1~5. This factor will multiply
+    // the weights that define the influence of neighbors on the
+    // classification of a given pixel. The higher the value, the more uniform
+    // will be the regions resulting from the classification refinement.
+    //
+    // Software Guide : EndLatex
+
+    // Software Guide : BeginCodeSnippet
+    mrfFilter->SetSmoothingFactor(smoothingFactor);
+    // Software Guide : EndCodeSnippet
+
+
+    // Software Guide : BeginLatex
+    //
+    // Given that the MRF filter need to continually relabel the pixels, it
+    // needs access to a set of membership functions that will measure to what
+    // degree every pixel belongs to a particular class.  The classification
+    // is performed by the \doxygen{ImageClassifierBase} class, that is
+    // instantiated using the type of the input vector image and the type of
+    // the labeled image.
+    //
+    // Software Guide : EndLatex
+
+    // Software Guide : BeginCodeSnippet
+    using SupervisedClassifierType =
+      itk::ImageClassifierBase<ArrayImageType, LabelImageType>;
+
+    auto classifier = SupervisedClassifierType::New();
+    // Software Guide : EndCodeSnippet
+
+
+    // Software Guide : BeginLatex
+    //
+    // The classifier need a decision rule to be set by the user. Note that we
+    // must use \code{GetPointer()} in the call of the
+    // \code{SetDecisionRule()} method because we are passing a SmartPointer,
+    // and smart pointer cannot perform polymorphism, we must then extract the
+    // raw pointer that is associated to the smart pointer. This extraction is
+    // done with the GetPointer() method.
+    //
+    // Software Guide : EndLatex
+
+    // Software Guide : BeginCodeSnippet
+    using DecisionRuleType = itk::Statistics::MinimumDecisionRule;
+
+    auto classifierDecisionRule = DecisionRuleType::New();
+
+    classifier->SetDecisionRule(classifierDecisionRule);
+    // Software Guide : EndCodeSnippet
+
+
+    // Software Guide : BeginLatex
+    //
+    // We now instantiate the membership functions. In this case we use the
+    // \subdoxygen{Statistics}{DistanceToCentroidMembershipFunction} class
+    // templated over the pixel type of the vector image, that in our example
+    // happens to be a vector of dimension 1.
+    //
+    // Software Guide : EndLatex
+
+    // Software Guide : BeginCodeSnippet
+    using MembershipFunctionType =
+      itk::Statistics::DistanceToCentroidMembershipFunction<ArrayPixelType>;
+
+    using MembershipFunctionPointer = MembershipFunctionType::Pointer;
+
+
+    double                               meanDistance = 0;
+    MembershipFunctionType::CentroidType centroid(1);
+    for (unsigned int i = 0; i < numberOfClasses; ++i)
+    {
+      const MembershipFunctionPointer membershipFunction =
+        MembershipFunctionType::New();
+
+      centroid[0] = std::stod(argv[i + numberOfArgumentsBeforeMeans]);
+
+      membershipFunction->SetCentroid(centroid);
+
+      classifier->AddMembershipFunction(membershipFunction);
+      meanDistance += static_cast<double>(centroid[0]);
+    }
+    if (numberOfClasses > 0)
+    {
+      meanDistance /= numberOfClasses;
+    }
+    else
+    {
+      std::cerr << "ERROR: numberOfClasses is 0" << std::endl;
+      return EXIT_FAILURE;
+    }
+    // Software Guide : EndCodeSnippet
+
+    // Software Guide : BeginLatex
+    //
+    // We set the Smoothing factor. This factor will multiply the weights that
+    // define the influence of neighbors on the classification of a given
+    // pixel. The higher the value, the more uniform will be the regions
+    // resulting from the classification refinement.
+    //
+    // Software Guide : EndLatex
+
+    // Software Guide : BeginCodeSnippet
+    mrfFilter->SetSmoothingFactor(smoothingFactor);
+    // Software Guide : EndCodeSnippet
+
+
+    // Software Guide : BeginLatex
+    //
+    // and we set the neighborhood radius that will define the size of the
+    // clique to be used in the computation of the neighbors' influence in the
+    // classification of any given pixel. Note that despite the fact that we
+    // call this a radius, it is actually the half size of an hypercube. That
+    // is, the actual region of influence will not be circular but rather an
+    // n-dimensional box. For example, a neighborhood radius of 2 in a 3D
+    // image will result in a clique of size 5x5x5 pixels, and a radius of 1
+    // will result in a clique of size 3x3x3 pixels.
+    //
+    // Software Guide : EndLatex
+
+    // Software Guide : BeginCodeSnippet
+    mrfFilter->SetNeighborhoodRadius(1);
+    // Software Guide : EndCodeSnippet
+
+
+    // Software Guide : BeginLatex
+    //
+    // We should now set the weights used for the neighbors. This is done by
+    // passing an array of values that contains the linear sequence of weights
+    // for the neighbors. For example, in a neighborhood of size 3x3x3, we
+    // should provide a linear array of 9 weight values. The values are
+    // packaged in a \code{std::vector} and are supposed to be \code{double}.
+    // The following lines illustrate a typical set of values for a 3x3x3
+    // neighborhood. The array is arranged and then passed to the filter by
+    // using the method \code{SetMRFNeighborhoodWeight()}.
+    //
+    // Software Guide : EndLatex
+
+    // Software Guide : BeginCodeSnippet
+    std::vector<double> weights;
+    weights.push_back(1.5);
+    weights.push_back(2.0);
+    weights.push_back(1.5);
+    weights.push_back(2.0);
+    weights.push_back(0.0); // This is the central pixel
+    weights.push_back(2.0);
+    weights.push_back(1.5);
+    weights.push_back(2.0);
+    weights.push_back(1.5);
+    // Software Guide : EndCodeSnippet
+
+
+    // Software Guide : BeginLatex
+    //
+    // We now scale weights so that the smoothing function and the image
+    // fidelity functions have comparable value. This is necessary since the
+    // label image and the input image can have different dynamic ranges. The
+    // fidelity function is usually computed using a distance function, such
+    // as the \doxygen{DistanceToCentroidMembershipFunction} or one of the
+    // other membership functions. They tend to have values in the order of
+    // the means specified.
+    //
+    // Software Guide : EndLatex
+
+    // Software Guide : BeginCodeSnippet
+    double totalWeight = 0;
+    for (const double weight : weights)
+    {
+      totalWeight += weight;
+    }
+    for (double & weight : weights)
+    {
+      weight = static_cast<double>(weight * meanDistance / (2 * totalWeight));
+    }
+
+    mrfFilter->SetMRFNeighborhoodWeight(weights);
+    // Software Guide : EndCodeSnippet
+
+
+    // Software Guide : BeginLatex
+    //
+    // Finally, the classifier class is connected to the Markov Random Fields
+    // filter.
+    //
+    // Software Guide : EndLatex
+
+    // Software Guide : BeginCodeSnippet
+    mrfFilter->SetClassifier(classifier);
+    // Software Guide : EndCodeSnippet
+
+
+    // Software Guide : BeginLatex
+    //
+    // The output image produced by the \doxygen{MRFImageFilter} has the same
+    // pixel type as the labeled input image. In the following lines we use
+    // the
+    // \code{OutputImageType} in order to instantiate the type of a
+    // \doxygen{ImageFileWriter}. Then create one, and connect it to the
+    // output of the classification filter after passing it through an
+    // intensity rescaler to rescale it to an 8 bit dynamic range
+    //
+    // Software Guide : EndLatex
+
+    // Software Guide : BeginCodeSnippet
+    using OutputImageType = MRFFilterType::OutputImageType;
+    // Software Guide : EndCodeSnippet
+
+    // Rescale outputs to the dynamic range of the display
+    using RescaledOutputImageType = itk::Image<unsigned char, Dimension>;
+    using RescalerType =
+      itk::RescaleIntensityImageFilter<OutputImageType,
+                                       RescaledOutputImageType>;
+
+    auto intensityRescaler = RescalerType::New();
+    intensityRescaler->SetOutputMinimum(0);
+    intensityRescaler->SetOutputMaximum(255);
+    intensityRescaler->SetInput(mrfFilter->GetOutput());
+
+    // Software Guide : BeginLatex
+    //
+    // We are now ready for triggering the execution of the pipeline. This is
+    // done by simply invoking the \code{WriteImage()} function. This call
+    // will propagate the update request to the MRF filter and writes the
+    // processed image to the specified file. After the filter has been
+    // updated, we can get the number of iterations and the stop condition. At
+    // the end of the program, we close the try block with a catch statement.
+    //
+    // Software Guide : EndLatex
+
+
+    // Software Guide : BeginCodeSnippet
     itk::WriteImage(intensityRescaler->GetOutput(), outputImageFileName);
+
+    std::cout << "Number of Iterations : ";
+    std::cout << mrfFilter->GetNumberOfIterations() << std::endl;
+    std::cout << "Stop condition: " << std::endl;
+    std::cout << "  (1) Maximum number of iterations " << std::endl;
+    std::cout << "  (2) Error tolerance:  " << std::endl;
+    std::cout << mrfFilter->GetStopCondition() << std::endl;
   }
   catch (const itk::ExceptionObject & excp)
   {
-    std::cerr << excp << std::endl;
+    std::cerr << "ITK exception caught:\n" << excp << std::endl;
     return EXIT_FAILURE;
   }
+  return EXIT_SUCCESS;
   // Software Guide : EndCodeSnippet
-
-  std::cout << "Number of Iterations : ";
-  std::cout << mrfFilter->GetNumberOfIterations() << std::endl;
-  std::cout << "Stop condition: " << std::endl;
-  std::cout << "  (1) Maximum number of iterations " << std::endl;
-  std::cout << "  (2) Error tolerance:  " << std::endl;
-  std::cout << mrfFilter->GetStopCondition() << std::endl;
 
   //  Software Guide : BeginLatex
   //
@@ -473,6 +467,4 @@ main(int argc, char * argv[])
   //  and the means were estimated by ScalarImageKmeansModelEstimator.cxx.
   //
   //  Software Guide : EndLatex
-
-  return EXIT_SUCCESS;
 }

--- a/Examples/Statistics/ScalarImageMarkovRandomField1.cxx
+++ b/Examples/Statistics/ScalarImageMarkovRandomField1.cxx
@@ -117,8 +117,16 @@ main(int argc, char * argv[])
   constexpr unsigned int Dimension = 2;
 
   using ImageType = itk::Image<PixelType, Dimension>;
-
-  const auto input = itk::ReadImage<ImageType>(inputImageFileName);
+  ImageType::Pointer input;
+  try
+  {
+    input = itk::ReadImage<ImageType>(inputImageFileName);
+  }
+  catch (const itk::ExceptionObject & excp)
+  {
+    std::cerr << excp << std::endl;
+    return EXIT_FAILURE;
+  }
   // Software Guide : EndCodeSnippet
 
 
@@ -420,23 +428,12 @@ main(int argc, char * argv[])
   intensityRescaler->SetOutputMaximum(255);
   intensityRescaler->SetInput(mrfFilter->GetOutput());
 
-  // Software Guide : BeginCodeSnippet
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-
-  auto writer = WriterType::New();
-
-  writer->SetInput(intensityRescaler->GetOutput());
-
-  writer->SetFileName(outputImageFileName);
-  // Software Guide : EndCodeSnippet
-
-
   // Software Guide : BeginLatex
   //
   // We are now ready for triggering the execution of the pipeline. This is
-  // done by simply invoking the \code{Update()} method in the writer. This
-  // call will propagate the update request to the reader and then to the MRF
-  // filter.
+  // done by simply invoking the \code{WriteImage()} function. This call will
+  // propagate the update request to the MRF filter and writes the  processed
+  // image to the specified file.
   //
   // Software Guide : EndLatex
 
@@ -444,12 +441,10 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   try
   {
-    writer->Update();
+    itk::WriteImage(intensityRescaler->GetOutput(), outputImageFileName);
   }
   catch (const itk::ExceptionObject & excp)
   {
-    std::cerr << "Problem encountered while writing ";
-    std::cerr << " image file : " << argv[2] << std::endl;
     std::cerr << excp << std::endl;
     return EXIT_FAILURE;
   }


### PR DESCRIPTION
This commit addresses the review comments from PR #5163 related to issue #2802. In this commit Examples related to statistics has been changed to use itk::ReadImage and itk::WriteImage

Part of #2802. This is a re-imagining of #5214. Closes #5214.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
