### PR TITLE
Replace `auto var = T{...}` with `T var{...}`

### DIFF
--- a/Modules/Core/Common/include/itkGaussianKernelFunction.h
+++ b/Modules/Core/Common/include/itkGaussianKernelFunction.h
@@ -59,7 +59,7 @@ public:
   TRealValueType
   Evaluate(const TRealValueType & u) const override
   {
-    constexpr auto negHalf = TRealValueType{ -0.5 };
+    constexpr TRealValueType negHalf{ -0.5 };
     return std::exp(negHalf * itk::Math::sqr(u)) * Math::one_over_sqrt2pi;
   }
 

--- a/Modules/Core/Common/include/itkVector.hxx
+++ b/Modules/Core/Common/include/itkVector.hxx
@@ -103,7 +103,7 @@ template <typename T, unsigned int TVectorDimension>
 auto
 Vector<T, TVectorDimension>::GetSquaredNorm() const -> RealValueType
 {
-  auto sum = T{};
+  T sum{};
   for (unsigned int i = 0; i < TVectorDimension; ++i)
   {
     const RealValueType value = (*this)[i];
@@ -198,7 +198,7 @@ template <typename T, unsigned int TVectorDimension>
 typename Vector<T, TVectorDimension>::ValueType
 Vector<T, TVectorDimension>::operator*(const Self & other) const
 {
-  auto value = T{};
+  T value{};
   for (unsigned int i = 0; i < TVectorDimension; ++i)
   {
     value += (*this)[i] * other[i];

--- a/Modules/Core/ImageFunction/include/itkMeanImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMeanImageFunction.hxx
@@ -34,7 +34,7 @@ template <typename TInputImage, typename TCoordinate>
 auto
 MeanImageFunction<TInputImage, TCoordinate>::EvaluateAtIndex(const IndexType & index) const -> RealType
 {
-  auto sum = RealType{};
+  RealType sum{};
 
   const InputImageType * const image = this->GetInputImage();
 

--- a/Modules/Core/ImageFunction/include/itkSumOfSquaresImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkSumOfSquaresImageFunction.hxx
@@ -35,7 +35,7 @@ template <typename TInputImage, typename TCoordinate>
 auto
 SumOfSquaresImageFunction<TInputImage, TCoordinate>::EvaluateAtIndex(const IndexType & index) const -> RealType
 {
-  auto sumOfSquares = RealType{};
+  RealType sumOfSquares{};
 
   const InputImageType * const image = this->GetInputImage();
 

--- a/Modules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx
@@ -46,7 +46,7 @@ CreateImageFilledWithSequenceOfNaturalNumbers(const typename TImage::SizeType & 
   const auto image = TImage::New();
   image->SetRegions(imageSize);
   image->Allocate();
-  const auto imageBufferRange = itk::ImageBufferRange{ *image };
+  const itk::ImageBufferRange imageBufferRange{ *image };
   std::iota(imageBufferRange.begin(), imageBufferRange.end(), PixelType{ 1 });
   return image;
 }
@@ -158,7 +158,7 @@ TEST(SumOfSquaresImageFunction, EvaluateAtCenterPixelOfImageOfSize3x3)
 
   imageFunction->SetInputImage(image);
 
-  const auto imageBufferRange = itk::ImageBufferRange{ *image };
+  const itk::ImageBufferRange imageBufferRange{ *image };
 
   // Sum of squares of all pixels of the image:
   const auto expectedResult = std::accumulate(

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -41,7 +41,7 @@ ImageMaskSpatialObject<TDimension, TPixel>::IsInsideInObjectSpace(const PointTyp
 
   const bool is_inside = Superclass::GetBufferedRegion().IsInside(index);
 
-  const auto background_zero = PixelType{};
+  const PixelType background_zero{};
 
   return is_inside && ((m_UseMaskValue == true && Math::ExactlyEquals(image->GetPixel(index), this->m_MaskValue)) ||
                        (m_UseMaskValue == false && Math::NotExactlyEquals(image->GetPixel(index), background_zero)));
@@ -152,7 +152,7 @@ ImageMaskSpatialObject<TDimension, TPixel>::ComputeMyBoundingBoxInIndexSpace() c
   const auto HasForegroundPixels = [&image, useMaskValue, maskValue](const RegionType & region) {
     for (const PixelType pixelValue : ImageRegionRange{ image, region })
     {
-      constexpr auto zeroValue = PixelType{};
+      constexpr PixelType zeroValue{};
 
       if (pixelValue != zeroValue && (useMaskValue == false || pixelValue == maskValue))
       {

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkGradientNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkGradientNDAnisotropicDiffusionFunction.hxx
@@ -78,7 +78,7 @@ GradientNDAnisotropicDiffusionFunction<TImage>::ComputeUpdate(const Neighborhood
                                                               const FloatOffsetType &) -> PixelType
 {
   // PixelType is scalar in this context
-  auto delta = PixelRealType{};
+  PixelRealType delta{};
 
   // Calculate the centralized derivatives for each dimension.
   PixelRealType dx[ImageDimension];

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorAnisotropicDiffusionFunction.hxx
@@ -54,8 +54,8 @@ VectorAnisotropicDiffusionFunction<TImage>::CalculateAverageGradientMagnitudeSqu
   auto                            fit = faceList.begin();
 
   // Now do the actual processing
-  double accumulator = 0.0;
-  auto   counter = SizeValueType{};
+  double        accumulator = 0.0;
+  SizeValueType counter{};
 
   // First process the non-boundary region
 

--- a/Modules/Filtering/Colormap/include/itkCustomColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkCustomColormapFunction.hxx
@@ -62,7 +62,7 @@ CustomColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const 
   RGBPixelType pixel;
   NumericTraits<TRGBPixel>::SetLength(pixel, 3);
 
-  for (auto color = size_t{ RED }; color <= size_t{ BLUE }; ++color)
+  for (size_t color{ RED }; color <= size_t{ BLUE }; ++color)
   {
     pixel[color] = this->RescaleRGBComponentValue(RGBValue[color]);
   }

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
@@ -317,7 +317,7 @@ protected:
     unsigned int j;
     TRealType    dx;
     TRealType    sum;
-    auto         accum = TRealType{};
+    TRealType    accum{};
     for (i = 0; i < ImageDimension; ++i)
     {
       sum = TRealType{};

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
@@ -221,7 +221,7 @@ itkGradientRecursiveGaussianFilterTest3(int argc, char * argv[])
   using myImageScalarType = itk::Image<myScalarPixelType, myDimension>;
 
   myGradImage1DType::Pointer scalarPixelGradImage = nullptr;
-  auto                       pixelBorder = myScalarPixelType{};
+  myScalarPixelType          pixelBorder{};
   auto                       pixelFill = static_cast<myScalarPixelType>(100.0);
   runResult = itkGradientRecursiveGaussianFilterTest3Run<myImageScalarType, myGradImage1DType, myComponents1D>(
     pixelBorder, pixelFill, scalarPixelGradImage, argv[2]);

--- a/Modules/Filtering/Smoothing/include/itkMeanImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkMeanImageFilter.hxx
@@ -89,7 +89,7 @@ MeanImageFilter<TInputImage, TOutputImage>::GenerateDataInSubregion(
   {
     neighborhoodRange.SetLocation(index);
 
-    auto sum = InputRealType{};
+    InputRealType sum{};
 
     for (const InputPixelType pixelValue : neighborhoodRange)
     {

--- a/Modules/Filtering/Smoothing/test/itkMeanImageFilterGTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkMeanImageFilterGTest.cxx
@@ -68,7 +68,7 @@ CreateImageFilledWithSequenceOfNaturalNumbers(const typename TImage::RegionType 
   const auto image = TImage::New();
   image->SetRegions(imageRegion);
   image->Allocate();
-  const auto imageBufferRange = itk::ImageBufferRange{ *image };
+  const itk::ImageBufferRange imageBufferRange{ *image };
   std::iota(imageBufferRange.begin(), imageBufferRange.end(), PixelType{ 1 });
   return image;
 }

--- a/Modules/Filtering/Smoothing/test/itkMedianImageFilterGTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkMedianImageFilterGTest.cxx
@@ -66,7 +66,7 @@ CreateImageFilledWithSequenceOfNaturalNumbers(const typename TImage::RegionType 
   const auto image = TImage::New();
   image->SetRegions(imageRegion);
   image->Allocate();
-  const auto imageBufferRange = itk::ImageBufferRange{ *image };
+  const itk::ImageBufferRange imageBufferRange{ *image };
   std::iota(imageBufferRange.begin(), imageBufferRange.end(), PixelType{ 1 });
   return image;
 }

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -585,7 +585,7 @@ TIFFImageIO::InternalWrite(const void * buffer)
   const double resolution_y{ m_Spacing[1] != 0.0 ? 25.4 / m_Spacing[1] : 0.0 };
   // rowsperstrip is set to a default value but modified based on the tif scanlinesize before
   // passing it into the TIFFSetField (see below).
-  auto     rowsperstrip = uint32_t{ 0 };
+  uint32_t rowsperstrip{ 0 };
   uint16_t bps;
 
   switch (this->GetComponentType())

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunctionWithRefitTerm.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunctionWithRefitTerm.hxx
@@ -80,7 +80,7 @@ LevelSetFunctionWithRefitTerm<TImageType, TSparseImageType>::ComputeCurvature(
     stride[j] = neighborhood.GetStride(j);
     indicator[j] = one << j;
   }
-  auto curvature = ScalarValueType{};
+  ScalarValueType curvature{};
 
   for (unsigned int counterN = 0; counterN < m_NumVertex; ++counterN)
   {

--- a/Modules/Segmentation/LevelSets/include/itkNormalVectorDiffusionFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkNormalVectorDiffusionFunction.hxx
@@ -139,7 +139,7 @@ NormalVectorDiffusionFunction<TSparseImageType>::PrecomputeSparseUpdate(Neighbor
       // now compute the intrinsic derivative
       for (unsigned int j = 0; j < ImageDimension; ++j) // component axis
       {
-        auto DotProduct = NodeValueType{};
+        NodeValueType DotProduct{};
         for (unsigned int k = 0; k < ImageDimension; ++k) // derivative axis
         {
           DotProduct += (gradient[k][j] * CenterNode->m_ManifoldNormal[i][k]);
@@ -173,7 +173,7 @@ NormalVectorDiffusionFunction<TSparseImageType>::ComputeSparseUpdate(Neighborhoo
 
   const NeighborhoodScalesType neighborhoodScales = this->ComputeNeighborhoodScales();
 
-  auto change = NormalVectorType{};
+  NormalVectorType change{};
   for (unsigned int i = 0; i < ImageDimension; ++i) // flux offset axis
   {
     const auto NextNode = it.GetNext(i);

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
@@ -203,7 +203,7 @@ template <typename TInputImage, typename TOutputImage>
 void
 SparseFieldFourthOrderLevelSetImageFilter<TInputImage, TOutputImage>::ProcessNormals()
 {
-  auto temp = ValueType{ ImageDimension };
+  ValueType temp{ ImageDimension };
 
   const typename NormalVectorFilterType::Pointer   NormalVectorFilter = NormalVectorFilterType::New();
   const typename NormalVectorFunctionType::Pointer NormalVectorFunction = NormalVectorFunctionType::New();

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
@@ -97,7 +97,7 @@ SparseFieldFourthOrderLevelSetImageFilter<TInputImage, TOutputImage>::ComputeCur
     indicator[j] = one << j;
   }
 
-  auto curvature = ValueType{};
+  ValueType curvature{};
 
   for (unsigned int counter = 0; counter < m_NumVertex; ++counter)
   {

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -957,7 +957,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::PropagateLayerValues(
     statusIt.NeedToUseBoundaryConditionOff();
   }
 
-  auto             value = ValueType{};
+  ValueType        value{};
   const StatusType past_end = static_cast<StatusType>(m_Layers.size()) - 1;
 
   auto toIt = m_Layers[to]->Begin();

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
@@ -163,8 +163,8 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
       {
         neighborhoodRange.SetLocation(*si);
 
-        auto neighborhoodSum = InputRealType{ 0.0 };
-        auto neighborhoodSumOfSquares = InputRealType{ 0.0 };
+        InputRealType neighborhoodSum{ 0.0 };
+        InputRealType neighborhoodSumOfSquares{ 0.0 };
 
         for (const InputImagePixelType pixelValue : neighborhoodRange)
         {

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
@@ -299,8 +299,8 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
     secondFunction->SetInputImage(outputImage);
     secondFunction->ThresholdBetween(m_ReplaceValue, m_ReplaceValue);
 
-    auto                                 sum = InputRealType{};
-    auto                                 sumOfSquares = InputRealType{};
+    InputRealType                        sum{};
+    InputRealType                        sumOfSquares{};
     typename TOutputImage::SizeValueType numberOfSamples = 0;
 
     SecondIteratorType sit(inputImage, secondFunction, m_Seeds);


### PR DESCRIPTION
Two little style commits:
 - Replace `auto var = T{}` with `T var{}`
 - Replace `auto var = T{ x }` with `T var{ x }`

Note that these proposed changes are not at all in disagreement  with clang-tidy [modernize-use-auto](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-auto.html). 😃 