### PR TITLE
ENH: Update Montage remote module mostly to fix warnings

### DIFF
--- a/Modules/Remote/Montage.remote.cmake
+++ b/Modules/Remote/Montage.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "Reconstruction of 3D volumetric dataset from a collection of 2D slices"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKMontage.git
-  GIT_TAG 79c81953d87f891f9a2c96457480bdc9f9110f24
+  GIT_TAG f310be543baf7b233d231c6040a2d509d62bacba
   )


### PR DESCRIPTION
This should be merged to release and master too. Trying to clean up build warnings on the nightly dashboard: https://open.cdash.org/viewBuildError.php?type=1&buildid=10305778.