### PR TITLE
 Make `GetComponentTypeAsString` and `GetPixelTypeAsString` functions static 

### DIFF
--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
@@ -582,7 +582,7 @@ Bruker2dseqImageIO::Read(void * buffer)
       Rescale(static_cast<double *>(buffer), slopes, offsets, frameSize, frameCount);
       break;
     default:
-      itkExceptionMacro("Datatype not supported: " << this->GetComponentTypeAsString(this->m_ComponentType));
+      itkExceptionMacro("Datatype not supported: " << ImageIOBase::GetComponentTypeAsString(this->m_ComponentType));
   }
 
   //
@@ -641,7 +641,7 @@ Bruker2dseqImageIO::Read(void * buffer)
           SwapSlicesAndVolumes(static_cast<double *>(buffer), x, y, z, sizeToSwap, noswap);
           break;
         default:
-          itkExceptionMacro("Datatype not supported: " << this->GetComponentTypeAsString(this->m_ComponentType));
+          itkExceptionMacro("Datatype not supported: " << ImageIOBase::GetComponentTypeAsString(this->m_ComponentType));
       }
     }
   }
@@ -686,7 +686,7 @@ Bruker2dseqImageIO::Read(void * buffer)
         ReverseSliceOrder(static_cast<double *>(buffer), x, y, z, v);
         break;
       default:
-        itkExceptionMacro("Datatype not supported: " << this->GetComponentTypeAsString(this->m_ComponentType));
+        itkExceptionMacro("Datatype not supported: " << ImageIOBase::GetComponentTypeAsString(this->m_ComponentType));
     }
   }
 }

--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -399,8 +399,8 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateData()
     // the pixel types don't match so a type conversion needs to be
     // performed
     itkDebugMacro("Buffer conversion required from: "
-                  << m_ImageIO->GetComponentTypeAsString(m_ImageIO->GetComponentType())
-                  << " to: " << m_ImageIO->GetComponentTypeAsString(ioType) << " ConvertPixelTraits::NumComponents "
+                  << ImageIOBase::GetComponentTypeAsString(m_ImageIO->GetComponentType())
+                  << " to: " << ImageIOBase::GetComponentTypeAsString(ioType) << " ConvertPixelTraits::NumComponents "
                   << ConvertPixelTraits::GetNumberOfComponents() << " m_ImageIO->NumComponents "
                   << m_ImageIO->GetNumberOfComponents());
 
