### PR TITLE
`BSplineDecompositionImageFilter::SetInitialCausalCoefficient`: Reduced scope of local `horizon` and other style commits

### DIFF
--- a/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
@@ -194,8 +194,8 @@ BSplineDecompositionImageFilter<TInputImage, TOutputImage>::SetInitialCausalCoef
   {
     // Full loop
     const double iz = 1.0 / z;
-    double       z2n = std::pow(z, static_cast<double>(m_DataLength[m_IteratorDirection] - 1L));
-    CoeffType    sum = m_Scratch[0] + z2n * m_Scratch[m_DataLength[m_IteratorDirection] - 1L];
+    double       z2n = std::pow(z, static_cast<double>(m_DataLength[m_IteratorDirection] - 1));
+    CoeffType    sum = m_Scratch[0] + z2n * m_Scratch[m_DataLength[m_IteratorDirection] - 1];
     z2n *= z2n * iz;
     for (SizeValueType n = 1; n <= (m_DataLength[m_IteratorDirection] - 2); ++n)
     {

--- a/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
@@ -177,7 +177,7 @@ BSplineDecompositionImageFilter<TInputImage, TOutputImage>::SetInitialCausalCoef
   double        zn = z;
   if (m_Tolerance > 0.0)
   {
-    horizon = (SizeValueType)std::ceil(std::log(m_Tolerance) / std::log(itk::Math::abs(z)));
+    horizon = static_cast<SizeValueType>(std::ceil(std::log(m_Tolerance) / std::log(std::abs(z))));
   }
   if (horizon < m_DataLength[m_IteratorDirection])
   {

--- a/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
@@ -172,39 +172,39 @@ BSplineDecompositionImageFilter<TInputImage, TOutputImage>::SetInitialCausalCoef
 {
   // See Unser, 1999, Box 2 for explanation
 
-  // This initialization corresponds to mirror boundaries
-  SizeValueType horizon = m_DataLength[m_IteratorDirection];
-  double        zn = z;
+  double zn = z;
+
   if (m_Tolerance > 0.0)
   {
-    horizon = static_cast<SizeValueType>(std::ceil(std::log(m_Tolerance) / std::log(std::abs(z))));
-  }
-  if (horizon < m_DataLength[m_IteratorDirection])
-  {
-    // Accelerated loop
-    CoeffType sum = m_Scratch[0]; // verify this
-    for (SizeValueType n = 1; n < horizon; ++n)
+    if (const auto horizon = static_cast<SizeValueType>(std::ceil(std::log(m_Tolerance) / std::log(std::abs(z))));
+        horizon < m_DataLength[m_IteratorDirection])
     {
-      sum += zn * m_Scratch[n];
-      zn *= z;
+      // Accelerated loop
+      CoeffType sum = m_Scratch[0]; // verify this
+      for (SizeValueType n = 1; n < horizon; ++n)
+      {
+        sum += zn * m_Scratch[n];
+        zn *= z;
+      }
+      m_Scratch[0] = sum;
+
+      // Return early.
+      return;
     }
-    m_Scratch[0] = sum;
   }
-  else
+
+  // Full loop
+  const double iz = 1.0 / z;
+  double       z2n = std::pow(z, static_cast<double>(m_DataLength[m_IteratorDirection] - 1));
+  CoeffType    sum = m_Scratch[0] + z2n * m_Scratch[m_DataLength[m_IteratorDirection] - 1];
+  z2n *= z2n * iz;
+  for (SizeValueType n = 1; n <= (m_DataLength[m_IteratorDirection] - 2); ++n)
   {
-    // Full loop
-    const double iz = 1.0 / z;
-    double       z2n = std::pow(z, static_cast<double>(m_DataLength[m_IteratorDirection] - 1));
-    CoeffType    sum = m_Scratch[0] + z2n * m_Scratch[m_DataLength[m_IteratorDirection] - 1];
-    z2n *= z2n * iz;
-    for (SizeValueType n = 1; n <= (m_DataLength[m_IteratorDirection] - 2); ++n)
-    {
-      sum += (zn + z2n) * m_Scratch[n];
-      zn *= z;
-      z2n *= iz;
-    }
-    m_Scratch[0] = sum / (1.0 - zn * zn);
+    sum += (zn + z2n) * m_Scratch[n];
+    zn *= z;
+    z2n *= iz;
   }
+  m_Scratch[0] = sum / (1.0 - zn * zn);
 }
 
 template <typename TInputImage, typename TOutputImage>


### PR DESCRIPTION
Coding style improvements to `BSplineDecompositionImageFilter::SetInitialCausalCoefficient`:

- Replaced `1L` with `1`, to avoid platform dependent behavior because of `sizeof(long)`
- Replaced C-style cast, `(SizeValueType)`, with `static_cast<SizeValueType>`
- Replaced `itk::Math::abs(z)` with `std::abs(z)`
- Reduced the scope of the `horizon` variable, skipping initialization "to mirror boundaries" by returning early.

----

🤓  When reviewing, it may help to hide whitespace changes: https://github.com/InsightSoftwareConsortium/ITK/pull/5332/files?w=1