### PR TITLE
COMP: Include `itkNumericTraitsCovariantVectorPixel.h` file in test

### DIFF
--- a/Modules/Core/Common/test/itkNumericTraitsTest.cxx
+++ b/Modules/Core/Common/test/itkNumericTraitsTest.cxx
@@ -38,6 +38,7 @@
 #endif
 
 #include "itkNumericTraitsArrayPixel.h"
+#include "itkNumericTraitsCovariantVectorPixel.h"
 #include "itkNumericTraitsRGBAPixel.h"
 #include "itkNumericTraitsRGBPixel.h"
 #include "itkNumericTraitsTensorPixel.h"


### PR DESCRIPTION
Include `itkNumericTraitsCovariantVectorPixelType.h` header file in test so that the appropriate definitions are available.

Fixes:
```
[CTest: warning matched]
 /Users/builder/externalModules/Core/Common/test/itkNumericTraitsTest.cxx:151:112:
 warning: instantiation of variable 'itk::NumericTraits<itk::CovariantVector<char, 1> >::Zero'
 required here, but no definition is available [-Wundefined-var-template]
  std::cout << "\tZero: " << static_cast<typename itk::NumericTraits<T>::PrintType>((T)(itk::NumericTraits<T>::Zero))
                                                                                                               ^
[CTest: warning matched]
 /Users/builder/externalModules/Core/Common/test/itkNumericTraitsTest.cxx:430:3:
 note: in instantiation of function template specialization
 '(anonymous namespace)::CheckFixedArrayTraits<itk::CovariantVector<char, 1> >' requested here
  CheckFixedArrayTraits(itk::CovariantVector<char, 1>());
  ^
[CTest: warning matched]
 /Users/builder/externalModules/Core/Common/include/itkNumericTraitsCovariantVectorPixel.h:196:38:
 note: forward declaration of template entity is here
  static const Self ITKCommon_EXPORT Zero;
                                     ^
[CTest: warning matched]
 /Users/builder/externalModules/Core/Common/test/itkNumericTraitsTest.cxx:151:112:
 note: add an explicit instantiation declaration to suppress this warning if
 'itk::NumericTraits<itk::CovariantVector<char, 1> >::Zero' is explicitly instantiated in another translation unit
  std::cout << "\tZero: " << static_cast<typename itk::NumericTraits<T>::PrintType>((T)(itk::NumericTraits<T>::Zero))
                                                                                                               ^
```

and
```
[CTest: warning matched]
 /Users/builder/externalModules/Core/Common/test/itkNumericTraitsTest.cxx:153:111:
 warning: instantiation of variable 'itk::NumericTraits<itk::CovariantVector<char, 1> >::One'
 required here, but no definition is available [-Wundefined-var-template]
  std::cout << "\tOne: " << static_cast<typename itk::NumericTraits<T>::PrintType>((T)(itk::NumericTraits<T>::One))
                                                                                                              ^
[CTest: warning matched]
 /Users/builder/externalModules/Core/Common/include/itkNumericTraitsCovariantVectorPixel.h:197:38:
 note: forward declaration of template entity is here
  static const Self ITKCommon_EXPORT One;
                                     ^
[CTest: warning matched] /Users/builder/externalModules/Core/Common/test/itkNumericTraitsTest.cxx:153:111:
 note: add an explicit instantiation declaration to suppress this warning if
 'itk::NumericTraits<itk::CovariantVector<char, 1> >::One' is explicitly instantiated in another translation unit
  std::cout << "\tOne: " << static_cast<typename itk::NumericTraits<T>::PrintType>((T)(itk::NumericTraits<T>::One))
                                                                                                              ^
```

raised for example in:
https://open.cdash.org/viewBuildError.php?type=1&buildid=10332365

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)