@@ -496,12 +496,12 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::DoConvertBuffer(const void * 
   ITK_CONVERT_BUFFER_IF_BLOCK(IOComponentEnum::DOUBLE, double)
   else
   {
-#define TYPENAME(x) m_ImageIO->GetComponentTypeAsString(ImageIOBase::MapPixelType<x>::CType)
+#define TYPENAME(x) ImageIOBase::GetComponentTypeAsString(ImageIOBase::MapPixelType<x>::CType)
 
     ImageFileReaderException e(__FILE__, __LINE__);
     std::ostringstream       msg;
     msg << "Couldn't convert component type: " << std::endl
-        << "    " << m_ImageIO->GetComponentTypeAsString(m_ImageIO->GetComponentType()) << std::endl
+        << "    " << ImageIOBase::GetComponentTypeAsString(m_ImageIO->GetComponentType()) << std::endl
         << "to one of: " << std::endl
         << "    " << TYPENAME(unsigned char) << std::endl
         << "    " << TYPENAME(char) << std::endl

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -1159,8 +1159,8 @@ ImageIOBase::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "IORegion: " << std::endl;
   m_IORegion.Print(os, indent.GetNextIndent());
   os << indent << "NumberOfComponents/Pixel: " << m_NumberOfComponents << std::endl;
-  os << indent << "PixeType: " << this->GetPixelTypeAsString(m_PixelType) << std::endl;
-  os << indent << "ComponentType: " << this->GetComponentTypeAsString(m_ComponentType) << std::endl;
+  os << indent << "PixeType: " << Self::GetPixelTypeAsString(m_PixelType) << std::endl;
+  os << indent << "ComponentType: " << Self::GetComponentTypeAsString(m_ComponentType) << std::endl;
   os << indent << "Dimensions: " << m_Dimensions << std::endl;
   os << indent << "Origin: " << m_Origin << std::endl;
   os << indent << "Spacing: " << m_Spacing << std::endl;

--- a/Modules/IO/MRC/src/itkMRCImageIO.cxx
+++ b/Modules/IO/MRC/src/itkMRCImageIO.cxx
@@ -417,8 +417,8 @@ MRCImageIO::UpdateHeaderFromImageIO()
   if (header.mode == -1)
   {
     itkExceptionMacro("Unsupported pixel type: "
-                      << this->GetPixelTypeAsString(this->GetPixelType()) << ' '
-                      << this->GetComponentTypeAsString(this->GetComponentType()) << std::endl
+                      << ImageIOBase::GetPixelTypeAsString(this->GetPixelType()) << ' '
+                      << ImageIOBase::GetComponentTypeAsString(this->GetComponentType()) << std::endl
                       << "Supported pixel types include unsigned byte, unsigned short, short, float, rgb "
                          "unsigned char, float complex");
   }

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
@@ -356,8 +356,8 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Re
     // the point pixel types don't match a type conversion needs to be
     // performed
     itkDebugMacro("Buffer conversion required from: "
-                  << m_MeshIO->GetComponentTypeAsString(m_MeshIO->GetPointPixelComponentType()) << " to: "
-                  << m_MeshIO->GetComponentTypeAsString(
+                  << MeshIOBase::GetComponentTypeAsString(m_MeshIO->GetPointPixelComponentType()) << " to: "
+                  << MeshIOBase::GetComponentTypeAsString(
                        MeshIOBase::MapComponentType<typename ConvertPointPixelTraits::ComponentType>::CType)
                   << "ConvertPointPixelTraits::NumberOfComponents " << ConvertPointPixelTraits::GetNumberOfComponents()
                   << " m_MeshIO->NumberOfComponents " << m_MeshIO->GetNumberOfPointPixelComponents());
@@ -397,8 +397,8 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Re
     // the cell pixel types don't match a type conversion needs to be
     // performed
     itkDebugMacro("Buffer conversion required from: "
-                  << m_MeshIO->GetComponentTypeAsString(m_MeshIO->GetCellPixelComponentType()) << " to: "
-                  << m_MeshIO->GetComponentTypeAsString(
+                  << MeshIOBase::GetComponentTypeAsString(m_MeshIO->GetCellPixelComponentType()) << " to: "
+                  << MeshIOBase::GetComponentTypeAsString(
                        MeshIOBase::MapComponentType<typename ConvertCellPixelTraits::ComponentType>::CType)
                   << "ConvertCellPixelTraits::NumberOfComponents " << ConvertCellPixelTraits::GetNumberOfComponents()
                   << " m_MeshIO->NumberOfComponents " << m_MeshIO->GetNumberOfCellPixelComponents());
@@ -722,23 +722,27 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Co
     MeshFileReaderException e(__FILE__, __LINE__);
     std::ostringstream      msg;
     msg << "Couldn't convert component type: " << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(m_MeshIO->GetPointPixelComponentType()) << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(m_MeshIO->GetPointPixelComponentType()) << std::endl
         << "to one of: " << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<unsigned char>::CType) << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<char>::CType) << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<unsigned short>::CType)
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<unsigned char>::CType)
         << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<short>::CType) << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<unsigned int>::CType) << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<int>::CType) << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<unsigned long>::CType) << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<long>::CType) << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<unsigned long long>::CType)
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<char>::CType) << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<unsigned short>::CType)
         << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<long long>::CType) << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<float>::CType) << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<double>::CType) << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<long double>::CType) << std::endl;
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<short>::CType) << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<unsigned int>::CType)
+        << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<int>::CType) << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<unsigned long>::CType)
+        << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<long>::CType) << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<unsigned long long>::CType)
+        << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<long long>::CType) << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<float>::CType) << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<double>::CType) << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<long double>::CType)
+        << std::endl;
     e.SetDescription(msg.str().c_str());
     e.SetLocation(ITK_LOCATION);
     throw e;
@@ -793,23 +797,27 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Co
     MeshFileReaderException e(__FILE__, __LINE__);
     std::ostringstream      msg;
     msg << "Couldn't convert component type: " << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(m_MeshIO->GetCellPixelComponentType()) << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(m_MeshIO->GetCellPixelComponentType()) << std::endl
         << "to one of: " << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<unsigned char>::CType) << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<char>::CType) << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<unsigned short>::CType)
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<unsigned char>::CType)
         << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<short>::CType) << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<unsigned int>::CType) << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<int>::CType) << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<unsigned long>::CType) << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<long>::CType) << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<unsigned long long>::CType)
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<char>::CType) << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<unsigned short>::CType)
         << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<long long>::CType) << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<float>::CType) << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<double>::CType) << std::endl
