### PR TITLE
BUG:  Incorrect size for looping closed parametric dimension.

### DIFF
--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -530,7 +530,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::Threade
         idx[i] += static_cast<unsigned int>(p[i]);
         if (this->m_CloseDimension[i])
         {
-          idx[i] %= size[i];
+          idx[i] %= currentThreadDeltaLattice->GetLargestPossibleRegion().GetSize()[i];
         }
       }
       const RealType wc = this->m_PointWeights->GetElement(n);

--- a/Modules/Filtering/ImageGrid/test/Baseline/itkBSplineScatteredDataPointSetToImageFilterTest05_magnitude.png.cid
+++ b/Modules/Filtering/ImageGrid/test/Baseline/itkBSplineScatteredDataPointSetToImageFilterTest05_magnitude.png.cid
@@ -1,1 +1,1 @@
-bafkreifhzzuhtzerxqynchashazjhqlmp6jpipvp6j5azkbfjfla5nuuxm
+bafkreigzmzk6nws4pgxdbildcqclzog7gmnsnsuw2tavurzoioma3sktay

--- a/Modules/Filtering/ImageGrid/test/Baseline/itkBSplineScatteredDataPointSetToImageFilterTest05_magnitude.png.cid
+++ b/Modules/Filtering/ImageGrid/test/Baseline/itkBSplineScatteredDataPointSetToImageFilterTest05_magnitude.png.cid
@@ -1,1 +1,1 @@
-bafkreigzmzk6nws4pgxdbildcqclzog7gmnsnsuw2tavurzoioma3sktay
+bafkreigjqp66knrolkjjaqvrbp5jamed2exaney7brxgqb3oor7boimzua


### PR DESCRIPTION
BUG:   Incorrect size for looping closed parametric dimension.

Bug producing an incorrect result for the specific case of a closed parametric dimension, e.g., closed loop or cylinder.  This doesn't effect the usual image output.    

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
