### PR TITLE
STYLE: Do not abbreviate ExceptionObject parameter names (`desc`, `loc`)

### DIFF
--- a/Modules/Core/Common/include/itkExceptionObject.h
+++ b/Modules/Core/Common/include/itkExceptionObject.h
@@ -58,8 +58,8 @@ public:
 
   explicit ExceptionObject(std::string  file,
                            unsigned int lineNumber = 0,
-                           std::string  desc = "None",
-                           std::string  loc = {});
+                           std::string  description = "None",
+                           std::string  location = {});
 
   /** Copy-constructor. */
   ExceptionObject(const ExceptionObject &) noexcept = default;

--- a/Modules/Core/Common/src/itkExceptionObject.cxx
+++ b/Modules/Core/Common/src/itkExceptionObject.cxx
@@ -65,8 +65,12 @@ private:
 };
 
 
-ExceptionObject::ExceptionObject(std::string file, unsigned int lineNumber, std::string desc, std::string loc)
-  : m_ExceptionData(std::make_shared<const ExceptionData>(std::move(file), lineNumber, std::move(desc), std::move(loc)))
+ExceptionObject::ExceptionObject(std::string  file,
+                                 unsigned int lineNumber,
+                                 std::string  description,
+                                 std::string  location)
+  : m_ExceptionData(
+      std::make_shared<const ExceptionData>(std::move(file), lineNumber, std::move(description), std::move(location)))
 {}
 
 

--- a/Modules/IO/ImageBase/include/itkImageFileReaderException.h
+++ b/Modules/IO/ImageBase/include/itkImageFileReaderException.h
@@ -40,8 +40,8 @@ public:
   ImageFileReaderException(std::string  file,
                            unsigned int line,
                            std::string  message = "Error in IO",
-                           std::string  loc = {})
-    : ExceptionObject(std::move(file), line, std::move(message), std::move(loc))
+                           std::string  location = {})
+    : ExceptionObject(std::move(file), line, std::move(message), std::move(location))
   {}
 
   /** Has to have empty throw(). */

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.h
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.h
@@ -43,8 +43,8 @@ public:
   ImageFileWriterException(std::string  file,
                            unsigned int line,
                            std::string  message = "Error in IO",
-                           std::string  loc = {})
-    : ExceptionObject(std::move(file), line, std::move(message), std::move(loc))
+                           std::string  location = {})
+    : ExceptionObject(std::move(file), line, std::move(message), std::move(location))
   {}
 
   /** Has to have empty throw(). */

--- a/Modules/IO/MeshBase/include/itkMeshFileReaderException.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileReaderException.h
@@ -44,7 +44,7 @@ public:
   MeshFileReaderException(std::string  file,
                           unsigned int line,
                           std::string  message = "Error in IO",
-                          std::string  loc = {});
+                          std::string  location = {});
 };
 } // end namespace itk
 

--- a/Modules/IO/MeshBase/include/itkMeshFileWriterException.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriterException.h
@@ -44,7 +44,7 @@ public:
   MeshFileWriterException(std::string  file,
                           unsigned int line,
                           std::string  message = "Error in IO",
-                          std::string  loc = {});
+                          std::string  location = {});
 };
 } // end namespace itk
 

--- a/Modules/IO/MeshBase/src/itkMeshFileReaderException.cxx
+++ b/Modules/IO/MeshBase/src/itkMeshFileReaderException.cxx
@@ -24,7 +24,7 @@ MeshFileReaderException::~MeshFileReaderException() noexcept = default;
 MeshFileReaderException::MeshFileReaderException(std::string  file,
                                                  unsigned int line,
                                                  std::string  message,
-                                                 std::string  loc)
-  : ExceptionObject(std::move(file), line, std::move(message), std::move(loc))
+                                                 std::string  location)
+  : ExceptionObject(std::move(file), line, std::move(message), std::move(location))
 {}
 } // namespace itk

--- a/Modules/IO/MeshBase/src/itkMeshFileWriterException.cxx
+++ b/Modules/IO/MeshBase/src/itkMeshFileWriterException.cxx
@@ -24,7 +24,7 @@ MeshFileWriterException::~MeshFileWriterException() noexcept = default;
 MeshFileWriterException::MeshFileWriterException(std::string  file,
                                                  unsigned int line,
                                                  std::string  message,
-                                                 std::string  loc)
-  : ExceptionObject(std::move(file), line, std::move(message), std::move(loc))
+                                                 std::string  location)
+  : ExceptionObject(std::move(file), line, std::move(message), std::move(location))
 {}
 } // namespace itk


### PR DESCRIPTION
Renamed the `ExceptionObject` constructor parameters for the description and the location of the exception. Also renamed the location parameters of derived exception classes.

Following ITKSoftwareGuide, CodingStyleGuide, section Naming Conventions, which says: "Names are generally spelled out; use of abbreviations is discouraged."