### PR TITLE
STYLE: Enclose the majority of the main function in a try-catch block for Examples/SpatialObjects and Examples/RegistrationITKV4

### DIFF
--- a/Examples/RegistrationITKv4/MultiResImageRegistration1.cxx
+++ b/Examples/RegistrationITKv4/MultiResImageRegistration1.cxx
@@ -313,10 +313,10 @@ public:
 private:
   unsigned int m_CumulativeIterationIndex{ 0 };
 };
-
-
+namespace
+{
 int
-main(int argc, const char * argv[])
+ExampleMain(int argc, const char * const argv[])
 {
   if (argc < 4)
   {
@@ -481,19 +481,12 @@ main(int argc, const char * argv[])
   //
   //  Software Guide : EndLatex
 
-  try
-  {
-    registration->Update();
-    std::cout << "Optimizer stop condition: "
-              << registration->GetOptimizer()->GetStopConditionDescription()
-              << std::endl;
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "ExceptionObject caught !" << std::endl;
-    std::cout << err << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  registration->Update();
+  std::cout << "Optimizer stop condition: "
+            << registration->GetOptimizer()->GetStopConditionDescription()
+            << std::endl;
+
 
   ParametersType finalParameters = transform->GetParameters();
 
@@ -665,4 +658,26 @@ main(int argc, const char * argv[])
 
 
   return EXIT_SUCCESS;
+}
+} // namespace
+int
+main(int argc, char * argv[])
+{
+  try
+  {
+    return ExampleMain(argc, argv);
+  }
+  catch (const itk::ExceptionObject & exceptionObject)
+  {
+    std::cerr << "ITK exception caught:\n" << exceptionObject << '\n';
+  }
+  catch (const std::exception & stdException)
+  {
+    std::cerr << "std exception caught:\n" << stdException.what() << '\n';
+  }
+  catch (...)
+  {
+    std::cerr << "Unhandled exception!\n";
+  }
+  return EXIT_FAILURE;
 }

--- a/Examples/RegistrationITKv4/MultiResImageRegistration2.cxx
+++ b/Examples/RegistrationITKv4/MultiResImageRegistration2.cxx
@@ -166,8 +166,11 @@ public:
   }
 };
 
+namespace
+{
+
 int
-main(int argc, char * argv[])
+ExampleMain(int argc, const char * const argv[])
 {
   if (argc < 4)
   {
@@ -438,19 +441,12 @@ main(int argc, char * argv[])
   registration->AddObserver(itk::IterationEvent(), command);
   registration->SetNumberOfLevels(3);
 
-  try
-  {
-    registration->Update();
-    std::cout << "Optimizer stop condition: "
-              << registration->GetOptimizer()->GetStopConditionDescription()
-              << std::endl;
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "ExceptionObject caught !" << std::endl;
-    std::cout << err << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  registration->Update();
+  std::cout << "Optimizer stop condition: "
+            << registration->GetOptimizer()->GetStopConditionDescription()
+            << std::endl;
+
 
   std::cout << "Optimizer Stopping Condition = "
             << optimizer->GetStopCondition() << std::endl;
@@ -622,4 +618,27 @@ main(int argc, char * argv[])
   }
 
   return EXIT_SUCCESS;
+}
+} // namespace
+
+int
+main(int argc, char * argv[])
+{
+  try
+  {
+    return ExampleMain(argc, argv);
+  }
+  catch (const itk::ExceptionObject & exceptionObject)
+  {
+    std::cerr << "ITK exception caught:\n" << exceptionObject << '\n';
+  }
+  catch (const std::exception & stdException)
+  {
+    std::cerr << "std exception caught:\n" << stdException.what() << '\n';
+  }
+  catch (...)
+  {
+    std::cerr << "Unhandled exception!\n";
+  }
+  return EXIT_FAILURE;
 }

--- a/Examples/RegistrationITKv4/MultiResImageRegistration3.cxx
+++ b/Examples/RegistrationITKv4/MultiResImageRegistration3.cxx
@@ -134,9 +134,10 @@ public:
   }
 };
 
