### PR TITLE
BUG: Jacobian determinant filter results depended on index space orientation

### DIFF
--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.h
@@ -81,14 +81,9 @@ namespace itk
  * C array of TRealValue type.
  *
  * \par Constraints
- * We use vnl_det for determinant computation, which only supports square
- * matrices. So the vector dimension of the input image values must be equal
- * to the image dimensions, which is trivially true for a deformation field
- * that maps an n-dimensional space onto itself.
-
- * Currently, dimensions up to and including 4 are supported. This
- * limitation comes from the presence of vnl_det() functions for matrices of
- * dimension up to 4x4.
+ * The vector dimension of the input image values must equal the image
+ * dimensions, which is trivially true for a deformation field that maps
+ * an n-dimensional space onto itself.
  *
  * The template parameter TRealType must be floating point (float or double) or
  * a user-defined "real" numerical type with arithmetic operations defined
@@ -150,6 +145,10 @@ public:
   using RealType = TRealType;
   using RealVectorType = Vector<TRealType, InputPixelType::Dimension>;
   using RealVectorImageType = Image<RealVectorType, TInputImage::ImageDimension>;
+
+  /** Matrix type used to store the input direction matrix and the gradient matrix from
+      which the Jacobian determinant is computed. */
+  using InternalMatrixType = vnl_matrix_fixed<TRealType, ImageDimension, ImageDimension>;
 
   /** Type of the iterator that will be used to move through the image.  Also
       the type which will be passed to the evaluate function */
@@ -271,6 +270,8 @@ private:
   typename ImageBaseType::ConstPointer m_RealValuedInputImage{};
 
   RadiusType m_NeighborhoodRadius{};
+
+  InternalMatrixType m_InputDirection{};
 };
 } // end namespace itk
 

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.h
@@ -21,7 +21,8 @@
 #include "itkNeighborhoodIterator.h"
 #include "itkImageToImageFilter.h"
 #include "itkVector.h"
-#include "vnl/vnl_matrix.h"
+#include "vnl/vnl_matrix_fixed.h"
+#include "vnl/vnl_vector_fixed.h"
 #include "vnl/vnl_det.h"
 
 namespace itk
@@ -146,10 +147,6 @@ public:
   using RealVectorType = Vector<TRealType, InputPixelType::Dimension>;
   using RealVectorImageType = Image<RealVectorType, TInputImage::ImageDimension>;
 
-  /** Matrix type used to store the input direction matrix and the gradient matrix from
-      which the Jacobian determinant is computed. */
-  using InternalMatrixType = vnl_matrix_fixed<TRealType, ImageDimension, ImageDimension>;
-
   /** Type of the iterator that will be used to move through the image.  Also
       the type which will be passed to the evaluate function */
   using ConstNeighborhoodIteratorType = ConstNeighborhoodIterator<RealVectorImageType>;
@@ -263,6 +260,10 @@ protected:
   WeightsType m_HalfDerivativeWeights{};
 
 private:
+  /** Matrix type used to store the input direction matrix and the gradient matrix from
+      which the Jacobian determinant is computed. */
+  using InternalMatrixType = vnl_matrix_fixed<TRealType, ImageDimension, ImageDimension>;
+
   bool m_UseImageSpacing{ true };
 
   ThreadIdType m_RequestedNumberOfWorkUnits{};

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
@@ -27,6 +27,7 @@
 
 #include "itkMath.h"
 #include "itkPrintHelper.h"
