### PR TITLE
STYLE: Set black formatting of python files

### DIFF
--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -393,7 +393,7 @@ itk.transformwrite(transforms[0], sys.argv[7], compression=True)
 
 # BridgeNumPy
 
-arr = np.zeros([3,4,5],dtype=np.dtype('uintc'))
+arr = np.zeros([3, 4, 5], dtype=np.dtype("uintc"))
 image = itk.image_from_array(arr)
 assert itk.template(image)[1] == (itk.UI, 3)
 

--- a/Wrapping/Generators/Python/itk/support/extras.py
+++ b/Wrapping/Generators/Python/itk/support/extras.py
@@ -1027,7 +1027,7 @@ def dict_from_polyline(polyline: "itkt.PolylineParametricPath") -> dict:
 
 
 def dict_from_transform(
-    transform: Union["itkt.TransformBase", list["itkt.TransformBase"]]
+    transform: Union["itkt.TransformBase", list["itkt.TransformBase"]],
 ) -> Union[list[dict], dict]:
     """Serialize a Python itk.Transform object to a pickable Python dictionary.
 
@@ -1106,7 +1106,7 @@ def dict_from_transform(
 
 
 def transform_from_dict(
-    transform_dict: Union[dict, list[dict]]
+    transform_dict: Union[dict, list[dict]],
 ) -> "itkt.TransformBase":
     """Deserialize a dictionary representing an itk.Transform object.
 

--- a/Wrapping/Generators/Python/itk/support/init_helpers.py
+++ b/Wrapping/Generators/Python/itk/support/init_helpers.py
@@ -39,7 +39,7 @@ class AutoProgressTypes(IntEnum):
 
 
 def auto_progress(
-    progress_type: Union[bool, AutoProgressTypes] = AutoProgressTypes.TERMINAL
+    progress_type: Union[bool, AutoProgressTypes] = AutoProgressTypes.TERMINAL,
 ) -> None:
     """Set up auto progress report
 


### PR DESCRIPTION
Enforce black formatting to keep aligned with pre-commit
hook enforcements.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)