### PR TITLE
COMP: Remove `{}` default member initializer from `m_ExceptionData`

### DIFF
--- a/Modules/Core/Common/include/itkExceptionObject.h
+++ b/Modules/Core/Common/include/itkExceptionObject.h
@@ -133,7 +133,7 @@ public:
 private:
   class ExceptionData;
 
-  std::shared_ptr<const ExceptionData> m_ExceptionData{};
+  std::shared_ptr<const ExceptionData> m_ExceptionData;
 };
 
 /** Generic inserter operator for ExceptionObject and its subclasses. */


### PR DESCRIPTION
Worked around an LLVM 19.1.7 clang-tidy warning, saying:

    itkExceptionObject.h(136): warning: suspicious exception object created but not thrown; did you mean 'throw shared_ptr'? [bugprone-throw-keyword-missing]
      136 |   std::shared_ptr<const ExceptionData> m_ExceptionData{};
          |                                                       ^

- As reported at issue https://github.com/llvm/llvm-project/issues/129675 '[clang-tidy] bugprone-throw-keyword-missing on default member initializer: "did you mean 'throw shared_ptr'?"'

Note that the `{}` wasn't really necessary here. It was just there for the sake of consistency (as a matter of style).
