### PR TITLE
Remove `MersenneTwisterRandomVariateGenerator::` prefixes within its implementation

### DIFF
--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -81,7 +81,7 @@ MersenneTwisterRandomVariateGenerator::Pointer
 MersenneTwisterRandomVariateGenerator::CreateInstance()
 {
   // Try the factory first
-  MersenneTwisterRandomVariateGenerator::Pointer obj = ObjectFactory<Self>::Create();
+  Pointer obj = ObjectFactory<Self>::Create();
   // If the factory did not provide one, then create it here
   if (!obj)
   {
@@ -96,7 +96,7 @@ MersenneTwisterRandomVariateGenerator::CreateInstance()
 MersenneTwisterRandomVariateGenerator::Pointer
 MersenneTwisterRandomVariateGenerator::New()
 {
-  MersenneTwisterRandomVariateGenerator::Pointer obj = Self::CreateInstance();
+  Pointer obj = Self::CreateInstance();
 
   obj->InitializeWithoutMutexLocking(Self::GetNextSeed());
   return obj;

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -96,9 +96,9 @@ MersenneTwisterRandomVariateGenerator::CreateInstance()
 MersenneTwisterRandomVariateGenerator::Pointer
 MersenneTwisterRandomVariateGenerator::New()
 {
-  MersenneTwisterRandomVariateGenerator::Pointer obj = MersenneTwisterRandomVariateGenerator::CreateInstance();
+  MersenneTwisterRandomVariateGenerator::Pointer obj = Self::CreateInstance();
 
-  obj->InitializeWithoutMutexLocking(MersenneTwisterRandomVariateGenerator::GetNextSeed());
+  obj->InitializeWithoutMutexLocking(Self::GetNextSeed());
   return obj;
 }
 
@@ -110,7 +110,7 @@ MersenneTwisterRandomVariateGenerator::GetInstance()
 
   if (!m_PimplGlobals->m_StaticInstance)
   {
-    m_PimplGlobals->m_StaticInstance = MersenneTwisterRandomVariateGenerator::CreateInstance();
+    m_PimplGlobals->m_StaticInstance = Self::CreateInstance();
     m_PimplGlobals->m_StaticInstance->InitializeWithoutMutexLocking(Self::CreateRandomSeed());
   }
 
@@ -162,7 +162,7 @@ IntegerType
 MersenneTwisterRandomVariateGenerator::GetNextSeed()
 {
   itkInitGlobalsMacro(PimplGlobals);
-  return GetInstance()->m_Seed + m_PimplGlobals->m_StaticDiffer++;
+  return Self::GetInstance()->m_Seed + m_PimplGlobals->m_StaticDiffer++;
 }
 
 

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -68,9 +68,9 @@ struct MersenneTwisterGlobals
   MersenneTwisterGlobals() = default;
   ~MersenneTwisterGlobals() = default;
 
-  MersenneTwisterRandomVariateGenerator::Pointer                  m_StaticInstance{};
-  std::mutex                                                      m_StaticInstanceMutex{};
-  std::atomic<MersenneTwisterRandomVariateGenerator::IntegerType> m_StaticDiffer{};
+  MersenneTwisterRandomVariateGenerator::Pointer m_StaticInstance{};
+  std::mutex                                     m_StaticInstanceMutex{};
+  std::atomic<IntegerType>                       m_StaticDiffer{};
 };
 
 itkGetGlobalSimpleMacro(MersenneTwisterRandomVariateGenerator, MersenneTwisterGlobals, PimplGlobals);
@@ -133,7 +133,7 @@ MersenneTwisterRandomVariateGenerator::MersenneTwisterRandomVariateGenerator()
 
 MersenneTwisterRandomVariateGenerator::~MersenneTwisterRandomVariateGenerator() = default;
 
-MersenneTwisterRandomVariateGenerator::IntegerType
+IntegerType
 MersenneTwisterRandomVariateGenerator::hash(const time_t t, const clock_t c)
 {
   itkInitGlobalsMacro(PimplGlobals);
@@ -158,7 +158,7 @@ MersenneTwisterRandomVariateGenerator::hash(const time_t t, const clock_t c)
   return (h1 + m_PimplGlobals->m_StaticDiffer++) ^ h2;
 }
 
-MersenneTwisterRandomVariateGenerator::IntegerType
+IntegerType
 MersenneTwisterRandomVariateGenerator::GetNextSeed()
 {
   itkInitGlobalsMacro(PimplGlobals);
@@ -225,7 +225,7 @@ MersenneTwisterRandomVariateGenerator::reload()
 
 
 /** Get an integer variate in [0, 2^32-1] */
-MersenneTwisterRandomVariateGenerator::IntegerType
+IntegerType
 MersenneTwisterRandomVariateGenerator::GetIntegerVariate()
 {
   if (m_Left == 0)
@@ -242,7 +242,7 @@ MersenneTwisterRandomVariateGenerator::GetIntegerVariate()
 }
 
 
-MersenneTwisterRandomVariateGenerator::IntegerType
+IntegerType
 MersenneTwisterRandomVariateGenerator::GetIntegerVariate(const IntegerType n)
 {
   // Find which bits are used in n


### PR DESCRIPTION
A minor style improvement, aiming to improve code readability.