-
+namespace
+{
 int
-main(int argc, char * argv[])
+ExampleMain(int argc, const char * const argv[])
 {
   if (argc < 4)
   {
@@ -278,19 +279,12 @@ main(int argc, char * argv[])
 
   registration->SetNumberOfLevels(3);
 
-  try
-  {
-    registration->Update();
-    std::cout << "Optimizer stop condition: "
-              << registration->GetOptimizer()->GetStopConditionDescription()
-              << std::endl;
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "ExceptionObject caught !" << std::endl;
-    std::cout << err << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  registration->Update();
+  std::cout << "Optimizer stop condition: "
+            << registration->GetOptimizer()->GetStopConditionDescription()
+            << std::endl;
+
 
   ParametersType finalParameters = registration->GetLastTransformParameters();
 
@@ -381,4 +375,27 @@ main(int argc, char * argv[])
   }
 
   return EXIT_SUCCESS;
+}
+} // namespace
+
+int
+main(int argc, char * argv[])
+{
+  try
+  {
+    return ExampleMain(argc, argv);
+  }
+  catch (const itk::ExceptionObject & exceptionObject)
+  {
+    std::cerr << "ITK exception caught:\n" << exceptionObject << '\n';
+  }
+  catch (const std::exception & stdException)
+  {
+    std::cerr << "std exception caught:\n" << stdException.what() << '\n';
+  }
+  catch (...)
+  {
+    std::cerr << "Unhandled exception!\n";
+  }
+  return EXIT_FAILURE;
 }

--- a/Examples/RegistrationITKv4/MultiStageImageRegistration1.cxx
+++ b/Examples/RegistrationITKv4/MultiStageImageRegistration1.cxx
@@ -170,9 +170,10 @@ public:
 private:
   unsigned int m_CumulativeIterationIndex{ 0 };
 };
