### PR TITLE
BUG: Do not run pre-commit GHA on push

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,8 +2,6 @@ name: pre-commit
 
 on:
   pull_request:
-  push:
-    branches: [master]
 
 jobs:
   pre-commit:


### PR DESCRIPTION
Fails the `no-commit-to-branch` check for merges, but should be
unnecessary.
