### PR TITLE
BUG: Allow rescaling int to uint of same size

### DIFF
--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -537,7 +537,7 @@ GDCMImageIO::InternalReadImageInformation()
     switch (outputpt)
     {
       // Default comparison uses the > operator and the order in ScalarType enum
-      // INT types needs to be adjusted so signed input is allowed to produce unsigned output
+      // INT types need to be adjusted so signed input is allowed to produce unsigned output
       case gdcm::PixelFormat::UINT8:
         ptLarger = pixeltype > gdcm::PixelFormat::INT8;
         break;

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -533,7 +533,32 @@ GDCMImageIO::InternalReadImageInformation()
       outputpt = r.ComputeInterceptSlopePixelType();
     }
 
-    if (pixeltype > outputpt)
+    bool ptLarger = false;
+    switch (outputpt)
+    {
+      // Default comparison uses the > operator and the order in ScalarType enum
+      // INT types needs to be adjusted so signed input is allowed to produce unsigned output
+      case gdcm::PixelFormat::UINT8:
+        ptLarger = pixeltype > gdcm::PixelFormat::INT8;
+        break;
+      case gdcm::PixelFormat::UINT12:
+        ptLarger = pixeltype > gdcm::PixelFormat::INT12;
+        break;
+      case gdcm::PixelFormat::UINT16:
+        ptLarger = pixeltype > gdcm::PixelFormat::INT16;
+        break;
+      case gdcm::PixelFormat::UINT32:
+        ptLarger = pixeltype > gdcm::PixelFormat::INT32;
+        break;
+      case gdcm::PixelFormat::UINT64:
+        ptLarger = pixeltype > gdcm::PixelFormat::INT64;
+        break;
+      default:
+        ptLarger = pixeltype > outputpt;
+        break;
+    }
+
+    if (ptLarger)
     {
       itkAssertInDebugOrThrowInReleaseMacro("Pixel type larger than output type")
     }

--- a/Modules/IO/GDCM/test/Baseline/itkGDCMImageIOTestIntToUint.mha.cid
+++ b/Modules/IO/GDCM/test/Baseline/itkGDCMImageIOTestIntToUint.mha.cid
@@ -1,0 +1,1 @@
+bafkreifqaycilgy52jjjytkjbfrfaioc57bfjnfhfuuynozr3g3xmv6apu

--- a/Modules/IO/GDCM/test/CMakeLists.txt
+++ b/Modules/IO/GDCM/test/CMakeLists.txt
@@ -252,6 +252,19 @@ itk_add_test(
 
 itk_add_test(
   NAME
+  itkGDCMImageIOIntToUintTest
+  COMMAND
+  ITKIOGDCMTestDriver
+  --compare
+  DATA{Baseline/itkGDCMImageIOTestIntToUint.mha}
+  ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTestIntToUint.mha
+  itkGDCMImageReadWriteTest
+  DATA{Input/030658_001.dcm}
+  ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTestIntToUint.mha
+  scalar)
+
+itk_add_test(
+  NAME
   itkGDCMImageIO32bitsStoredTest
   COMMAND
   ITKIOGDCMTestDriver

--- a/Modules/IO/GDCM/test/Input/030658_001.dcm.cid
+++ b/Modules/IO/GDCM/test/Input/030658_001.dcm.cid
@@ -1,0 +1,1 @@
+bafkreieyej3y53xaqg6dcedbv5pa6y5m25rdrg42wdqm43oh4ijjrlpl4a


### PR DESCRIPTION
Dicomfile with signed int data (pixel rep=1) can be decoded as uint with the correct intercept. The assertion blocking this behavior has been changed to a more meaningful check.

Closes #5290


With a dicom image stored as short, which has a rescaling into the "unsigned short".

```
Bits allocated 16
Bits stored 16
High Bit 15
Pixel Representation 1

Rescale Intercept 32768
Rescale Slope 1
Rescale Type US
```

The following code was not working before this commit, and now works correctly:


```cpp
#include <iostream>


#include <itkImageFileReader.h>
#include <itkGDCMImageIO.h>

int
main(int argc, char ** argv)
{
  const auto path = "<myfilepath>";

  using ReaderType = itk::ImageFileReader<itk::Image<uint16_t, 2>>;
  typename ReaderType::Pointer reader = ReaderType::New();
  reader->SetFileName(path);
  reader->SetImageIO(itk::GDCMImageIO::New());
  reader->Update();

  return 0;
}
```
