### PR TITLE
STYLE: Change `IOScanco` remote module GitHub organization

### DIFF
--- a/Modules/Remote/IOScanco.remote.cmake
+++ b/Modules/Remote/IOScanco.remote.cmake
@@ -45,6 +45,6 @@ itk_fetch_module(
   IOScanco
   "An ITK module to read and write Scanco microCT .isq files."
   MODULE_COMPLIANCE_LEVEL 2
-  GIT_REPOSITORY https://github.com/KitwareMedical/ITKIOScanco.git
+  GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKIOScanco.git
   GIT_TAG 10b80f69048e79ab3069e89635822a6851099278
   )


### PR DESCRIPTION
Change `IOScanco` remote module GitHub organization to `InsightSoftwareConsortium` after transferring it from `KitwareMedical` by Dženan Zukić on May, 27 2025.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
