### PR TITLE
STYLE: Replace `static_cast<T>(Dimension)` with `T{ Dimension }`

### DIFF
--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
@@ -185,7 +185,7 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::ComputeInternalIndex(cons
 {
   OffsetType ans;
   auto       r = static_cast<unsigned long>(n);
-  for (long i = static_cast<long>(Dimension) - 1; i >= 0; --i)
+  for (long i = long{ Dimension } - 1; i >= 0; --i)
   {
     ans[i] = static_cast<OffsetValueType>(r / this->GetStride(i));
     r = r % this->GetStride(i);

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
@@ -108,7 +108,7 @@ ConstNeighborhoodIteratorWithOnlyIndex<TImage>::ComputeInternalIndex(NeighborInd
 {
   OffsetType ans;
   auto       r = static_cast<unsigned long>(n);
-  for (long i = static_cast<long>(Dimension) - 1; i >= 0; --i)
+  for (long i = long{ Dimension } - 1; i >= 0; --i)
   {
     ans[i] = static_cast<OffsetValueType>(r / this->GetStride(i));
     r = r % this->GetStride(i);

--- a/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.hxx
@@ -29,7 +29,7 @@ FiniteCylinderSpatialFunction<VDimension, TInput>::FiniteCylinderSpatialFunction
 {
   // a normalized {1,1,...1} vector is
   // { 1.0 / sqrt( VDim ), ... }
-  const double orientationVal = 1.0 / std::sqrt(static_cast<double>(VDimension));
+  const double orientationVal = 1.0 / std::sqrt(double{ VDimension });
   m_Orientation.Fill(orientationVal);
   m_NormalizedOrientation.Fill(orientationVal);
   m_AxisLength = 1.0f; // Length of cylinder axis.

--- a/Modules/Core/Common/include/itkImportImageFilter.hxx
+++ b/Modules/Core/Common/include/itkImportImageFilter.hxx
@@ -38,14 +38,14 @@ ImportImageFilter<TPixel, VImageDimension>::PrintSelf(std::ostream & os, Indent 
   itkPrintSelfObjectMacro(ImportImageContainer);
   os << indent << "Import buffer size: " << m_Size << std::endl;
   os << indent << "Spacing: [";
-  for (i = 0; i < static_cast<int>(VImageDimension) - 1; ++i)
+  for (i = 0; i < int{ VImageDimension } - 1; ++i)
   {
     os << m_Spacing[i] << ", ";
   }
   os << m_Spacing[i] << ']' << std::endl;
 
   os << indent << "Origin: [";
-  for (i = 0; i < static_cast<int>(VImageDimension) - 1; ++i)
+  for (i = 0; i < int{ VImageDimension } - 1; ++i)
   {
     os << m_Origin[i] << ", ";
   }

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
@@ -422,11 +422,11 @@ BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::Gene
     int           pp = p;
     unsigned long indexFactor[ImageDimension];
     indexFactor[0] = 1;
-    for (int j = 1; j < static_cast<int>(ImageDimension); ++j)
+    for (int j = 1; j < int{ ImageDimension }; ++j)
     {
       indexFactor[j] = indexFactor[j - 1] * (m_SplineOrder + 1);
     }
-    for (int j = (static_cast<int>(ImageDimension) - 1); j >= 0; j--)
+    for (int j = (int{ ImageDimension } - 1); j >= 0; j--)
     {
       m_PointsToIndex[p][j] = pp / indexFactor[j];
       pp = pp % indexFactor[j];

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
@@ -171,7 +171,7 @@ bool
 ObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::IsObjectPixelOnBoundary(
   const InputNeighborhoodIteratorType & iNIter)
 {
-  static const auto s = static_cast<unsigned int>(std::pow(3.0, static_cast<double>(ImageDimension)));
+  static const auto s = static_cast<unsigned int>(std::pow(3.0, double{ ImageDimension }));
 
   PixelType    tf;
   unsigned int i;

--- a/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
@@ -194,10 +194,10 @@ SignedMaurerDistanceMapImageFilter<TInputImage, TOutputImage>::ThreadedGenerateD
   // set the progress reporter. Use a pointer to be able to destroy it before
   // the creation of progress2
   // so it won't set wrong progress at the end of ThreadedGenerateData()
-  float progressPerDimension = 0.67f / static_cast<float>(ImageDimension);
+  float progressPerDimension = 0.67f / float{ ImageDimension };
   if (!this->m_SquaredDistance)
   {
-    progressPerDimension = 0.67f / (static_cast<float>(ImageDimension) + 1);
+    progressPerDimension = 0.67f / (float{ ImageDimension } + 1);
   }
   auto progress =
     std::make_unique<ProgressReporter>(this,

--- a/Modules/Filtering/DistanceMap/test/itkContourMeanDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkContourMeanDistanceImageFilterTest.cxx
@@ -105,7 +105,7 @@ itkContourMeanDistanceImageFilterTest(int argc, char * argv[])
     // check results
 
     constexpr FilterType::RealType trueDistance = 8.07158;
-    // std::sqrt( static_cast<double>(ImageDimension) );
+    // std::sqrt( double{ ImageDimension } );
     const FilterType::RealType distance = filter->GetMeanDistance();
 
     std::cout << " True     distance: " << trueDistance << std::endl;

--- a/Modules/Filtering/DistanceMap/test/itkDirectedHausdorffDistanceImageFilterTest1.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkDirectedHausdorffDistanceImageFilterTest1.cxx
@@ -92,7 +92,7 @@ itkDirectedHausdorffDistanceImageFilterTest1(int, char *[])
     filter->Update();
 
     // Check results
-    const FilterType::RealType trueDistance = 10 * std::sqrt(static_cast<double>(ImageDimension));
+    const FilterType::RealType trueDistance = 10 * std::sqrt(double{ ImageDimension });
     const FilterType::RealType distance = filter->GetDirectedHausdorffDistance();
 
     std::cout << " True distance: " << trueDistance << std::endl;
@@ -122,7 +122,7 @@ itkDirectedHausdorffDistanceImageFilterTest1(int, char *[])
     filter->Update();
 
     // Check results
-    const FilterType::RealType trueDistance = 5 * std::sqrt(static_cast<double>(ImageDimension));
+    const FilterType::RealType trueDistance = 5 * std::sqrt(double{ ImageDimension });
     const FilterType::RealType distance = filter->GetDirectedHausdorffDistance();
 
     std::cout << " True distance: " << trueDistance << std::endl;

--- a/Modules/Filtering/DistanceMap/test/itkHausdorffDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkHausdorffDistanceImageFilterTest.cxx
@@ -100,7 +100,7 @@ itkHausdorffDistanceImageFilterTest(int argc, char * argv[])
     filter->Update();
 
     // Check results
-    const FilterType::RealType trueDistance = 10 * std::sqrt(static_cast<double>(ImageDimension));
+    const FilterType::RealType trueDistance = 10 * std::sqrt(double{ ImageDimension });
     const FilterType::RealType distance = filter->GetHausdorffDistance();
 
     std::cout << " True distance: " << trueDistance << std::endl;
@@ -129,7 +129,7 @@ itkHausdorffDistanceImageFilterTest(int argc, char * argv[])
     filter->Update();
 
     // Check results
-    const FilterType::RealType trueDistance = 10 * std::sqrt(static_cast<double>(ImageDimension));
+    const FilterType::RealType trueDistance = 10 * std::sqrt(double{ ImageDimension });
     const FilterType::RealType distance = filter->GetHausdorffDistance();
 
     std::cout << " True distance: " << trueDistance << std::endl;

--- a/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
@@ -280,7 +280,7 @@ HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
       // Deal with the 2D case.
       if (numberOfSmoothingFilters > 0)
       {
-        const int                   temp_dim = static_cast<int>(ImageDimension) - 3;
+        const int                   temp_dim = int{ ImageDimension } - 3;
         const GaussianFilterPointer lastFilter = m_SmoothingFilters[temp_dim];
         lastFilter->UpdateLargestPossibleRegion();
         derivativeImage = lastFilter->GetOutput();

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
@@ -271,7 +271,7 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
   // manually release memory in last filter in the mini-pipeline
   if constexpr (ImageDimension > 1)
   {
-    const int temp_dim = static_cast<int>(ImageDimension) - 2;
+    const int temp_dim = int{ ImageDimension } - 2;
     m_SmoothingFilters[temp_dim]->GetOutput()->ReleaseData();
   }
   else

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -534,7 +534,7 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ComputePerimeter(LabelObjectType * lab
   // a data structure to store the number of intercepts on each direction
   using MapInterceptType = typename std::map<OffsetType, SizeValueType, Functor::LexicographicCompare>;
   MapInterceptType intercepts;
-  // int nbOfDirections = static_cast<int>(std::pow(2.0, static_cast<int>(ImageDimension))) - 1;
+  // int nbOfDirections = static_cast<int>(std::pow(2.0, int{ ImageDimension })) - 1;
   // intercepts.resize(nbOfDirections + 1);  // code begins at position 1
 
   // now iterate over the vectors of lines

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
@@ -909,7 +909,7 @@ FlatStructuringElement<VDimension>::Cross(RadiusType radius)
   {
     *kernel_it = false;
   }
-  for (int d = 0; d < static_cast<int>(VDimension); ++d)
+  for (int d = 0; d < int{ VDimension }; ++d)
   {
     OffsetType o{};
     for (int i = -static_cast<int>(radius[d]); i <= static_cast<int>(radius[d]); ++i)
@@ -938,7 +938,7 @@ FlatStructuringElement<VDimension>::Ball(RadiusType radius, bool radiusIsParamet
   //
   auto       sourceImage = ImageType::New();
   RadiusType size = radius;
-  for (i = 0; i < static_cast<int>(VDimension); ++i)
+  for (i = 0; i < int{ VDimension }; ++i)
   {
     size[i] = 2 * size[i] + 1;
   }
@@ -1205,7 +1205,7 @@ FlatStructuringElement<VDimension>::ComputeBufferFromLines()
   //
   auto       sourceImage = ImageType::New();
   RadiusType size = this->GetRadius();
-  for (int i = 0; i < static_cast<int>(VDimension); ++i)
+  for (int i = 0; i < int{ VDimension }; ++i)
   {
     size[i] = 2 * size[i] + 1;
   }
@@ -1227,7 +1227,7 @@ FlatStructuringElement<VDimension>::ComputeBufferFromLines()
 
   // set the center pixel to 1
   typename ImageType::IndexType center;
-  for (int i = 0; i < static_cast<int>(VDimension); ++i)
+  for (int i = 0; i < int{ VDimension }; ++i)
   {
     center[i] = this->GetRadius()[i];
   }

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
@@ -269,7 +269,7 @@ TestImageOfSymMats(const std::string & fname)
   //      direction matrix.
   const typename DtiImageType::DirectionType myDirection = PreFillDirection<VDimension>();
 
-  std::cout << " === Testing DtiImageType:  Image Dimension " << static_cast<int>(VDimension) << std::endl
+  std::cout << " === Testing DtiImageType:  Image Dimension " << int{ VDimension } << std::endl
             << "======================== Initialized Direction" << std::endl
             << myDirection << std::endl;
 

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
@@ -65,8 +65,7 @@ TestImageOfVectors(const std::string & fname, const std::string & intentCode = "
   //      direction matrix.
   const typename VectorImageType::DirectionType myDirection = PreFillDirection<TDimension>();
 
-  std::cout << " === Testing VectorLength: " << TVecLength << " Image Dimension " << static_cast<int>(TDimension)
-            << std::endl;
+  std::cout << " === Testing VectorLength: " << TVecLength << " Image Dimension " << int{ TDimension } << std::endl;
   std::cout << "======================== Initialized Direction" << std::endl;
   std::cout << myDirection << std::endl;
 

--- a/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.hxx
@@ -245,7 +245,7 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateO
     requestedSize = requestedRegion.GetSize();
     requestedIndex = requestedRegion.GetIndex();
 
-    for (int idim = 0; idim < static_cast<int>(ImageDimension); ++idim)
+    for (int idim = 0; idim < int{ ImageDimension }; ++idim)
     {
       factors[idim] = this->GetSchedule()[ilevel - 1][idim] / this->GetSchedule()[ilevel][idim];
 
@@ -282,7 +282,7 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateO
     requestedSize = requestedRegion.GetSize();
     requestedIndex = requestedRegion.GetIndex();
 
-    for (int idim = 0; idim < static_cast<int>(ImageDimension); ++idim)
+    for (int idim = 0; idim < int{ ImageDimension }; ++idim)
     {
       factors[idim] = this->GetSchedule()[ilevel][idim] / this->GetSchedule()[ilevel + 1][idim];
 

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
@@ -159,7 +159,7 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::In
   {
     m_Normalizer += fixedImageSpacing[k] * fixedImageSpacing[k];
   }
-  m_Normalizer /= static_cast<double>(ImageDimension);
+  m_Normalizer /= double{ ImageDimension };
 
   // setup gradient calculator
   m_FixedImageGradientCalculator->SetInputImage(this->GetFixedImage());

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.hxx
@@ -124,7 +124,7 @@ DemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Initi
   {
     m_Normalizer += fixedImageSpacing[k] * fixedImageSpacing[k];
   }
-  m_Normalizer /= static_cast<double>(ImageDimension);
+  m_Normalizer /= double{ ImageDimension };
 
   // setup gradient calculator
   m_FixedImageGradientCalculator->SetInputImage(this->GetFixedImage());

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
@@ -132,7 +132,7 @@ ESMDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::In
     {
       m_Normalizer += m_FixedImageSpacing[k] * m_FixedImageSpacing[k];
     }
-    m_Normalizer *= m_MaximumUpdateStepLength * m_MaximumUpdateStepLength / static_cast<double>(ImageDimension);
+    m_Normalizer *= m_MaximumUpdateStepLength * m_MaximumUpdateStepLength / double{ ImageDimension };
   }
   else
   {

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.hxx
@@ -121,7 +121,7 @@ FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDispla
   {
     m_Normalizer += fixedImageSpacing[k] * fixedImageSpacing[k];
   }
-  m_Normalizer /= static_cast<double>(ImageDimension);
+  m_Normalizer /= double{ ImageDimension };
 
   // setup gradient calculator
   m_FixedImageGradientCalculator->SetInputImage(this->GetFixedImage());

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
@@ -116,7 +116,7 @@ SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplaceme
   {
     m_Normalizer += m_FixedImageSpacing[k] * m_FixedImageSpacing[k];
   }
-  m_Normalizer /= static_cast<double>(ImageDimension);
+  m_Normalizer /= double{ ImageDimension };
 
   // setup gradient calculator
   m_FixedImageGradientCalculator->SetInputImage(this->GetFixedImage());

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -58,7 +58,7 @@ ParallelSparseFieldCityBlockNeighborList<TNeighborhoodType>::ParallelSparseField
       m_ArrayIndex.push_back(nCenter - it.GetStride(d));
       m_NeighborhoodOffset[i][d] = -1;
     }
-    for (int d = 0; d < static_cast<int>(Dimension); ++d, ++i)
+    for (int d = 0; d < int{ Dimension }; ++d, ++i)
     {
       m_ArrayIndex.push_back(nCenter + it.GetStride(d));
       m_NeighborhoodOffset[i][d] = 1;

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
@@ -44,7 +44,7 @@ SparseFieldFourthOrderLevelSetImageFilter<TInputImage, TOutputImage>::SparseFiel
   m_MaxRefitIteration = 100;
   m_MaxNormalIteration = 25;
   m_RMSChangeNormalProcessTrigger = ValueType{};
-  m_CurvatureBandWidth = static_cast<ValueType>(ImageDimension) + 0.5;
+  m_CurvatureBandWidth = ValueType{ ImageDimension } + 0.5;
   m_NormalProcessType = 0;
   m_NormalProcessConductance = ValueType{};
   m_NormalProcessUnsharpFlag = false;
@@ -203,7 +203,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 SparseFieldFourthOrderLevelSetImageFilter<TInputImage, TOutputImage>::ProcessNormals()
 {
-  auto temp = static_cast<ValueType>(ImageDimension);
+  auto temp = ValueType{ ImageDimension };
 
   const typename NormalVectorFilterType::Pointer   NormalVectorFilter = NormalVectorFilterType::New();
   const typename NormalVectorFunctionType::Pointer NormalVectorFunction = NormalVectorFunctionType::New();

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -54,7 +54,7 @@ SparseFieldCityBlockNeighborList<TNeighborhoodType>::SparseFieldCityBlockNeighbo
       m_ArrayIndex.push_back(nCenter - it.GetStride(d));
       m_NeighborhoodOffset[i][d] = -1;
     }
-    for (int d = 0; d < static_cast<int>(Dimension); ++d, ++i)
+    for (int d = 0; d < int{ Dimension }; ++d, ++i)
     {
       m_ArrayIndex.push_back(nCenter + it.GetStride(d));
       m_NeighborhoodOffset[i][d] = 1;

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
@@ -645,7 +645,7 @@ Segmenter<TInputImage>::GenerateConnectivity()
     m_Connectivity.direction[i][d] = -1;
     ++i;
   }
-  for (int d = 0; d < static_cast<int>(ImageDimension); ++d)
+  for (int d = 0; d < int{ ImageDimension }; ++d)
   {
     const unsigned int stride = it.GetStride(d);
     m_Connectivity.index[i] = nCenter + stride;


### PR DESCRIPTION
Replaced `static_cast<(\w+)>\(([A-Za-z]*Dimension)\)` with `$1{ $2 }`, using regular expressions.

Excluded [`static_cast<double>(SizeAccumulateDimension)`](https://github.com/InsightSoftwareConsortium/ITK/blob/3c574f611d983e3c1f763d630a48a30c87940cd9/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx#L162), as it is not a compile-time constant expression.

Following C++ Core Guidelines, ["Avoid casts"](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es48-avoid-casts)

----

Unlike `static_cast<T>(Dimension)`, `T{ Dimension }` checks at compile-time that the dimension can be converted losslessly, for example: https://godbolt.org/z/Eoc9fhnnz

```cpp
    static constexpr unsigned int SmallDimension{ 2 };
    static constexpr unsigned int LargeDimension{ UINT_MAX };

    return static_cast<int>(SmallDimension); // OK
    return static_cast<int>(LargeDimension); // overflow, but no error!
    return int{ SmallDimension }; // OK, this conversion is safe.
    return int{ LargeDimension }; // Compile error!

```