### PR TITLE
ENH: Let `itk::Array` support class template argument deduction (CTAD)

### DIFF
--- a/Modules/Core/Common/include/itkArray.h
+++ b/Modules/Core/Common/include/itkArray.h
@@ -78,22 +78,25 @@ public:
    * the array does not manage the memory of the buffer. It merely points to
    * that location and it is the user's responsibility to delete it.
    * If "LetArrayManageMemory" is true, then this class will free the
-   * memory when this object is destroyed. */
-  Array(ValueType * datain, SizeValueType sz, bool LetArrayManageMemory = false);
+   * memory when this object is destroyed.
+   * \note This constructor supports class template argument deduction (CTAD). */
+  Array(TValue * datain, SizeValueType sz, bool LetArrayManageMemory = false);
 
 #if defined(ITK_LEGACY_REMOVE)
   /** Constructor that initializes array with contents from a user supplied
    * const buffer. The pointer to the buffer and the length is specified. By default,
    * the array does a deep copy of the const pointer data, so the array class also
-   * manages memory. */
-  Array(const ValueType * datain, SizeValueType sz);
+   * manages memory.
+   * \note This constructor supports class template argument deduction (CTAD). */
+  Array(const TValue * datain, SizeValueType sz);
 
 #else // defined ( ITK_LEGACY_REMOVE )
   /** Constructor that initializes array with contents from a user supplied
    * buffer. The pointer to the buffer and the length is specified. The array
    * does a deep copy of the const pointer data, so the array class also
-   * manages memory. The 3rd argument is only for backward compatibility. */
-  Array(const ValueType * datain, SizeValueType sz, bool LetArrayManageMemory = false);
+   * manages memory. The 3rd argument is only for backward compatibility.
+   * \note This constructor supports class template argument deduction (CTAD). */
+  Array(const TValue * datain, SizeValueType sz, bool LetArrayManageMemory = false);
 #endif
 
   /** Constructor to initialize an array from another of any data type */
@@ -207,6 +210,10 @@ private:
   /** Indicates whether this array manages the memory of its data. */
   bool m_LetArrayManageMemory{ true };
 };
+
+// Deduction guide to avoid compiler warnings (-wctad-maybe-unsupported) when using class template argument deduction.
+template <typename TValue>
+Array(TValue *, typename vnl_vector<TValue>::size_type, bool) -> Array<TValue>;
 
 template <typename TValue>
 std::ostream &

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -1714,6 +1714,7 @@ if(ITK_BUILD_SHARED_LIBS AND ITK_DYNAMIC_LOADING)
 endif()
 
 set(ITKCommonGTests
+    itkArrayGTest.cxx
     itkArray2DGTest.cxx
     itkAggregateTypesGTest.cxx
     itkBitCastGTest.cxx

--- a/Modules/Core/Common/test/itkArrayGTest.cxx
+++ b/Modules/Core/Common/test/itkArrayGTest.cxx
@@ -1,0 +1,44 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkArray.h"
+#include <gtest/gtest.h>
+
+namespace
+{
+// Checks that `itk::Array` supports class template argument deduction (CTAD).
+template <typename TValue>
+constexpr bool
+CheckClassTemplateArgumentDeduction()
+{
+  using ExpectedType = itk::Array<TValue>;
+
+  const TValue constValue{};
+  static_assert(std::is_same_v<decltype(itk::Array(&constValue, 1)), ExpectedType>,
+                "The `Array(const ValueType *, ...)` constructor should support CTAD!");
+
+  TValue nonConstValue{};
+  static_assert(std::is_same_v<decltype(itk::Array(&nonConstValue, 1)), ExpectedType>,
+                "The `Array(ValueType *, ...)` constructor should support CTAD!");
+  return true;
+}
+} // namespace
+
+
+static_assert(CheckClassTemplateArgumentDeduction<int>() && CheckClassTemplateArgumentDeduction<float>());


### PR DESCRIPTION
Added a deduction guide to avoid `-wctad-maybe-unsupported` compiler warnings.
Included a compile-time unit test.
