### PR TITLE
STYLE: Remove Exception constructor overloads for `char *` arguments

### DIFF
--- a/Modules/Core/Common/include/itkDataObject.h
+++ b/Modules/Core/Common/include/itkDataObject.h
@@ -59,10 +59,7 @@ public:
   ~DataObjectError() noexcept override = default;
 
   /** Constructor. Needed to ensure the exception object can be copied. */
-  DataObjectError(const char * file, unsigned int lineNumber);
-
-  /** Constructor. Needed to ensure the exception object can be copied. */
-  DataObjectError(const std::string & file, unsigned int lineNumber);
+  DataObjectError(std::string file, unsigned int lineNumber);
 
   /** Copy constructor. Needed to ensure the exception object can be copied. */
   DataObjectError(const DataObjectError & orig) noexcept;
@@ -117,10 +114,7 @@ public:
   ~InvalidRequestedRegionError() noexcept override = default;
 
   /** Constructor. Needed to ensure the exception object can be copied. */
-  InvalidRequestedRegionError(const char * file, unsigned int lineNumber);
-
-  /** Constructor. Needed to ensure the exception object can be copied. */
-  InvalidRequestedRegionError(const std::string & file, unsigned int lineNumber);
+  InvalidRequestedRegionError(std::string file, unsigned int lineNumber);
 
   /** Copy constructor.  Needed to ensure the exception object can be copied. */
   InvalidRequestedRegionError(const InvalidRequestedRegionError & orig) noexcept;

--- a/Modules/Core/Common/include/itkExceptionObject.h
+++ b/Modules/Core/Common/include/itkExceptionObject.h
@@ -56,10 +56,6 @@ public:
   /** Explicitly-defaulted default-constructor. Creates an empty exception object. */
   ExceptionObject() noexcept = default;
 
-  explicit ExceptionObject(const char * file,
-                           unsigned int lineNumber = 0,
-                           const char * desc = "None",
-                           const char * loc = "Unknown");
   explicit ExceptionObject(std::string  file,
                            unsigned int lineNumber = 0,
                            std::string  desc = "None",
@@ -226,18 +222,9 @@ public:
   }
 
   /** Constructor. Needed to ensure the exception object can be copied. */
-  ProcessAborted(const char * file, unsigned int lineNumber)
-    : ExceptionObject(file, lineNumber)
-  {
-    this->SetDescription("Filter execution was aborted by an external request");
-  }
-
-  /** Constructor. Needed to ensure the exception object can be copied. */
-  ProcessAborted(const std::string & file, unsigned int lineNumber)
-    : ExceptionObject(file, lineNumber)
-  {
-    this->SetDescription("Filter execution was aborted by an external request");
-  }
+  ProcessAborted(std::string file, unsigned int lineNumber)
+    : ExceptionObject(std::move(file), lineNumber, "Filter execution was aborted by an external request")
+  {}
 
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ProcessAborted);

--- a/Modules/Core/Common/src/itkDataObject.cxx
+++ b/Modules/Core/Common/src/itkDataObject.cxx
@@ -39,12 +39,8 @@ DataObjectError::DataObjectError() noexcept
   : ExceptionObject()
 {}
 
-DataObjectError::DataObjectError(const char * file, unsigned int lineNumber)
-  : ExceptionObject(file, lineNumber)
-{}
-
-DataObjectError::DataObjectError(const std::string & file, unsigned int lineNumber)
-  : ExceptionObject(file, lineNumber)
+DataObjectError::DataObjectError(std::string file, unsigned int lineNumber)
+  : ExceptionObject(std::move(file), lineNumber)
 {}
 
 DataObjectError::DataObjectError(const DataObjectError & orig) noexcept
@@ -98,12 +94,8 @@ InvalidRequestedRegionError::InvalidRequestedRegionError() noexcept
   : DataObjectError()
 {}
 
-InvalidRequestedRegionError::InvalidRequestedRegionError(const char * file, unsigned int lineNumber)
-  : DataObjectError(file, lineNumber)
-{}
-
-InvalidRequestedRegionError::InvalidRequestedRegionError(const std::string & file, unsigned int lineNumber)
-  : DataObjectError(file, lineNumber)
+InvalidRequestedRegionError::InvalidRequestedRegionError(std::string file, unsigned int lineNumber)
+  : DataObjectError(std::move(file), lineNumber)
 {}
 
 InvalidRequestedRegionError::InvalidRequestedRegionError(const InvalidRequestedRegionError &) noexcept = default;

