### PR TITLE
STYLE: Let MersenneTwisterRandomVariateGenerator pass integers by value

### DIFF
--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -204,7 +204,7 @@ public:
 
   /** Get an integer variate in [0, n] for n < 2^32 */
   IntegerType
-  GetIntegerVariate(const IntegerType & n);
+  GetIntegerVariate(const IntegerType n);
 
   /** Access to 53-bit random numbers (capacity of IEEE double precision)
    * in the range [0,1) */
@@ -275,28 +275,28 @@ protected:
   reload();
 
   IntegerType
-  hiBit(const IntegerType & u) const
+  hiBit(const IntegerType u) const
   {
     return u & 0x80000000;
   }
   IntegerType
-  loBit(const IntegerType & u) const
+  loBit(const IntegerType u) const
   {
     return u & 0x00000001;
   }
   IntegerType
-  loBits(const IntegerType & u) const
+  loBits(const IntegerType u) const
   {
     return u & 0x7fffffff;
   }
   IntegerType
-  mixBits(const IntegerType & u, const IntegerType & v) const
+  mixBits(const IntegerType u, const IntegerType v) const
   {
     return hiBit(u) | loBits(v);
   }
 
   IntegerType
-  twist(const IntegerType & m, const IntegerType & s0, const IntegerType & s1) const
+  twist(const IntegerType m, const IntegerType s0, const IntegerType s1) const
   {
     return m ^ (mixBits(s0, s1) >> 1) ^ (-static_cast<int32_t>(loBit(s1)) & 0x9908b0df);
   }
@@ -471,7 +471,7 @@ MersenneTwisterRandomVariateGenerator::GetVariateWithOpenRange(const double n)
 }
 
 inline MersenneTwisterRandomVariateGenerator::IntegerType
-MersenneTwisterRandomVariateGenerator::GetIntegerVariate(const IntegerType & n)
+MersenneTwisterRandomVariateGenerator::GetIntegerVariate(const IntegerType n)
 {
   // Find which bits are used in n
   IntegerType used = n;


### PR DESCRIPTION
Following C++ Core Guidelines, [For “in” parameters, pass cheaply-copied types by value and others by reference to `const`](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-in)