### PR TITLE
DOC: Update Wiki links to GitHub Pages archive

### DIFF
--- a/Documentation/Maintenance/Release.md
+++ b/Documentation/Maintenance/Release.md
@@ -992,13 +992,13 @@ excellent packaging.
 [ITK Open Collective page]: https://opencollective.org/itk
 [ITK issue tracking]: https://issues.itk.org/
 [ITK Software Guide]: https://itk.org/ItkSoftwareGuide.pdf
-[ITK wiki]: https://itk.org/Wiki/ITK
+[ITK wiki]: https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK
 [ITK Sphinx examples]: https://examples.itk.org/
 [ITKReleases NumFOCUS GDrive]: https://drive.google.com/drive/folders/1-uE7lKAZN4PT52vJJuDqr6KT656r6Dn_?usp=drive_link
 [kubo]: https://github.com/ipfs/kubo
 [pinata]: https://pinata.cloud
-[releases page]: https://itk.org/Wiki/ITK/Releases
-[release schedule]: https://itk.org/Wiki/ITK/Release_Schedule
+[releases page]: https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK/Releases
+[release schedule]: https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK/Release_Schedule
 [signed release]: https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#signed-releases
 [Software Guide]: https://itk.org/ItkSoftwareGuide.pdf
 [@web3-storage/w3cli]: https://www.npmjs.com/package/@web3-storage/w3cli

