### PR TITLE
DOC: Fix Doxygen group name in math morphology class documentation

### DIFF
--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalMaximaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalMaximaImageFilter.h
@@ -48,7 +48,7 @@ namespace itk
  * \sa HMinimaImageFilter
  *
  * \ingroup MathematicalMorphologyImageFilters
- * \ingroup ITKITKMathematicalMorphology
+ * \ingroup ITKMathematicalMorphology
  *
  * \sphinx
  * \sphinxexample{Filtering/MathematicalMorphology/ValuedRegionalMaximaImage,Valued Regional Maxima Image}


### PR DESCRIPTION
Fix Doxygen group name in math morphology class documentation: remove the duplicated "ITK" prefix.

Fixes:
```
Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalMaximaImageFilter.h:28:
 warning: Found non-existing group 'ITKITKMathematicalMorphology' for the command '@ingroup', ignoring command
```

raised for example in:
https://open.cdash.org/viewBuildError.php?type=1&buildid=10297994

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes]