### PR TITLE
STYLE: Make randomization input ComplexConjugateImageAdaptorTest useful

### DIFF
--- a/Modules/Core/ImageAdaptors/test/itkComplexConjugateImageAdaptorTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkComplexConjugateImageAdaptorTest.cxx
@@ -44,8 +44,6 @@ itkComplexConjugateImageAdaptorTest(int, char *[])
     iter.Set(pixel);
   }
 
-  image->FillBuffer(PixelType(2.0, -3.7));
-
   // Create adaptor.
   auto adaptor = AdaptorType::New();
   adaptor->SetImage(image);


### PR DESCRIPTION
Removed the `image->FillBuffer` call from this test, as it appeared to make the randomization of input pixel values useless. As noticed by Bradley Lowekamp (@blowekamp) at https://github.com/InsightSoftwareConsortium/ITK/pull/5337#discussion_r2071665502

Cory Quammen (@cquammen) (who originally wrote the test) also suggested removing this line of code.