### PR TITLE
STYLE: Flip signs by `x *= -1`, instead of by `x = -x`

### DIFF
--- a/Modules/Bridge/VtkGlue/include/itkViewImage.hxx
+++ b/Modules/Bridge/VtkGlue/include/itkViewImage.hxx
@@ -101,8 +101,8 @@ ViewImage<TImage>::View(const ImageType * img, const std::string & winTitle, siz
   cam->GetViewUp(vup);
   for (unsigned int i = 0; i < 3; ++i)
   {
-    pos[i] = -pos[i];
-    vup[i] = -vup[i];
+    pos[i] *= -1;
+    vup[i] *= -1;
   }
   cam->SetPosition(pos);
   cam->SetViewUp(vup);

--- a/Modules/Core/Common/include/itkVariableLengthVector.hxx
+++ b/Modules/Core/Common/include/itkVariableLengthVector.hxx
@@ -350,7 +350,7 @@ VariableLengthVector<TValue>::operator-()
 {
   for (ElementIdentifier i = 0; i < m_NumElements; ++i)
   {
-    m_Data[i] = -m_Data[i];
+    m_Data[i] *= -1;
   }
   return *this;
 }

--- a/Modules/Core/Common/include/itkVariableSizeMatrix.hxx
+++ b/Modules/Core/Common/include/itkVariableSizeMatrix.hxx
@@ -180,7 +180,7 @@ VariableSizeMatrix<T>::operator-()
   {
     for (unsigned int c = 0; c < this->Cols(); ++c)
     {
-      m_Matrix(r, c) = -m_Matrix(r, c);
+      m_Matrix(r, c) *= -1;
     }
   }
   return *this;

--- a/Modules/Core/Transform/include/itkRigid2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkRigid2DTransform.hxx
@@ -101,7 +101,7 @@ Rigid2DTransform<TParametersValueType>::ComputeMatrixParameters()
   m_Angle = std::acos(r[0][0]);
   if (r[1][0] < 0.0)
   {
-    m_Angle = -m_Angle;
+    m_Angle *= -1;
   }
 
   if (r[1][0] - std::sin(m_Angle) > 0.000001)

--- a/Modules/Filtering/FFT/include/itkFFTShiftImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTShiftImageFilter.hxx
@@ -41,7 +41,7 @@ FFTShiftImageFilter<TInputImage, TOutputImage>::GenerateData()
     shift[i] = (size[i] / 2);
     if (m_Inverse)
     {
-      shift[i] = -shift[i];
+      shift[i] *= -1;
     }
   }
 

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
@@ -294,8 +294,8 @@ HoughTransform2DLinesImageFilter<TInputPixelType, TOutputPixelType>::GetLines() 
           {
             if (teta >= Math::pi / 2)
             {
-              VyNorm = -VyNorm;
-              VxNorm = -VxNorm;
+              VyNorm *= -1;
+              VxNorm *= -1;
             }
 
             LinePointType p;

--- a/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
@@ -86,7 +86,7 @@ RecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetUp(ScalarRealType sp
   if (spacing < 0.0)
   {
     direction = -1.0;
-    spacing = -spacing;
+    spacing *= -1;
   }
 
   if (spacing < spacingTolerance)

--- a/Modules/IO/BMP/src/itkBMPImageIO.cxx
+++ b/Modules/IO/BMP/src/itkBMPImageIO.cxx
@@ -456,7 +456,7 @@ BMPImageIO::ReadImageInformation()
   // is corner in upper left or lower left
   if (ysize < 0)
   {
-    ysize = -ysize;
+    ysize *= -1;
     m_FileLowerLeft = false;
   }
   else

--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -226,10 +226,10 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateOutputInformation()
   {
     if (spacing[i] < 0)
     {
-      spacing[i] = -spacing[i];
+      spacing[i] *= -1;
       for (unsigned int j = 0; j < TOutputImage::ImageDimension; ++j)
       {
-        direction[j][i] = -direction[j][i];
+        direction[j][i] *= -1;
       }
     }
   }

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -1152,7 +1152,7 @@ MINCImageIO::WriteImageInformation()
             miget_dimension_size(m_MINCPImpl->m_MincApparentDims[j], &_sz);
 
             _start = _start + (_sz - 1) * _sep;
-            _sep = -_sep;
+            _sep *= -1;
 
             miset_dimension_separation(m_MINCPImpl->m_MincApparentDims[j], _sep);
             miset_dimension_start(m_MINCPImpl->m_MincApparentDims[j], _start);

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -2302,9 +2302,9 @@ NiftiImageIO::SetNIfTIOrientationFromImageIO(unsigned short origdims, unsigned s
     }
     //  Read comments in nifti1.h about interpreting
     //  "DICOM Image Orientation (Patient)"
-    dirx[2] = -dirx[2];
-    diry[2] = -diry[2];
-    dirz[2] = -dirz[2];
+    dirx[2] *= -1;
+    diry[2] *= -1;
+    dirz[2] *= -1;
   }
   else
   {

--- a/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
@@ -792,7 +792,7 @@ PhilipsRECImageIO::ReadImageInformation()
   center[2] = (par.slice - 1) / 2.0;
   center[3] = 1;
   PointVector origin = final * center;
-  origin = -origin;
+  origin *= -1;
 #ifdef DEBUG_ORIENTATION
   std::cout << "Origin before offset = " << origin << std::endl;
 #endif

--- a/Modules/Nonunit/Review/include/itkDirectFourierReconstructionImageToImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkDirectFourierReconstructionImageToImageFilter.hxx
@@ -316,7 +316,7 @@ DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::Genera
       if (theta < 0)
       {
         theta += m_PI;
-        r = -r;
+        r *= -1;
       }
 
       // Convert into alpha-image indices
@@ -324,7 +324,7 @@ DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::Genera
       if (alpha >= alpha_size)
       {
         alpha -= alpha_size;
-        r = -r;
+        r *= -1;
       }
 
       FFTLineType::PixelType out;

--- a/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
@@ -36,10 +36,10 @@ FRPROptimizer::GetValueAndDerivative(ParametersType & p, double * val, Parameter
   this->m_CostFunction->GetValueAndDerivative(p, *val, *xi);
   if (this->GetMaximize())
   {
-    (*val) = -(*val);
+    (*val) *= -1;
     for (unsigned int i = 0; i < this->GetSpaceDimension(); ++i)
     {
-      (*xi)[i] = -(*xi)[i];
+      (*xi)[i] *= -1;
     }
   }
   if (this->GetUseUnitLengthGradient())

--- a/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
@@ -93,7 +93,7 @@ PowellOptimizer::GetLineValue(double x, ParametersType & tempCoord) const
   }
   if (m_Maximize)
   {
-    val = -val;
+    val *= -1;
   }
   itkDebugMacro("val = " << val);
   return val;
@@ -296,11 +296,11 @@ PowellOptimizer::BracketedLineOptimize(double           ax,
 
       if (q > 0.0) /* q was calculated with the op-*/
       {
-        p = -p; /* posite sign; make q positive  */
+        p *= -1; /* posite sign; make q positive  */
       }
       else /* and assign possible minus to  */
       {
-        q = -q; /* p        */
+        q *= -1; /* p        */
       }
 
       /* Check if x+p/q falls in [a,b] and  not too close to a and b

--- a/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
@@ -299,11 +299,11 @@ PowellOptimizerv4<TInternalComputationValueType>::BracketedLineOptimize(double  
 
       if (q > 0.0) /* q was calculated with the */
       {
-        p = -p; /* opposite sign; make q positive  */
+        p *= -1; /* opposite sign; make q positive  */
       }
       else /* and assign possible minus to  */
       {
-        q = -q; /* p        */
+        q *= -1; /* p        */
       }
 
       /* Check if x+p/q falls in [a,b] and  not too close to a and b

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
@@ -321,7 +321,7 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::TakeAPrior(const B
     }
     if (diffMean[i] < 0)
     {
-      diffMean[i] = -diffMean[i];
+      diffMean[i] *= -1;
     }
     if (m_STD[i] != 0.0)
     {
@@ -333,7 +333,7 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::TakeAPrior(const B
     }
     if (diffSTD[i] < 0)
     {
-      diffSTD[i] = -diffSTD[i];
+      diffSTD[i] *= -1;
     }
     if (this->GetUseBackgroundInAPrior())
     {


### PR DESCRIPTION
Avoided specifying the same expression twice (`<expression> = -<expression>`), and avoided evaluating that expression twice.

Using the following regular expression in Visual Studio:

    Find what:   (.+) = -\1;
    Replace with:   $1 *= -1;