### PR TITLE
WIP: COMP: Set CMP0177 in wrapping

### DIFF
--- a/Wrapping/Generators/Python/CMakeLists.txt
+++ b/Wrapping/Generators/Python/CMakeLists.txt
@@ -74,6 +74,10 @@ if(NOT PY_SITE_PACKAGES_PATH)
   message(SEND_ERROR "Please set PY_SITE_PACKAGES_PATH to the Python bindings installation directory.")
 endif()
 
+# install DESTINATION normalization
+if (POLICY CMP0177)
+  cmake_policy(SET CMP0177 NEW)
+endif()
 macro(WRAP_ITK_PYTHON_BINDINGS_INSTALL path wrapper_library_name)
   set(_component_module "")
   if(WRAP_ITK_INSTALL_COMPONENT_PER_MODULE)
@@ -85,7 +89,7 @@ macro(WRAP_ITK_PYTHON_BINDINGS_INSTALL path wrapper_library_name)
   endif()
   install(
     FILES ${ARGN}
-    DESTINATION "${PY_SITE_PACKAGES_PATH}/${path}"
+    DESTINATION "${PY_SITE_PACKAGES_PATH}${path}"
     COMPONENT ${_component_module}${WRAP_ITK_INSTALL_COMPONENT_IDENTIFIER}RuntimeLibraries)
   unset(_component_module)
 endmacro()


### PR DESCRIPTION
This policy, added in CMake 3.31, changes the behavior of install(DESTINATION per

  https://cmake.org/cmake/help/latest/policy/CMP0177.html

Also remove the extra "/" in DESTINATION.

I am testing this in ITKPythonPackage.