### PR TITLE
Global max threads during initialization

### DIFF
--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -217,8 +217,8 @@ MultiThreaderBase::SetGlobalMaximumNumberOfThreads(ThreadIdType val)
   m_PimplGlobals->m_GlobalMaximumNumberOfThreads = std::clamp<ThreadIdType>(val, 1, ITK_MAX_THREADS);
 
   // If necessary reset the default to be used from now on.
-  m_PimplGlobals->m_GlobalDefaultNumberOfThreads =
-    std::min(m_PimplGlobals->m_GlobalDefaultNumberOfThreads, m_PimplGlobals->m_GlobalMaximumNumberOfThreads);
+  MultiThreaderBase::SetGlobalDefaultNumberOfThreads(
+    std::min(Self::GetGlobalDefaultNumberOfThreads(), Self::GetGlobalMaximumNumberOfThreads()));
 }
 
 ThreadIdType

--- a/Modules/Core/Common/test/itkMultiThreaderBaseTest.cxx
+++ b/Modules/Core/Common/test/itkMultiThreaderBaseTest.cxx
@@ -103,6 +103,12 @@ SetAndVerify(int number)
 int
 itkMultiThreaderBaseTest(int argc, char * argv[])
 {
+  bool result = true;
+
+  itk::MultiThreaderBase::SetGlobalMaximumNumberOfThreads(1);
+  result &= itk::MultiThreaderBase::GetGlobalMaximumNumberOfThreads() == 1;
+  result &= itk::MultiThreaderBase::GetGlobalDefaultNumberOfThreads() == 1;
+
   // Choose a number of threads.
   int numberOfThreads = 10;
   if (argc > 1)
@@ -114,12 +120,20 @@ itkMultiThreaderBaseTest(int argc, char * argv[])
     }
   }
 
-  bool result = true;
   TEST_SINGLE_CLASS(PlatformMultiThreader);
   TEST_SINGLE_CLASS(PoolMultiThreader);
 #ifdef ITK_USE_TBB
   TEST_SINGLE_CLASS(TBBMultiThreader);
 #endif
+
+
+  itk::MultiThreaderBase::SetGlobalMaximumNumberOfThreads(2);
+  result &= VerifyRange(
+    itk::MultiThreaderBase::GetGlobalMaximumNumberOfThreads(), 1, 2, "Range error in MaximumNumberOfThreads");
+  itk::MultiThreaderBase::SetGlobalDefaultNumberOfThreads(4);
+  result &= VerifyRange(
+    itk::MultiThreaderBase::GetGlobalDefaultNumberOfThreads(), 1, 2, "Range error in DefaultNumberOfThreads");
+
 
   itk::MultiThreaderBase::SetGlobalDefaultNumberOfThreads(numberOfThreads);
 
@@ -133,7 +147,6 @@ itkMultiThreaderBaseTest(int argc, char * argv[])
   result &= SetAndVerify(itk::MultiThreaderBase::GetGlobalMaximumNumberOfThreads());
   result &= SetAndVerify(itk::MultiThreaderBase::GetGlobalMaximumNumberOfThreads() - 1);
   result &= SetAndVerify(itk::MultiThreaderBase::GetGlobalMaximumNumberOfThreads() + 1);
-
 
   // Test streaming enumeration for MultiThreaderBaseEnums::Threader elements
   const std::set<itk::MultiThreaderBaseEnums::Threader> allThreader{


### PR DESCRIPTION
 Clamp GlobalDefault threads with GlobalMaximum with initialization

 We must call GetGlobalDefaultNumberOfThreads() when clamping the value
 in SetGlobalMaximumNumberOfThreads, which has the side effect of
 initializing static variables so the desired clamping occurs.

This issue will only be observed before a threader like the
itk::PoolMultiThreader is instantiated because
GetGlobalDefaultNumberOfThreads() is called in its constructor.

Addresses #4773.