### PR TITLE
COMP: Remove constexpr from check on runtime value in JPEGImageIO

### DIFF
--- a/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
+++ b/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
@@ -364,11 +364,14 @@ JPEGImageIO::ReadImageInformation()
 
   // jpeg_calc_output_dimensions to calculate cinfo.output_components
   jpeg_calc_output_dimensions(&cinfo);
-  if constexpr (sizeof(void *) < 8 && (static_cast<unsigned long long>(cinfo.output_width) * cinfo.output_height *
-                                       cinfo.output_components) > 0xffffffff)
+  if constexpr (sizeof(void *) < 8)
   {
-    jpeg_destroy_decompress(&cinfo);
-    itkExceptionMacro("JPEG image is too big " << this->GetFileName());
+    if ((static_cast<unsigned long long>(cinfo.output_width) * cinfo.output_height * cinfo.output_components) >
+        0xffffffff)
+    {
+      jpeg_destroy_decompress(&cinfo);
+      itkExceptionMacro("JPEG image is too big " << this->GetFileName());
+    }
   }
 
   // pull out the width/height


### PR DESCRIPTION
Remove constexpr for runtime value `cinfo`.

Fixed a Visual C++ x86 (32-bit) error:
```log
error C2131: expression did not evaluate to a constant
```