### PR TITLE
BUG: Replace `pow` with `Math::UnsignedPower` in NumberToString GTest

### DIFF
--- a/Modules/Core/Common/test/itkNumberToStringGTest.cxx
+++ b/Modules/Core/Common/test/itkNumberToStringGTest.cxx
@@ -18,8 +18,8 @@
 
 // First include the header file to be tested:
 #include "itkNumberToString.h"
+#include "itkMath.h"
 #include <gtest/gtest.h>
-#include <cmath> // For std::pow.
 
 namespace
 {
@@ -91,22 +91,22 @@ Test_decimal_notation_supports_up_to_twentyone_digits()
   const itk::NumberToString<TValue> numberToString{};
   const auto                        message = std::string("Floating point type: ") + floatingPointTypeName<TValue>;
 
-  for (int8_t exponent{ 20 }; exponent > 0; --exponent)
+  for (uint64_t exponent{ 20 }; exponent > 0; --exponent)
   {
-    const TValue power_of_ten{ std::pow(TValue{ 10 }, static_cast<TValue>(exponent)) };
+    const TValue power_of_ten{ static_cast<TValue>(itk::Math::UnsignedPower(10, exponent - 1)) * TValue{ 10 } };
 
     // Test +/- 10 ^ exponent
     EXPECT_EQ(numberToString(power_of_ten), '1' + std::string(exponent, '0')) << message;
     EXPECT_EQ(numberToString(-power_of_ten), "-1" + std::string(exponent, '0')) << message;
   }
 
-  for (int8_t exponent{ -6 }; exponent < 0; ++exponent)
+  for (uint64_t exponent{ 6 }; exponent > 0; --exponent)
   {
-    const TValue power_of_ten{ std::pow(TValue{ 10 }, static_cast<TValue>(exponent)) };
+    const TValue power_of_ten{ TValue{ 1 } / static_cast<TValue>(itk::Math::UnsignedPower(10, exponent)) };
 
-    // Test +/- 10 ^ exponent
-    EXPECT_EQ(numberToString(power_of_ten), "0." + std::string(-1 - exponent, '0') + '1') << message;
-    EXPECT_EQ(numberToString(-power_of_ten), "-0." + std::string(-1 - exponent, '0') + '1') << message;
+    // Test +/- 10 ^ -exponent
+    EXPECT_EQ(numberToString(power_of_ten), "0." + std::string(exponent - 1, '0') + '1') << message;
+    EXPECT_EQ(numberToString(-power_of_ten), "-0." + std::string(exponent - 1, '0') + '1') << message;
   }
 }
 


### PR DESCRIPTION
Aims to address test failures reported by @yurivict, at https://github.com/InsightSoftwareConsortium/ITK/issues/5245, saying:

```
/usr/ports/science/InsightToolkit/work/ITK-5.4.2/Modules/Core/Common/test/itkNumberToStringGTest.cxx:99: Failure
Expected equality of these values:
  numberToString(power_of_ten)
    Which is: "100000010000"
  '1' + std::string(exponent, '0')
    Which is: "100000000000"
Floating point type: float

...

/usr/ports/science/InsightToolkit/work/ITK-5.4.2/Modules/Core/Common/test/itkNumberToStringGTest.cxx:108: Failure
Expected equality of these values:
  numberToString(power_of_ten)
    Which is: "0.000009999999999999999"
  "0." + std::string(-1 - exponent, '0') + '1'
    Which is: "0.00001"
Floating point type: double
```

Using clang-19 on FreeBSD 14.2.

Sean McBride (@seanm) confirmed that this commit would solve the issue on his FreeBSD VM.