### PR TITLE
Add `DefaultSeed = 121212` to MersenneTwisterRandomVariateGenerator

### DIFF
--- a/.github/workflows/itk_dict.txt
+++ b/.github/workflows/itk_dict.txt
@@ -618,6 +618,7 @@ memcpy
 memmove
 memset
 merchantability
+mersenne
 meshpixperelt
 metacharacters
 metricb

--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -163,6 +163,15 @@ public:
   static void
   ResetNextSeed();
 
+  /** The initial seed of a default-constructed generator.
+   *
+   * \note The global generator retrieved by `GetInstance()`, and local generators created by `New()` may all have a
+   * different (non-default) seeds.
+   * \note The Mersenne Twister random number engine of the Standard C++ Library `std::mersenne_twister_engine`
+   * (`std::mt19937`) has a different default seed, `default_seed == 5489`.
+   */
+  static constexpr IntegerType DefaultSeed = 121212;
+
   /** Length of state vector */
   static constexpr IntegerType StateVectorLength = 624;
 

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -128,7 +128,7 @@ MersenneTwisterRandomVariateGenerator::ResetNextSeed()
 
 MersenneTwisterRandomVariateGenerator::MersenneTwisterRandomVariateGenerator()
 {
-  this->InitializeWithoutMutexLocking(121212);
+  this->InitializeWithoutMutexLocking(DefaultSeed);
 }
 
 MersenneTwisterRandomVariateGenerator::~MersenneTwisterRandomVariateGenerator() = default;

--- a/Modules/Core/Common/test/itkMersenneTwisterRandomVariateGeneratorGTest.cxx
+++ b/Modules/Core/Common/test/itkMersenneTwisterRandomVariateGeneratorGTest.cxx
@@ -25,6 +25,29 @@
 using itk::Statistics::MersenneTwisterRandomVariateGenerator;
 
 
+// Check that the default seed is not just zero!
+static_assert(MersenneTwisterRandomVariateGenerator::DefaultSeed != 0);
+
+
+// Tests that DefaultSeed is the seed of a default-constructed generator.
+TEST(MersenneTwisterRandomVariateGenerator, DefaultSeed)
+{
+  // Derived generator class whose `New()` simply calls the default-constructor.
+  class DerivedGenerator : public MersenneTwisterRandomVariateGenerator
+  {
+  public:
+    ITK_DISALLOW_COPY_AND_MOVE(DerivedGenerator);
+    itkSimpleNewMacro(DerivedGenerator);
+
+  protected:
+    DerivedGenerator() = default;
+    ~DerivedGenerator() override = default;
+  };
+
+  EXPECT_EQ(DerivedGenerator::New()->GetSeed(), MersenneTwisterRandomVariateGenerator::DefaultSeed);
+}
+
+
 // Tests that GetIntegerVariate() conforms with the C++11 requirement for std::mt19937,
 // when the ITK generator uses the default seed of std::mt19937:
 // "The 10000th consecutive invocation of a default-constructed object of type mt19937

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_14.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_14.cxx
@@ -237,7 +237,7 @@ itkImageRegistrationMethodTest_14(int, char *[])
   metric->SetFixedImageStandardDeviation(5.0);
   metric->SetNumberOfSpatialSamples(50);
   metric->SetFixedImageRegion(fixedImage->GetBufferedRegion());
