### PR TITLE
ENH: Test the `itk::ScaleTransform::SetIdentity` method

### DIFF
--- a/Modules/Core/Transform/test/itkScaleTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkScaleTransformTest.cxx
@@ -19,6 +19,8 @@
 #include <iostream>
 
 #include "itkScaleTransform.h"
+#include "itkTestingMacros.h"
+
 
 int
 itkScaleTransformTest(int, char *[])
@@ -53,6 +55,17 @@ itkScaleTransformTest(int, char *[])
         break;
       }
     }
+
+    // Set a non-identity value to the transform and then set it to the identity
+    scale = 2.0;
+    identityTransform->SetScale(scale);
+    ITK_TEST_SET_GET_VALUE(scale, identityTransform->GetScale());
+
+    identityTransform->SetIdentity();
+
+    typename TransformType::ScaleType identityScale{ 1.0 };
+    ITK_TEST_SET_GET_VALUE(identityScale, identityTransform->GetScale());
+
     if (!Ok)
     {
       std::cerr << "Identity doesn't have a unit scale " << std::endl;


### PR DESCRIPTION
Test the `itk::ScaleTransform::SetIdentity` method: check that after setting the scale to a non-identity value, the method effectively sets the scale to the identity.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)