### PR TITLE
STYLE: Increase NIfTI test argument check consistency

### DIFF
--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest12.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest12.cxx
@@ -27,7 +27,7 @@ itkNiftiImageIOTest12(int argc, char * argv[])
   // first argument is passing in the writable directory to do all testing
   if (argc != 3)
   {
-    std::cerr << "Incorrect command line usage:" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
     std::cerr << itkNameOfTestExecutableMacro(argv) << " <TempOutputDirectory> <filename>" << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest13.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest13.cxx
@@ -26,6 +26,8 @@ itkNiftiImageIOTest13(int argc, char * argv[])
 {
   if (argc != 2)
   {
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv) << " inputFileName" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest14.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest14.cxx
@@ -32,6 +32,7 @@ itkNiftiImageIOTest14(int argc, char * argv[])
   // images should have the same size, spacing, and origin, but may have different units
   if (argc != 4)
   {
+    std::cerr << "Missing parameters." << std::endl;
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " output_test_fn ref_image test_image" << std::endl;
     return EXIT_FAILURE;
   }


### PR DESCRIPTION
Increase NIfTI test input argument check consistency:
- Increase consistency in the missing argument check message: follow the ITK SW guide coding guidelines. Specifically, make the error message be consistent.
- Add the test name and input parameters to the error message where missing. Specifically, use the `itkNameOfTestExecutableMacro(argv)` macro call to print the test message.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)