### PR TITLE
Allow initializing MersenneTwisterRandomVariateGenerator without mutex locking 

### DIFF
--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -330,6 +330,10 @@ private:
     return hash(time(nullptr), clock());
   }
 
+  /** Internal method to initialize a generator object without mutex locking. */
+  void
+  InitializeWithoutMutexLocking(const IntegerType seed);
+
   // Internal state
   IntegerType m_State[StateVectorLength];
 

--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -275,8 +275,7 @@ public:
   void
   SetSeed()
   {
-    // use time() and clock() to generate a unlikely-to-repeat seed.
-    SetSeed(hash(time(nullptr), clock()));
+    SetSeed(Self::CreateRandomSeed());
   }
   /** @ITKEndGrouping */
   /** Return the current seed
@@ -323,6 +322,13 @@ private:
   /** Internal method to actually create a new object. */
   static Pointer
   CreateInstance();
+
+  /** Uses time() and clock() to generate a unlikely-to-repeat seed. */
+  static IntegerType
+  CreateRandomSeed()
+  {
+    return hash(time(nullptr), clock());
+  }
 
   // Internal state
   IntegerType m_State[StateVectorLength];

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -34,8 +34,8 @@ hiBit(const IntegerType u)
 {
   return u & 0x80000000;
 }
-IntegerType
 
+IntegerType
 loBit(const IntegerType u)
 {
   return u & 0x00000001;

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -98,7 +98,7 @@ MersenneTwisterRandomVariateGenerator::New()
 {
   MersenneTwisterRandomVariateGenerator::Pointer obj = MersenneTwisterRandomVariateGenerator::CreateInstance();
 
-  obj->SetSeed(MersenneTwisterRandomVariateGenerator::GetNextSeed());
+  obj->InitializeWithoutMutexLocking(MersenneTwisterRandomVariateGenerator::GetNextSeed());
   return obj;
 }
 
@@ -111,7 +111,7 @@ MersenneTwisterRandomVariateGenerator::GetInstance()
   if (!m_PimplGlobals->m_StaticInstance)
   {
     m_PimplGlobals->m_StaticInstance = MersenneTwisterRandomVariateGenerator::CreateInstance();
-    m_PimplGlobals->m_StaticInstance->SetSeed();
+    m_PimplGlobals->m_StaticInstance->InitializeWithoutMutexLocking(Self::CreateRandomSeed());
   }
 
   return m_PimplGlobals->m_StaticInstance;
@@ -126,7 +126,10 @@ MersenneTwisterRandomVariateGenerator::ResetNextSeed()
 }
 
 
-MersenneTwisterRandomVariateGenerator::MersenneTwisterRandomVariateGenerator() { SetSeed(121212); }
+MersenneTwisterRandomVariateGenerator::MersenneTwisterRandomVariateGenerator()
+{
+  this->InitializeWithoutMutexLocking(121212);
+}
 
 MersenneTwisterRandomVariateGenerator::~MersenneTwisterRandomVariateGenerator() = default;
 
@@ -162,10 +165,18 @@ MersenneTwisterRandomVariateGenerator::GetNextSeed()
   return GetInstance()->m_Seed + m_PimplGlobals->m_StaticDiffer++;
 }
 
+
 void
 MersenneTwisterRandomVariateGenerator::Initialize(const IntegerType seed)
 {
+  // This is a public member function, so it must lock the mutex of the instance.
   const std::lock_guard<std::mutex> lockGuard(m_InstanceMutex);
+  this->InitializeWithoutMutexLocking(seed);
+}
+
+void
+MersenneTwisterRandomVariateGenerator::InitializeWithoutMutexLocking(const IntegerType seed)
+{
   m_Seed = seed;
   // Initialize generator state with seed
   // See Knuth TAOCP Vol 2, 3rd Ed, p.106 for multiplier.


### PR DESCRIPTION
Allowed `New()`, `GetInstance()`, and the default-constructor of `MersenneTwisterRandomVariateGenerator` to initialize a
generator object without locking its `m_InstanceMutex`.

Implemented by adding two private member functions: `InitializeWithoutMutexLocking(IntegerType)` and `CreateRandomSeed()`.