### PR TITLE
COMP: Identify numpy bool attr as bool instead of bool8

### DIFF
--- a/Wrapping/Generators/Python/itk/support/types.py
+++ b/Wrapping/Generators/Python/itk/support/types.py
@@ -140,7 +140,7 @@ class itkCType:
         _SS: "itkCType" = itkCType("signed short", "SS", np.dtype(np.int16))
         _SI: "itkCType" = itkCType("signed int", "SI", np.dtype(np.int32))
         _SLL: "itkCType" = itkCType("signed long long", "SLL", np.dtype(np.int64))
-        _B: "itkCType" = itkCType("bool", "B", np.dtype(np.bool8))
+        _B: "itkCType" = itkCType("bool", "B", np.dtype(np.bool))
         return _F, _D, _UC, _US, _UI, _UL, _SL, _LD, _ULL, _SC, _SS, _SI, _SLL, _B
 
 


### PR DESCRIPTION
For:

Traceback (most recent call last):
  File "/home/matt/src/ITK/Wrapping/Generators/Python/Tests/test_metadata.py", line 26, in <module>
    import itk
  File "/home/matt/src/ITK/build-python/Wrapping/Generators/Python/itk/__init__.py", line 28, in <module>
    from itk.support.extras import *
  File "/home/matt/src/ITK/build-python/Wrapping/Generators/Python/itk/support/extras.py", line 37, in <module>
    import itk.support.types as itkt
  File "/home/matt/src/ITK/build-python/Wrapping/Generators/Python/itk/support/types.py", line 178, in <module>
    ) = itkCType.initialize_c_types_once()
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/matt/src/ITK/build-python/Wrapping/Generators/Python/itk/support/types.py", line 143, in initialize_c_types_once
    _B: "itkCType" = itkCType("bool", "B", np.dtype(np.bool8))
                                                    ^^^^^^^^
  File "/home/matt/src/ITK/.pixi/envs/python/lib/python3.12/site-packages/numpy/__init__.py", line 414, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'bool8'. Did you mean: 'bool'?

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
