### PR TITLE
COMP: Remove spare closing bracket

### DIFF
--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionImageFilter.hxx
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionImageFilter.hxx
@@ -63,7 +63,7 @@ GPUAnisotropicDiffusionImageFilter<TInputImage, TOutputImage, TParentImageFilter
     itkWarningMacro("Anisotropic diffusion unstable time step: "
                     << this->GetTimeStep() << std::endl
                     << "Stable time step for this image must be smaller than "
-                    << minSpacing / double{ 1ULL << (ImageDimension + 1) }));
+                    << minSpacing / double{ 1ULL << (ImageDimension + 1) });
   }
 
   if (this->m_GradientMagnitudeIsFixed == false)


### PR DESCRIPTION
Remove spare closing bracket.

Left behind inadvertently in commit 2bd9f0a.

Fixes:
```
T:\Dashboard\ITK\Modules\Filtering\GPUAnisotropicSmoothing\include\itkGPUAnisotropicDiffusionImageFilter.hxx(66,76):
 error C2187: syntax error: ')' was unexpected here
 [T:\Dashboard\ITK-build\Modules\Filtering\GPUAnisotropicSmoothing\ITKGPUAnisotropicSmoothingHeaderTest1.vcxproj]
```

raised for example in:
https://open.cdash.org/viewBuildError.php?buildid=10232159

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)