### PR TITLE
Add `constexpr` to `if` when comparing dimensions, remove a few unnecessary `static_cast`'s

### DIFF
--- a/Modules/Core/Common/include/itkExtractImageFilter.hxx
+++ b/Modules/Core/Common/include/itkExtractImageFilter.hxx
@@ -130,7 +130,7 @@ ExtractImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   typename OutputImageType::DirectionType outputDirection;
   typename OutputImageType::PointType     outputOrigin{};
 
-  if (static_cast<unsigned int>(OutputImageDimension) > static_cast<unsigned int>(InputImageDimension))
+  if (OutputImageDimension > InputImageDimension)
   {
     // copy the input to the output and fill the rest of the
     // output with zeros.

--- a/Modules/Core/Common/include/itkExtractImageFilter.hxx
+++ b/Modules/Core/Common/include/itkExtractImageFilter.hxx
@@ -183,7 +183,7 @@ ExtractImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   // if, after rebuilding the direction cosines, there's a zero
   // length cosine vector, reset the directions to identity
   // or throw an exception, depending on the collapse strategy.
-  if (static_cast<int>(InputImageDimension) != static_cast<int>(OutputImageDimension))
+  if (InputImageDimension != OutputImageDimension)
   {
     switch (m_DirectionCollapseStrategy)
     {

--- a/Modules/Core/Common/include/itkExtractImageFilter.hxx
+++ b/Modules/Core/Common/include/itkExtractImageFilter.hxx
@@ -130,7 +130,7 @@ ExtractImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   typename OutputImageType::DirectionType outputDirection;
   typename OutputImageType::PointType     outputOrigin{};
 
-  if (OutputImageDimension > InputImageDimension)
+  if constexpr (OutputImageDimension > InputImageDimension)
   {
     // copy the input to the output and fill the rest of the
     // output with zeros.
@@ -183,7 +183,7 @@ ExtractImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   // if, after rebuilding the direction cosines, there's a zero
   // length cosine vector, reset the directions to identity
   // or throw an exception, depending on the collapse strategy.
-  if (InputImageDimension != OutputImageDimension)
+  if constexpr (InputImageDimension != OutputImageDimension)
   {
     switch (m_DirectionCollapseStrategy)
     {

--- a/Modules/Core/Common/include/itkInPlaceImageFilter.hxx
+++ b/Modules/Core/Common/include/itkInPlaceImageFilter.hxx
@@ -57,10 +57,9 @@ InPlaceImageFilter<TInputImage, TOutputImage>::InternalAllocateOutputs()
   // additionally the buffered and requested regions of the input and
   // output must match.
   bool rMatch = true;
-  if (inputPtr != nullptr &&
-      static_cast<unsigned int>(InputImageDimension) == static_cast<unsigned int>(OutputImageDimension))
+  if (inputPtr != nullptr && InputImageDimension == OutputImageDimension)
   {
-    for (unsigned int i = 0; i < static_cast<unsigned int>(InputImageDimension); ++i)
+    for (unsigned int i = 0; i < InputImageDimension; ++i)
     {
       if (inputPtr->GetBufferedRegion().GetIndex(i) != outputPtr->GetRequestedRegion().GetIndex(i))
       {

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshLineCell.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshLineCell.hxx
@@ -274,7 +274,7 @@ template <typename TCellInterface>
 unsigned int
 QuadEdgeMeshLineCell<TCellInterface>::GetDimension() const
 {
-  return static_cast<unsigned int>(Self::CellDimension);
+  return CellDimension;
 }
 
 // ---------------------------------------------------------------------

--- a/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
@@ -142,7 +142,7 @@ ExtractSliceImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   typename OutputImageType::DirectionType outputDirection;
   typename OutputImageType::PointType     outputOrigin{};
 
-  if (OutputImageDimension > InputImageDimension)
+  if constexpr (OutputImageDimension > InputImageDimension)
   {
     // copy the input to the output and fill the rest of the
     // output with zeros.

--- a/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
@@ -142,7 +142,7 @@ ExtractSliceImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   typename OutputImageType::DirectionType outputDirection;
   typename OutputImageType::PointType     outputOrigin{};
 
-  if (static_cast<unsigned int>(OutputImageDimension) > static_cast<unsigned int>(InputImageDimension))
+  if (OutputImageDimension > InputImageDimension)
   {
     // copy the input to the output and fill the rest of the
     // output with zeros.

--- a/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
+++ b/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
@@ -95,7 +95,7 @@ JoinSeriesImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   this->CallCopyInputRegionToOutputRegion(outputLargestPossibleRegion, inputPtr->GetLargestPossibleRegion());
 
   // for the new dimension, assuming the index has been set 0.
-  outputLargestPossibleRegion.SetSize(static_cast<unsigned int>(InputImageDimension),
+  outputLargestPossibleRegion.SetSize(InputImageDimension,
                                       static_cast<SizeValueType>(this->GetNumberOfIndexedInputs()));
 
   outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);

--- a/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.hxx
@@ -69,7 +69,7 @@ ProjectionImageFilter<TInputImage, TOutputImage, TAccumulator>::GenerateOutputIn
   // Set the LargestPossibleRegion of the output.
   // Reduce the size of the accumulated dimension.
 
-  if (InputImageDimension == OutputImageDimension)
+  if constexpr (InputImageDimension == OutputImageDimension)
   {
     for (unsigned int i = 0; i < InputImageDimension; ++i)
     {
@@ -156,7 +156,7 @@ ProjectionImageFilter<TInputImage, TOutputImage, TAccumulator>::GenerateInputReq
     inputLargSize = this->GetInput()->GetLargestPossibleRegion().GetSize();
     inputLargIndex = this->GetInput()->GetLargestPossibleRegion().GetIndex();
 
-    if (InputImageDimension == OutputImageDimension)
+    if constexpr (InputImageDimension == OutputImageDimension)
     {
       for (unsigned int i = 0; i < TInputImage::ImageDimension; ++i)
       {
@@ -235,7 +235,7 @@ ProjectionImageFilter<TInputImage, TOutputImage, TAccumulator>::DynamicThreadedG
   typename TInputImage::SizeType   inputSizeForThread = inputSize;
   typename TInputImage::IndexType  inputIndexForThread = inputIndex;
 
-  if (InputImageDimension == OutputImageDimension)
+  if constexpr (InputImageDimension == OutputImageDimension)
   {
     for (unsigned int i = 0; i < InputImageDimension; ++i)
     {
@@ -298,7 +298,7 @@ ProjectionImageFilter<TInputImage, TOutputImage, TAccumulator>::DynamicThreadedG
     typename TOutputImage::IndexType oIdx;
     typename TInputImage::IndexType  iIdx = iIt.GetIndex();
 
-    if (InputImageDimension == OutputImageDimension)
+    if constexpr (InputImageDimension == OutputImageDimension)
     {
       for (unsigned int i = 0; i < InputImageDimension; ++i)
       {

--- a/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.hxx
@@ -69,7 +69,7 @@ ProjectionImageFilter<TInputImage, TOutputImage, TAccumulator>::GenerateOutputIn
   // Set the LargestPossibleRegion of the output.
   // Reduce the size of the accumulated dimension.
 
-  if (static_cast<unsigned int>(InputImageDimension) == static_cast<unsigned int>(OutputImageDimension))
+  if (InputImageDimension == OutputImageDimension)
   {
     for (unsigned int i = 0; i < InputImageDimension; ++i)
     {
@@ -156,7 +156,7 @@ ProjectionImageFilter<TInputImage, TOutputImage, TAccumulator>::GenerateInputReq
     inputLargSize = this->GetInput()->GetLargestPossibleRegion().GetSize();
     inputLargIndex = this->GetInput()->GetLargestPossibleRegion().GetIndex();
 
-    if (static_cast<unsigned int>(InputImageDimension) == static_cast<unsigned int>(OutputImageDimension))
+    if (InputImageDimension == OutputImageDimension)
     {
       for (unsigned int i = 0; i < TInputImage::ImageDimension; ++i)
       {
@@ -235,7 +235,7 @@ ProjectionImageFilter<TInputImage, TOutputImage, TAccumulator>::DynamicThreadedG
   typename TInputImage::SizeType   inputSizeForThread = inputSize;
   typename TInputImage::IndexType  inputIndexForThread = inputIndex;
 
-  if (static_cast<unsigned int>(InputImageDimension) == static_cast<unsigned int>(OutputImageDimension))
+  if (InputImageDimension == OutputImageDimension)
   {
     for (unsigned int i = 0; i < InputImageDimension; ++i)
     {
@@ -298,7 +298,7 @@ ProjectionImageFilter<TInputImage, TOutputImage, TAccumulator>::DynamicThreadedG
     typename TOutputImage::IndexType oIdx;
     typename TInputImage::IndexType  iIdx = iIt.GetIndex();
 
-    if (static_cast<unsigned int>(InputImageDimension) == static_cast<unsigned int>(OutputImageDimension))
+    if (InputImageDimension == OutputImageDimension)
     {
       for (unsigned int i = 0; i < InputImageDimension; ++i)
       {

--- a/Modules/Numerics/Statistics/include/itkHistogramToImageFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogramToImageFilter.hxx
@@ -83,8 +83,7 @@ HistogramToImageFilter<THistogram, TImage, TFunction>::GenerateOutputInformation
   SpacingType spacing;
   // Set the image size to the number of bins along each dimension.
   // TODO: is it possible to have a size 0 on one of the dimension? if yes, the size must be checked
-  const unsigned int minDim =
-    std::min(static_cast<unsigned int>(ImageDimension), inputHistogram->GetMeasurementVectorSize());
+  const unsigned int minDim = std::min(ImageDimension, inputHistogram->GetMeasurementVectorSize());
   for (unsigned int i = 0; i < minDim; ++i)
   {
     size[i] = inputHistogram->GetSize(i);

--- a/Modules/Segmentation/Classifiers/include/itkImageGaussianModelEstimator.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageGaussianModelEstimator.hxx
@@ -244,7 +244,7 @@ ImageGaussianModelEstimator<TInputImage, TMembershipFunction, TTrainingImage>::E
     if (m_NumberOfSamples[classIndex][0] > 0)
     {
       auto lastInX = static_cast<unsigned int>(VectorDimension - 1);
-      auto upperY = static_cast<unsigned int>(VectorDimension);
+      auto upperY = VectorDimension;
       for (unsigned int band_x = 0; band_x < lastInX; ++band_x)
       {
         for (unsigned int band_y = band_x + 1; band_y < upperY; ++band_y)

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -475,7 +475,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::InitializeAct
     shiftedIt.SetLocation(activeIt->m_Index);
 
     ValueType length = m_ValueZero;
-    for (unsigned int i = 0; i < static_cast<unsigned int>(ImageDimension); ++i)
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       const auto stride = shiftedIt.GetStride(i);
 
@@ -1261,7 +1261,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedCalcu
       ValueType norm_grad_phi_squared = 0.0;
 
       typename FiniteDifferenceFunctionType::FloatOffsetType offset;
-      for (unsigned int i = 0; i < static_cast<unsigned int>(ImageDimension); ++i)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         const ValueType forwardValue = outputIt.GetPixel(center + m_NeighborList.GetStride(i));
         const ValueType backwardValue = outputIt.GetPixel(center - m_NeighborList.GetStride(i));
@@ -1301,7 +1301,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedCalcu
         norm_grad_phi_squared += offset[i] * offset[i];
       }
 
-      for (unsigned int i = 0; i < static_cast<unsigned int>(ImageDimension); ++i)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         offset[i] = (offset[i] * outputIt.GetCenterPixel()) / (norm_grad_phi_squared + MIN_NORM);
       }

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
@@ -25,7 +25,7 @@ template <typename TInputImage, typename TClassifiedImage>
 MRFImageFilter<TInputImage, TClassifiedImage>::MRFImageFilter()
   : m_ClassifierPtr(nullptr)
 {
-  if (static_cast<int>(InputImageDimension) != static_cast<int>(ClassifiedImageDimension))
+  if (InputImageDimension != ClassifiedImageDimension)
   {
     std::ostringstream msg;
     msg << "Input image dimension: " << InputImageDimension

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
@@ -25,7 +25,7 @@ template <typename TInputImage, typename TClassifiedImage>
 MRFImageFilter<TInputImage, TClassifiedImage>::MRFImageFilter()
   : m_ClassifierPtr(nullptr)
 {
-  if (InputImageDimension != ClassifiedImageDimension)
+  if constexpr (InputImageDimension != ClassifiedImageDimension)
   {
     std::ostringstream msg;
     msg << "Input image dimension: " << InputImageDimension


### PR DESCRIPTION
A few style commits, using the fact that dimensions are defined as `constexpr unsigned int`.