### PR TITLE
STYLE: Replace `std::pow(2, dim)` calls with `1 << dim`

### DIFF
--- a/Modules/Core/Common/include/itkFloodFilledSpatialFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkFloodFilledSpatialFunctionConditionalConstIterator.hxx
@@ -111,7 +111,7 @@ FloodFilledSpatialFunctionConditionalConstIterator<TImage, TFunction>::IsPixelIn
       // To reiterate... DO NOT use this on images higher than 16D
 
       constexpr unsigned int dim = TImage::ImageDimension;
-      auto                   numReps = static_cast<unsigned int>(std::pow(2.0, static_cast<double>(dim)));
+      constexpr unsigned int numReps{ 1ULL << dim };
 
 
       // First we loop over the binary counter
@@ -154,8 +154,9 @@ FloodFilledSpatialFunctionConditionalConstIterator<TImage, TFunction>::IsPixelIn
 
       // To reiterate... DO NOT use this on images higher than 16D
 
-      const unsigned int dim = TImage::ImageDimension;
-      auto               numReps = static_cast<unsigned int>(std::pow(2.0, static_cast<double>(dim)));
+      constexpr unsigned int dim = TImage::ImageDimension;
+      constexpr unsigned int numReps{ 1ULL << dim };
+
       // First we loop over the binary counter
       for (unsigned int counter = 0; counter < numReps; ++counter)
       {

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionImageFilter.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionImageFilter.hxx
@@ -29,7 +29,7 @@ AnisotropicDiffusionImageFilter<TInputImage, TOutputImage>::AnisotropicDiffusion
   m_ConductanceParameter = 1.0;
   m_ConductanceScalingParameter = 1.0;
   m_ConductanceScalingUpdateInterval = 1;
-  m_TimeStep = 0.5 / std::pow(2.0, static_cast<double>(ImageDimension));
+  m_TimeStep = 0.5 / double{ 1ULL << ImageDimension };
   m_FixedAverageGradientMagnitude = 1.0;
   m_GradientMagnitudeIsFixed = false;
 }
@@ -66,14 +66,14 @@ AnisotropicDiffusionImageFilter<TInputImage, TOutputImage>::InitializeIteration(
   {
     minSpacing = 1.0;
   }
-  if (m_TimeStep > (minSpacing / std::pow(2.0, static_cast<double>(ImageDimension) + 1)))
+  if (m_TimeStep > (minSpacing / double{ 1ULL << (ImageDimension + 1) }))
   {
     //    f->SetTimeStep(1.0 / std::pow(2.0,
     // static_cast<double>(ImageDimension)));
     itkWarningMacro("Anisotropic diffusion unstable time step: "
                     << m_TimeStep << std::endl
                     << "Stable time step for this image must be smaller than "
-                    << minSpacing / std::pow(2.0, static_cast<double>(ImageDimension + 1)));
+                    << minSpacing / double{ 1ULL << (ImageDimension + 1) });
   }
 
   if (m_GradientMagnitudeIsFixed == false)

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionImageFilter.hxx
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionImageFilter.hxx
@@ -56,14 +56,14 @@ GPUAnisotropicDiffusionImageFilter<TInputImage, TOutputImage, TParentImageFilter
   {
     minSpacing = 1.0;
   }
-  if (this->GetTimeStep() > (minSpacing / std::pow(2.0, static_cast<double>(ImageDimension) + 1)))
+  if (this->GetTimeStep() > (minSpacing / double{ 1ULL << (ImageDimension + 1) }))
   {
     //    f->SetTimeStep(1.0 / std::pow(2.0,
     // static_cast<double>(ImageDimension)));
     itkWarningMacro("Anisotropic diffusion unstable time step: "
                     << this->GetTimeStep() << std::endl
                     << "Stable time step for this image must be smaller than "
-                    << minSpacing / std::pow(2.0, static_cast<double>(ImageDimension + 1)));
+                    << minSpacing / double{ 1ULL << (ImageDimension + 1) }));
   }
 
   if (this->m_GradientMagnitudeIsFixed == false)


### PR DESCRIPTION
Replaced `std::pow(2.0, x)` with `1ULL << x` where `x` is either `ImageDimension` or `ImageDimension + 1`. Declared a few more variables `constexpr`.

In general, a left-shift may be faster than an `std::pow` call.