### PR TITLE
MersenneTwisterRandomVariateGenerator: Rename `state` member variable, remove `this->`, move inline functions in-class, add `static`

### DIFF
--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -339,7 +339,7 @@ inline void
 MersenneTwisterRandomVariateGenerator::Initialize(const IntegerType seed)
 {
   const std::lock_guard<std::mutex> lockGuard(m_InstanceMutex);
-  this->m_Seed = seed;
+  m_Seed = seed;
   // Initialize generator state with seed
   // See Knuth TAOCP Vol 2, 3rd Ed, p.106 for multiplier.
   // In previous versions, most significant bits (MSBs) of the seed affect
@@ -409,7 +409,7 @@ MersenneTwisterRandomVariateGenerator::SetSeed()
 inline MersenneTwisterRandomVariateGenerator::IntegerType
 MersenneTwisterRandomVariateGenerator::GetSeed() const
 {
-  return this->m_Seed;
+  return m_Seed;
 }
 
 /** Get an integer variate in [0, 2^32-1] */

--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -313,29 +313,29 @@ protected:
   void
   reload();
 
-  IntegerType
-  hiBit(const IntegerType u) const
+  static IntegerType
+  hiBit(const IntegerType u)
   {
     return u & 0x80000000;
   }
-  IntegerType
-  loBit(const IntegerType u) const
+  static IntegerType
+  loBit(const IntegerType u)
   {
     return u & 0x00000001;
   }
-  IntegerType
-  loBits(const IntegerType u) const
+  static IntegerType
+  loBits(const IntegerType u)
   {
     return u & 0x7fffffff;
   }
-  IntegerType
-  mixBits(const IntegerType u, const IntegerType v) const
+  static IntegerType
+  mixBits(const IntegerType u, const IntegerType v)
   {
     return hiBit(u) | loBits(v);
   }
 
-  IntegerType
-  twist(const IntegerType m, const IntegerType s0, const IntegerType s1) const
+  static IntegerType
+  twist(const IntegerType m, const IntegerType s0, const IntegerType s1)
   {
     return m ^ (mixBits(s0, s1) >> 1) ^ (-static_cast<int32_t>(loBit(s1)) & 0x9908b0df);
   }

--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -313,7 +313,7 @@ private:
   CreateInstance();
 
   // Internal state
-  IntegerType state[StateVectorLength];
+  IntegerType m_State[StateVectorLength];
 
   // Next value to get from state
   IntegerType * m_PNext{};
@@ -344,8 +344,8 @@ MersenneTwisterRandomVariateGenerator::Initialize(const IntegerType seed)
   // See Knuth TAOCP Vol 2, 3rd Ed, p.106 for multiplier.
   // In previous versions, most significant bits (MSBs) of the seed affect
   // only MSBs of the state array.  Modified 9 Jan 2002 by Makoto Matsumoto.
-  IntegerType * s = state;
-  IntegerType * r = state;
+  IntegerType * s = m_State;
+  IntegerType * r = m_State;
 
   *s++ = seed;
   for (IntegerType i = 1; i < MersenneTwisterRandomVariateGenerator::StateVectorLength; ++i)
@@ -369,7 +369,7 @@ MersenneTwisterRandomVariateGenerator::reload()
   // get rid of VS warning
   constexpr auto index = int{ M } - int{ MersenneTwisterRandomVariateGenerator::StateVectorLength };
 
-  IntegerType * p = state;
+  IntegerType * p = m_State;
 
   for (int i = MersenneTwisterRandomVariateGenerator::StateVectorLength - M; i--; ++p)
   {
@@ -379,10 +379,10 @@ MersenneTwisterRandomVariateGenerator::reload()
   {
     *p = twist(p[index], p[0], p[1]);
   }
-  *p = twist(p[index], p[0], state[0]);
+  *p = twist(p[index], p[0], m_State[0]);
 
   m_Left = MersenneTwisterRandomVariateGenerator::StateVectorLength;
-  m_PNext = state;
+  m_PNext = m_State;
 }
 
 inline void

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -138,9 +138,9 @@ MersenneTwisterRandomVariateGenerator::PrintSelf(std::ostream & os, Indent inden
   Superclass::PrintSelf(os, indent);
 
   // Print state vector contents
-  os << indent << "State vector: " << state << std::endl;
+  os << indent << "State vector: " << m_State << std::endl;
   os << indent;
-  const IntegerType * s = state;
+  const IntegerType * s = m_State;
   int                 i = StateVectorLength;
   for (; i--; os << *s++ << '\t')
   {


### PR DESCRIPTION
A few style improvements for `MersenneTwisterRandomVariateGenerator`.