+#include "vnl/algo/vnl_determinant.h"
 
 namespace itk
 {
@@ -138,6 +139,16 @@ DisplacementFieldJacobianDeterminantFilter<TInputImage, TRealType, TOutputImage>
 {
   Superclass::BeforeThreadedGenerateData();
 
+  // Cache the direction matrix from the input
+  const auto & dir_d = this->GetInput()->GetDirection().GetVnlMatrix();
+  for (unsigned int i = 0; i < ImageDimension; ++i)
+  {
+    for (unsigned int j = 0; j < ImageDimension; ++j)
+    {
+      m_InputDirection(i, j) = static_cast<TRealType>(dir_d(i, j));
+    }
+  }
+
   // Set the weights on the derivatives.
   // Are we using image spacing in the calculations?  If so we must update now
   // in case our input image has changed.
@@ -207,18 +218,40 @@ TRealType
 DisplacementFieldJacobianDeterminantFilter<TInputImage, TRealType, TOutputImage>::EvaluateAtNeighborhood(
   const ConstNeighborhoodIteratorType & it) const
 {
-  vnl_matrix_fixed<TRealType, ImageDimension, VectorDimension> J;
-  for (unsigned int i = 0; i < ImageDimension; ++i)
+  InternalMatrixType localGrad;
+  InternalMatrixType physicalGrad;
+
+  for (unsigned int col = 0; col < ImageDimension; ++col)
   {
-    for (unsigned int j = 0; j < VectorDimension; ++j)
+    // Take finite difference along index axis col
+    for (unsigned int row = 0; row < ImageDimension; ++row)
     {
-      J[i][j] = m_HalfDerivativeWeights[i] * (it.GetNext(i)[j] - it.GetPrevious(i)[j]);
+      TRealType localComponentGrad = m_HalfDerivativeWeights[col] * (it.GetNext(col)[row] - it.GetPrevious(col)[row]);
+
+      localGrad[row][col] = localComponentGrad;
     }
-    // add one on the diagonal to consider the warping and not only the
-    // deformation field
-    J[i][i] += 1.0;
   }
-  return vnl_det(J);
+
+  for (unsigned int row = 0; row < ImageDimension; ++row)
+  {
+    vnl_vector_fixed<TRealType, ImageDimension> localComponentGrad_d;
+    for (unsigned int col = 0; col < ImageDimension; ++col)
+    {
+      localComponentGrad_d[col] = localGrad[row][col];
+    }
+
+    vnl_vector_fixed<TRealType, ImageDimension> physicalComponentGrad = m_InputDirection * localComponentGrad_d;
+
+    for (unsigned int col = 0; col < ImageDimension; ++col)
+    {
+      physicalGrad[row][col] = physicalComponentGrad[col];
+    }
+
+    physicalGrad[row][row] += itk::NumericTraits<TRealType>::OneValue();
+  }
+
+  // Return determinant of physical Jacobian:
+  return vnl_determinant(physicalGrad);
 }
 
 template <typename TInputImage, typename TRealType, typename TOutputImage>

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldJacobianDeterminantFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldJacobianDeterminantFilterTest.cxx
@@ -18,8 +18,10 @@
 
 #include <iostream>
 #include "itkDisplacementFieldJacobianDeterminantFilter.h"
+#include "itkFlipImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkNullImageToImageFilterDriver.hxx"
+#include "itkPermuteAxesImageFilter.h"
 #include "itkStdStreamStateSave.h"
 #include "itkTestingMacros.h"
 
@@ -119,7 +121,113 @@ TestDisplacementJacobianDeterminantValue()
   }
   else
   {
-    std::cout << "Test passed." << std::endl;
+    std::cout << "Determinant value test passed" << std::endl;
+  }
+
+  // Now test that the determinant is consistent if the voxel space is different, but the physical space is the same.
+
+  // Define physical point to test
+  itk::Point<double, 2> physPt;
+  dispacementfield->TransformIndexToPhysicalPoint(index, physPt);
+
+  // Use this function to get the determinant at a specified physical point (it will be a different index between tests)
+  auto GetDeterminantAtPoint = [](FieldType::Pointer image, const itk::Point<double, 2> & pt) -> float {
+    auto filter = FilterType::New();
+    filter->SetInput(image);
+    filter->SetUseImageSpacing(true);
+    filter->Update();
+
+    itk::Index<2> mappedIdx = image->TransformPhysicalPointToIndex(pt);
+
+    return filter->GetOutput()->GetPixel(mappedIdx);
+  };
+
+  const float detOriginal = GetDeterminantAtPoint(dispacementfield, physPt);
+
+  // Check that this is the same as above, just to be sure the function above works
+  if (itk::Math::abs(detOriginal - expectedJacobianDeterminant) > epsilon)
+  {
+    std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
+    std::cerr << "Test failed " << std::endl;
+    std::cerr << "Error in pixel value at physical point " << physPt << std::endl;
+    std::cerr << "Expected value " << expectedJacobianDeterminant << std::endl;
+    std::cerr << " differs from " << detOriginal;
+    std::cerr << " by more than " << epsilon << std::endl;
+    testPassed = false;
+  }
+
+  using PermuteFilterType = itk::PermuteAxesImageFilter<FieldType>;
+  auto permute = PermuteFilterType::New();
+
+  PermuteFilterType::PermuteOrderArrayType order;
+  order[0] = 1;
+  order[1] = 0; // swap X <-> Y
+  permute->SetOrder(order);
+  permute->SetInput(dispacementfield);
+  permute->Update();
+
+  auto dispacementfieldPermuted = permute->GetOutput();
+
+  // Adjust direction to match permutation
+  itk::Matrix<double, 2, 2> origDir = dispacementfield->GetDirection();
+  itk::Matrix<double, 2, 2> newDirPermute;
+  newDirPermute[0][0] = origDir[1][0];
+  newDirPermute[0][1] = origDir[1][1];
+  newDirPermute[1][0] = origDir[0][0];
+  newDirPermute[1][1] = origDir[0][1];
+
+  dispacementfieldPermuted->SetDirection(newDirPermute);
+  dispacementfieldPermuted->SetOrigin(dispacementfield->GetOrigin());
+  dispacementfieldPermuted->SetSpacing(dispacementfield->GetSpacing());
+
+  const float detPermuted = GetDeterminantAtPoint(dispacementfieldPermuted, physPt);
+
+  using FlipFilterType = itk::FlipImageFilter<FieldType>;
+  auto flip = FlipFilterType::New();
+
+  FlipFilterType::FlipAxesArrayType flipAxes;
+  flipAxes[0] = true;  // Flip X
+  flipAxes[1] = false; // Keep Y
+  flip->SetFlipAxes(flipAxes);
+  flip->SetInput(dispacementfield);
+  flip->FlipAboutOriginOff();
+  flip->Update();
+
+  auto dispacementfieldFlip = flip->GetOutput();
+
+  // Adjust direction to compensate flip
+  itk::Matrix<double, 2, 2> newDirFlip = dispacementfield->GetDirection();
+  newDirFlip[0][0] *= -1.0;
+  newDirFlip[0][1] *= -1.0;
+
+  dispacementfieldFlip->SetDirection(newDirFlip);
+  dispacementfieldFlip->SetOrigin(dispacementfield->GetOrigin());
+  dispacementfieldFlip->SetSpacing(dispacementfield->GetSpacing());
+
+  const float detFlipped = GetDeterminantAtPoint(dispacementfieldFlip, physPt);
+
+  std::cout << "Determinant at point " << physPt << ":" << std::endl;
+  std::cout << "  Original: " << detOriginal << std::endl;
+  std::cout << "  Permuted: " << detPermuted << std::endl;
+  std::cout << "  Flipped:  " << detFlipped << std::endl;
+
+  constexpr double delta = 1e-13;
+
+  if (itk::Math::abs(detPermuted - detOriginal) > delta)
+  {
+    std::cerr << "Test failed: determinant differs after Permute." << std::endl;
+    testPassed = false;
+  }
+
+  if (itk::Math::abs(detFlipped - detOriginal) > delta)
+  {
+    std::cerr << "Test failed: determinant differs after Flip." << std::endl;
+    testPassed = false;
+  }
+
+  if (testPassed)
+  {
+    std::cout << "Test passed: determinant consistent after Permute and Flip." << std::endl;
   }
 
   return testPassed;

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldJacobianDeterminantFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldJacobianDeterminantFilterTest.cxx
@@ -132,14 +132,14 @@ TestDisplacementJacobianDeterminantValue()
 
   // Use this function to get the determinant at a specified physical point (it will be a different index between tests)
   auto GetDeterminantAtPoint = [](FieldType::Pointer image, const itk::Point<double, 2> & pt) -> float {
-    auto filter = FilterType::New();
-    filter->SetInput(image);
-    filter->SetUseImageSpacing(true);
-    filter->Update();
+    auto innerFilter = FilterType::New();
+    innerFilter->SetInput(image);
+    innerFilter->SetUseImageSpacing(true);
+    innerFilter->Update();
 
     itk::Index<2> mappedIdx = image->TransformPhysicalPointToIndex(pt);
 
-    return filter->GetOutput()->GetPixel(mappedIdx);
+    return innerFilter->GetOutput()->GetPixel(mappedIdx);
   };
 
   const float detOriginal = GetDeterminantAtPoint(dispacementfield, physPt);
@@ -196,13 +196,13 @@ TestDisplacementJacobianDeterminantValue()
   auto dispacementfieldFlip = flip->GetOutput();
 
   // Adjust direction to compensate flip
-  itk::Matrix<double, 2, 2> newDirFlip = dispacementfield->GetDirection();
-  newDirFlip[0][0] *= -1.0;
-  newDirFlip[0][1] *= -1.0;
+  itk::Matrix<double, 2, 2> flipMat;
+  flipMat.SetIdentity();
+  flipMat[0][0] = -1.0;
+
+  itk::Matrix<double, 2, 2> newDirFlip = flipMat * dispacementfield->GetDirection();
 
   dispacementfieldFlip->SetDirection(newDirFlip);
-  dispacementfieldFlip->SetOrigin(dispacementfield->GetOrigin());
-  dispacementfieldFlip->SetSpacing(dispacementfield->GetSpacing());
 
   const float detFlipped = GetDeterminantAtPoint(dispacementfieldFlip, physPt);
 

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldJacobianDeterminantFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldJacobianDeterminantFilterTest.cxx
@@ -39,23 +39,23 @@ TestDisplacementJacobianDeterminantValue()
   using VectorImageType = FieldType;
 
 
-  std::cout << "Create the dispacementfield image pattern." << std::endl;
+  std::cout << "Create the displacementField image pattern." << std::endl;
   VectorImageType::RegionType region;
   // NOTE:  Making the image size much larger than necessary in order to get
   //       some meaningful time measurements.  Simulate a 256x256x256 image.
   constexpr VectorImageType::SizeType size{ 4096, 4096 };
   region.SetSize(size);
 
-  auto dispacementfield = VectorImageType::New();
-  dispacementfield->SetLargestPossibleRegion(region);
-  dispacementfield->SetBufferedRegion(region);
-  dispacementfield->Allocate();
+  auto displacementField = VectorImageType::New();
+  displacementField->SetLargestPossibleRegion(region);
+  displacementField->SetBufferedRegion(region);
+  displacementField->Allocate();
 
   VectorType values;
   values[0] = 0;
   values[1] = 0;
   using Iterator = itk::ImageRegionIteratorWithIndex<VectorImageType>;
-  for (Iterator inIter(dispacementfield, region); !inIter.IsAtEnd(); ++inIter)
+  for (Iterator inIter(displacementField, region); !inIter.IsAtEnd(); ++inIter)
   {
     const unsigned int i = inIter.GetIndex()[0];
     const unsigned int j = inIter.GetIndex()[1];
@@ -97,7 +97,7 @@ TestDisplacementJacobianDeterminantValue()
 #endif
   ITK_TEST_SET_GET_BOOLEAN(filter, UseImageSpacing, useImageSpacing);
 
-  filter->SetInput(dispacementfield);
+  filter->SetInput(displacementField);
   filter->Update();
 
 
@@ -128,7 +128,7 @@ TestDisplacementJacobianDeterminantValue()
 
   // Define physical point to test
   itk::Point<double, 2> physPt;
-  dispacementfield->TransformIndexToPhysicalPoint(index, physPt);
+  displacementField->TransformIndexToPhysicalPoint(index, physPt);
 
   // Use this function to get the determinant at a specified physical point (it will be a different index between tests)
   auto GetDeterminantAtPoint = [](FieldType::Pointer image, const itk::Point<double, 2> & pt) -> float {
@@ -142,7 +142,7 @@ TestDisplacementJacobianDeterminantValue()
     return innerFilter->GetOutput()->GetPixel(mappedIdx);
   };
 
-  const float detOriginal = GetDeterminantAtPoint(dispacementfield, physPt);
+  const float detOriginal = GetDeterminantAtPoint(displacementField, physPt);
 
   // Check that this is the same as above, just to be sure the function above works
   if (itk::Math::abs(detOriginal - expectedJacobianDeterminant) > epsilon)
@@ -163,24 +163,24 @@ TestDisplacementJacobianDeterminantValue()
   order[0] = 1;
   order[1] = 0; // swap X <-> Y
   permute->SetOrder(order);
-  permute->SetInput(dispacementfield);
+  permute->SetInput(displacementField);
   permute->Update();
 
-  auto dispacementfieldPermuted = permute->GetOutput();
+  auto displacementFieldPermuted = permute->GetOutput();
 
   // Adjust direction to match permutation
-  itk::Matrix<double, 2, 2> origDir = dispacementfield->GetDirection();
+  itk::Matrix<double, 2, 2> origDir = displacementField->GetDirection();
   itk::Matrix<double, 2, 2> newDirPermute;
   newDirPermute[0][0] = origDir[1][0];
   newDirPermute[0][1] = origDir[1][1];
   newDirPermute[1][0] = origDir[0][0];
   newDirPermute[1][1] = origDir[0][1];
 
-  dispacementfieldPermuted->SetDirection(newDirPermute);
-  dispacementfieldPermuted->SetOrigin(dispacementfield->GetOrigin());
-  dispacementfieldPermuted->SetSpacing(dispacementfield->GetSpacing());
+  displacementFieldPermuted->SetDirection(newDirPermute);
+  displacementFieldPermuted->SetOrigin(displacementField->GetOrigin());
+  displacementFieldPermuted->SetSpacing(displacementField->GetSpacing());
 
-  const float detPermuted = GetDeterminantAtPoint(dispacementfieldPermuted, physPt);
+  const float detPermuted = GetDeterminantAtPoint(displacementFieldPermuted, physPt);
 
   using FlipFilterType = itk::FlipImageFilter<FieldType>;
   auto flip = FlipFilterType::New();
@@ -189,22 +189,22 @@ TestDisplacementJacobianDeterminantValue()
   flipAxes[0] = true;  // Flip X
   flipAxes[1] = false; // Keep Y
   flip->SetFlipAxes(flipAxes);
-  flip->SetInput(dispacementfield);
+  flip->SetInput(displacementField);
   flip->FlipAboutOriginOff();
   flip->Update();
 
-  auto dispacementfieldFlip = flip->GetOutput();
+  auto displacementFieldFlip = flip->GetOutput();
 
   // Adjust direction to compensate flip
   itk::Matrix<double, 2, 2> flipMat;
   flipMat.SetIdentity();
   flipMat[0][0] = -1.0;
 
-  itk::Matrix<double, 2, 2> newDirFlip = flipMat * dispacementfield->GetDirection();
+  itk::Matrix<double, 2, 2> newDirFlip = flipMat * displacementField->GetDirection();
 
-  dispacementfieldFlip->SetDirection(newDirFlip);
+  displacementFieldFlip->SetDirection(newDirFlip);
 
-  const float detFlipped = GetDeterminantAtPoint(dispacementfieldFlip, physPt);
+  const float detFlipped = GetDeterminantAtPoint(displacementFieldFlip, physPt);
 
   std::cout << "Determinant at point " << physPt << ":" << std::endl;
   std::cout << "  Original: " << detOriginal << std::endl;


### PR DESCRIPTION
Fixing #5358 

I updated the ITK test to check the determinants after permuting or flipping the index space, and updating the header to compensate. I think I've done this correctly, at least I can now get the same answer as with an identity transform.

I did some more tests in some sample data I made for debugging ANTs jacobians (linked in the issue). 

This PR makes the filter more comparable to what you would get by iterating over the displacement field voxels and calling the `ComputeJacobianWithRespectToPosition` function at each point. It's not exactly the same, because the finite difference sampling scheme is not the same, although the filter allows users to set custom weights, so maybe it could be made more similar. 

One other thing (which I can fix): in the test, the seeming typo variable name "dispacementfield" was used throughout one function, I thought it might be intentional, so I didn't change it. But happy to update if needed.