### PR TITLE
BUG: SWIG typechecks reject foreign wrapped types

### DIFF
--- a/Modules/Core/ImageFunction/wrapping/test/CMakeLists.txt
+++ b/Modules/Core/ImageFunction/wrapping/test/CMakeLists.txt
@@ -7,4 +7,9 @@ if(ITK_WRAP_PYTHON)
     NAME itkWindowedSincInterpolateImageFunctionPythonTest
     EXPRESSION "windowed_sinc = itk.WindowedSincInterpolateImageFunction.New()"
   )
+  itk_python_add_test(
+    NAME itkLinearImageFunctionWrappingTest
+    COMMAND
+      ${CMAKE_CURRENT_SOURCE_DIR}/itkLinearImageFunctionWrappingTest.py
+  )
 endif()

--- a/Modules/Core/ImageFunction/wrapping/test/itkLinearImageFunctionWrappingTest.py
+++ b/Modules/Core/ImageFunction/wrapping/test/itkLinearImageFunctionWrappingTest.py
@@ -1,0 +1,65 @@
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================
+
+# Regression test for Discourse #7495 / GitHub #5310:
+#   `ImageFunction::IsInsideBuffer` has three C++ overloads (Index,
+#   ContinuousIndex, Point), but in older releases SWIG's overload
+#   dispatcher always selected the integer-only Index overload because
+#   the typecheck typemap accepted any object satisfying
+#   PySequence_Check + length == dim — which wrapped ContinuousIndex
+#   and Point instances do via their __getitem__/__len__.  All of the
+#   following calls must succeed, each reaching its intended overload.
+
+import itk
+import numpy as np
+
+image = itk.GetImageFromArray(np.full((10, 10, 10), 1.0, dtype=np.float32))
+interp = itk.LinearInterpolateImageFunction.New(image)
+
+# All four documented overloads must be reachable and produce True for
+# coordinates that are inside the buffer.
+
+# 1. Raw Python list of ints  -> Index overload.
+assert interp.IsInsideBuffer([1, 2, 3]) is True
+
+# 2. Wrapped ContinuousIndex   -> ContinuousIndex overload.
+cindex = itk.ContinuousIndex[itk.D, 3]()
+cindex[0] = 1.5
+cindex[1] = 2.5
+cindex[2] = 3.5
+assert interp.IsInsideBuffer(cindex) is True
+
+# 3. Wrapped Point             -> Point overload.
+point = itk.Point[itk.D, 3]()
+point[0] = 1.5
+point[1] = 2.5
+point[2] = 3.5
+assert interp.IsInsideBuffer(point) is True
+
+# 4. Raw Python list of floats -> ContinuousIndex overload (selected
+#    after the Index typecheck correctly rejects a float-element list).
+assert interp.IsInsideBuffer([1.5, 2.5, 3.5]) is True
+
+# Out-of-buffer cases must return False, not throw.
+assert interp.IsInsideBuffer([100, 100, 100]) is False
+out_point = itk.Point[itk.D, 3]()
+for d in range(3):
+    out_point[d] = 100.0
+assert interp.IsInsideBuffer(out_point) is False
+
+print("All IsInsideBuffer overload-dispatch checks passed.")