-
+namespace
+{
 int
-main(int argc, char * argv[])
+ExampleMain(int argc, const char * const argv[])
 {
   if (argc < 4)
   {
@@ -393,20 +394,13 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  try
-  {
-    transRegistration->Update();
-    std::cout
-      << "Optimizer stop condition: "
-      << transRegistration->GetOptimizer()->GetStopConditionDescription()
-      << std::endl;
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "ExceptionObject caught !" << std::endl;
-    std::cout << err << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  transRegistration->Update();
+  std::cout
+    << "Optimizer stop condition: "
+    << transRegistration->GetOptimizer()->GetStopConditionDescription()
+    << std::endl;
+
 
   compositeTransform->AddTransform(
     transRegistration->GetModifiableTransform());
@@ -741,20 +735,12 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  try
-  {
-    affineRegistration->Update();
-    std::cout
-      << "Optimizer stop condition: "
-      << affineRegistration->GetOptimizer()->GetStopConditionDescription()
-      << std::endl;
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "ExceptionObject caught !" << std::endl;
-    std::cout << err << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  affineRegistration->Update();
+  std::cout
+    << "Optimizer stop condition: "
+    << affineRegistration->GetOptimizer()->GetStopConditionDescription()
+    << std::endl;
 
   compositeTransform->AddTransform(
     affineRegistration->GetModifiableTransform());
@@ -931,15 +917,9 @@ main(int argc, char * argv[])
   // Before registration
   using TransformType = itk::IdentityTransform<double, Dimension>;
   TransformType::Pointer identityTransform;
-  try
-  {
-    identityTransform = TransformType::New();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    err.Print(std::cerr);
-    return EXIT_FAILURE;
-  }
+
+  identityTransform = TransformType::New();
+
   identityTransform->SetIdentity();
   resample->SetTransform(identityTransform);
 
@@ -956,4 +936,28 @@ main(int argc, char * argv[])
   }
 
   return EXIT_SUCCESS;
+}
+} // namespace
+
+
+int
+main(int argc, char * argv[])
+{
+  try
+  {
+    return ExampleMain(argc, argv);
+  }
+  catch (const itk::ExceptionObject & exceptionObject)
+  {
+    std::cerr << "ITK exception caught:\n" << exceptionObject << '\n';
+  }
+  catch (const std::exception & stdException)
+  {
+    std::cerr << "std exception caught:\n" << stdException.what() << '\n';
+  }
+  catch (...)
+  {
+    std::cerr << "Unhandled exception!\n";
+  }
+  return EXIT_FAILURE;
 }

--- a/Examples/RegistrationITKv4/MultiStageImageRegistration2.cxx
+++ b/Examples/RegistrationITKv4/MultiStageImageRegistration2.cxx
@@ -174,8 +174,10 @@ private:
   unsigned int m_CumulativeIterationIndex{ 0 };
 };
 
+namespace
+{
 int
-main(int argc, char * argv[])
+ExampleMain(int argc, const char * const argv[])
 {
   if (argc < 4)
   {
@@ -484,20 +486,14 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  try
-  {
-    affineRegistration->Update();
-    std::cout
-      << "Optimizer stop condition: "
-      << affineRegistration->GetOptimizer()->GetStopConditionDescription()
-      << std::endl;
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    std::cout << "ExceptionObject caught !" << std::endl;
-    std::cout << err << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  affineRegistration->Update();
+  std::cout
+    << "Optimizer stop condition: "
+    << affineRegistration->GetOptimizer()->GetStopConditionDescription()
+    << std::endl;
+
+
   // Software Guide : EndCodeSnippet
 
   //  Software Guide : BeginLatex
@@ -650,15 +646,9 @@ main(int argc, char * argv[])
   // Before registration
   using TransformType = itk::IdentityTransform<double, Dimension>;
   TransformType::Pointer identityTransform;
-  try
-  {
-    identityTransform = TransformType::New();
-  }
-  catch (const itk::ExceptionObject & err)
-  {
-    err.Print(std::cerr);
-    return EXIT_FAILURE;
-  }
+
+  identityTransform = TransformType::New();
+
   identityTransform->SetIdentity();
   resample->SetTransform(identityTransform);
 
@@ -675,4 +665,26 @@ main(int argc, char * argv[])
   }
 
   return EXIT_SUCCESS;
+}
+} // namespace
+int
+main(int argc, char * argv[])
+{
+  try
+  {
+    return ExampleMain(argc, argv);
+  }
+  catch (const itk::ExceptionObject & exceptionObject)
+  {
+    std::cerr << "ITK exception caught:\n" << exceptionObject << '\n';
+  }
+  catch (const std::exception & stdException)
+  {
+    std::cerr << "std exception caught:\n" << stdException.what() << '\n';
+  }
+  catch (...)
+  {
+    std::cerr << "Unhandled exception!\n";
+  }
+  return EXIT_FAILURE;
 }

--- a/Examples/RegistrationITKv4/ThinPlateSplineWarp.cxx
+++ b/Examples/RegistrationITKv4/ThinPlateSplineWarp.cxx
@@ -40,9 +40,10 @@
 #include "itkPointSet.h"
 #include <fstream>
 
-
+namespace
+{
 int
-main(int argc, char * argv[])
+ExampleMain(int argc, const char * const argv[])
 {
   if (argc < 4)
   {
@@ -72,16 +73,8 @@ main(int argc, char * argv[])
     itk::LinearInterpolateImageFunction<InputImageType, double>;
 
   InputImageType::ConstPointer inputImage;
-  try
-  {
-    inputImage = itk::ReadImage<InputImageType>(argv[2]);
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Exception thrown " << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  inputImage = itk::ReadImage<InputImageType>(argv[2]);
 
 
   // Software Guide : BeginLatex
@@ -157,16 +150,8 @@ main(int argc, char * argv[])
   resampler->SetInput(inputImage);
 
   // Set and write deformed image
-  try
-  {
-    itk::WriteImage(resampler->GetOutput(), argv[3]);
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Exception thrown " << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  itk::WriteImage(resampler->GetOutput(), argv[3]);
 
 
   // Software Guide : BeginLatex
@@ -206,15 +191,31 @@ main(int argc, char * argv[])
   }
 
   // Write computed deformation field
+
+  itk::WriteImage(field, argv[4]);
+
+
+  return EXIT_SUCCESS;
+}
+} // namespace
+int
+main(int argc, char * argv[])
+{
   try
   {
-    itk::WriteImage(field, argv[4]);
+    return ExampleMain(argc, argv);
   }
-  catch (const itk::ExceptionObject & excp)
+  catch (const itk::ExceptionObject & exceptionObject)
   {
-    std::cerr << "Exception thrown " << std::endl;
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
+    std::cerr << "ITK exception caught:\n" << exceptionObject << '\n';
   }
-  return EXIT_SUCCESS;
+  catch (const std::exception & stdException)
+  {
+    std::cerr << "std exception caught:\n" << stdException.what() << '\n';
+  }
+  catch (...)
+  {
+    std::cerr << "Unhandled exception!\n";
+  }
+  return EXIT_FAILURE;
 }

--- a/Examples/SpatialObjects/BoundingBoxFromImageMaskSpatialObject.cxx
+++ b/Examples/SpatialObjects/BoundingBoxFromImageMaskSpatialObject.cxx
@@ -36,8 +36,10 @@
 
 #include "itkImageFileReader.h"
 
+namespace
+{
 int
-main(int argc, char * argv[])
+ExampleMain(int argc, const char * const argv[])
 {
 
   if (argc < 2)
@@ -52,15 +54,8 @@ main(int argc, char * argv[])
 
   using ImageType = ImageMaskSpatialObject::ImageType;
   ImageType::Pointer input;
-  try
-  {
-    input = itk::ReadImage<ImageType>(argv[1]);
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  input = itk::ReadImage<ImageType>(argv[1]);
+
 
   auto maskSO = ImageMaskSpatialObject::New();
 
@@ -72,4 +67,27 @@ main(int argc, char * argv[])
             << std::endl;
 
   return EXIT_SUCCESS;
+}
+} // namespace
+
+int
+main(int argc, char * argv[])
+{
+  try
+  {
+    return ExampleMain(argc, argv);
+  }
+  catch (const itk::ExceptionObject & exceptionObject)
+  {
+    std::cerr << "ITK exception caught:\n" << exceptionObject << '\n';
+  }
+  catch (const std::exception & stdException)
+  {
+    std::cerr << "std exception caught:\n" << stdException.what() << '\n';
+  }
+  catch (...)
+  {
+    std::cerr << "Unhandled exception!\n";
+  }
+  return EXIT_FAILURE;
 }


### PR DESCRIPTION
This commit addresses the review comments from PR #5223 related to issue #2802 . In this commit, examples related to SpatialObjects and RegistrationITKV4 have been enclosed with try catch block.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

