### PR TITLE
ENH: Reset conj-grad learning rate for multi-start optimization

### DIFF
--- a/Modules/Numerics/Optimizersv4/include/itkConjugateGradientLineSearchOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkConjugateGradientLineSearchOptimizerv4.h
@@ -78,6 +78,28 @@ public:
   void
   StartOptimization(bool doOnlyInitialization = false) override;
 
+  /**
+   * Set the learning rate for optimization. It is overridden by
+   * automatic learning rate estimation if enabled via a ScalesEstimator.
+   * The learning rate is updated during optimization according to the golden
+   * section line search, even if no ScalesEstimator is set.
+   *
+   * The learning rate set by this method is stored and re-used in subsequent
+   * calls to StartOptimization() unless overridden by automatic learning rate
+   * estimation.
+   */
+  void
+  SetLearningRate(TInternalComputationValueType learningRate) override;
+
+  /**
+   * Set/Get the initial learning rate, which is used in the first iteration of
+   * optimization unless overridden by automatic learning rate estimation.
+   * Setting the learning rate via SetLearningRate() will also change the initial
+   * learning rate for future optimizations.
+   */
+  itkSetMacro(InitialLearningRate, TInternalComputationValueType);
+  itkGetConstReferenceMacro(InitialLearningRate, TInternalComputationValueType);
+
 protected:
   /** Advance one Step following the gradient direction.
    * Includes transform update. */
@@ -94,8 +116,9 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  DerivativeType m_LastGradient{};
-  DerivativeType m_ConjugateGradient{};
+  DerivativeType                m_LastGradient{};
+  DerivativeType                m_ConjugateGradient{};
+  TInternalComputationValueType m_InitialLearningRate{ 1 };
 };
 
 /** This helps to meet backward compatibility */

--- a/Modules/Numerics/Optimizersv4/include/itkConjugateGradientLineSearchOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkConjugateGradientLineSearchOptimizerv4.hxx
@@ -38,6 +38,7 @@ void
 ConjugateGradientLineSearchOptimizerv4Template<TInternalComputationValueType>::StartOptimization(
   bool doOnlyInitialization)
 {
+  this->m_LearningRate = this->m_InitialLearningRate;
   this->m_ConjugateGradient.SetSize(this->m_Metric->GetNumberOfParameters());
   this->m_ConjugateGradient.Fill(TInternalComputationValueType{});
   this->m_LastGradient.SetSize(this->m_Metric->GetNumberOfParameters());
@@ -53,7 +54,6 @@ void
 ConjugateGradientLineSearchOptimizerv4Template<TInternalComputationValueType>::AdvanceOneStep()
 {
   itkDebugMacro("AdvanceOneStep");
-
   this->ModifyGradientByScales();
   if (this->m_CurrentIteration == 0)
   {
@@ -99,6 +99,15 @@ ConjugateGradientLineSearchOptimizerv4Template<TInternalComputationValueType>::A
   }
 
   this->InvokeEvent(IterationEvent());
+}
+
+template <typename TInternalComputationValueType>
+void
+ConjugateGradientLineSearchOptimizerv4Template<TInternalComputationValueType>::SetLearningRate(
+  TInternalComputationValueType learningRate)
+{
+  this->m_InitialLearningRate = learningRate; // Store initial learning rate - used in the first iteration
+  Superclass::SetLearningRate(learningRate);  // Call base class method to set the base class m_LearningRate
 }
 
 } // namespace itk

--- a/Modules/Numerics/Optimizersv4/test/itkConjugateGradientLineSearchOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkConjugateGradientLineSearchOptimizerv4Test.cxx
@@ -240,7 +240,7 @@ itkConjugateGradientLineSearchOptimizerv4Test(int, char *[])
   }
 
   //
-  // test with non-idenity scales
+  // test with non-identity scales
   //
   std::cout << "Test optimization with non-identity scales:" << std::endl;
   metric->SetParameters(initialPosition);


### PR DESCRIPTION
When used as a local optimizer in multi-start optimization, itkConjugateGradientLineSearchOptimizerv4 gives inconsistent results because its learningRate is carried over from the end of one optimization to the beginning of the next.

Added a function to store the initial learning rate when SetLearningRate is called - this is then restored on the first iteration when StartOptimization is called.

Added a test to check that repeated optimizations with the same starting parameters converge to the same result.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
