### PR TITLE
releaase-5.4 BUG: Python version mis-match during build and test

### DIFF
--- a/Wrapping/macro_files/itk_end_wrap_module.cmake
+++ b/Wrapping/macro_files/itk_end_wrap_module.cmake
@@ -421,8 +421,10 @@ ${DO_NOT_WAIT_FOR_THREADS_CALLS}
       if (ITK_USE_PYTHON_LIMITED_API)
         set_target_properties(${lib} PROPERTIES SUFFIX .abi3.so)
       else()
-        find_package(Python)
-        if(PYTHON_FOUND)
+        if(NOT PYTHON3_FOUND)
+          find_package(Python3 ${PYTHON_REQUIRED_VERSION} COMPONENTS Interpreter Development.Module ${SKBUILD_SABI_COMPONENT})
+        endif()
+        if(PYTHON3_FOUND)
 # Graalpy Patch
           set_target_properties(${lib} PROPERTIES SUFFIX .${Python_SOABI}.so)
         else()


### PR DESCRIPTION
```txt
grep "Found Python" ITK.macOS.Python.logs

-- Found Python3: /Users/runner/hostedtoolcache/Python/3.9.22/x64/bin/python3 (found suitable version "3.9.22", required range is "3.9...3.999") found components: Interpreter Development.Module
-- Found Python: /usr/local/Frameworks/Python.framework/Versions/3.13/bin/python3.13 (found version "3.13.3") found components: Interpreter
Linking CXX shared module Wrapping/Generators/Python/itk/_ITKPyBasePython.cpython-313-darwin.so
```

NOTE:  Python3.13 is found after Python 3.9 is set.  The issue is that python3.9 is used to run the tests, but the shared libraries are built with 3.13.


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
