### PR TITLE
FUTURE REMOVE `MersenneTwisterRandomVariateGenerator::Initialize`

### DIFF
--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.h
@@ -129,7 +129,7 @@ public:
   void
   ReinitializeSeed() const
   {
-    m_Generator->Initialize();
+    m_Generator->SetSeed();
   }
 
   void

--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -175,9 +175,17 @@ public:
   /** Length of state vector */
   static constexpr IntegerType StateVectorLength = 624;
 
-  /** Sets the seed and initializes the internal state of this generator. */
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  /** Sets the seed and initializes the internal state of this generator.
+   * \deprecated ITK 6 discourages using this member function. Please use `SetSeed` instead!
+   */
+  ITK_FUTURE_DEPRECATED("ITK 6 discourages using this member function. Please use `SetSeed` instead!")
   void
-  Initialize(const IntegerType seed = Self::CreateRandomSeed());
+  Initialize(const IntegerType seed = Self::CreateRandomSeed())
+  {
+    this->SetSeed(seed);
+  }
+#endif
 
   /** Get a random variate in the range [0, 1] */
   double
@@ -267,11 +275,7 @@ public:
    * \note This method is thread-safe.
    */
   void
-  SetSeed(const IntegerType seed = Self::CreateRandomSeed())
-  {
-    // Seed the generator.
-    Initialize(seed);
-  }
+  SetSeed(const IntegerType seed = Self::CreateRandomSeed());
 
   /** Return the current seed
    *

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -167,7 +167,7 @@ MersenneTwisterRandomVariateGenerator::GetNextSeed()
 
 
 void
-MersenneTwisterRandomVariateGenerator::Initialize(const IntegerType seed)
+MersenneTwisterRandomVariateGenerator::SetSeed(const IntegerType seed)
 {
   // This is a public member function, so it must lock the mutex of the instance.
   const std::lock_guard<std::mutex> lockGuard(m_InstanceMutex);

--- a/Modules/Core/Common/test/itkCompensatedSummationTest.cxx
+++ b/Modules/Core/Common/test/itkCompensatedSummationTest.cxx
@@ -38,7 +38,7 @@ itkCompensatedSummationTest(int, char *[])
 
   using GeneratorType = itk::Statistics::MersenneTwisterRandomVariateGenerator;
   auto generator = GeneratorType::New();
-  generator->Initialize(seedValue);
+  generator->SetSeed(seedValue);
 
   FloatType vanillaSum = 0.0;
   using CompensatedSummationType = itk::CompensatedSummation<FloatType>;

--- a/Modules/Core/Common/test/itkMersenneTwisterRandomVariateGeneratorTest.cxx
+++ b/Modules/Core/Common/test/itkMersenneTwisterRandomVariateGeneratorTest.cxx
@@ -17,6 +17,10 @@
  *=========================================================================*/
 
 
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+#  define ITK_LEGACY_SILENT
+#endif
+
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkTestingMacros.h"
 
@@ -104,6 +108,7 @@ itkMersenneTwisterRandomVariateGeneratorTest(int, char *[])
     return EXIT_FAILURE;
   }
 
+#ifndef ITK_FUTURE_LEGACY_REMOVE
   twister->Initialize();
   twister->SetSeed(1234);
   const Twister::IntegerType withSetSeed = twister->GetIntegerVariate();
@@ -114,6 +119,7 @@ itkMersenneTwisterRandomVariateGeneratorTest(int, char *[])
     std::cerr << "Result initializing with SetSeed() did not equal result with Initialize()." << std::endl;
     return EXIT_FAILURE;
   }
+#endif
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.hxx
@@ -51,7 +51,7 @@ SaltAndPepperNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
   }
   auto           rand = Statistics::MersenneTwisterRandomVariateGenerator::New();
   const uint32_t seed = Self::Hash(this->GetSeed(), uint32_t(indSeed));
-  rand->Initialize(seed);
+  rand->SetSeed(seed);
 
   // Define the portion of the input to walk for this thread, using
   // the CallCopyOutputRegionToInputRegion method allows for the input

--- a/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
@@ -52,7 +52,7 @@ ShotNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
   }
   auto           rand = Statistics::MersenneTwisterRandomVariateGenerator::New();
   const uint32_t seed = Self::Hash(this->GetSeed(), uint32_t(indSeed));
