### PR TITLE
STYLE: Replace `std::pow(x, 2)` calls with `Math::sqr(x)`

### DIFF
--- a/Modules/Core/Common/include/itkEllipsoidInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkEllipsoidInteriorExteriorSpatialFunction.hxx
@@ -18,6 +18,7 @@
 #ifndef itkEllipsoidInteriorExteriorSpatialFunction_hxx
 #define itkEllipsoidInteriorExteriorSpatialFunction_hxx
 
+#include "itkMath.h"
 #include <cmath>
 
 namespace itk
@@ -43,8 +44,7 @@ EllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::Evaluate(const Inp
     {
       orientationVector[j] = m_Orientations[i][j];
     }
-    distanceSquared +=
-      std::pow(static_cast<double>((orientationVector * pointVector) / (.5 * m_Axes[i])), static_cast<double>(2));
+    distanceSquared += Math::sqr(static_cast<double>((orientationVector * pointVector) / (.5 * m_Axes[i])));
   }
 
   if (distanceSquared <= 1)

--- a/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.hxx
@@ -19,6 +19,7 @@
 #define itkFiniteCylinderSpatialFunction_hxx
 
 #include "itkFloatingPointExceptions.h"
+#include "itkMath.h"
 #include <cmath>
 
 namespace itk
@@ -102,7 +103,7 @@ FiniteCylinderSpatialFunction<VDimension, TInput>::Evaluate(const InputType & po
   }
 
   if (itk::Math::abs(distanceFromCenter) <= (halfAxisLength) &&
-      m_Radius >= std::sqrt(std::pow(pointVector.GetNorm(), 2.0) - std::pow(distanceFromCenter, 2.0)))
+      m_Radius >= std::sqrt(Math::sqr(pointVector.GetNorm()) - Math::sqr(distanceFromCenter)))
   {
     return 1;
   }

--- a/Modules/Core/Common/include/itkSymmetricEllipsoidInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkSymmetricEllipsoidInteriorExteriorSpatialFunction.hxx
@@ -18,6 +18,7 @@
 #ifndef itkSymmetricEllipsoidInteriorExteriorSpatialFunction_hxx
 #define itkSymmetricEllipsoidInteriorExteriorSpatialFunction_hxx
 
+#include "itkMath.h"
 #include <cmath>
 
 namespace itk
@@ -48,11 +49,9 @@ SymmetricEllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::Evaluate(
     pointVector[i] = position[i] - m_Center[i];
   }
 
-  uniqueTerm =
-    std::pow(static_cast<double>(((pointVector * m_Orientation) / (.5 * m_UniqueAxis))), static_cast<double>(2));
+  uniqueTerm = Math::sqr(static_cast<double>(((pointVector * m_Orientation) / (.5 * m_UniqueAxis))));
   symmetricVector = pointVector - (m_Orientation * (pointVector * m_Orientation));
