### PR TITLE
BUG:  itkNiftiReadWriteDirectionTest is unstable

### DIFF
--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -47,7 +47,7 @@ print_hex_vals(const char * const data, const int nbytes, FILE * const fp)
   return 0;
 }
 
-static const char * const
+static const char *
 str_intent(const unsigned int intent)
 {
   switch (intent)

--- a/Modules/IO/NIFTI/test/CMakeLists.txt
+++ b/Modules/IO/NIFTI/test/CMakeLists.txt
@@ -225,6 +225,7 @@ itk_add_test(
   DATA{${ITK_DATA_ROOT}/Input/LPSLabels_nosform.nii.gz}
   DATA{${ITK_DATA_ROOT}/Input/NonOrthoSform.nii.gz}
   ${ITK_TEST_OUTPUT_DIR}
+  "test_filled_qform_itkNiftiReadWriteDirectionTest.nii.gz"
   8.0 # Tolerance in degrees for direction recovered from non-orthogonal sform
   )
 
@@ -240,6 +241,7 @@ itk_add_test(
   DATA{Input/SmallVoxels_nosform.nii.gz}
   DATA{Input/SmallVoxelsNonOrthoSform.nii.gz}
   ${ITK_TEST_OUTPUT_DIR}
+  "test_filled_qform_itkNiftiReadWriteDirectionSmallVoxelTest.nii.gz"
   4.0 # Tolerance in degrees for direction recovered from non-orthogonal sform
   )
 


### PR DESCRIPTION
The following error occurs occasionally that causes the test to fail.  It is very hard to replicate consistently.
```
Trying itk::WriteImage(inputImageNoSform, testFilename)
ITK test driver caught an ITK exception:

itk::ImageFileReaderException (000000CF6E0FF570)
Location: "unknown"
File: T:\Dashboard\ITK\Modules\IO\ImageBase\include\itkImageFileReader.hxx
Line: 137
Description:  Could not create IO object for reading file T:/Dashboard/ITK-build/Testing/Temporary/ITKIONIFTI/test_filled_sform.nii.gz
  Tried to create one of the following:
    MetaImageIO
    GDCMImageIO
    JPEGImageIO
    VTKImageIO
    PNGImageIO
    TIFFImageIO
    BMPImageIO
    NrrdImageIO
    GiplImageIO
    NiftiImageIO
  You probably failed to set a file suffix, or
    set the suffix to an unsupported type.
```

The hypothesis is that the file is somehow cached or in an indeterminate state on disk before being re-read in.  In an attempt to make the test more stable on the dashboards, add a 1/4 second delay between writing and reading.  Also pin the readers and writers to only use the NiftiIO reader that is being tested.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