-        << "    " << m_MeshIO->GetComponentTypeAsString(MeshIOBase::MapComponentType<long double>::CType) << std::endl;
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<short>::CType) << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<unsigned int>::CType)
+        << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<int>::CType) << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<unsigned long>::CType)
+        << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<long>::CType) << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<unsigned long long>::CType)
+        << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<long long>::CType) << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<float>::CType) << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<double>::CType) << std::endl
+        << "    " << MeshIOBase::GetComponentTypeAsString(MeshIOBase::MapComponentType<long double>::CType)
+        << std::endl;
     e.SetDescription(msg.str().c_str());
     e.SetLocation(ITK_LOCATION);
     throw e;

--- a/Modules/IO/MeshBase/include/itkMeshIOBase.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOBase.h
@@ -479,11 +479,11 @@ public:
 
   /** Convenience method returns the IOComponentEnum as a string. This can be
    * used for writing output files. */
-  std::string GetComponentTypeAsString(IOComponentEnum) const;
+  static std::string GetComponentTypeAsString(IOComponentEnum);
 
   /** Convenience method returns the IOPixelEnum as a string. This can be
    * used for writing output files. */
-  std::string GetPixelTypeAsString(IOPixelEnum) const;
+  static std::string GetPixelTypeAsString(IOPixelEnum);
 
   /** These methods control whether the file is written binary or ASCII.
    * Many file formats (i.e., subclasses) ignore this flag. */

--- a/Modules/IO/MeshBase/src/itkMeshIOBase.cxx
+++ b/Modules/IO/MeshBase/src/itkMeshIOBase.cxx
@@ -125,7 +125,7 @@ MeshIOBase::GetByteOrderAsString(IOByteOrderEnum t) const
 }
 
 std::string
-MeshIOBase::GetComponentTypeAsString(IOComponentEnum t) const
+MeshIOBase::GetComponentTypeAsString(IOComponentEnum t)
 {
   switch (t)
   {
@@ -160,11 +160,11 @@ MeshIOBase::GetComponentTypeAsString(IOComponentEnum t) const
     default:
       break;
   }
-  itkExceptionMacro("Unknown component type: " << static_cast<char>(t));
+  itkGenericExceptionMacro("Unknown component type: " << static_cast<char>(t));
 }
 
 std::string
-MeshIOBase::GetPixelTypeAsString(IOPixelEnum t) const
+MeshIOBase::GetPixelTypeAsString(IOPixelEnum t)
 {
   switch (t)
   {
@@ -203,7 +203,7 @@ MeshIOBase::GetPixelTypeAsString(IOPixelEnum t) const
     default:
       break;
   }
-  itkExceptionMacro("Unknown pixel type: " << static_cast<char>(t));
+  itkGenericExceptionMacro("Unknown pixel type: " << static_cast<char>(t));
 }
 
 void

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -799,7 +799,8 @@ NiftiImageIO::Read(void * buffer)
       default:
         if (this->GetPixelType() == IOPixelEnum::SCALAR)
         {
-          itkExceptionMacro("Datatype: " << this->GetComponentTypeAsString(this->m_ComponentType) << " not supported");
+          itkExceptionMacro("Datatype: " << ImageIOBase::GetComponentTypeAsString(this->m_ComponentType)
+                                         << " not supported");
         }
     }
   }
@@ -820,7 +821,7 @@ NiftiImageIO::Read(void * buffer)
         ConvertRASToFromLPS_CXYZT(static_cast<double *>(buffer), numElts * numComponents);
         break;
       default:
-        itkExceptionMacro("RAS conversion of datatype " << this->GetComponentTypeAsString(this->m_ComponentType)
+        itkExceptionMacro("RAS conversion of datatype " << ImageIOBase::GetComponentTypeAsString(this->m_ComponentType)
                                                         << " is not supported");
     }
   }
@@ -2492,8 +2493,8 @@ NiftiImageIO::Write(const void * buffer)
           ConvertRASToFromLPS_XYZTC(reinterpret_cast<double *>(nifti_buf.get()), numComponents * seriesdist);
           break;
         default:
-          itkExceptionMacro("RAS conversion of datatype " << this->GetComponentTypeAsString(this->m_ComponentType)
-                                                          << " is not supported");
+          itkExceptionMacro("RAS conversion of datatype "
+                            << ImageIOBase::GetComponentTypeAsString(this->m_ComponentType) << " is not supported");
       }
     }
 

