### PR TITLE
Replace `TInputImage::SizeValueType` with `itk::SizeValueType`

### DIFF
--- a/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
@@ -180,11 +180,11 @@ BSplineDecompositionImageFilter<TInputImage, TOutputImage>::SetInitialCausalCoef
   // See Unser, 1999, Box 2 for explanation
 
   // Yhis initialization corresponds to mirror boundaries
-  typename TInputImage::SizeValueType horizon = m_DataLength[m_IteratorDirection];
-  double                              zn = z;
+  SizeValueType horizon = m_DataLength[m_IteratorDirection];
+  double        zn = z;
   if (m_Tolerance > 0.0)
   {
-    horizon = (typename TInputImage::SizeValueType)std::ceil(std::log(m_Tolerance) / std::log(itk::Math::abs(z)));
+    horizon = (SizeValueType)std::ceil(std::log(m_Tolerance) / std::log(itk::Math::abs(z)));
   }
   if (horizon < m_DataLength[m_IteratorDirection])
   {

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.h
@@ -104,7 +104,7 @@ public:
   using InputImagePixelType = typename TInputImage::PixelType;
   using OutputImagePixelType = typename TOutputImage::PixelType;
   using IndexType = typename TInputImage::IndexType;
-  using SizeValueType = typename TInputImage::SizeValueType;
+  using SizeValueType = itk::SizeValueType;
 
   /** The default boundary condition is used unless overridden
    *in the Evaluate() method. */

--- a/Modules/Filtering/ImageFilterBase/include/itkBoxImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkBoxImageFilter.h
@@ -70,7 +70,7 @@ public:
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
   /** n-dimensional Kernel radius. */
   using RadiusType = typename TInputImage::SizeType;
-  using RadiusValueType = typename TInputImage::SizeValueType;
+  using RadiusValueType = SizeValueType;
 
   virtual void
   SetRadius(const RadiusType & radius);

--- a/Modules/Filtering/ImageGrid/include/itkBSplineCenteredResampleImageFilterBase.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineCenteredResampleImageFilterBase.h
@@ -98,7 +98,7 @@ protected:
 
 private:
   using IndexValueType = typename TInputImage::IndexValueType;
-  using SizeValueType = typename TInputImage::SizeValueType;
+  using SizeValueType = itk::SizeValueType;
 
   // implemented
 };

--- a/Modules/Filtering/ImageGrid/include/itkPadImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkPadImageFilter.h
@@ -73,7 +73,7 @@ public:
   using OutputImageSizeType = typename TOutputImage::SizeType;
   using InputImageSizeType = typename TInputImage::SizeType;
   using SizeType = typename TInputImage::SizeType;
-  using SizeValueType = typename TInputImage::SizeValueType;
+  using SizeValueType = itk::SizeValueType;
 
   /** Typedef to describe the boundary condition. */
   using BoundaryConditionType = ImageBoundaryCondition<TInputImage, TOutputImage>;

--- a/Modules/Filtering/ImageGrid/include/itkPadImageFilterBase.h
+++ b/Modules/Filtering/ImageGrid/include/itkPadImageFilterBase.h
@@ -73,7 +73,7 @@ public:
   using OutputImageSizeType = typename TOutputImage::SizeType;
   using InputImageSizeType = typename TInputImage::SizeType;
   using SizeType = typename TInputImage::SizeType;
-  using SizeValueType = typename TInputImage::SizeValueType;
+  using SizeValueType = itk::SizeValueType;
 
   /** Typedef to describe the boundary condition. */
   using BoundaryConditionType = ImageBoundaryCondition<TInputImage, TOutputImage>;

--- a/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
@@ -158,8 +158,8 @@ AccumulateImageFilter<TInputImage, TOutputImage>::GenerateData()
   typename TInputImage::SizeType  AccumulatedSize = inputImage->GetLargestPossibleRegion().GetSize();
   typename TInputImage::IndexType AccumulatedIndex = inputImage->GetLargestPossibleRegion().GetIndex();
 
-  const typename TInputImage::SizeValueType SizeAccumulateDimension = AccumulatedSize[m_AccumulateDimension];
-  const auto sizeAccumulateDimensionDouble = static_cast<double>(SizeAccumulateDimension);
+  const SizeValueType SizeAccumulateDimension = AccumulatedSize[m_AccumulateDimension];
+  const auto          sizeAccumulateDimensionDouble = static_cast<double>(SizeAccumulateDimension);
   const typename TInputImage::IndexValueType IndexAccumulateDimension = AccumulatedIndex[m_AccumulateDimension];
   for (unsigned int i = 0; i < InputImageDimension; ++i)
   {

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.h
@@ -90,7 +90,7 @@ public:
    */
   using OutputPixelType = typename TOutputImage::PixelType;
   using InputPixelType = typename TInputImage::PixelType;
-  using SizeValueType = typename TInputImage::SizeValueType;
+  using SizeValueType = itk::SizeValueType;
   using OffsetValueType = typename TInputImage::OffsetValueType;
   static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;


### PR DESCRIPTION
- Replaced `using SizeValueType = typename TInputImage::SizeValueType` with `using SizeValueType = itk::SizeValueType`.

- Replaced `typename TInputImage::SizeValueType` with `SizeValueType`.

In practice, `TInputImage::SizeValueType` is always just an alias of `itk::SizeValueType` anyway.

---

Clarification: The image types of ITK are derived from `itk::ImageBase<VImageDimension>`, which defines `itk::ImageBase::SizeValueType = itk::Size<VImageDimension>::SizeValueType`, as follows:

https://github.com/InsightSoftwareConsortium/ITK/blob/0751ace2961d5bc066dbe06fab4ab007ea13efb8/Modules/Core/Common/include/itkImageBase.h#L149-L151

And `itk::Size<VImageDimension>::SizeValueType = itk::SizeValueType`, as defined at https://github.com/InsightSoftwareConsortium/ITK/blob/0751ace2961d5bc066dbe06fab4ab007ea13efb8/Modules/Core/Common/include/itkSize.h#L80

Q.E.D. 🤓 