-  rand->Initialize(seed);
+  rand->SetSeed(seed);
   auto randn = Statistics::NormalVariateGenerator::New();
   randn->Initialize(bit_cast<int32_t>(seed));
 

--- a/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
@@ -51,7 +51,7 @@ SpeckleNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
   }
   auto           rand = Statistics::MersenneTwisterRandomVariateGenerator::New();
   const uint32_t seed = Self::Hash(this->GetSeed(), uint32_t(indSeed));
-  rand->Initialize(seed);
+  rand->SetSeed(seed);
 
   // Define the portion of the input to walk for this thread, using
   // the CallCopyOutputRegionToInputRegion method allows for the input

--- a/Modules/Numerics/Statistics/test/itkKdTreeTest1.cxx
+++ b/Modules/Numerics/Statistics/test/itkKdTreeTest1.cxx
@@ -38,7 +38,7 @@ itkKdTreeTest1(int argc, char * argv[])
   using NumberGeneratorType = itk::Statistics::MersenneTwisterRandomVariateGenerator;
 
   const NumberGeneratorType::Pointer randomNumberGenerator = NumberGeneratorType::GetInstance();
-  randomNumberGenerator->Initialize();
+  randomNumberGenerator->SetSeed();
 
   using MeasurementVectorType = itk::Array<double>;
   using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;

--- a/Modules/Numerics/Statistics/test/itkKdTreeTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkKdTreeTest3.cxx
@@ -39,7 +39,7 @@ itkKdTreeTest3(int argc, char * argv[])
   using NumberGeneratorType = itk::Statistics::MersenneTwisterRandomVariateGenerator;
 
   const NumberGeneratorType::Pointer randomNumberGenerator = NumberGeneratorType::GetInstance();
-  randomNumberGenerator->Initialize();
+  randomNumberGenerator->SetSeed();
 
   using MeasurementVectorType = itk::Array<double>;
   using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;

--- a/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest1.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest1.cxx
@@ -37,7 +37,7 @@ itkWeightedCentroidKdTreeGeneratorTest1(int argc, char * argv[])
   using NumberGeneratorType = itk::Statistics::MersenneTwisterRandomVariateGenerator;
 
   const NumberGeneratorType::Pointer randomNumberGenerator = NumberGeneratorType::GetInstance();
-  randomNumberGenerator->Initialize();
+  randomNumberGenerator->SetSeed();
 
   using MeasurementVectorType = itk::Array<double>;
   using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;

--- a/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest8.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest8.cxx
@@ -38,7 +38,7 @@ itkWeightedCentroidKdTreeGeneratorTest8(int argc, char * argv[])
   using NumberGeneratorType = itk::Statistics::MersenneTwisterRandomVariateGenerator;
 
   const NumberGeneratorType::Pointer randomNumberGenerator = NumberGeneratorType::GetInstance();
-  randomNumberGenerator->Initialize();
+  randomNumberGenerator->SetSeed();
 
   constexpr unsigned int measurementVectorSize = 2;
 

--- a/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest9.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest9.cxx
@@ -39,7 +39,7 @@ itkWeightedCentroidKdTreeGeneratorTest9(int argc, char * argv[])
   using NumberGeneratorType = itk::Statistics::MersenneTwisterRandomVariateGenerator;
 
   auto randomNumberGenerator = NumberGeneratorType::New();
-  randomNumberGenerator->Initialize();
+  randomNumberGenerator->SetSeed();
 
   using MeasurementVectorType = itk::VariableLengthVector<double>;
   using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;

--- a/Modules/Registration/Common/test/itkMeanSquaresImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMeanSquaresImageMetricTest.cxx
@@ -323,7 +323,7 @@ itkMeanSquaresImageMetricTest(int, char *[])
   // Set bSplineTransform parameters with MersenneTwister
   ParametersType bSplineParameters(bSplineTransform->GetNumberOfParameters());
   auto           generator = GeneratorType::New();
-  generator->Initialize();
+  generator->SetSeed();
   for (unsigned int d = 0; d < bSplineParameters.Size(); ++d)
   {
     bSplineParameters[d] = generator->GetNormalVariate();


### PR DESCRIPTION
The MersenneTwisterRandomVariateGenerator member function `Initialize` behaves just like `SetSeed`, but `SetSeed` is more commonly used, and clearer.