--- a/Wrapping/Generators/Python/PyBase/pyBase.i
+++ b/Wrapping/Generators/Python/PyBase/pyBase.i
@@ -1107,13 +1107,26 @@ str = str
 
     %typemap(typecheck) swig_name & {
         void *ptr;
-        if (SWIG_ConvertPtr($input, &ptr, $1_descriptor, 0) == -1
-            && ( !PySequence_Check($input) || PyObject_Length($input) != dim )
-            && !PyInt_Check($input) && !PyFloat_Check($input) ) {
-            _v = 0;
-            PyErr_Clear();
-        } else {
+        _v = 0;
+        if (SWIG_ConvertPtr($input, &ptr, $1_descriptor, 0) != -1) {
             _v = 1;
+        } else {
+            PyErr_Clear();
+            /* Reject inputs that are SWIG-wrapped instances of an
+             * unrelated type.  Wrapped types like itk::Index,
+             * itk::ContinuousIndex and itk::Point all expose
+             * __getitem__ / __len__, which makes them satisfy
+             * PySequence_Check below — that previously caused this
+             * typecheck to claim viability for foreign types and the
+             * overload dispatcher would pick the wrong overload
+             * (see Discourse #7495). */
+            if (SWIG_Python_GetSwigThis($input) != NULL) {
+                _v = 0;
+            } else if (PyInt_Check($input) || PyFloat_Check($input)) {
+                _v = 1;
+            } else if (PySequence_Check($input) && PyObject_Length($input) == dim) {
+                _v = 1;
+            }
         }
     }
 
@@ -1160,13 +1173,18 @@ str = str
 
     %typemap(typecheck) swig_name {
         void *ptr;
-        if (SWIG_ConvertPtr($input, &ptr, $descriptor(swig_name *), 0) == -1
-            && ( !PySequence_Check($input) || PyObject_Length($input) != dim )
-            && !PyInt_Check($input) && !PyFloat_Check($input) ) {
-            _v = 0;
-            PyErr_Clear();
-        } else {
+        _v = 0;
+        if (SWIG_ConvertPtr($input, &ptr, $descriptor(swig_name *), 0) != -1) {
             _v = 1;
+        } else {
+            PyErr_Clear();
+            if (SWIG_Python_GetSwigThis($input) != NULL) {
+                _v = 0;
+            } else if (PyInt_Check($input) || PyFloat_Check($input)) {
+                _v = 1;
+            } else if (PySequence_Check($input) && PyObject_Length($input) == dim) {
+                _v = 1;
+            }
         }
     }
 
@@ -1223,12 +1241,19 @@ str = str
 
     %typemap(typecheck) type & {
         void *ptr;
-        if (SWIG_ConvertPtr($input, &ptr, $1_descriptor, 0) == -1
-            && !PySequence_Check($input) ) {
-            _v = 0;
-            PyErr_Clear();
-        } else {
+        _v = 0;
+        if (SWIG_ConvertPtr($input, &ptr, $1_descriptor, 0) != -1) {
             _v = 1;
+        } else {
+            PyErr_Clear();
+            /* Reject SWIG wrappers of unrelated types — they all expose
+             * __getitem__ / __len__ and would otherwise trick this
+             * typecheck into claiming overload viability. */
+            if (SWIG_Python_GetSwigThis($input) != NULL) {
+                _v = 0;
+            } else if (PySequence_Check($input)) {
+                _v = 1;
+            }
         }
     }
 
@@ -1269,12 +1294,16 @@ str = str
 
     %typemap(typecheck) type {
         void *ptr;
-        if (SWIG_ConvertPtr($input, &ptr, $descriptor(type *), 0) == -1
-            && !PySequence_Check($input) ) {
-            _v = 0;
-            PyErr_Clear();
-        } else {
+        _v = 0;
+        if (SWIG_ConvertPtr($input, &ptr, $descriptor(type *), 0) != -1) {
             _v = 1;
+        } else {
+            PyErr_Clear();
+            if (SWIG_Python_GetSwigThis($input) != NULL) {
+                _v = 0;
+            } else if (PySequence_Check($input)) {
+                _v = 1;
+            }
         }
     }
 
@@ -1332,13 +1361,31 @@ str = str
 
     %typemap(typecheck) swig_name & {
         void *ptr;
-        if (SWIG_ConvertPtr($input, &ptr, $1_descriptor, 0) == -1
-            && ( !PySequence_Check($input) || PyObject_Length($input) != dim )
-            && !PyInt_Check($input) ) {
-            _v = 0;
-            PyErr_Clear();
-        } else {
+        _v = 0;
+        if (SWIG_ConvertPtr($input, &ptr, $1_descriptor, 0) != -1) {
             _v = 1;
+        } else {
+            PyErr_Clear();
+            /* Reject SWIG-wrapped instances of an unrelated type
+             * (see ContinuousIndex/Point note in DECL_PYTHON_VEC_TYPEMAP). */
+            if (SWIG_Python_GetSwigThis($input) != NULL) {
+                _v = 0;
+            } else if (PyInt_Check($input) || PyLong_Check($input)) {
+                _v = 1;
+            } else if (PySequence_Check($input) && PyObject_Length($input) == dim) {
+                /* This typemap is integer-only.  Peek at element 0 and
+                 * reject sequences whose elements are not integers
+                 * (e.g. [1.5, 2.5, 3.5]).  Without this check, the
+                 * Index overload claimed viability for float lists and
+                 * the dispatcher never reached the ContinuousIndex /
+                 * Point overloads (see Discourse #7495). */
+                PyObject *o = PySequence_GetItem($input, 0);
+                if (o != NULL && (PyInt_Check(o) || PyLong_Check(o))) {
+                    _v = 1;
+                }
+                Py_XDECREF(o);
+                PyErr_Clear();
+            }
         }
     }
 
@@ -1378,13 +1425,23 @@ str = str
 
     %typemap(typecheck) swig_name {
         void *ptr;
-        if (SWIG_ConvertPtr($input, &ptr, $descriptor(swig_name *), 0) == -1
-            && ( !PySequence_Check($input) || PyObject_Length($input) != dim )
-            && !(PyInt_Check($input) || PyLong_Check($input)) ) {
-            _v = 0;
-            PyErr_Clear();
-        } else {
+        _v = 0;
+        if (SWIG_ConvertPtr($input, &ptr, $descriptor(swig_name *), 0) != -1) {
             _v = 1;
+        } else {
+            PyErr_Clear();
+            if (SWIG_Python_GetSwigThis($input) != NULL) {
+                _v = 0;
+            } else if (PyInt_Check($input) || PyLong_Check($input)) {
+                _v = 1;
+            } else if (PySequence_Check($input) && PyObject_Length($input) == dim) {
+                PyObject *o = PySequence_GetItem($input, 0);
+                if (o != NULL && (PyInt_Check(o) || PyLong_Check(o))) {
+                    _v = 1;
+                }
+                Py_XDECREF(o);
+                PyErr_Clear();
+            }
         }
     }
 


### PR DESCRIPTION
Based on code provided on the forum: https://discourse.itk.org/t/improper-wrapping-of-imagefunction-isinsidebuffer/7495


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
