### PR TITLE
Avoid manual memory management `ImageSeriesReader::m_MetaDataDictionaryArray`

### DIFF
--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.h
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.h
@@ -205,10 +205,6 @@ protected:
    */
   unsigned int m_NumberOfDimensionsInImage{ 0 };
 
-  /** Array of MetaDataDictionaries. This allows to hold information from the
-   * ImageIO objects after reading every sub image in the series */
-  DictionaryArrayType m_MetaDataDictionaryArray{};
-
   bool m_UseStreaming{ true };
 
   bool m_SpacingDefined{ false };
@@ -220,6 +216,10 @@ private:
 
   int
   ComputeMovingDimensionIndex(ReaderType * reader);
+
+  /** Array of MetaDataDictionaries. This allows to hold information from the
+   * ImageIO objects after reading every sub image in the series */
+  DictionaryArrayType m_MetaDataDictionaryArray{};
 
   /** Modified time of the MetaDataDictionaryArray */
   TimeStamp m_MetaDataDictionaryArrayMTime{};

--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.h
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.h
@@ -178,7 +178,7 @@ protected:
     : m_ImageIO(nullptr)
 
   {}
-  ~ImageSeriesReader() override;
+  ~ImageSeriesReader() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
@@ -220,6 +220,9 @@ private:
   /** Array of MetaDataDictionaries. This allows to hold information from the
    * ImageIO objects after reading every sub image in the series */
   DictionaryArrayType m_MetaDataDictionaryArray{};
+
+  /** The internal storage of MetaDataDictionaries. */
+  std::vector<MetaDataDictionary> m_InternalMetaDataDictionaries{};
 
   /** Modified time of the MetaDataDictionaryArray */
   TimeStamp m_MetaDataDictionaryArrayMTime{};


### PR DESCRIPTION
No longer manually allocated the MetaDataDictionary objects of `ImageSeriesReader` on the heap. Stored them in an internal `std::vector` instead.

Declared `ImageSeriesReader::m_MetaDataDictionaryArray` private, just like `ImageSeriesWriter::m_MetaDataDictionaryArray`.

