### PR TITLE
DOC: Empty `\cite` label

### DIFF
--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
@@ -385,8 +385,8 @@ private:
    *  Function adapted from netlib/tred1.c.
    *  [Changed: remove static vars, enforce const correctness.
    *            Use vnl routines as necessary].
-   *  For algorithmic descriptions see \cite martin1968 and  \cite
-   *  martin1971. */
+   *  For algorithmic descriptions see \cite martin1968 and
+   *  \cite martin1971. */
   void
   ReduceToTridiagonalMatrix(double * a, double * d, double * e, double * e2) const;
 
@@ -408,8 +408,8 @@ private:
    *  Function adapted from netlib/tred2.c.
    *  [Changed: remove static vars, enforce const correctness.
    *            Use vnl routines as necessary].
-   *  For algorithmic descriptions see \cite martin1968 and \cite
-   *  martin1971. */
+   *  For algorithmic descriptions see \cite martin1968 and
+   *  \cite martin1971. */
   void
   ReduceToTridiagonalMatrixAndGetTransformation(const double * a, double * d, double * e, double * z) const;
 

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.h
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.h
@@ -51,8 +51,7 @@ namespace itk
  * parameter (namely, sigma) using leave-one-out cross validation. It implements schemes for random
  * sampling of patches non-locally (from the entire image) as well as semi-locally (from the spatial
  * proximity of the pixel being denoised at the specific point in time). It implements a specific
- * scheme for defining patch weights (mask) as described in \cite
- * awate2005 and \cite awate2006.
+ * scheme for defining patch weights (mask) as described in \cite awate2005 and \cite awate2006.
  *
  * \ingroup Filtering
  * \ingroup ITKDenoising

--- a/Modules/Filtering/ImageGrid/include/itkBSplineL2ResampleImageFilterBase.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineL2ResampleImageFilterBase.h
@@ -39,8 +39,8 @@ namespace itk
  *        to up/down sample an image by a factor of 2.
  *
  * This class defines N-Dimension B-Spline transformation.
- * It is based on \cite unser1999, \cite unser1993, \cite
- * unser1993a, and \cite brigger1999.
+ * It is based on \cite unser1999, \cite unser1993,
+ * \cite unser1993a, and \cite brigger1999.
  * Code obtained from bigwww.epfl.ch by Philippe Thevenaz
  *
  * Limitations:  Spline order for the centered l2 pyramid must be 0,1,3, or 5.

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
@@ -60,8 +60,8 @@ namespace itk
  * both the mutual information and its derivatives with respect to the
  * transform parameters.
  *
- * The calculations are based on the method of Mattes et al \cite
- * mattes2001, \cite mattes2003 where the probability density distribution are estimated using
+ * The calculations are based on the method of Mattes et al
+ * \cite mattes2001, \cite mattes2003 where the probability density distribution are estimated using
  * Parzen histograms. Since the fixed image PDF does not contribute
  * to the derivatives, it does not need to be smooth. Hence,
  * a zero order (box car) BSpline kernel is used

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.h
@@ -41,8 +41,8 @@ namespace itk
  * This class is templated over the FixedImage type and the MovingImage
  * type.
  *
- * The calculations are based on the method of Mattes et al \cite
- * mattes2001, \cite mattes2003,
+ * The calculations are based on the method of Mattes et al
+ * \cite mattes2001, \cite mattes2003,
  * where the probability density distribution are estimated using
  * Parzen histograms. Since the fixed image PDF does not contribute
  * to the derivatives, it does not need to be smooth. Hence,

--- a/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.h
@@ -30,8 +30,8 @@ namespace itk
  * \brief Deformably register two images using a diffeomorphic demons algorithm.
  *
  * This class was contributed by Tom Vercauteren, INRIA & Mauna Kea Technologies,
- * based on a variation of the DemonsRegistrationFilter \cite
- * vercauteren2007. The basic modification is to use diffeomorphism exponentials.
+ * based on a variation of the DemonsRegistrationFilter
+ * \cite vercauteren2007. The basic modification is to use diffeomorphism exponentials.
  *
  * DiffeomorphicDemonsRegistrationFilter implements the demons deformable algorithm that
  * register two images by computing the deformation field which will map a


### PR DESCRIPTION
On a number of lines the `\cite` command and the cite label were on different lines and that is currently not allowed in doxygen.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