--- a/Modules/Core/Common/src/itkExceptionObject.cxx
+++ b/Modules/Core/Common/src/itkExceptionObject.cxx
@@ -65,13 +65,6 @@ private:
 };
 
 
-ExceptionObject::ExceptionObject(const char * file, unsigned int lineNumber, const char * desc, const char * loc)
-  : m_ExceptionData(std::make_shared<const ExceptionData>(file == nullptr ? "" : file,
-                                                          lineNumber,
-                                                          desc == nullptr ? "" : desc,
-                                                          loc == nullptr ? "" : loc))
-{}
-
 ExceptionObject::ExceptionObject(std::string file, unsigned int lineNumber, std::string desc, std::string loc)
   : m_ExceptionData(std::make_shared<const ExceptionData>(std::move(file), lineNumber, std::move(desc), std::move(loc)))
 {}

--- a/Modules/IO/ImageBase/include/itkImageFileReaderException.h
+++ b/Modules/IO/ImageBase/include/itkImageFileReaderException.h
@@ -37,19 +37,11 @@ public:
   itkOverrideGetNameOfClassMacro(ImageFileReaderException);
 
   /** Constructor. */
-  ImageFileReaderException(const char * file,
+  ImageFileReaderException(std::string  file,
                            unsigned int line,
-                           const char * message = "Error in IO",
-                           const char * loc = "Unknown")
-    : ExceptionObject(file, line, message, loc)
-  {}
-
-  /** Constructor. */
-  ImageFileReaderException(const std::string & file,
-                           unsigned int        line,
-                           const char *        message = "Error in IO",
-                           const char *        loc = "Unknown")
-    : ExceptionObject(file, line, message, loc)
+                           std::string  message = "Error in IO",
+                           std::string  loc = "Unknown")
+    : ExceptionObject(std::move(file), line, std::move(message), std::move(loc))
   {}
 
   /** Has to have empty throw(). */

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.h
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.h
@@ -40,19 +40,11 @@ public:
   itkOverrideGetNameOfClassMacro(ImageFileWriterException);
 
   /** Constructor. */
-  ImageFileWriterException(const char * file,
+  ImageFileWriterException(std::string  file,
                            unsigned int line,
-                           const char * message = "Error in IO",
-                           const char * loc = "Unknown")
-    : ExceptionObject(file, line, message, loc)
-  {}
-
-  /** Constructor. */
-  ImageFileWriterException(const std::string & file,
-                           unsigned int        line,
-                           const char *        message = "Error in IO",
-                           const char *        loc = "Unknown")
-    : ExceptionObject(file, line, message, loc)
+                           std::string  message = "Error in IO",
+                           std::string  loc = "Unknown")
+    : ExceptionObject(std::move(file), line, std::move(message), std::move(loc))
   {}
 
   /** Has to have empty throw(). */

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.h
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.h
@@ -40,18 +40,9 @@ public:
   itkOverrideGetNameOfClassMacro(ImageSeriesWriterException);
 
   /** Constructor. */
-  ImageSeriesWriterException(char * file, unsigned int line, const char * message = "Error in IO")
-    : ExceptionObject(file, line)
-  {
-    SetDescription(message);
-  }
-
-  /** Constructor. */
-  ImageSeriesWriterException(const std::string & file, unsigned int line, const char * message = "Error in IO")
-    : ExceptionObject(file, line)
-  {
-    SetDescription(message);
-  }
+  ImageSeriesWriterException(std::string file, unsigned int line, std::string message = "Error in IO")
+    : ExceptionObject(std::move(file), line, std::move(message))
+  {}
 };
 
 /** \class ImageSeriesWriter

--- a/Modules/IO/MeshBase/include/itkMeshFileReaderException.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileReaderException.h
@@ -41,16 +41,10 @@ public:
   itkOverrideGetNameOfClassMacro(MeshFileReaderException);
 
   /** Constructor. */