-  symmetricTerm =
-    std::pow(static_cast<double>(((symmetricVector.GetNorm()) / (.5 * m_SymmetricAxes))), static_cast<double>(2));
+  symmetricTerm = Math::sqr(static_cast<double>(((symmetricVector.GetNorm()) / (.5 * m_SymmetricAxes))));
 
   if ((uniqueTerm + symmetricTerm) >= 0 && (uniqueTerm + symmetricTerm) <= 1)
   {

--- a/Modules/Core/Common/include/itkTorusInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkTorusInteriorExteriorSpatialFunction.hxx
@@ -18,6 +18,8 @@
 #ifndef itkTorusInteriorExteriorSpatialFunction_hxx
 #define itkTorusInteriorExteriorSpatialFunction_hxx
 
+#include "itkMath.h"
+
 
 namespace itk
 {
@@ -29,7 +31,7 @@ TorusInteriorExteriorSpatialFunction<VDimension, TInput>::Evaluate(const InputTy
   const double y = position[1] - m_Origin[1];
   const double z = position[2] - m_Origin[2];
 
-  const double k = std::pow(m_MajorRadius - std::sqrt(x * x + y * y), 2.0) + z * z;
+  const double k = Math::sqr(m_MajorRadius - std::sqrt(x * x + y * y)) + z * z;
 
   if (k <= (m_MinorRadius * m_MinorRadius))
   {

--- a/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.hxx
@@ -143,7 +143,7 @@ IterativeInverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::Generat
         smallestError = 0;
         for (unsigned int j = 0; j < ImageDimension; ++j)
         {
-          smallestError += std::pow(mappedPoint[j] + forwardVector[j] - originalPoint[j], 2);
+          smallestError += Math::sqr(mappedPoint[j] + forwardVector[j] - originalPoint[j]);
         }
         smallestError = std::sqrt(smallestError);
       }
@@ -167,7 +167,7 @@ IterativeInverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::Generat
             double                      tmp = 0;
             for (unsigned int l = 0; l < ImageDimension; ++l)
             {
-              tmp += std::pow(mappedPoint[l] + forwardVector[l] - originalPoint[l], 2);
+              tmp += Math::sqr(mappedPoint[l] + forwardVector[l] - originalPoint[l]);
             }
             tmp = std::sqrt(tmp);
             if (tmp < smallestError)
@@ -187,7 +187,7 @@ IterativeInverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::Generat
             double                      tmp = 0;
             for (unsigned int l = 0; l < ImageDimension; ++l)
             {
-              tmp += std::pow(mappedPoint[l] + forwardVector[l] - originalPoint[l], 2);
+              tmp += Math::sqr(mappedPoint[l] + forwardVector[l] - originalPoint[l]);
             }
             tmp = std::sqrt(tmp);
             if (tmp < smallestError)

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -475,7 +475,7 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ComputeFeretDiameter(LabelObjectType *
       for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         const OffsetValueType indexDifference = (iIt1->operator[](i) - iIt2->operator[](i));
-        length += std::pow(indexDifference * spacing[i], 2);
+        length += Math::sqr(indexDifference * spacing[i]);
       }
       if (feretDiameter < length)
       {

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
@@ -128,7 +128,7 @@ StatisticsLabelMapFilter<TImage, TFeatureImage>::ThreadedProcessLabelObject(Labe
 
     // increase the sums
     sum += v;
-    sum2 += std::pow(static_cast<double>(v), 2);
+    sum2 += Math::sqr(static_cast<double>(v));
     sum3 += std::pow(static_cast<double>(v), 3);
     sum4 += std::pow(static_cast<double>(v), 4);
 
@@ -154,7 +154,7 @@ StatisticsLabelMapFilter<TImage, TFeatureImage>::ThreadedProcessLabelObject(Labe
   const double                                          mean = sum / totalFreq;
   // Note that totalFreq could be 1. Stats on a population of size 1 are not useful.
   // We protect against dividing by 0 in that case.
-  const double variance = (totalFreq > 1) ? (sum2 - (std::pow(sum, 2) / totalFreq)) / (totalFreq - 1) : 0;
+  const double variance = (totalFreq > 1) ? (sum2 - (Math::sqr(sum) / totalFreq)) / (totalFreq - 1) : 0;
   const double sigma = std::sqrt(variance);
   const double mean2 = mean * mean;
   double       skewness;

--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianCostFunction.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianCostFunction.cxx
@@ -50,7 +50,7 @@ CumulativeGaussianCostFunction::CalculateFitError(MeasureType * setTestArray)
   double fitError = 0.0;
   for (int i = 0; i < static_cast<int>(numberOfElements); ++i)
   {
-    fitError += std::pow((setTestArray->get(i) - m_OriginalDataArray.get(i)), 2);
+    fitError += Math::sqr(setTestArray->get(i) - m_OriginalDataArray.get(i));
   }
   return (std::sqrt((1 / numberOfElements) * fitError));
 }

--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
@@ -57,7 +57,7 @@ CumulativeGaussianOptimizer::ExtendGaussian(MeasureType * originalArray,
 
   for (int i = 0; i < static_cast<int>(extendedArray->GetNumberOfElements()); ++i)
   {
-    extendedArray->put(i, amplitude * std::exp(-(std::pow((i - mean), 2) / (2 * std::pow(sd, 2)))));
+    extendedArray->put(i, amplitude * std::exp(-(Math::sqr(i - mean) / (2 * Math::sqr(sd)))));
   }
   // Then insert the originalArray over the middle section of extendedArray.
   for (int i = 0; i < static_cast<int>(originalArray->GetNumberOfElements()); ++i)
@@ -185,7 +185,7 @@ CumulativeGaussianOptimizer::MeasureGaussianParameters(MeasureType * array)
   // Calculate the standard deviation
   for (int i = 0; i < static_cast<int>(array->GetNumberOfElements()); ++i)
   {
-    m_ComputedStandardDeviation += array->get(i) * std::pow((i - m_ComputedMean), 2);
+    m_ComputedStandardDeviation += array->get(i) * Math::sqr(i - m_ComputedMean);
   }
   m_ComputedStandardDeviation = std::sqrt(m_ComputedStandardDeviation / sum);
 
@@ -232,7 +232,7 @@ CumulativeGaussianOptimizer::RecalculateExtendedArrayFromGaussianParameters(Meas
     if (i < startingPointForInsertion ||
         i >= startingPointForInsertion + static_cast<int>(originalArray->GetNumberOfElements()))
     {
-      extendedArray->put(i, amplitude * std::exp(-(std::pow((i - mean), 2) / (2 * std::pow(sd, 2)))));
+      extendedArray->put(i, amplitude * std::exp(-(Math::sqr(i - mean) / (2 * Math::sqr(sd)))));
     }
   }
   return extendedArray;
@@ -283,9 +283,9 @@ CumulativeGaussianOptimizer::StartOptimization()
   // Generate new Gaussian array with final parameters.
   for (int i = 0; i < sampledGaussianArraySize; ++i)
   {
-    sampledGaussianArray->put(i,
-                              m_ComputedAmplitude * std::exp(-(std::pow((i - m_ComputedMean), 2) /
-                                                               (2 * std::pow(m_ComputedStandardDeviation, 2)))));
+    sampledGaussianArray->put(
+      i,
+      m_ComputedAmplitude * std::exp(-(Math::sqr(i - m_ComputedMean) / (2 * Math::sqr(m_ComputedStandardDeviation)))));
   }
   // Add 0.5 to the mean of the sampled Gaussian curve to make up for the 0.5
   // shift during derivation, then take the integral of the Gaussian sample

--- a/Modules/Registration/Common/include/itkCorrelationCoefficientHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkCorrelationCoefficientHistogramImageToImageMetric.hxx
@@ -18,6 +18,7 @@
 #ifndef itkCorrelationCoefficientHistogramImageToImageMetric_hxx
 #define itkCorrelationCoefficientHistogramImageToImageMetric_hxx
 
+#include "itkMath.h"
 
 namespace itk
 {
@@ -81,10 +82,10 @@ CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::Va
   for (unsigned int i = 0; i < this->m_HistogramSize[0]; ++i)
   {
     varX += static_cast<double>(histogram.GetFrequency(i, 0)) / histogram.GetTotalFrequency() *
-            std::pow(histogram.GetMeasurement(i, 0), 2);
+            Math::sqr(histogram.GetMeasurement(i, 0));
   }
 
-  return varX - std::pow(MeanX(histogram), 2);
+  return varX - Math::sqr(MeanX(histogram));
 }
 
 template <typename TFixedImage, typename TMovingImage>
@@ -97,10 +98,10 @@ CorrelationCoefficientHistogramImageToImageMetric<TFixedImage, TMovingImage>::Va
   for (unsigned int i = 0; i < this->m_HistogramSize[1]; ++i)
   {
     varY += static_cast<double>(histogram.GetFrequency(i, 1)) / histogram.GetTotalFrequency() *
-            std::pow(histogram.GetMeasurement(i, 1), 2);
+            Math::sqr(histogram.GetMeasurement(i, 1));
   }
 
-  return varY - std::pow(MeanY(histogram), 2);
+  return varY - Math::sqr(MeanY(histogram));
 }
 
 template <typename TFixedImage, typename TMovingImage>

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
@@ -19,6 +19,7 @@
 #define itkMeanReciprocalSquareDifferencePointSetToImageMetric_hxx
 
 #include "itkImageRegionConstIteratorWithIndex.h"
+#include "itkMath.h"
 
 namespace itk
 {
@@ -51,7 +52,7 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
   MeasureType measure{};
 
   this->m_NumberOfPixelsCounted = 0;
-  const double lambdaSquared = std::pow(this->m_Lambda, 2);
+  const double lambdaSquared = Math::sqr(this->m_Lambda);
 
   this->SetTransformParameters(parameters);
 
@@ -107,7 +108,7 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
 
   this->m_NumberOfPixelsCounted = 0;
 
-  const double lambdaSquared = std::pow(this->m_Lambda, 2);
+  const double lambdaSquared = Math::sqr(this->m_Lambda);
 
   this->SetTransformParameters(parameters);
 
@@ -161,7 +162,7 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
         {
           // Will it be computationally more efficient to instead calculate the
           // derivative using finite differences ?
-          sum -= jacobian(dim, par) * gradient[dim] / (std::pow(lambdaSquared + diffSquared, 2));
+          sum -= jacobian(dim, par) * gradient[dim] / Math::sqr(lambdaSquared + diffSquared);
         }
         derivative[par] += diff * sum;
       }
@@ -207,7 +208,7 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
   MeasureType measure{};
 
   this->SetTransformParameters(parameters);
-  const double lambdaSquared = std::pow(this->m_Lambda, 2);
+  const double lambdaSquared = Math::sqr(this->m_Lambda);
 
   const unsigned int ParametersDimension = this->GetNumberOfParameters();
   derivative = DerivativeType(ParametersDimension);
@@ -258,7 +259,7 @@ MeanReciprocalSquareDifferencePointSetToImageMetric<TFixedPointSet, TMovingImage
         RealType sum{};
         for (unsigned int dim = 0; dim < Self::FixedPointSetDimension; ++dim)
         {
-          sum -= jacobian(dim, par) * gradient[dim] * std::pow(lambdaSquared + diffSquared, 2);
+          sum -= jacobian(dim, par) * gradient[dim] * Math::sqr(lambdaSquared + diffSquared);
         }
         derivative[par] += diff * sum;
       }


### PR DESCRIPTION
`Math::sqr(x)` appears slightly more readable than `std::pow(x, 2)`.