### PR TITLE
Remove magic numbers `0xffffffff`, `4294967295`, and `4294967296` from MersenneTwisterRandomVariateGenerator

### DIFF
--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -345,10 +345,10 @@ MersenneTwisterRandomVariateGenerator::Initialize(const IntegerType seed)
   IntegerType * s = state;
   IntegerType * r = state;
 
-  *s++ = seed & 0xffffffffUL;
+  *s++ = seed;
   for (IntegerType i = 1; i < MersenneTwisterRandomVariateGenerator::StateVectorLength; ++i)
   {
-    *s++ = (1812433253UL * (*r ^ (*r >> 30)) + i) & 0xffffffffUL;
+    *s++ = uint32_t{ (uint32_t{ 1812433253 } * (*r ^ (*r >> 30)) + i) };
     ++r;
   }
   reload();

--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -29,6 +29,7 @@
 #include <mutex>
 #include <climits>
 #include <ctime>
+#include <limits>
 
 namespace itk
 {
@@ -430,7 +431,7 @@ MersenneTwisterRandomVariateGenerator::GetIntegerVariate()
 inline double
 MersenneTwisterRandomVariateGenerator::GetVariateWithClosedRange()
 {
-  return static_cast<double>(GetIntegerVariate()) * (1.0 / 4294967295.0);
+  return static_cast<double>(GetIntegerVariate()) * (1.0 / double{ std::numeric_limits<uint32_t>::max() });
 }
 
 /** Get a random variate in the range [0, n] */

--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -444,7 +444,7 @@ MersenneTwisterRandomVariateGenerator::GetVariateWithClosedRange(const double n)
 inline double
 MersenneTwisterRandomVariateGenerator::GetVariateWithOpenUpperRange()
 {
-  return static_cast<double>(GetIntegerVariate()) * (1.0 / 4294967296.0);
+  return static_cast<double>(GetIntegerVariate()) / double{ 1ULL << 32ULL };
 }
 
 /** Get a range variate in the range [0, n) */
@@ -458,7 +458,7 @@ MersenneTwisterRandomVariateGenerator::GetVariateWithOpenUpperRange(const double
 inline double
 MersenneTwisterRandomVariateGenerator::GetVariateWithOpenRange()
 {
-  return (static_cast<double>(GetIntegerVariate()) + 0.5) * (1.0 / 4294967296.0);
+  return (static_cast<double>(GetIntegerVariate()) + 0.5) / double{ 1ULL << 32ULL };
 }
 
 /** Get a range variate in the range (0, n) */


### PR DESCRIPTION
Three style improvements within `MersenneTwisterRandomVariateGenerator` member functions:

- Removed unnecessary `& 0xffffffffUL` from `Initialize`
- Replaced multiplication by `1 / 4294967296.0` with division by `double{ 1ULL << 32 }` in `GetVariateWithOpenUpperRange` and `GetVariateWithOpenRange` 
- Replaced `4294967295` with `numeric_limits<uint32_t>::max()` in `GetVariateWithClosedRange`

Following C++ Core Guidelines, [Avoid “magic constants”](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-magic)