### PR TITLE
MersenneTwisterRandomVariateGenerator: Simplify `GetNextSeed()`, and other style improvements

### DIFF
--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -262,10 +262,9 @@ MersenneTwisterRandomVariateGenerator::PrintSelf(std::ostream & os, Indent inden
   // Print state vector contents
   os << indent << "State vector: " << m_State << std::endl;
   os << indent;
-  const IntegerType * s = m_State;
-  int                 i = StateVectorLength;
-  for (; i--; os << *s++ << '\t')
+  for (const IntegerType stateValue : m_State)
   {
+    os << stateValue << '\t';
   }
   os << std::endl;
 

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -179,7 +179,7 @@ MersenneTwisterRandomVariateGenerator::Initialize(const IntegerType seed)
   const IntegerType * r = m_State;
 
   *s++ = seed;
-  for (IntegerType i = 1; i < MersenneTwisterRandomVariateGenerator::StateVectorLength; ++i)
+  for (IntegerType i = 1; i < StateVectorLength; ++i)
   {
     *s++ = uint32_t{ (uint32_t{ 1812433253 } * (*r ^ (*r >> 30)) + i) };
     ++r;
@@ -198,11 +198,11 @@ MersenneTwisterRandomVariateGenerator::reload()
   static constexpr unsigned int M = 397;
 
   // get rid of VS warning
-  constexpr auto index = int{ M } - int{ MersenneTwisterRandomVariateGenerator::StateVectorLength };
+  constexpr auto index = int{ M } - int{ StateVectorLength };
 
   IntegerType * p = m_State;
 
-  for (int i = MersenneTwisterRandomVariateGenerator::StateVectorLength - M; i--; ++p)
+  for (int i = StateVectorLength - M; i--; ++p)
   {
     *p = twist(p[M], p[0], p[1]);
   }
@@ -212,7 +212,7 @@ MersenneTwisterRandomVariateGenerator::reload()
   }
   *p = twist(p[index], p[0], m_State[0]);
 
-  m_Left = MersenneTwisterRandomVariateGenerator::StateVectorLength;
+  m_Left = StateVectorLength;
   m_PNext = m_State;
 }
 

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -159,7 +159,7 @@ MersenneTwisterRandomVariateGenerator::IntegerType
 MersenneTwisterRandomVariateGenerator::GetNextSeed()
 {
   itkInitGlobalsMacro(PimplGlobals);
-  IntegerType newSeed = GetInstance()->GetSeed();
+  IntegerType newSeed = GetInstance()->m_Seed;
   {
     newSeed += m_PimplGlobals->m_StaticDiffer++;
   }

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -159,11 +159,7 @@ MersenneTwisterRandomVariateGenerator::IntegerType
 MersenneTwisterRandomVariateGenerator::GetNextSeed()
 {
   itkInitGlobalsMacro(PimplGlobals);
-  IntegerType newSeed = GetInstance()->m_Seed;
-  {
-    newSeed += m_PimplGlobals->m_StaticDiffer++;
-  }
-  return newSeed;
+  return GetInstance()->m_Seed + m_PimplGlobals->m_StaticDiffer++;
 }
 
 void

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -175,8 +175,8 @@ MersenneTwisterRandomVariateGenerator::Initialize(const IntegerType seed)
   // See Knuth TAOCP Vol 2, 3rd Ed, p.106 for multiplier.
   // In previous versions, most significant bits (MSBs) of the seed affect
   // only MSBs of the state array.  Modified 9 Jan 2002 by Makoto Matsumoto.
-  IntegerType * s = m_State;
-  IntegerType * r = m_State;
+  IntegerType *       s = m_State;
+  const IntegerType * r = m_State;
 
   *s++ = seed;
   for (IntegerType i = 1; i < MersenneTwisterRandomVariateGenerator::StateVectorLength; ++i)


### PR DESCRIPTION
Five little style improvements in the implementation of MersenneTwisterRandomVariateGenerator.