-  MeshFileReaderException(const char * file,
+  MeshFileReaderException(std::string  file,
                           unsigned int line,
-                          const char * message = "Error in IO",
-                          const char * loc = "Unknown");
-
-  /** Constructor. */
-  MeshFileReaderException(const std::string & file,
-                          unsigned int        line,
-                          const char *        message = "Error in IO",
-                          const char *        loc = "Unknown");
+                          std::string  message = "Error in IO",
+                          std::string  loc = "Unknown");
 };
 } // end namespace itk
 

--- a/Modules/IO/MeshBase/include/itkMeshFileWriterException.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriterException.h
@@ -41,16 +41,10 @@ public:
   itkOverrideGetNameOfClassMacro(MeshFileWriterException);
 
   /** Constructor. */
-  MeshFileWriterException(const char * file,
+  MeshFileWriterException(std::string  file,
                           unsigned int line,
-                          const char * message = "Error in IO",
-                          const char * loc = "Unknown");
-
-  /** Constructor. */
-  MeshFileWriterException(const std::string & file,
-                          unsigned int        line,
-                          const char *        message = "Error in IO",
-                          const char *        loc = "Unknown");
+                          std::string  message = "Error in IO",
+                          std::string  loc = "Unknown");
 };
 } // end namespace itk
 

--- a/Modules/IO/MeshBase/src/itkMeshFileReaderException.cxx
+++ b/Modules/IO/MeshBase/src/itkMeshFileReaderException.cxx
@@ -21,17 +21,10 @@ namespace itk
 {
 MeshFileReaderException::~MeshFileReaderException() noexcept = default;
 
-MeshFileReaderException::MeshFileReaderException(const char * file,
+MeshFileReaderException::MeshFileReaderException(std::string  file,
                                                  unsigned int line,
-                                                 const char * message,
-                                                 const char * loc)
-  : ExceptionObject(file, line, message, loc)
-{}
-
-MeshFileReaderException::MeshFileReaderException(const std::string & file,
-                                                 unsigned int        line,
-                                                 const char *        message,
-                                                 const char *        loc)
-  : ExceptionObject(file, line, message, loc)
+                                                 std::string  message,
+                                                 std::string  loc)
+  : ExceptionObject(std::move(file), line, std::move(message), std::move(loc))
 {}
 } // namespace itk

--- a/Modules/IO/MeshBase/src/itkMeshFileWriterException.cxx
+++ b/Modules/IO/MeshBase/src/itkMeshFileWriterException.cxx
@@ -21,17 +21,10 @@ namespace itk
 {
 MeshFileWriterException::~MeshFileWriterException() noexcept = default;
 
-MeshFileWriterException::MeshFileWriterException(const char * file,
+MeshFileWriterException::MeshFileWriterException(std::string  file,
                                                  unsigned int line,
-                                                 const char * message,
-                                                 const char * loc)
-  : ExceptionObject(file, line, message, loc)
-{}
-
-MeshFileWriterException::MeshFileWriterException(const std::string & file,
-                                                 unsigned int        line,
-                                                 const char *        message,
-                                                 const char *        loc)
-  : ExceptionObject(file, line, message, loc)
+                                                 std::string  message,
+                                                 std::string  loc)
+  : ExceptionObject(std::move(file), line, std::move(message), std::move(loc))
 {}
 } // namespace itk

--- a/Modules/Numerics/FEM/include/itkFEMException.h
+++ b/Modules/Numerics/FEM/include/itkFEMException.h
@@ -49,7 +49,7 @@ public:
    * you should use __FILE__ and __LINE__ macros to specify file name
    * and line number.
    */
-  FEMException(const char * file, unsigned int lineNumber, std::string location = "Unknown");
+  FEMException(std::string file, unsigned int lineNumber, std::string location = "Unknown");
 
   /** Virtual destructor needed for subclasses. Has to have empty throw(). */
   ~FEMException() noexcept override;
@@ -73,7 +73,7 @@ public:
    * must be provided: file, lineNumber, location and a detailed description
    * of the exception.
    */
-  FEMExceptionIO(const char * file, unsigned int lineNumber, std::string location, std::string moreDescription);
+  FEMExceptionIO(std::string file, unsigned int lineNumber, std::string location, std::string moreDescription);
 
   /** Virtual destructor needed for subclasses. Has to have empty throw(). */
   ~FEMExceptionIO() noexcept override;
