### PR TITLE
BUG: Fix random number in `RGBGibbsPriorFilter::GibbsTotalEnergy`

### DIFF
--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
@@ -289,7 +289,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GibbsTotalEnergy(int i)
     if (changeflag)
     {
       difenergy = energy[label] - energy[1 - label];
-      const double rand_num{ rand() / 32768.0 };
+      const double rand_num{ rand() / (RAND_MAX + 1.0) };
       double       energy_num{ std::exp(static_cast<double>(difenergy * 0.5 * size / (2 * size - m_Temp))) };
       if (rand_num < energy_num)
       {


### PR DESCRIPTION
The original division of `rand()` by `32768.0` was probably meant to yield a number between `[0, 1>`. However, `rand()` returns an integer between `[​0​, RAND_MAX]`, and `RAND_MAX` may not be `32767`. In practice, when using GCC, `RAND_MAX` may be as large as `2147483647`.

The "magic number" `32768.0` was introduced on 12 Jan 2002 already, with commit 074c74f036a7faea5555a6125a2c740d1afe7caa.