### PR TITLE
Avoid protected data MersenneTwisterRandomVariateGenerator data

### DIFF
--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -302,6 +302,14 @@ protected:
   static IntegerType
   hash(time_t t, clock_t c);
 
+private:
+  /** Only used to synchronize the global variable across static libraries.*/
+  itkGetGlobalDeclarationMacro(MersenneTwisterGlobals, PimplGlobals);
+
+  /** Internal method to actually create a new object. */
+  static Pointer
+  CreateInstance();
+
   // Internal state
   IntegerType state[StateVectorLength];
 
@@ -313,14 +321,6 @@ protected:
 
   // Seed value
   std::atomic<IntegerType> m_Seed{};
-
-private:
-  /** Only used to synchronize the global variable across static libraries.*/
-  itkGetGlobalDeclarationMacro(MersenneTwisterGlobals, PimplGlobals);
-
-  /** Internal method to actually create a new object. */
-  static Pointer
-  CreateInstance();
 
   // Local lock to enable concurrent access to singleton
   std::mutex m_InstanceMutex{};

--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -268,9 +268,6 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  /** Period parameter */
-  static constexpr unsigned int M = 397;
-
   /** Reload array with N new values. */
   void
   reload();
@@ -363,6 +360,9 @@ MersenneTwisterRandomVariateGenerator::reload()
   // Generate N new values in state
   // Made clearer and faster by Matthew Bellew
   // matthew dot bellew at home dot com
+
+  // Period parameter
+  static constexpr unsigned int M = 397;
 
   // get rid of VS warning
   constexpr auto index = int{ M } - int{ MersenneTwisterRandomVariateGenerator::StateVectorLength };


### PR DESCRIPTION
Aims to simplify the random number generator, by making its `M` constant local to the (only) function that uses it, and by making its other protected data members private.

Following the following C++ Core Guidelines:
- [Keep scopes small](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es5-keep-scopes-small)
- [Avoid protected data](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-protected)