### PR TITLE
ENH: Add location (function) to text returned by ExceptionObject::what()

### DIFF
--- a/Modules/Core/Common/src/itkExceptionObject.cxx
+++ b/Modules/Core/Common/src/itkExceptionObject.cxx
@@ -42,7 +42,12 @@ public:
     , m_Line(line)
   {
     m_What = m_File;
-    m_What += ':' + std::to_string(m_Line) + ":\n";
+    m_What += ':' + std::to_string(m_Line) + ':';
+    if (!m_Location.empty())
+    {
+      m_What += " in '" + m_Location + "':";
+    }
+    m_What += '\n';
     m_What += m_Description;
   }
 

--- a/Modules/Core/Common/test/itkExceptionObjectGTest.cxx
+++ b/Modules/Core/Common/test/itkExceptionObjectGTest.cxx
@@ -84,18 +84,48 @@ TEST(ExceptionObject, TestDescriptionFromSpecializedExceptionMacro)
 
 
 // Tests that `ExceptionObject::what()` returns the expected concatenation of
-// file name, line number, and description.
+// file name, line number, location and description.
 TEST(ExceptionObject, TestWhat)
 {
-  const itk::ExceptionObject exceptionObject(__FILE__, __LINE__, "test description");
+  {
+    // Test with empty location.
+    const itk::ExceptionObject exceptionObject(__FILE__, __LINE__, "test description", "");
 
-  const char * const what = exceptionObject.what();
-  const char * const file = exceptionObject.GetFile();
-  const char * const description = exceptionObject.GetDescription();
+    const char * const what = exceptionObject.what();
+    const char * const file = exceptionObject.GetFile();
+    const char * const description = exceptionObject.GetDescription();
 
-  ASSERT_NE(what, nullptr);
-  ASSERT_NE(file, nullptr);
-  ASSERT_NE(description, nullptr);
+    ASSERT_NE(what, nullptr);
+    ASSERT_NE(file, nullptr);
+    ASSERT_NE(description, nullptr);
 
-  EXPECT_EQ(what, file + (":" + std::to_string(exceptionObject.GetLine()) + ":\n") + description);
+    EXPECT_EQ(what, file + (":" + std::to_string(exceptionObject.GetLine()) + ":\n") + description);
+  }
+  {
+    // Test with location = ITK_LOCATION (as used by ITK's exception macro's).
+    const itk::ExceptionObject exceptionObject(__FILE__, __LINE__, "test description", ITK_LOCATION);
+
+    const char * const what = exceptionObject.what();
+    const char * const file = exceptionObject.GetFile();
+    const char * const description = exceptionObject.GetDescription();
+    const char * const location = exceptionObject.GetLocation();
+
+    ASSERT_NE(what, nullptr);
+    ASSERT_NE(file, nullptr);
+    ASSERT_NE(description, nullptr);
+    ASSERT_NE(location, nullptr);
+
+
+    EXPECT_EQ(what,
+              file + (":" + std::to_string(exceptionObject.GetLine()) + ": in '" + location + "':\n") + description);
+
+    try
+    {
+      itkGenericExceptionMacro("Oops, something went exceptionally wrong!");
+    }
+    catch (const std::exception & exception)
+    {
+      std::cout << exception.what() << '\n';
+    }
+  }
 }


### PR DESCRIPTION
- Triggered by encouraging feedback from Hans (@hjmjohnson) and Dženan (@dzenanz) at https://github.com/InsightSoftwareConsortium/ITK/pull/5265#discussion_r1983786150

---

With this pull request, a call like `itkGenericExceptionMacro("Oops, something horribly wrong!")` will create a "what text" like the following:

```
D:\MyProject\MySource.cxx:42: in 'void MyObject::DoMyThing(int)':
ITK ERROR: Oops, something horribly wrong!

```
So it adds something like ` in 'void MyObject::DoMyThing(int)':` to the first line.