-  metric->ReinitializeSeed(121212);
+  metric->ReinitializeSeed(itk::Statistics::MersenneTwisterRandomVariateGenerator::DefaultSeed);
 
   /******************************************************************
    * Set up the registrator.

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_15.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_15.cxx
@@ -18,6 +18,7 @@
 
 #include "itkImageRegistrationMethod.h"
 #include "itkMattesMutualInformationImageToImageMetric.h"
+#include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkGradientDescentOptimizer.h"
 
 #include "itkTextOutput.h"
@@ -224,7 +225,7 @@ itkImageRegistrationMethodTest_15(int, char *[])
   region.SetSize(size);
   region.SetIndex(index);
   metric->SetFixedImageRegion(region);
-  metric->ReinitializeSeed(121212);
+  metric->ReinitializeSeed(itk::Statistics::MersenneTwisterRandomVariateGenerator::DefaultSeed);
 
   /******************************************************************
    * Set up the registrator.

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_17.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_17.cxx
@@ -18,6 +18,7 @@
 
 #include "itkImageRegistrationMethod.h"
 #include "itkMattesMutualInformationImageToImageMetric.h"
+#include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkGradientDescentOptimizer.h"
 
 #include "itkTextOutput.h"
@@ -232,7 +233,7 @@ itkImageRegistrationMethodTest_17(int, char *[])
   region.SetSize(size);
   region.SetIndex(index);
   metric->SetFixedImageRegion(region);
-  metric->ReinitializeSeed(121212);
+  metric->ReinitializeSeed(itk::Statistics::MersenneTwisterRandomVariateGenerator::DefaultSeed);
 
   /******************************************************************
    * Set up the registrator.

--- a/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
@@ -217,7 +217,7 @@ TestMattesMetricWithAffineTransform(TInterpolator * interpolator,
   ITK_TEST_SET_GET_BOOLEAN(metric, UseExplicitPDFDerivatives, useExplicitJointPDFDerivatives);
 
   metric->SetUseCachingOfBSplineWeights(useCachingBSplineWeights);
-  metric->ReinitializeSeed(121212);
+  metric->ReinitializeSeed(itk::Statistics::MersenneTwisterRandomVariateGenerator::DefaultSeed);
 
   metric->SetFixedImageSamplesIntensityThreshold(100);
   if (metric->GetFixedImageSamplesIntensityThreshold() != 100)

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_1.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_1.cxx
@@ -18,6 +18,7 @@
 
 #include "itkMutualInformationImageToImageMetric.h"
 
+#include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkTextOutput.h"
 #include "itkSimpleMultiResolutionImageRegistrationUI.h"
 #include "itkTestingMacros.h"
@@ -267,7 +268,7 @@ itkMultiResolutionImageRegistrationMethodTest_1(int, char *[])
 
     try
     {
-      metric->ReinitializeSeed(121212);
+      metric->ReinitializeSeed(itk::Statistics::MersenneTwisterRandomVariateGenerator::DefaultSeed);
       registration->SetNumberOfLevels(numberOfLevels);
       registration->SetInitialTransformParameters(initialParameters);
 
@@ -491,7 +492,7 @@ itkMultiResolutionImageRegistrationMethodTest_1(int, char *[])
 
     try
     {
-      metric->ReinitializeSeed(121212);
+      metric->ReinitializeSeed(itk::Statistics::MersenneTwisterRandomVariateGenerator::DefaultSeed);
       registration->SetSchedules(fixedImageSchedule, movingImageSchedule);
       ITK_TEST_SET_GET_VALUE(fixedImageSchedule, registration->GetFixedImagePyramidSchedule());
       ITK_TEST_SET_GET_VALUE(movingImageSchedule, registration->GetMovingImagePyramidSchedule());

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_2.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_2.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkQuaternionRigidTransform.h"
+#include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkMutualInformationImageToImageMetric.h"
 #include "itkQuaternionRigidTransformGradientDescentOptimizer.h"
 
@@ -210,7 +211,7 @@ itkMultiResolutionImageRegistrationMethodTest_2(int, char *[])
   metric->SetMovingImageStandardDeviation(5.0);
   metric->SetFixedImageStandardDeviation(5.0);
   metric->SetNumberOfSpatialSamples(50);
-  metric->ReinitializeSeed(121212);
+  metric->ReinitializeSeed(itk::Statistics::MersenneTwisterRandomVariateGenerator::DefaultSeed);
 
   /******************************************************************
    * Set up the registrator.

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
@@ -446,7 +446,8 @@ itkSimpleImageRegistrationTest(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  itk::Statistics::MersenneTwisterRandomVariateGenerator::GetInstance()->SetSeed(121212);
+  itk::Statistics::MersenneTwisterRandomVariateGenerator::GetInstance()->SetSeed(
+    itk::Statistics::MersenneTwisterRandomVariateGenerator::DefaultSeed);
 
   switch (std::stoi(argv[2]))
   {


### PR DESCRIPTION
Added `MersenneTwisterRandomVariateGenerator::DefaultSeed`

It appears useful to have a named constant for this value, for ITK as well as for [elastix](https://github.com/SuperElastix/elastix).

Following C++ Core Guidelines, [Avoid “magic constants”; use symbolic constants](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es45-avoid-magic-constants-use-symbolic-constants)
