### PR TITLE
STYLE: Clean-up experimental code `ExceptionObject.TestWhat` unit test

### DIFF
--- a/Modules/Core/Common/test/itkExceptionObjectGTest.cxx
+++ b/Modules/Core/Common/test/itkExceptionObjectGTest.cxx
@@ -118,14 +118,5 @@ TEST(ExceptionObject, TestWhat)
 
     EXPECT_EQ(what,
               file + (":" + std::to_string(exceptionObject.GetLine()) + ": in '" + location + "':\n") + description);
-
-    try
-    {
-      itkGenericExceptionMacro("Oops, something went exceptionally wrong!");
-    }
-    catch (const std::exception & exception)
-    {
-      std::cout << exception.what() << '\n';
-    }
   }
 }


### PR DESCRIPTION
The try-catch wasn't meant to be part of the unit test!
