### PR TITLE
Remove a few local `stringstream` variables from ResourceProbe and ExceptionObject 

### DIFF
--- a/Modules/Core/Common/include/itkResourceProbe.hxx
+++ b/Modules/Core/Common/include/itkResourceProbe.hxx
@@ -427,8 +427,6 @@ template <typename ValueType, typename MeanType>
 void
 ResourceProbe<ValueType, MeanType>::JSONReport(std::ostream & os)
 {
-  const std::stringstream ss;
-
   ValueType ratioOfMeanToMinimum;
   if (Math::ExactlyEquals(this->GetMinimum(), 0.0))
   {

--- a/Modules/Core/Common/include/itkResourceProbe.hxx
+++ b/Modules/Core/Common/include/itkResourceProbe.hxx
@@ -583,10 +583,9 @@ ResourceProbe<ValueType, MeanType>::PrintJSONSystemInformation(std::ostream & os
   PrintJSONvar(os, "Bitness", (systeminfo.Is64Bits() ? "64 bit" : "32 bit"), 6, false);
   os << "    },\n";
 
-  std::ostringstream itkVersionStringStream;
-  itkVersionStringStream << ITK_VERSION_STRING << '.' << ITK_VERSION_PATCH;
+  const std::string itkVersionString = ITK_VERSION_STRING "." + std::to_string(ITK_VERSION_PATCH);
 
-  PrintJSONvar(os, "ITKVersion", itkVersionStringStream.str(), 4, false);
+  PrintJSONvar(os, "ITKVersion", itkVersionString, 4, false);
   os << "  }";
 }
 

--- a/Modules/Core/Common/src/itkExceptionObject.cxx
+++ b/Modules/Core/Common/src/itkExceptionObject.cxx
@@ -41,11 +41,8 @@ public:
     , m_File(std::move(file))
     , m_Line(line)
   {
-    std::ostringstream loc;
-
-    loc << ':' << m_Line << ":\n";
     m_What = m_File;
-    m_What += loc.str();
+    m_What += ':' + std::to_string(m_Line) + ":\n";
     m_What += m_Description;
   }
 


### PR DESCRIPTION
Three small style improvements.