### PR TITLE
BUG: Fix AP axis flipping for case LeftAnteriorSuperior in NRRDImageIO

### DIFF
--- a/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
+++ b/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
@@ -488,8 +488,8 @@ NrrdImageIO::ReadImageInformation()
                 iFlipFactors[1] = -1;
                 break;
               case nrrdSpaceLeftAnteriorSuperior:
-                spaceDir[0] *= -1; // R -> L
-                iFlipFactors[0] = -1;
+                spaceDir[1] *= -1; // A -> P
+                iFlipFactors[1] = -1;
                 break;
               case nrrdSpaceLeftPosteriorSuperior:
                 // no change needed
@@ -537,7 +537,7 @@ NrrdImageIO::ReadImageInformation()
             spaceOrigin[1] *= -1; // A -> P
             break;
           case nrrdSpaceLeftAnteriorSuperior:
-            spaceOrigin[0] *= -1; // R -> L
+            spaceOrigin[1] *= -1; // A -> P
             break;
           case nrrdSpaceLeftPosteriorSuperior:
             // no change needed


### PR DESCRIPTION
The old code was flipping left/right axis instead of anterior/posterior. The bug was introduced with the original feature on November 22, 2005: 15372e8c17ef2344d47767d47cc27c5fe9c6c17a. Closes #5207.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
