### PR TITLE
STYLE: Remove `std::pow` calls from `BoundingBox::ComputeCorners()`

### DIFF
--- a/Modules/Core/Common/include/itkBoundingBox.hxx
+++ b/Modules/Core/Common/include/itkBoundingBox.hxx
@@ -29,6 +29,7 @@
 #define itkBoundingBox_hxx
 
 #include <algorithm> // For max.
+#include <bitset>
 
 namespace itk
 {
@@ -94,12 +95,11 @@ BoundingBox<TPointIdentifier, VPointDimension, TCoordinate, TPointsContainer>::C
 
   for (SizeValueType j = 0; j < NumberOfCorners; ++j)
   {
-    PointType pnt;
+    const std::bitset<PointDimension> cornerBitset{ j };
+    PointType                         pnt;
     for (unsigned int i = 0; i < PointDimension; ++i)
     {
-      pnt[i] = center[i] +
-               std::pow(-1.0, (static_cast<double>(j / (static_cast<int>(std::pow(2.0, static_cast<double>(i))))))) *
-                 radius[i];
+      pnt[i] = center[i] + (cornerBitset[i] ? -1 : 1) * radius[i];
     }
 
     result[j] = pnt;


### PR DESCRIPTION
~~The use of bit-shift and modulo is a bit more elegant in this case, it may be slightly faster, and it takes away the need to do static_cast's.~~

The use of `std::bitset` is a bit clearer in this case, it may be slightly faster than those `std::pow` calls, and it takes away the need to do static_cast's.