--- a/Modules/IO/VTK/include/itkVTKImageIO.h
+++ b/Modules/IO/VTK/include/itkVTKImageIO.h
@@ -157,8 +157,9 @@ protected:
 
 private:
   void
-              SetPixelTypeFromString(const std::string & pixelType);
-  std::string GetComponentTypeAsString(IOComponentEnum);
+  SetPixelTypeFromString(const std::string & pixelType);
+
+  static std::string GetComponentTypeAsString(IOComponentEnum);
 
   /** Return the number of pixels in the IOregion. */
   SizeType

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -686,18 +686,18 @@ VTKImageIO::WriteImageInformation(const void * itkNotUsed(buffer))
   // Prefer the VECTORS representation when possible:
   else if (this->GetPixelType() == IOPixelEnum::VECTOR && this->GetNumberOfComponents() == 3)
   {
-    file << "VECTORS vectors " << this->GetComponentTypeAsString(m_ComponentType) << '\n';
+    file << "VECTORS vectors " << Self::GetComponentTypeAsString(m_ComponentType) << '\n';
   }
   else if (this->GetPixelType() == IOPixelEnum::SYMMETRICSECONDRANKTENSOR)
   {
-    file << "TENSORS tensors " << this->GetComponentTypeAsString(m_ComponentType) << '\n';
+    file << "TENSORS tensors " << Self::GetComponentTypeAsString(m_ComponentType) << '\n';
   }
   else
   {
     // According to VTK documentation number of components should in
     // range (1,4):
     // todo this should be asserted or checked earlier!
-    file << "SCALARS scalars " << this->GetComponentTypeAsString(m_ComponentType) << ' '
+    file << "SCALARS scalars " << Self::GetComponentTypeAsString(m_ComponentType) << ' '
          << this->GetNumberOfComponents() << '\n'
          << "LOOKUP_TABLE default\n";
   }

--- a/Modules/Video/IO/include/itkVideoFileReader.hxx
+++ b/Modules/Video/IO/include/itkVideoFileReader.hxx
@@ -195,8 +195,8 @@ VideoFileReader<TOutputVideoStream>::InitializeVideoIO()
     // the pixel types don't match so a type conversion needs to be
     // performed
     itkDebugMacro("Buffer conversion required from: "
-                  << m_VideoIO->GetComponentTypeAsString(m_VideoIO->GetComponentType())
-                  << " to: " << m_VideoIO->GetComponentTypeAsString(ioType) << " ConvertPixelTraits::NumComponents "
+                  << ImageIOBase::GetComponentTypeAsString(m_VideoIO->GetComponentType())
+                  << " to: " << ImageIOBase::GetComponentTypeAsString(ioType) << " ConvertPixelTraits::NumComponents "
                   << ConvertPixelTraits::GetNumberOfComponents() << " m_VideoIO->NumComponents "
                   << m_VideoIO->GetNumberOfComponents());
     m_PixelConversionNeeded = true;
@@ -290,12 +290,12 @@ VideoFileReader<TOutputVideoStream>::DoConvertBuffer(const void * inputData, Fra
   ITK_CONVERT_BUFFER_IF_BLOCK(IOComponentEnum::DOUBLE, double)
   else
   {
-#define TYPENAME_VideoFileReader(x) m_VideoIO->GetComponentTypeAsString(ImageIOBase::MapPixelType<x>::CType)
+#define TYPENAME_VideoFileReader(x) ImageIOBase::GetComponentTypeAsString(ImageIOBase::MapPixelType<x>::CType)
 
     ExceptionObject    e(__FILE__, __LINE__);
     std::ostringstream msg;
     msg << "Couldn't convert component type: " << std::endl
-        << "    " << m_VideoIO->GetComponentTypeAsString(m_VideoIO->GetComponentType()) << std::endl
+        << "    " << ImageIOBase::GetComponentTypeAsString(m_VideoIO->GetComponentType()) << std::endl
         << "to one of: " << std::endl
         << "    " << TYPENAME_VideoFileReader(unsigned char) << std::endl
         << "    " << TYPENAME_VideoFileReader(char) << std::endl


### PR DESCRIPTION
Follow-up to commit 2cedb035e9c35a22236c4b64de7cd621c1415b92, "ENH: Make string/type conversion functions static in ImageIOBase", David Doria, May 10, 2011.

Adjusted the calls to those member functions, following [clang-tidy static-accessed-through-instance](https://clang.llvm.org/extra/clang-tidy/checks/readability/static-accessed-through-instance.html
) ("Checks for member expressions that access static members through instances").