--- a/Documentation/docs/learn/faq.md
+++ b/Documentation/docs/learn/faq.md
@@ -43,7 +43,7 @@ images.
 | [ITK HDF5](https://support.hdfgroup.org/HDF5/) | | |
 | [JPEG](https://en.wikipedia.org/wiki/JPEG_File_Interchange_Format) † | [`itk::JPEGImageIO`](https://docs.itk.org/projects/doxygen/en/stable/classitk_1_1JPEGImageIO.html) | |
 | [LSM](https://www.openwetware.org/wiki/Dissecting_LSM_files) | [`itk::LSMImageIO`](https://docs.itk.org/projects/doxygen/en/stable/classitk_1_1LSMImageIO.html) | |
-| [MetaImage](./metaio.md) (.mha/.mhd) | [`itk::MetaImageIO`](https://docs.itk.org/projects/doxygen/en/stable/classitk_1_1MetaImageIO.html) | |
+| [MetaImage](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK/MetaIO/Documentation) (.mha/.mhd) | [`itk::MetaImageIO`](https://docs.itk.org/projects/doxygen/en/stable/classitk_1_1MetaImageIO.html) | |
 | [MINC 2.0](https://en.wikibooks.org/wiki/MINC/SoftwareDevelopment/MINC2.0_File_Format_Reference) (Medical Image NetCDF) | [`itk::MINCImagIO`](https://docs.itk.org/projects/doxygen/en/stable/classitk_1_1MINCImageIO.html) | |
 | [MGH](https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/MghFormat) | [`itk:MGHImageIO`](https://docs.itk.org/projects/doxygen/en/stable/classitk_1_1MGHImageIO.html) | |
 | [MRC](http://www.ccpem.ac.uk/mrc_format/mrc_format.php) | [`itk::MRCImageIO`](https://docs.itk.org/projects/doxygen/en/stable/classitk_1_1MRCImageIO.html) | |
@@ -366,7 +366,7 @@ Please see the [Contribute to ITK page](https://docs.itk.org/en/latest/contribut
 
 ### Is ITK tested?
 
-Please see this page: [ITK/Testing](https://itk.org/Wiki/ITK/Testing).
+Please see this page: [ITK/Testing](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK/Testing).
 
 ## Working with image data
 

--- a/Documentation/docs/releases/4.0.md
+++ b/Documentation/docs/releases/4.0.md
@@ -8,12 +8,12 @@ will continue to be contributed to the ITK version 3 code.
 
 ## Download
 
--   [Download](https://itk.org/Wiki/ITK_Release_4/Download)
+-   [Download](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Download)
 
 ## Release Notes
 
 -   [Release
-    Notes](https://itk.org/Wiki/ITK_Release_4/Migration_Plan/Release_Notes)
+    Notes](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Migration_Plan/Migration_Plan)
 
 ## LICENSE Change
 
@@ -22,14 +22,14 @@ Apache 2.0 License.
 
 More details here:
 
--   [Licensing](https://itk.org/Wiki/ITK_Release_4/Licensing)
+-   [Licensing](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Licensing)
 
 ## Revision Control
 
 -   Adopt a modern revision control system
     -   Move from cvs to [git](https://git-scm.com) for distributed
         source code management
-    -   [ITK Git Instructions](https://itk.org/Wiki/ITK/Git)
+    -   [ITK Git Instructions](https://docs.itk.org/en/latest/contributing/index.html)
 
 ## Code Review
 
@@ -40,7 +40,7 @@ More details here:
 
 ## Modern C++
 
--   [Modern C++](https://itk.org/Wiki/ITK_Release_4/Modern_C++)
+-   [Modern C++](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Modern_C\%2B\%2B)
 
 <!-- -->
 
@@ -57,22 +57,22 @@ More details here:
 ## Wrapping
 
 -   Improved ITK Wrapping at the class level (WrapITK)
-    -   [Wrapping](https://itk.org/Wiki/ITK_Release_4/Wrapping)
+    -   [Wrapping](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Wrapping/Wrapping)
     -   Particularly for Python 2.x, Python 3, Java and C\#
 
 ## Simplify
 
--   Addition of [Simple ITK Layer](https://itk.org/Wiki/ITK_Release_4/SimpleITK)
+-   Addition of [Simple ITK Layer](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/SimpleITK/SimpleITK)
 
 ## Modularize
 
--   Refactor for [Modularity](https://itk.org/Wiki/ITK_Release_4/Modularization)
+-   Refactor for [Modularity](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Modularization/Modularization)
     -   ITKCore, ITKRegistrationModule, and Optional Modules
 
 ## Testing Crowdsourcing
 
 -   [Testing
-    Crowdsourcing](https://itk.org/Wiki/ITK_Release_4/Testing_Crowdsourcing)
+    Crowdsourcing](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Testing_Crowdsourcing)
 
 ## Improve Software Process
 
@@ -82,23 +82,23 @@ More details here:
 
 -   Better management for Testing
     Data
--   Data Collection [MIDAS](https://itk.org/Wiki/ITK_Release_4/Data_Collection)
+-   Data Collection [MIDAS](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Data_Collection)
 
 ### Distributed Testing (cdash@home)
 
 -   Testing On Demand
-    [cdash@home](https://itk.org/Wiki/ITK_Release_4/Testing_On_Demand)
+    [cdash@home](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Testing_On_Demand/Testing_On_Demand)
 
 ### Testing Framework
 
--   [New unit testing framework](https://itk.org/Wiki/ITK_Release_4/UnitTesting)
+-   [New unit testing framework](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/UnitTesting)
     based on [Google Test](https://code.google.com/p/googletest/)
     -   Particularly to support module development, testing, and
         maintenance
 
 ### Coding Style
 
--   [Coding Style](https://itk.org/Wiki/ITK_Release_4/Coding_Style)
+-   [Coding Style](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Coding_Style/Coding_Style)
 
 ## Revise
 
@@ -124,22 +124,22 @@ More details here:
 ### Image Registration Framework
 
 -   [Enhancing Image Registration
-    Framework](https://itk.org/Wiki/ITK_Release_4/Enhancing_Image_Registration_Framework)
+    Framework](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Enhancing_Image_Registration_Framework/Enhancing_Image_Registration_Framework)
 
 ### Spatial Objects
 
 -   [ Spatial Object Refactoring project
-    page](https://itk.org/Wiki/ITK_Release_4/SpatialObjects)
+    page](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/SpatialObjects/SpatialObjects)
 
 ### Global Code Review
 
--   [ Global Code Review](https://itk.org/Wiki/ITK_Release_4/Global_Code_Review)
+-   [ Global Code Review](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Global_Code_Review/Global_Code_Review)
 
 ## Accelerate
 
 ### GPU
 
--   [GPU Acceleration - V4](https://itk.org/Wiki/ITK_Release_4/GPU_Acceleration)
+-   [GPU Acceleration - V4](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/GPU_Acceleration/GPU_Acceleration)
     -   With support for distributed computing in the future
 
 <!-- -->
@@ -150,53 +150,53 @@ More details here:
 ### Numerical Libraries
 
 -   [Refactor Numerical
-    Libraries](https://itk.org/Wiki/ITK_Release_4/Refactor_Numerical_Libraries)
+    Libraries](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Refactor_Numerical_Libraries/Refactor_Numerical_Libraries/)
 
 ## Release schedules
 
--   [Release Schedules](https://itk.org/Wiki/ITK_Release_4/ReleaseSchedules)
+-   [Release Schedules](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/ReleaseSchedules)
 
 ## The Team
 
-[The Team](https://itk.org/Wiki/ITK_Release_4/The_Team)
+[The Team](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/The_Team/The_Team/)
 
 ## Wish List
 
-[Wish List](https://itk.org/Wiki/ITK_Release_4/Wish_List)
+[Wish List](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Wish_List)
 
 ## Migration Plan (Developers)
 
-[Migration Plan](https://itk.org/Wiki/ITK_Release_4/Migration_Plan)
+[Migration Plan](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Migration_Plan/Migration_Plan/)
 
 ## Migration Guide (for Users)
 
-[Users Migration Guide](https://itk.org/Wiki/ITK_Release_4/Users_Migration_Guide)
+[Users Migration Guide](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Users_Migration_Guide/Users_Migration_Guide/)
 
 ## Software Guide (Update)
 
-[Software Guide Update](https://itk.org/Wiki/ITK_Release_4/Software_Guide_Update)
+[Software Guide Update](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Software_Guide_Update)
 
 ## A2D2 Projects
 
-[A2D2 Projects](https://itk.org/Wiki/ITK_Release_4/A2D2_Projects)
+[A2D2 Projects](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/A2D2_Projects/A2D2_Projects/)
 
 ## New Fields
 
 ITKv4 will provide improved support for
 
--   [Video](https://itk.org/Wiki/ITK_Release_4/Video)
--   [Microscopy](https://itk.org/Wiki/ITK_Release_4/Microscopy)
--   [Remote Sensing](https://itk.org/Wiki/ITK_Release_4/Remote_Sensing)
+-   [Video](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Video/Video)
+-   [Microscopy](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Microscopy/Microscopy/)
+-   [Remote Sensing](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Remote_Sensing)
 
 ## Discussion Points
 
-[Discussion Points](https://itk.org/Wiki/ITK_Release_4/Discussion_Points)
+[Discussion Points](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Discussion_Points)
 
 ## Outreach
 
-[Outreach](https://itk.org/Wiki/ITK_Release_4/Outreach)
+[Outreach](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Outreach/Outreach/)
 
 ## New Code Contribution Process
 
 [New Code Contribution
-Process](https://itk.org/Wiki/ITK_Release_4/New_Code_Contribution_Process)
+Process](https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/New_Code_Contribution_Process)

--- a/Documentation/docs/releases/4.5.md
+++ b/Documentation/docs/releases/4.5.md
@@ -17,13 +17,13 @@ New Documentation
 <!-- -->
 
 -   ITK Wiki examples tarball.  A buildable archive of the outstanding
-    examples indexed at <https://itk.org/Wiki/ITK/Examples> is available
+    examples indexed at <https://github.com/InsightSoftwareConsortium/ITKWikiExamples> is available
     to download, build against the current release, and learn from.
 
 <!-- -->
 
 -   ITK Sphinx examples downloads.  Examples available online at
-    <https://itk.org/ITKExamples/> are stored in Git version control but
+    <https://examples.itk.org/> are stored in Git version control but
     rendered in HTML, PDF, and EPUB output formats with the Sphinx
     documentation system.  They have CTest unit tests, inline Doxygen
     class descriptions and links to full Doxygen class documentation,

--- a/Modules/Core/Common/CMakeLists.txt
+++ b/Modules/Core/Common/CMakeLists.txt
@@ -120,7 +120,7 @@ endif()
 # This is required on Mac OSX to avoid dynamic_cast failures across binaries.
 # See Change-Id: Ib4a6b8cafe8720c3a2a5b3e6ba833d11002978df for more information."
 option(ITK_TEMPLATE_VISIBILITY_DEFAULT
-       "Set symbol visibility to default for template class declarations. https://itk.org/Wiki/ITK/FAQ"
+       "Set symbol visibility to default for template class declarations. https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK/FAQ"
        "${_template_visibility_init}")
 mark_as_advanced(ITK_TEMPLATE_VISIBILITY_DEFAULT)
 

--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -128,7 +128,9 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateOutputInformation()
       else
       {
         msg << "  There are no registered IO factories." << std::endl
-            << "  Please visit https://www.itk.org/Wiki/ITK/FAQ#NoFactoryException to diagnose the problem."
+            << "  Please visit "
+               "https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK/FAQ#NoFactoryException to diagnose "
+               "the problem."
             << std::endl;
       }
     }

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
@@ -131,8 +131,11 @@ ImageFileWriter<TInputImage>::Write()
     }
     else
     {
-      msg << "  There are no registered IO factories." << std::endl
-          << "  Please visit https://www.itk.org/Wiki/ITK/FAQ#NoFactoryException to diagnose the problem." << std::endl;
+      msg
+        << "  There are no registered IO factories." << std::endl
+        << "  Please visit https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK/FAQ#NoFactoryException "
+           "to diagnose the problem."
+        << std::endl;
     }
     e.SetDescription(msg.str().c_str());
     e.SetLocation(ITK_LOCATION);

--- a/Modules/IO/Meta/include/itkMetaImageIO.h
+++ b/Modules/IO/Meta/include/itkMetaImageIO.h
@@ -35,7 +35,7 @@ namespace itk
  *  \brief Read MetaImage file format.
  *
  *  For a detailed description of using this format, please see
- *  https://www.itk.org/Wiki/ITK/MetaIO/Documentation
+ *  https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK/MetaIO/Documentation
  *
  *  \ingroup IOFilters
  * \ingroup ITKIOMeta

--- a/Modules/IO/TransformBase/src/itkTransformFileReader.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformFileReader.cxx
@@ -120,7 +120,9 @@ TransformFileReaderTemplate<TParametersValueType>::Update()
       else
       {
         msg << "  There are no registered Transform IO factories." << std::endl
-            << "  Please visit https://www.itk.org/Wiki/ITK/FAQ#NoFactoryException to diagnose the problem."
+            << "  Please visit "
+               "https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK/FAQ#NoFactoryException to diagnose "
+               "the problem."
             << std::endl;
       }
 

--- a/Modules/IO/TransformBase/src/itkTransformFileWriterSpecializations.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformFileWriterSpecializations.cxx
@@ -147,7 +147,9 @@ TransformFileWriterTemplate<TParametersValueType>::Update()
       else
       {
         msg << "  There are no registered Transform IO factories." << std::endl
-            << "  Please visit https://www.itk.org/Wiki/ITK/FAQ#NoFactoryException to diagnose the problem."
+            << "  Please visit "
+               "https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK/FAQ#NoFactoryException to diagnose "
+               "the problem."
             << std::endl;
       }
 

--- a/Utilities/Debugger/ITK.natvis
+++ b/Utilities/Debugger/ITK.natvis
@@ -162,6 +162,6 @@
 
   <!-- This file is incomplete.
   You can extend it by adding custom visualizations for more ITK types.
-  If you do, please contribute: https://itk.org/Wiki/ITK/Git/Develop -->
+  If you do, please contribute: https://docs.itk.org/en/latest/contributing/index.html -->
 
 </AutoVisualizer>

--- a/Utilities/Doxygen/DoxygenConfig.cmake
+++ b/Utilities/Doxygen/DoxygenConfig.cmake
@@ -12,9 +12,6 @@ set(DOXYGEN_TAB_SIZE "2")
 set(DOXYGEN_NUM_PROC_THREADS "0")
 set(DOXYGEN_ALIASES
     "starteraliasnotused=@par not used"
-    "wiki=\\par Wiki Examples: ^^ \\li <a href=\\\"https://www.itk.org/Wiki/ITK/Examples\\\">All Media Wiki Examples</a> ^^"
-    "wikiexample{2}= \\li <a href=\\\"https://www.itk.org/Wiki/ITK/Examples/\\1\\\">\\2</a> ^^"
-    "endwiki=^^ ^^ ^^"
     "sphinx=\\par ITK Sphinx Examples: ^^ \\li <a href=\\\"https://itk.org/ITKExamples\\\">All ITK Sphinx Examples</a> ^^"
     "sphinxexample{2}=\\li <a href=\\\"https://itk.org/ITKExamples/src/\\1/Documentation.html\\\">\\2</a> ^^"
     "endsphinx=^^ ^^ ^^"

--- a/Utilities/Maintenance/UpdateCopyrightStatementsInITK.py
+++ b/Utilities/Maintenance/UpdateCopyrightStatementsInITK.py
@@ -28,7 +28,7 @@ import re
 import sys
 import os
 
-## New license as specified on: https://itk.org/Wiki/ITK_Release_4/Licensing
+## New license as specified on: https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK_Release_4/Licensing
 NewITKCopyrightNotice = """/*=========================================================================
  *
  *  Copyright NumFOCUS


### PR DESCRIPTION
The ITK MediaWiki instance is no longer available. Update links to point
to an archive hosted on GitHub Pages.