@@ -103,7 +103,7 @@ public:
 class ITK_ABI_EXPORT FEMExceptionWrongClass : public FEMException
 {
 public:
-  FEMExceptionWrongClass(const char * file, unsigned int lineNumber, std::string location);
+  FEMExceptionWrongClass(std::string file, unsigned int lineNumber, std::string location);
 
   /** Virtual destructor needed for subclasses. Has to have empty throw(). */
   ~FEMExceptionWrongClass() noexcept override;
@@ -123,7 +123,7 @@ public:
 class ITK_ABI_EXPORT FEMExceptionObjectNotFound : public FEMException
 {
 public:
-  FEMExceptionObjectNotFound(const char * file,
+  FEMExceptionObjectNotFound(std::string  file,
                              unsigned int lineNumber,
                              std::string  location,
                              std::string  baseClassName,
@@ -158,7 +158,7 @@ public:
    * must be provided: file, lineNumber, location and a detailed description
    * of the exception.
    */
-  FEMExceptionSolution(const char * file, unsigned int lineNumber, std::string location, std::string moreDescription);
+  FEMExceptionSolution(std::string file, unsigned int lineNumber, std::string location, std::string moreDescription);
 
   /** Virtual destructor needed for subclasses. Has to have empty throw(). */
   ~FEMExceptionSolution() noexcept override;

--- a/Modules/Numerics/FEM/include/itkFEMItpackSparseMatrix.h
+++ b/Modules/Numerics/FEM/include/itkFEMItpackSparseMatrix.h
@@ -305,7 +305,7 @@ public:
    * must be provided: file, lineNumber, location and a detailed description
    * of the exception, and the invalid index
    */
-  FEMExceptionItpackSparseMatrixSbagn(const char * file,
+  FEMExceptionItpackSparseMatrixSbagn(std::string  file,
                                       unsigned int lineNumber,
                                       std::string  location,
                                       integer      errorCode);
@@ -336,7 +336,7 @@ public:
    * must be provided: file, lineNumber, location and a detailed description
    * of the exception, and the invalid index
    */
-  FEMExceptionItpackSparseMatrixSbsij(const char * file,
+  FEMExceptionItpackSparseMatrixSbsij(std::string  file,
                                       unsigned int lineNumber,
                                       std::string  location,
                                       integer      errorCode);

--- a/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapper.h
+++ b/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapper.h
@@ -542,7 +542,7 @@ public:
    * must be provided: file, lineNumber, location and a detailed description
    * of the exception.
    */
-  FEMExceptionLinearSystem(const char * file,
+  FEMExceptionLinearSystem(std::string  file,
                            unsigned int lineNumber,
                            std::string  location,
                            std::string  moreDescription);
@@ -562,7 +562,7 @@ public:
    * must be provided: file, lineNumber, location and a detailed description
    * of the exception, and the invalid index
    */
-  FEMExceptionLinearSystemBounds(const char * file,
+  FEMExceptionLinearSystemBounds(std::string  file,
                                  unsigned int lineNumber,
                                  std::string  location,
                                  std::string  moreDescription,
@@ -572,7 +572,7 @@ public:
    * Constructor. In order to construct this exception object, six parameters
    * must be provided: file, lineNumber, location and a detailed description
    * of the exception, the first index, and the second index   */
-  FEMExceptionLinearSystemBounds(const char * file,
+  FEMExceptionLinearSystemBounds(std::string  file,
                                  unsigned int lineNumber,
                                  std::string  location,
                                  std::string  moreDescription,

--- a/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapperItpack.h
+++ b/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapperItpack.h
@@ -770,7 +770,7 @@ public:
    * must be provided: file, lineNumber, location and a detailed description
    * of the exception.
    */
-  FEMExceptionItpackSolver(const char * file, unsigned int lineNumber, std::string location, integer errorCode);
+  FEMExceptionItpackSolver(std::string file, unsigned int lineNumber, std::string location, integer errorCode);
 
   /** Virtual destructor needed for subclasses. Has to have empty throw(). */
   ~FEMExceptionItpackSolver() noexcept override = default;

--- a/Modules/Numerics/FEM/src/itkFEMException.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMException.cxx
@@ -24,41 +24,37 @@ namespace itk
 {
 namespace fem
 {
-FEMException::FEMException(const char * file, unsigned int lineNumber, std::string location)
-  : ExceptionObject(file, lineNumber)
-{
-  SetDescription("Unhandled exception in FEM class!");
-  SetLocation(location);
-}
+FEMException::FEMException(std::string file, unsigned int lineNumber, std::string location)
+  : ExceptionObject(std::move(file), lineNumber, "Unhandled exception in FEM class!", std::move(location))
+{}
 
 FEMException::~FEMException() noexcept = default;
 
-FEMExceptionIO::FEMExceptionIO(const char * file,
+FEMExceptionIO::FEMExceptionIO(std::string  file,
                                unsigned int lineNumber,
                                std::string  location,
                                std::string  moreDescription)
-  : FEMException(file, lineNumber)
+  : FEMException(std::move(file), lineNumber, std::move(location))
 {
   SetDescription("IO error in FEM class: " + moreDescription);
-  SetLocation(location);
 }
 
 FEMExceptionIO::~FEMExceptionIO() noexcept = default;
 
-FEMExceptionWrongClass::FEMExceptionWrongClass(const char * file, unsigned int lineNumber, std::string location)
-  : FEMException(file, lineNumber, location)
+FEMExceptionWrongClass::FEMExceptionWrongClass(std::string file, unsigned int lineNumber, std::string location)
+  : FEMException(std::move(file), lineNumber, std::move(location))
 {
   SetDescription("Object was of wrong class!");
 }
 
 FEMExceptionWrongClass::~FEMExceptionWrongClass() noexcept = default;
 
-FEMExceptionObjectNotFound::FEMExceptionObjectNotFound(const char * file,
+FEMExceptionObjectNotFound::FEMExceptionObjectNotFound(std::string  file,
                                                        unsigned int lineNumber,
                                                        std::string  location,
                                                        std::string  baseClassName,
                                                        int          GN)
-  : FEMException(file, lineNumber, location)
+  : FEMException(std::move(file), lineNumber, std::move(location))
 {
   m_baseClassName = baseClassName;
   m_GlobalNumber = GN;
@@ -69,14 +65,13 @@ FEMExceptionObjectNotFound::FEMExceptionObjectNotFound(const char * file,
 
 FEMExceptionObjectNotFound::~FEMExceptionObjectNotFound() noexcept = default;
 
-FEMExceptionSolution::FEMExceptionSolution(const char * file,
+FEMExceptionSolution::FEMExceptionSolution(std::string  file,
                                            unsigned int lineNumber,
                                            std::string  location,
                                            std::string  moreDescription)
-  : FEMException(file, lineNumber)
+  : FEMException(std::move(file), lineNumber, std::move(location))
 {
   SetDescription("Error when solving FEM problem: " + moreDescription);
-  SetLocation(location);
 }
 
 FEMExceptionSolution::~FEMExceptionSolution() noexcept = default;

--- a/Modules/Numerics/FEM/src/itkFEMItpackSparseMatrix.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMItpackSparseMatrix.cxx
@@ -429,11 +429,11 @@ ItpackSparseMatrix::~ItpackSparseMatrix()
   delete[] m_IWORK;
 }
 
-FEMExceptionItpackSparseMatrixSbagn::FEMExceptionItpackSparseMatrixSbagn(const char * file,
+FEMExceptionItpackSparseMatrixSbagn::FEMExceptionItpackSparseMatrixSbagn(std::string  file,
                                                                          unsigned int lineNumber,
                                                                          std::string  location,
                                                                          integer      errorCode)
-  : FEMException(file, lineNumber)
+  : FEMException(std::move(file), lineNumber, std::move(location))
 {
   std::string solverError;
 
@@ -450,17 +450,15 @@ FEMExceptionItpackSparseMatrixSbagn::FEMExceptionItpackSparseMatrixSbagn(const c
   buf << "Error: " << solverError;
 
   SetDescription(buf.str().c_str());
-
-  SetLocation(location);
 }
 
 FEMExceptionItpackSparseMatrixSbagn::~FEMExceptionItpackSparseMatrixSbagn() noexcept = default;
 
-FEMExceptionItpackSparseMatrixSbsij::FEMExceptionItpackSparseMatrixSbsij(const char * file,
+FEMExceptionItpackSparseMatrixSbsij::FEMExceptionItpackSparseMatrixSbsij(std::string  file,
                                                                          unsigned int lineNumber,
                                                                          std::string  location,
                                                                          integer      errorCode)
-  : FEMException(file, lineNumber)
+  : FEMException(std::move(file), lineNumber, std::move(location))
 {
   std::string solverError;
 
@@ -480,8 +478,6 @@ FEMExceptionItpackSparseMatrixSbsij::FEMExceptionItpackSparseMatrixSbsij(const c
   buf << "Error: " << solverError;
 
   SetDescription(buf.str().c_str());
-
-  SetLocation(location);
 }
 
 FEMExceptionItpackSparseMatrixSbsij::~FEMExceptionItpackSparseMatrixSbsij() noexcept = default;

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapper.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapper.cxx
@@ -398,22 +398,21 @@ LinearSystemWrapper::FollowConnectionsCuthillMckeeOrdering(unsigned int  rowNumb
 
 FEMExceptionLinearSystem::~FEMExceptionLinearSystem() noexcept = default;
 
-FEMExceptionLinearSystem::FEMExceptionLinearSystem(const char * file,
+FEMExceptionLinearSystem::FEMExceptionLinearSystem(std::string  file,
                                                    unsigned int lineNumber,
                                                    std::string  location,
                                                    std::string  moreDescription)
-  : FEMException(file, lineNumber)
+  : FEMException(std::move(file), lineNumber, std::move(location))
 {
   SetDescription("Error in linear system: " + moreDescription);
-  SetLocation(location);
 }
 
-FEMExceptionLinearSystemBounds::FEMExceptionLinearSystemBounds(const char * file,
+FEMExceptionLinearSystemBounds::FEMExceptionLinearSystemBounds(std::string  file,
                                                                unsigned int lineNumber,
                                                                std::string,
                                                                std::string  moreDescription,
                                                                unsigned int index1)
-  : FEMException(file, lineNumber)
+  : FEMException(std::move(file), lineNumber)
 {
   std::ostringstream buf;
 
@@ -421,13 +420,13 @@ FEMExceptionLinearSystemBounds::FEMExceptionLinearSystemBounds(const char * file
   SetDescription(buf.str().c_str());
 }
 
-FEMExceptionLinearSystemBounds::FEMExceptionLinearSystemBounds(const char * file,
+FEMExceptionLinearSystemBounds::FEMExceptionLinearSystemBounds(std::string  file,
                                                                unsigned int lineNumber,
                                                                std::string,
                                                                std::string,
                                                                unsigned int index1,
                                                                unsigned int index2)
-  : FEMException(file, lineNumber)
+  : FEMException(std::move(file), lineNumber)
 {
   std::ostringstream buf;
 

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperItpack.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperItpack.cxx
@@ -1007,11 +1007,11 @@ LinearSystemWrapperItpack::~LinearSystemWrapperItpack()
   }
 }
 
-FEMExceptionItpackSolver::FEMExceptionItpackSolver(const char * file,
+FEMExceptionItpackSolver::FEMExceptionItpackSolver(std::string  file,
                                                    unsigned int lineNumber,
                                                    std::string  location,
                                                    integer      errorCode)
-  : FEMException(file, lineNumber)
+  : FEMException(std::move(file), lineNumber, std::move(location))
 {
   std::string solverError;
 
@@ -1075,8 +1075,6 @@ FEMExceptionItpackSolver::FEMExceptionItpackSolver(const char * file,
   buf << "Error: " << solverError;
 
   SetDescription(buf.str().c_str());
-
-  SetLocation(location);
 }
 
 } // end namespace fem


### PR DESCRIPTION
Internally, `ExceptionObject` stores its file name, description, and location as `std::string`, so the corresponding constructor parameters might as well just be of type `std::string`.

Whenever such a parameter was originally declared `const std::string &`, this commit has removed the `const` and the `&`, in order to efficiently "move" the parameters from derived exception classes to their base class.

Note that this commit drops the support for null pointers as arguments.
