### PR TITLE
STYLE: Replace "Unknown" default for exception location with `{}`

### DIFF
--- a/Modules/Core/Common/include/itkExceptionObject.h
+++ b/Modules/Core/Common/include/itkExceptionObject.h
@@ -59,7 +59,7 @@ public:
   explicit ExceptionObject(std::string  file,
                            unsigned int lineNumber = 0,
                            std::string  desc = "None",
-                           std::string  loc = "Unknown");
+                           std::string  loc = {});
 
   /** Copy-constructor. */
   ExceptionObject(const ExceptionObject &) noexcept = default;

--- a/Modules/IO/ImageBase/include/itkImageFileReaderException.h
+++ b/Modules/IO/ImageBase/include/itkImageFileReaderException.h
@@ -40,7 +40,7 @@ public:
   ImageFileReaderException(std::string  file,
                            unsigned int line,
                            std::string  message = "Error in IO",
-                           std::string  loc = "Unknown")
+                           std::string  loc = {})
     : ExceptionObject(std::move(file), line, std::move(message), std::move(loc))
   {}
 

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.h
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.h
@@ -43,7 +43,7 @@ public:
   ImageFileWriterException(std::string  file,
                            unsigned int line,
                            std::string  message = "Error in IO",
-                           std::string  loc = "Unknown")
+                           std::string  loc = {})
     : ExceptionObject(std::move(file), line, std::move(message), std::move(loc))
   {}
 

--- a/Modules/IO/MeshBase/include/itkMeshFileReaderException.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileReaderException.h
@@ -44,7 +44,7 @@ public:
   MeshFileReaderException(std::string  file,
                           unsigned int line,
                           std::string  message = "Error in IO",
-                          std::string  loc = "Unknown");
+                          std::string  loc = {});
 };
 } // end namespace itk
 

--- a/Modules/IO/MeshBase/include/itkMeshFileWriterException.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriterException.h
@@ -44,7 +44,7 @@ public:
   MeshFileWriterException(std::string  file,
                           unsigned int line,
                           std::string  message = "Error in IO",
-                          std::string  loc = "Unknown");
+                          std::string  loc = {});
 };
 } // end namespace itk
 

--- a/Modules/Numerics/FEM/include/itkFEMException.h
+++ b/Modules/Numerics/FEM/include/itkFEMException.h
@@ -49,7 +49,7 @@ public:
    * you should use __FILE__ and __LINE__ macros to specify file name
    * and line number.
    */
-  FEMException(std::string file, unsigned int lineNumber, std::string location = "Unknown");
+  FEMException(std::string file, unsigned int lineNumber, std::string location = {});
 
   /** Virtual destructor needed for subclasses. Has to have empty throw(). */
   ~FEMException() noexcept override;


### PR DESCRIPTION
It is preferable not duplicate a literal string so many times (following [the DRY principle](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)). Moreover, it appears sufficient to use an empty string value (`{}`), to indicate that the location of an exception is unspecified.

Note that an unspecified location may be "unknown", but instead, it may also be "irrelevant", or "hidden". So it may depend on the application.

- Triggered by a discussion with Bradley (@blowekamp) at https://github.com/InsightSoftwareConsortium/ITK/pull/5266#discussion_r1985469317