### PR TITLE
STYLE: Assign initial values to variables

### DIFF
--- a/Modules/Core/Common/include/itkAnnulusOperator.hxx
+++ b/Modules/Core/Common/include/itkAnnulusOperator.hxx
@@ -59,9 +59,10 @@ auto
 AnnulusOperator<TPixel, TDimension, TAllocator>::GenerateCoefficients() -> CoefficientVector
 {
   // Determine the initial kernel values...
-  double interiorV;
-  double annulusV;
-  double exteriorV;
+  // values for a specified kernel
+  double interiorV = m_InteriorValue;
+  double annulusV = m_AnnulusValue;
+  double exteriorV = m_ExteriorValue;
 
   if (m_Normalize)
   {
@@ -71,13 +72,6 @@ AnnulusOperator<TPixel, TDimension, TAllocator>::GenerateCoefficients() -> Coeff
     interiorV = bright;
     annulusV = -1.0 * bright;
     exteriorV = 0.0;
-  }
-  else
-  {
-    // values for a specified kernel
-    interiorV = m_InteriorValue;
-    annulusV = m_AnnulusValue;
-    exteriorV = m_ExteriorValue;
   }
 
   // Compute the size of the kernel in pixels

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
@@ -219,7 +219,7 @@ public:
   PixelType
   GetPixel(const OffsetType & o) const
   {
-    bool inbounds;
+    bool inbounds = false;
 
     return (this->GetPixel(this->GetNeighborhoodIndex(o), inbounds));
   }

--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
@@ -41,14 +41,10 @@ GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients
 
 
   // Calculate scale-space normalization factor for derivatives
-  double norm;
+  double norm = 1.0;
   if (m_NormalizeAcrossScale)
   {
     norm = std::pow(m_Variance, m_Order / 2.0);
-  }
-  else
-  {
-    norm = 1.0;
   }
 
   // additional normalization for spacing
@@ -166,7 +162,7 @@ template <typename TPixel, unsigned int VDimension, typename TAllocator>
 double
 GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::ModifiedBesselI0(double y)
 {
-  double accumulator;
+  double accumulator = NAN;
 
   const double d = itk::Math::abs(y);
   if (d < 3.75)
@@ -195,7 +191,7 @@ template <typename TPixel, unsigned int VDimension, typename TAllocator>
 double
 GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::ModifiedBesselI1(double y)
 {
-  double       accumulator;
+  double       accumulator = NAN;
   const double d = itk::Math::abs(y);
   if (d < 3.75)
   {
@@ -235,7 +231,7 @@ GaussianDerivativeOperator<TPixel, VDimension, TAllocator>::ModifiedBesselI(int 
                                                                                                  // placeholder
   }
 
-  double accumulator;
+  double accumulator = NAN;
   if (y == 0.0)
   {
     return 0.0;

--- a/Modules/Core/Common/include/itkGaussianDerivativeSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkGaussianDerivativeSpatialFunction.hxx
@@ -31,7 +31,7 @@ GaussianDerivativeSpatialFunction<TOutput, VImageDimension, TInput>::Evaluate(co
   // Normalizing the Gaussian is important for statistical applications
   // but is generally not desirable for creating images because of the
   // very small numbers involved (would need to use doubles)
-  double prefixDenom;
+  double prefixDenom = 1.0;
 
   if (m_Normalized)
   {
@@ -43,10 +43,6 @@ GaussianDerivativeSpatialFunction<TOutput, VImageDimension, TInput>::Evaluate(co
     }
 
     prefixDenom *= 2 * std::pow(2 * itk::Math::pi, VImageDimension / 2.0);
-  }
-  else
-  {
-    prefixDenom = 1.0;
   }
 
   double suffixExp = 0;

--- a/Modules/Core/Common/include/itkGaussianOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianOperator.hxx
@@ -76,7 +76,7 @@ double
 GaussianOperator<TPixel, VDimension, TAllocator>::ModifiedBesselI0(double y)
 {
   const double d = itk::Math::abs(y);
-  double       accumulator;
+  double       accumulator = NAN;
 
   if (d < 3.75)
   {
@@ -105,7 +105,7 @@ double
 GaussianOperator<TPixel, VDimension, TAllocator>::ModifiedBesselI1(double y)
 {
   const double d = itk::Math::abs(y);
-  double       accumulator;
+  double       accumulator = NAN;
 
   if (d < 3.75)
   {

--- a/Modules/Core/Common/include/itkImageRegionReverseConstIterator.h
+++ b/Modules/Core/Common/include/itkImageRegionReverseConstIterator.h
@@ -266,12 +266,10 @@ public:
       const typename ImageConstIterator<TImage>::SizeType &  size = this->m_Region.GetSize();
 
       // Decrement along a row, then wrap at the beginning of the region row.
-      bool         done;
-      unsigned int dim;
 
       // Check to see if we are past the first pixel in the region
       // Note that --ind[0] moves to the previous pixel along the row.
-      done = (--ind[0] == startIndex[0] - 1);
+      bool done = (--ind[0] == startIndex[0] - 1);
       for (unsigned int i = 1; done && i < this->ImageIteratorDimension; ++i)
       {
         done = (ind[i] == startIndex[i]);
@@ -279,7 +277,7 @@ public:
 
       // if the iterator is outside the region (but not past region begin) then
       // we need to wrap around the region
-      dim = 0;
+      unsigned int dim = 0;
       if (!done)
       {
         while ((dim < this->ImageIteratorDimension - 1) && (ind[dim] < startIndex[dim]))
@@ -322,12 +320,9 @@ public:
       const typename ImageIterator<TImage>::SizeType &  size = this->m_Region.GetSize();
 
       // Increment along a row, then wrap at the end of the region row.
-      bool         done;
-      unsigned int dim;
-
       // Check to see if we are past the last pixel in the region
       // Note that ++ind[0] moves to the next pixel along the row.
-      done = (++ind[0] == startIndex[0] + static_cast<OffsetValueType>(size[0]));
+      bool done = (++ind[0] == startIndex[0] + static_cast<OffsetValueType>(size[0]));
       for (unsigned int i = 1; done && i < this->ImageIteratorDimension; ++i)
       {
         done = (ind[i] == startIndex[i] + static_cast<OffsetValueType>(size[i]) - 1);
@@ -335,7 +330,7 @@ public:
 
       // if the iterator is outside the region (but not past region end) then
       // we need to wrap around the region
-      dim = 0;
+      unsigned int dim = 0;
       if (!done)
       {
         while ((dim < this->ImageIteratorDimension - 1) &&

--- a/Modules/Core/Common/include/itkImageReverseConstIterator.h
+++ b/Modules/Core/Common/include/itkImageReverseConstIterator.h
@@ -170,14 +170,12 @@ public:
    * the iterator at the begin of the region. */
   ImageReverseConstIterator(const ImageType * ptr, const RegionType & region)
   {
-    SizeValueType offset;
-
     m_Image = ptr;
     m_Buffer = m_Image->GetBufferPointer();
     m_Region = region;
 
     // Compute the end offset, one pixel before the first pixel
-    offset = m_Image->ComputeOffset(m_Region.GetIndex());
+    SizeValueType offset = m_Image->ComputeOffset(m_Region.GetIndex());
     m_EndOffset = offset - 1;
 
     // Compute the begin offset, the last pixel in the region

--- a/Modules/Core/Common/include/itkImportImageContainer.hxx
+++ b/Modules/Core/Common/include/itkImportImageContainer.hxx
@@ -155,7 +155,7 @@ TElement *
 ImportImageContainer<TElementIdentifier, TElement>::AllocateElements(ElementIdentifier size,
                                                                      bool              UseValueInitialization) const
 {
-  TElement * data;
+  TElement * data = nullptr;
 
   try
   {

--- a/Modules/Core/Common/include/itkImportImageFilter.hxx
+++ b/Modules/Core/Common/include/itkImportImageFilter.hxx
@@ -31,14 +31,13 @@ template <typename TPixel, unsigned int VImageDimension>
 void
 ImportImageFilter<TPixel, VImageDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
-  int i;
-
   Superclass::PrintSelf(os, indent);
 
   itkPrintSelfObjectMacro(ImportImageContainer);
   os << indent << "Import buffer size: " << m_Size << std::endl;
   os << indent << "Spacing: [";
-  for (i = 0; i < int{ VImageDimension } - 1; ++i)
+  int i = 0;
+  for (; i < int{ VImageDimension } - 1; ++i)
   {
     os << m_Spacing[i] << ", ";
   }

--- a/Modules/Core/Common/include/itkNeighborhoodAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodAlgorithm.hxx
@@ -73,15 +73,11 @@ ImageBoundaryFacesCalculator<TImage>::Compute(const TImage & img, RegionType reg
     // otherwise there would be overlap between two boundary regions.
     // in the case, we reduce upper boundary size to remove overlap.
 
-    IndexValueType overlapHigh;
+    IndexValueType overlapHigh = static_cast<IndexValueType>((bStart[i] + radius[i]) - (rStart[i] + rSize[i]));
 
     if (bSize[i] > 2 * radius[i])
     {
       overlapHigh = static_cast<IndexValueType>((bStart[i] + bSize[i]) - (rStart[i] + rSize[i] + radius[i]));
-    }
-    else
-    {
-      overlapHigh = static_cast<IndexValueType>((bStart[i] + radius[i]) - (rStart[i] + rSize[i]));
     }
 
     if (overlapLow < 0)                                 // out of bounds condition, define

--- a/Modules/Core/Common/include/itkObjectStore.hxx
+++ b/Modules/Core/Common/include/itkObjectStore.hxx
@@ -57,13 +57,11 @@ template <typename TObjectType>
 auto
 ObjectStore<TObjectType>::Borrow() -> ObjectType *
 {
-  ObjectType * p;
-
   if (m_FreeList.empty()) // must allocate more memory
   {
     this->Reserve(m_Size + this->GetGrowthSize());
   }
-  p = m_FreeList.back();
+  ObjectType * p = m_FreeList.back();
   m_FreeList.pop_back();
   return p;
 

--- a/Modules/Core/Common/include/itkSpecialCoordinatesImage.hxx
+++ b/Modules/Core/Common/include/itkSpecialCoordinatesImage.hxx
@@ -36,10 +36,8 @@ template <typename TPixel, unsigned int VImageDimension>
 void
 SpecialCoordinatesImage<TPixel, VImageDimension>::Allocate(bool initialize)
 {
-  SizeValueType num;
-
   this->ComputeOffsetTable();
-  num = static_cast<SizeValueType>(this->GetOffsetTable()[VImageDimension]);
+  SizeValueType num = static_cast<SizeValueType>(this->GetOffsetTable()[VImageDimension]);
 
   m_Buffer->Reserve(num, initialize);
 }

--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.hxx
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.hxx
@@ -410,7 +410,6 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesUsingQ
   {
     return 1;
   }
-  unsigned int m;
   for (unsigned int i = 1; i < m_Order; ++i)
   {
     e[i - 1] = e[i];
@@ -429,7 +428,8 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesUsingQ
       tst1 = h;
     }
     // Look for small sub-diagonal element
-    for (m = l; m < m_Order - 1; ++m)
+    unsigned int m = l;
+    for (; m < m_Order - 1; ++m)
     {
       const double tst2 = tst1 + itk::Math::abs(e[m]);
       if (tst2 == tst1)
@@ -441,7 +441,7 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesUsingQ
 
     if (m != l)
     {
-      double tst2;
+      double tst2 = NAN;
       do
       {
         if (j == 30)
@@ -574,9 +574,10 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ComputeEigenValuesAndVec
     }
 
     // Look for small sub-diagonal element
-    unsigned int m;
-    double       tst2;
-    for (m = l; m < m_Order - 1; ++m)
+
+    double       tst2 = NAN;
+    unsigned int m = l;
+    for (; m < m_Order - 1; ++m)
     {
       tst2 = tst1 + itk::Math::abs(e[m]);
       if (tst2 == tst1)

--- a/Modules/Core/Common/include/itkSymmetricEllipsoidInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkSymmetricEllipsoidInteriorExteriorSpatialFunction.hxx
@@ -36,11 +36,7 @@ auto
 SymmetricEllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::Evaluate(const InputType & position) const
   -> OutputType
 {
-  double uniqueTerm;    // Term in ellipsoid equation for unique axis
-  double symmetricTerm; // Term in ellipsoid equation for symmetric axes
-
   Vector<double, VDimension> pointVector;
-  Vector<double, VDimension> symmetricVector;
 
   // Project the position onto the major axis, normalize by axis length,
   // and determine whether position is inside ellipsoid.
@@ -48,10 +44,11 @@ SymmetricEllipsoidInteriorExteriorSpatialFunction<VDimension, TInput>::Evaluate(
   {
     pointVector[i] = position[i] - m_Center[i];
   }
-
-  uniqueTerm = Math::sqr(static_cast<double>(((pointVector * m_Orientation) / (.5 * m_UniqueAxis))));
-  symmetricVector = pointVector - (m_Orientation * (pointVector * m_Orientation));
-  symmetricTerm = Math::sqr(static_cast<double>(((symmetricVector.GetNorm()) / (.5 * m_SymmetricAxes))));
+  // Term in ellipsoid equation for unique axis
+  double uniqueTerm = Math::sqr(static_cast<double>(((pointVector * m_Orientation) / (.5 * m_UniqueAxis))));
+  Vector<double, VDimension> symmetricVector = pointVector - (m_Orientation * (pointVector * m_Orientation));
+  // Term in ellipsoid equation for symmetric axes
+  double symmetricTerm = Math::sqr(static_cast<double>(((symmetricVector.GetNorm()) / (.5 * m_SymmetricAxes))));
 
   if ((uniqueTerm + symmetricTerm) >= 0 && (uniqueTerm + symmetricTerm) <= 1)
   {

--- a/Modules/Core/Common/include/itkSymmetricSecondRankTensor.hxx
+++ b/Modules/Core/Common/include/itkSymmetricSecondRankTensor.hxx
@@ -171,7 +171,7 @@ template <typename T, unsigned int VDimension>
 auto
 SymmetricSecondRankTensor<T, VDimension>::operator()(unsigned int row, unsigned int col) const -> const ValueType &
 {
-  unsigned int k;
+  unsigned int k = 0;
 
   if (row < col)
   {
@@ -197,17 +197,8 @@ template <typename T, unsigned int VDimension>
 auto
 SymmetricSecondRankTensor<T, VDimension>::operator()(unsigned int row, unsigned int col) -> ValueType &
 {
-  unsigned int k;
-
-  if (row < col)
-  {
-    k = row * Dimension + col - row * (row + 1) / 2;
-  }
-  else
-  {
-    k = col * Dimension + row - col * (col + 1) / 2;
-  }
-
+  unsigned int k =
+    (row < col) ? row * Dimension + col - row * (row + 1) / 2 : col * Dimension + row - col * (col + 1) / 2;
   if (k >= InternalDimension)
   {
     k = 0;

--- a/Modules/Core/Common/include/itkTetrahedronCell.hxx
+++ b/Modules/Core/Common/include/itkTetrahedronCell.hxx
@@ -184,7 +184,7 @@ TetrahedronCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
       for (int i = 0; i < 4; ++i)
       {
         this->GetFace(i, triangle);
-        double dist2;
+        double dist2 = NAN;
         triangle->EvaluatePosition(x, points, closest, pc, &dist2, nullptr);
 
         if (dist2 < *minDist2)

--- a/Modules/Core/Common/include/itkTriangleCell.hxx
+++ b/Modules/Core/Common/include/itkTriangleCell.hxx
@@ -364,9 +364,6 @@ TriangleCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
                                                double *                  minDist2,
                                                InterpolationWeightType * weights)
 {
-  double          dist2Point;
-  double          dist2Line1;
-  double          dist2Line2;
   PointType       closest;
   PointType       closestPoint1;
   PointType       closestPoint2;
@@ -423,7 +420,7 @@ TriangleCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
   // Test if the projected point is inside the cell.
 
   // Zero with epsilon
-  const double zwe = -NumericTraits<double>::min();
+  constexpr double zwe = -NumericTraits<double>::min();
 
   // Since the three barycentric coordinates are interdependent
   // only three tests should be necessary. That is, we only need
@@ -462,16 +459,16 @@ TriangleCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
 
   if (closestPoint)
   {
-    double lt; // parameter along the line (not used)
+    double lt = NAN; // parameter along the line (not used)
     if (b1 < 0.0 && b2 < 0.0)
     {
-      dist2Point = 0;
+      double dist2Point = 0;
       for (unsigned int i = 0; i < PointDimension; ++i)
       {
         dist2Point += (x[i] - pt3[i]) * (x[i] - pt3[i]);
       }
-      dist2Line1 = this->DistanceToLine(x, pt1, pt3, lt, closestPoint1);
-      dist2Line2 = this->DistanceToLine(x, pt3, pt2, lt, closestPoint2);
+      double dist2Line1 = this->DistanceToLine(x, pt1, pt3, lt, closestPoint1);
+      double dist2Line2 = this->DistanceToLine(x, pt3, pt2, lt, closestPoint2);
       if (dist2Point < dist2Line1)
       {
         *minDist2 = dist2Point;
@@ -499,13 +496,13 @@ TriangleCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
     }
     else if (b2 < 0.0 && b3 < 0.0)
     {
-      dist2Point = 0;
+      double dist2Point = 0;
       for (unsigned int i = 0; i < PointDimension; ++i)
       {
         dist2Point += (x[i] - pt1[i]) * (x[i] - pt1[i]);
       }
-      dist2Line1 = this->DistanceToLine(x, pt1, pt3, lt, closestPoint1);
-      dist2Line2 = this->DistanceToLine(x, pt1, pt2, lt, closestPoint2);
+      double dist2Line1 = this->DistanceToLine(x, pt1, pt3, lt, closestPoint1);
+      double dist2Line2 = this->DistanceToLine(x, pt1, pt2, lt, closestPoint2);
       if (dist2Point < dist2Line1)
       {
         *minDist2 = dist2Point;
@@ -533,13 +530,13 @@ TriangleCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
     }
     else if (b1 < 0.0 && b3 < 0.0)
     {
-      dist2Point = 0;
+      double dist2Point = 0;
       for (unsigned int i = 0; i < PointDimension; ++i)
       {
         dist2Point += (x[i] - pt2[i]) * (x[i] - pt2[i]);
       }
-      dist2Line1 = this->DistanceToLine(x, pt2, pt3, lt, closestPoint1);
-      dist2Line2 = this->DistanceToLine(x, pt1, pt2, lt, closestPoint2);
+      double dist2Line1 = this->DistanceToLine(x, pt2, pt3, lt, closestPoint1);
+      double dist2Line2 = this->DistanceToLine(x, pt1, pt2, lt, closestPoint2);
       if (dist2Point < dist2Line1)
       {
         *minDist2 = dist2Point;

--- a/Modules/Core/Common/include/itkVectorImage.hxx
+++ b/Modules/Core/Common/include/itkVectorImage.hxx
@@ -42,9 +42,8 @@ VectorImage<TPixel, VImageDimension>::Allocate(const bool UseValueInitialization
     itkExceptionMacro("Cannot allocate VectorImage with VectorLength = 0");
   }
 
-  SizeValueType num;
   this->ComputeOffsetTable();
-  num = this->GetOffsetTable()[VImageDimension];
+  SizeValueType num = this->GetOffsetTable()[VImageDimension];
 
   m_Buffer->Reserve(num * m_VectorLength, UseValueInitialization);
 }

--- a/Modules/Core/Common/src/itkFloatingPointExceptions_unix_signalhandler.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions_unix_signalhandler.cxx
@@ -137,8 +137,9 @@ extern "C"
     if (sig == SIGFPE)
     {
 #if DEFINED_INTEL
-      unsigned short x87cr, x87sr;
-      unsigned int   mxcsr;
+      unsigned short x87cr = 0;
+      unsigned short x87sr = 0;
+      unsigned int   mxcsr = 0;
 
       getx87cr(x87cr);
       getx87sr(x87sr);

--- a/Modules/Core/Common/src/itkLightObject.cxx
+++ b/Modules/Core/Common/src/itkLightObject.cxx
@@ -191,7 +191,7 @@ LightObject::PrintSelf(std::ostream & os, Indent indent) const
 {
 #ifdef GCC_USEDEMANGLE
   const char * mangledName = typeid(*this).name();
-  int          status;
+  int          status = 0;
   char *       unmangled = abi::__cxa_demangle(mangledName, nullptr, nullptr, &status);
 
   os << indent << "RTTI typeinfo:   ";

--- a/Modules/Core/Common/src/itkMemoryUsageObserver.cxx
+++ b/Modules/Core/Common/src/itkMemoryUsageObserver.cxx
@@ -287,8 +287,8 @@ LinuxMemoryUsageObserver::GetMemoryUsage()
 
   // the two fields we want
   //
-  unsigned long vsize;
-  long          rss;
+  unsigned long vsize = 0;
+  long          rss = 0;
 
   procstats >> pid >> comm >> state >> ppid >> pgrp >> session >> tty_nr >> tpgid >> flags >> minflt >> cminflt >>
     majflt >> cmajflt >> utime >> stime >> cutime >> cstime >> priority >> nice >> O >> itrealvalue >> starttime >>

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -255,7 +255,7 @@ MersenneTwisterRandomVariateGenerator::GetIntegerVariate(const IntegerType n)
   used |= used >> 16;
 
   // Draw numbers until one is found in [0,n]
-  IntegerType i;
+  IntegerType i = 0;
   do
   {
     i = GetIntegerVariate() & used; // toss unused bits to shorten search

--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -351,16 +351,15 @@ MultiThreaderBase::GetGlobalDefaultNumberOfThreadsByPlatform()
 #endif
 
 #if defined(ITK_USE_PTHREADS)
-  ThreadIdType num;
 
 // Default the number of threads to be the number of available
 // processors if we are using pthreads()
 #  ifdef _SC_NPROCESSORS_ONLN
-  num = static_cast<ThreadIdType>(sysconf(_SC_NPROCESSORS_ONLN));
+  ThreadIdType num = static_cast<ThreadIdType>(sysconf(_SC_NPROCESSORS_ONLN));
 #  elif defined(_SC_NPROC_ONLN)
-  num = static_cast<ThreadIdType>(sysconf(_SC_NPROC_ONLN));
+  ThreadIdType num = static_cast<ThreadIdType>(sysconf(_SC_NPROC_ONLN));
 #  else
-  num = 1;
+  ThreadIdType num = 1;
 #  endif
 
   itksys::SystemInformation mySys;

--- a/Modules/Core/Common/src/itkPlatformMultiThreaderPosix.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreaderPosix.cxx
@@ -169,7 +169,7 @@ ThreadProcessIdType
 PlatformMultiThreader::SpawnDispatchSingleMethodThread(PlatformMultiThreader::WorkUnitInfo * threadInfo)
 {
   // Using POSIX threads
-  pthread_t threadHandle;
+  pthread_t threadHandle = 0;
   const int threadError = pthread_create(&threadHandle,
                                          nullptr,
                                          reinterpret_cast<c_void_cast>(this->SingleMethodProxy),

--- a/Modules/Core/Common/src/itkPoolMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkPoolMultiThreader.cxx
@@ -258,7 +258,7 @@ PoolMultiThreader::ParallelizeImageRegion(unsigned int         dimension,
       ProgressReporter                reporter(filter, 0, splitCount);
       itkAssertOrThrowMacro(splitCount <= m_NumberOfWorkUnits, "Split count is greater than number of work units!");
       ImageIORegion iRegion;
-      ThreadIdType  total;
+      ThreadIdType  total = 0;
       for (ThreadIdType i = 1; i < splitCount; ++i)
       {
         iRegion = region;

--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -1093,7 +1093,7 @@ ProcessObject::MakeIndexFromName(const DataObjectIdentifierType & name) const
     itkExceptionMacro("Not an indexed data object: " << name);
   }
   const DataObjectIdentifierType idxStr = name.substr(baseSize);
-  DataObjectPointerArraySizeType idx;
+  DataObjectPointerArraySizeType idx = 0;
   if (!(std::istringstream(idxStr) >> idx))
   {
     itkDebugMacro("MakeIndexFromName(" << name << ") -> exception not an index");

--- a/Modules/Core/Common/src/itkThreadPool.cxx
+++ b/Modules/Core/Common/src/itkThreadPool.cxx
@@ -146,7 +146,7 @@ ThreadPool::GetNumberOfCurrentlyIdleThreads() const
 void
 ThreadPool::CleanUp()
 {
-  bool shouldNotify;
+  bool shouldNotify = false;
   {
     const std::lock_guard<std::mutex> lockGuard(m_PimplGlobals->m_Mutex);
 

--- a/Modules/Core/Common/test/itkBitCastGTest.cxx
+++ b/Modules/Core/Common/test/itkBitCastGTest.cxx
@@ -40,6 +40,6 @@ TEST(BitCast, ResultIsBitwiseEqualToArgument)
     Expect_return_value_is_bitwise_equal_to_function_argument<unsigned int>(i);
   }
 
-  [[maybe_unused]] int value;
+  [[maybe_unused]] int value = 0;
   Expect_return_value_is_bitwise_equal_to_function_argument<intptr_t>(&value);
 }

--- a/Modules/Core/Common/test/itkCommandObserverObjectTest.cxx
+++ b/Modules/Core/Common/test/itkCommandObserverObjectTest.cxx
@@ -76,9 +76,6 @@ testDeleteObserverDuringEvent()
 {
   const itk::Object::Pointer o = itk::Object::New();
 
-
-  unsigned long idToRemove;
-
   const itk::CStyleCommand::Pointer removeCmd = itk::CStyleCommand::New();
   removeCmd->SetCallback(onUserRemove);
   removeCmd->SetObjectName("Remove Command");
@@ -89,7 +86,7 @@ testDeleteObserverDuringEvent()
 
   // Add Order 1
   o->AddObserver(itk::UserEvent(), removeCmd);
-  idToRemove = o->AddObserver(itk::AnyEvent(), cmd);
+  unsigned long idToRemove = o->AddObserver(itk::AnyEvent(), cmd);
   o->AddObserver(itk::AnyEvent(), cmd);
   removeCmd->SetClientData(&idToRemove);
 
@@ -218,8 +215,6 @@ testCommandRecursiveObject()
   const itk::Object::Pointer      o = itk::Object::New();
   const itk::Object::ConstPointer co = o;
 
-  unsigned long idToRemove;
-
   const itk::CStyleCommand::Pointer cmd = itk::CStyleCommand::New();
   cmd->SetCallback(onAny);
   cmd->SetObjectName("Any Command 1");
@@ -233,7 +228,7 @@ testCommandRecursiveObject()
   cmdInvoke->SetObjectName("Any Invoke User");
 
   // On 1 Remove 1
-  idToRemove = o->AddObserver(itk::AnyEvent(), cmdInvoke);
+  unsigned long idToRemove = o->AddObserver(itk::AnyEvent(), cmdInvoke);
   o->AddObserver(itk::UserEvent(), removeCmd);
   o->AddObserver(itk::AnyEvent(), cmd);
   removeCmd->SetClientData(&idToRemove);

--- a/Modules/Core/Common/test/itkCompensatedSummationTest.cxx
+++ b/Modules/Core/Common/test/itkCompensatedSummationTest.cxx
@@ -43,7 +43,7 @@ itkCompensatedSummationTest(int, char *[])
   FloatType vanillaSum = 0.0;
   using CompensatedSummationType = itk::CompensatedSummation<FloatType>;
   CompensatedSummationType floatAccumulator;
-  FloatType                randomNumber;
+  FloatType                randomNumber = NAN;
   for (itk::SizeValueType ii = 0; ii < accumSize; ++ii)
   {
     randomNumber = generator->GetVariate();

--- a/Modules/Core/Common/test/itkDataObjectAndProcessObjectTest.cxx
+++ b/Modules/Core/Common/test/itkDataObjectAndProcessObjectTest.cxx
@@ -107,16 +107,10 @@ itkDataObjectAndProcessObjectTest(int, char *[])
   // create a TestProcessObject
   itk::TestProcessObject::Pointer process = itk::TestProcessObject::New();
 
-  // some vars to test the methods
-  itk::TestProcessObject::NameArray              names;
-  itk::TestProcessObject::DataObjectPointerArray dataObjects;
-  itk::DataObject::Pointer                       dataObject;
-  itk::ModifiedTimeType                          mtime;
-
   // and exercise various methods
-  names = process->GetInputNames();
+  itk::TestProcessObject::NameArray names = process->GetInputNames();
   ITK_TEST_SET_GET_VALUE(0, names.size());
-  dataObjects = process->GetInputs();
+  itk::TestProcessObject::DataObjectPointerArray dataObjects = process->GetInputs();
   ITK_TEST_SET_GET_VALUE(0, dataObjects.size());
   //   constDataObjects = process->GetInputs();
   //   ITK_TEST_SET_GET_VALUE( 0, constDataObjects.size() );
@@ -142,7 +136,7 @@ itkDataObjectAndProcessObjectTest(int, char *[])
   ITK_TEST_SET_GET_VALUE(0, process->GetNumberOfIndexedOutputs());
   //   ITK_TEST_SET_GET_VALUE( 0, process->GetNumberOfValidRequiredOutputs() );
 
-  dataObject = process->MakeOutput(0);
+  itk::DataObject::Pointer dataObject = process->MakeOutput(0);
   ITK_TEST_SET_GET_VALUE(true, dataObject.IsNotNull());
   dataObject = process->MakeOutput(1);
   ITK_TEST_SET_GET_VALUE(true, dataObject.IsNotNull());
@@ -183,7 +177,7 @@ itkDataObjectAndProcessObjectTest(int, char *[])
   }
 
   // shouldn't do anything: there is no output at this point
-  mtime = process->GetMTime();
+  itk::ModifiedTimeType mtime = process->GetMTime();
   process->Update();
   ITK_TEST_SET_GET_VALUE(mtime, process->GetMTime());
 

--- a/Modules/Core/Common/test/itkEllipsoidInteriorExteriorSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkEllipsoidInteriorExteriorSpatialFunctionTest.cxx
@@ -69,8 +69,7 @@ itkEllipsoidInteriorExteriorSpatialFunctionTest(int, char *[])
   double
     testPosition[dimension]; // position of a pixel in the function doitkEllipsoidInteriorExteriorSpatialFunctionTest
 
-  bool functionValue;            // Value of pixel at a given position
-  int  interiorPixelCounter = 0; // Count pixels inside ellipsoid
+  int interiorPixelCounter = 0; // Count pixels inside ellipsoid
 
   for (int x = 0; x < xExtent; ++x)
   {
@@ -81,8 +80,9 @@ itkEllipsoidInteriorExteriorSpatialFunctionTest(int, char *[])
         testPosition[0] = x;
         testPosition[1] = y;
         testPosition[2] = z;
-        functionValue = spatialFunc->Evaluate(testPosition);
-        if (functionValue == 1)
+        // Value of pixel at a given position
+        bool functionValue = spatialFunc->Evaluate(testPosition);
+        if (functionValue)
         {
           interiorPixelCounter++;
         }
@@ -95,7 +95,7 @@ itkEllipsoidInteriorExteriorSpatialFunctionTest(int, char *[])
   testPosition[0] = center[0];
   testPosition[1] = center[1];
   testPosition[2] = center[2];
-  functionValue = spatialFunc->Evaluate(testPosition);
+  bool functionValue = spatialFunc->Evaluate(testPosition);
 
   // Volume of ellipsoid using V=(4/3)*pi*(a/2)*(b/2)*(c/2)
   const double volume = 4.18879013333 * (axes[0] / 2) * (axes[1] / 2) * (axes[2] / 2);
@@ -107,7 +107,7 @@ itkEllipsoidInteriorExteriorSpatialFunctionTest(int, char *[])
 
   // 5% error was randomly chosen as a successful ellipsoid fill.
   // This should actually be some function of the image/ellipsoid size.
-  if (volumeError <= 5 || functionValue == 1)
+  if (volumeError <= 5 || functionValue)
   {
 
     // With testing settings, results should yield:

--- a/Modules/Core/Common/test/itkExtractImageTest.cxx
+++ b/Modules/Core/Common/test/itkExtractImageTest.cxx
@@ -92,8 +92,6 @@ itkExtractImageTest(int, char *[])
   const itk::FileOutputWindow::Pointer fow = itk::FileOutputWindow::New();
   fow->SetInstance(fow);
 
-  int nextVal;
-
   // type alias to simplify the syntax
   using SimpleImage = itk::Image<short, 2>;
   auto simpleImage = SimpleImage::New();
@@ -192,7 +190,7 @@ itkExtractImageTest(int, char *[])
       }
       else
       {
-        nextVal = 8 * column + row;
+        int nextVal = 8 * column + row;
         if (iteratorIn1.Get() != nextVal)
         {
           std::cout << "Error: (" << row << ", " << column << "), expected " << nextVal << " got " << iteratorIn1.Get()
@@ -268,7 +266,7 @@ itkExtractImageTest(int, char *[])
         }
         else
         {
-          nextVal = 8 * column + row;
+          int nextVal = 8 * column + row;
           if (iteratorIn2.Get() != nextVal)
           {
             std::cout << "Error: (" << row << ", " << column << "), expected " << nextVal << " got "

--- a/Modules/Core/Common/test/itkFiniteCylinderSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkFiniteCylinderSpatialFunctionTest.cxx
@@ -72,10 +72,8 @@ itkFiniteCylinderSpatialFunctionTest(int, char *[])
 
   // Evaluate all points in the spatial function and count the number of
   // pixels that are inside the cylinder.
-  double testPosition[dimension]; // position of a pixel
-
-  bool functionValue;            // Value of pixel at a given position
-  int  interiorPixelCounter = 0; // Count pixels inside cylinder
+  double testPosition[dimension];  // position of a pixel
+  int    interiorPixelCounter = 0; // Count pixels inside cylinder
 
   for (int x = 0; x < xExtent; ++x)
   {
@@ -86,8 +84,9 @@ itkFiniteCylinderSpatialFunctionTest(int, char *[])
         testPosition[0] = x;
         testPosition[1] = y;
         testPosition[2] = z;
-        functionValue = spatialFunc->Evaluate(testPosition);
-        if (functionValue == 1)
+        // Value of pixel at a given position
+        const bool functionValue = spatialFunc->Evaluate(testPosition);
+        if (functionValue)
         {
           interiorPixelCounter++;
         }
@@ -100,7 +99,7 @@ itkFiniteCylinderSpatialFunctionTest(int, char *[])
   testPosition[0] = center[0];
   testPosition[1] = center[1];
   testPosition[2] = center[2];
-  functionValue = spatialFunc->Evaluate(testPosition);
+  const bool functionValue = spatialFunc->Evaluate(testPosition);
 
   // Volume of cylinder using V=pi*r^2*h
   const double volume = 3.14159 * pow(radius, 2) * axis;
@@ -112,7 +111,7 @@ itkFiniteCylinderSpatialFunctionTest(int, char *[])
 
   // 5% error was randomly chosen as a successful ellipsoid fill.
   // This should actually be some function of the image/ellipsoid size.
-  if (volumeError <= 7.0 && functionValue == 1)
+  if (volumeError <= 7.0 && functionValue)
   {
 
     // With testing settings, results should yield:

--- a/Modules/Core/Common/test/itkImageIteratorsForwardBackwardTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorsForwardBackwardTest.cxx
@@ -48,9 +48,7 @@ itkImageIteratorsForwardBackwardTest(int, char *[])
 
   IteratorType it(myImage, region);
 
-  ImageType::PixelType value;
-
-  value = ImageType::PixelType{};
+  ImageType::PixelType value = ImageType::PixelType{};
 
   // Store information on the Image
   std::cout << "Storing data on the image ... " << std::endl;

--- a/Modules/Core/Common/test/itkImportContainerTest.cxx
+++ b/Modules/Core/Common/test/itkImportContainerTest.cxx
@@ -30,7 +30,7 @@ itkImportContainerTest(int, char *[])
   itk::OutputWindow::SetInstance(itk::TextOutput::New());
 
   // First test with ContainerManagesMemory false
-  PixelType * ptr1;
+  PixelType * ptr1 = nullptr;
   {
     // Test 1: Create an empty container and print it
     auto container1 = ContainerType::New();

--- a/Modules/Core/Common/test/itkNumericTraitsTest.cxx
+++ b/Modules/Core/Common/test/itkNumericTraitsTest.cxx
@@ -93,7 +93,7 @@ CheckVariableLengthArrayTraits(const T & t)
   std::string name;
 #ifdef GCC_USEDEMANGLE
   const char * mangledName = typeid(t).name();
-  int          status;
+  int          status = 0;
   char *       unmangled = abi::__cxa_demangle(mangledName, nullptr, nullptr, &status);
   name = unmangled;
   free(unmangled);
@@ -139,7 +139,7 @@ CheckFixedArrayTraits(const T & t)
   std::string name;
 #ifdef GCC_USEDEMANGLE
   const char * mangledName = typeid(t).name();
-  int          status;
+  int          status = 0;
   char *       unmangled = abi::__cxa_demangle(mangledName, nullptr, nullptr, &status);
   name = unmangled;
   free(unmangled);

--- a/Modules/Core/Common/test/itkStdStreamStateSaveTest.cxx
+++ b/Modules/Core/Common/test/itkStdStreamStateSaveTest.cxx
@@ -84,7 +84,7 @@ itkStdStreamStateSaveTest(int, char *[])
   // Verify the value read from the stream matches the original value
   // written to the stream. If they do not match, then the hex state
   // is still in effect.
-  int inputInt;
+  int inputInt = 0;
   stream >> inputInt;
   ITK_TEST_EXPECT_EQUAL(originalInt, inputInt);
 

--- a/Modules/Core/Common/test/itkSymmetricEllipsoidInteriorExteriorSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricEllipsoidInteriorExteriorSpatialFunctionTest.cxx
@@ -65,8 +65,7 @@ itkSymmetricEllipsoidInteriorExteriorSpatialFunctionTest(int, char *[])
   double testPosition[dimension]; // position of a pixel in the function
                                   // doitkSymmetricEllipsoidInteriorExteriorSpatialFunctionTest
 
-  bool functionValue;            // Value of pixel at a given position
-  int  interiorPixelCounter = 0; // Count pixels inside ellipsoid
+  int interiorPixelCounter = 0; // Count pixels inside ellipsoid
 
   for (int x = 0; x < xExtent; ++x)
   {
@@ -77,8 +76,9 @@ itkSymmetricEllipsoidInteriorExteriorSpatialFunctionTest(int, char *[])
         testPosition[0] = x;
         testPosition[1] = y;
         testPosition[2] = z;
-        functionValue = spatialFunc->Evaluate(testPosition);
-        if (functionValue == 1)
+        // Value of pixel at a given position
+        const bool functionValue = spatialFunc->Evaluate(testPosition);
+        if (functionValue)
         {
           interiorPixelCounter++;
         }
@@ -91,7 +91,6 @@ itkSymmetricEllipsoidInteriorExteriorSpatialFunctionTest(int, char *[])
   testPosition[0] = center[0];
   testPosition[1] = center[1];
   testPosition[2] = center[2];
-  functionValue = spatialFunc->Evaluate(testPosition);
 
   // Volume of ellipsoid using V=(4/3)*pi*(a/2)*(b/2)*(c/2)
   constexpr double volume =
@@ -102,7 +101,8 @@ itkSymmetricEllipsoidInteriorExteriorSpatialFunctionTest(int, char *[])
 
   // 5% error was randomly chosen as a successful ellipsoid fill.
   // This should actually be some function of the image/ellipsoid size.
-  if (volumeError <= 5 || functionValue == 1)
+  const bool functionValue = spatialFunc->Evaluate(testPosition);
+  if (volumeError <= 5 || functionValue)
   {
     // With testing settings, results should yield:
     // calculated ellipsoid volume = 21205.8 pixels

--- a/Modules/Core/ImageAdaptors/include/itkImageAdaptor.hxx
+++ b/Modules/Core/ImageAdaptors/include/itkImageAdaptor.hxx
@@ -83,7 +83,7 @@ ImageAdaptor<TImage, TAccessor>::Graft(const DataObject * data)
   if (data)
   {
     // Attempt to cast data to an ImageAdaptor
-    const Self * imgData;
+    const Self * imgData = nullptr;
 
     try
     {

--- a/Modules/Core/ImageFunction/include/itkMahalanobisDistanceThresholdImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMahalanobisDistanceThresholdImageFunction.hxx
@@ -106,21 +106,11 @@ MahalanobisDistanceThresholdImageFunction<TInputImage, TCoordinate>::EvaluateDis
   const double mahalanobisDistanceSquared =
     m_MahalanobisDistanceMembershipFunction->Evaluate(this->GetInputImage()->GetPixel(index));
 
-  double mahalanobisDistance;
-
   // Deal with cases that are barely negative.
   // In theory they should never appear, but
   // they may happen and would produce NaNs
   // in the std::sqrt
-  if (mahalanobisDistanceSquared < 0.0)
-  {
-    mahalanobisDistance = 0.0;
-  }
-  else
-  {
-    mahalanobisDistance = std::sqrt(mahalanobisDistanceSquared);
-  }
-
+  const double mahalanobisDistance = (mahalanobisDistanceSquared > 0.0) ? std::sqrt(mahalanobisDistanceSquared) : 0.0;
   return mahalanobisDistance;
 }
 

--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
@@ -924,8 +924,8 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::Adjust
   }
 
   int  Istart[3];
-  bool startOK;
-  bool endOK;
+  bool startOK = false;
+  bool endOK = false;
   do
   {
     startOK = false;
@@ -1201,8 +1201,8 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::GetCur
   const auto c = static_cast<double>(*m_RayIntersectionVoxels[2] - a);
   const auto d = static_cast<double>(*m_RayIntersectionVoxels[3] - a - b - c);
 
-  double y;
-  double z;
+  double y = NAN;
+  double z = NAN;
   switch (m_TraversalDirection)
   {
     case TraversalDirectionEnum::TRANSVERSE_IN_X:

--- a/Modules/Core/ImageFunction/test/itkBSplineDecompositionImageFilterTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineDecompositionImageFilterTest.cxx
@@ -39,11 +39,10 @@ ParseSplinePoles(char * splinePolesIn)
   typename TFilter::SplinePolesVectorType splinePolesOut;
 
   // Get the individual components
-  char *                                              endPtr;
-  typename TFilter::SplinePolesVectorType::value_type value;
   while (*splinePolesIn)
   {
-    value = strtod(splinePolesIn, &endPtr);
+    char *                                              endPtr = nullptr;
+    typename TFilter::SplinePolesVectorType::value_type value = strtod(splinePolesIn, &endPtr);
     if (splinePolesIn == endPtr)
     {
       (*splinePolesIn)++;

--- a/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
@@ -634,7 +634,7 @@ testEvaluateValueAndDerivative()
   const CovariantVectorType dx_1 = interpolator->EvaluateDerivativeAtContinuousIndex(x);
   CovariantVectorType       dx_2;
 
-  BSplineInterpolatorFunctionType::OutputType value;
+  BSplineInterpolatorFunctionType::OutputType value = NAN;
   interpolator->EvaluateValueAndDerivativeAtContinuousIndex(x, value, dx_2);
 
   for (unsigned int i = 0; i < ImageDimension; ++i)

--- a/Modules/Core/ImageFunction/test/itkImageAdaptorInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkImageAdaptorInterpolateImageFunctionTest.cxx
@@ -207,10 +207,10 @@ itkImageAdaptorInterpolateImageFunctionTest(int, char *[])
   /* Test evaluation at continuous indices and corresponding
      gemetric points */
   std::cout << "Evaluate at: " << std::endl;
-  OutputType          output;
+  OutputType          output = NAN;
   ContinuousIndexType cindex;
   PointType           point;
-  bool                passed;
+  bool                passed = false;
 
   // an integer position inside the image
   {

--- a/Modules/Core/ImageFunction/test/itkVectorInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkVectorInterpolateImageFunctionTest.cxx
@@ -120,32 +120,37 @@ TestContinuousIndex(const InterpolatorType *    interp,
 
   if (isInside)
   {
-    int        k;
     OutputType value = interp->EvaluateAtContinuousIndex(index);
     std::cout << " Value: ";
-    for (k = 0; k < VectorDimension - 1; ++k)
     {
-      std::cout << value[k] << ", ";
-    }
-    std::cout << value[k] << std::endl;
-
-    for (k = 0; k < VectorDimension; ++k)
-    {
-      if (itk::Math::abs(value[k] - trueValue[k]) > 1e-9)
+      unsigned int k = 0;
+      for (; k < VectorDimension - 1; ++k)
       {
-        break;
+        std::cout << value[k] << ", ";
       }
+      std::cout << value[k] << std::endl;
     }
 
-    if (k != VectorDimension)
     {
-      std::cout << " *** Error: Value should be: ";
-      for (k = 0; k < VectorDimension - 1; ++k)
+      unsigned int k = 0;
+      for (; k < VectorDimension; ++k)
       {
-        std::cout << trueValue[k] << ", ";
+        if (itk::Math::abs(value[k] - trueValue[k]) > 1e-9)
+        {
+          break;
+        }
       }
-      std::cout << trueValue[k] << std::endl;
-      return false;
+
+      if (k != VectorDimension)
+      {
+        std::cout << " *** Error: Value should be: ";
+        for (k = 0; k < VectorDimension - 1; ++k)
+        {
+          std::cout << trueValue[k] << ", ";
+        }
+        std::cout << trueValue[k] << std::endl;
+        return false;
+      }
     }
   }
 
@@ -212,7 +217,7 @@ itkVectorInterpolateImageFunctionTest(int, char *[])
   OutputType          output;
   ContinuousIndexType cindex;
   PointType           point;
-  bool                passed;
+  bool                passed = false;
 
   // an integer position inside the image
   {

--- a/Modules/Core/ImageFunction/test/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunctionTest.cxx
@@ -228,25 +228,20 @@ itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunctionTest(int, char 
   /* Test evaluation at continuous indices and corresponding
      geometric points */
   std::cout << "Evaluate at: " << std::endl;
-  OutputType          output;
-  ContinuousIndexType cindex;
-  PointType           point;
-  bool                passed;
-
   // an integer position inside the image
-  {
-    itk::SpacePrecisionType darray[3] = { 10, 20, 40 };
-    double                  temp[3] = { 70, 140, 210 };
-    output = OutputType(temp);
-    cindex = ContinuousIndexType(darray);
-    passed = TestContinuousIndex(interp, cindex, true, output);
-  }
+
+
+  double                  temp1[3] = { 70, 140, 210 };
+  OutputType              output = OutputType(temp1);
+  itk::SpacePrecisionType darray1[3] = { 10, 20, 40 };
+  ContinuousIndexType     cindex = ContinuousIndexType(darray1);
+  bool                    passed = TestContinuousIndex(interp, cindex, true, output);
 
   if (!passed)
   {
     flag = 1;
   }
-
+  PointType point;
   image->TransformContinuousIndexToPhysicalPoint(cindex, point);
   passed = TestGeometricPoint(interp, point, true, output);
 

--- a/Modules/Core/ImageFunction/test/itkWindowedSincInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkWindowedSincInterpolateImageFunctionTest.cxx
@@ -192,10 +192,10 @@ itkWindowedSincInterpolateImageFunctionTest(int, char *[])
   /* Test evaluation at continuous indices and corresponding
      gemetric points */
   std::cout << "Evaluate at: " << std::endl;
-  OutputType          output;
+  OutputType          output = NAN;
   ContinuousIndexType cindex;
   PointType           point;
-  bool                passed;
+  bool                passed = false;
 
   // an integer position inside the image
   {

--- a/Modules/Core/Mesh/include/itkAutomaticTopologyMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkAutomaticTopologyMeshSource.hxx
@@ -44,7 +44,7 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddPoint(const PointType & p0) -> Iden
 {
   const IdentifierType nextNewPointID = m_OutputMesh->GetNumberOfPoints();
   IdentifierType &     pointIDPlusOne = m_PointsHashTable[p0];
-  IdentifierType       pointID;
+  IdentifierType       pointID = 0;
 
   if (pointIDPlusOne != 0)
   {
@@ -105,7 +105,7 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddVertex(const IdentifierArrayType & 
   // m_PointsHashTable[ foo ] is set to 0 if foo is not found, but I
   // want the initial identifier to be 0.
   IdentifierType * cellIDPlusOne = &m_CellsHashTable[pointIDs];
-  IdentifierType   cellID;
+  IdentifierType   cellID = 0;
 
   if (*cellIDPlusOne != 0)
   {
@@ -135,7 +135,7 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddLine(const IdentifierArrayType & po
 {
   // Check to see if the cell is already referenced in the hash table.
   IdentifierType * cellIDPlusOne = &m_CellsHashTable[pointIDs];
-  IdentifierType   cellID;
+  IdentifierType   cellID = 0;
 
   if (*cellIDPlusOne != 0)
   {
@@ -182,7 +182,7 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddTriangle(const IdentifierArrayType 
 {
   // Check to see if the cell is already referenced in the hash table.
   IdentifierType * cellIDPlusOne = &m_CellsHashTable[pointIDs];
-  IdentifierType   cellID;
+  IdentifierType   cellID = 0;
 
   if (*cellIDPlusOne != 0)
   {
@@ -243,7 +243,7 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddQuadrilateral(const IdentifierArray
 {
   // Check to see if the cell is already referenced in the hash table.
   IdentifierType * cellIDPlusOne = &m_CellsHashTable[pointIDs];
-  IdentifierType   cellID;
+  IdentifierType   cellID = 0;
 
   if (*cellIDPlusOne != 0)
   {
@@ -303,7 +303,7 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddTetrahedron(const IdentifierArrayTy
 {
   // Check to see if the cell is already referenced in the hash table.
   IdentifierType * cellIDPlusOne = &m_CellsHashTable[pointIDs];
-  IdentifierType   cellID;
+  IdentifierType   cellID = 0;
 
   if (*cellIDPlusOne != 0)
   {
@@ -379,7 +379,7 @@ AutomaticTopologyMeshSource<TOutputMesh>::AddHexahedron(const IdentifierArrayTyp
 {
   // Check to see if the cell is already referenced in the hash table.
   IdentifierType * cellIDPlusOne = &m_CellsHashTable[pointIDs];
-  IdentifierType   cellID;
+  IdentifierType   cellID = 0;
 
   if (*cellIDPlusOne != 0)
   {

--- a/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
@@ -105,13 +105,10 @@ template <typename TInputImage, typename TOutputMesh>
 void
 BinaryMask3DMeshSource<TInputImage, TOutputMesh>::XFlip(unsigned char * x)
 {
-  unsigned char nodeindex;
-
   int i = 0;
-
   while (i < 3)
   {
-    nodeindex = x[i];
+    const auto nodeindex = x[i];
     switch (static_cast<int>(nodeindex))
     {
       case 1:
@@ -157,13 +154,10 @@ template <typename TInputImage, typename TOutputMesh>
 void
 BinaryMask3DMeshSource<TInputImage, TOutputMesh>::YFlip(unsigned char * x)
 {
-  unsigned char nodeindex;
-
   int i = 0;
-
   while (i < 3)
   {
-    nodeindex = x[i];
+    const auto nodeindex = x[i];
     switch (static_cast<int>(nodeindex))
     {
       case 1:
@@ -209,13 +203,10 @@ template <typename TInputImage, typename TOutputMesh>
 void
 BinaryMask3DMeshSource<TInputImage, TOutputMesh>::ZFlip(unsigned char * x)
 {
-  unsigned char nodeindex;
-
   int i = 0;
-
   while (i < 3)
   {
-    nodeindex = x[i];
+    const auto nodeindex = x[i];
     switch (static_cast<int>(nodeindex))
     {
       case 1:
@@ -261,13 +252,10 @@ template <typename TInputImage, typename TOutputMesh>
 void
 BinaryMask3DMeshSource<TInputImage, TOutputMesh>::XRotation(unsigned char * x)
 {
-  unsigned char nodeindex;
-
   int i = 0;
-
   while (i < 3)
   {
-    nodeindex = x[i];
+    const auto nodeindex = x[i];
     switch (static_cast<int>(nodeindex))
     {
       case 1:
@@ -317,13 +305,10 @@ template <typename TInputImage, typename TOutputMesh>
 void
 BinaryMask3DMeshSource<TInputImage, TOutputMesh>::YRotation(unsigned char * x)
 {
-  unsigned char nodeindex;
-
   int i = 0;
-
   while (i < 3)
   {
-    nodeindex = x[i];
+    const auto nodeindex = x[i];
     switch (static_cast<int>(nodeindex))
     {
       case 1:
@@ -373,13 +358,10 @@ template <typename TInputImage, typename TOutputMesh>
 void
 BinaryMask3DMeshSource<TInputImage, TOutputMesh>::ZRotation(unsigned char * x)
 {
-  unsigned char nodeindex;
-
   int i = 0;
-
   while (i < 3)
   {
-    nodeindex = x[i];
+    const auto nodeindex = x[i];
     switch (static_cast<int>(nodeindex))
     {
       case 1:
@@ -1057,7 +1039,6 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::CreateMesh()
       ++i;
     }
   }
-  unsigned char vertexindex;
 
   if (m_CurrentRow)
   {
@@ -1093,7 +1074,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::CreateMesh()
     int i = 0;
     while (!it4.IsAtEnd())
     {
-      vertexindex = 0;
+      unsigned char vertexindex = 0;
 
       if (Math::ExactlyEquals(it1.Value(), m_ObjectValue))
       {
@@ -1185,17 +1166,14 @@ template <typename TInputImage, typename TOutputMesh>
 void
 BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltype, unsigned char celltran, int index)
 {
-  IdentifierType ** currentrowtmp;
-  IdentifierType ** currentframetmp;
-
-  currentrowtmp = (IdentifierType **)malloc(4 * sizeof(IdentifierType *));
+  IdentifierType ** currentrowtmp = (IdentifierType **)malloc(4 * sizeof(IdentifierType *));
   for (int i = 0; i < 4; ++i)
   {
     currentrowtmp[i] = (IdentifierType *)malloc(2 * sizeof(IdentifierType));
     currentrowtmp[i][0] = 0;
     currentrowtmp[i][1] = 0;
   }
-  currentframetmp = (IdentifierType **)malloc(4 * sizeof(IdentifierType *));
+  IdentifierType ** currentframetmp = (IdentifierType **)malloc(4 * sizeof(IdentifierType *));
   for (int i = 0; i < 4; ++i)
   {
     currentframetmp[i] = (IdentifierType *)malloc(2 * sizeof(IdentifierType));
@@ -2583,12 +2561,10 @@ template <typename TInputImage, typename TOutputMesh>
 IdentifierType
 BinaryMask3DMeshSource<TInputImage, TOutputMesh>::SearchThroughLastRow(int index, int start, int end)
 {
-  int  mid;
   auto lindex = static_cast<IdentifierType>(index);
-
   if ((end - start) > 1)
   {
-    mid = static_cast<int>(std::floor(static_cast<float>((start + end) / 2)));
+    const auto mid = static_cast<int>(std::floor(static_cast<float>((start + end) / 2)));
     if (lindex == m_LastRow[mid][0])
     {
       m_PointFound = 1;
@@ -2624,13 +2600,12 @@ template <typename TInputImage, typename TOutputMesh>
 IdentifierType
 BinaryMask3DMeshSource<TInputImage, TOutputMesh>::SearchThroughLastFrame(int index, int start, int end)
 {
-  int            mid;
   auto           lindex = static_cast<IdentifierType>(index);
   IdentifierType result = 0;
 
   if ((end - start) > 1)
   {
-    mid = static_cast<int>(std::floor(static_cast<float>((start + end) / 2)));
+    const auto mid = static_cast<int>(std::floor(static_cast<float>((start + end) / 2)));
     if (lindex == m_LastFrame[mid][0])
     {
       m_PointFound = 1;

--- a/Modules/Core/Mesh/include/itkSimplexMesh.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMesh.hxx
@@ -230,7 +230,7 @@ void
 SimplexMesh<TPixelType, VDimension, TMeshTraits>::SetGeometryData(PointIdentifier       pointId,
                                                                   SimplexMeshGeometry * geometryData)
 {
-  SimplexMeshGeometry * oldGeometryData;
+  SimplexMeshGeometry * oldGeometryData = nullptr;
   if (m_GeometryData->GetElementIfIndexExists(pointId, &oldGeometryData))
   {
     delete oldGeometryData;

--- a/Modules/Core/Mesh/include/itkSphereMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkSphereMeshSource.hxx
@@ -85,53 +85,22 @@ SphereMeshSource<TOutputMesh>::GenerateData()
       double v = vbeg;
       for (IdentifierType j = 0; j < m_ResolutionY; v += vstep, j++)
       {
-        int signu;
-        if (std::cos(u) > 0)
-        {
-          signu = 1;
-        }
-        else
-        {
-          signu = -1;
-        }
-        int signv;
-        if (std::cos(v) > 0)
-        {
-          signv = 1;
-        }
-        else
-        {
-          signv = -1;
-        }
+        int signu = (std::cos(u) > 0) ? 1 : -1;
+        int signv = (std::cos(v) > 0) ? 1 : -1;
 
         p1[0] = m_Scale[0] * signu *
                   (std::pow(static_cast<float>(itk::Math::abs(std::cos(u))), static_cast<float>(m_Squareness1)))*signv *
                   (std::pow(static_cast<float>(itk::Math::abs(std::cos(v))), static_cast<float>(m_Squareness2))) +
                 m_Center[0];
 
-        if (std::sin(v) > 0)
-        {
-          signv = 1;
-        }
-        else
-        {
-          signv = -1;
-        }
+        signv = (std::sin(v) > 0) ? 1 : -1;
 
         p1[1] = m_Scale[1] * signu *
                   (std::pow(static_cast<float>(itk::Math::abs(std::cos(u))), static_cast<float>(m_Squareness1)))*signv *
                   (std::pow(static_cast<float>(itk::Math::abs(std::sin(v))), static_cast<float>(m_Squareness2))) +
                 m_Center[1];
 
-        if (std::sin(u) > 0)
-        {
-          signu = 1;
-        }
-        else
-        {
-          signu = -1;
-        }
-
+        signu = (std::sin(u) > 0) ? 1 : -1;
         p1[2] = m_Scale[2] * signu *
                   (std::pow(static_cast<float>(itk::Math::abs(std::sin(u))), static_cast<float>(m_Squareness1))) +
                 m_Center[2];

--- a/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
@@ -246,7 +246,7 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::PolygonToImageRaster(
   } // end of for loop
 
   // area is not really needed, we just need the sign
-  int sign;
+  int sign = 0;
   if (area < 0.0)
   {
     sign = -1;

--- a/Modules/Core/Mesh/include/itkVTKPolyDataReader.hxx
+++ b/Modules/Core/Mesh/include/itkVTKPolyDataReader.hxx
@@ -215,7 +215,7 @@ VTKPolyDataReader<TOutputMesh>::GenerateData()
   // Load the polygons into the itk::Mesh
   //
 
-  long numberOfCellPoints;
+  long numberOfCellPoints = 0;
   long ids[3]; // need a signed type on input.
 
   for (CellIdentifier i = 0; i < itk::Math::CastWithRangeCheck<CellIdentifier>(numberOfPolygons); ++i)
@@ -233,7 +233,7 @@ VTKPolyDataReader<TOutputMesh>::GenerateData()
       itkExceptionMacro("Error reading file: " << m_FileName << "\nRead keyword DATA");
     }
 
-    int got;
+    int got = 0;
     if ((got = sscanf(line.c_str(), "%ld %ld %ld %ld", &numberOfCellPoints, &ids[0], &ids[1], &ids[2])) != 4)
     {
       itkExceptionMacro("Error reading file: "
@@ -317,7 +317,7 @@ VTKPolyDataReader<TOutputMesh>::GenerateData()
                                                << "\nUnexpected end-of-file while trying to read POINT_DATA.");
     }
 
-    double pointData;
+    double pointData = NAN;
 
     for (PointIdentifier pid = 0; pid < itk::Math::CastWithRangeCheck<PointIdentifier>(numberOfPoints); ++pid)
     {

--- a/Modules/Core/Mesh/test/itkMeshTest.cxx
+++ b/Modules/Core/Mesh/test/itkMeshTest.cxx
@@ -346,7 +346,7 @@ itkMeshTest(int, char *[])
     std::cout << typeid(cellPointer0).name() << std::endl;
     std::cout << "GetCellBoundaryFeature() return AutoPointer owner = " << cellPointer0.IsOwner() << std::endl;
 
-    HexaCellType::FaceType * quad;
+    HexaCellType::FaceType * quad = nullptr;
     try
     {
       quad = dynamic_cast<HexaCellType::FaceType *>(cellPointer0.GetPointer());
@@ -530,7 +530,7 @@ itkMeshTest(int, char *[])
       std::cout << typeid(vertexPointer).name() << std::endl;
       std::cout << "GetCellBoundaryFeature() return AutoPointer owner = " << vertexPointer.IsOwner() << std::endl;
 
-      QuadraticEdgeCellType::VertexType * vertex;
+      QuadraticEdgeCellType::VertexType * vertex = nullptr;
       try
       {
         vertex = dynamic_cast<QuadraticEdgeCellType::VertexType *>(vertexPointer.GetPointer());
@@ -606,7 +606,7 @@ itkMeshTest(int, char *[])
       std::cout << typeid(vertexPointer).name() << std::endl;
       std::cout << "GetCellBoundaryFeature() return AutoPointer owner = " << vertexPointer.IsOwner() << std::endl;
 
-      QuadraticTriangleCellType::VertexType * vertex;
+      QuadraticTriangleCellType::VertexType * vertex = nullptr;
       try
       {
         vertex = dynamic_cast<QuadraticTriangleCellType::VertexType *>(vertexPointer.GetPointer());
@@ -645,7 +645,7 @@ itkMeshTest(int, char *[])
       std::cout << typeid(edgePointer).name() << std::endl;
       std::cout << "GetCellBoundaryFeature() return AutoPointer owner = " << edgePointer.IsOwner() << std::endl;
 
-      QuadraticTriangleCellType::EdgeType * edge;
+      QuadraticTriangleCellType::EdgeType * edge = nullptr;
       try
       {
         edge = dynamic_cast<QuadraticTriangleCellType::EdgeType *>(edgePointer.GetPointer());

--- a/Modules/Core/Mesh/test/itkQuadrilateralCellTest.cxx
+++ b/Modules/Core/Mesh/test/itkQuadrilateralCellTest.cxx
@@ -163,7 +163,7 @@ itkQuadrilateralCellTest(int, char *[])
   std::cout << inputPoint[2] << std::endl;
 
   QuadrilateralCellType::CoordinateType          closestPoint[3];
-  double                                         distance;
+  double                                         distance = NAN;
   QuadrilateralCellType::InterpolationWeightType weights[4];
   QuadrilateralCellType::CoordinateType          pcoords[2]; // Quadrilateral has 2 parametric coordinates
   bool isInside = testCell1->EvaluatePosition(inputPoint, points, closestPoint, pcoords, &distance, weights);

--- a/Modules/Core/Mesh/test/itkTriangleCellTest.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleCellTest.cxx
@@ -156,7 +156,6 @@ itkTriangleCellTest(int, char *[])
   TriangleCellType::PointsContainer *       points = mesh->GetPoints();
   TriangleCellType::CoordinateType          closestPoint[3];
   TriangleCellType::CoordinateType          pcoords[3];
-  double                                    distance;
   TriangleCellType::InterpolationWeightType weights[3];
 
   constexpr double tolerance = 1e-5;
@@ -170,8 +169,8 @@ itkTriangleCellTest(int, char *[])
   std::cout << inputPoint[0] << ", ";
   std::cout << inputPoint[1] << ", ";
   std::cout << inputPoint[2] << std::endl;
-
-  bool isInside = testCell->EvaluatePosition(inputPoint, points, closestPoint, pcoords, &distance, weights);
+  double distance = NAN;
+  bool   isInside = testCell->EvaluatePosition(inputPoint, points, closestPoint, pcoords, &distance, weights);
 
   if (!isInside)
   {

--- a/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.hxx
@@ -562,19 +562,11 @@ GeometricalQuadEdge<TVRef, TFRef, TPrimalData, TDualData, PrimalDual>::ReorderOn
     return (false);
   }
 
-  Self * bsplice; // Does not require initialisation;
-  // Disconnect the triangles containing second:
-  if (second->IsLeftSet())
-  {
-    bsplice = second->GetNextBorderEdgeWithUnsetLeft();
-    second->GetOprev()->Splice(bsplice);
-  }
-  else
-  {
-    // Orientation is locally clockwise:
-    bsplice = second;
-    second->GetOprev()->Splice(bsplice);
-  }
+  // Disconnect the triangles containing second
+  Self * bsplice = (second->IsLeftSet()) ? second->GetNextBorderEdgeWithUnsetLeft() : second;
+  // Orientation is locally counter clockwise: Orientation is locally clockwise:
+
+  second->GetOprev()->Splice(bsplice);
 
   // Reconnect second after first:
   first->Splice(bsplice);

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
@@ -338,8 +338,8 @@ void
 QuadEdgeMesh<TPixel, VDimension, TTraits>::SetCell(CellIdentifier itkNotUsed(cId), CellAutoPointer & cell)
 {
   // NOTE ALEX: should add some checking to be sure everything went fine
-  EdgeCellType *    qe;
-  PolygonCellType * pe;
+  EdgeCellType *    qe = nullptr;
+  PolygonCellType * pe = nullptr;
 
   // The QuadEdgeMeshCellTypes first
   if ((qe = dynamic_cast<EdgeCellType *>(cell.GetPointer())) != nullptr)
@@ -470,17 +470,12 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::SqueezePointsIds()
     --lastData;
   }
 
-  // Some Temp var to be used in the while loop
-  PointIdentifier FilledPointID;
-  QEType *        EdgeRingEntry;
-  QEType *        EdgeRingIter;
-
   // for all the free indexes and while there is any gap
   while ((!m_FreePointIndexes.empty()) && (last.Index() >= this->GetNumberOfPoints()))
   {
 
     // duplicate last point into the empty slot and pop the id from freeID list
-    FilledPointID = AddPoint(GetPoint(last.Index()));
+    PointIdentifier FilledPointID = AddPoint(GetPoint(last.Index()));
 
     // same thing for the data if any
     if (HasPointData)
@@ -490,10 +485,11 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::SqueezePointsIds()
 
     // make sure that all the edges/faces now refer to the new ID
     // i.e. enforce the integrity at the QE level now.
-    EdgeRingEntry = GetPoint(last.Index()).GetEdge();
+    QEType * EdgeRingEntry = GetPoint(last.Index()).GetEdge();
     if (EdgeRingEntry)
     {
-      EdgeRingIter = EdgeRingEntry;
+
+      QEType * EdgeRingIter = EdgeRingEntry;
       do
       {
         EdgeRingIter->SetOrigin(FilledPointID);
@@ -1013,7 +1009,7 @@ void
 QuadEdgeMesh<TPixel, VDimension, TTraits>::DeleteFace(FaceRefType faceToDelete)
 {
   const CellsContainerPointer cells = this->GetCells();
-  CellType *                  c;
+  CellType *                  c = nullptr;
 
   if (!cells->GetElementIfIndexExists(faceToDelete, &c))
   {
@@ -1084,7 +1080,7 @@ template <typename TPixel, unsigned int VDimension, typename TTraits>
 auto
 QuadEdgeMesh<TPixel, VDimension, TTraits>::GetEdge(const CellIdentifier & eid) const -> QEPrimal *
 {
-  CellType * c;
+  CellType * c = nullptr;
 
   if (!this->GetEdgeCells()->GetElementIfIndexExists(eid, &c))
   {
@@ -1264,7 +1260,6 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::AddFaceWithSecurePointList(const Poin
   }
 
   // Reorder all Onext rings
-  QEPrimal * e1;
   QEPrimal * e0 = FaceQEList.back();
 
   auto fIt = FaceQEList.begin();
@@ -1272,7 +1267,7 @@ QuadEdgeMesh<TPixel, VDimension, TTraits>::AddFaceWithSecurePointList(const Poin
 
   while (fIt != fEnd)
   {
-    e1 = e0->GetSym();
+    QEPrimal * e1 = e0->GetSym();
     e0 = *fIt;
 
     e0->ReorderOnextRingBeforeAddFace(e1);

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexFunction.hxx
@@ -91,7 +91,6 @@ QuadEdgeMeshEulerOperatorDeleteCenterVertexFunction<TMesh, TQEType>::Evaluate(QE
 
   // let's do the job now.
   QEType * h = g->GetLprev();
-  QEType * temp;
   this->m_OldPointID = g->GetDestination();
   this->m_Mesh->LightWeightDeleteEdge(g);
   g = h->GetLnext();
@@ -103,7 +102,7 @@ QuadEdgeMeshEulerOperatorDeleteCenterVertexFunction<TMesh, TQEType>::Evaluate(QE
     }
     if (g != h)
     {
-      temp = g->GetLprev();
+      QEType * temp = g->GetLprev();
       this->m_Mesh->LightWeightDeleteEdge(g);
       g = temp;
     }

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.hxx
@@ -288,7 +288,6 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::IsFaceIsolated(QETy
                                                                             const bool              iWasLeftFace,
                                                                             std::stack<TQEType *> & oToBeDeleted)
 {
-  bool     border;
   QEType * e_sym = e->GetSym();
 
   // turn around the face (left or right one) while edges are on the border
@@ -300,6 +299,7 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::IsFaceIsolated(QETy
   oToBeDeleted.push(e_it);
   e_it = e_it->GetLnext();
 
+  bool border = false;
   do
   {
     oToBeDeleted.push(e_it);
@@ -554,7 +554,7 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::IsEdgeLinkingTwoDif
 {
   QEType * t = e;
   QEType * e_it = t;
-  bool     org_border;
+  bool     org_border = false;
 
   do
   {
@@ -568,7 +568,7 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::IsEdgeLinkingTwoDif
 
   t = e->GetSym();
   e_it = t;
-  bool dest_border;
+  bool dest_border = false;
   do
   {
     dest_border = e_it->IsAtBorder();

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorsTestHelper.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorsTestHelper.h
@@ -99,11 +99,9 @@ CreateSquareQuadMesh(typename TMesh::Pointer mesh)
   }
 
   typename CellType::CellAutoPointer cellpointer;
-  QEPolygonCellType *                poly;
-
   for (int i = 0; i < expectedNumCells; ++i)
   {
-    poly = new QEPolygonCellType(4);
+    QEPolygonCellType * poly = new QEPolygonCellType(4);
     cellpointer.TakeOwnership(poly);
     cellpointer->SetPointId(0, simpleSquareCells[4 * i]);
     cellpointer->SetPointId(1, simpleSquareCells[4 * i + 1]);
@@ -147,11 +145,9 @@ CreateSquareTriangularMesh(typename TMesh::Pointer mesh)
   }
 
   typename CellType::CellAutoPointer cellpointer;
-  QEPolygonCellType *                poly;
-
   for (int i = 0; i < expectedNumCells; ++i)
   {
-    poly = new QEPolygonCellType(3);
+    QEPolygonCellType * poly = new QEPolygonCellType(3);
     cellpointer.TakeOwnership(poly);
     cellpointer->SetPointId(0, simpleSquareCells[3 * i]);
     cellpointer->SetPointId(1, simpleSquareCells[3 * i + 1]);

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorJoinVertexTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorJoinVertexTest.cxx
@@ -40,7 +40,7 @@ itkQuadEdgeMeshEulerOperatorJoinVertexTest(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  int               InputType;
+  int               InputType = 0;
   std::stringstream ssout(argv[1]);
   ssout >> InputType;
 

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshIteratorTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshIteratorTest.cxx
@@ -135,15 +135,12 @@ itkQuadEdgeMeshIteratorTest(int, char *[])
   for (IteratorGeom itDnext = foundEdges[0]->BeginGeomDnext(); itDnext != foundEdges[0]->EndGeomDnext();
        itDnext++, edgeNumber++)
   {
-    MeshType::QEPrimal * expectedEdge;
+    MeshType::QEPrimal * expectedEdge = foundEdges[edgeNumber];
     if (edgeNumber)
     {
       expectedEdge = foundEdges[edgeNumber]->GetSym();
     }
-    else
-    {
-      expectedEdge = foundEdges[edgeNumber];
-    }
+
     MeshType::QEPrimal * currentEdge = itDnext.Value();
     if (currentEdge != expectedEdge)
     {

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
@@ -67,13 +67,12 @@ template <unsigned int TDimension>
 bool
 EllipseSpatialObject<TDimension>::IsInsideInObjectSpace(const PointType & point) const
 {
-  double d;
   double r = 0;
   for (unsigned int i = 0; i < TDimension; ++i)
   {
     if (m_RadiusInObjectSpace[i] > 0.0)
     {
-      d = point[i] - m_CenterInObjectSpace[i];
+      double d = point[i] - m_CenterInObjectSpace[i];
       r += (d * d) / (m_RadiusInObjectSpace[i] * m_RadiusInObjectSpace[i]);
     }
     else if (point[i] != 0.0 || m_RadiusInObjectSpace[i] < 0)

--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
@@ -207,7 +207,7 @@ MetaSceneConverter<VDimension, PixelType, TMeshTraits>::CreateMetaScene(const Sp
   auto it = childrenList->begin();
   auto itEnd = childrenList->end();
 
-  MetaObject * currentMeta;
+  MetaObject * currentMeta = nullptr;
 
   while (it != itEnd)
   {

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -93,7 +93,7 @@ SpatialObject<TDimension>::DerivativeAtInObjectSpace(const PointType &          
 
   if (order == 0)
   {
-    double r;
+    double r = NAN;
 
     ValueAtInObjectSpace(point, r, depth, name);
     value.Fill(r);

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
@@ -178,10 +178,9 @@ TubeSpatialObject<TDimension, TTubePointType>::IsInsideInObjectSpace(const Point
 {
   if (this->GetMyBoundingBoxInObjectSpace()->IsInside(point))
   {
-    double tempDist;
-    auto   it = this->m_Points.begin();
-    auto   first = it;
-    auto   it2 = it;
+    auto it = this->m_Points.begin();
+    auto first = it;
+    auto it2 = it;
     ++it2;
     auto end = this->m_Points.end();
     auto last = end;
@@ -270,8 +269,7 @@ TubeSpatialObject<TDimension, TTubePointType>::IsInsideInObjectSpace(const Point
             p[i] = a[i] + lambda * (b[i] - a[i]);
           }
 
-          tempDist = point.EuclideanDistanceTo(p);
-
+          double tempDist = point.EuclideanDistanceTo(p);
           if (tempDist <= lambdaR)
           {
             return true;

--- a/Modules/Core/SpatialObjects/test/itkBlobSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkBlobSpatialObjectTest.cxx
@@ -178,7 +178,7 @@ itkBlobSpatialObjectTest(int, char *[])
   // Testing IsEvaluableAt()
   std::cout << "ValueAt: ";
 
-  double value;
+  double value = NAN;
   if (!blob->ValueAtInWorldSpace(in, value))
   {
     std::cout << "[FAILED]" << std::endl;

--- a/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
@@ -41,8 +41,6 @@ itkDTITubeSpatialObjectTest(int, char *[])
   using ChildrenListType = std::list<itk::SpatialObject<3>::Pointer>;
   using ChildrenListPointer = ChildrenListType *;
 
-  bool passed = true;
-
   //======================================
   // testing of a single SpatialObject...
   //======================================
@@ -115,16 +113,7 @@ itkDTITubeSpatialObjectTest(int, char *[])
 
   std::cout << "[PASSED]" << std::endl;
 
-
   std::cout << "itkTubeSpatialObjectTest ";
-  if (passed)
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
-  else
-  {
-    std::cout << "[FAILED]" << std::endl;
-  }
 
   //==============================================
   // testing of a single CompositeSpatialObject...
@@ -132,10 +121,6 @@ itkDTITubeSpatialObjectTest(int, char *[])
 
   std::cout << "==================================" << std::endl;
   std::cout << "Testing GroupSpatialObject:" << std::endl << std::endl;
-
-  ChildrenListType    childrenList;
-  ChildrenListPointer returnedList;
-  unsigned int        nbChildren;
 
   const TubePointer tube2 = TubeType::New();
   tube2->GetProperty().SetName("Tube 2");
@@ -159,7 +144,7 @@ itkDTITubeSpatialObjectTest(int, char *[])
   tubeNet1->Update();
 
   // testing the AddChild() function...
-  nbChildren = tubeNet1->GetNumberOfChildren();
+  unsigned int nbChildren = tubeNet1->GetNumberOfChildren();
 
   std::cout << "AddChild()...";
   if (nbChildren != 3)
@@ -195,13 +180,14 @@ itkDTITubeSpatialObjectTest(int, char *[])
   tubeNet1->AddChild(tube2);
   tubeNet1->AddChild(tube3);
 
+  ChildrenListType childrenList;
   // testing the GetChildren() function...
   childrenList.emplace_back(tube1);
   childrenList.emplace_back(tube2);
   childrenList.emplace_back(tube3);
 
-  returnedList = tubeNet1->GetChildren();
-
+  ChildrenListPointer returnedList = tubeNet1->GetChildren();
+  bool                passed = true;
   if (childrenList.size() == returnedList->size())
   {
     auto itTest = returnedList->begin();

--- a/Modules/Core/SpatialObjects/test/itkGaussianSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkGaussianSpatialObjectTest.cxx
@@ -61,7 +61,7 @@ itkGaussianSpatialObjectTest(int, char *[])
   // Once all values of the Gaussian have been set, it must be updated
   myGaussian->Update();
 
-  double value;
+  double value = NAN;
   myGaussian->ValueAtInWorldSpace(in, value);
   std::cout << "ValueAt(" << in << ") = " << value << std::endl;
 

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
@@ -116,7 +116,7 @@ itkImageMaskSpatialObjectTest2(int, char *[])
       image->TransformIndexToPhysicalPoint(constIndex, point);
       const bool isInsideTest = maskSO->IsInsideInWorldSpace(point);
 
-      double outsideIfZeroValue;
+      double outsideIfZeroValue = NAN;
       maskSO->ValueAtInWorldSpace(point, outsideIfZeroValue);
       if (isInsideTest && itk::Math::AlmostEquals(outsideIfZeroValue, 0.0))
       {

--- a/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
@@ -94,7 +94,7 @@ itkImageSpatialObjectTest(int, char *[])
   q.Fill(15.1);
   double expectedValue = 555;
 
-  double returnedValue;
+  double returnedValue = NAN;
   ITK_TRY_EXPECT_NO_EXCEPTION(imageSO->ValueAtInWorldSpace(q, returnedValue));
 
 

--- a/Modules/Core/SpatialObjects/test/itkLineSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkLineSpatialObjectTest.cxx
@@ -149,7 +149,7 @@ itkLineSpatialObjectTest(int, char *[])
   // Testing IsEvaluableAt()
   std::cout << "ValueAt: ";
 
-  double value;
+  double value = NAN;
   if (!line->ValueAtInWorldSpace(in, value))
   {
     std::cout << "[FAILED]" << std::endl;

--- a/Modules/Core/SpatialObjects/test/itkMeshSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkMeshSpatialObjectTest.cxx
@@ -115,7 +115,7 @@ itkMeshSpatialObjectTest(int, char *[])
 
   // Testing is valueAt
   std::cout << "Testing ValueAt: ";
-  double value;
+  double value = NAN;
   meshSO->ValueAtInWorldSpace(inside, value);
   if (!value)
   {

--- a/Modules/Core/SpatialObjects/test/itkPolygonSpatialObjectIsInsideInObjectSpaceTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkPolygonSpatialObjectIsInsideInObjectSpaceTest.cxx
@@ -72,7 +72,7 @@ itkPolygonSpatialObjectIsInsideInObjectSpaceTest(int argc, char * argv[])
   {
     // read over first line
     fs.getline(data, sizeof(data), '\n');
-    char commaDelim;
+    char commaDelim = 0;
     while (fs.getline(data, sizeof(data), '\n'))
     {
       std::stringstream ss(data);

--- a/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
@@ -145,7 +145,7 @@ itkSurfaceSpatialObjectTest(int, char *[])
   // Testing IsEvaluableAt()
   std::cout << "ValueAt: ";
 
-  double value;
+  double value = NAN;
   if (!Surface->ValueAtInWorldSpace(in, value))
   {
     std::cout << "[FAILED]" << std::endl;

--- a/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
@@ -41,8 +41,6 @@ itkTubeSpatialObjectTest(int, char *[])
   using ChildrenListType = std::list<itk::SpatialObject<3>::Pointer>;
   using ChildrenListPointer = ChildrenListType *;
 
-  bool passed = true;
-
   //======================================
   // testing of a single SpatialObject...
   //======================================
@@ -128,14 +126,8 @@ itkTubeSpatialObjectTest(int, char *[])
 
 
   std::cout << "itkTubeSpatialObjectTest ";
-  if (passed)
-  {
-    std::cout << "[PASSED]" << std::endl;
-  }
-  else
-  {
-    std::cout << "[FAILED]" << std::endl;
-  }
+  bool passed = true;
+  std::cout << "[PASSED]" << std::endl;
 
   //==============================================
   // testing of a single CompositeSpatialObject...
@@ -144,9 +136,7 @@ itkTubeSpatialObjectTest(int, char *[])
   std::cout << "==================================" << std::endl;
   std::cout << "Testing GroupSpatialObject:" << std::endl << std::endl;
 
-  ChildrenListType    childrenList;
-  ChildrenListPointer returnedList;
-  unsigned int        nbChildren;
+  ChildrenListType childrenList;
 
   const TubePointer tube2 = TubeType::New();
   tube2->GetProperty().SetName("Tube 2");
@@ -170,7 +160,7 @@ itkTubeSpatialObjectTest(int, char *[])
   tubeNet1->Update();
 
   // testing the AddChild() function...
-  nbChildren = tubeNet1->GetNumberOfChildren();
+  unsigned int nbChildren = tubeNet1->GetNumberOfChildren();
 
   std::cout << "AddChild()...";
   if (nbChildren != 3)
@@ -211,7 +201,7 @@ itkTubeSpatialObjectTest(int, char *[])
   childrenList.emplace_back(tube2);
   childrenList.emplace_back(tube3);
 
-  returnedList = tubeNet1->GetChildren();
+  ChildrenListPointer returnedList = tubeNet1->GetChildren();
 
   if (childrenList.size() == returnedList->size())
   {

--- a/Modules/Core/TestKernel/include/itkTestDriverBeforeTest.inc
+++ b/Modules/Core/TestKernel/include/itkTestDriverBeforeTest.inc
@@ -23,7 +23,7 @@
   try
     {
     std::ofstream redirectStream;
-    std::streambuf *redirectBuf;
+    std::streambuf *redirectBuf = nullptr;
     std::streambuf *oldCoutBuf = nullptr;
     RedirectOutputParameters const& redirectOutputParameters = GetRedirectOutputParameters();
     if (redirectOutputParameters.redirect)

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
@@ -300,7 +300,7 @@ BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::TransformP
   WeightsType             weights;
   ParameterIndexArrayType indices;
   OutputPointType         outputPoint;
-  bool                    inside;
+  bool                    inside = false;
 
   this->TransformPoint(point, outputPoint, weights, indices, inside);
 

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
@@ -213,7 +213,7 @@ itkBSplineDeformableTransformTest1()
 
   WeightsType    weights;
   IndexArrayType indices;
-  bool           inside;
+  bool           inside = false;
 
   inputPoint.Fill(8.3);
   transform->TransformPoint(inputPoint, outputPoint, weights, indices, inside);
@@ -231,16 +231,14 @@ itkBSplineDeformableTransformTest1()
   // transformation
   constexpr unsigned int numberOfCoefficientInSupportRegion = TransformType::NumberOfWeights;
   const unsigned int     numberOfParametersPerDimension = transform->GetNumberOfParametersPerDimension();
-  unsigned int           linearIndex;
-  unsigned int           baseIndex;
 
   std::cout << "Index" << '\t' << "Value" << '\t' << "Weight" << std::endl;
   for (unsigned int j = 0; j < SpaceDimension; ++j)
   {
-    baseIndex = j * numberOfParametersPerDimension;
+    const auto baseIndex = j * numberOfParametersPerDimension;
     for (unsigned int k = 0; k < numberOfCoefficientInSupportRegion; ++k)
     {
-      linearIndex = indices[k] + baseIndex;
+      const auto linearIndex = indices[k] + baseIndex;
       std::cout << linearIndex << '\t';
       std::cout << parameters[linearIndex] << '\t';
       std::cout << weights[k] << '\t';

--- a/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
@@ -235,7 +235,7 @@ itkBSplineTransformTest1()
 
   WeightsType    weights;
   IndexArrayType indices;
-  bool           inside;
+  bool           inside = false;
 
   inputPoint.Fill(8.3);
   transform->TransformPoint(inputPoint, outputPoint, weights, indices, inside);
@@ -253,16 +253,14 @@ itkBSplineTransformTest1()
   // transformation
   constexpr unsigned int numberOfCoefficientInSupportRegion = TransformType::NumberOfWeights;
   const unsigned int     numberOfParametersPerDimension = transform->GetNumberOfParametersPerDimension();
-  unsigned int           linearIndex;
-  unsigned int           baseIndex;
 
   std::cout << "Index" << '\t' << "Value" << '\t' << "Weight" << std::endl;
   for (unsigned int j = 0; j < SpaceDimension; ++j)
   {
-    baseIndex = j * numberOfParametersPerDimension;
+    const auto baseIndex = j * numberOfParametersPerDimension;
     for (unsigned int k = 0; k < numberOfCoefficientInSupportRegion; ++k)
     {
-      linearIndex = indices[k] + baseIndex;
+      const auto linearIndex = indices[k] + baseIndex;
       std::cout << linearIndex << '\t';
       std::cout << parameters[linearIndex] << '\t';
       std::cout << weights[k] << '\t';

--- a/Modules/Core/Transform/test/itkQuaternionRigidTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkQuaternionRigidTransformTest.cxx
@@ -720,15 +720,14 @@ itkQuaternionRigidTransformTest(int, char *[])
   {
     // Testing SetMatrix()
     std::cout << "Testing SetMatrix() ... ";
-    unsigned int par;
 
     using MatrixType = TransformType::MatrixType;
     MatrixType matrix;
 
     auto t = TransformType::New();
 
-    // attempt to set an non-orthogonal matrix
-    par = 0;
+    // attempt to set a non-orthogonal matrix
+    unsigned int par = 0;
     for (unsigned int row = 0; row < 3; ++row)
     {
       for (unsigned int col = 0; col < 3; ++col)

--- a/Modules/Core/Transform/test/itkRigid3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkRigid3DTransformTest.cxx
@@ -598,7 +598,7 @@ itkRigid3DTransformTest(int, char *[])
     {
       // Testing SetMatrix()
       std::cout << "Testing SetMatrix() ... ";
-      unsigned int par;
+
 
       using MatrixType = TransformType::MatrixType;
       MatrixType matrix;
@@ -606,7 +606,7 @@ itkRigid3DTransformTest(int, char *[])
       auto t = TransformType::New();
 
       // attempt to set an non-orthogonal matrix
-      par = 0;
+      unsigned int par = 0;
       for (unsigned int row = 0; row < 3; ++row)
       {
         for (unsigned int col = 0; col < 3; ++col)

--- a/Modules/Core/Transform/test/itkSimilarity3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkSimilarity3DTransformTest.cxx
@@ -492,15 +492,12 @@ itkSimilarity3DTransformTest(int, char *[])
   {
     // Testing SetMatrix()
     std::cout << "Testing SetMatrix() ... ";
-    bool         Ok;
-    unsigned int par;
-
     MatrixType matrix;
 
     auto t = TransformType::New();
 
     // attempt to set an non-orthogonal matrix
-    par = 0;
+    unsigned int par = 0;
     for (unsigned int row = 0; row < 3; ++row)
     {
       for (unsigned int col = 0; col < 3; ++col)
@@ -510,7 +507,7 @@ itkSimilarity3DTransformTest(int, char *[])
       }
     }
 
-    Ok = false;
+    bool Ok = false;
 
     std::cout << "Setting non-orthogonal matrix = " << std::endl;
     std::cout << matrix << std::endl;

--- a/Modules/Core/Transform/test/itkTransformsSetParametersTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformsSetParametersTest.cxx
@@ -91,22 +91,16 @@ TestKernelTransform(const char * name, KernelType *)
 int
 itkTransformsSetParametersTest(int, char *[])
 {
-
-
-  itk::ModifiedTimeType beginMTime;
-  itk::ModifiedTimeType endMTime;
-
-
   std::cout << "Begin testing of SetParameters() method for all itkTransforms" << std::endl << std::endl;
 
   std::cout << "AffineTransform->SetParameters() - " << std::flush;
   using Affine = itk::AffineTransform<double, 3>;
-  auto affine = Affine::New();
-  beginMTime = affine->GetMTime();
+  auto                   affine = Affine::New();
+  itk::ModifiedTimeType  beginMTime = affine->GetMTime();
   Affine::ParametersType affineParams = affine->GetParameters();
   affineParams[0] = 1.0;
   affine->SetParameters(affineParams);
-  endMTime = affine->GetMTime();
+  itk::ModifiedTimeType endMTime = affine->GetMTime();
   if (endMTime > beginMTime)
   {
     std::cout << "PASS" << std::endl;

--- a/Modules/Core/Transform/test/itkVersorRigid3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkVersorRigid3DTransformTest.cxx
@@ -416,15 +416,12 @@ itkVersorRigid3DTransformTest(int, char *[])
   {
     // Testing SetMatrix()
     std::cout << "Testing SetMatrix() ... ";
-    unsigned int par;
-    bool         Ok;
-
     MatrixType matrix;
 
     auto t = TransformType::New();
 
     // attempt to set an non-orthogonal matrix
-    par = 0;
+    unsigned int par = 0;
     for (unsigned int row = 0; row < 3; ++row)
     {
       for (unsigned int col = 0; col < 3; ++col)
@@ -434,7 +431,7 @@ itkVersorRigid3DTransformTest(int, char *[])
       }
     }
 
-    Ok = false;
+    bool Ok = false;
     try
     {
       t->SetMatrix(matrix);

--- a/Modules/Core/Transform/test/itkVersorTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkVersorTransformTest.cxx
@@ -352,15 +352,12 @@ itkVersorTransformTest(int, char *[])
   {
     // Testing SetMatrix()
     std::cout << "Testing SetMatrix() ... ";
-    unsigned int par;
-    bool         Ok;
-
     MatrixType matrix;
 
     auto t = TransformType::New();
 
     // attempt to set an non-orthogonal matrix
-    par = 0;
+    unsigned int par = 0;
     for (unsigned int row = 0; row < 3; ++row)
     {
       for (unsigned int col = 0; col < 3; ++col)
@@ -370,7 +367,7 @@ itkVersorTransformTest(int, char *[])
       }
     }
 
-    Ok = false;
+    bool Ok = false;
     try
     {
       t->SetMatrix(matrix);

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionImageFilter.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionImageFilter.hxx
@@ -18,6 +18,7 @@
 #ifndef itkAnisotropicDiffusionImageFilter_hxx
 #define itkAnisotropicDiffusionImageFilter_hxx
 
+#include <cmath>
 
 namespace itk
 {
@@ -48,7 +49,7 @@ AnisotropicDiffusionImageFilter<TInputImage, TOutputImage>::InitializeIteration(
   f->SetTimeStep(m_TimeStep);
 
   // Check the timestep for stability
-  double minSpacing;
+  double minSpacing = 1.0;
   if (this->GetUseImageSpacing())
   {
     const auto & spacing = this->GetInput()->GetSpacing();
@@ -62,10 +63,7 @@ AnisotropicDiffusionImageFilter<TInputImage, TOutputImage>::InitializeIteration(
       }
     }
   }
-  else
-  {
-    minSpacing = 1.0;
-  }
+
   if (m_TimeStep > (minSpacing / double{ 1ULL << (ImageDimension + 1) }))
   {
     //    f->SetTimeStep(1.0 / double{ 1ULL << ImageDimension });

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkCurvatureNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkCurvatureNDAnisotropicDiffusionFunction.hxx
@@ -112,15 +112,10 @@ CurvatureNDAnisotropicDiffusionFunction<TImage>::ComputeUpdate(const Neighborhoo
     const double grad_mag = std::sqrt(m_MIN_NORM + grad_mag_sq);
     const double grad_mag_d = std::sqrt(m_MIN_NORM + grad_mag_sq_d);
 
-    double Cx;
-    double Cxd;
+    double Cx = 0.0;
+    double Cxd = 0.0;
     // Conductance Terms
-    if (m_K == 0.0)
-    {
-      Cx = 0.0;
-      Cxd = 0.0;
-    }
-    else
+    if (m_K != 0.0)
     {
       Cx = std::exp(grad_mag_sq / m_K);
       Cxd = std::exp(grad_mag_sq_d / m_K);

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkGradientNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkGradientNDAnisotropicDiffusionFunction.hxx
@@ -118,14 +118,9 @@ GradientNDAnisotropicDiffusionFunction<TImage>::ComputeUpdate(const Neighborhood
       }
     }
 
-    double Cx;
-    double Cxd;
-    if (m_K == 0.0)
-    {
-      Cx = 0.0;
-      Cxd = 0.0;
-    }
-    else
+    double Cx = 0.0;
+    double Cxd = 0.0;
+    if (m_K != 0.0)
     {
       Cx = std::exp((itk::Math::sqr(dx_forward) + accum) / m_K);
       Cxd = std::exp((itk::Math::sqr(dx_backward) + accum_d) / m_K);

--- a/Modules/Filtering/AnisotropicSmoothing/test/itkMinMaxCurvatureFlowImageFilterTest.cxx
+++ b/Modules/Filtering/AnisotropicSmoothing/test/itkMinMaxCurvatureFlowImageFilterTest.cxx
@@ -134,7 +134,7 @@ testMinMaxCurvatureFlow(itk::Size<VImageDimension> & size,         // ND image s
   using DenoiserType = itk::MinMaxCurvatureFlowImageFilter<ImageType, ImageType>;
   auto denoiser = DenoiserType::New();
 
-  int j;
+  int j = 0;
 
   /**
    * Create an image containing a circle/sphere with intensity of 0
@@ -162,21 +162,13 @@ testMinMaxCurvatureFlow(itk::Size<VImageDimension> & size,         // ND image s
   for (; !circleIter.IsAtEnd(); ++circleIter)
   {
     typename ImageType::IndexType index = circleIter.GetIndex();
-    float                         value;
 
     double lhs = 0.0;
     for (j = 0; j < ImageDimension; ++j)
     {
       lhs += itk::Math::sqr(static_cast<double>(index[j]) - static_cast<double>(size[j]) * 0.5);
     }
-    if (lhs < sqrRadius)
-    {
-      value = foreground;
-    }
-    else
-    {
-      value = background;
-    }
+    float value = (lhs < sqrRadius) ? foreground : background;
 
     if (vnl_sample_uniform(0.0, 1.0) < fractionNoise)
     {

--- a/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.hxx
@@ -58,7 +58,6 @@ MRASlabIdentifier<TInputImage>::GenerateSlabRegions()
   const IndexValueType lastSlice = firstSlice + size[m_SlicingDirection];
   const SizeValueType  totalSlices = size[m_SlicingDirection];
 
-  double              sum;
   std::vector<double> avgMin(totalSlices);
   // calculate minimum intensities for each slice
   ImagePixelType pixel;
@@ -103,7 +102,7 @@ MRASlabIdentifier<TInputImage>::GenerateSlabRegions()
       ++iter;
     }
 
-    sum = 0.0;
+    double sum = 0.0;
     while (!mins.empty())
     {
       sum += mins.top();
@@ -117,8 +116,8 @@ MRASlabIdentifier<TInputImage>::GenerateSlabRegions()
   }
 
   // calculate overall average
-  sum = 0.0;
-  auto am_iter = avgMin.begin();
+  double sum = 0.0;
+  auto   am_iter = avgMin.begin();
   while (am_iter != avgMin.end())
   {
     sum += *am_iter;
@@ -130,20 +129,16 @@ MRASlabIdentifier<TInputImage>::GenerateSlabRegions()
   // determine slabs
   am_iter = avgMin.begin();
 
-  double prevSign = *am_iter - average;
-  double avgMinValue;
-
-  ImageIndexType  slabIndex;
+  double          prevSign = *am_iter - average;
   ImageRegionType slabRegion;
-  ImageSizeType   slabSize;
 
   SizeValueType  slabLength = 0;
   IndexValueType slabBegin = firstSlice;
-  slabSize = size;
-  slabIndex = index;
+  ImageSizeType  slabSize = size;
+  ImageIndexType slabIndex = index;
   while (am_iter != avgMin.end())
   {
-    avgMinValue = *am_iter;
+    double       avgMinValue = *am_iter;
     const double sign = avgMinValue - average;
     if ((sign * prevSign < 0) && (itk::Math::abs(sign) > m_Tolerance))
     {

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -885,24 +885,18 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::AdjustSlabR
     const IndexValueType coordLast2 =
       coordFirst2 + static_cast<IndexValueType>(iter->GetSize()[m_SlicingDirection]) - 1;
 
-    IndexValueType tempCoordFirst;
+    IndexValueType tempCoordFirst = coordFirst2;
     if (coordFirst > coordFirst2)
     {
       tempCoordFirst = coordFirst;
     }
-    else
-    {
-      tempCoordFirst = coordFirst2;
-    }
-    IndexValueType tempCoordLast;
+
+    IndexValueType tempCoordLast = coordLast2;
     if (coordLast < coordLast2)
     {
       tempCoordLast = coordLast;
     }
-    else
-    {
-      tempCoordLast = coordLast2;
-    }
+
     if (tempCoordFirst <= tempCoordLast)
     {
       tempIndex[m_SlicingDirection] = tempCoordFirst;

--- a/Modules/Filtering/BiasCorrection/test/itkMRIBiasFieldCorrectionFilterTest.cxx
+++ b/Modules/Filtering/BiasCorrection/test/itkMRIBiasFieldCorrectionFilterTest.cxx
@@ -149,10 +149,9 @@ itkMRIBiasFieldCorrectionFilterTest(int, char *[])
   BiasFieldType::SimpleForwardIterator b_iter(&bias);
   i_iter.GoToBegin();
   ib_iter.GoToBegin();
-  float temp;
   while (!i_iter.IsAtEnd())
   {
-    temp = i_iter.Get() * (2 + b_iter.Get()); // this is a multiplicative bias field
+    float temp = i_iter.Get() * (2 + b_iter.Get()); // this is a multiplicative bias field
     ib_iter.Set(temp);
     ++i_iter;
     ++ib_iter;

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
@@ -294,7 +294,7 @@ BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
               if (bIsOnBorder)
               {
                 // neighbour pixel is a border pixel mark it
-                bool status;
+                bool status = false;
                 nit.SetPixel(i, borderTag, status);
 
                 // check whether we could set the pixel.  can only set
@@ -321,7 +321,7 @@ BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
               else
               {
                 // neighbour pixel is an inner pixel
-                bool status;
+                bool status = false;
                 nit.SetPixel(i, innerTag, status);
               }
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
@@ -287,7 +287,7 @@ BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
               {
                 // neighbour pixel is a border pixel
                 // mark it
-                bool status;
+                bool status = false;
                 nit.SetPixel(i, borderTag, status);
 
                 // check whether we could set the pixel.  can only set
@@ -313,7 +313,7 @@ BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
               else
               {
                 // neighbour pixel is an inner pixel
-                bool status;
+                bool status = false;
                 nit.SetPixel(i, innerTag, status);
               }
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.hxx
@@ -185,7 +185,7 @@ BinaryMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::AnalyzeKernel()
           if (SEoNeighbIt.GetPixel(ii))
           {
             // Mark it
-            bool bIsBounds;
+            bool bIsBounds = false;
             SEoNeighbIt.SetPixel(ii, false, bIsBounds);
 
             // Push

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.hxx
@@ -116,21 +116,6 @@ BinaryThinningImageFilter<TInputImage, TOutputImage>::ComputeThinImage()
   const OffsetType o8 = { { -1, 0 } };
   const OffsetType o9 = { { -1, -1 } };
 
-  PixelType p2;
-  PixelType p3;
-  PixelType p4;
-  PixelType p5;
-  PixelType p6;
-  PixelType p7;
-  PixelType p8;
-  PixelType p9;
-
-  // These tests correspond to the conditions listed in Gonzalez and Woods
-  bool testA;
-  bool testB;
-  bool testC;
-  bool testD;
-
   std::vector<IndexType>                    pixelsToDelete;
   typename std::vector<IndexType>::iterator pixelsToDeleteIt;
 
@@ -147,19 +132,20 @@ BinaryThinningImageFilter<TInputImage, TOutputImage>::ComputeThinImage()
       for (ot.GoToBegin(); !ot.IsAtEnd(); ++ot)
       {
         // Each iteration over the image, set all tests to false.
-        testA = false;
-        testB = false;
-        testC = false;
-        testD = false;
+        // These tests correspond to the conditions listed in Gonzalez and Woods
+        bool testA = false;
+        bool testB = false;
+        bool testC = false;
+        bool testD = false;
 
-        p2 = ot.GetPixel(o2);
-        p3 = ot.GetPixel(o3);
-        p4 = ot.GetPixel(o4);
-        p5 = ot.GetPixel(o5);
-        p6 = ot.GetPixel(o6);
-        p7 = ot.GetPixel(o7);
-        p8 = ot.GetPixel(o8);
-        p9 = ot.GetPixel(o9);
+        const PixelType p2 = ot.GetPixel(o2);
+        const PixelType p3 = ot.GetPixel(o3);
+        const PixelType p4 = ot.GetPixel(o4);
+        const PixelType p5 = ot.GetPixel(o5);
+        const PixelType p6 = ot.GetPixel(o6);
+        const PixelType p7 = ot.GetPixel(o7);
+        const PixelType p8 = ot.GetPixel(o8);
+        const PixelType p9 = ot.GetPixel(o9);
 
         // Determine whether the pixel should be deleted in the
         // following if statements.

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkDilateObjectMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkDilateObjectMorphologyImageFilter.hxx
@@ -33,17 +33,16 @@ void
 DilateObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::Evaluate(OutputNeighborhoodIteratorType & nit,
                                                                                 const KernelType &               kernel)
 {
-  unsigned int             i;
-  KernelIteratorType       kernel_it;
-  const KernelIteratorType kernelEnd = kernel.End();
-
   bool valid = true;
-
-  for (i = 0, kernel_it = kernel.Begin(); kernel_it < kernelEnd; ++kernel_it, ++i)
   {
-    if (*kernel_it)
+    KernelIteratorType       kernel_it = kernel.Begin();
+    const KernelIteratorType kernelEnd = kernel.End();
+    for (unsigned int i = 0; kernel_it < kernelEnd; ++kernel_it, ++i)
     {
-      nit.SetPixel(i, this->GetObjectValue(), valid);
+      if (*kernel_it)
+      {
+        nit.SetPixel(i, this->GetObjectValue(), valid);
+      }
     }
   }
 }

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkErodeObjectMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkErodeObjectMorphologyImageFilter.hxx
@@ -35,13 +35,12 @@ void
 ErodeObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::Evaluate(OutputNeighborhoodIteratorType & nit,
                                                                                const KernelType &               kernel)
 {
-  unsigned int             i;
-  KernelIteratorType       kernel_it;
+  KernelIteratorType       kernel_it = kernel.Begin();
   const KernelIteratorType kernelEnd = kernel.End();
 
   bool valid = true;
 
-  for (i = 0, kernel_it = kernel.Begin(); kernel_it < kernelEnd; ++kernel_it, ++i)
+  for (unsigned int i = 0; kernel_it < kernelEnd; ++kernel_it, ++i)
   {
     if (*kernel_it)
     {

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
@@ -173,15 +173,11 @@ ObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::IsObjectPixelOn
 {
   static const auto s = static_cast<unsigned int>(std::pow(3.0, double{ ImageDimension }));
 
-  PixelType    tf;
-  unsigned int i;
-  bool         isInside = true;
-
   if (m_UseBoundaryCondition)
   {
-    for (i = 0; i < s; ++i)
+    for (unsigned int i = 0; i < s; ++i)
     {
-      tf = iNIter.GetPixel(i);
+      PixelType tf = iNIter.GetPixel(i);
       if (Math::NotExactlyEquals(tf, m_ObjectValue))
       {
         return true;
@@ -190,9 +186,10 @@ ObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::IsObjectPixelOn
   }
   else
   {
-    for (i = 0; i < s; ++i)
+    for (unsigned int i = 0; i < s; ++i)
     {
-      tf = iNIter.GetPixel(i, isInside);
+      bool      isInside = true;
+      PixelType tf = iNIter.GetPixel(i, isInside);
       if (Math::NotExactlyEquals(tf, m_ObjectValue) && isInside)
       {
         return true;

--- a/Modules/Filtering/Colormap/test/itkCustomColormapFunctionTest.cxx
+++ b/Modules/Filtering/Colormap/test/itkCustomColormapFunctionTest.cxx
@@ -122,7 +122,7 @@ itkCustomColormapFunctionTest(int argc, char * argv[])
   std::getline(str, line);
   std::istringstream issr(line);
 
-  double value;
+  double value = NAN;
 
   std::vector<double> redChannel;
   while (issr >> value)

--- a/Modules/Filtering/Colormap/test/itkScalarToRGBColormapImageFilterTest.cxx
+++ b/Modules/Filtering/Colormap/test/itkScalarToRGBColormapImageFilterTest.cxx
@@ -337,12 +337,12 @@ itkScalarToRGBColormapImageFilterTest(int argc, char * argv[])
     std::ifstream str(argv[4]);
     std::string   line;
 
-    float                     value;
     ColormapType::ChannelType channel;
 
     // Get red values
     std::getline(str, line);
     std::istringstream issr(line);
+    float              value = NAN;
     while (issr >> value)
     {
       channel.push_back(value);

--- a/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
@@ -190,7 +190,7 @@ FFTConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrec
     needsKernelPadding = needsKernelPadding || lower > 0 || upper > 0;
   }
 
-  const InputImageType * kernelPaddedInput;
+  const InputImageType * kernelPaddedInput = input;
   if (needsKernelPadding)
   {
     auto inputPadder = InputPadFilterType::New();
@@ -204,10 +204,6 @@ FFTConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrec
     remainingProgress -= 0.2f;
     inputPadder->Update();
     kernelPaddedInput = inputPadder->GetOutput();
-  }
-  else
-  {
-    kernelPaddedInput = input;
   }
 
   // Crop to region of interest to minimize FFT requested region size.
@@ -225,7 +221,7 @@ FFTConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrec
   }
   const InputRegionType regionOfInterest = InputRegionType(regionOfInterestIndex, regionOfInterestSize);
 
-  const InputImageType * regionOfInterestImage;
+  const InputImageType * regionOfInterestImage = kernelPaddedInput;
   if (outputRequestedRegion != inputLargestRegion)
   {
 
@@ -256,10 +252,6 @@ FFTConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrec
     remainingProgress -= 0.001f;
     inputInfoFilter->Update();
     regionOfInterestImage = inputInfoFilter->GetOutput();
-  }
-  else
-  {
-    regionOfInterestImage = kernelPaddedInput;
   }
 
   // Pad for FFT so that each image side is factorable by at most

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
@@ -60,11 +60,11 @@ MinMaxCurvatureFlowFunction<TImage>::InitializeStencilOperator()
 
   m_StencilOperator.SetRadius(m_StencilRadius);
 
-  RadiusValueType       counter[ImageDimension];
-  unsigned int          j;
+  RadiusValueType counter[ImageDimension];
+
   const RadiusValueType span = 2 * m_StencilRadius + 1;
   const RadiusValueType sqrRadius = m_StencilRadius * m_StencilRadius;
-  for (j = 0; j < ImageDimension; ++j)
+  for (unsigned int j = 0; j < ImageDimension; ++j)
   {
     counter[j] = 0;
   }
@@ -80,7 +80,7 @@ MinMaxCurvatureFlowFunction<TImage>::InitializeStencilOperator()
     *opIter = PixelType{};
 
     RadiusValueType length = 0;
-    for (j = 0; j < ImageDimension; ++j)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       length += static_cast<RadiusValueType>(
         itk::Math::sqr(static_cast<IndexValueType>(counter[j]) - static_cast<IndexValueType>(m_StencilRadius)));
@@ -92,7 +92,7 @@ MinMaxCurvatureFlowFunction<TImage>::InitializeStencilOperator()
     }
 
     bool carryOver = true;
-    for (j = 0; carryOver && j < ImageDimension; ++j)
+    for (unsigned int j = 0; carryOver && j < ImageDimension; ++j)
     {
       counter[j] += 1;
       carryOver = false;
@@ -123,17 +123,12 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const DispatchBase &, cons
 
   // Compute gradient
   PixelType     gradient[ImageDimension];
-  PixelType     gradMagnitude;
-  SizeValueType stride;
-  SizeValueType center;
-  unsigned int  j;
+  SizeValueType center = it.Size() / 2;
 
-  center = it.Size() / 2;
-
-  gradMagnitude = PixelType{};
-  for (j = 0; j < ImageDimension; ++j)
+  PixelType gradMagnitude = PixelType{};
+  for (unsigned int j = 0; j < ImageDimension; ++j)
   {
-    stride = it.GetStride((SizeValueType)j);
+    SizeValueType stride = it.GetStride((SizeValueType)j);
     gradient[j] = 0.5 * (it.GetPixel(center + stride) - it.GetPixel(center - stride));
     gradient[j] *= this->m_ScaleCoefficients[j];
 
@@ -152,7 +147,7 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const DispatchBase &, cons
 
   RadiusValueType       counter[ImageDimension];
   const RadiusValueType span = 2 * m_StencilRadius + 1;
-  for (j = 0; j < ImageDimension; ++j)
+  for (unsigned int j = 0; j < ImageDimension; ++j)
   {
     counter[j] = 0;
   }
@@ -169,7 +164,7 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const DispatchBase &, cons
     PixelType dotProduct{};
     PixelType vectorMagnitude{};
 
-    for (j = 0; j < ImageDimension; ++j)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       const IndexValueType diff =
         static_cast<IndexValueType>(counter[j]) - static_cast<IndexValueType>(m_StencilRadius);
@@ -192,7 +187,7 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const DispatchBase &, cons
     }
 
     bool carryOver = true;
-    for (j = 0; carryOver && j < ImageDimension; ++j)
+    for (unsigned int j = 0; carryOver && j < ImageDimension; ++j)
     {
       counter[j] += 1;
       carryOver = false;
@@ -228,20 +223,17 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const Dispatch<2> &, const
 
   // Compute gradient
   double        gradient[imageDimension];
-  double        gradMagnitude;
-  SizeValueType stride;
-  SizeValueType center;
   SizeValueType position[imageDimension];
 
-  center = it.Size() / 2;
+  SizeValueType center = it.Size() / 2;
 
   gradient[0] = 0.5 * (it.GetPixel(center + 1) - it.GetPixel(center - 1));
   unsigned int k = 0;
   gradient[k] *= this->m_ScaleCoefficients[k];
-  gradMagnitude = Math::sqr(gradient[k]);
+  double gradMagnitude = Math::sqr(gradient[k]);
   ++k;
 
-  stride = it.GetStride(1);
+  SizeValueType stride = it.GetStride(1);
   gradient[k] = 0.5 * (it.GetPixel(center + stride) - it.GetPixel(center - stride));
   gradient[k] *= this->m_ScaleCoefficients[k];
   gradMagnitude += Math::sqr(gradient[k]);
@@ -290,20 +282,16 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const Dispatch<3> &, const
 
   // Compute gradient
   double        gradient[imageDimension];
-  double        gradMagnitude;
-  SizeValueType strideY;
-  SizeValueType strideZ;
-  SizeValueType center;
   SizeValueType position[imageDimension];
 
-  center = it.Size() / 2;
-  strideY = it.GetStride(1);
-  strideZ = it.GetStride(2);
+  SizeValueType center = it.Size() / 2;
+  SizeValueType strideY = it.GetStride(1);
+  SizeValueType strideZ = it.GetStride(2);
 
   gradient[0] = 0.5 * (it.GetPixel(center + 1) - it.GetPixel(center - 1));
   unsigned int k = 0;
   gradient[k] *= this->m_ScaleCoefficients[k];
-  gradMagnitude = itk::Math::sqr(gradient[k]);
+  double gradMagnitude = itk::Math::sqr(gradient[k]);
   ++k;
 
   gradient[k] = 0.5 * (it.GetPixel(center + strideY) - it.GetPixel(center - strideY));
@@ -327,8 +315,6 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const Dispatch<3> &, const
     j /= gradMagnitude;
   }
 
-  double theta;
-  double phi;
   if (gradient[2] > 1.0)
   {
     gradient[2] = 1.0;
@@ -337,15 +323,12 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const Dispatch<3> &, const
   {
     gradient[2] = -1.0;
   }
-  theta = std::acos(gradient[2]);
+  double theta = std::acos(gradient[2]);
 
+  double phi = std::atan(gradient[1] / gradient[0]);
   if (Math::AlmostEquals(gradient[0], PixelType{}))
   {
     phi = Math::pi * 0.5;
-  }
-  else
-  {
-    phi = std::atan(gradient[1] / gradient[0]);
   }
 
   const double cosTheta = std::cos(theta);

--- a/Modules/Filtering/CurvatureFlow/test/itkBinaryMinMaxCurvatureFlowImageFilterTest.cxx
+++ b/Modules/Filtering/CurvatureFlow/test/itkBinaryMinMaxCurvatureFlowImageFilterTest.cxx
@@ -127,20 +127,17 @@ testBinaryMinMaxCurvatureFlow(itk::Size<VImageDimension> & size, // ND image siz
   for (IteratorType circleIter(circleImage, circleImage->GetBufferedRegion()); !circleIter.IsAtEnd(); ++circleIter)
   {
     typename ImageType::IndexType index = circleIter.GetIndex();
-    float                         value;
 
     double lhs = 0.0;
     for (int j = 0; j < ImageDimension; ++j)
     {
       lhs += itk::Math::sqr(static_cast<double>(index[j]) - static_cast<double>(size[j]) * 0.5);
     }
+
+    float value = background;
     if (lhs < sqrRadius)
     {
       value = foreground;
-    }
-    else
-    {
-      value = background;
     }
 
     if (vnl_sample_uniform(0.0, 1.0) < fractionNoise)

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -2140,7 +2140,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ComputeGradientJointE
 
   for (unsigned int jj = 0; jj < lengthPatch; ++jj)
   {
-    bool isInBounds;
+    bool isInBounds = false;
     currentPatchVec[jj] = currentPatch.GetPixel(jj, isInBounds);
     patchWeightVec[jj].SetSize(m_NumIndependentComponents);
     patchWeightVec[jj].Fill(patchWeights[jj]);

--- a/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterTest.cxx
+++ b/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterTest.cxx
@@ -40,12 +40,11 @@ ParseKernelBandwithSigma(char * kernelBandwithSigmaIn, unsigned int numIndepende
   kernelBandwithSigmaOut.SetSize(numIndependentComponents);
 
   // Get the individual components
-  char *                                     endPtr;
-  unsigned int                               i = 0;
-  typename TFilter::RealArrayType::ValueType value;
+  unsigned int i = 0;
   while (*kernelBandwithSigmaIn && i < numIndependentComponents)
   {
-    value = strtod(kernelBandwithSigmaIn, &endPtr);
+    char *                                     endPtr;
+    typename TFilter::RealArrayType::ValueType value = strtod(kernelBandwithSigmaIn, &endPtr);
     if (kernelBandwithSigmaIn == endPtr)
     {
       (*kernelBandwithSigmaIn)++;

--- a/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
@@ -143,7 +143,7 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GenerateDataND()
         // Experiment an InlineGetPixel()
         if (val[neighbor_type[i]] < it.GetPixel(i))
         {
-          bool in_bounds;
+          bool in_bounds = false;
           it.SetPixel(i, val[neighbor_type[i]], in_bounds);
         }
       }
@@ -162,7 +162,7 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GenerateDataND()
         // Experiment an InlineGetPixel()
         if (val[neighbor_type[i]] > it.GetPixel(i))
         {
-          bool in_bounds;
+          bool in_bounds = false;
           it.SetPixel(i, val[neighbor_type[i]], in_bounds);
         }
       }
@@ -237,7 +237,7 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GenerateDataND()
         // Experiment an InlineGetPixel()
         if (val[neighbor_type[i]] < it.GetPixel(i))
         {
-          bool in_bounds;
+          bool in_bounds = false;
           it.SetPixel(i, val[neighbor_type[i]], in_bounds);
         }
       }
@@ -257,7 +257,7 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GenerateDataND()
         // Experiment an InlineGetPixel()
         if (val[neighbor_type[i]] > it.GetPixel(i))
         {
-          bool in_bounds;
+          bool in_bounds = false;
           it.SetPixel(i, val[neighbor_type[i]], in_bounds);
         }
       }

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
@@ -264,11 +264,9 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::ThreadedGenerateDataBa
   auto       bandIt = m_NarrowBandRegion[threadId].Begin;
   const auto bandEnd = m_NarrowBandRegion[threadId].End;
 
-  unsigned int n;
-
   InputSizeType radiusIn;
   SizeType      radiusOut;
-  for (n = 0; n < ImageDimension; ++n)
+  for (unsigned int n = 0; n < ImageDimension; ++n)
   {
     radiusIn[n] = 2;
     radiusOut[n] = 1;
@@ -281,7 +279,7 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::ThreadedGenerateDataBa
   // Get Stride information to move across dimension
   std::vector<OffsetValueType> stride(ImageDimension, 0);
 
-  for (n = 0; n < ImageDimension; ++n)
+  for (unsigned int n = 0; n < ImageDimension; ++n)
   {
     stride[n] = inNeigIt.GetStride(n);
   }

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest1.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest1.cxx
@@ -75,7 +75,7 @@ itkSignedDanielssonDistanceMapImageFilterTest1(int argc, char * argv[])
     ImageDimension = std::stoi(argv[3]);
   }
 
-  int result;
+  int result = EXIT_FAILURE;
   if (ImageDimension == 2)
   {
     result = itkSignedDanielssonDistanceMapImageFilterTest1<2>(argv);
@@ -87,10 +87,6 @@ itkSignedDanielssonDistanceMapImageFilterTest1(int argc, char * argv[])
   else if (ImageDimension == 4)
   {
     result = itkSignedDanielssonDistanceMapImageFilterTest1<4>(argv);
-  }
-  else
-  {
-    result = EXIT_FAILURE;
   }
 
   return result;

--- a/Modules/Filtering/DistanceMap/test/itkSignedMaurerDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedMaurerDistanceMapImageFilterTest.cxx
@@ -73,7 +73,7 @@ itkSignedMaurerDistanceMapImageFilterTest(int argc, char * argv[])
     ImageDimension = std::stoi(argv[3]);
   }
 
-  int result;
+  int result = EXIT_FAILURE;
   if (ImageDimension == 2)
   {
     result = itkSignedMaurerDistanceMapImageFilterTest<2>(argv);
@@ -85,10 +85,6 @@ itkSignedMaurerDistanceMapImageFilterTest(int argc, char * argv[])
   else if (ImageDimension == 4)
   {
     result = itkSignedMaurerDistanceMapImageFilterTest<4>(argv);
-  }
-  else
-  {
-    result = EXIT_FAILURE;
   }
 
   return result;

--- a/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.hxx
@@ -151,15 +151,13 @@ FFTWComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::ThreadedGenerat
   inputIt.SetDirection(this->m_Direction);
   outputIt.SetDirection(this->m_Direction);
 
-  typename InputIteratorType::PixelType *  inputBufferIt;
-  typename OutputIteratorType::PixelType * outputBufferIt;
-
   // for every fft line
   for (inputIt.GoToBegin(), outputIt.GoToBegin(); !inputIt.IsAtEnd(); outputIt.NextLine(), inputIt.NextLine())
   {
     // copy the input line into our buffer
     inputIt.GoToBeginOfLine();
-    inputBufferIt = reinterpret_cast<typename InputIteratorType::PixelType *>(m_InputBufferArray[threadID]);
+    typename InputIteratorType::PixelType * inputBufferIt =
+      reinterpret_cast<typename InputIteratorType::PixelType *>(m_InputBufferArray[threadID]);
     while (!inputIt.IsAtEndOfLine())
     {
       *inputBufferIt = inputIt.Get();
@@ -173,7 +171,8 @@ FFTWComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::ThreadedGenerat
     if (this->m_TransformDirection == Superclass::DIRECT)
     {
       // copy the output from the buffer into our line
-      outputBufferIt = reinterpret_cast<typename OutputIteratorType::PixelType *>(m_OutputBufferArray[threadID]);
+      typename OutputIteratorType::PixelType * outputBufferIt =
+        reinterpret_cast<typename OutputIteratorType::PixelType *>(m_OutputBufferArray[threadID]);
       outputIt.GoToBeginOfLine();
       while (!outputIt.IsAtEndOfLine())
       {

--- a/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.hxx
@@ -138,15 +138,12 @@ FFTWForward1DFFTImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(con
   inputIt.SetDirection(this->GetDirection());
   outputIt.SetDirection(this->GetDirection());
 
-  typename FFTW1DProxyType::ComplexType * inputBufferIt;
-  typename FFTW1DProxyType::ComplexType * outputBufferIt;
-
   // for every fft line
   for (inputIt.GoToBegin(), outputIt.GoToBegin(); !inputIt.IsAtEnd(); outputIt.NextLine(), inputIt.NextLine())
   {
     // copy the input line into our buffer
     inputIt.GoToBeginOfLine();
-    inputBufferIt = m_InputBufferArray[threadID];
+    typename FFTW1DProxyType::ComplexType * inputBufferIt = m_InputBufferArray[threadID];
     while (!inputIt.IsAtEndOfLine())
     {
       (*inputBufferIt)[0] = inputIt.Get();
@@ -159,7 +156,7 @@ FFTWForward1DFFTImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(con
     FFTW1DProxyType::Execute(m_PlanArray[threadID]);
 
     // copy the output from the buffer into our line
-    outputBufferIt = m_OutputBufferArray[threadID];
+    typename FFTW1DProxyType::ComplexType * outputBufferIt = m_OutputBufferArray[threadID];
     outputIt.GoToBeginOfLine();
     while (!outputIt.IsAtEndOfLine())
     {

--- a/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.hxx
@@ -142,15 +142,13 @@ FFTWInverse1DFFTImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(con
   inputIt.SetDirection(this->m_Direction);
   outputIt.SetDirection(this->m_Direction);
 
-  typename InputIteratorType::PixelType * inputBufferIt;
-  typename FFTW1DProxyType::ComplexType * outputBufferIt;
-
   // for every fft line
   for (inputIt.GoToBegin(), outputIt.GoToBegin(); !inputIt.IsAtEnd(); outputIt.NextLine(), inputIt.NextLine())
   {
     // copy the input line into our buffer
     inputIt.GoToBeginOfLine();
-    inputBufferIt = reinterpret_cast<typename InputIteratorType::PixelType *>(m_InputBufferArray[threadID]);
+    typename InputIteratorType::PixelType * inputBufferIt =
+      reinterpret_cast<typename InputIteratorType::PixelType *>(m_InputBufferArray[threadID]);
     while (!inputIt.IsAtEndOfLine())
     {
       *inputBufferIt = inputIt.Get();
@@ -162,7 +160,7 @@ FFTWInverse1DFFTImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(con
     FFTW1DProxyType::Execute(m_PlanArray[threadID]);
 
     // copy the output from the buffer into our line
-    outputBufferIt = m_OutputBufferArray[threadID];
+    typename FFTW1DProxyType::ComplexType * outputBufferIt = m_OutputBufferArray[threadID];
     outputIt.GoToBeginOfLine();
     while (!outputIt.IsAtEndOfLine())
     {

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
@@ -264,9 +264,7 @@ FastMarchingImageFilter<TLevelSet, TSpeedImage>::GenerateData()
   }
 
   // process points on the heap
-  AxisNodeType node;
-  double       currentValue;
-  double       oldProgress = 0;
+  double oldProgress = 0;
 
   this->UpdateProgress(0.0); // Send first progress event
 
@@ -274,11 +272,11 @@ FastMarchingImageFilter<TLevelSet, TSpeedImage>::GenerateData()
   while (!m_TrialHeap.empty())
   {
     // get the node with the smallest value
-    node = m_TrialHeap.top();
+    AxisNodeType node = m_TrialHeap.top();
     m_TrialHeap.pop();
 
     // does this node contain the current value ?
-    currentValue = static_cast<double>(output->GetPixel(node.GetIndex()));
+    double currentValue = static_cast<double>(output->GetPixel(node.GetIndex()));
 
     if (Math::ExactlyEquals(node.GetValue(), currentValue))
     {
@@ -435,7 +433,7 @@ FastMarchingImageFilter<TLevelSet, TSpeedImage>::UpdateValue(const IndexType &  
 
   OutputSpacingType spacing = /* this->GetOutput() */ output->GetSpacing();
 
-  double discrim;
+  double discrim = NAN;
 
   for (unsigned int j = 0; j < SetDimension; ++j)
   {

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -955,14 +955,10 @@ FastMarchingImageFilterBase<TInput, TOutput>::InitializeIndices3D()
 
   for (unsigned int i = 1; i < 4; ++i)
   {
-    int addend;
+    int addend = 1;
     if (i == 2)
     {
       addend = 2;
-    }
-    else
-    {
-      addend = 1;
     }
     for (unsigned int j = 0; j < 8; ++j)
     {

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingExtensionImageFilterTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingExtensionImageFilterTest.cxx
@@ -65,7 +65,7 @@ itkFastMarchingExtensionImageFilterTest(int, char *[])
   marcher->AddObserver(itk::ProgressEvent(), command);
 
 
-  bool passed;
+  bool passed = false;
 
   // setup trial points
   using NodePairType = MarcherType::NodePairType;
@@ -259,20 +259,16 @@ itkFastMarchingExtensionImageFilterTest(int, char *[])
 
   while (!iterator.IsAtEnd())
   {
-    FloatImageType::IndexType tempIndex;
-    double                    distance;
-    float                     outputValue;
-
-    tempIndex = iterator.GetIndex();
+    FloatImageType::IndexType tempIndex = iterator.GetIndex();
     tempIndex -= offset0;
-    distance = 0.0;
+    double distance = 0.0;
     for (int j = 0; j < 2; ++j)
     {
       distance += tempIndex[j] * tempIndex[j];
     }
     distance = std::sqrt(distance);
 
-    outputValue = static_cast<float>(iterator.Get());
+    float outputValue = static_cast<float>(iterator.Get());
 
     if (itk::Math::NotAlmostEquals(distance, 0.0))
     {

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
@@ -205,21 +205,16 @@ itkFastMarchingTest(int argc, char * argv[])
 
   for (; !iterator.IsAtEnd(); ++iterator)
   {
-
-    FloatImage::IndexType tempIndex;
-    double                distance;
-    float                 outputValue;
-
-    tempIndex = iterator.GetIndex();
+    FloatImage::IndexType tempIndex = iterator.GetIndex();
     tempIndex -= offset0;
-    distance = 0.0;
+    double distance = 0.0;
     for (int j = 0; j < 2; ++j)
     {
       distance += tempIndex[j] * tempIndex[j];
     }
     distance = std::sqrt(distance);
 
-    outputValue = static_cast<float>(iterator.Get());
+    float outputValue = static_cast<float>(iterator.Get());
 
     if (distance < itk::NumericTraits<double>::epsilon())
     {

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientBaseTest.cxx
@@ -147,20 +147,16 @@ itkFastMarchingUpwindGradientBaseTest(int, char *[])
 
   while (!iterator.IsAtEnd())
   {
-    FloatGradientImage::IndexType tempIndex;
-    double                        distance;
-    GradientPixelType             outputPixel;
-
-    tempIndex = iterator.GetIndex();
+    FloatGradientImage::IndexType tempIndex = iterator.GetIndex();
     tempIndex -= offset0;
-    distance = 0.0;
+    double distance = 0.0;
     for (int j = 0; j < 2; ++j)
     {
       distance += tempIndex[j] * tempIndex[j];
     }
     distance = std::sqrt(distance);
 
-    outputPixel = iterator.Get();
+    GradientPixelType outputPixel = iterator.Get();
 
     const double outputPixelNorm{ outputPixel.GetNorm() };
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientTest.cxx
@@ -185,21 +185,16 @@ itkFastMarchingUpwindGradientTest(int, char *[])
 
   for (; !iterator.IsAtEnd(); ++iterator)
   {
-
-    FloatGradientImage::IndexType tempIndex;
-    double                        distance;
-    GradientPixelType             outputPixel;
-
-    tempIndex = iterator.GetIndex();
+    FloatGradientImage::IndexType tempIndex = iterator.GetIndex();
     tempIndex -= offset0;
-    distance = 0.0;
+    double distance = 0.0;
     for (int j = 0; j < 2; ++j)
     {
       distance += tempIndex[j] * tempIndex[j];
     }
     distance = std::sqrt(distance);
 
-    outputPixel = iterator.Get();
+    GradientPixelType outputPixel = iterator.Get();
 
     const double outputPixelNorm{ outputPixel.GetNorm() };
 

--- a/Modules/Filtering/ImageCompare/test/itkSTAPLEImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkSTAPLEImageFilterTest.cxx
@@ -233,8 +233,7 @@ itkSTAPLEImageFilterTest(int argc, char * argv[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(stapleImageFilter, STAPLEImageFilter, ImageToImageFilter);
 
 
-  StaplerBase * stapler;
-
+  StaplerBase * stapler = nullptr;
   if (std::stoi(argv[1]) == 2)
   {
     stapler = new Stapler<2>;

--- a/Modules/Filtering/ImageCompare/test/itkTestingComparisonImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkTestingComparisonImageFilterTest.cxx
@@ -96,7 +96,7 @@ itkTestingComparisonImageFilterTest(int argc, char * argv[])
 
   const unsigned long numberOfPixelsWithDifferences = filter->GetNumberOfPixelsWithDifferences();
 
-  char * end;
+  char * end = nullptr;
   ITK_TEST_EXPECT_EQUAL(numberOfPixelsWithDifferences, std::strtoul(argv[7], &end, 10));
 
   auto minimumDifference = static_cast<typename FilterType::OutputPixelType>(std::stod(argv[8]));

--- a/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
+++ b/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
@@ -108,7 +108,6 @@ JoinSeriesImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
     // Copy what we can from the image from spacing and origin of the input
     // This logic needs to be augmented with logic that select which
     // dimensions to copy
-    unsigned int                                 ii;
     const typename InputImageType::SpacingType & inputSpacing = inputPtr->GetSpacing();
     const typename InputImageType::PointType &   inputOrigin = inputPtr->GetOrigin();
 
@@ -117,7 +116,8 @@ JoinSeriesImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
 
     // Copy the input to the output and fill the rest of the
     // output with zeros.
-    for (ii = 0; ii < InputImageDimension; ++ii)
+    unsigned int ii = 0;
+    for (; ii < InputImageDimension; ++ii)
     {
       outputSpacing[ii] = inputSpacing[ii];
       outputOrigin[ii] = inputOrigin[ii];

--- a/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
@@ -72,11 +72,10 @@ BilateralImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
 
   // Pad the image by 2.5*sigma in all directions
   typename TInputImage::SizeType radius;
-  unsigned int                   i;
 
   if (m_AutomaticKernelSize)
   {
-    for (i = 0; i < ImageDimension; ++i)
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       radius[i] = (typename TInputImage::SizeType::SizeValueType)std::ceil(m_DomainMu * m_DomainSigma[i] /
                                                                            this->GetInput()->GetSpacing()[i]);
@@ -84,7 +83,7 @@ BilateralImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
   }
   else
   {
-    for (i = 0; i < ImageDimension; ++i)
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       radius[i] = m_Radius[i];
     }
@@ -126,7 +125,6 @@ BilateralImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()
   //
   // Gaussian image size will be (2*std::ceil(2.5*sigma)+1) x
   // (2*std::ceil(2.5*sigma)+1)
-  unsigned int i;
 
   typename InputImageType::SizeType radius;
   typename InputImageType::SizeType domainKernelSize;
@@ -138,7 +136,7 @@ BilateralImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()
 
   if (m_AutomaticKernelSize)
   {
-    for (i = 0; i < ImageDimension; ++i)
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       radius[i] =
         (typename TInputImage::SizeType::SizeValueType)std::ceil(m_DomainMu * m_DomainSigma[i] / inputSpacing[i]);
@@ -147,7 +145,7 @@ BilateralImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()
   }
   else
   {
-    for (i = 0; i < ImageDimension; ++i)
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       radius[i] = m_Radius[i];
       domainKernelSize[i] = 2 * radius[i] + 1;
@@ -165,7 +163,7 @@ BilateralImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()
   gaussianImage->SetScale(1.0);
   gaussianImage->SetNormalized(true);
 
-  for (i = 0; i < ImageDimension; ++i)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     mean[i] = inputSpacing[i] * radius[i] + inputOrigin[i]; // center pixel pos
     sigma[i] = m_DomainSigma[i];
@@ -211,20 +209,22 @@ BilateralImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()
   const double rangeGaussianDenom = m_RangeSigma * std::sqrt(2.0 * itk::Math::pi);
 
   // Maximum delta for the dynamic range
-  double tableDelta;
-  double v;
+
 
   m_DynamicRange = (static_cast<double>(statistics->GetMaximum()) - static_cast<double>(statistics->GetMinimum()));
 
   m_DynamicRangeUsed = m_RangeMu * m_RangeSigma;
 
-  tableDelta = m_DynamicRangeUsed / static_cast<double>(m_NumberOfRangeGaussianSamples);
+  double tableDelta = m_DynamicRangeUsed / static_cast<double>(m_NumberOfRangeGaussianSamples);
 
   // Finally, build the table
   m_RangeGaussianTable.resize(m_NumberOfRangeGaussianSamples);
-  for (i = 0, v = 0.0; i < m_NumberOfRangeGaussianSamples; ++i, v += tableDelta)
   {
-    m_RangeGaussianTable[i] = std::exp(-0.5 * v * v / rangeVariance) / rangeGaussianDenom;
+    double v = 0.0;
+    for (unsigned int i = 0; i < m_NumberOfRangeGaussianSamples; ++i, v += tableDelta)
+    {
+      m_RangeGaussianTable[i] = std::exp(-0.5 * v * v / rangeVariance) / rangeGaussianDenom;
+    }
   }
 }
 

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
@@ -273,9 +273,9 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::HysteresisThresholding
   // gradients of the image. HysteresisThresholding of this image should give
   // the Canny output.
   const typename OutputImageType::Pointer input = m_MultiplyImageFilter->GetOutput();
-  float                                   value;
+  float                                   value = NAN;
 
-  ListNodeType * node;
+  ListNodeType * node = nullptr;
 
   // fix me
   ImageRegionIterator<TOutputImage> oit(input, input->GetRequestedRegion());
@@ -314,10 +314,6 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::FollowEdge(IndexType  
   // the Canny output.
   const InputImageRegionType inputRegion = multiplyImageFilterOutput->GetRequestedRegion();
 
-  IndexType      nIndex;
-  IndexType      cIndex;
-  ListNodeType * node;
-
   // Assign iterator radius
   constexpr auto radius = Size<ImageDimension>::Filled(1);
 
@@ -331,9 +327,9 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::FollowEdge(IndexType  
     // Remove the node if we are not going to follow it!
     //
     // Pop the front node from the list and read its index value.
-    node = m_NodeList->Front(); // get a pointer to the first node
-    m_NodeList->PopFront();     // unlink the front node
-    m_NodeStore->Return(node);  // return the memory for reuse
+    auto node = m_NodeList->Front(); // get a pointer to the first node
+    m_NodeList->PopFront();          // unlink the front node
+    m_NodeStore->Return(node);       // return the memory for reuse
     return;
   }
 
@@ -341,10 +337,10 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::FollowEdge(IndexType  
   while (!m_NodeList->Empty())
   {
     // Pop the front node from the list and read its index value.
-    node = m_NodeList->Front(); // Get a pointer to the first node
-    cIndex = node->m_Value;     // Read the value of the first node
-    m_NodeList->PopFront();     // Unlink the front node
-    m_NodeStore->Return(node);  // Return the memory for reuse
+    auto       node = m_NodeList->Front(); // Get a pointer to the first node
+    const auto cIndex = node->m_Value;     // Read the value of the first node
+    m_NodeList->PopFront();                // Unlink the front node
+    m_NodeStore->Return(node);             // Return the memory for reuse
 
     // Move iterators to the correct index position.
     oit.SetLocation(cIndex);
@@ -354,7 +350,7 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::FollowEdge(IndexType  
     // Search the neighbors for new indices to add to the list.
     for (int i = 0; i < nSize; ++i)
     {
-      nIndex = oit.GetIndex(i);
+      const auto nIndex = oit.GetIndex(i);
       uit.SetIndex(nIndex);
       if (inputRegion.IsInside(nIndex))
       {

--- a/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.hxx
@@ -69,14 +69,11 @@ Hessian3DToVesselnessMeasureImageFilter<TPixel>::GenerateData()
     // Similarity measure to a line structure
     if (normalizeValue > 0)
     {
-      double lineMeasure;
+      double lineMeasure = std::exp(-0.5 * itk::Math::sqr(eigenValue[2] / (m_Alpha2 * normalizeValue)));
+
       if (eigenValue[2] <= 0)
       {
         lineMeasure = std::exp(-0.5 * itk::Math::sqr(eigenValue[2] / (m_Alpha1 * normalizeValue)));
-      }
-      else
-      {
-        lineMeasure = std::exp(-0.5 * itk::Math::sqr(eigenValue[2] / (m_Alpha2 * normalizeValue)));
       }
 
       lineMeasure *= normalizeValue;

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -129,7 +129,7 @@ HoughTransform2DCirclesImageFilter<TInputPixelType, TOutputPixelType, TRadiusPix
         for (double angle = -m_SweepAngle; angle <= m_SweepAngle; angle += 0.05)
         {
           double i = m_MinimumRadius;
-          double distance;
+          double distance = 0.0;
 
           do
           {

--- a/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.hxx
@@ -279,13 +279,12 @@ template <typename TInputImage, typename THessianImage, typename TOutputImage>
 double
 MultiScaleHessianBasedMeasureImageFilter<TInputImage, THessianImage, TOutputImage>::ComputeSigmaValue(int scaleLevel)
 {
-  double sigmaValue;
-
   if (m_NumberOfSigmaSteps < 2)
   {
     return m_SigmaMinimum;
   }
 
+  double sigmaValue = NAN;
   switch (m_SigmaStepMethod)
   {
     case Self::SigmaStepMethodEnum::EquispacedSigmaSteps:

--- a/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.hxx
@@ -43,13 +43,6 @@ void
 SimpleContourExtractorImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   const OutputImageRegionType & outputRegionForThread)
 {
-  unsigned int i;
-
-  ZeroFluxNeumannBoundaryCondition<InputImageType> nbc;
-
-  ConstNeighborhoodIterator<InputImageType> bit;
-  ImageRegionIterator<OutputImageType>      it;
-
   // Allocate output
   const typename OutputImageType::Pointer     output = this->GetOutput();
   const typename InputImageType::ConstPointer input = this->GetInput();
@@ -63,16 +56,18 @@ SimpleContourExtractorImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
 
   // Process each of the boundary faces.  These are N-d regions which border
   // the edge of the buffer.
+  ZeroFluxNeumannBoundaryCondition<InputImageType> nbc;
   for (const auto & face : faceList)
   {
-    bit = ConstNeighborhoodIterator<InputImageType>(this->GetRadius(), input, face);
-    const unsigned int neighborhoodSize = bit.Size();
-    it = ImageRegionIterator<OutputImageType>(output, face);
+    ConstNeighborhoodIterator<InputImageType> bit =
+      ConstNeighborhoodIterator<InputImageType>(this->GetRadius(), input, face);
+    const unsigned int                   neighborhoodSize = bit.Size();
+    ImageRegionIterator<OutputImageType> it = ImageRegionIterator<OutputImageType>(output, face);
 
     bit.OverrideBoundaryCondition(&nbc);
     bit.GoToBegin();
 
-    bool bIsOnContour;
+    bool bIsOnContour = false;
 
     while (!bit.IsAtEnd())
     {
@@ -82,7 +77,7 @@ SimpleContourExtractorImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
       {
         bIsOnContour = false;
 
-        for (i = 0; i < neighborhoodSize; ++i)
+        for (unsigned int i = 0; i < neighborhoodSize; ++i)
         {
           // second test if at least one neighbour pixel is off
           // the center pixel belongs to contour

--- a/Modules/Filtering/ImageFeature/include/itkSobelEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkSobelEdgeDetectionImageFilter.hxx
@@ -91,8 +91,6 @@ SobelEdgeDetectionImageFilter<TInputImage, TOutputImage>::GenerateData()
   using AddFilter = NaryAddImageFilter<OutputImageType, OutputImageType>;
   using SqrtFilter = SqrtImageFilter<OutputImageType, OutputImageType>;
 
-  unsigned int i;
-
   const typename TOutputImage::Pointer output = this->GetOutput();
   output->SetBufferedRegion(output->GetRequestedRegion());
   output->Allocate();
@@ -106,7 +104,7 @@ SobelEdgeDetectionImageFilter<TInputImage, TOutputImage>::GenerateData()
   typename MultFilter::Pointer multFilter[ImageDimension];
   auto                         addFilter = AddFilter::New();
   auto                         sqrtFilter = SqrtFilter::New();
-  for (i = 0; i < ImageDimension; ++i)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     // Create the filters for this axis.
     opFilter[i] = OpFilter::New();

--- a/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.hxx
@@ -39,12 +39,7 @@ void
 NoiseImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   const OutputImageRegionType & outputRegionForThread)
 {
-  unsigned int i;
-
   ZeroFluxNeumannBoundaryCondition<InputImageType> nbc;
-
-  ConstNeighborhoodIterator<InputImageType> bit;
-  ImageRegionIterator<OutputImageType>      it;
 
   // Allocate output
   const typename OutputImageType::Pointer     output = this->GetOutput();
@@ -57,37 +52,32 @@ NoiseImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
   TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
 
-  InputRealType value;
-  InputRealType sum;
-  InputRealType sumOfSquares;
-  InputRealType var;
-  InputRealType num;
-
   // Process each of the boundary faces.  These are N-d regions which border
   // the edge of the buffer.
   for (const auto & face : faceList)
   {
-    bit = ConstNeighborhoodIterator<InputImageType>(this->GetRadius(), input, face);
+    ConstNeighborhoodIterator<InputImageType> bit =
+      ConstNeighborhoodIterator<InputImageType>(this->GetRadius(), input, face);
     const unsigned int neighborhoodSize = bit.Size();
-    num = static_cast<InputRealType>(bit.Size());
+    InputRealType      num = static_cast<InputRealType>(bit.Size());
 
-    it = ImageRegionIterator<OutputImageType>(output, face);
+    ImageRegionIterator<OutputImageType> it = ImageRegionIterator<OutputImageType>(output, face);
     bit.OverrideBoundaryCondition(&nbc);
     bit.GoToBegin();
 
     while (!bit.IsAtEnd())
     {
-      sum = InputRealType{};
-      sumOfSquares = InputRealType{};
-      for (i = 0; i < neighborhoodSize; ++i)
+      InputRealType sum = InputRealType{};
+      InputRealType sumOfSquares = InputRealType{};
+      for (unsigned int i = 0; i < neighborhoodSize; ++i)
       {
-        value = static_cast<InputRealType>(bit.GetPixel(i));
+        InputRealType value = static_cast<InputRealType>(bit.GetPixel(i));
         sum += value;
         sumOfSquares += (value * value);
       }
 
       // calculate the standard deviation value
-      var = (sumOfSquares - (sum * sum / num)) / (num - 1.0);
+      InputRealType var = (sumOfSquares - (sum * sum / num)) / (num - 1.0);
       it.Set(static_cast<OutputPixelType>(std::sqrt(var)));
 
       ++bit;

--- a/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
@@ -78,7 +78,7 @@ GetCastTypeName()
   std::string name;
 #ifdef GCC_USEDEMANGLE
   const char * mangledName = typeid(T).name();
-  int          status;
+  int          status = 0;
   char *       unmangled = abi::__cxa_demangle(mangledName, nullptr, nullptr, &status);
   name = unmangled;
   free(unmangled);

--- a/Modules/Filtering/ImageFusion/test/itkScalarToRGBPixelFunctorTest.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkScalarToRGBPixelFunctorTest.cxx
@@ -30,8 +30,7 @@ itkScalarToRGBPixelFunctorTest(int, char *[])
 
   std::cout << "Testing unsigned long integers in big endian mode" << std::endl;
   ulf.SetBigEndian();
-  unsigned long ul;
-  for (ul = 0; ul < 100; ++ul)
+  for (unsigned long ul = 0; ul < 100; ++ul)
   {
     pixel = ulf(ul);
     std::cout << ul << "->" << static_cast<int>(pixel[0]) << ' ' << static_cast<int>(pixel[1]) << ' '
@@ -40,7 +39,7 @@ itkScalarToRGBPixelFunctorTest(int, char *[])
   std::cout << "Testing unsigned long integers in little endian mode" << std::endl;
 
   ulf.SetLittleEndian();
-  for (ul = 0; ul < 100; ++ul)
+  for (unsigned long ul = 0; ul < 100; ++ul)
   {
     pixel = ulf(ul);
     std::cout << ul << "->" << static_cast<int>(pixel[0]) << ' ' << static_cast<int>(pixel[1]) << ' '
@@ -59,11 +58,10 @@ itkScalarToRGBPixelFunctorTest(int, char *[])
   }
 
   // Test with float
-  itk::Functor::ScalarToRGBPixelFunctor<float> ff;
-  float                                        f;
   std::cout << "Testing float in big endian mode" << std::endl;
+  itk::Functor::ScalarToRGBPixelFunctor<float> ff;
   ff.SetBigEndian();
-  for (f = 0; f < 100; ++f)
+  for (float f = 0; f < 100; ++f)
   {
     pixel = ff(f);
 
@@ -73,7 +71,7 @@ itkScalarToRGBPixelFunctorTest(int, char *[])
   std::cout << "Testing float in little endian mode" << std::endl;
 
   ff.SetLittleEndian();
-  for (f = 0; f < 100; ++f)
+  for (float f = 0; f < 100; ++f)
   {
     pixel = ff(f);
     std::cout << f << "->" << static_cast<int>(pixel[0]) << ' ' << static_cast<int>(pixel[1]) << ' '

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
@@ -96,8 +96,6 @@ void
 GradientMagnitudeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   const OutputImageRegionType & outputRegionForThread)
 {
-  unsigned int i;
-
   ZeroFluxNeumannBoundaryCondition<TInputImage> nbc;
 
   ConstNeighborhoodIterator<TInputImage> nit;
@@ -112,7 +110,7 @@ GradientMagnitudeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerate
   // Set up operators
   DerivativeOperator<RealType, ImageDimension> op[ImageDimension];
 
-  for (i = 0; i < ImageDimension; ++i)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     // The operator has default values for its direction (0) and its order (1).
     op[i].CreateDirectional();
@@ -146,7 +144,7 @@ GradientMagnitudeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerate
   nit = ConstNeighborhoodIterator<TInputImage>(radius, input, faceList.front());
 
   std::slice x_slice[ImageDimension];
-  for (i = 0; i < ImageDimension; ++i)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     static constexpr SizeValueType neighborhoodSize = Math::UnsignedPower(3, ImageDimension);
     static constexpr SizeValueType center = neighborhoodSize / 2;
@@ -166,7 +164,7 @@ GradientMagnitudeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerate
     while (!bit.IsAtEnd())
     {
       RealType a{};
-      for (i = 0; i < ImageDimension; ++i)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         const RealType g = SIP(x_slice[i], bit, op[i]);
         a += g * g;

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
@@ -313,17 +313,14 @@ protected:
   TRealType
   NonPCEvaluateAtNeighborhood(const ConstNeighborhoodIteratorType & it) const
   {
-    unsigned int i;
-    unsigned int j;
-    TRealType    dx;
-    TRealType    sum;
-    TRealType    accum{};
-    for (i = 0; i < ImageDimension; ++i)
+    TRealType accum{};
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
-      sum = TRealType{};
-      for (j = 0; j < VectorDimension; ++j)
+      TRealType sum = TRealType{};
+      for (unsigned int j = 0; j < VectorDimension; ++j)
       {
-        dx = m_DerivativeWeights[i] * m_SqrtComponentWeights[j] * 0.5 * (it.GetNext(i)[j] - it.GetPrevious(i)[j]);
+        TRealType dx =
+          m_DerivativeWeights[i] * m_SqrtComponentWeights[j] * 0.5 * (it.GetNext(i)[j] - it.GetPrevious(i)[j]);
         sum += dx * dx;
       }
       accum += sum;
@@ -335,20 +332,18 @@ protected:
   EvaluateAtNeighborhood3D(const ConstNeighborhoodIteratorType & it) const
   {
     // WARNING:  ONLY CALL THIS METHOD WHEN PROCESSING A 3D IMAGE
-    unsigned int i;
-    unsigned int j;
-    double       Lambda[3];
-    double       CharEqn[3];
-    double       ans;
+    double Lambda[3];
+    double CharEqn[3];
+    double ans = NAN;
 
     vnl_matrix<TRealType>                        g(ImageDimension, ImageDimension);
     vnl_vector_fixed<TRealType, VectorDimension> d_phi_du[TInputImage::ImageDimension];
 
     // Calculate the directional derivatives for each vector component using
     // central differences.
-    for (i = 0; i < ImageDimension; ++i)
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
-      for (j = 0; j < VectorDimension; ++j)
+      for (unsigned int j = 0; j < VectorDimension; ++j)
       {
         d_phi_du[i][j] =
           m_DerivativeWeights[i] * m_SqrtComponentWeights[j] * 0.5 * (it.GetNext(i)[j] - it.GetPrevious(i)[j]);
@@ -356,9 +351,9 @@ protected:
     }
 
     // Calculate the symmetric metric tensor g
-    for (i = 0; i < ImageDimension; ++i)
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
-      for (j = i; j < ImageDimension; ++j)
+      for (unsigned int j = i; j < ImageDimension; ++j)
       {
         g[j][i] = g[i][j] = dot_product(d_phi_du[i], d_phi_du[j]);
       }
@@ -449,17 +444,14 @@ protected:
   TRealType
   EvaluateAtNeighborhood(const ConstNeighborhoodIteratorType & it) const
   {
-    unsigned int i;
-    unsigned int j;
-
     vnl_matrix<TRealType>                        g(ImageDimension, ImageDimension);
     vnl_vector_fixed<TRealType, VectorDimension> d_phi_du[TInputImage::ImageDimension];
 
     // Calculate the directional derivatives for each vector component using
     // central differences.
-    for (i = 0; i < ImageDimension; ++i)
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
-      for (j = 0; j < VectorDimension; ++j)
+      for (unsigned int j = 0; j < VectorDimension; ++j)
       {
         d_phi_du[i][j] =
           m_DerivativeWeights[i] * m_SqrtComponentWeights[j] * 0.5 * (it.GetNext(i)[j] - it.GetPrevious(i)[j]);
@@ -467,9 +459,9 @@ protected:
     }
 
     // Calculate the symmetric metric tensor g
-    for (i = 0; i < ImageDimension; ++i)
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
-      for (j = i; j < ImageDimension; ++j)
+      for (unsigned int j = i; j < ImageDimension; ++j)
       {
         g[j][i] = g[i][j] = dot_product(d_phi_du[i], d_phi_du[j]);
       }

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
@@ -254,7 +254,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::CubicS
   // coefficients of the polynomial: x^3 + c[2]x^2 + c[1]x^1 + c[0].  The roots
   // s are not necessarily sorted, and int is the number of distinct roots
   // found in s.
-  int              num;
+
   const double     dpi = itk::Math::pi;
   constexpr double epsilon = 1.0e-11;
 
@@ -267,6 +267,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::CubicS
   const double cb_p = p * p * p;
   const double D = q * q + cb_p;
 
+  int num = 0;
   if (D < -epsilon) // D < 0, three real solutions, by far the common case.
   {
     const double phi = 1.0 / 3.0 * std::acos(-q / std::sqrt(-cb_p));
@@ -277,7 +278,6 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::CubicS
     s[2] = -t * std::cos(phi - dpi / 3);
     num = 3;
   }
-
   else if (D < epsilon) // D == 0
   {
     if (q > -epsilon && q < epsilon)

--- a/Modules/Filtering/ImageGrid/include/itkBSplineCenteredResampleImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineCenteredResampleImageFilterBase.hxx
@@ -302,13 +302,10 @@ BSplineCenteredResampleImageFilterBase<TInputImage, TOutputImage>::Expand1DImage
   inModK = outTraverseSize;
   const IndexValueType k0 = (this->m_HSize / 2) * 2 - 1L;
 
-  double outVal;
-  double outVal2;
-
   for (inK = 0; inK < (IndexValueType)inTraverseSize; ++inK)
   {
     // outK = inK * 2L;
-    outVal = in[inK] * this->m_H[0];
+    double outVal = in[inK] * this->m_H[0];
     for (int k = 2; k < this->m_HSize; k += 2)
     {
       i1 = inK - k / 2L;
@@ -336,7 +333,7 @@ BSplineCenteredResampleImageFilterBase<TInputImage, TOutputImage>::Expand1DImage
     }
     out.Set(static_cast<OutputImagePixelType>(outVal));
     ++out;
-    outVal2 = 0;
+    double outVal2 = 0;
     for (IndexValueType k = -k0; k < this->m_HSize; k += 2L)
     {
       const IndexValueType kk = itk::Math::abs(static_cast<int>(k));
@@ -368,9 +365,9 @@ BSplineCenteredResampleImageFilterBase<TInputImage, TOutputImage>::Expand1DImage
   for (IndexValueType j = outTraverseSize - 1; j > 0L; --j)
   {
     // out[j] = (out[j] + out[j-1]/2.0;
-    outVal = out.Get();
+    double outVal = out.Get();
     --out;
-    outVal2 = out.Get();
+    double outVal2 = out.Get();
     outVal = (outVal + outVal2) / 2.0;
     ++out;
     out.Set(static_cast<OutputImagePixelType>(outVal));

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
@@ -335,17 +335,13 @@ BSplineControlPointImageFilter<TInputImage, TOutputImage>::SplitRequestedRegion(
 
   const SizeType requestedRegionSize = outputPtr->GetRequestedRegion().GetSize();
 
-  int                              splitAxis;
-  typename TOutputImage::IndexType splitIndex;
-  typename TOutputImage::SizeType  splitSize;
-
   // Initialize the splitRegion to the output requested region
   splitRegion = outputPtr->GetRequestedRegion();
-  splitIndex = splitRegion.GetIndex();
-  splitSize = splitRegion.GetSize();
+  typename TOutputImage::IndexType splitIndex = splitRegion.GetIndex();
+  typename TOutputImage::SizeType  splitSize = splitRegion.GetSize();
 
   // split on the outermost dimension
-  splitAxis = outputPtr->GetImageDimension() - 1;
+  const auto splitAxis = outputPtr->GetImageDimension() - 1;
 
   // determine the actual number of pieces that will be generated
   const typename SizeType::SizeValueType range = requestedRegionSize[splitAxis];

--- a/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.hxx
@@ -76,14 +76,13 @@ BSplineDownsampleImageFilter<TInputImage, TOutputImage, ResamplerType>::Generate
   inputPtr->SetRequestedRegionToLargestPossibleRegion();
 
   // we need to compute the input requested region (size and start index)
-  unsigned int                             i;
   const typename TOutputImage::SizeType &  outputRequestedRegionSize = outputPtr->GetRequestedRegion().GetSize();
   const typename TOutputImage::IndexType & outputRequestedRegionStartIndex = outputPtr->GetRequestedRegion().GetIndex();
 
   typename TInputImage::SizeType  inputRequestedRegionSize;
   typename TInputImage::IndexType inputRequestedRegionStartIndex;
 
-  for (i = 0; i < TInputImage::ImageDimension; ++i)
+  for (unsigned int i = 0; i < TInputImage::ImageDimension; ++i)
   {
     inputRequestedRegionSize[i] = outputRequestedRegionSize[i] * 2;
     inputRequestedRegionStartIndex[i] = outputRequestedRegionStartIndex[i] * 2;
@@ -116,7 +115,6 @@ BSplineDownsampleImageFilter<TInputImage, TOutputImage, ResamplerType>::Generate
 
   // we need to compute the output spacing, the output image size, and the
   // output image start index
-  unsigned int                              i;
   const typename TInputImage::SpacingType & inputSpacing = inputPtr->GetSpacing();
   const typename TInputImage::SizeType &    inputSize = inputPtr->GetLargestPossibleRegion().GetSize();
   const typename TInputImage::IndexType &   inputStartIndex = inputPtr->GetLargestPossibleRegion().GetIndex();
@@ -125,7 +123,7 @@ BSplineDownsampleImageFilter<TInputImage, TOutputImage, ResamplerType>::Generate
   typename TOutputImage::SizeType    outputSize;
   typename TOutputImage::IndexType   outputStartIndex;
 
-  for (i = 0; i < TOutputImage::ImageDimension; ++i)
+  for (unsigned int i = 0; i < TOutputImage::ImageDimension; ++i)
   {
     // TODO:  Verify this is being rounded correctly.
     outputSpacing[i] = inputSpacing[i] * 2.0;

--- a/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.hxx
@@ -87,14 +87,13 @@ BSplineUpsampleImageFilter<TInputImage, TOutputImage, ResamplerType>::GenerateIn
   inputPtr->SetRequestedRegionToLargestPossibleRegion();
 
   // Compute the input requested region (size and start index)
-  unsigned int                             i;
   const typename TOutputImage::SizeType &  outputRequestedRegionSize = outputPtr->GetRequestedRegion().GetSize();
   const typename TOutputImage::IndexType & outputRequestedRegionStartIndex = outputPtr->GetRequestedRegion().GetIndex();
 
   typename TInputImage::SizeType  inputRequestedRegionSize;
   typename TInputImage::IndexType inputRequestedRegionStartIndex;
 
-  for (i = 0; i < TInputImage::ImageDimension; ++i)
+  for (unsigned int i = 0; i < TInputImage::ImageDimension; ++i)
   {
     inputRequestedRegionSize[i] = outputRequestedRegionSize[i] / 2;
     inputRequestedRegionStartIndex[i] = outputRequestedRegionStartIndex[i] / 2;
@@ -126,7 +125,6 @@ BSplineUpsampleImageFilter<TInputImage, TOutputImage, ResamplerType>::GenerateOu
 
   // we need to compute the output spacing, the output image size, and the
   // output image start index
-  unsigned int                              i;
   const typename TInputImage::SpacingType & inputSpacing = inputPtr->GetSpacing();
   const typename TInputImage::SizeType &    inputSize = inputPtr->GetLargestPossibleRegion().GetSize();
   const typename TInputImage::IndexType &   inputStartIndex = inputPtr->GetLargestPossibleRegion().GetIndex();
@@ -135,7 +133,7 @@ BSplineUpsampleImageFilter<TInputImage, TOutputImage, ResamplerType>::GenerateOu
   typename TOutputImage::SizeType    outputSize;
   typename TOutputImage::IndexType   outputStartIndex;
 
-  for (i = 0; i < TOutputImage::ImageDimension; ++i)
+  for (unsigned int i = 0; i < TOutputImage::ImageDimension; ++i)
   {
     // TODO:  Verify this is being rounded correctly.
     outputSpacing[i] = inputSpacing[i] / 2.0;

--- a/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.hxx
@@ -31,8 +31,6 @@ ChangeInformationImageFilter<TInputImage>::GenerateOutputInformation()
 {
   Superclass::GenerateOutputInformation();
 
-  unsigned int i;
-
   typename TInputImage::RegionType outputRegion;
   typename TInputImage::SizeType   inputSize;
   typename TInputImage::SizeType   outputSize;
@@ -111,12 +109,12 @@ ChangeInformationImageFilter<TInputImage>::GenerateOutputInformation()
     typename TInputImage::PointType                     centerPoint;
     ContinuousIndex<SpacePrecisionType, ImageDimension> centerIndex;
 
-    for (i = 0; i < ImageDimension; ++i)
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       centerIndex[i] = static_cast<double>((outputSize[i] - 1) / 2.0);
     }
     output->TransformContinuousIndexToPhysicalPoint(centerIndex, centerPoint);
-    for (i = 0; i < ImageDimension; ++i)
+    for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       origin[i] = output->GetOrigin()[i] - centerPoint[i];
     }

--- a/Modules/Filtering/ImageGrid/include/itkCoxDeBoorBSplineKernelFunction.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkCoxDeBoorBSplineKernelFunction.hxx
@@ -152,14 +152,10 @@ CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::Evaluate(const TRe
 {
   const TRealValueType absValue = itk::Math::abs(u);
 
-  unsigned int which;
+  unsigned int which = static_cast<unsigned int>(absValue);
   if (this->m_SplineOrder % 2 == 0)
   {
     which = static_cast<unsigned int>(absValue + TRealValueType{ 0.5 });
-  }
-  else
-  {
-    which = static_cast<unsigned int>(absValue);
   }
 
   if (which < this->m_BSplineShapeFunctions.rows())
@@ -184,14 +180,10 @@ CoxDeBoorBSplineKernelFunction<VSplineOrder, TRealValueType>::EvaluateNthDerivat
 {
   const TRealValueType absValue = itk::Math::abs(u);
 
-  unsigned int which;
+  unsigned int which = static_cast<unsigned int>(absValue);
   if (this->m_SplineOrder % 2 == 0)
   {
     which = static_cast<unsigned int>(absValue + TRealValueType{ 0.5 });
-  }
-  else
-  {
-    which = static_cast<unsigned int>(absValue);
   }
 
   if (which < this->m_BSplineShapeFunctions.rows())

--- a/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.hxx
@@ -47,14 +47,15 @@ ExpandImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inden
 {
   Superclass::PrintSelf(os, indent);
 
-  unsigned int j;
   os << indent << "ExpandFactors: [";
-  for (j = 0; j < ImageDimension - 1; ++j)
   {
-    os << m_ExpandFactors[j] << ", ";
+    unsigned int j = 0;
+    for (; j < ImageDimension - 1; ++j)
+    {
+      os << m_ExpandFactors[j] << ", ";
+    }
+    os << m_ExpandFactors[j] << ']' << std::endl;
   }
-  os << m_ExpandFactors[j] << ']' << std::endl;
-
   os << indent << "Interpolator: ";
   os << m_Interpolator.GetPointer() << std::endl;
 }
@@ -160,7 +161,6 @@ ExpandImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
   itkAssertInDebugAndIgnoreInReleaseMacro(outputPtr);
 
   // We need to compute the input requested region (size and start index)
-  unsigned int                             i;
   const typename TOutputImage::SizeType &  outputRequestedRegionSize = outputPtr->GetRequestedRegion().GetSize();
   const typename TOutputImage::IndexType & outputRequestedRegionStartIndex = outputPtr->GetRequestedRegion().GetIndex();
 
@@ -171,7 +171,7 @@ ExpandImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
    * inputRequestedSize = (outputRequestedSize / ExpandFactor) + 1)
    * The extra 1 above is to take care of edge effects when streaming.
    */
-  for (i = 0; i < TInputImage::ImageDimension; ++i)
+  for (unsigned int i = 0; i < TInputImage::ImageDimension; ++i)
   {
     inputRequestedRegionSize[i] = (SizeValueType)std::ceil(static_cast<double>(outputRequestedRegionSize[i]) /
                                                            static_cast<double>(m_ExpandFactors[i])) +

--- a/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
@@ -39,8 +39,6 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::GenerateNextOutputRegion(long *
                                                                           std::vector<long> *     sizes,
                                                                           OutputImageRegionType & outputRegion)
 {
-  unsigned int         ctr;
-  int                  done = 0;
   OutputImageIndexType nextIndex = outputRegion.GetIndex();
   OutputImageSizeType  nextSize = outputRegion.GetSize();
 
@@ -49,7 +47,8 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::GenerateNextOutputRegion(long *
   // value for the region parameters.  If we wrap on a region, then we
   // also increment to the next region for the next higher dimension.
   //
-  for (ctr = 0; (ctr < ImageDimension) && !done; ++ctr)
+  int done = 0;
+  for (unsigned int ctr = 0; (ctr < ImageDimension) && !done; ++ctr)
   {
     regIndices[ctr]++;
     done = 1;
@@ -72,7 +71,7 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::GenerateNextOutputRegion(long *
   // If any dimension has zero size, then we do not need to process this
   // region.  Report this back to the calling routine.
   //
-  for (ctr = 0; ctr < ImageDimension; ++ctr)
+  for (unsigned int ctr = 0; ctr < ImageDimension; ++ctr)
   {
     if (nextSize[ctr] == 0)
     {
@@ -96,7 +95,7 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::GenerateNextInputRegion(long * 
                                                                          std::vector<long> *    sizes,
                                                                          InputImageRegionType & inputRegion)
 {
-  unsigned int        ctr;
+  unsigned int        ctr = 0;
   int                 done = 0;
   InputImageIndexType nextIndex = inputRegion.GetIndex();
   InputImageSizeType  nextSize = inputRegion.GetSize();
@@ -280,7 +279,7 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::BuildInterRegions(std::vector<l
 
   // Size of the in region is the area from index 0 to the end of the
   // input or the output, whichever comes first.
-  long sizeTemp; // Holder for current size calculation.
+  long sizeTemp = 0; // Holder for current size calculation.
   if ((inputIndex + inputSize) < (outputIndex + outputSize))
   {
     sizeTemp = inputIndex + inputSize - outputRegionStart[0];

--- a/Modules/Filtering/ImageGrid/include/itkPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPadImageFilter.hxx
@@ -100,7 +100,6 @@ PadImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
 
   // we need to compute the output image size, and the
   // output image start index
-  unsigned int                     i;
   typename TOutputImage::SizeType  outputSize;
   typename TOutputImage::IndexType outputStartIndex;
   typename TInputImage::SizeType   inputSize;
@@ -109,7 +108,7 @@ PadImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   inputSize = inputPtr->GetLargestPossibleRegion().GetSize();
   inputStartIndex = inputPtr->GetLargestPossibleRegion().GetIndex();
 
-  for (i = 0; i < TOutputImage::ImageDimension; ++i)
+  for (unsigned int i = 0; i < TOutputImage::ImageDimension; ++i)
   {
     outputSize[i] = inputSize[i] + m_PadLowerBound[i] + m_PadUpperBound[i];
     outputStartIndex[i] = inputStartIndex[i] - static_cast<OffsetValueType>(m_PadLowerBound[i]);

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
@@ -275,7 +275,6 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
     tit.GoToBegin();
     while (!tit.IsAtEnd())
     {
-      int dsize;
       int count = 0;
       while (!tit.IsAtEndOfLine())
       {
@@ -284,7 +283,7 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
         {
           if (i < InputImageDimension)
           {
-            dsize = this->GetInput(value)->GetLargestPossibleRegion().GetSize()[i];
+            int dsize = this->GetInput(value)->GetLargestPossibleRegion().GetSize()[i];
             if (dsize > sizes[i][count])
             {
               sizes[i][count] = dsize;

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest.cxx
@@ -52,12 +52,10 @@ itkResampleImageTest(int, char *[])
   image->Allocate();
 
   // Fill image with a ramp
-  itk::ImageRegionIteratorWithIndex<ImageType> iter(image, region);
-  PixelType                                    value;
-  for (iter.GoToBegin(); !iter.IsAtEnd(); ++iter)
+  for (itk::ImageRegionIteratorWithIndex<ImageType> iter(image, region); !iter.IsAtEnd(); ++iter)
   {
     index = iter.GetIndex();
-    value = index[0] + index[1];
+    PixelType value = index[0] + index[1];
     iter.Set(value);
   }
 
@@ -95,14 +93,13 @@ itkResampleImageTest(int, char *[])
   resample->Update();
 
   // Check if desired results were obtained
-  bool                                         passed = true;
-  const ImageType::RegionType                  region2 = resample->GetOutput()->GetRequestedRegion();
-  itk::ImageRegionIteratorWithIndex<ImageType> iter2(resample->GetOutput(), region2);
-  constexpr double                             tolerance = 1e-30;
-  for (iter2.GoToBegin(); !iter2.IsAtEnd(); ++iter2)
+  bool                        passed = true;
+  const ImageType::RegionType region2 = resample->GetOutput()->GetRequestedRegion();
+  constexpr double            tolerance = 1e-30;
+  for (itk::ImageRegionIteratorWithIndex<ImageType> iter2(resample->GetOutput(), region2); !iter2.IsAtEnd(); ++iter2)
   {
     index = iter2.GetIndex();
-    value = iter2.Get();
+    PixelType       value = iter2.Get();
     const PixelType pixval = value;
     auto            expectedValue = static_cast<PixelType>((index[0] + index[1]) / 2.0);
     if (!itk::Math::FloatAlmostEqual(expectedValue, pixval, 10, tolerance))

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
@@ -150,12 +150,11 @@ itkResampleImageTest8(int, char *[])
   inputImage->Allocate();
 
   // Fill input image with a ramp
-  itk::ImageRegionIteratorWithIndex<InputImageType> iter(inputImage, inputRegion);
-  PixelType                                         value;
-  for (iter.GoToBegin(); !iter.IsAtEnd(); ++iter)
+
+  for (itk::ImageRegionIteratorWithIndex<InputImageType> iter(inputImage, inputRegion); !iter.IsAtEnd(); ++iter)
   {
     inputIndex = iter.GetIndex();
-    value = inputIndex[0] + inputIndex[1];
+    PixelType value = inputIndex[0] + inputIndex[1];
     iter.Set(value);
   }
 
@@ -197,14 +196,14 @@ itkResampleImageTest8(int, char *[])
   resample->Update();
 
   // Check if desired results were obtained
-  bool                                               passed = true;
-  const OutputImageType::RegionType                  region2 = resample->GetOutput()->GetRequestedRegion();
-  itk::ImageRegionIteratorWithIndex<OutputImageType> iter2(resample->GetOutput(), region2);
-  constexpr double                                   tolerance = 1e-30;
-  for (iter2.GoToBegin(); !iter2.IsAtEnd(); ++iter2)
+  bool                              passed = true;
+  const OutputImageType::RegionType region2 = resample->GetOutput()->GetRequestedRegion();
+  constexpr double                  tolerance = 1e-30;
+  for (itk::ImageRegionIteratorWithIndex<OutputImageType> iter2(resample->GetOutput(), region2); !iter2.IsAtEnd();
+       ++iter2)
   {
     outputIndex = iter2.GetIndex();
-    value = iter2.Get();
+    PixelType       value = iter2.Get();
     const PixelType pixval = value;
     auto            expectedValue = static_cast<PixelType>((outputIndex[0] + outputIndex[1]) / 2.0);
     if (!itk::Math::FloatAlmostEqual(expectedValue, pixval, 10, tolerance))

--- a/Modules/Filtering/ImageGrid/test/itkResamplePhasedArray3DSpecialCoordinatesImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResamplePhasedArray3DSpecialCoordinatesImageTest.cxx
@@ -58,13 +58,11 @@ itkResamplePhasedArray3DSpecialCoordinatesImageTest(int, char *[])
 
   // Fill image with isoshells
   std::cout << "\nOriginal 3D Phased Array Data" << std::endl;
-  itk::ImageRegionIteratorWithIndex<InputImageType> iter(image, region);
-  PixelType                                         value;
-  for (; !iter.IsAtEnd(); ++iter)
+  for (itk::ImageRegionIteratorWithIndex<InputImageType> iter(image, region); !iter.IsAtEnd(); ++iter)
   {
     index = iter.GetIndex();
     // value = index[0] + index[1] + index[2];
-    value = index[2];
+    PixelType value = index[2];
     iter.Set(value);
     // display one slice of the volume
     if (index[0] == static_cast<int>(size[0] - 1) / 2)
@@ -106,11 +104,10 @@ itkResamplePhasedArray3DSpecialCoordinatesImageTest(int, char *[])
   std::cout << "\nData resampled onto a translated Cartesian image grid." << std::endl;
   ImageType::RegionType region2;
   region2 = resample->GetOutput()->GetRequestedRegion();
-  itk::ImageRegionIteratorWithIndex<ImageType> iter2(resample->GetOutput(), region2);
-  for (; !iter2.IsAtEnd(); ++iter2)
+  for (itk::ImageRegionIteratorWithIndex<ImageType> iter2(resample->GetOutput(), region2); !iter2.IsAtEnd(); ++iter2)
   {
     index = iter2.GetIndex();
-    value = iter2.Get();
+    PixelType value = iter2.Get();
     // display one slice of the volume
     if (index[0] == static_cast<int>(cubeSize[0] - 1) / 2)
     {
@@ -159,11 +156,11 @@ itkResamplePhasedArray3DSpecialCoordinatesImageTest(int, char *[])
   backResample->Update();
   // Check how close we were to the original image
   std::cout << "\nResampled recovery of 3D Phased Array Data from Cartesian space" << std::endl;
-  itk::ImageRegionIteratorWithIndex<InputImageType> iter3(backResample->GetOutput(), region);
-  for (; !iter3.IsAtEnd(); ++iter3)
+  for (itk::ImageRegionIteratorWithIndex<InputImageType> iter3(backResample->GetOutput(), region); !iter3.IsAtEnd();
+       ++iter3)
   {
     index = iter3.GetIndex();
-    value = iter3.Get();
+    PixelType value = iter3.Get();
     // display one slice of the volume
     if (index[0] == static_cast<int>(size[0] - 1) / 2)
     {

--- a/Modules/Filtering/ImageGrid/test/itkSliceBySliceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkSliceBySliceImageFilterTest.cxx
@@ -102,7 +102,7 @@ itkSliceBySliceImageFilterTest(int argc, char * argv[])
   writer->SetInput(filter->GetOutput());
   writer->SetFileName(argv[2]);
 
-  unsigned int       slicingDimension;
+  unsigned int       slicingDimension = 0;
   std::istringstream istrm(argv[3]);
   istrm >> slicingDimension;
   filter->SetDimension(slicingDimension);
@@ -203,12 +203,11 @@ itkSliceBySliceImageFilterTest(int argc, char * argv[])
   //
   // Exercise exceptions
   //
-  bool caughtException;
   auto badFilter = FilterType::New();
 
   std::cout << "Testing with no filter set..." << std::endl;
   badFilter->SetInput(reader->GetOutput());
-  caughtException = false;
+  bool caughtException = false;
   try
   {
     badFilter->Update();

--- a/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
@@ -79,11 +79,13 @@ class ShowProgressObject
 {
 public:
   ShowProgressObject(itk::ProcessObject * o) { m_Process = o; }
+
   void
   ShowProgress()
   {
     std::cout << "Progress " << m_Process->GetProgress() << std::endl;
   }
+
   itk::ProcessObject::Pointer m_Process;
 };
 
@@ -112,11 +114,9 @@ itkWarpVectorImageFilterTest(int, char *[])
   input->SetBufferedRegion(region);
   input->Allocate();
 
-
-  unsigned int                 j;
   ImagePattern<ImageDimension> pattern;
   pattern.m_Offset = 64;
-  for (j = 0; j < ImageDimension; ++j)
+  for (unsigned int j = 0; j < ImageDimension; ++j)
   {
     pattern.m_Coeff[j] = 1.0;
   }
@@ -136,7 +136,7 @@ itkWarpVectorImageFilterTest(int, char *[])
 
   ImageType::RegionType fieldRegion;
   ImageType::SizeType   fieldSize;
-  for (j = 0; j < ImageDimension; ++j)
+  for (unsigned int j = 0; j < ImageDimension; ++j)
   {
     fieldSize[j] = size[j] * factors[j] + 5;
   }
@@ -153,7 +153,7 @@ itkWarpVectorImageFilterTest(int, char *[])
   {
     IndexType  index = fieldIter.GetIndex();
     VectorType displacement;
-    for (j = 0; j < ImageDimension; ++j)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       displacement[j] = static_cast<float>(index[j]) * ((1.0 / factors[j]) - 1.0);
     }
@@ -215,7 +215,7 @@ itkWarpVectorImageFilterTest(int, char *[])
   ImageType::SizeType decrementForScaling;
   ImageType::SizeType clampSizeDecrement;
   ImageType::SizeType clampSize;
-  for (j = 0; j < ImageDimension; ++j)
+  for (unsigned int j = 0; j < ImageDimension; ++j)
   {
     validSize[j] = size[j] * factors[j];
 
@@ -248,7 +248,7 @@ itkWarpVectorImageFilterTest(int, char *[])
   validRegion.SetSize(validSize);
 
   // adjust the pattern coefficients to match
-  for (j = 0; j < ImageDimension; ++j)
+  for (unsigned int j = 0; j < ImageDimension; ++j)
   {
     pattern.m_Coeff[j] /= static_cast<double>(factors[j]);
   }

--- a/Modules/Filtering/ImageGrid/test/itkWrapPadImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWrapPadImageTest.cxx
@@ -128,7 +128,7 @@ itkWrapPadImageTest(int, char *[])
             << wrapPad->GetOutput()->GetSpacing()[1] << std::endl;
 
   ShortImage::RegionType requestedRegion;
-  bool                   passed;
+  bool                   passed = false;
 
   // CASE 1
   lowerBound[0] = 1;

--- a/Modules/Filtering/ImageIntensity/include/itkDiscreteGaussianDerivativeImageFunction.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkDiscreteGaussianDerivativeImageFunction.hxx
@@ -66,8 +66,6 @@ void
 DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::RecomputeGaussianKernel()
 {
   // Create N operators (N=ImageDimension) with the order specified in m_Order
-  unsigned int idx;
-
   for (unsigned int direction = 0; direction < Self::ImageDimension2; ++direction)
   {
     m_OperatorArray[direction].SetDirection(direction);
@@ -112,7 +110,7 @@ DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::RecomputeGaussian
 
   // Initially the kernel image will be an impulse at the center
   auto centerIndex = KernelImageType::IndexType::Filled(2 * m_OperatorArray[0].GetRadius()[0]); // include also
-                                                                                                // boundaries
+  // boundaries
   kernelImage->SetPixel(centerIndex, itk::NumericTraits<TOutput>::OneValue());
 
   // Create an image region to be used later that does not include boundaries
@@ -141,7 +139,7 @@ DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::RecomputeGaussian
   // Copy kernel image to neighborhood. Do not copy boundaries.
   ImageRegionConstIterator<KernelImageType> it(kernelImage, kernelRegion);
   it.GoToBegin();
-  idx = 0;
+  unsigned int idx = 0;
 
   while (!it.IsAtEnd())
   {

--- a/Modules/Filtering/ImageIntensity/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
@@ -65,14 +65,14 @@ DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::RecomputeG
   /** Create 2*N operators (N=ImageDimension) where the
    * first N are zero-order and the second N are first-order */
 
-  unsigned int idx;
+
   unsigned int maxRadius = 0;
 
   for (unsigned int direction = 0; direction < Self::ImageDimension2; ++direction)
   {
     for (unsigned int order = 0; order <= 1; ++order)
     {
-      idx = Self::ImageDimension2 * order + direction;
+      unsigned int idx = Self::ImageDimension2 * order + direction;
       m_OperatorArray[idx].SetDirection(direction);
       m_OperatorArray[idx].SetMaximumKernelWidth(m_MaximumKernelWidth);
       m_OperatorArray[idx].SetMaximumError(m_MaximumError);
@@ -137,7 +137,7 @@ DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::RecomputeG
   using NeighborhoodFilterType = itk::NeighborhoodOperatorImageFilter<KernelImageType, KernelImageType>;
   auto convolutionFilter = NeighborhoodFilterType::New();
 
-  unsigned int opidx; // current operator index in m_OperatorArray
+  unsigned int opidx = 0; // current operator index in m_OperatorArray
 
   for (unsigned int i = 0; i < Self::ImageDimension2; ++i)
   {
@@ -161,7 +161,7 @@ DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::RecomputeG
     // Copy kernel image to neighborhood. Do not copy boundaries.
     ImageRegionConstIterator<KernelImageType> it(kernelImage, kernelRegion);
     it.GoToBegin();
-    idx = 0;
+    unsigned int idx = 0;
 
     while (!it.IsAtEnd())
     {

--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
@@ -337,8 +337,8 @@ HistogramMatchingImageFilter<TInputImage, TOutputImage, THistogramMeasurement>::
         break;
       }
     }
-
-    double mappedValue;
+    // Linear interpolate from point[j] and point[j+1].
+    double mappedValue = m_QuantileTable[1][j - 1] + (srcValue - m_QuantileTable[0][j - 1]) * m_Gradients[j - 1];
     if (j == 0)
     {
       // Linear interpolate from min to point[0]
@@ -349,12 +349,6 @@ HistogramMatchingImageFilter<TInputImage, TOutputImage, THistogramMeasurement>::
       // Linear interpolate from point[m_NumberOfMatchPoints+1] to max
       mappedValue = m_ReferenceMaxValue + (srcValue - m_SourceMaxValue) * m_UpperGradient;
     }
-    else
-    {
-      // Linear interpolate from point[j] and point[j+1].
-      mappedValue = m_QuantileTable[1][j - 1] + (srcValue - m_QuantileTable[0][j - 1]) * m_Gradients[j - 1];
-    }
-
     outIter.Set(static_cast<OutputPixelType>(mappedValue));
   }
 }

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
@@ -107,8 +107,6 @@ PolylineMask2DImageFilter<TInputImage, TPolyline, TOutputImage>::GenerateData()
   // reset piter
   piter = container->Begin();
 
-  /* define flag to indicate the line segment slope */
-  bool pflag;
 
   /* define background, foreground pixel values and unlabeled pixel value */
   constexpr PixelType zero_val{};
@@ -131,7 +129,8 @@ PolylineMask2DImageFilter<TInputImage, TPolyline, TOutputImage>::GenerateData()
 
   while (piter != container->End())
   {
-    pflag = false;
+    /* define flag to indicate the line segment slope */
+    bool pflag = false;
     startVertex = tmpVertex;
     endVertex = piter.Value();
 
@@ -178,7 +177,7 @@ PolylineMask2DImageFilter<TInputImage, TPolyline, TOutputImage>::GenerateData()
   }
 
   /* Close the polygon */
-  pflag = false;
+  bool pflag = false;
   startVertex = tmpVertex;
   endVertex = pstartVertex;
 

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -338,9 +338,6 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
   VertexType projectionIndex;
   VertexType pstartIndex;
 
-  // Define a flag to indicate the line segment slope
-  bool pflag;
-
   // Define background, foreground, and unlabeled pixel values
   auto u_val = static_cast<ProjectionImagePixelType>(0);
   auto b_val = static_cast<ProjectionImagePixelType>(2);
@@ -364,7 +361,8 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
 
   while (piter != container->End())
   {
-    pflag = false;
+    // Define a flag to indicate the line segment slope
+    bool pflag = false;
     startIndex = projectionIndex;
     endIndex = piter.Value();
 
@@ -413,7 +411,7 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
   }
 
   // Close the polygon
-  pflag = false;
+  bool pflag = false;
   startIndex = projectionIndex;
   endIndex = pstartIndex;
 

--- a/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.hxx
@@ -51,13 +51,15 @@ VectorExpandImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os,
 {
   Superclass::PrintSelf(os, indent);
 
-  unsigned int j;
-  os << indent << "ExpandFactors: [";
-  for (j = 0; j < ImageDimension - 1; ++j)
   {
-    os << m_ExpandFactors[j] << ", ";
+    os << indent << "ExpandFactors: [";
+    unsigned int j = 0;
+    for (; j < ImageDimension - 1; ++j)
+    {
+      os << m_ExpandFactors[j] << ", ";
+    }
+    os << m_ExpandFactors[j] << ']' << std::endl;
   }
-  os << m_ExpandFactors[j] << ']' << std::endl;
 
   os << indent << "Interpolator: ";
   os << m_Interpolator.GetPointer() << std::endl;
@@ -166,7 +168,6 @@ VectorExpandImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion
   }
 
   // We need to compute the input requested region (size and start index)
-  unsigned int                             i;
   const typename TOutputImage::SizeType &  outputRequestedRegionSize = outputPtr->GetRequestedRegion().GetSize();
   const typename TOutputImage::IndexType & outputRequestedRegionStartIndex = outputPtr->GetRequestedRegion().GetIndex();
 
@@ -175,7 +176,7 @@ VectorExpandImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion
 
   // inputRequestedSize = (outputRequestedSize / ExpandFactor) + 1)
   // The extra 1 above is to take care of edge effects when streaming.
-  for (i = 0; i < TInputImage::ImageDimension; ++i)
+  for (unsigned int i = 0; i < TInputImage::ImageDimension; ++i)
   {
     inputRequestedRegionSize[i] = (SizeValueType)std::ceil(static_cast<double>(outputRequestedRegionSize[i]) /
                                                            static_cast<double>(m_ExpandFactors[i])) +

--- a/Modules/Filtering/ImageIntensity/test/itkClampImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkClampImageFilterTest.cxx
@@ -40,15 +40,14 @@ template <typename T>
 std::string
 GetClampTypeName()
 {
-  std::string name;
 #ifdef GCC_USEDEMANGLE
-  const char * mangledName = typeid(T).name();
-  int          status;
-  char *       unmangled = abi::__cxa_demangle(mangledName, nullptr, nullptr, &status);
-  name = unmangled;
+  const char *      mangledName = typeid(T).name();
+  int               status = 0;
+  char *            unmangled = abi::__cxa_demangle(mangledName, nullptr, nullptr, &status);
+  const std::string name = unmangled;
   free(unmangled);
 #else
-  name = typeid(T).name();
+  const std::string name = typeid(T).name();
 #endif
 
   return name;

--- a/Modules/Filtering/ImageIntensity/test/itkMatrixIndexSelectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMatrixIndexSelectionImageFilterTest.cxx
@@ -118,8 +118,8 @@ itkMatrixIndexSelectionImageFilterTest(int argc, char * argv[])
   constexpr unsigned int indexB = 1;
   filter->SetIndices(indexA, indexB);
 
-  unsigned int testIndexA;
-  unsigned int testIndexB;
+  unsigned int testIndexA = 0;
+  unsigned int testIndexB = 0;
   filter->GetIndices(testIndexA, testIndexB);
 
   if (indexA != testIndexA || indexB != testIndexB)

--- a/Modules/Filtering/ImageIntensity/test/itkVectorExpandImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkVectorExpandImageFilterTest.cxx
@@ -100,10 +100,10 @@ itkVectorExpandImageFilterTest(int, char *[])
   input->SetBufferedRegion(region);
   input->Allocate();
 
-  int                          j, k;
+
   ImagePattern<ImageDimension> pattern;
   pattern.m_Offset = 64;
-  for (j = 0; j < ImageDimension; ++j)
+  for (unsigned int j = 0; j < ImageDimension; ++j)
   {
     pattern.m_Coeff[j] = 1.0;
   }
@@ -118,7 +118,7 @@ itkVectorExpandImageFilterTest(int, char *[])
 
     const double value = pattern.Evaluate(inIter.GetIndex());
     PixelType    pixel;
-    for (k = 0; k < VectorDimension; ++k)
+    for (unsigned int k = 0; k < VectorDimension; ++k)
     {
       pixel[k] = vectorCoeff[k] * value;
     }
@@ -166,14 +166,13 @@ itkVectorExpandImageFilterTest(int, char *[])
 
 
   std::cout << "Checking the output against expected." << std::endl;
-  Iterator outIter(expanderOutput, expanderOutput->GetBufferedRegion());
 
   // compute non-padded output region
   ImageType::RegionType     validRegion = expanderOutput->GetLargestPossibleRegion();
   const ImageType::SizeType validSize = validRegion.GetSize();
 
   validRegion.SetSize(validSize);
-
+  Iterator outIter(expanderOutput, expanderOutput->GetBufferedRegion());
   for (; !outIter.IsAtEnd(); ++outIter)
   {
     const ImageType::IndexType index = outIter.GetIndex();
@@ -187,7 +186,8 @@ itkVectorExpandImageFilterTest(int, char *[])
       const ImageType::IndexType inputIndex = input->TransformPhysicalPointToIndex(point);
       const double               baseValue = pattern.Evaluate(inputIndex);
 
-      for (k = 0; k < VectorDimension; ++k)
+      unsigned int k = 0;
+      for (; k < VectorDimension; ++k)
       {
         if (itk::Math::abs(baseValue * vectorCoeff[k] - value[k]) > 1e-4)
         {
@@ -205,8 +205,8 @@ itkVectorExpandImageFilterTest(int, char *[])
     }
     else
     {
-
-      for (k = 0; k < VectorDimension; ++k)
+      unsigned int k = 0;
+      for (; k < VectorDimension; ++k)
       {
         if (itk::Math::NotExactlyEquals(value[k], padValue[k]))
         {
@@ -256,7 +256,7 @@ itkVectorExpandImageFilterTest(int, char *[])
   while (!outIter.IsAtEnd())
   {
 
-    for (k = 0; k < VectorDimension; ++k)
+    for (unsigned int k = 0; k < VectorDimension; ++k)
     {
       if (itk::Math::NotExactlyEquals(outIter.Get()[k], streamIter.Get()[k]))
       {

--- a/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.hxx
@@ -36,7 +36,7 @@ template <class TInputImage, class TOutputImage>
 void
 NoiseBaseImageFilter<TInputImage, TOutputImage>::SetSeed()
 {
-  time_t t;
+  time_t t = 0;
 
   time(&t);
   this->SetSeed(Hash(t, clock()));

--- a/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
@@ -80,8 +80,8 @@ SpeckleNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
     {
       // First generate the gamma distributed random variable
       // ref https://en.wikipedia.org/wiki/Gamma_distribution#Generating_gamma-distributed_random_variables
-      double xi;
-      double nu;
+      double xi = NAN;
+      double nu = NAN;
       do
       {
         const double v1 = 1.0 - rand->GetVariateWithOpenUpperRange(); // open *lower* range -- (0,1]

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
@@ -83,8 +83,7 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::GenerateInputRequestedRe
 
     // Set the requested region of the remaining input to the largest possible
     // region of the first input
-    unsigned int idx;
-    for (idx = 1; idx < this->GetNumberOfIndexedInputs(); ++idx)
+    for (unsigned int idx = 1; idx < this->GetNumberOfIndexedInputs(); ++idx)
     {
       if (this->GetInput(idx))
       {
@@ -115,8 +114,7 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::GenerateData()
   auto numberOfOutputs = static_cast<unsigned int>(this->GetNumberOfIndexedOutputs());
 
   const InputImagePointer input = const_cast<TInputImage *>(this->GetInput(0));
-  unsigned int            j;
-  for (j = 0; j < numberOfOutputs; ++j)
+  for (unsigned int j = 0; j < numberOfOutputs; ++j)
   {
     const OutputImagePointer output = this->GetOutput(j);
     output->SetBufferedRegion(output->GetRequestedRegion());
@@ -143,8 +141,8 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::GenerateData()
   // Now fill the principal component outputs
   unsigned int       kthLargestPrincipalComp = m_NumberOfTrainingImages;
   const unsigned int numberOfValidOutputs = std::min(numberOfOutputs, m_NumberOfTrainingImages + 1);
-
-  for (j = 1; j < numberOfValidOutputs; ++j)
+  unsigned int       j = 1;
+  for (; j < numberOfValidOutputs; ++j)
   {
     // Extract one column vector at a time
     m_OneEigenVector = m_EigenVectors.get_column(kthLargestPrincipalComp - 1);
@@ -199,13 +197,11 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::SetNumberOfPrincipalComp
     // Modify the required number of outputs ( 1 extra for the mean image )
     this->SetNumberOfRequiredOutputs(m_NumberOfPrincipalComponentsRequired + 1);
 
-    auto         numberOfOutputs = static_cast<unsigned int>(this->GetNumberOfIndexedOutputs());
-    unsigned int idx;
-
+    auto numberOfOutputs = static_cast<unsigned int>(this->GetNumberOfIndexedOutputs());
     if (numberOfOutputs < m_NumberOfPrincipalComponentsRequired + 1)
     {
       // Make and add extra outputs
-      for (idx = numberOfOutputs; idx <= m_NumberOfPrincipalComponentsRequired; ++idx)
+      for (unsigned int idx = numberOfOutputs; idx <= m_NumberOfPrincipalComponentsRequired; ++idx)
       {
         const typename DataObject::Pointer output = this->MakeOutput(idx);
         this->SetNthOutput(idx, output.GetPointer());
@@ -214,7 +210,7 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::SetNumberOfPrincipalComp
     else if (numberOfOutputs > m_NumberOfPrincipalComponentsRequired + 1)
     {
       // Remove the extra outputs
-      for (idx = numberOfOutputs - 1; idx >= m_NumberOfPrincipalComponentsRequired + 1; idx--)
+      for (unsigned int idx = numberOfOutputs - 1; idx >= m_NumberOfPrincipalComponentsRequired + 1; idx--)
       {
         this->RemoveOutput(idx);
       }
@@ -369,15 +365,13 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::EstimatePCAShapeModelPar
   m_EigenVectors.set_size(m_NumberOfPixels, m_NumberOfTrainingImages);
   m_EigenVectors.fill(0);
 
-  double                  pix_value;
-  InputImageConstIterator tempImageItA;
 
   for (unsigned int img_number = 0; img_number < m_NumberOfTrainingImages; ++img_number)
   {
-    tempImageItA = m_InputImageIteratorArray[img_number];
+    InputImageConstIterator tempImageItA = m_InputImageIteratorArray[img_number];
     for (unsigned int pix_number = 0; pix_number < m_NumberOfPixels; ++pix_number)
     {
-      pix_value = tempImageItA.Get();
+      const double pix_value = tempImageItA.Get();
       for (unsigned int vec_number = 0; vec_number < m_NumberOfTrainingImages; ++vec_number)
       {
         m_EigenVectors[pix_number][vec_number] +=

--- a/Modules/Filtering/ImageStatistics/test/itkImageMomentsTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImageMomentsTest.cxx
@@ -250,26 +250,14 @@ itkImageMomentsTest(int argc, char * argv[])
 
   /* Return error if differences are too large */
   const int stat = tmerr > maxerr || cgerr > maxerr || pmerr > maxerr || paerr > maxerr || trerr > maxerr;
-
   std::cout << std::endl;
-  bool pass;
   if (stat)
   {
     std::cout << "Errors are larger than defined maximum value." << std::endl;
     std::cout << "Test FAILED !" << std::endl;
-    pass = false;
-  }
-  else
-  {
-    std::cout << "Errors are acceptable" << std::endl;
-    std::cout << "Test PASSED !" << std::endl;
-    pass = true;
-  }
-
-  if (!pass)
-  {
     return EXIT_FAILURE;
   }
-
+  std::cout << "Errors are acceptable" << std::endl;
+  std::cout << "Test PASSED !" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/LabelMap/include/itkAttributeUniqueLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAttributeUniqueLabelMapFilter.hxx
@@ -131,7 +131,7 @@ AttributeUniqueLabelMapFilter<TImage, TAttributeAccessor>::GenerateData()
         // which line to keep. This is necessary to avoid the case where a
         // part of a label is over
         // a second label, and below in another part of the image.
-        bool                                                  keepCurrent;
+        bool                                                  keepCurrent = false;
         const typename TAttributeAccessor::AttributeValueType prevAttr = accessor(prev.labelObject);
         const typename LabelObjectType::LabelType             prevLabel = prev.labelObject->GetLabel();
         // this may be changed to a single boolean expression, but may become

--- a/Modules/Filtering/LabelMap/include/itkLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapFilter.hxx
@@ -86,7 +86,7 @@ LabelMapFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(const Out
   TotalProgressReporter progress(this, numberOfLabelObjects, numberOfLabelObjects);
   while (true)
   {
-    LabelObjectType * labelObject;
+    LabelObjectType * labelObject = nullptr;
     // begin mutex lock
     {
       const std::lock_guard<std::mutex> lockGuard(m_LabelObjectContainerLock);

--- a/Modules/Filtering/LabelMap/include/itkObjectByObjectLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkObjectByObjectLabelMapFilter.hxx
@@ -230,13 +230,12 @@ ObjectByObjectLabelMapFilter<TInputImage,
     // It seems to be a bug in the autocrop filter :-(
     m_Crop->Modified();
 
-    // to store the label objects
-    LabelMapType * labelMap;
-
     // to be reused later
     const typename OutputImageType::LabelObjectType * inLo = inIt.GetLabelObject();
 
     // update the pipeline
+    // to store the label objects
+    LabelMapType * labelMap = nullptr;
     if (m_BinaryInternalOutput)
     {
       m_BI2LM->UpdateLargestPossibleRegion();

--- a/Modules/Filtering/LabelMap/include/itkShapeUniqueLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeUniqueLabelMapFilter.h
@@ -195,11 +195,12 @@ protected:
           // which line to keep. This is necessary to avoid the case where a
           // part of a label is over
           // a second label, and below in another part of the image.
-          bool                                                  keepCurrent;
+
           const typename TAttributeAccessor::AttributeValueType prevAttr = accessor(prev.labelObject);
           const typename TAttributeAccessor::AttributeValueType attr = accessor(l.labelObject);
           // this may be changed to a single boolean expression, but may become
           // quite difficult to read
+          bool keepCurrent = false;
           if (Math::ExactlyEquals(attr, prevAttr))
           {
             if (l.labelObject->GetLabel() > prev.labelObject->GetLabel())

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
@@ -157,24 +157,17 @@ StatisticsLabelMapFilter<TImage, TFeatureImage>::ThreadedProcessLabelObject(Labe
   const double variance = (totalFreq > 1) ? (sum2 - (Math::sqr(sum) / totalFreq)) / (totalFreq - 1) : 0;
   const double sigma = std::sqrt(variance);
   const double mean2 = mean * mean;
-  double       skewness;
+  double       skewness = 0.0;
   if (itk::Math::abs(variance * sigma) > itk::NumericTraits<double>::min())
   {
     skewness = ((sum3 - 3.0 * mean * sum2) / totalFreq + 2.0 * mean * mean2) / (variance * sigma);
   }
-  else
-  {
-    skewness = 0.0;
-  }
-  double kurtosis;
+
+  double kurtosis = 0.0;
   if (itk::Math::abs(variance) > itk::NumericTraits<double>::min())
   {
     kurtosis =
       ((sum4 - 4.0 * mean * sum3 + 6.0 * mean2 * sum2) / totalFreq - 3.0 * mean2 * mean2) / (variance * variance) - 3.0;
-  }
-  else
-  {
-    kurtosis = 0.0;
   }
 
   // the median

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateLine.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateLine.hxx
@@ -173,7 +173,7 @@ AnchorErodeDilateLine<TInputPix, TCompare>::StartLine(std::vector<TInputPix> & b
   // This returns true to indicate return to startLine label in pseudo
   // code, and false to indicate finishLine
   int currentP = inLeftP + 1;
-  int sentinel;
+  int sentinel = 0;
 
   while ((currentP < inRightP) && Compare(inbuffer[currentP], Extreme))
   {

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseImageFilter.hxx
@@ -196,8 +196,8 @@ AnchorOpenCloseImageFilter<TImage, TKernel, TCompare1, TCompare2>::DoFaceOpen(
   for (unsigned int it = 0; it < face.GetNumberOfPixels(); ++it)
   {
     const typename TImage::IndexType Ind = dumbImg->ComputeIndex(it);
-    unsigned int                     start;
-    unsigned int                     end;
+    unsigned int                     start = 0;
+    unsigned int                     end = 0;
     if (FillLineBuffer<TImage, BresType, KernelLType>(
           input, Ind, NormLine, tol, LineOffsets, AllImage, outbuffer, start, end))
     {

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorUtilities.hxx
@@ -66,8 +66,8 @@ DoAnchorFace(const TImage *                            input,
   for (unsigned int it = 0; it < face.GetNumberOfPixels(); ++it)
   {
     const typename TImage::IndexType Ind = dumbImg->ComputeIndex(it);
-    unsigned int                     start;
-    unsigned int                     end;
+    unsigned int                     start = 0;
+    unsigned int                     end = 0;
     if (FillLineBuffer<TImage, TBres, TLine>(input, Ind, NormLine, tol, LineOffsets, AllImage, inbuffer, start, end))
     {
       const unsigned int len = end - start + 1;

--- a/Modules/Filtering/MathematicalMorphology/include/itkBasicDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBasicDilateImageFilter.hxx
@@ -34,13 +34,9 @@ BasicDilateImageFilter<TInputImage, TOutputImage, TKernel>::Evaluate(const Neigh
                                                                      const KernelIteratorType         kernelBegin,
                                                                      const KernelIteratorType kernelEnd) -> PixelType
 {
-  unsigned int i;
-  PixelType    max = NumericTraits<PixelType>::NonpositiveMin();
-  PixelType    temp;
-
-  KernelIteratorType kernel_it;
-
-  for (i = 0, kernel_it = kernelBegin; kernel_it < kernelEnd; ++kernel_it, ++i)
+  PixelType          max = NumericTraits<PixelType>::NonpositiveMin();
+  KernelIteratorType kernel_it = kernelBegin;
+  for (unsigned int i = 0; kernel_it < kernelEnd; ++kernel_it, ++i)
   {
     // if structuring element is positive, use the pixel under that element
     // in the image
@@ -48,7 +44,7 @@ BasicDilateImageFilter<TInputImage, TOutputImage, TKernel>::Evaluate(const Neigh
     {
       // note we use GetPixel() on the SmartNeighborhoodIterator to
       // respect boundary conditions
-      temp = nit.GetPixel(i);
+      const auto temp = nit.GetPixel(i);
 
       if (temp > max)
       {

--- a/Modules/Filtering/MathematicalMorphology/include/itkBasicErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBasicErodeImageFilter.hxx
@@ -34,13 +34,10 @@ BasicErodeImageFilter<TInputImage, TOutputImage, TKernel>::Evaluate(const Neighb
                                                                     const KernelIteratorType         kernelBegin,
                                                                     const KernelIteratorType kernelEnd) -> PixelType
 {
-  unsigned int i;
-  PixelType    min = NumericTraits<PixelType>::max();
-  PixelType    temp;
+  PixelType min = NumericTraits<PixelType>::max();
 
-  KernelIteratorType kernel_it;
-
-  for (i = 0, kernel_it = kernelBegin; kernel_it < kernelEnd; ++kernel_it, ++i)
+  KernelIteratorType kernel_it = kernelBegin;
+  for (unsigned int i = 0; kernel_it < kernelEnd; ++kernel_it, ++i)
   {
     // if structuring element is positive, use the pixel under that element
     // in the image
@@ -48,7 +45,7 @@ BasicErodeImageFilter<TInputImage, TOutputImage, TKernel>::Evaluate(const Neighb
     {
       // note we use GetPixel() on the NeighborhoodIterator in order
       // to respect boundary conditions.
-      temp = nit.GetPixel(i);
+      const auto temp = nit.GetPixel(i);
 
       if (temp < min)
       {

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
@@ -932,13 +932,11 @@ FlatStructuringElement<VDimension>::Ball(RadiusType radius, bool radiusIsParamet
   res.m_Decomposable = false;
   res.SetRadiusIsParametric(radiusIsParametric);
 
-  unsigned int i;
-
   // Create an image to hold the ellipsoid
   //
   auto       sourceImage = ImageType::New();
   RadiusType size = radius;
-  for (i = 0; i < int{ VDimension }; ++i)
+  for (unsigned int i = 0; i < int{ VDimension }; ++i)
   {
     size[i] = 2 * size[i] + 1;
   }
@@ -969,7 +967,7 @@ FlatStructuringElement<VDimension>::Ball(RadiusType radius, bool radiusIsParamet
 
   // Define and set the axes lengths for the ellipsoid
   typename EllipsoidType::InputType axes;
-  for (i = 0; i < VDimension; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     if (res.GetRadiusIsParametric())
     {
@@ -984,7 +982,7 @@ FlatStructuringElement<VDimension>::Ball(RadiusType radius, bool radiusIsParamet
 
   // Define and set the center of the ellipsoid in physical space
   typename EllipsoidType::InputType center;
-  for (i = 0; i < VDimension; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     // put the center of ellipse in the middle of the center pixel
     center[i] = res.GetRadius(i) + 0.5;
@@ -999,7 +997,7 @@ FlatStructuringElement<VDimension>::Ball(RadiusType radius, bool radiusIsParamet
   spatialFunction->SetOrientations(orientations);
 
   typename ImageType::IndexType seed;
-  for (i = 0; i < VDimension; ++i)
+  for (unsigned int i = 0; i < VDimension; ++i)
   {
     seed[i] = res.GetRadius(i);
   }

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionDilateImageFilter.hxx
@@ -35,13 +35,10 @@ GrayscaleFunctionDilateImageFilter<TInputImage, TOutputImage, TKernel>::Evaluate
                                                                                  const KernelIteratorType kernelEnd)
   -> PixelType
 {
-  unsigned int i;
-  PixelType    max = NumericTraits<PixelType>::NonpositiveMin();
-  PixelType    temp;
+  PixelType max = NumericTraits<PixelType>::NonpositiveMin();
 
-  KernelIteratorType kernel_it;
-
-  for (i = 0, kernel_it = kernelBegin; kernel_it < kernelEnd; ++kernel_it, ++i)
+  KernelIteratorType kernel_it = kernelBegin;
+  for (unsigned int i = 0; kernel_it < kernelEnd; ++kernel_it, ++i)
   {
     // if structuring element is positive, use the pixel under that element
     // in the image plus the structuring element value
@@ -50,8 +47,7 @@ GrayscaleFunctionDilateImageFilter<TInputImage, TOutputImage, TKernel>::Evaluate
       // add the structuring element value to the pixel value, note we use
       // GetPixel() on SmartNeighborhoodIterator to respect boundary
       // conditions
-      temp = nit.GetPixel(i) + (PixelType)*kernel_it;
-
+      const PixelType temp = nit.GetPixel(i) + (PixelType)*kernel_it;
       if (temp > max)
       {
         max = temp;

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionErodeImageFilter.hxx
@@ -35,13 +35,11 @@ GrayscaleFunctionErodeImageFilter<TInputImage, TOutputImage, TKernel>::Evaluate(
                                                                                 const KernelIteratorType kernelEnd)
   -> PixelType
 {
-  unsigned int i;
-  PixelType    min = NumericTraits<PixelType>::max();
-  PixelType    temp;
+  PixelType min = NumericTraits<PixelType>::max();
 
-  KernelIteratorType kernel_it;
+  KernelIteratorType kernel_it = kernelBegin;
 
-  for (i = 0, kernel_it = kernelBegin; kernel_it < kernelEnd; ++kernel_it, ++i)
+  for (unsigned int i = 0; kernel_it < kernelEnd; ++kernel_it, ++i)
   {
     // if structuring element is positive, use the pixel under that element
     // in the image minus the structuring element value
@@ -50,8 +48,7 @@ GrayscaleFunctionErodeImageFilter<TInputImage, TOutputImage, TKernel>::Evaluate(
       // subtract the structuring element value to the pixel value,
       // note we use GetPixel() on SmartNeighborhoodIterator to respect
       // boundary condition
-      temp = nit.GetPixel(i) - (PixelType)*kernel_it;
-
+      const PixelType temp = nit.GetPixel(i) - (PixelType)*kernel_it;
       if (temp < min)
       {
         min = temp;

--- a/Modules/Filtering/MathematicalMorphology/include/itkRankHistogram.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRankHistogram.h
@@ -157,8 +157,8 @@ public:
   {
     const SizeValueType target = (SizeValueType)(m_Rank * (m_Entries - 1)) + 1;
     SizeValueType       total = m_Below;
-    SizeValueType       ThisBin;
-    bool                eraseFlag = false;
+
+    bool eraseFlag = false;
 
     if (total < target)
     {
@@ -171,7 +171,7 @@ public:
         // the loop. Currently makes sure that the search iterator is
         // incremented before deleting
         ++searchIt;
-        ThisBin = searchIt->second;
+        SizeValueType ThisBin = searchIt->second;
         total += ThisBin;
         if (eraseFlag)
         {
@@ -202,7 +202,7 @@ public:
 
       while (searchIt != m_Map.begin())
       {
-        ThisBin = searchIt->second;
+        SizeValueType      ThisBin = searchIt->second;
         const unsigned int tbelow = total - ThisBin;
         if (tbelow < target) // we've overshot
         {

--- a/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanUtilities.hxx
@@ -150,8 +150,8 @@ DoFace(typename TImage::ConstPointer             input,
   for (unsigned int it = 0; it < face.GetNumberOfPixels(); ++it)
   {
     const typename TImage::IndexType Ind = dumbImg->ComputeIndex(it);
-    unsigned int                     start; /*one-line-declaration*/
-    unsigned int                     end;   /*one-line-declaration*/
+    unsigned int                     start = 0; /*one-line-declaration*/
+    unsigned int                     end = 0;   /*one-line-declaration*/
     if (FillLineBuffer<TImage, TBres, TLine>(input, Ind, NormLine, tol, LineOffsets, AllImage, pixbuffer, start, end))
     {
       const unsigned int len = end - start + 1;

--- a/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest.cxx
@@ -186,16 +186,11 @@ bool
 ComputeAreaError(const SEType & k, unsigned int thickness)
 {
   float expectedOuterForegroundArea = 1;
-  float expectedInnerForegroundArea;
+  float expectedInnerForegroundArea = 1; // Annulus does have inner area to subtract.
   if (thickness == 0)
   {
     // Circle/Ellipse has no inner area to subtract.
     expectedInnerForegroundArea = 0;
-  }
-  else
-  {
-    // Annulus does have inner area to subtract.
-    expectedInnerForegroundArea = 1;
   }
   if (SEType::NeighborhoodDimension == 2)
   {

--- a/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest2.cxx
@@ -53,8 +53,8 @@ GetImage(const itk::FlatStructuringElement<VDimension> & flatElement)
   image->Allocate();
 
   ImageRegionIterator<ImageType> img_it(image, region);
-  ConstIterator                  kernel_it;
-  for (img_it.GoToBegin(), kernel_it = flatElement.Begin(); !img_it.IsAtEnd(); ++img_it, ++kernel_it)
+  ConstIterator                  kernel_it = flatElement.Begin();
+  for (img_it.GoToBegin(); !img_it.IsAtEnd(); ++img_it, ++kernel_it)
   {
     if (*kernel_it)
     {

--- a/Modules/Filtering/Path/include/itkChainCodeToFourierSeriesPathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkChainCodeToFourierSeriesPathFilter.hxx
@@ -34,13 +34,7 @@ template <typename TInputChainCodePath, typename TOutputFourierSeriesPath>
 void
 ChainCodeToFourierSeriesPathFilter<TInputChainCodePath, TOutputFourierSeriesPath>::GenerateData()
 {
-  IndexType           index;
-  VectorType          indexVector;
-  VectorType          cosCoefficient;
-  VectorType          sinCoefficient;
-  OutputPathInputType theta;
 
-  size_t       numSteps;
   unsigned int numHarmonics = m_NumberOfHarmonics; // private copy
   const int    dimension = OffsetType::GetOffsetDimension();
 
@@ -52,7 +46,7 @@ ChainCodeToFourierSeriesPathFilter<TInputChainCodePath, TOutputFourierSeriesPath
   // outputPtr->SetLargestPossibleRegion( inputPtr->GetLargestPossibleRegion() );
   // outputPtr->Allocate();  // Allocate() is an Image function
 
-  numSteps = inputPtr->NumberOfSteps();
+  const auto numSteps = inputPtr->NumberOfSteps();
   outputPtr->Clear();
 
   const double nPI = 4.0 * std::atan(1.0);
@@ -69,21 +63,23 @@ ChainCodeToFourierSeriesPathFilter<TInputChainCodePath, TOutputFourierSeriesPath
 
   for (unsigned int n = 0; n < numHarmonics; ++n)
   {
-    index = inputPtr->GetStart();
+    auto       index = inputPtr->GetStart();
+    VectorType cosCoefficient;
     cosCoefficient.Fill(0.0);
+    VectorType sinCoefficient;
     sinCoefficient.Fill(0.0);
 
     for (InputPathInputType step = 0; step < numSteps; ++step)
     {
       index += inputPtr->Evaluate(step);
-      theta = 2 * n * nPI * (static_cast<double>(step + 1)) / numSteps;
+      const auto theta = 2 * n * nPI * (static_cast<double>(step + 1)) / numSteps;
 
       // turn the current index into a vector
+      VectorType indexVector;
       for (int d = 0; d < dimension; ++d)
       {
         indexVector[d] = index[d];
       }
-
       cosCoefficient += indexVector * (std::cos(theta) / numSteps);
       sinCoefficient += indexVector * (std::sin(theta) / numSteps);
     }

--- a/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.hxx
@@ -118,33 +118,27 @@ ExtractOrthogonalSwath2DImageFilter<TImage>::GenerateData()
   using OutputIterator = ImageRegionIteratorWithIndex<ImageType>;
   using InterpolatorType = LinearInterpolateImageFunction<ImageType, itk::SpacePrecisionType>;
 
-  ImageIndexType                      index;
-  double                              orthogonalOffset;
-  PathInputType                       pathInput;
-  ContinuousIndex<SpacePrecisionType> continousIndex;
-  PathVectorType                      pathDerivative;
-
   auto interpolator = InterpolatorType::New();
   interpolator->SetInputImage(inputImagePtr);
 
   // Iterate through the output image
   for (OutputIterator outputIt(outputPtr, outputPtr->GetRequestedRegion()); !outputIt.IsAtEnd(); ++outputIt)
   {
-    index = outputIt.GetIndex();
+    ImageIndexType index = outputIt.GetIndex();
 
     // what position along the path corresponds to this column of the swath?
-    pathInput =
+    PathInputType pathInput =
       inputPathPtr->StartOfInput() + static_cast<double>(inputPathPtr->EndOfInput() - inputPathPtr->StartOfInput()) *
                                        static_cast<double>(index[0]) / static_cast<double>(m_Size[0]);
 
     // What is the orthogonal offset from the path in the input image for this
     // particular index in the output swath image?
     // Vertically centered swath pixels lie on the path in the input image.
-    orthogonalOffset = index[1] - static_cast<int>(m_Size[1] / 2); // use signed arithmetic
+    double orthogonalOffset = index[1] - static_cast<int>(m_Size[1] / 2); // use signed arithmetic
 
     // Make continuousIndex point to the source pixel in the input image
-    continousIndex = inputPathPtr->Evaluate(pathInput);
-    pathDerivative = inputPathPtr->EvaluateDerivative(pathInput);
+    ContinuousIndex<SpacePrecisionType> continousIndex = inputPathPtr->Evaluate(pathInput);
+    PathVectorType                      pathDerivative = inputPathPtr->EvaluateDerivative(pathInput);
     pathDerivative.Normalize();
     continousIndex[0] -= orthogonalOffset * pathDerivative[1];
     continousIndex[1] += orthogonalOffset * pathDerivative[0];

--- a/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.hxx
@@ -208,7 +208,7 @@ OrthogonalSwath2DPathFilter<TParametricPath, TSwathMeritImage>::FindAndStoreBest
                                                                                           unsigned int F,
                                                                                           unsigned int L)
 {
-  unsigned int bestL; // L with largest merit of L and its 2 neighbors L-1 & L+1
+  unsigned int bestL = 0; // L with largest merit of L and its 2 neighbors L-1 & L+1
 
   // Handle perimeter boundaries of the vert. gradient image
   if (L == 0)

--- a/Modules/Filtering/Path/include/itkParametricPath.hxx
+++ b/Modules/Filtering/Path/include/itkParametricPath.hxx
@@ -33,11 +33,9 @@ template <unsigned int VDimension>
 auto
 ParametricPath<VDimension>::EvaluateToIndex(const InputType & input) const -> IndexType
 {
-  ContinuousIndexType continuousIndex;
-  IndexType           index;
+  IndexType index;
 
-  continuousIndex = this->Evaluate(input);
-
+  const ContinuousIndexType continuousIndex = this->Evaluate(input);
   // Round each coordinate to the nearest integer value
   for (unsigned int i = 0; i < VDimension; ++i)
   {
@@ -51,30 +49,22 @@ template <unsigned int VDimension>
 auto
 ParametricPath<VDimension>::IncrementInput(InputType & input) const -> OffsetType
 {
-  int        iterationCount;
-  bool       tooSmall;
-  bool       tooBig;
-  InputType  inputStepSize;
-  InputType  finalInputValue;
-  OffsetType offset;
-  IndexType  currentImageIndex;
-  IndexType  nextImageIndex;
-  IndexType  finalImageIndex;
-
-  iterationCount = 0;
-  inputStepSize = m_DefaultInputStepSize;
+  int       iterationCount = 0;
+  InputType inputStepSize = m_DefaultInputStepSize;
 
   // Are we already at (or past) the end of the input?
-  finalInputValue = this->EndOfInput();
-  currentImageIndex = this->EvaluateToIndex(input);
-  finalImageIndex = this->EvaluateToIndex(finalInputValue);
-  offset = finalImageIndex - currentImageIndex;
+  InputType  finalInputValue = this->EndOfInput();
+  IndexType  currentImageIndex = this->EvaluateToIndex(input);
+  IndexType  finalImageIndex = this->EvaluateToIndex(finalInputValue);
+  OffsetType offset = finalImageIndex - currentImageIndex;
   if ((offset == this->GetZeroOffset() && Math::NotExactlyEquals(input, this->StartOfInput())) ||
       (input >= finalInputValue))
   {
     return this->GetZeroOffset();
   }
 
+  bool tooSmall = false;
+  bool tooBig = false;
   do
   {
     if (iterationCount++ > 10000)
@@ -82,7 +72,7 @@ ParametricPath<VDimension>::IncrementInput(InputType & input) const -> OffsetTyp
       itkExceptionMacro("Too many iterations");
     }
 
-    nextImageIndex = this->EvaluateToIndex(input + inputStepSize);
+    IndexType nextImageIndex = this->EvaluateToIndex(input + inputStepSize);
     offset = nextImageIndex - currentImageIndex;
 
     tooBig = false;

--- a/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
@@ -136,8 +136,6 @@ template <typename TInputPath, typename TOutputImage>
 void
 PathToImageFilter<TInputPath, TOutputImage>::GenerateData()
 {
-  unsigned int i;
-
   itkDebugMacro("PathToImageFilter::GenerateData() called");
 
   // Get the input and output pointers
@@ -148,7 +146,7 @@ PathToImageFilter<TInputPath, TOutputImage>::GenerateData()
   double   origin[OutputImageDimension];
   SizeType size;
 
-  for (i = 0; i < OutputImageDimension; ++i)
+  for (unsigned int i = 0; i < OutputImageDimension; ++i)
   {
     // Set Image size to the size of the path's bounding box
     // size[i] = (SizeValueType)
@@ -167,7 +165,7 @@ PathToImageFilter<TInputPath, TOutputImage>::GenerateData()
   // paths's bounding box will be used as default.
 
   bool specified = false;
-  for (i = 0; i < OutputImageDimension; ++i)
+  for (unsigned int i = 0; i < OutputImageDimension; ++i)
   {
     if (m_Size[i] != 0)
     {
@@ -195,7 +193,7 @@ PathToImageFilter<TInputPath, TOutputImage>::GenerateData()
   // the spatial object is used as default.
 
   specified = false;
-  for (i = 0; i < OutputImageDimension; ++i)
+  for (unsigned int i = 0; i < OutputImageDimension; ++i)
   {
     if (m_Spacing[i] != 0.0)
     {

--- a/Modules/Filtering/Path/test/itkPathToImageFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkPathToImageFilterTest.cxx
@@ -127,21 +127,11 @@ itkPathToImageFilterTest(int, char *[])
   {
     for (int j = 0; j <= 3; ++j)
     {
-      double targetValue;
-
       index[0] = 30 + i;
       index[1] = 30 + j;
 
-      if (0 < i && i < 3 && 0 < j && j < 3)
-      {
-        // Inside the closed path, but not on it
-        targetValue = 0;
-      }
-      else
-      {
-        // On the path
-        targetValue = 1;
-      }
+      //           ? 0-Inside the closed path, but not on it : 1-On the path
+      const double targetValue = (0 < i && i < 3 && 0 < j && j < 3) ? 0 : 1;
       if (itk::Math::NotAlmostEquals(image->GetPixel(index), targetValue))
       {
         std::cout << "[FAILURE]" << std::endl;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.hxx
@@ -286,15 +286,12 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::GetMeshBarycentre() -> InputP
 
   const InputPointsContainer * points = input->GetPoints();
 
-  InputPointType pt;
-  unsigned int   i;
-
   InputPointsContainerConstIterator PointIterator = points->Begin();
   while (PointIterator != points->End())
   {
-    pt = PointIterator.Value();
+    InputPointType pt = PointIterator.Value();
 
-    for (i = 0; i < PointDimension; ++i)
+    for (unsigned int i = 0; i < PointDimension; ++i)
     {
       oCenter[i] += pt[i];
     }
@@ -302,7 +299,7 @@ BorderQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::GetMeshBarycentre() -> InputP
   }
 
   const InputCoordinateType invNbOfPoints = 1.0 / static_cast<InputCoordinateType>(input->GetNumberOfPoints());
-  for (i = 0; i < PointDimension; ++i)
+  for (unsigned int i = 0; i < PointDimension; ++i)
   {
     oCenter[i] *= invNbOfPoints;
   }

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkCleanQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkCleanQuadEdgeMeshFilter.hxx
@@ -89,13 +89,11 @@ CleanQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::MergePoints(const InputCoordin
   // Copy Edge Cells
   InputCellsContainerIterator cellIt = decimatedMesh->GetEdgeCells()->Begin();
   InputCellsContainerIterator cellItEnd = decimatedMesh->GetEdgeCells()->End();
-  InputEdgeCellType *         qeCell;
-  InputQEPrimal *             qeGeometry;
 
   while (cellIt != cellItEnd)
   {
-    qeCell = dynamic_cast<InputEdgeCellType *>(cellIt.Value());
-    qeGeometry = qeCell->GetQEGeom();
+    auto qeCell = dynamic_cast<InputEdgeCellType *>(cellIt.Value());
+    auto qeGeometry = qeCell->GetQEGeom();
     output->AddEdgeWithSecurePointList(qeGeometry->GetOrigin(), qeGeometry->GetDestination());
     ++cellIt;
   }
@@ -103,11 +101,10 @@ CleanQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::MergePoints(const InputCoordin
   // Copy cells
   cellIt = decimatedMesh->GetCells()->Begin();
   cellItEnd = decimatedMesh->GetCells()->End();
-  InputPolygonCellType * polygonCell;
 
   while (cellIt != cellItEnd)
   {
-    polygonCell = dynamic_cast<InputPolygonCellType *>(cellIt.Value());
+    auto polygonCell = dynamic_cast<InputPolygonCellType *>(cellIt.Value());
     if (polygonCell)
     {
       InputPointIdList points;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDelaunayConformingQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDelaunayConformingQuadEdgeMeshFilter.hxx
@@ -34,7 +34,7 @@ DelaunayConformingQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::DelaunayConformin
 template <typename TInputMesh, typename TOutputMesh>
 DelaunayConformingQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::~DelaunayConformingQuadEdgeMeshFilter()
 {
-  OutputEdgeCellType * edge;
+  OutputEdgeCellType * edge = nullptr;
 
   while (!m_PriorityQueue->Empty())
   {
@@ -129,12 +129,6 @@ DelaunayConformingQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::Process()
   typename std::vector<OutputQEType *>           list_qe(5);
   typename std::vector<OutputQEType *>::iterator it;
 
-  OutputEdgeCellType * edge;
-  OutputQEType *       qe;
-  OutputQEType *       e_it;
-
-  CriterionValueType value;
-
   while (!m_PriorityQueue->Empty())
   {
     if (!m_PriorityQueue->Peek()->m_Priority.first)
@@ -142,8 +136,8 @@ DelaunayConformingQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::Process()
       break;
     }
 
-    edge = m_PriorityQueue->Peek()->m_Element;
-    qe = edge->GetQEGeom();
+    OutputEdgeCellType * edge = m_PriorityQueue->Peek()->m_Element;
+    OutputQEType *       qe = edge->GetQEGeom();
 
     list_qe[0] = qe->GetLnext();
     list_qe[1] = qe->GetLprev();
@@ -171,10 +165,10 @@ DelaunayConformingQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::Process()
 
       for (it = list_qe.begin(); it != list_qe.end(); ++it)
       {
-        e_it = *it;
+        OutputQEType * e_it = *it;
         if (e_it)
         {
-          value = Dyer07Criterion(output, e_it);
+          CriterionValueType value = Dyer07Criterion(output, e_it);
           if (value > 0.0)
           {
             edge = output->FindEdgeCell(e_it->GetOrigin(), e_it->GetDestination());

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.h
@@ -253,27 +253,22 @@ protected:
 
     using TriangleType = TriangleHelper<OutputPointType>;
 
-    bool                  orientation_ok(true);
-    OutputCellIdentifier  c_id(0);
-    OutputPolygonType *   poly;
-    OutputPointIdentifier p_id;
-
-    int             k(0);
+    bool            orientation_ok(true);
     int             replace_k(0);
     OutputPointType pt[3];
 
     while ((it != elements_to_be_tested.end()) && orientation_ok)
     {
-      c_id = *it;
-      poly = dynamic_cast<OutputPolygonType *>(cells->GetElement(c_id));
+      OutputCellIdentifier c_id = *it;
+      OutputPolygonType *  poly = dynamic_cast<OutputPolygonType *>(cells->GetElement(c_id));
 
       qe = poly->GetEdgeRingEntry();
       qe_it = qe;
-      k = 0;
+      int k = 0;
 
       do
       {
-        p_id = qe_it->GetOrigin();
+        OutputPointIdentifier p_id = qe_it->GetOrigin();
         if (p_id == iId)
         {
           replace_k = k;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.hxx
@@ -34,11 +34,9 @@ EdgeDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::EdgeDecimationQua
 template <typename TInput, typename TOutput, typename TCriterion>
 EdgeDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::~EdgeDecimationQuadEdgeMeshFilter()
 {
-  OutputQEType * edge;
-
   while (!m_PriorityQueue->Empty())
   {
-    edge = m_PriorityQueue->Peek()->m_Element;
+    OutputQEType * edge = m_PriorityQueue->Peek()->m_Element;
     m_PriorityQueue->Pop();
 
     auto it = m_QueueMapper.find(edge);
@@ -58,7 +56,7 @@ EdgeDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::FillPriorityQueue
   OutputCellsContainerIterator       it = output->GetEdgeCells()->Begin();
   const OutputCellsContainerIterator end = output->GetEdgeCells()->End();
 
-  OutputEdgeCellType * edge;
+  OutputEdgeCellType * edge = nullptr;
 
   // cache for use in MeasureEdge
   this->m_OutputMesh = this->GetOutput();

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.hxx
@@ -54,12 +54,11 @@ void
 NormalQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ComputeAllFaceNormals()
 {
   const OutputMeshPointer output = this->GetOutput();
-  OutputPolygonType *     poly;
 
   for (OutputCellsContainerConstIterator cell_it = output->GetCells()->Begin(); cell_it != output->GetCells()->End();
        ++cell_it)
   {
-    poly = dynamic_cast<OutputPolygonType *>(cell_it.Value());
+    OutputPolygonType * poly = dynamic_cast<OutputPolygonType *>(cell_it.Value());
 
     if (poly != nullptr)
     {
@@ -77,13 +76,12 @@ NormalQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::ComputeAllVertexNormals()
 {
   const OutputMeshPointer            output = this->GetOutput();
   const OutputPointsContainerPointer points = output->GetPoints();
-  OutputPointIdentifier              id;
 
   OutputMeshType * outputMesh = this->GetOutput();
 
   for (OutputPointsContainerIterator it = points->Begin(); it != points->End(); ++it)
   {
-    id = it->Index();
+    OutputPointIdentifier id = it->Index();
     output->SetPointData(id, ComputeVertexNormal(id, outputMesh));
   }
 }

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadricDecimationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadricDecimationQuadEdgeMeshFilter.hxx
@@ -29,19 +29,16 @@ QuadricDecimationQuadEdgeMeshFilter<TInput, TOutput, TCriterion>::Initialize()
   const OutputMeshPointer            output = this->GetOutput();
   const OutputPointsContainerPointer points = output->GetPoints();
   OutputPointsContainerIterator      it = points->Begin();
-  OutputPointIdentifier              p_id;
-  OutputQEType *                     qe;
-  OutputQEType *                     qe_it;
 
   OutputMeshType * outputMesh = this->GetOutput();
   while (it != points->End())
   {
-    p_id = it->Index();
+    OutputPointIdentifier p_id = it->Index();
 
-    qe = output->FindEdge(p_id);
+    OutputQEType * qe = output->FindEdge(p_id);
     if (qe != nullptr)
     {
-      qe_it = qe;
+      OutputQEType * qe_it = qe;
       do
       {
         QuadricAtOrigin(qe_it, m_Quadric[p_id], outputMesh);

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSmoothingQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSmoothingQuadEdgeMeshFilter.hxx
@@ -58,21 +58,6 @@ SmoothingQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
   const OutputPointsContainerPointer temp = OutputPointsContainer::New();
   temp->Reserve(numberOfPoints);
 
-  OutputPointsContainerPointer  points;
-  OutputPointsContainerIterator it;
-
-  OutputPointType  p;
-  OutputPointType  q;
-  OutputPointType  r;
-  OutputVectorType v;
-
-  OutputCoordType coeff;
-  OutputCoordType sum_coeff;
-  OutputCoordType den;
-
-  OutputQEType * qe;
-  OutputQEType * qe_it;
-
   if (this->m_DelaunayConforming)
   {
     m_InputDelaunayFilter->SetInput(this->GetInput());
@@ -102,30 +87,31 @@ SmoothingQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
 
   for (unsigned int iter = 0; iter < m_NumberOfIterations; ++iter)
   {
-    points = mesh->GetPoints();
+    OutputPointsContainerPointer points = mesh->GetPoints();
 
-    for (it = points->Begin(); it != points->End(); ++it)
+    for (OutputPointsContainerIterator it = points->Begin(); it != points->End(); ++it)
     {
-      p = it.Value();
-      qe = p.GetEdge();
+      OutputPointType p = it.Value();
+      OutputQEType *  qe = p.GetEdge();
       if (qe != nullptr)
       {
-        r = p;
+        OutputPointType  r = p;
+        OutputVectorType v;
         v.Fill(0.0);
-        qe_it = qe;
-        sum_coeff = 0.;
+        OutputQEType *  qe_it = qe;
+        OutputCoordType sum_coeff = 0.;
         do
         {
-          q = mesh->GetPoint(qe_it->GetDestination());
+          OutputPointType q = mesh->GetPoint(qe_it->GetDestination());
 
-          coeff = (*m_CoefficientsMethod)(mesh, qe_it);
+          OutputCoordType coeff = (*m_CoefficientsMethod)(mesh, qe_it);
           sum_coeff += coeff;
 
           v += coeff * (q - p);
           qe_it = qe_it->GetOnext();
         } while (qe_it != qe);
 
-        den = 1.0 / static_cast<OutputCoordType>(sum_coeff);
+        OutputCoordType den = 1.0 / static_cast<OutputCoordType>(sum_coeff);
         v *= den;
 
         r += m_RelaxationFactor * v;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkAutomaticTopologyQuadEdgeMeshSourceTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkAutomaticTopologyQuadEdgeMeshSourceTest.cxx
@@ -207,10 +207,8 @@ itkAutomaticTopologyQuadEdgeMeshSourceTest(int, char *[])
 
   // ... In more detail.
 
-  unsigned long i;
-
   std::cout << mesh->GetNumberOfPoints() << " points:" << std::endl;
-  for (i = 0; i < mesh->GetNumberOfPoints(); ++i)
+  for (MeshType::PointIdentifier i = 0; i < mesh->GetNumberOfPoints(); ++i)
   {
     PointType  point;
     const bool dummy = mesh->GetPoint(i, &point);
@@ -221,7 +219,7 @@ itkAutomaticTopologyQuadEdgeMeshSourceTest(int, char *[])
   }
 
   std::cout << '\n' << mesh->GetNumberOfCells() << " cells:" << std::endl;
-  for (i = 0; i < mesh->GetNumberOfCells(); ++i)
+  for (MeshType::CellIdentifier i = 0; i < mesh->GetNumberOfCells(); ++i)
   {
     using CellAutoPointer = MeshType::CellAutoPointer;
     CellAutoPointer cell;
@@ -241,7 +239,7 @@ itkAutomaticTopologyQuadEdgeMeshSourceTest(int, char *[])
   }
   std::cout << '\n';
 
-  for (i = 0; i < mesh->GetNumberOfCells(); ++i)
+  for (MeshType::CellIdentifier i = 0; i < mesh->GetNumberOfCells(); ++i)
   {
     using CellAutoPointer = MeshType::CellAutoPointer;
     CellAutoPointer cell;
@@ -283,7 +281,7 @@ itkAutomaticTopologyQuadEdgeMeshSourceTest(int, char *[])
 
   // Check that the right number of points has been added.
 
-  unsigned long numPoints = mesh->GetNumberOfPoints();
+  auto numPoints = mesh->GetNumberOfPoints();
   if (numPoints != 17)
   {
     std::cerr << "Mesh shows " << numPoints << " points, but 17 were added." << std::endl;
@@ -292,7 +290,7 @@ itkAutomaticTopologyQuadEdgeMeshSourceTest(int, char *[])
 
   // Check that the right number of cells has been added.
 
-  unsigned long numCells = mesh->GetNumberOfCells();
+  auto numCells = mesh->GetNumberOfCells();
   numCells += mesh->GetNumberOfEdges();
   if (numCells != 53)
   {
@@ -311,7 +309,6 @@ itkAutomaticTopologyQuadEdgeMeshSourceTest(int, char *[])
     std::cerr << "Mesh is being changed when invoking Update()" << std::endl;
     return EXIT_FAILURE;
   }
-
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkCleanQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkCleanQuadEdgeMeshFilterTest.cxx
@@ -54,7 +54,7 @@ itkCleanQuadEdgeMeshFilterTest(int argc, char * argv[])
 
   const MeshType::Pointer mesh = reader->GetOutput();
 
-  Coord             tol;
+  Coord             tol = NAN;
   std::stringstream ssout(argv[2]);
   ssout >> tol;
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkQuadricDecimationQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkQuadricDecimationQuadEdgeMeshFilterTest.cxx
@@ -60,7 +60,7 @@ itkQuadricDecimationQuadEdgeMeshFilterTest(int argc, char * argv[])
   using CriterionType = itk::NumberOfFacesCriterion<MeshType>;
   using DecimationType = itk::QuadricDecimationQuadEdgeMeshFilter<MeshType, MeshType, CriterionType>;
 
-  long              N;
+  long              N = 0;
   std::stringstream ssout(argv[2]);
   ssout >> N;
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkSmoothingQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkSmoothingQuadEdgeMeshFilterTest.cxx
@@ -48,15 +48,15 @@ itkSmoothingQuadEdgeMeshFilterTest(int argc, char * argv[])
   reader->SetFileName(argv[1]);
   ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
-  unsigned int      nb_iter;
+  unsigned int      nb_iter = 0;
   std::stringstream ssout(argv[2]);
   ssout >> nb_iter;
 
-  double            relaxation_factor;
+  double            relaxation_factor = NAN;
   std::stringstream ssout2(argv[3]);
   ssout2 >> relaxation_factor;
 
-  bool              del_conf;
+  bool              del_conf = false;
   std::stringstream ssout3(argv[4]);
   ssout3 >> del_conf;
 

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkSquaredEdgeLengthDecimationQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkSquaredEdgeLengthDecimationQuadEdgeMeshFilterTest.cxx
@@ -60,7 +60,7 @@ itkSquaredEdgeLengthDecimationQuadEdgeMeshFilterTest(int argc, char * argv[])
   using CriterionType = itk::NumberOfFacesCriterion<MeshType>;
   using DecimationType = itk::SquaredEdgeLengthDecimationQuadEdgeMeshFilter<MeshType, MeshType, CriterionType>;
 
-  long              N;
+  long              N = 0;
   std::stringstream ssout(argv[2]);
   ssout >> N;
 

--- a/Modules/Filtering/Smoothing/include/itkBoxUtilities.h
+++ b/Modules/Filtering/Smoothing/include/itkBoxUtilities.h
@@ -129,8 +129,7 @@ BoxAccumulateFunction(const TInputImage *               inputImage,
   // image being convolved so that the accumulation propagates
   // This should be implementable with neighborhood operators.
 
-  std::vector<int>                        weights;
-  typename NOutputIterator::ConstIterator sIt;
+  std::vector<int> weights;
   for (auto idxIt = noutIt.GetActiveIndexList().begin(); idxIt != noutIt.GetActiveIndexList().end(); ++idxIt)
   {
     OffsetType offset = noutIt.GetOffset(*idxIt);
@@ -149,10 +148,12 @@ BoxAccumulateFunction(const TInputImage *               inputImage,
   for (inIt.GoToBegin(), noutIt.GoToBegin(); !noutIt.IsAtEnd(); ++inIt, ++noutIt)
   {
     OutputPixelType sum = 0;
-    int             k;
-    for (k = 0, sIt = noutIt.Begin(); !sIt.IsAtEnd(); ++sIt, ++k)
     {
-      sum += sIt.Get() * weights[k];
+      typename NOutputIterator::ConstIterator sIt = noutIt.Begin();
+      for (int k = 0; !sIt.IsAtEnd(); ++sIt, ++k)
+      {
+        sum += sIt.Get() * weights[k];
+      }
     }
     noutIt.SetCenterPixel(sum + inIt.Get());
   }
@@ -601,7 +602,7 @@ BoxSquareAccumulateFunction(const TInputImage *               inputImage,
   {
     ValueType sum = 0;
     ValueType squareSum = 0;
-    int       k;
+    int       k = 0;
     for (k = 0, sIt = noutIt.Begin(); !sIt.IsAtEnd(); ++sIt, ++k)
     {
       const OutputPixelType & v = sIt.Get();

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.hxx
@@ -49,11 +49,8 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::IncrementThresholds(InstanceI
   const SizeValueType numberOfHistogramBins = histogram->Size();
   const auto          numberOfClasses = static_cast<const SizeValueType>(classMean.size());
 
-  unsigned int k;
-  int          j;
-
   // From the upper threshold down
-  for (j = static_cast<int>(m_NumberOfThresholds - 1); j >= 0; j--)
+  for (int j = static_cast<int>(m_NumberOfThresholds - 1); j >= 0; j--)
   {
     // If this threshold can be incremented (i.e. we're not at the end of the
     // histogram)
@@ -82,7 +79,7 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::IncrementThresholds(InstanceI
 
       // Set higher thresholds adjacent to their previous ones, and update mean
       // and frequency of the respective classes
-      for (k = j + 1; k < m_NumberOfThresholds; ++k)
+      for (unsigned int k = j + 1; k < m_NumberOfThresholds; ++k)
       {
         thresholdIndexes[k] = thresholdIndexes[k - 1] + 1;
         classFrequency[k] = histogram->GetFrequency(thresholdIndexes[k]);
@@ -100,7 +97,7 @@ OtsuMultipleThresholdsCalculator<TInputHistogram>::IncrementThresholds(InstanceI
       classFrequency[numberOfClasses - 1] = histogram->GetTotalFrequency();
       classMean[numberOfClasses - 1] = globalMean * histogram->GetTotalFrequency();
 
-      for (k = 0; k < numberOfClasses - 1; ++k)
+      for (unsigned int k = 0; k < numberOfClasses - 1; ++k)
       {
         classFrequency[numberOfClasses - 1] -= classFrequency[k];
         classMean[numberOfClasses - 1] -= classMean[k] * static_cast<MeanType>(classFrequency[k]);

--- a/Modules/Filtering/Thresholding/test/itkOtsuThresholdCalculatorTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuThresholdCalculatorTest.cxx
@@ -37,12 +37,11 @@ itkOtsuThresholdCalculatorTest(int, char *[])
   using CalculatorType = itk::OtsuThresholdCalculator<HistogramType>;
 
   // Allocate a simple test image
-  auto                  image = ImageType::New();
-  ImageType::RegionType region;
-
+  auto image = ImageType::New();
   // Define the image size and physical coordinates
   constexpr SizeType size = { { 20, 20, 20 } };
 
+  ImageType::RegionType region;
   region.SetSize(size);
   image->SetRegions(region);
   image->Allocate();
@@ -64,16 +63,14 @@ itkOtsuThresholdCalculatorTest(int, char *[])
   constexpr ImageType::PixelType r2 = range * 2 + 1;
 
   // Fill one half of with values of value1 +- 2
-  unsigned long i;
-
-  for (i = 0; i < numPixels / 2; ++i)
+  for (unsigned long i = 0; i < numPixels / 2; ++i)
   {
     iter.Set((i % r2) + value1 - range);
     ++iter;
   }
 
   // Fill the other half with values of value2 +- 2
-  for (i = numPixels / 2; i < numPixels; ++i)
+  for (unsigned long i = numPixels / 2; i < numPixels; ++i)
   {
     iter.Set((i % r2) + value2 - range);
     ++iter;

--- a/Modules/Filtering/Thresholding/test/itkThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkThresholdImageFilterTest.cxx
@@ -168,11 +168,10 @@ itkThresholdImageFilterTest(int, char *[])
     threshold->SetUpper(upper);
     ITK_TEST_SET_GET_VALUE(upper, threshold->GetUpper());
 
-    PixelType outputValue;
     // Above inputValue-1
     threshold->ThresholdAbove(inputValue - 1);
     threshold->Update();
-    outputValue = threshold->GetOutput()->GetPixel(index);
+    PixelType outputValue = threshold->GetOutput()->GetPixel(index);
     if (outputValue != outsideValue)
     {
       std::ostringstream os;

--- a/Modules/Filtering/Thresholding/test/itkThresholdLabelerImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkThresholdLabelerImageFilterTest.cxx
@@ -77,17 +77,19 @@ ThresholdLabelerImageFilterTestHelper(bool useRealTypeThresholds)
   labels.push_back(3 + offset);
 
   // Fill in the image
-  unsigned int                         i;
-  IndexValueVectorType::const_iterator indexIter;
-  for (indexIter = yindexes.begin(), i = 0; indexIter != yindexes.end(); ++indexIter, ++i)
   {
-    index[0] = 0;
-    index[1] = *indexIter;
-    region.SetIndex(index);
-    itk::ImageRegionIterator<InputImageType> iter(inputImage, region);
-    for (iter.GoToBegin(); !iter.IsAtEnd(); ++iter)
+    unsigned int i = 0;
+    for (IndexValueVectorType::const_iterator indexIter = yindexes.begin(); indexIter != yindexes.end();
+         ++indexIter, ++i)
     {
-      iter.Set(values[i]);
+      index[0] = 0;
+      index[1] = *indexIter;
+      region.SetIndex(index);
+      itk::ImageRegionIterator<InputImageType> iter(inputImage, region);
+      for (iter.GoToBegin(); !iter.IsAtEnd(); ++iter)
+      {
+        iter.Set(values[i]);
+      }
     }
   }
 
@@ -144,9 +146,9 @@ ThresholdLabelerImageFilterTestHelper(bool useRealTypeThresholds)
 
 
   // Check if labels coincide with expected labels
-  bool passed = true;
-
-  for (indexIter = yindexes.begin(), i = 0; indexIter != yindexes.end(); ++indexIter, ++i)
+  bool         passed = true;
+  unsigned int i = 0;
+  for (IndexValueVectorType::const_iterator indexIter = yindexes.begin(); indexIter != yindexes.end(); ++indexIter, ++i)
   {
     index[0] = 0;
     index[1] = *indexIter;

--- a/Modules/IO/BMP/src/itkBMPImageIO.cxx
+++ b/Modules/IO/BMP/src/itkBMPImageIO.cxx
@@ -82,9 +82,9 @@ BMPImageIO::CanReadFile(const char * filename)
     return false;
   }
   {
-    char magic_number1;
+    char magic_number1 = 0;
     inputStream.read((char *)&magic_number1, sizeof(char));
-    char magic_number2;
+    char magic_number2 = 0;
     inputStream.read((char *)&magic_number2, sizeof(char));
 
     if ((magic_number1 != 'B') || (magic_number2 != 'M'))
@@ -99,7 +99,7 @@ BMPImageIO::CanReadFile(const char * filename)
   constexpr size_t sizeLong = sizeof(long);
   if (sizeLong == 4)
   {
-    long tmp;
+    long tmp = 0;
     inputStream.read((char *)&tmp, 4);
     // skip 4 bytes
     inputStream.read((char *)&tmp, 4);
@@ -108,7 +108,7 @@ BMPImageIO::CanReadFile(const char * filename)
   }
   else
   {
-    int itmp; // in case we are on a 64bit machine
+    int itmp = 0; // in case we are on a 64bit machine
     inputStream.read((char *)&itmp, 4);
     // skip 4 bytes
     inputStream.read((char *)&itmp, 4);
@@ -119,7 +119,7 @@ BMPImageIO::CanReadFile(const char * filename)
   // get size of header
   if (sizeLong == 4) // if we are on a 32 bit machine
   {
-    long infoSize;
+    long infoSize = 0;
     inputStream.read((char *)&infoSize, sizeof(long));
     ByteSwapper<long>::SwapFromSystemToLittleEndian(&infoSize);
     // error checking
@@ -131,7 +131,7 @@ BMPImageIO::CanReadFile(const char * filename)
   }
   else // else we are on a 64bit machine
   {
-    int iinfoSize; // in case we are on a 64bit machine
+    int iinfoSize = 0; // in case we are on a 64bit machine
     inputStream.read((char *)&iinfoSize, 4);
     ByteSwapper<int>::SwapFromSystemToLittleEndian(&iinfoSize);
     const long infoSize = iinfoSize;
@@ -347,9 +347,9 @@ BMPImageIO::ReadImageInformation()
   this->OpenFileForReading(m_Ifstream, m_FileName);
 
   {
-    char magic_number1;
+    char magic_number1 = 0;
     m_Ifstream.read((char *)&magic_number1, sizeof(char));
-    char magic_number2;
+    char magic_number2 = 0;
     m_Ifstream.read((char *)&magic_number2, sizeof(char));
 
     if ((magic_number1 != 'B') || (magic_number2 != 'M'))
@@ -363,7 +363,7 @@ BMPImageIO::ReadImageInformation()
   constexpr size_t sizeLong = sizeof(long);
   if (sizeLong == 4)
   {
-    long tmp;
+    long tmp = 0;
     m_Ifstream.read((char *)&tmp, 4);
     // skip 4 bytes
     m_Ifstream.read((char *)&tmp, 4);
@@ -374,7 +374,7 @@ BMPImageIO::ReadImageInformation()
   }
   else
   {
-    int itmp; // in case we are on a 64bit machine
+    int itmp = 0; // in case we are on a 64bit machine
     m_Ifstream.read((char *)&itmp, 4);
     // skip 4 bytes
     m_Ifstream.read((char *)&itmp, 4);
@@ -384,9 +384,9 @@ BMPImageIO::ReadImageInformation()
     m_BitMapOffset = static_cast<long>(itmp);
   }
 
-  int  xsize;
-  int  ysize;
-  long infoSize;
+  int  xsize = 0;
+  int  ysize = 0;
+  long infoSize = 0;
   // get size of header
   if (sizeLong == 4) // if we are on a 32 bit machine
   {
@@ -409,7 +409,7 @@ BMPImageIO::ReadImageInformation()
     }
     else
     {
-      short stmp;
+      short stmp = 0;
       m_Ifstream.read((char *)&stmp, sizeof(short));
       ByteSwapper<short>::SwapFromSystemToLittleEndian(&stmp);
       xsize = stmp;
@@ -420,7 +420,7 @@ BMPImageIO::ReadImageInformation()
   }
   else // else we are on a 64bit machine
   {
-    int iinfoSize; // in case we are on a 64bit machine
+    int iinfoSize = 0; // in case we are on a 64bit machine
 
     m_Ifstream.read((char *)&iinfoSize, sizeof(int));
     ByteSwapper<int>::SwapFromSystemToLittleEndian(&iinfoSize);
@@ -469,7 +469,7 @@ BMPImageIO::ReadImageInformation()
   m_Dimensions[1] = ysize;
 
   // ignore planes
-  short stmp;
+  short stmp = 0;
   m_Ifstream.read((char *)&stmp, 2);
   // read depth
   m_Ifstream.read((char *)&m_Depth, 2);
@@ -492,7 +492,7 @@ BMPImageIO::ReadImageInformation()
       m_Ifstream.read((char *)&m_BMPDataSize, 4);
       ByteSwapper<unsigned long>::SwapFromSystemToLittleEndian(&m_BMPDataSize);
       // Horizontal Resolution
-      long tmp;
+      long tmp = 0;
       m_Ifstream.read((char *)&tmp, 4);
       // Vertical Resolution
       m_Ifstream.read((char *)&tmp, 4);
@@ -504,7 +504,7 @@ BMPImageIO::ReadImageInformation()
     }
     else
     {
-      int itmp; // in case we are on a 64bit machine
+      int itmp = 0; // in case we are on a 64bit machine
       // Compression
       m_Ifstream.read((char *)&itmp, 4);
       ByteSwapper<int>::SwapFromSystemToLittleEndian(&itmp);
@@ -551,7 +551,7 @@ BMPImageIO::ReadImageInformation()
   {
     m_ColorPaletteSize = 0;
   }
-  unsigned char uctmp;
+  unsigned char uctmp = 0;
   m_ColorPalette.resize(m_ColorPaletteSize);
   for (unsigned long i = 0; i < m_ColorPaletteSize; ++i)
   {
@@ -562,7 +562,7 @@ BMPImageIO::ReadImageInformation()
     p.SetGreen(uctmp);
     m_Ifstream.read((char *)&uctmp, 1);
     p.SetBlue(uctmp);
-    long tmp;
+    long tmp = 0;
     m_Ifstream.read((char *)&tmp, 1);
     m_ColorPalette[i] = p;
   }

--- a/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
+++ b/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
@@ -160,8 +160,9 @@ BioRadImageIO::CanReadFile(const char * filename)
   }
 
   // Check to see if its a BioRad file
-  unsigned short file_id;
   file.seekg(BIORAD_FILE_ID_OFFSET, std::ios::beg);
+
+  unsigned short file_id = 0;
   file.read((char *)(&file_id), 2);
   ByteSwapper<unsigned short>::SwapFromSystemToLittleEndian(&file_id);
 
@@ -276,7 +277,7 @@ BioRadImageIO::InternalReadImageInformation(std::ifstream & file)
     }
   }
   int          punt(0);
-  unsigned int notes;
+  unsigned int notes = 0;
   memcpy(&notes, h.notes, sizeof(notes));
   ByteSwapper<unsigned int>::SwapFromSystemToLittleEndian(&notes);
   if (notes != 0)
@@ -315,14 +316,14 @@ BioRadImageIO::InternalReadImageInformation(std::ifstream & file)
         std::istringstream ss(note_text);
         std::string        label;
         ss >> label;
-        short type;
+        short type = 0;
         ss >> type;
         if ((type & 0x00ff) != 1)
         {
           continue;
         }
-        double origin;
-        double spacing;
+        double origin = NAN;
+        double spacing = NAN;
         if (label == "AXIS_2")
         {
           ss >> origin; // skip origin

--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
@@ -237,7 +237,7 @@ ReadJCAMPDX(const std::string & filename, MetaDataDictionary & dict)
         {
           // An array of numbers
           std::stringstream   lineStream(lines);
-          double              doubleValue;
+          double              doubleValue = NAN;
           std::vector<double> doubleArray;
           while (lineStream >> doubleValue)
           {
@@ -289,7 +289,7 @@ ReadJCAMPDX(const std::string & filename, MetaDataDictionary & dict)
           {
             std::istringstream  arrayStream(lines.substr(leftBracket, rightBracket - leftBracket));
             std::vector<double> doubleArray;
-            double              doubleValue;
+            double              doubleValue = NAN;
             while (arrayStream >> doubleValue)
             {
               doubleArray.push_back(doubleValue);
@@ -311,7 +311,7 @@ ReadJCAMPDX(const std::string & filename, MetaDataDictionary & dict)
     {
       // A single value
       std::istringstream streamPar(par);
-      double             value;
+      double             value = NAN;
       streamPar >> value;
       if (streamPar.fail())
       {

--- a/Modules/IO/CSV/test/itkCSVArray2DFileReaderTest.cxx
+++ b/Modules/IO/CSV/test/itkCSVArray2DFileReaderTest.cxx
@@ -341,11 +341,8 @@ itkCSVArray2DFileReaderTest(int argc, char * argv[])
     std::cerr << exp << std::endl;
   }
 
-  double test_item;
-  double actual_item;
-
-  test_item = dfo->GetData(2, 2);
-  actual_item = 9;
+  double test_item = dfo->GetData(2, 2);
+  double actual_item = 9;
   if (!testValue(test_item, actual_item))
   {
     std::cerr << "Wrong value! Test Failed!";

--- a/Modules/IO/GE/src/itkGE4ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE4ImageIO.cxx
@@ -89,9 +89,7 @@ GE4ImageIO::ReadHeader(const char * FileNameToRead)
   // Set modality to UNKNOWN
   strcpy(hdr->modality, "UNK");
 
-  char  tmpStr[IOCommon::ITK_MAXPATHLEN + 1];
-  int   intTmp;
-  short tmpShort;
+  char tmpStr[IOCommon::ITK_MAXPATHLEN + 1];
 
   //
   // save off the name of the current file...
@@ -130,6 +128,7 @@ GE4ImageIO::ReadHeader(const char * FileNameToRead)
   /* Get the FOV from the SERIES Header */
   f.seekg(SIGNA_SEHDR_START * 2 + SIGNA_SEHDR_FOV * 2, std::ios::beg);
   IOCHECK();
+  int intTmp = 0;
   f.read((char *)&intTmp, sizeof(intTmp));
   IOCHECK();
   const float tmpFloat = MvtSunf(intTmp);
@@ -253,6 +252,7 @@ GE4ImageIO::ReadHeader(const char * FileNameToRead)
   hdr->NEX = static_cast<short>(MvtSunf(intTmp));
 
   /* Get Flip Angle from the IMAGE Header */
+  short tmpShort = 0;
   this->GetShortAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_FLIP * 2, &tmpShort);
 
   if (tmpShort > 0)

--- a/Modules/IO/GE/src/itkGE5ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE5ImageIO.cxx
@@ -200,15 +200,11 @@ GE5ImageIO::ReadHeader(const char * FileNameToRead)
   // if they don't have a header, we have to make assumptions
   // about where they start and hope we're right; below, the offset
   // is computed once the X & Y dims are known
-  bool pixelHdrFlag;
+  bool pixelHdrFlag = false;
   if (imageHdr.GENESIS_IH_img_magic == GE_5X_MAGIC_NUMBER)
   {
     pixelHdrFlag = true;
     curImage->offset = imageHdr.GENESIS_IH_img_hdr_length;
-  }
-  else
-  {
-    pixelHdrFlag = false;
   }
   strncpy(curImage->filename, FileNameToRead, IOCommon::ITK_MAXPATHLEN);
 

--- a/Modules/IO/GE/src/itkGEAdwImageIO.cxx
+++ b/Modules/IO/GE/src/itkGEAdwImageIO.cxx
@@ -57,19 +57,19 @@ GEAdwImageIO::CanReadFile(const char * FileNameToRead)
   // the size the file should be and compares it with the actual size.
   // if it's not reading a GEAdw file, chances are overwhelmingly good
   // that this operation will fail somewhere along the line.
-  short matrixX;
+  short matrixX = 0;
   if (this->GetShortAt(f, GE_ADW_IM_IMATRIX_X, &matrixX, false) != 0)
   {
     f.close();
     return false;
   }
-  short matrixY;
+  short matrixY = 0;
   if (this->GetShortAt(f, GE_ADW_IM_IMATRIX_Y, &matrixY, false) != 0)
   {
     f.close();
     return false;
   }
-  int varHdrSize;
+  int varHdrSize = 0;
   if (this->GetIntAt(f, GE_ADW_VARIABLE_HDR_LENGTH, &varHdrSize, false) != 0)
   {
     f.close();
@@ -120,7 +120,7 @@ GEAdwImageIO::ReadHeader(const char * FileNameToRead)
   this->GetStringAt(f, GE_ADW_EX_HOSPNAME, hdr->hospital, 34);
   hdr->hospital[33] = '\0';
 
-  int timeStamp;
+  int timeStamp = 0;
   this->GetIntAt(f, GE_ADW_EX_DATETIME, &timeStamp);
   this->statTimeToAscii(&timeStamp, hdr->date, sizeof(hdr->date));
 
@@ -152,7 +152,7 @@ GEAdwImageIO::ReadHeader(const char * FileNameToRead)
 
   this->GetFloatAt(f, GE_ADW_IM_PIXSIZE_Y, &hdr->imageYres);
 
-  short tmpShort;
+  short tmpShort = 0;
   this->GetShortAt(f, GE_ADW_IM_PLANE, &tmpShort);
   switch (tmpShort)
   {
@@ -179,7 +179,7 @@ GEAdwImageIO::ReadHeader(const char * FileNameToRead)
   }
   this->GetFloatAt(f, GE_ADW_IM_LOC, &(hdr->sliceLocation));
 
-  int tmpInt;
+  int tmpInt = 0;
   this->GetIntAt(f, GE_ADW_IM_TR, &tmpInt);
   hdr->TR = static_cast<float>(tmpInt) / 1000.0f;
 
@@ -193,7 +193,7 @@ GEAdwImageIO::ReadHeader(const char * FileNameToRead)
 
   this->GetShortAt(f, GE_ADW_IM_ECHONUM, &(hdr->echoNumber));
 
-  float tmpFloat;
+  float tmpFloat = NAN;
   this->GetFloatAt(f, GE_ADW_IM_NEX, &tmpFloat);
 
   hdr->NEX = static_cast<int>(tmpFloat);

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -121,7 +121,7 @@ GiplImageIO::CanReadFile(const char * filename)
     }
 
     inputStream.seekg(252);
-    unsigned int magic_number;
+    unsigned int magic_number = 0;
     inputStream.read((char *)&magic_number, static_cast<std::streamsize>(sizeof(unsigned int)));
 
     if (m_ByteOrder == IOByteOrderEnum::BigEndian)
@@ -150,7 +150,7 @@ GiplImageIO::CanReadFile(const char * filename)
     }
 
     gzseek(m_Internal->m_GzFile, 252, SEEK_SET);
-    unsigned int magic_number;
+    unsigned int magic_number = 0;
     gzread(m_Internal->m_GzFile, (char *)&magic_number, static_cast<unsigned int>(sizeof(unsigned int)));
 
     if (m_ByteOrder == IOByteOrderEnum::BigEndian)
@@ -216,7 +216,7 @@ GiplImageIO::Read(void * buffer)
     m_Ifstream.read(p, static_cast<std::streamsize>(this->GetImageSizeInBytes()));
   }
 
-  bool success;
+  bool success = false;
   if (m_IsCompressed)
   {
     if (p != nullptr)
@@ -317,7 +317,7 @@ GiplImageIO::ReadImageInformation()
     m_Dimensions[i] = dims[i];
   }
 
-  unsigned short image_type;
+  unsigned short image_type = 0;
 
   if (m_IsCompressed)
   {
@@ -426,7 +426,7 @@ GiplImageIO::ReadImageInformation()
     }
   }
 
-  char flag1; /*  186    1  Orientation flag (below)    */
+  char flag1 = 0; /*  186    1  Orientation flag (below)    */
   if (m_IsCompressed)
   {
     gzread(m_Internal->m_GzFile, (char *)&flag1, static_cast<unsigned int>(sizeof(char)));
@@ -445,7 +445,7 @@ GiplImageIO::ReadImageInformation()
     ByteSwapper<char>::SwapFromSystemToLittleEndian(&flag1);
   }
 
-  char flag2; /*  187    1                              */
+  char flag2 = 0; /*  187    1                              */
   if (m_IsCompressed)
   {
     gzread(m_Internal->m_GzFile, (char *)&flag2, static_cast<unsigned int>(sizeof(char)));
@@ -464,7 +464,7 @@ GiplImageIO::ReadImageInformation()
     ByteSwapper<char>::SwapFromSystemToLittleEndian(&flag2);
   }
 
-  double min; /*  188    8  Minimum voxel value         */
+  double min = NAN; /*  188    8  Minimum voxel value         */
   if (m_IsCompressed)
   {
     gzread(m_Internal->m_GzFile, (char *)&min, static_cast<unsigned int>(sizeof(double)));
@@ -474,7 +474,7 @@ GiplImageIO::ReadImageInformation()
     m_Ifstream.read((char *)&min, sizeof(double));
   }
 
-  double max; /*  196    8  Maximum voxel value         */
+  double max = NAN; /*  196    8  Maximum voxel value         */
   if (m_IsCompressed)
   {
     gzread(m_Internal->m_GzFile, (char *)&max, static_cast<unsigned int>(sizeof(double)));
@@ -511,7 +511,7 @@ GiplImageIO::ReadImageInformation()
     }
   }
 
-  float pixval_offset; /*  236    4                              */
+  float pixval_offset = NAN; /*  236    4                              */
   if (m_IsCompressed)
   {
     gzread(m_Internal->m_GzFile, (char *)&pixval_offset, static_cast<unsigned int>(sizeof(float)));
@@ -530,7 +530,7 @@ GiplImageIO::ReadImageInformation()
     ByteSwapper<float>::SwapFromSystemToLittleEndian(&pixval_offset);
   }
 
-  float pixval_cal; /*  240    4                              */
+  float pixval_cal = NAN; /*  240    4                              */
   if (m_IsCompressed)
   {
     gzread(m_Internal->m_GzFile, (char *)&pixval_cal, static_cast<unsigned int>(sizeof(float)));
@@ -549,7 +549,7 @@ GiplImageIO::ReadImageInformation()
     ByteSwapper<float>::SwapFromSystemToLittleEndian(&pixval_cal);
   }
 
-  float user_def1; /*  244    4  Inter-slice Gap             */
+  float user_def1 = NAN; /*  244    4  Inter-slice Gap             */
   if (m_IsCompressed)
   {
     gzread(m_Internal->m_GzFile, (char *)&user_def1, static_cast<unsigned int>(sizeof(float)));
@@ -568,7 +568,7 @@ GiplImageIO::ReadImageInformation()
     ByteSwapper<float>::SwapFromSystemToLittleEndian(&user_def1);
   }
 
-  float user_def2; /*  248    4  User defined field          */
+  float user_def2 = NAN; /*  248    4  User defined field          */
   if (m_IsCompressed)
   {
     gzread(m_Internal->m_GzFile, (char *)&user_def2, static_cast<unsigned int>(sizeof(float)));
@@ -587,7 +587,7 @@ GiplImageIO::ReadImageInformation()
     ByteSwapper<float>::SwapFromSystemToLittleEndian(&user_def2);
   }
 
-  unsigned int magic_number; /*  252    4 Magic Number                 */
+  unsigned int magic_number = 0; /*  252    4 Magic Number                 */
   if (m_IsCompressed)
   {
     gzread(m_Internal->m_GzFile, (char *)&magic_number, static_cast<unsigned int>(sizeof(unsigned int)));
@@ -722,7 +722,7 @@ GiplImageIO::Write(const void * buffer)
 
   for (unsigned int i = 0; i < 4; ++i)
   {
-    unsigned short value;
+    unsigned short value = 0;
     if (i < nDims)
     {
       value = this->GetDimensions(i);
@@ -766,7 +766,7 @@ GiplImageIO::Write(const void * buffer)
     }
   }
 
-  unsigned short image_type;
+  unsigned short image_type = 0;
   switch (m_ComponentType)
   {
     case IOComponentEnum::CHAR:

--- a/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
@@ -761,9 +761,8 @@ HDF5ImageIO::ReadImageInformation()
           // itk::Array<bool> apparently can't
           // happen because vnl_vector<bool> isn't
           // instantiated
-          bool val;
           auto tmpVal = this->ReadScalar<int>(localMetaDataName);
-          val = tmpVal != 0;
+          bool val = tmpVal != 0;
           EncapsulateMetaData<bool>(metaDict, name, val);
         }
         else if (doesAttrExist(metaDataSet, "isLong"))
@@ -792,9 +791,8 @@ HDF5ImageIO::ReadImageInformation()
           // itk::Array<bool> apparently can't
           // happen because vnl_vector<bool> isn't
           // instantiated
-          bool val;
           auto tmpVal = this->ReadScalar<int>(localMetaDataName);
-          val = tmpVal != 0;
+          bool val = tmpVal != 0;
           EncapsulateMetaData<bool>(metaDict, name, val);
         }
         else
@@ -1201,14 +1199,10 @@ HDF5ImageIO::WriteImageInformation()
         auto * constCstringObj = dynamic_cast<MetaDataObject<const char *> *>(metaObj);
         if (cstringObj != nullptr || constCstringObj != nullptr)
         {
-          const char * val;
+          const char * val = constCstringObj->GetMetaDataObjectValue();
           if (cstringObj != nullptr)
           {
             val = cstringObj->GetMetaDataObjectValue();
-          }
-          else
-          {
-            val = constCstringObj->GetMetaDataObjectValue();
           }
           this->WriteString(objName, val);
           continue;

--- a/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
+++ b/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
@@ -209,7 +209,7 @@ IPLCommonImageIO::ReadImageInformation()
     {
       continue;
     }
-    GEImageHeader * curImageHeader;
+    GEImageHeader * curImageHeader = nullptr;
     try
     {
       curImageHeader = this->ReadHeader(fullPath.c_str());
@@ -337,7 +337,7 @@ IPLCommonImageIO::GetStringAt(std::ifstream & f, std::streamoff Offset, char * b
 int
 IPLCommonImageIO::GetIntAt(std::ifstream & f, std::streamoff Offset, int * ip, bool throw_exception)
 {
-  int tmp;
+  int tmp = 0;
 
   if (this->GetStringAt(f, Offset, (char *)&tmp, sizeof(int), throw_exception) == 0)
   {
@@ -353,7 +353,7 @@ IPLCommonImageIO::GetIntAt(std::ifstream & f, std::streamoff Offset, int * ip, b
 int
 IPLCommonImageIO::GetShortAt(std::ifstream & f, std::streamoff Offset, short * ip, bool throw_exception)
 {
-  short tmp;
+  short tmp = 0;
 
   if (this->GetStringAt(f, Offset, (char *)&tmp, sizeof(short), throw_exception) == 0)
   {
@@ -369,7 +369,7 @@ IPLCommonImageIO::GetShortAt(std::ifstream & f, std::streamoff Offset, short * i
 int
 IPLCommonImageIO::GetFloatAt(std::ifstream & f, std::streamoff Offset, float * ip, bool throw_exception)
 {
-  float tmp;
+  float tmp = NAN;
 
   if (this->GetStringAt(f, Offset, (char *)&tmp, sizeof(float), throw_exception) == 0)
   {
@@ -385,7 +385,7 @@ IPLCommonImageIO::GetFloatAt(std::ifstream & f, std::streamoff Offset, float * i
 int
 IPLCommonImageIO::GetDoubleAt(std::ifstream & f, std::streamoff Offset, double * ip, bool throw_exception)
 {
-  double tmp;
+  double tmp = NAN;
 
   if (this->GetStringAt(f, Offset, (char *)&tmp, sizeof(double), throw_exception) == 0)
   {
@@ -401,7 +401,7 @@ IPLCommonImageIO::GetDoubleAt(std::ifstream & f, std::streamoff Offset, double *
 short
 IPLCommonImageIO::hdr2Short(char * hdr)
 {
-  short shortValue;
+  short shortValue = 0;
 
   memcpy(&shortValue, hdr, sizeof(short));
   ByteSwapper<short>::SwapFromSystemToBigEndian(&shortValue);
@@ -411,7 +411,7 @@ IPLCommonImageIO::hdr2Short(char * hdr)
 int
 IPLCommonImageIO::hdr2Int(char * hdr)
 {
-  int intValue;
+  int intValue = 0;
 
   memcpy(&intValue, hdr, sizeof(int));
   ByteSwapper<int>::SwapFromSystemToBigEndian(&intValue);
@@ -421,7 +421,7 @@ IPLCommonImageIO::hdr2Int(char * hdr)
 float
 IPLCommonImageIO::hdr2Float(char * hdr)
 {
-  float floatValue;
+  float floatValue = NAN;
 
   memcpy(&floatValue, hdr, 4);
   ByteSwapper<float>::SwapFromSystemToBigEndian(&floatValue);
@@ -432,7 +432,7 @@ IPLCommonImageIO::hdr2Float(char * hdr)
 double
 IPLCommonImageIO::hdr2Double(char * hdr)
 {
-  double doubleValue;
+  double doubleValue = NAN;
 
   memcpy(&doubleValue, hdr, sizeof(double));
   ByteSwapper<double>::SwapFromSystemToBigEndian(&doubleValue);
@@ -498,7 +498,7 @@ IPLCommonImageIO::statTimeToAscii(void * clock, char * timeString, int len)
 
   strncpy(timeString, asciiTime, len);
   timeString[len - 1] = '\0';
-  char * newline;
+  char * newline = nullptr;
   if ((newline = strrchr(timeString, '\n')) != nullptr || (newline = strrchr(timeString, '\r')))
   {
     *newline = '\0';

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
@@ -251,10 +251,9 @@ ImageFileWriter<TInputImage>::Write()
 
   // Determine the actual number of divisions of the input. This is determined
   // by what the ImageIO can do
-  unsigned int numDivisions;
 
   // this may fail and throw an exception if the configuration is not supported
-  numDivisions =
+  unsigned int numDivisions =
     m_ImageIO->GetActualNumberOfSplitsForWriting(m_NumberOfStreamDivisions, pasteIORegion, largestIORegion);
 
   /**

--- a/Modules/IO/ImageBase/test/itkIOCommonTest.cxx
+++ b/Modules/IO/ImageBase/test/itkIOCommonTest.cxx
@@ -28,7 +28,7 @@ CheckFileNameParsing(const std::string & fileName,
 {
   // the current kwsys way...
   std::cout << "(kwsys) Extracting...file name...";
-  char * nameOnly;
+  char * nameOnly = nullptr;
   {
     const std::string fileNameString =
       itksys::SystemTools::GetFilenameWithoutLastExtension(itksys::SystemTools::GetFilenameName(fileName));
@@ -37,7 +37,7 @@ CheckFileNameParsing(const std::string & fileName,
   }
 
   std::cout << "extension...";
-  char * extension;
+  char * extension = nullptr;
   {
     const std::string extensionString = itksys::SystemTools::GetFilenameLastExtension(fileName);
     // NB: remove the period (kwsys leaves it on, ITK precedent was to
@@ -54,7 +54,7 @@ CheckFileNameParsing(const std::string & fileName,
   }
 
   std::cout << "path...";
-  char * path;
+  char * path = nullptr;
   {
     std::string pathString = itksys::SystemTools::GetFilenamePath(fileName);
 #ifdef _WIN32
@@ -83,7 +83,7 @@ CheckFileNameParsing(const std::string & fileName,
   std::cout << "DONE" << std::endl;
 
   std::cout << "Comparing...file name...";
-  bool nameMatches;
+  bool nameMatches = false;
   if (strlen(nameOnly) == 0)
   {
     nameMatches = correctNameOnly.empty();
@@ -94,7 +94,7 @@ CheckFileNameParsing(const std::string & fileName,
   }
 
   std::cout << "extension...";
-  bool extensionMatches;
+  bool extensionMatches = false;
   if (strlen(extension) == 0)
   {
     extensionMatches = correctExtension.empty();
@@ -105,7 +105,7 @@ CheckFileNameParsing(const std::string & fileName,
   }
 
   std::cout << "path...";
-  bool pathMatches;
+  bool pathMatches = false;
   if (strlen(path) == 0)
   {
     pathMatches = correctPath.empty();

--- a/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
+++ b/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
@@ -495,15 +495,15 @@ JPEG2000ImageIO::Read(void * buffer)
 
   while (l_go_on)
   {
-    OPJ_INT32 l_current_tile_x0;
-    OPJ_INT32 l_current_tile_y0;
-    OPJ_INT32 l_current_tile_x1;
-    OPJ_INT32 l_current_tile_y1;
+    OPJ_INT32 l_current_tile_x0 = 0;
+    OPJ_INT32 l_current_tile_y0 = 0;
+    OPJ_INT32 l_current_tile_x1 = 0;
+    OPJ_INT32 l_current_tile_y1 = 0;
 
-    OPJ_UINT32 l_tile_index;
-    OPJ_UINT32 l_data_size;
+    OPJ_UINT32 l_tile_index = 0;
+    OPJ_UINT32 l_data_size = 0;
 
-    OPJ_UINT32     l_nb_comps;
+    OPJ_UINT32     l_nb_comps = 0;
     const OPJ_BOOL tileHeaderRead = opj_read_tile_header(this->m_Internal->m_Dinfo,
                                                          l_stream,
                                                          &l_tile_index,

--- a/Modules/IO/LSM/src/itkLSMImageIO.cxx
+++ b/Modules/IO/LSM/src/itkLSMImageIO.cxx
@@ -168,7 +168,7 @@ LSMImageIO::ReadImageInformation()
 
   // Now is a good time to check what was read and replaced it with LSM
   // information
-  unsigned int tif_cz_lsminfo_size;
+  unsigned int tif_cz_lsminfo_size = 0;
   void *       praw = this->TIFFImageIO::ReadRawByteFromTag(TIF_CZ_LSMINFO, tif_cz_lsminfo_size);
   auto *       zi = static_cast<zeiss_info *>(praw);
   if (praw == nullptr || tif_cz_lsminfo_size != TIF_CZ_LSMINFO_SIZE)
@@ -246,7 +246,7 @@ LSMImageIO::Write(const void * buffer)
   }
 
   const uint16_t scomponents = this->GetNumberOfComponents();
-  uint16_t       bps;
+  uint16_t       bps = 0;
   switch (this->GetComponentType())
   {
     case IOComponentEnum::UCHAR:
@@ -308,7 +308,7 @@ LSMImageIO::Write(const void * buffer)
       TIFFSetField(tif, TIFFTAG_EXTRASAMPLES, extra_samples, sample_info.get());
     }
 
-    uint16_t compression;
+    uint16_t compression = 0;
 
     if (m_UseCompression)
     {
@@ -339,7 +339,7 @@ LSMImageIO::Write(const void * buffer)
 
     uint16_t photometric = (scomponents == 1) ? PHOTOMETRIC_MINISBLACK : PHOTOMETRIC_RGB;
 
-    uint16_t predictor;
+    uint16_t predictor = 0;
     if (compression == COMPRESSION_JPEG)
     {
       TIFFSetField(tif, TIFFTAG_JPEGQUALITY, this->GetCompressionLevel()); // Parameter
@@ -373,7 +373,7 @@ LSMImageIO::Write(const void * buffer)
       TIFFSetField(tif, TIFFTAG_SUBFILETYPE, FILETYPE_PAGE);
     }
 
-    int rowLength; // in bytes
+    int rowLength = 0; // in bytes
     switch (this->GetComponentType())
     {
       case IOComponentEnum::UCHAR:

--- a/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
+++ b/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
@@ -16,6 +16,8 @@
  *
  *=========================================================================*/
 
+#include <cmath>
+
 #include "itkBYUMeshIO.h"
 
 #include "itksys/SystemTools.hxx"
@@ -97,8 +99,8 @@ BYUMeshIO::ReadMeshInformation()
   }
   else
   {
-    unsigned int firstId;
-    unsigned int lastId;
+    unsigned int firstId = 0;
+    unsigned int lastId = 0;
     for (unsigned int ii = 0; ii < m_PartId; ++ii)
     {
       inputFile >> firstId >> lastId;
@@ -136,7 +138,7 @@ BYUMeshIO::ReadMeshInformation()
   this->m_PointComponentType = IOComponentEnum::DOUBLE;
 
   // Read and omit points
-  double x;
+  double x = NAN;
   for (SizeValueType ii = 0; ii < this->m_NumberOfPoints; ++ii)
   {
     for (unsigned int jj = 0; jj < this->m_PointDimension; ++jj)
@@ -146,7 +148,7 @@ BYUMeshIO::ReadMeshInformation()
   }
 
   // Determine cellbuffersize
-  int ptId;
+  int ptId = 0;
   this->m_CellBufferSize = 0;
   SizeValueType numLines = 0;
   while (numLines < this->m_NumberOfCells)
@@ -237,7 +239,7 @@ BYUMeshIO::ReadCells(void * buffer)
   SizeValueType numPoints = 0;
   SizeValueType id{};
   SizeValueType index = 2;
-  int           ptId;
+  int           ptId = 0;
   m_FirstCellId -= 1;
   m_LastCellId -= 1;
   while (id < this->m_NumberOfCells)

--- a/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
@@ -331,15 +331,13 @@ MeshFileWriter<TInputMesh>::CopyCellsToBuffer(Output * data)
   const typename InputMeshType::CellsContainer * cells = this->GetInput()->GetCells();
 
   // Define required variables
-  const typename TInputMesh::PointIdentifier * ptIds;
-  typename TInputMesh::CellType *              cellPtr;
 
   // For each cell
   SizeValueType                                    index{};
   typename TInputMesh::CellsContainerConstIterator cter = cells->Begin();
   while (cter != cells->End())
   {
-    cellPtr = cter.Value();
+    typename TInputMesh::CellType * cellPtr = cter.Value();
 
     // Write the cell type
     switch (cellPtr->GetType())
@@ -381,8 +379,8 @@ MeshFileWriter<TInputMesh>::CopyCellsToBuffer(Output * data)
     // The second element is number of points for each cell
     data[index++] = cellPtr->GetNumberOfPoints();
     // Others are point identifiers in the cell
-    ptIds = cellPtr->GetPointIds();
-    const unsigned int numberOfPoints = cellPtr->GetNumberOfPoints();
+    const typename TInputMesh::PointIdentifier * ptIds = cellPtr->GetPointIds();
+    const unsigned int                           numberOfPoints = cellPtr->GetNumberOfPoints();
     for (unsigned int ii = 0; ii < numberOfPoints; ++ii)
     {
       data[index++] = static_cast<Output>(ptIds[ii]);

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
@@ -144,7 +144,7 @@ FreeSurferAsciiMeshIO::ReadPoints(void * buffer)
 
   // Read points
   m_InputFile.precision(12);
-  float value;
+  float value = NAN;
 
   SizeValueType index = 0;
   for (SizeValueType id = 0; id < this->m_NumberOfPoints; ++id)
@@ -165,7 +165,7 @@ FreeSurferAsciiMeshIO::ReadCells(void * buffer)
   SizeValueType          index = 0;
   constexpr unsigned int numberOfCellPoints = 3;
   const auto             data = make_unique_for_overwrite<unsigned int[]>(this->m_NumberOfCells * numberOfCellPoints);
-  float                  value;
+  float                  value = NAN;
 
   for (SizeValueType id = 0; id < this->m_NumberOfCells; ++id)
   {

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
@@ -120,10 +120,8 @@ FreeSurferBinaryMeshIO::ReadMeshInformation()
   {
     constexpr unsigned int numberOfCellPoints = 3;
     // Read input comment
-    int byte;
-
     //  Extract Comment, and ignore it.
-    byte = m_InputFile.get();
+    int byte = m_InputFile.get();
 
     std::string comment = "";
 
@@ -149,12 +147,12 @@ FreeSurferBinaryMeshIO::ReadMeshInformation()
     }
 
     // Read the number of points and number of cells
-    itk::uint32_t numberOfPoints;
+    itk::uint32_t numberOfPoints = 0;
     m_InputFile.read((char *)(&numberOfPoints), sizeof(numberOfPoints));
     itk::ByteSwapper<itk::uint32_t>::SwapFromSystemToBigEndian(&numberOfPoints);
     this->m_NumberOfPoints = static_cast<SizeValueType>(numberOfPoints);
 
-    itk::uint32_t numberOfCells;
+    itk::uint32_t numberOfCells = 0;
     m_InputFile.read((char *)(&numberOfCells), sizeof(numberOfCells));
     itk::ByteSwapper<itk::uint32_t>::SwapFromSystemToBigEndian(&numberOfCells);
     this->m_NumberOfCells = static_cast<SizeValueType>(numberOfCells);
@@ -192,18 +190,18 @@ FreeSurferBinaryMeshIO::ReadMeshInformation()
     this->m_UpdateCellData = false;
 
     // Read numberOfValuesPerPoint and numberOfPoints and numberOfCells
-    itk::uint32_t numberOfPoints;
+    itk::uint32_t numberOfPoints = 0;
     m_InputFile.read((char *)(&numberOfPoints), sizeof(numberOfPoints));
     itk::ByteSwapper<itk::uint32_t>::SwapFromSystemToBigEndian(&numberOfPoints);
     this->m_NumberOfPoints = static_cast<SizeValueType>(numberOfPoints);
     this->m_NumberOfPointPixels = this->m_NumberOfPoints;
 
-    itk::uint32_t numberOfCells;
+    itk::uint32_t numberOfCells = 0;
     m_InputFile.read((char *)(&numberOfCells), sizeof(numberOfCells));
     itk::ByteSwapper<itk::uint32_t>::SwapFromSystemToBigEndian(&numberOfCells);
     this->m_NumberOfCells = static_cast<SizeValueType>(numberOfCells);
 
-    itk::uint32_t numberOfValuesPerPoint;
+    itk::uint32_t numberOfValuesPerPoint = 0;
     m_InputFile.read((char *)(&numberOfValuesPerPoint), sizeof(numberOfValuesPerPoint));
     itk::ByteSwapper<itk::uint32_t>::SwapFromSystemToBigEndian(&numberOfValuesPerPoint);
 

--- a/Modules/IO/MeshGifti/src/itkGiftiMeshIO.cxx
+++ b/Modules/IO/MeshGifti/src/itkGiftiMeshIO.cxx
@@ -1788,8 +1788,8 @@ GiftiMeshIO::GetNumberOfPixelComponentsFromGifti(int datatype)
 {
   int numComponents = 0;
 
-  int BytePerVoxel;
-  int SwapSize;
+  int BytePerVoxel = 0;
+  int SwapSize = 0;
   nifti_datatype_sizes(datatype, &BytePerVoxel, &SwapSize);
 
   if (SwapSize == 0 && BytePerVoxel > 0)

--- a/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
+++ b/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
@@ -267,7 +267,6 @@ OBJMeshIO::ReadCells(void * buffer)
         std::vector<long> idList;
         while (ss >> item)
         {
-          long                   id;
           std::string::size_type pos = item.find('/');
           while (pos != std::string::npos)
           {
@@ -276,6 +275,7 @@ OBJMeshIO::ReadCells(void * buffer)
           }
 
           std::stringstream st(item);
+          long              id = 0;
           st >> id;
 
           idList.push_back(id);

--- a/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
+++ b/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
@@ -188,17 +188,17 @@ OFFMeshIO::ReadMeshInformation()
   else if (this->m_FileType == IOFileEnum::BINARY)
   {
     // Read the number of points
-    itk::uint32_t numberOfPoints;
+    itk::uint32_t numberOfPoints = 0;
     this->ReadBufferAsBinary(&numberOfPoints, m_InputFile, 1);
     this->m_NumberOfPoints = numberOfPoints;
 
     // Read the number of cells
-    itk::uint32_t numberOfCells;
+    itk::uint32_t numberOfCells = 0;
     this->ReadBufferAsBinary(&numberOfCells, m_InputFile, 1);
     this->m_NumberOfCells = numberOfCells;
 
     // Read number of edges
-    itk::uint32_t numberOfEdges;
+    itk::uint32_t numberOfEdges = 0;
     this->ReadBufferAsBinary(&numberOfEdges, m_InputFile, 1);
 
     // Get points start position

--- a/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
+++ b/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
@@ -388,8 +388,8 @@ VTKPolyDataMeshIO::ReadMeshInformation()
       ss >> item; // should be "VERTICES"
 
       // Get number of Points
-      unsigned int numberOfVertices;
-      unsigned int numberOfVertexIndices;
+      unsigned int numberOfVertices = 0;
+      unsigned int numberOfVertexIndices = 0;
       ss >> numberOfVertices;
       ss >> numberOfVertexIndices;
       if (this->m_ReadMeshVersionMajor >= 5)
@@ -434,8 +434,8 @@ VTKPolyDataMeshIO::ReadMeshInformation()
       ss >> item; // should be "LINES"
 
       // Get number of Polylines
-      unsigned int numberOfLines;
-      unsigned int numberOfLineIndices;
+      unsigned int numberOfLines = 0;
+      unsigned int numberOfLineIndices = 0;
       ss >> numberOfLines;
       ss >> numberOfLineIndices;
       if (this->m_ReadMeshVersionMajor >= 5)
@@ -480,8 +480,8 @@ VTKPolyDataMeshIO::ReadMeshInformation()
       ss >> item; // should be "POLYGONS"
 
       // Get number of Polygons
-      unsigned int numberOfPolygons;
-      unsigned int numberOfPolygonIndices;
+      unsigned int numberOfPolygons = 0;
+      unsigned int numberOfPolygonIndices = 0;
       ss >> numberOfPolygons;
       ss >> numberOfPolygonIndices;
       if (this->m_ReadMeshVersionMajor >= 5)
@@ -984,7 +984,7 @@ VTKPolyDataMeshIO::ReadCellsBufferAsASCII(std::ifstream & inputFile, void * buff
 {
   std::string   line;
   SizeValueType index = 0;
-  unsigned int  numPoints; // number of point in each cell
+  unsigned int  numPoints = 0; // number of point in each cell
 
   const MetaDataDictionary & metaDic = this->GetMetaDataDictionary();
   using GeometryIntegerType = unsigned int;
@@ -1225,7 +1225,7 @@ VTKPolyDataMeshIO::ReadCellsBufferAsBINARYConnectivityType(std::ifstream & input
 
   std::string                line;
   const MetaDataDictionary & metaDic = this->GetMetaDataDictionary();
-  unsigned int               numPoints; // number of point in each cell
+  unsigned int               numPoints = 0; // number of point in each cell
 
   auto * outputBuffer = static_cast<unsigned int *>(buffer);
   while (!inputFile.eof())

--- a/Modules/IO/Meta/test/testMetaMesh.cxx
+++ b/Modules/IO/Meta/test/testMetaMesh.cxx
@@ -180,10 +180,9 @@ testMetaMesh(int argc, char * argv[])
   }
 
   // Add Cells
-  MeshCell * cell;
   for (int i = 0; i < 6; ++i)
   {
-    cell = new MeshCell(4); // tetrahedra
+    MeshCell * cell = new MeshCell(4); // tetrahedra
     cell->m_Id = i;
     cell->m_PointsId[0] = i;
     cell->m_PointsId[1] = i + 1;
@@ -195,7 +194,7 @@ testMetaMesh(int argc, char * argv[])
   // Add other type of cells
   for (int i = 0; i < 4; ++i)
   {
-    cell = new MeshCell(3); // triangle
+    MeshCell * cell = new MeshCell(3); // triangle
     cell->m_Id = i;
     cell->m_PointsId[0] = i;
     cell->m_PointsId[1] = i + 1;

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -704,7 +704,7 @@ NiftiImageIO::Read(void * buffer)
     //
     // as per ITK bug 0007485
     // NIfTI is lower triangular, ITK is upper triangular.
-    int * vecOrder;
+    int * vecOrder = nullptr;
     if (this->GetPixelType() == IOPixelEnum::DIFFUSIONTENSOR3D ||
         this->GetPixelType() == IOPixelEnum::SYMMETRICSECONDRANKTENSOR)
     {
@@ -2436,7 +2436,7 @@ NiftiImageIO::Write(const void * buffer)
     // ITK stores it a b c d e f, but NIfTI is a b d c e f
     // so on read, step sequentially through the source vector, but
     // reverse the order of vec[2] and vec[3]
-    int * vecOrder;
+    int * vecOrder = nullptr;
     if (this->GetPixelType() == IOPixelEnum::DIFFUSIONTENSOR3D ||
         this->GetPixelType() == IOPixelEnum::SYMMETRICSECONDRANKTENSOR)
     {

--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -170,13 +170,13 @@ PNGImageIO::Read(void * buffer)
 
   png_read_info(png_ptr, info_ptr);
 
-  png_uint_32 width;
-  png_uint_32 height;
-  int         bitDepth;
-  int         colorType;
-  int         interlaceType;
-  int         compression_type;
-  int         filter_method;
+  png_uint_32 width = 0;
+  png_uint_32 height = 0;
+  int         bitDepth = 0;
+  int         colorType = 0;
+  int         interlaceType = 0;
+  int         compression_type = 0;
+  int         filter_method = 0;
   png_get_IHDR(
     png_ptr, info_ptr, &width, &height, &bitDepth, &colorType, &interlaceType, &compression_type, &filter_method);
 
@@ -224,7 +224,7 @@ PNGImageIO::Read(void * buffer)
 #else
   if (png_get_valid(png_ptr, info_ptr, PNG_INFO_sBIT))
   {
-    png_color_8p bits;
+    png_color_8p bits = nullptr;
     png_get_sBIT(png_ptr, info_ptr, &bits);
     png_set_shift(png_ptr, bits);
   }
@@ -365,13 +365,13 @@ PNGImageIO::ReadImageInformation()
 
   png_read_info(png_ptr, info_ptr);
 
-  png_uint_32 width;
-  png_uint_32 height;
-  int         bitDepth;
-  int         colorType;
-  int         interlaceType;
-  int         compression_type;
-  int         filter_method;
+  png_uint_32 width = 0;
+  png_uint_32 height = 0;
+  int         bitDepth = 0;
+  int         colorType = 0;
+  int         interlaceType = 0;
+  int         compression_type = 0;
+  int         filter_method = 0;
   png_get_IHDR(
     png_ptr, info_ptr, &width, &height, &bitDepth, &colorType, &interlaceType, &compression_type, &filter_method);
 
@@ -389,8 +389,8 @@ PNGImageIO::ReadImageInformation()
 
       m_IsReadAsScalarPlusPalette = true;
 
-      png_colorp palette;
-      int        num_entry;
+      png_colorp palette = nullptr;
+      int        num_entry = 0;
       png_get_PLTE(png_ptr, info_ptr, &palette, &num_entry);
 
       if (num_entry < 0)
@@ -525,7 +525,7 @@ PNGImageIO::WriteSlice(const std::string & fileName, const void * const buffer)
     throw excp;
   }
 
-  volatile int bitDepth;
+  volatile int bitDepth = 0;
   switch (this->GetComponentType())
   {
     case IOComponentEnum::UCHAR:
@@ -572,7 +572,7 @@ PNGImageIO::WriteSlice(const std::string & fileName, const void * const buffer)
                                                             << "Reason: " << itksys::SystemTools::GetLastSystemError());
   }
 
-  int                colorType;
+  int                colorType = 0;
   const unsigned int numComp = this->GetNumberOfComponents();
   switch (numComp)
   {

--- a/Modules/IO/RAW/test/itkRawImageIOTest4.cxx
+++ b/Modules/IO/RAW/test/itkRawImageIOTest4.cxx
@@ -193,11 +193,9 @@ itkRawImageIOTest4(int argc, char * argv[])
   RawImageIOReadFileTester<ImageType> readTester;
 
 
-  int status;
-
   std::cout << "Testing read of Big Endian File" << std::endl;
   bool fileIsBigEndian = true;
-  status = readTester.Read(argv[1], fileIsBigEndian, dims);
+  int  status = readTester.Read(argv[1], fileIsBigEndian, dims);
   if (status == EXIT_FAILURE)
   {
     std::cerr << "Reading Raw BigEndian FAILED !!" << std::endl;

--- a/Modules/IO/Siemens/src/itkSiemensVisionImageIO.cxx
+++ b/Modules/IO/Siemens/src/itkSiemensVisionImageIO.cxx
@@ -51,7 +51,7 @@ SiemensVisionImageIO::CanReadFile(const char * FileNameToRead)
   {
     return false;
   }
-  int matrixX;
+  int matrixX = 0;
   //
   // another lame heuristic, check the actual file size against
   // the image size suggested in header + the header size.
@@ -75,8 +75,6 @@ SiemensVisionImageIO::ReadHeader(const char * FileNameToRead)
   {
     RAISE_EXCEPTION();
   }
-  int    tmpInt;
-  double tmpDble;
 
   // #define DEBUGHEADER
 #if defined(DEBUGHEADER)
@@ -116,17 +114,17 @@ SiemensVisionImageIO::ReadHeader(const char * FileNameToRead)
   hdr->name[HDR_PAT_NAME_LEN] = '\0';
   DB(hdr->name);
 
-  int year;
+  int year = 0;
   this->GetIntAt(f, HDR_REG_YEAR, &year);
-  int month;
+  int month = 0;
   this->GetIntAt(f, HDR_REG_MONTH, &month);
-  int day;
+  int day = 0;
   this->GetIntAt(f, HDR_REG_DAY, &day);
-  int hour;
+  int hour = 0;
   this->GetIntAt(f, HDR_REG_HOUR, &hour);
-  int minute;
+  int minute = 0;
   this->GetIntAt(f, HDR_REG_MIN, &minute);
-  int second;
+  int second = 0;
   this->GetIntAt(f, HDR_REG_SEC, &second);
 
   snprintf(hdr->date, sizeof(hdr->date), "%d/%d/%d %d:%d:%d", year, month, day, hour, minute, second);
@@ -164,7 +162,7 @@ SiemensVisionImageIO::ReadHeader(const char * FileNameToRead)
   hdr->sliceGap = 0.0f;
 
   DB(hdr->sliceThickness);
-
+  int tmpInt = 0;
   this->GetIntAt(f, HDR_DISPLAY_SIZE, &tmpInt, sizeof(int));
   hdr->imageXsize = static_cast<int>(tmpInt);
   DB(hdr->imageXsize);
@@ -191,6 +189,7 @@ SiemensVisionImageIO::ReadHeader(const char * FileNameToRead)
   hdr->yFOV = static_cast<float>(std::stod(tmpStr));
   DB(hdr->yFOV);
 
+  double tmpDble = NAN;
   this->GetDoubleAt(f, HDR_PIXELSIZE_ROW, &tmpDble, sizeof(double));
   hdr->imageXres = static_cast<float>(tmpDble);
   DB(hdr->imageXres);

--- a/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
+++ b/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
@@ -115,9 +115,10 @@ PolygonGroupSpatialObjectXMLFileReader::EndElement(const char * name)
   {
     double       pval[3];
     const char * s = m_CurCharacterData.c_str();
-    char *       endptr;
+
     for (double & i : pval)
     {
+      char * endptr = nullptr;
       i = strtod(s, &endptr);
       if (s == endptr)
       {

--- a/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
+++ b/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
@@ -220,7 +220,7 @@ StimulateImageIO::InternalReadImageInformation(std::ifstream & file)
 
     if (text.find("numDim") < text.length())
     {
-      unsigned int dim;
+      unsigned int dim = 0;
       sscanf(line, "%*s %u", &dim);
       this->SetNumberOfDimensions(dim);
     }

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -119,9 +119,9 @@ TIFFImageIO::GetFormat()
         {
           for (uint64_t cc = 0; cc < m_TotalColors; ++cc)
           {
-            uint16_t red;
-            uint16_t green;
-            uint16_t blue;
+            uint16_t red = 0;
+            uint16_t green = 0;
+            uint16_t blue = 0;
             this->GetColor(cc, &red, &green, &blue);
             if (red != green || red != blue)
             {
@@ -307,9 +307,9 @@ TIFFImageIO::InitializeColors()
     return;
   }
 
-  unsigned short * red_orig;
-  unsigned short * green_orig;
-  unsigned short * blue_orig;
+  unsigned short * red_orig = nullptr;
+  unsigned short * green_orig = nullptr;
+  unsigned short * blue_orig = nullptr;
   if (!TIFFGetField(m_InternalImage->m_Image, TIFFTAG_COLORMAP, &red_orig, &green_orig, &blue_orig))
   {
     return;
@@ -476,9 +476,9 @@ TIFFImageIO::ReadImageInformation()
     // detect if palette appears to be 8-bit or 16-bit
     for (uint64_t cc = 0; cc < m_TotalColors; ++cc)
     {
-      uint16_t red;
-      uint16_t green;
-      uint16_t blue;
+      uint16_t red = 0;
+      uint16_t green = 0;
+      uint16_t blue = 0;
       this->GetColor(cc, &red, &green, &blue);
       if (red > 255 || green > 255 || blue > 255)
       {
@@ -593,7 +593,7 @@ TIFFImageIO::InternalWrite(const void * buffer)
   // rowsperstrip is set to a default value but modified based on the tif scanlinesize before
   // passing it into the TIFFSetField (see below).
   uint32_t rowsperstrip{ 0 };
-  uint16_t bps;
+  uint16_t bps = 0;
 
   switch (this->GetComponentType())
   {
@@ -616,7 +616,7 @@ TIFFImageIO::InternalWrite(const void * buffer)
       itkExceptionMacro("TIFF supports unsigned/signed char, unsigned/signed short, and float");
   }
 
-  uint16_t predictor;
+  uint16_t predictor = 0;
 
   const char * mode = "w";
 
@@ -693,7 +693,7 @@ TIFFImageIO::InternalWrite(const void * buffer)
       TIFFSetField(tif, TIFFTAG_EXTRASAMPLES, extra_samples, sample_info.get());
     }
 
-    uint16_t compression;
+    uint16_t compression = 0;
 
     if (m_UseCompression)
     {
@@ -807,7 +807,7 @@ TIFFImageIO::InternalWrite(const void * buffer)
       // Set the page number
       TIFFSetField(tif, TIFFTAG_PAGENUMBER, page, pages);
     }
-    SizeValueType rowLength; // in bytes
+    SizeValueType rowLength = 0; // in bytes
 
     switch (this->GetComponentType())
     {
@@ -947,13 +947,13 @@ TIFFImageIO::ReadRawByteFromTag(unsigned int t, unsigned int & value_count)
   int ret = 0;
   if (TIFFFieldReadCount(fld) == TIFF_VARIABLE2)
   {
-    uint32_t cnt;
+    uint32_t cnt = 0;
     ret = TIFFGetField(m_InternalImage->m_Image, tag, &cnt, &raw_data);
     value_count = cnt;
   }
   else if (TIFFFieldReadCount(fld) == TIFF_VARIABLE)
   {
-    uint16_t cnt;
+    uint16_t cnt = 0;
     ret = TIFFGetField(m_InternalImage->m_Image, tag, &cnt, &raw_data);
     value_count = cnt;
   }
@@ -982,9 +982,9 @@ TIFFImageIO::PopulateColorPalette()
     m_ColorPalette.resize(m_TotalColors);
     for (uint64_t cc = 0; cc < m_TotalColors; ++cc)
     {
-      uint16_t red;
-      uint16_t green;
-      uint16_t blue;
+      uint16_t red = 0;
+      uint16_t green = 0;
+      uint16_t blue = 0;
       this->GetColor(cc, &red, &green, &blue);
 
       RGBPixelType p;
@@ -1102,7 +1102,7 @@ TIFFImageIO::ReadTIFFTags()
     {
       if (read_count == TIFF_VARIABLE2)
       {
-        uint32_t cnt;
+        uint32_t cnt = 0;
         if (TIFFGetField(m_InternalImage->m_Image, tag, &cnt, &raw_data) != 1)
         {
           continue;
@@ -1111,7 +1111,7 @@ TIFFImageIO::ReadTIFFTags()
       }
       else if (read_count == TIFF_VARIABLE)
       {
-        uint16_t cnt;
+        uint16_t cnt = 0;
         if (TIFFGetField(m_InternalImage->m_Image, tag, &cnt, &raw_data) != 1)
         {
           continue;
@@ -1335,12 +1335,11 @@ TIFFImageIO::ReadGenericImage(void * _out, unsigned int width, unsigned int heig
   tsize_t isize = TIFFScanlineSize(m_InternalImage->m_Image);
 #endif
 
-  size_t  inc;
+  size_t  inc = 0;
   tdata_t buf = _TIFFmalloc(static_cast<tmsize_t>(isize));
   isize /= sizeof(ComponentType);
 
-  auto *          out = static_cast<ComponentType *>(_out);
-  ComponentType * image;
+  auto * out = static_cast<ComponentType *>(_out);
 
   if (m_InternalImage->m_PlanarConfig != PLANARCONFIG_CONTIG && m_InternalImage->m_SamplesPerPixel != 1)
   {
@@ -1385,7 +1384,7 @@ TIFFImageIO::ReadGenericImage(void * _out, unsigned int width, unsigned int heig
     {
       itkExceptionMacro("Problem reading the row: " << row);
     }
-
+    ComponentType * image = nullptr;
     if (m_InternalImage->m_Orientation == ORIENTATION_TOPLEFT)
     {
       image = out + inc * row * width;

--- a/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
+++ b/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
@@ -175,7 +175,7 @@ HDF5TransformIOTemplate<TParametersValueType>::ReadParameters(const std::string 
   {
     itkExceptionMacro("Wrong # of dims for TransformType in HDF5 File");
   }
-  hsize_t dim;
+  hsize_t dim = 0;
   Space.getSimpleExtentDims(&dim, nullptr);
   ParametersType ParameterArray;
   ParameterArray.SetSize(dim);
@@ -221,7 +221,7 @@ HDF5TransformIOTemplate<TParametersValueType>::ReadFixedParameters(const std::st
   {
     itkExceptionMacro("Wrong # of dims for TransformType in HDF5 File");
   }
-  hsize_t dim;
+  hsize_t dim = 0;
   Space.getSimpleExtentDims(&dim, nullptr);
   FixedParametersType FixedParameterArray;
 

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -856,14 +856,13 @@ VTKImageIO::WriteSymmetricTensorBufferAsBinary(std::ostream &                 os
 {
   std::streamsize bytesRemaining = num;
   const SizeType  componentSize = this->GetComponentSize();
-  SizeType        pixelSize;
   constexpr char  zero[1024]{};
 
   switch (this->GetNumberOfComponents())
   {
     case 3:
     {
-      pixelSize = componentSize * 3;
+      SizeType pixelSize = componentSize * 3;
       while (bytesRemaining)
       {
         // row 1
@@ -883,7 +882,7 @@ VTKImageIO::WriteSymmetricTensorBufferAsBinary(std::ostream &                 os
     }
     case 6:
     {
-      pixelSize = componentSize * 6;
+      SizeType pixelSize = componentSize * 6;
       while (bytesRemaining)
       {
         // row 1

--- a/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.hxx
@@ -196,22 +196,6 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
   CellIterator cellIterator = inputMesh->GetCells()->Begin();
   CellIterator cellEnd = inputMesh->GetCells()->End();
 
-  PointIdentifier ptIdA;
-  PointIdentifier ptIdB;
-  PointIdentifier ptIdC;
-
-  double cosABC;
-  double cosBCA;
-  double cosCAB;
-
-  double sinABC;
-  double sinBCA;
-  double sinCAB;
-
-  double cotgABC;
-  double cotgBCA;
-  double cotgCAB;
-
   while (cellIterator != cellEnd)
   {
     CellType *   aCell = cellIterator.Value();
@@ -241,13 +225,13 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
 
     pointIditer = aCell->PointIdsBegin();
 
-    ptIdA = *pointIditer;
+    PointIdentifier ptIdA = *pointIditer;
     ++pointIditer;
 
-    ptIdB = *pointIditer;
+    PointIdentifier ptIdB = *pointIditer;
     ++pointIditer;
 
-    ptIdC = *pointIditer;
+    PointIdentifier ptIdC = *pointIditer;
 
     inputMesh->GetPoint(ptIdA, &ptA);
     inputMesh->GetPoint(ptIdB, &ptB);
@@ -292,9 +276,9 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
     double prodBCCA = BC[0] * CA[0] + BC[1] * CA[1] + BC[2] * CA[2];
     prodCAAB = CA[0] * AB[0] + CA[1] * AB[1] + CA[2] * AB[2];
 
-    cosABC = -prodABBC / (normAB * normBC);
-    cosBCA = -prodBCCA / (normBC * normCA);
-    cosCAB = -prodCAAB / (normCA * normAB);
+    const double cosABC = -prodABBC / (normAB * normBC);
+    const double cosBCA = -prodBCCA / (normBC * normCA);
+    const double cosCAB = -prodCAAB / (normCA * normAB);
 
     if (cosABC <= -1.0 || cosABC >= 1.0)
     {
@@ -311,9 +295,9 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
       itkExceptionMacro("cosCAB= " << cosCAB);
     }
 
-    sinABC = std::sqrt(1.0 - cosABC * cosABC);
-    sinBCA = std::sqrt(1.0 - cosBCA * cosBCA);
-    sinCAB = std::sqrt(1.0 - cosCAB * cosCAB);
+    const double sinABC = std::sqrt(1.0 - cosABC * cosABC);
+    const double sinBCA = std::sqrt(1.0 - cosBCA * cosBCA);
+    const double sinCAB = std::sqrt(1.0 - cosCAB * cosCAB);
 
     if (sinABC < 1e-10)
     {
@@ -330,9 +314,9 @@ ConformalFlatteningMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
       itkExceptionMacro("sinCAB= " << sinCAB);
     }
 
-    cotgABC = cosABC / sinABC;
-    cotgBCA = cosBCA / sinBCA;
-    cotgCAB = cosCAB / sinCAB;
+    const double cotgABC = cosABC / sinABC;
+    const double cotgBCA = cosBCA / sinBCA;
+    const double cotgCAB = cosCAB / sinCAB;
 
     D(ptIdA, ptIdA) += cotgABC + cotgBCA;
     D(ptIdA, ptIdB) -= cotgBCA;

--- a/Modules/Nonunit/Review/include/itkDirectFourierReconstructionImageToImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkDirectFourierReconstructionImageToImageFilter.hxx
@@ -177,7 +177,7 @@ DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::Genera
   InputSliceIteratorType inputIt(inputImage, inputROI);
   inputIt.SetFirstDirection(m_RDirection);      // Iterate first along r
   inputIt.SetSecondDirection(m_AlphaDirection); // then alpha (slice), and
-                                                // finally z (stack)
+  // finally z (stack)
   inputIt.GoToBegin();
 
   // Setup projection line
@@ -281,22 +281,17 @@ DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::Genera
       inputIt.NextLine();
     } // while ( !inputIt.IsAtEndOfSlice() )
 
-    double       u, v;
-    double       theta, r;
-    double       alpha;
-    unsigned int a_lo;
-
     // Resample the cartesian FFT Slice from polar lines
     for (FFTSliceIt.GoToBegin(); !FFTSliceIt.IsAtEnd(); ++FFTSliceIt)
     {
       sIdx = FFTSliceIt.GetIndex();
 
       // center on DC
-      u = static_cast<double>(sIdx[0]) - static_cast<double>(FFTSliceSize[0]) / 2;
-      v = static_cast<double>(sIdx[1]) - static_cast<double>(FFTSliceSize[1]) / 2;
+      double u = static_cast<double>(sIdx[0]) - static_cast<double>(FFTSliceSize[0]) / 2;
+      double v = static_cast<double>(sIdx[1]) - static_cast<double>(FFTSliceSize[1]) / 2;
 
       // Calculate polar radius
-      r = sqrt(u * u + v * v) / m_OverSampling;
+      double r = sqrt(u * u + v * v) / m_OverSampling;
 
       // Radial cutoff frequency
       if (r >= r_max)
@@ -305,11 +300,8 @@ DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::Genera
       }
 
       // Get polar angle - and map into [0 PI]
-      if (u == 0.0 && v == 0.0)
-      {
-        theta = 0.0;
-      }
-      else
+      double theta = 0.0;
+      if (!(u == 0.0 && v == 0.0))
       {
         theta = std::atan2(v, u);
       }
@@ -320,7 +312,7 @@ DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::Genera
       }
 
       // Convert into alpha-image indices
-      alpha = theta * alpha_size / m_PI;
+      double alpha = theta * alpha_size / m_PI;
       if (alpha >= alpha_size)
       {
         alpha -= alpha_size;
@@ -330,7 +322,7 @@ DirectFourierReconstructionImageToImageFilter<TInputImage, TOutputImage>::Genera
       FFTLineType::PixelType out;
 
       // radial BSpline / linear angle interpolation
-      a_lo = Math::Floor<unsigned int>(alpha);
+      unsigned int a_lo = Math::Floor<unsigned int>(alpha);
 
       if (a_lo < alpha_size - 1) // no date-line crossing
       {

--- a/Modules/Nonunit/Review/include/itkGridForwardWarpImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkGridForwardWarpImageFilter.hxx
@@ -62,14 +62,13 @@ GridForwardWarpImageFilter<TDisplacementField, TOutputImage>::GenerateData()
   // Bresenham line iterator
   using LineIteratorType = LineIterator<OutputImageType>;
 
-  IndexType                              index, refIndex, targetIndex;
+  IndexType                              refIndex;
+  IndexType                              targetIndex;
   ContinuousIndex<float, ImageDimension> contindex;
-  DisplacementType                       displacement;
-  bool                                   inside, targetIn;
 
   for (iter.GoToBegin(), fieldIt.GoToBegin(); !iter.IsAtEnd(); ++iter, ++fieldIt)
   {
-    index = iter.GetIndex();
+    IndexType index = iter.GetIndex();
 
     unsigned int numGridIntersect = 0;
     for (unsigned int dim = 0; dim < ImageDimension; ++dim)
@@ -82,10 +81,10 @@ GridForwardWarpImageFilter<TDisplacementField, TOutputImage>::GenerateData()
       // We are on a grid point => transform it
 
       // Get the required displacement
-      displacement = fieldIt.Get();
+      DisplacementType displacement = fieldIt.Get();
 
       // Compute the mapped point
-      inside = true;
+      bool inside = true;
       for (unsigned int j = 0; j < ImageDimension; ++j)
       {
         contindex[j] = index[j] + displacement[j] / spacing[j];
@@ -112,7 +111,7 @@ GridForwardWarpImageFilter<TDisplacementField, TOutputImage>::GenerateData()
             displacement = fieldPtr->GetPixel(targetIndex);
 
             // Compute the mapped point
-            targetIn = true;
+            bool targetIn = true;
             for (unsigned int j = 0; j < ImageDimension; ++j)
             {
               contindex[j] = targetIndex[j] + displacement[j] / spacing[j];

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -54,7 +54,7 @@ CalculateRotationMatrix(const vnl_symmetric_eigensystem<double> & eig)
   // If it is, then the vectors do not follow the right-hand rule.  We
   // can fix this by making one of them negative.  Make the last
   // eigenvector (with smallest eigenvalue) negative.
-  float matrixDet;
+  float matrixDet = NAN;
   if constexpr (VDimension == 2)
   {
     matrixDet = vnl_det(rotationMatrix[0], rotationMatrix[1]);
@@ -521,12 +521,11 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::CalculateOrientedBoundin
   // vertices.
   unsigned int   numberOfVertices = 1 << ImageDimension;
   MatrixType     transformedBoundingBoxVertices(ImageDimension, numberOfVertices, 0);
-  int            val;
   LabelIndexType binaryIndex;
-  int            arrayIndex;
+  int            arrayIndex = 0;
   for (unsigned int i = 0; i < numberOfVertices; ++i)
   {
-    val = i;
+    int val = i;
     for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       // This is the binary index as described above.

--- a/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.hxx
@@ -120,14 +120,12 @@ typename MultiphaseDenseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, 
     FaceCalculatorType faceCalculator;
     FaceListType       faceList = faceCalculator(levelset, levelset->GetLargestPossibleRegion(), radius);
 
-    void * globalData;
-
     // Ask the function object for a pointer to a data structure it
     // will use to manage any global values it needs.  We'll pass this
     // back to the function object at each calculation and then
     // again so that the function object can use it to determine a
     // time step for this iteration.
-    globalData = df->GetGlobalDataPointer();
+    void * globalData = df->GetGlobalDataPointer();
 
     for (auto fIt = faceList.begin(); fIt != faceList.end(); ++fIt)
     {

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
@@ -426,8 +426,8 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
 {
   SparseDataStruct * sparsePtr = this->m_SparseData[this->m_CurrentFunctionIndex];
 
-  bool       bounds_status;
-  StatusType neighbor_status;
+  bool       bounds_status = false;
+  StatusType neighbor_status = 0;
 
   NeighborhoodIterator<StatusImageType> statusIt(m_NeighborList.GetRadius(),
                                                  sparsePtr->m_StatusImage,
@@ -576,7 +576,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
           if (outputIt.GetPixel(idx) < LOWER_ACTIVE_THRESHOLD ||
               itk::Math::abs(temp_value) < itk::Math::abs(outputIt.GetPixel(idx)))
           {
-            bool bounds_status;
+            bool bounds_status = false;
             UpdatePixel(this->m_CurrentFunctionIndex, idx, outputIt, temp_value, bounds_status);
           }
         }
@@ -630,7 +630,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
           if (outputIt.GetPixel(idx) >= UPPER_ACTIVE_THRESHOLD ||
               itk::Math::abs(temp_value) < itk::Math::abs(outputIt.GetPixel(idx)))
           {
-            bool bounds_status;
+            bool bounds_status = false;
             UpdatePixel(this->m_CurrentFunctionIndex, idx, outputIt, temp_value, bounds_status);
           }
         }
@@ -648,7 +648,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
     }
     else
     {
-      bool bounds_status;
+      bool bounds_status = false;
       UpdatePixel(this->m_CurrentFunctionIndex, outputIt.Size() / 2, outputIt, new_value, bounds_status);
     }
 
@@ -669,8 +669,6 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
   const ValueType  MIN_NORM = 1.0e-6;
   InputSpacingType spacing = this->m_LevelSet[0]->GetSpacing();
 
-  double temp;
-
   for (IdCellType i = 0; i < this->m_FunctionCount; ++i)
   {
     SparseDataStruct * sparsePtr = this->m_SparseData[i];
@@ -684,9 +682,9 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
     sparsePtr->m_UpdateBuffer.clear();
     sparsePtr->m_UpdateBuffer.reserve(sparsePtr->m_Layers[0]->Size());
 
-    unsigned int center; // index to active layer pixel
-    center = outputIt.Size() / 2;
-    ValueType dx, gradientMagnitude, gradientMagnitudeSqr, distance, forward, current, backward;
+    // index to active layer pixel
+    unsigned int center = outputIt.Size() / 2;
+    ValueType    dx, gradientMagnitude, gradientMagnitudeSqr, distance, forward, current, backward;
 
     // For all indices in the active layer...
     activeIt = sparsePtr->m_Layers[0]->Begin();
@@ -747,7 +745,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
     while (activeIt != sparsePtr->m_Layers[0]->End())
     {
       // Update the accumulator value using the update buffer
-      temp = static_cast<double>(sparsePtr->m_UpdateBuffer.front() - levelset->GetPixel(activeIt->m_Value));
+      double temp = static_cast<double>(sparsePtr->m_UpdateBuffer.front() - levelset->GetPixel(activeIt->m_Value));
       m_RMSSum += temp * temp;
       ++m_RMSCounter;
 
@@ -904,7 +902,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
     {
       // Set the new value using the smallest distance
       // found in our "from" neighbors.
-      bool         bounds_status;
+      bool         bounds_status = false;
       unsigned int center = outputIt.Size() / 2;
 
       UpdatePixel(sparsePtr->m_Index, center, outputIt, value, bounds_status);
@@ -1236,7 +1234,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
             // in the list
             if (statusIt.GetPixel(neighborIndex) == m_StatusNull)
             {
-              bool bounds_status;
+              bool bounds_status = false;
               statusIt.SetPixel(neighborIndex, layer_number, bounds_status);
 
               if (bounds_status) // In bounds.
@@ -1279,7 +1277,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
       unsigned int neighborIndex = m_NeighborList.GetArrayIndex(i);
       if (statusIt.GetPixel(neighborIndex) == m_StatusNull)
       {
-        bool boundary_status;
+        bool boundary_status = false;
         statusIt.SetPixel(neighborIndex, to, boundary_status);
         if (boundary_status) // in bounds
         {

--- a/Modules/Nonunit/Review/include/itkStochasticFractalDimensionImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkStochasticFractalDimensionImageFilter.hxx
@@ -113,7 +113,7 @@ StochasticFractalDimensionImageFilter<TInputImage, TMaskImage, TOutputImage>::Ge
 
       for (unsigned int i = 0; i < It.GetNeighborhood().Size(); ++i)
       {
-        bool           IsInBounds1;
+        bool           IsInBounds1 = false;
         InputPixelType pixel1 = It.GetPixel(i, IsInBounds1);
 
         if (!IsInBounds1)
@@ -133,7 +133,7 @@ StochasticFractalDimensionImageFilter<TInputImage, TMaskImage, TOutputImage>::Ge
               continue;
             }
 
-            bool           IsInBounds2;
+            bool           IsInBounds2 = false;
             InputPixelType pixel2 = It.GetPixel(j, IsInBounds2);
 
             if (!IsInBounds2)

--- a/Modules/Nonunit/Review/src/itkVoxBoCUBImageIO.cxx
+++ b/Modules/Nonunit/Review/src/itkVoxBoCUBImageIO.cxx
@@ -343,7 +343,7 @@ VoxBoCUBImageIO::CreateReader(const char * filename)
 {
   try
   {
-    bool compressed;
+    bool compressed = false;
     if (CheckExtension(filename, compressed))
     {
       if (compressed)
@@ -371,7 +371,7 @@ VoxBoCUBImageIO::CreateWriter(const char * filename)
 {
   try
   {
-    bool compressed;
+    bool compressed = false;
     if (CheckExtension(filename, compressed))
     {
       if (compressed)
@@ -442,7 +442,7 @@ VoxBoCUBImageIO::CanReadFile(const char * filename)
 bool
 VoxBoCUBImageIO::CanWriteFile(const char * name)
 {
-  bool compressed;
+  bool compressed = false;
 
   return CheckExtension(name, compressed);
 }
@@ -525,7 +525,7 @@ VoxBoCUBImageIO::ReadImageInformation()
 
       else if (key == m_VB_ORIGIN)
       {
-        double ox, oy, oz;
+        double ox = NAN, oy = NAN, oz = NAN;
         iss >> ox;
         iss >> oy;
         iss >> oz;
@@ -718,7 +718,7 @@ VoxBoCUBImageIO::WriteImageInformation()
     ExposeMetaData<std::string>(dic, key, word);
     if (!strcmp(key.c_str(), "resample_date"))
     {
-      time_t rawtime;
+      time_t rawtime = 0;
       time(&rawtime);
       word = ctime(&rawtime);
       header << key << ":\t" << word;

--- a/Modules/Nonunit/Review/test/itkOptMattesMutualInformationImageToImageMetricThreadsTest1.cxx
+++ b/Modules/Nonunit/Review/test/itkOptMattesMutualInformationImageToImageMetricThreadsTest1.cxx
@@ -104,10 +104,10 @@ itkOptMattesMutualInformationImageToImageMetricThreadsTest1(int argc, char * arg
   using MeasureType = MetricType::MeasureType;
   using DerivativeType = MetricType::DerivativeType;
 
-  MeasureType    value_combined;
+  MeasureType    value_combined = NAN;
   DerivativeType derivative_combined;
 
-  MeasureType    value_separate;
+  MeasureType    value_separate = NAN;
   DerivativeType derivative_separate;
 
   std::vector<MeasureType>    values;

--- a/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.hxx
+++ b/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.hxx
@@ -225,14 +225,11 @@ NarrowBandImageFilterBase<TInputImage, TOutputImage>::ThreadedApplyUpdate(const 
   // constexpr int INNER_MASK = 2;
   constexpr signed char INNER_MASK = 2;
 
-  typename NarrowBandType::ConstIterator  it;
   const typename OutputImageType::Pointer image = this->GetOutput();
-  typename OutputImageType::PixelType     oldvalue;
-  typename OutputImageType::PixelType     newvalue;
-  for (it = regionToProcess.first; it != regionToProcess.last; ++it)
+  for (typename NarrowBandType::ConstIterator it = regionToProcess.first; it != regionToProcess.last; ++it)
   {
-    oldvalue = image->GetPixel(it->m_Index);
-    newvalue = oldvalue + dt * it->m_Data;
+    typename OutputImageType::PixelType oldvalue = image->GetPixel(it->m_Index);
+    typename OutputImageType::PixelType newvalue = oldvalue + dt * it->m_Data;
     // Check whether solution is out the inner band or not
     m_TouchedForThread[threadId] =
       (m_TouchedForThread[threadId] || (!(it->m_NodeState & INNER_MASK) && ((oldvalue > 0) != (newvalue > 0))));
@@ -250,8 +247,6 @@ NarrowBandImageFilterBase<TInputImage, TOutputImage>::ThreadedCalculateChange(co
   using NeighborhoodIteratorType = typename FiniteDifferenceFunctionType::NeighborhoodType;
 
   const typename OutputImageType::Pointer output = this->GetOutput();
-  TimeStepType                            timeStep;
-  void *                                  globalData;
 
   // Get the FiniteDifferenceFunction to use in calculations.
   const typename FiniteDifferenceFunctionType::Pointer df = this->GetDifferenceFunction();
@@ -261,7 +256,7 @@ NarrowBandImageFilterBase<TInputImage, TOutputImage>::ThreadedCalculateChange(co
   // manage any global values it needs.  We'll pass this back to the function
   // object at each calculation so that the function object can use it to
   // determine a time step for this iteration.
-  globalData = df->GetGlobalDataPointer();
+  void * globalData = df->GetGlobalDataPointer();
 
   typename NarrowBandType::Iterator bandIt;
   NeighborhoodIteratorType          outputIt(radius, output, output->GetRequestedRegion());
@@ -275,7 +270,7 @@ NarrowBandImageFilterBase<TInputImage, TOutputImage>::ThreadedCalculateChange(co
   // Ask the finite difference function to compute the time step for
   // this iteration.  We give it the global data pointer to use, then
   // ask it to free the global data memory.
-  timeStep = df->ComputeGlobalTimeStep(globalData);
+  TimeStepType timeStep = df->ComputeGlobalTimeStep(globalData);
   df->ReleaseGlobalDataPointer(globalData);
 
   return timeStep;

--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianCostFunction.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianCostFunction.cxx
@@ -59,7 +59,7 @@ double
 CumulativeGaussianCostFunction::EvaluateCumulativeGaussian(double argument) const
 {
   // Evaluate the Cumulative Gaussian for a given argument.
-  double erfValue;
+  double erfValue = NAN;
 
   // Out of bounds of the table, but it's close to 1 or -1.
   if (argument < -3 || argument > 3)
@@ -73,9 +73,7 @@ CumulativeGaussianCostFunction::EvaluateCumulativeGaussian(double argument) cons
       erfValue = -1;
     }
   }
-
-  // Interpolation between table lookup entries.
-  else
+  else // Interpolation between table lookup entries.
   {
     // Tabulated error function evaluated for 0 to 299.
     const double y[300] = {

--- a/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
@@ -73,9 +73,9 @@ FRPROptimizer::LineOptimize(ParametersType * p, ParametersType & xi, double * va
   double ax = 0.0;
   double fa = (*val);
   double xx = this->GetStepLength();
-  double fx;
-  double bx;
-  double fb;
+  double fx = NAN;
+  double bx = NAN;
+  double fb = NAN;
 
   this->LineBracket(&ax, &xx, &bx, &fa, &fx, &fb, tempCoord);
   this->SetCurrentLinePoint(xx, fx);
@@ -114,7 +114,7 @@ FRPROptimizer::StartOptimization()
   p = this->GetInitialPosition();
   this->SetCurrentPosition(p);
 
-  double fp;
+  double fp = NAN;
   this->GetValueAndDerivative(p, &fp, &xi);
 
   for (unsigned int i = 0; i < this->GetSpaceDimension(); ++i)

--- a/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
@@ -130,14 +130,10 @@ GradientDescentOptimizer::AdvanceOneStep()
 {
   itkDebugMacro("AdvanceOneStep");
 
-  double direction;
+  double direction = -1.0;
   if (this->m_Maximize)
   {
     direction = 1.0;
-  }
-  else
-  {
-    direction = -1.0;
   }
 
   const unsigned int spaceDimension = m_CostFunction->GetNumberOfParameters();

--- a/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
@@ -75,7 +75,7 @@ PowellOptimizer::GetLineValue(double x, ParametersType & tempCoord) const
     tempCoord[i] = this->m_LineOrigin[i] + x * this->m_LineDirection[i];
   }
   itkDebugMacro("x = " << x);
-  double val;
+  double val = NAN;
   try
   {
     val = (this->m_CostFunction->GetValue(tempCoord));
@@ -445,8 +445,8 @@ PowellOptimizer::StartOptimization()
       double ax = 0.0;
       double fa = fx;
       xx = m_StepLength;
-      double bx;
-      double fb;
+      double bx = NAN;
+      double fb = NAN;
       this->LineBracket(&ax, &xx, &bx, &fa, &fx, &fb, tempCoord);
       this->BracketedLineOptimize(ax, xx, bx, fa, fx, fb, &xx, &fx, tempCoord);
       this->SetCurrentLinePoint(xx, fx);
@@ -488,8 +488,8 @@ PowellOptimizer::StartOptimization()
         double ax = 0.0;
         double fa = fx;
         xx = 1;
-        double bx;
-        double fb;
+        double bx = NAN;
+        double fb = NAN;
         this->LineBracket(&ax, &xx, &bx, &fa, &fx, &fb, tempCoord);
         this->BracketedLineOptimize(ax, xx, bx, fa, fx, fb, &xx, &fx, tempCoord);
         this->SetCurrentLinePoint(xx, fx);

--- a/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
@@ -218,14 +218,10 @@ RegularStepGradientDescentBaseOptimizer::AdvanceOneStep()
     return;
   }
 
-  double direction;
+  double direction = -1.0;
   if (this->m_Maximize)
   {
     direction = 1.0;
-  }
-  else
-  {
-    direction = -1.0;
   }
 
   const double factor = direction * m_CurrentStepLength / gradientMagnitude;

--- a/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
@@ -175,15 +175,7 @@ SPSAOptimizer::AdvanceOneStep()
   itkDebugMacro("AdvanceOneStep");
 
   // Maximize of Minimize the function?
-  double direction;
-  if (this->m_Maximize)
-  {
-    direction = 1.0;
-  }
-  else
-  {
-    direction = -1.0;
-  }
+  const double direction = (this->m_Maximize) ? 1.0 : -1.0;
 
   // The number of parameters
   const unsigned int spaceDimension = m_CostFunction->GetNumberOfParameters();

--- a/Modules/Numerics/Optimizers/src/itkSingleValuedVnlCostFunctionAdaptor.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSingleValuedVnlCostFunctionAdaptor.cxx
@@ -136,7 +136,6 @@ SingleValuedVnlCostFunctionAdaptor::compute(const InternalParametersType & x,
 {
   // delegate the computation to the CostFunction
   ParametersType parameters(x.size());
-  double         measure;
 
   if (m_ScalesInitialized)
   {
@@ -151,6 +150,7 @@ SingleValuedVnlCostFunctionAdaptor::compute(const InternalParametersType & x,
     parameters.SetDataSameSize(const_cast<double *>(x.data_block()), false);
   }
 
+  double measure = NAN;
   m_CostFunction->GetValueAndDerivative(parameters, measure, m_CachedDerivative);
   if (g) // sometimes Vnl doesn't pass a valid pointer
   {

--- a/Modules/Numerics/Optimizers/test/itkAmoebaOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkAmoebaOptimizerTest.cxx
@@ -171,15 +171,8 @@ public:
   double
   GetValue(const ParametersType & parameters) const override
   {
-    double val;
-    if (parameters[0] < 0)
-    {
-      val = parameters[0] * parameters[0] + 4 * parameters[0];
-    }
-    else
-    {
-      val = 2 * parameters[0] * parameters[0] - 8 * parameters[0];
-    }
+    const double val = (parameters[0] < 0) ? parameters[0] * parameters[0] + 4 * parameters[0]
+                                           : 2 * parameters[0] * parameters[0] - 8 * parameters[0];
     return val;
   }
 

--- a/Modules/Numerics/Optimizers/test/itkParticleSwarmOptimizerTestFunctions.h
+++ b/Modules/Numerics/Optimizers/test/itkParticleSwarmOptimizerTestFunctions.h
@@ -52,16 +52,9 @@ public:
   double
   GetValue(const ParametersType & parameters) const override
   {
-    double val;
+    const double val = (parameters[0] < 0) ? parameters[0] * parameters[0] + 4 * parameters[0]
+                                           : 2 * parameters[0] * parameters[0] - 8 * parameters[0];
 
-    if (parameters[0] < 0)
-    {
-      val = parameters[0] * parameters[0] + 4 * parameters[0];
-    }
-    else
-    {
-      val = 2 * parameters[0] * parameters[0] - 8 * parameters[0];
-    }
     return val;
   }
 

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.hxx
@@ -149,7 +149,7 @@ LBFGS2Optimizerv4Template<TInternalComputationValueType>::EvaluateCost(
 
   this->m_Gradient.SetSize(n);
   this->m_Gradient.SetData(g, n, false);
-  PrecisionType value;
+  PrecisionType value = NAN;
   this->m_Metric->GetValueAndDerivative(value, this->m_Gradient);
 
   this->ModifyGradientByScales();

--- a/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
@@ -68,7 +68,7 @@ PowellOptimizerv4<TInternalComputationValueType>::GetLineValue(double x, Paramet
   }
   this->m_Metric->SetParameters(tempCoord);
   itkDebugMacro("x = " << x);
-  double val;
+  double val = NAN;
   try
   {
     val = (this->m_Metric->GetValue());
@@ -233,42 +233,29 @@ PowellOptimizerv4<TInternalComputationValueType>::BracketedLineOptimize(double  
                                                                         double *         extVal,
                                                                         ParametersType & tempCoord)
 {
-  double x;
   double v = 0.0;
-  double w; /* Abscissae, descr. see above  */
-  double a;
-  double b;
 
-  a = (ax < cx ? ax : cx);
-  b = (ax > cx ? ax : cx);
+  double a = (ax < cx ? ax : cx);
+  double b = (ax > cx ? ax : cx);
 
-  x = bx;
-  w = bx;
+  double x = bx;
+  double w = bx; /* Abscissae, descr. see above  */
 
   const double goldenSectionRatio = (3.0 - std::sqrt(5.0)) / 2; /* Gold
                                                                  section
                                                                  ratio    */
   constexpr double POWELL_TINY = 1.0e-20;
 
-  double functionValueOfX; /* f(x)        */
-  double functionValueOfV; /* f(v)        */
-  double functionValueOfW; /* f(w)        */
-
-  functionValueOfV = functionValueOfb;
-  functionValueOfX = functionValueOfV;
-  functionValueOfW = functionValueOfV;
+  double functionValueOfV = functionValueOfb; /* f(x)        */
+  double functionValueOfX = functionValueOfV; /* f(v)        */
+  double functionValueOfW = functionValueOfV; /* f(w)        */
 
   for (m_CurrentLineIteration = 0; m_CurrentLineIteration < m_MaximumLineIteration; ++m_CurrentLineIteration)
   {
     const double middle_range = (a + b) / 2;
 
-    double new_step; /* Step at this iteration       */
-
-    double tolerance1;
-    double tolerance2;
-
-    tolerance1 = m_StepTolerance * itk::Math::abs(x) + POWELL_TINY;
-    tolerance2 = 2.0 * tolerance1;
+    double tolerance1 = m_StepTolerance * itk::Math::abs(x) + POWELL_TINY;
+    double tolerance2 = 2.0 * tolerance1;
 
     if (itk::Math::abs(x - middle_range) <= (tolerance2 - 0.5 * (b - a)) || 0.5 * (b - a) < m_StepTolerance)
     {
@@ -282,18 +269,15 @@ PowellOptimizerv4<TInternalComputationValueType>::BracketedLineOptimize(double  
     }
 
     /* Obtain the gold section step  */
-    new_step = goldenSectionRatio * (x < middle_range ? b - x : a - x);
+    double new_step = goldenSectionRatio * (x < middle_range ? b - x : a - x); /* Step at this iteration       */
 
     /* Decide if the interpolation can be tried  */
     if (itk::Math::abs(x - w) >= tolerance1) /* If x and w are distinct      */
     {
       const double t = (x - w) * (functionValueOfX - functionValueOfV);
 
-      double q; /* ted as p/q; division operation*/
-      q = (x - v) * (functionValueOfX - functionValueOfW);
-
-      double p; /* Interpolation step is calculated */
-      p = (x - v) * q - (x - w) * t;
+      double q = (x - v) * (functionValueOfX - functionValueOfW); /* ted as p/q; division operation*/
+      double p = (x - v) * q - (x - w) * t;                       /* Interpolation step is calculated */
 
       q = 2 * (q - t);
 
@@ -447,8 +431,8 @@ PowellOptimizerv4<TInternalComputationValueType>::StartOptimization(bool /* doOn
       double ax = 0.0;
       double fa = fx;
       xx = m_StepLength;
-      double bx;
-      double fb;
+      double bx = NAN;
+      double fb = NAN;
       this->LineBracket(&ax, &xx, &bx, &fa, &fx, &fb, tempCoord);
       this->BracketedLineOptimize(ax, xx, bx, fa, fx, fb, &xx, &fx, tempCoord);
       this->SetCurrentLinePoint(xx, fx);
@@ -499,8 +483,8 @@ PowellOptimizerv4<TInternalComputationValueType>::StartOptimization(bool /* doOn
         double ax = 0.0;
         double fa = fx;
         xx = 1;
-        double bx;
-        double fb;
+        double bx = NAN;
+        double fb = NAN;
         this->LineBracket(&ax, &xx, &bx, &fa, &fx, &fb, tempCoord);
         this->BracketedLineOptimize(ax, xx, bx, fa, fx, fb, &xx, &fx, tempCoord);
         this->SetCurrentLinePoint(xx, fx);

--- a/Modules/Numerics/Optimizersv4/src/itkSingleValuedVnlCostFunctionAdaptorv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkSingleValuedVnlCostFunctionAdaptorv4.cxx
@@ -111,7 +111,6 @@ SingleValuedVnlCostFunctionAdaptorv4::compute(const InternalParametersType & x,
 {
   // delegate the computation to the ObjectMetric
   ParametersType parameters(x.size());
-  double         measure;
 
   if (m_ScalesInitialized)
   {
@@ -126,6 +125,7 @@ SingleValuedVnlCostFunctionAdaptorv4::compute(const InternalParametersType & x,
   }
 
   this->m_ObjectMetric->SetParameters(parameters);
+  double measure = NAN;
   this->m_ObjectMetric->GetValueAndDerivative(measure, m_CachedDerivative);
   if (g) // sometimes Vnl doesn't pass a valid pointer
   {

--- a/Modules/Numerics/Optimizersv4/test/itkAmoebaOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAmoebaOptimizerv4Test.cxx
@@ -185,15 +185,8 @@ public:
   GetValue() const override
   {
     const double x = this->m_Parameters[0];
-    double       val;
-    if (x < 0)
-    {
-      val = x * x + 4 * x;
-    }
-    else
-    {
-      val = 2 * x * x - 8 * x;
-    }
+    const double val = (x < 0) ? x * x + 4 * x : 2 * x * x - 8 * x;
+
     return val;
   }
 

--- a/Modules/Numerics/Optimizersv4/test/itkConjugateGradientLineSearchOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkConjugateGradientLineSearchOptimizerv4Test.cxx
@@ -69,7 +69,7 @@ public:
   void
   GetDerivative(DerivativeType & derivative) const override
   {
-    MeasureType value;
+    MeasureType value = NAN;
     GetValueAndDerivative(value, derivative);
   }
 

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentLineSearchOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentLineSearchOptimizerv4Test.cxx
@@ -71,7 +71,7 @@ public:
   void
   GetDerivative(DerivativeType & derivative) const override
   {
-    MeasureType value;
+    MeasureType value = NAN;
     GetValueAndDerivative(value, derivative);
   }
 

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test.cxx
@@ -70,7 +70,7 @@ public:
   void
   GetDerivative(DerivativeType & derivative) const override
   {
-    MeasureType value;
+    MeasureType value = NAN;
     GetValueAndDerivative(value, derivative);
   }
 

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test2.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test2.cxx
@@ -65,7 +65,7 @@ public:
   void
   GetDerivative(DerivativeType & derivative) const override
   {
-    MeasureType value;
+    MeasureType value = NAN;
     GetValueAndDerivative(value, derivative);
   }
 

--- a/Modules/Numerics/Optimizersv4/test/itkRegularStepGradientDescentOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegularStepGradientDescentOptimizerv4Test.cxx
@@ -70,7 +70,7 @@ public:
   void
   GetDerivative(DerivativeType & derivative) const override
   {
-    MeasureType value;
+    MeasureType value = NAN;
     GetValueAndDerivative(value, derivative);
   }
 

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -218,12 +218,13 @@ Histogram<TMeasurement, TFrequencyContainer>::Initialize(const SizeType &       
 {
   this->Initialize(size);
 
-  float interval;
+
   for (unsigned int i = 0; i < this->GetMeasurementVectorSize(); ++i)
   {
     if (size[i] > 0)
     {
-      interval = (static_cast<float>(upperBound[i]) - static_cast<float>(lowerBound[i])) / static_cast<float>(size[i]);
+      float interval =
+        (static_cast<float>(upperBound[i]) - static_cast<float>(lowerBound[i])) / static_cast<float>(size[i]);
 
       // Set the min vector and max vector
       for (unsigned int j = 0; j < static_cast<unsigned int>(size[i] - 1); ++j)
@@ -593,8 +594,8 @@ Histogram<TMeasurement, TFrequencyContainer>::Quantile(unsigned int dimension, d
   auto   totalFrequency = static_cast<double>(this->GetTotalFrequency());
 
 
-  double f_n;
-  double p_n_prev;
+  double f_n = NAN;
+  double p_n_prev = NAN;
   if (p < 0.5)
   {
     InstanceIdentifier n = 0;

--- a/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.hxx
@@ -86,10 +86,10 @@ HistogramToTextureFeaturesFilter<THistogram>::GenerateData()
 
   // Now get the various means and variances. This is takes two passes
   // through the histogram.
-  double pixelMean;
-  double marginalMean;
-  double marginalDevSquared;
-  double pixelVariance;
+  double pixelMean = NAN;
+  double marginalMean = NAN;
+  double marginalDevSquared = NAN;
+  double pixelVariance = NAN;
 
   this->ComputeMeansAndVariances(pixelMean, marginalMean, marginalDevSquared, pixelVariance);
 

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleFilter.hxx
@@ -92,15 +92,11 @@ ImageToListSampleFilter<TImage, TMaskImage>::GetMeasurementVectorSize() const
     itkExceptionMacro("Input image has not been set yet");
   }
 
-  unsigned int measurementVectorSize;
+  unsigned int measurementVectorSize = input->GetNumberOfComponentsPerPixel();
 
   if (!MeasurementVectorTraits::IsResizable<MeasurementVectorType>({}))
   {
     measurementVectorSize = NumericTraits<MeasurementVectorType>::GetLength({});
-  }
-  else
-  {
-    measurementVectorSize = input->GetNumberOfComponentsPerPixel();
   }
 
   return measurementVectorSize;

--- a/Modules/Numerics/Statistics/include/itkKdTree.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTree.hxx
@@ -228,10 +228,6 @@ KdTree<TSample>::NearestNeighborSearchLoop(const KdTreeNodeType *        node,
                                            MeasurementVectorType &       upperBound,
                                            NearestNeighbors &            nearestNeighbors) const
 {
-  unsigned int       i;
-  InstanceIdentifier tempId;
-  double             tempDistance;
-
   if (node->IsTerminal())
   {
     // terminal node
@@ -241,10 +237,10 @@ KdTree<TSample>::NearestNeighborSearchLoop(const KdTreeNodeType *        node,
       return 0;
     }
 
-    for (i = 0; i < node->Size(); ++i)
+    for (unsigned int i = 0; i < node->Size(); ++i)
     {
-      tempId = node->GetInstanceIdentifier(i);
-      tempDistance = this->m_DistanceMetric->Evaluate(query, this->m_Sample->GetMeasurementVector(tempId));
+      InstanceIdentifier tempId = node->GetInstanceIdentifier(i);
+      double tempDistance = this->m_DistanceMetric->Evaluate(query, this->m_Sample->GetMeasurementVector(tempId));
       if (tempDistance < nearestNeighbors.GetLargestDistance())
       {
         nearestNeighbors.ReplaceFarthestNeighbor(tempId, tempDistance);
@@ -259,17 +255,16 @@ KdTree<TSample>::NearestNeighborSearchLoop(const KdTreeNodeType *        node,
     return 0;
   }
 
-  unsigned int    partitionDimension;
+  unsigned int    partitionDimension = 0;
   MeasurementType partitionValue;
-  MeasurementType tempValue;
   node->GetParameters(partitionDimension, partitionValue);
 
   //
   // Check the point associated with the nonterminal node
   // and potentially add it to the list of nearest neighbors
   //
-  tempId = node->GetInstanceIdentifier(0);
-  tempDistance = this->m_DistanceMetric->Evaluate(query, this->m_Sample->GetMeasurementVector(tempId));
+  InstanceIdentifier tempId = node->GetInstanceIdentifier(0);
+  double tempDistance = this->m_DistanceMetric->Evaluate(query, this->m_Sample->GetMeasurementVector(tempId));
   if (tempDistance < nearestNeighbors.GetLargestDistance())
   {
     nearestNeighbors.ReplaceFarthestNeighbor(tempId, tempDistance);
@@ -281,7 +276,7 @@ KdTree<TSample>::NearestNeighborSearchLoop(const KdTreeNodeType *        node,
   if (query[partitionDimension] <= partitionValue)
   {
     // search the closer child node
-    tempValue = upperBound[partitionDimension];
+    MeasurementType tempValue = upperBound[partitionDimension];
     upperBound[partitionDimension] = partitionValue;
     if (this->NearestNeighborSearchLoop(node->Left(), query, lowerBound, upperBound, nearestNeighbors))
     {
@@ -301,7 +296,7 @@ KdTree<TSample>::NearestNeighborSearchLoop(const KdTreeNodeType *        node,
   else
   {
     // search the closer child node
-    tempValue = lowerBound[partitionDimension];
+    MeasurementType tempValue = lowerBound[partitionDimension];
     lowerBound[partitionDimension] = partitionValue;
     if (this->NearestNeighborSearchLoop(node->Right(), query, lowerBound, upperBound, nearestNeighbors))
     {
@@ -360,7 +355,7 @@ KdTree<TSample>::SearchLoop(const KdTreeNodeType *         node,
                             InstanceIdentifierVectorType & neighbors) const
 {
   InstanceIdentifier tempId;
-  double             tempDistance;
+  double             tempDistance = NAN;
 
   if (node->IsTerminal())
   {
@@ -398,7 +393,7 @@ KdTree<TSample>::SearchLoop(const KdTreeNodeType *         node,
     }
   }
 
-  unsigned int    partitionDimension;
+  unsigned int    partitionDimension = 0;
   MeasurementType partitionValue;
   MeasurementType tempValue;
   node->GetParameters(partitionDimension, partitionValue);
@@ -541,7 +536,7 @@ KdTree<TSample>::PrintTree(KdTreeNodeType * node,
     return;
   }
 
-  unsigned int    partitionDimension;
+  unsigned int    partitionDimension = 0;
   MeasurementType partitionValue;
 
   node->GetParameters(partitionDimension, partitionValue);
@@ -583,7 +578,7 @@ template <typename TSample>
 void
 KdTree<TSample>::PlotTree(KdTreeNodeType * node, std::ostream & os) const
 {
-  unsigned int    partitionDimension;
+  unsigned int    partitionDimension = 0;
   MeasurementType partitionValue;
 
   node->GetParameters(partitionDimension, partitionValue);

--- a/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
@@ -66,12 +66,10 @@ double
 KdTreeBasedKmeansEstimator<TKdTree>::GetSumOfSquaredPositionChanges(InternalParametersType & previous,
                                                                     InternalParametersType & current)
 {
-  double temp;
   double sum = 0.0;
-
   for (unsigned int i = 0; i < static_cast<unsigned int>(previous.size()); ++i)
   {
-    temp = m_DistanceMetric->Evaluate(previous[i], current[i]);
+    double temp = m_DistanceMetric->Evaluate(previous[i], current[i]);
     sum += temp;
   }
   return sum;
@@ -83,12 +81,11 @@ KdTreeBasedKmeansEstimator<TKdTree>::GetClosestCandidate(ParameterType & measure
 {
   int    closest = 0;
   double closestDistance = NumericTraits<double>::max();
-  double tempDistance;
 
   auto iter = validIndexes.begin();
   while (iter != validIndexes.end())
   {
-    tempDistance = m_DistanceMetric->Evaluate(m_CandidateVector[*iter].Centroid, measurements);
+    double tempDistance = m_DistanceMetric->Evaluate(m_CandidateVector[*iter].Centroid, measurements);
     if (tempDistance < closestDistance)
     {
       closest = *iter;
@@ -203,7 +200,7 @@ KdTreeBasedKmeansEstimator<TKdTree>::Filter(KdTreeNodeType *        node,
     }
     else
     {
-      unsigned int    partitionDimension;
+      unsigned int    partitionDimension = 0;
       MeasurementType partitionValue;
       MeasurementType tempValue;
       node->GetParameters(partitionDimension, partitionValue);

--- a/Modules/Numerics/Statistics/include/itkKdTreeGenerator.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTreeGenerator.hxx
@@ -121,14 +121,8 @@ KdTreeGenerator<TSample>::GenerateNonterminalNode(unsigned int            beginI
                                                   unsigned int            level) -> KdTreeNodeType *
 {
   using NodeType = typename KdTreeType::KdTreeNodeType;
-  MeasurementType dimensionLowerBound;
-  MeasurementType dimensionUpperBound;
-  MeasurementType partitionValue;
-  unsigned int    partitionDimension = 0;
-  unsigned int    i;
-  MeasurementType spread;
-  MeasurementType maxSpread;
-  unsigned int    medianIndex;
+
+  unsigned int partitionDimension = 0;
 
   const SubsamplePointer subsample = this->GetSubsample();
 
@@ -136,10 +130,10 @@ KdTreeGenerator<TSample>::GenerateNonterminalNode(unsigned int            beginI
   Algorithm::FindSampleBoundAndMean<SubsampleType>(
     subsample, beginIndex, endIndex, m_TempLowerBound, m_TempUpperBound, m_TempMean);
 
-  maxSpread = NumericTraits<MeasurementType>::NonpositiveMin();
-  for (i = 0; i < m_MeasurementVectorSize; ++i)
+  MeasurementType maxSpread = NumericTraits<MeasurementType>::NonpositiveMin();
+  for (unsigned int i = 0; i < m_MeasurementVectorSize; ++i)
   {
-    spread = m_TempUpperBound[i] - m_TempLowerBound[i];
+    MeasurementType spread = m_TempUpperBound[i] - m_TempLowerBound[i];
     if (spread >= maxSpread)
     {
       maxSpread = spread;
@@ -147,20 +141,20 @@ KdTreeGenerator<TSample>::GenerateNonterminalNode(unsigned int            beginI
     }
   }
 
-  medianIndex = (endIndex - beginIndex) / 2;
+  unsigned int medianIndex = (endIndex - beginIndex) / 2;
 
   //
   // Find the medial element by using the NthElement function
   // based on the STL implementation of the QuickSelect algorithm.
   //
-  partitionValue =
+  MeasurementType partitionValue =
     Algorithm::NthElement<SubsampleType>(m_Subsample, partitionDimension, beginIndex, endIndex, medianIndex);
 
   medianIndex += beginIndex;
 
   // save bounds for cutting dimension
-  dimensionLowerBound = lowerBound[partitionDimension];
-  dimensionUpperBound = upperBound[partitionDimension];
+  MeasurementType dimensionLowerBound = lowerBound[partitionDimension];
+  MeasurementType dimensionUpperBound = upperBound[partitionDimension];
 
   upperBound[partitionDimension] = partitionValue;
   const unsigned int beginLeftIndex = beginIndex;

--- a/Modules/Numerics/Statistics/include/itkSampleToHistogramFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkSampleToHistogramFilter.hxx
@@ -252,17 +252,14 @@ SampleToHistogramFilter<TSample, THistogram>::GenerateData()
   typename SampleType::ConstIterator       iter = inputSample->Begin();
   const typename SampleType::ConstIterator last = inputSample->End();
 
-  typename SampleType::MeasurementVectorType lvector;
 
   typename HistogramType::IndexType             index(measurementVectorSize);
   typename HistogramType::MeasurementVectorType hvector(measurementVectorSize);
 
-  unsigned int i;
-
   while (iter != last)
   {
-    lvector = iter.GetMeasurementVector();
-    for (i = 0; i < inputSample->GetMeasurementVectorSize(); ++i)
+    typename SampleType::MeasurementVectorType lvector = iter.GetMeasurementVector();
+    for (unsigned int i = 0; i < inputSample->GetMeasurementVectorSize(); ++i)
     {
       hvector[i] = SafeAssign(lvector[i]);
     }

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.hxx
@@ -99,8 +99,6 @@ ScalarImageToCooccurrenceListSampleFilter<TImage>::GenerateData()
 
   constexpr OffsetType center_offset{};
 
-  bool isInside;
-
   for (const auto & face : faceList)
   {
     ShapedNeighborhoodIteratorType it(radius, input, face);
@@ -122,6 +120,7 @@ ScalarImageToCooccurrenceListSampleFilter<TImage>::GenerateData()
 
         // Check if the point is inside and add the measurement vector
         // only if its inside
+        bool            isInside = false;
         const PixelType pixel_intensity = it.GetPixel(ci.GetNeighborhoodIndex(), isInside);
         if (isInside)
         {

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.hxx
@@ -212,7 +212,7 @@ ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, 
     typename HistogramType::IndexType    index;
     for (offsets = m_Offsets->Begin(); offsets != m_Offsets->End(); ++offsets)
     {
-      bool            pixelInBounds;
+      bool            pixelInBounds = false;
       const PixelType pixelIntensity = neighborIt.GetPixel(offsets.Value(), pixelInBounds);
 
       if (!pixelInBounds)
@@ -288,7 +288,7 @@ ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, 
         continue; // Go to the next loop if we're not in the mask
       }
 
-      bool            pixelInBounds;
+      bool            pixelInBounds = false;
       const PixelType pixelIntensity = neighborIt.GetPixel(offsets.Value(), pixelInBounds);
 
       if (!pixelInBounds)

--- a/Modules/Numerics/Statistics/include/itkStatisticsAlgorithm.hxx
+++ b/Modules/Numerics/Statistics/include/itkStatisticsAlgorithm.hxx
@@ -339,7 +339,7 @@ FindSampleBoundAndMean(const TSubsample *                           sample,
 
   for (unsigned int i = 0; i < Dimension; ++i)
   {
-    mean[i] = (MeasurementType)(sum[i] / frequencySum);
+    mean[i] = static_cast<MeasurementType>(sum[i] / frequencySum);
   }
 }
 
@@ -520,12 +520,9 @@ template <typename TSubsample>
 inline void
 InsertSort(TSubsample * sample, unsigned int activeDimension, int beginIndex, int endIndex)
 {
-  int backwardSearchBegin;
-  int backwardIndex;
-
-  for (backwardSearchBegin = beginIndex + 1; backwardSearchBegin < endIndex; ++backwardSearchBegin)
+  for (int backwardSearchBegin = beginIndex + 1; backwardSearchBegin < endIndex; ++backwardSearchBegin)
   {
-    backwardIndex = backwardSearchBegin;
+    int backwardIndex = backwardSearchBegin;
     while (backwardIndex > beginIndex)
     {
       using SampleMeasurementType = typename TSubsample::MeasurementType;

--- a/Modules/Numerics/Statistics/include/itkWeightedCentroidKdTreeGenerator.hxx
+++ b/Modules/Numerics/Statistics/include/itkWeightedCentroidKdTreeGenerator.hxx
@@ -39,16 +39,6 @@ WeightedCentroidKdTreeGenerator<TSample>::GenerateNonterminalNode(unsigned int  
                                                                   MeasurementVectorType & upperBound,
                                                                   unsigned int            level) -> KdTreeNodeType *
 {
-  MeasurementType dimensionLowerBound;
-  MeasurementType dimensionUpperBound;
-  MeasurementType partitionValue;
-  unsigned int    partitionDimension = 0;
-  unsigned int    i;
-  unsigned int    j;
-  MeasurementType spread;
-  MeasurementType maxSpread;
-  unsigned int    medianIndex;
-
   const SubsamplePointer subsample = this->GetSubsample();
 
   // Sanity check. Verify that the subsample has measurement vectors of the
@@ -65,10 +55,10 @@ WeightedCentroidKdTreeGenerator<TSample>::GenerateNonterminalNode(unsigned int  
   MeasurementVectorType tempVector;
   weightedCentroid.Fill(MeasurementType{});
 
-  for (i = beginIndex; i < endIndex; ++i)
+  for (unsigned int i = beginIndex; i < endIndex; ++i)
   {
     tempVector = subsample->GetMeasurementVectorByIndex(i);
-    for (j = 0; j < this->GetMeasurementVectorSize(); ++j)
+    for (unsigned int j = 0; j < this->GetMeasurementVectorSize(); ++j)
     {
       weightedCentroid[j] += tempVector[j];
     }
@@ -78,10 +68,11 @@ WeightedCentroidKdTreeGenerator<TSample>::GenerateNonterminalNode(unsigned int  
   Algorithm::FindSampleBoundAndMean<SubsampleType>(
     this->GetSubsample(), beginIndex, endIndex, m_TempLowerBound, m_TempUpperBound, m_TempMean);
 
-  maxSpread = NumericTraits<MeasurementType>::NonpositiveMin();
-  for (i = 0; i < this->GetMeasurementVectorSize(); ++i)
+  unsigned int    partitionDimension = 0;
+  MeasurementType maxSpread = NumericTraits<MeasurementType>::NonpositiveMin();
+  for (unsigned int i = 0; i < this->GetMeasurementVectorSize(); ++i)
   {
-    spread = m_TempUpperBound[i] - m_TempLowerBound[i];
+    MeasurementType spread = m_TempUpperBound[i] - m_TempLowerBound[i];
     if (spread >= maxSpread)
     {
       maxSpread = spread;
@@ -89,20 +80,20 @@ WeightedCentroidKdTreeGenerator<TSample>::GenerateNonterminalNode(unsigned int  
     }
   }
 
-  medianIndex = (endIndex - beginIndex) / 2;
+  unsigned int medianIndex = (endIndex - beginIndex) / 2;
 
   //
   // Find the medial element by using the NthElement function
   // based on the STL implementation of the QuickSelect algorithm.
   //
-  partitionValue =
+  MeasurementType partitionValue =
     Algorithm::NthElement<SubsampleType>(this->GetSubsample(), partitionDimension, beginIndex, endIndex, medianIndex);
 
   medianIndex += beginIndex;
 
   // save bounds for cutting dimension
-  dimensionLowerBound = lowerBound[partitionDimension];
-  dimensionUpperBound = upperBound[partitionDimension];
+  MeasurementType dimensionLowerBound = lowerBound[partitionDimension];
+  MeasurementType dimensionUpperBound = upperBound[partitionDimension];
 
   upperBound[partitionDimension] = partitionValue;
   const unsigned int beginLeftIndex = beginIndex;

--- a/Modules/Numerics/Statistics/src/itkNormalVariateGenerator.cxx
+++ b/Modules/Numerics/Statistics/src/itkNormalVariateGenerator.cxx
@@ -107,29 +107,29 @@ NormalVariateGenerator::GetVariate()
 double
 NormalVariateGenerator::FastNorm()
 {
-  int    i;
+  int    i = 0;
   int    inc = 0;
-  int    skew;
+  int    skew = 0;
   int    stride;
   int    mask = 0;
-  int    p;
-  int    q;
-  int    r;
-  int    s;
-  int    t;
+  int    p = 0;
+  int    q = 0;
+  int    r = 0;
+  int    s = 0;
+  int    t = 0;
   int *  pa = nullptr;
   int *  pb = nullptr;
   int *  pc = nullptr;
   int *  pd = nullptr;
-  int *  pe;
+  int *  pe = nullptr;
   int *  p0 = nullptr;
-  int    mtype;
-  int    stype;
-  double ts;
-  double tr;
-  double tx;
-  double ty;
-  double tz;
+  int    mtype = 0;
+  int    stype = 0;
+  double ts = NAN;
+  double tr = NAN;
+  double tx = NAN;
+  double ty = NAN;
+  double tz = NAN;
 
   /*    See if time to make a new set of 'original' deviates  */
   /*    or at least to correct for a drift in sum-of-squares    */

--- a/Modules/Numerics/Statistics/test/itkChiSquareDistributionTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkChiSquareDistributionTest.cxx
@@ -401,7 +401,7 @@ itkChiSquareDistributionTest(int, char *[])
   distributionFunction->SetDegreesOfFreedom(1); // clear settings
 
 
-  double last_x;
+  double last_x = NAN;
 
   for (int i = 0; i <= 5; ++i)
   {

--- a/Modules/Numerics/Statistics/test/itkExpectationMaximizationMixtureModelEstimatorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkExpectationMaximizationMixtureModelEstimatorTest.cxx
@@ -99,7 +99,7 @@ itkExpectationMaximizationMixtureModelEstimatorTest(int argc, char * argv[])
 
   PointSetType::PointsContainerIterator p_iter = pointsContainer->Begin();
   PointSetType::PointType               point;
-  double                                temp;
+  double                                temp = NAN;
   std::ifstream                         dataStream(dataFileName);
   if (!dataStream)
   {
@@ -150,8 +150,8 @@ itkExpectationMaximizationMixtureModelEstimatorTest(int argc, char * argv[])
 
   std::cout << "DEBUG: current iteration = " << estimator->GetCurrentIteration() << std::endl;
 
-  bool               passed = true;
-  double             displacement;
+  bool passed = true;
+
   const unsigned int measurementVectorSize = sample->GetMeasurementVectorSize();
   for (unsigned int i = 0; i < numberOfClasses; ++i)
   {
@@ -160,7 +160,7 @@ itkExpectationMaximizationMixtureModelEstimatorTest(int argc, char * argv[])
     std::cout << "         " << (components[i])->GetFullParameters() << std::endl;
     std::cout << "    Proportion: ";
     std::cout << "         " << (estimator->GetProportions())[i] << std::endl;
-    displacement = 0.0;
+    double displacement = 0.0;
     for (unsigned int j = 0; j < measurementVectorSize; ++j)
     {
       temp = (components[i])->GetFullParameters()[j] - trueParameters[i][j];

--- a/Modules/Numerics/Statistics/test/itkGaussianDistributionTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkGaussianDistributionTest.cxx
@@ -41,11 +41,6 @@ itkGaussianDistributionTest(int, char *[])
 
   distributionFunction->Print(std::cout);
 
-  int    i;
-  double x;
-  double value;
-  double diff;
-
   int status = EXIT_SUCCESS;
 
   // Tolerance for the values.
@@ -64,13 +59,13 @@ itkGaussianDistributionTest(int, char *[])
                                    9.999683287581669e-001, 9.999997133484281e-001 };
 
   std::cout << "Gaussian CDF" << std::endl;
-  for (i = -5; i <= 5; ++i)
+  for (int i = -5; i <= 5; ++i)
   {
-    x = static_cast<double>(i);
+    double x = static_cast<double>(i);
 
-    value = distributionFunction->EvaluateCDF(x);
+    double value = distributionFunction->EvaluateCDF(x);
 
-    diff = itk::Math::abs(value - expected1[i + 5]);
+    double diff = itk::Math::abs(value - expected1[i + 5]);
 
     std::cout << "Gaussian cdf at ";
     std::cout.width(2);
@@ -95,11 +90,11 @@ itkGaussianDistributionTest(int, char *[])
 
 
   std::cout << "Inverse Gaussian CDF" << std::endl;
-  for (i = -5; i <= 5; ++i)
+  for (int i = -5; i <= 5; ++i)
   {
-    value = distributionFunction->EvaluateInverseCDF(expected1[i + 5]);
+    double value = distributionFunction->EvaluateInverseCDF(expected1[i + 5]);
 
-    diff = itk::Math::abs(value - static_cast<double>(i));
+    double diff = itk::Math::abs(value - static_cast<double>(i));
 
     std::cout << "Inverse Gaussian cdf at ";
     std::cout.width(22);
@@ -135,13 +130,13 @@ itkGaussianDistributionTest(int, char *[])
                                    2.397500610934768e-001, 5.000000000000000e-001 };
 
   std::cout << "Gaussian CDF" << std::endl;
-  for (i = -5; i <= 5; ++i)
+  for (int i = -5; i <= 5; ++i)
   {
-    x = static_cast<double>(i);
+    double x = static_cast<double>(i);
 
-    value = distributionFunction->EvaluateCDF(x);
+    double value = distributionFunction->EvaluateCDF(x);
 
-    diff = itk::Math::abs(value - expected2[i + 5]);
+    double diff = itk::Math::abs(value - expected2[i + 5]);
 
     std::cout << "Gaussian cdf at ";
     std::cout.width(2);
@@ -180,13 +175,13 @@ itkGaussianDistributionTest(int, char *[])
                                    2.397500610934768e-001, 5.000000000000000e-001 };
 
   std::cout << "Gaussian CDF (parameter vector API)" << std::endl;
-  for (i = -5; i <= 5; ++i)
+  for (int i = -5; i <= 5; ++i)
   {
-    x = static_cast<double>(i);
+    double x = static_cast<double>(i);
 
-    value = distributionFunction->EvaluateCDF(x, params);
+    double value = distributionFunction->EvaluateCDF(x, params);
 
-    diff = itk::Math::abs(value - expected3[i + 5]);
+    double diff = itk::Math::abs(value - expected3[i + 5]);
 
     std::cout << "Gaussian cdf at ";
     std::cout.width(2);
@@ -218,13 +213,13 @@ itkGaussianDistributionTest(int, char *[])
                                    2.397500610934768e-001, 5.000000000000000e-001 };
 
   std::cout << "Gaussian CDF (separate parameter API)" << std::endl;
-  for (i = -5; i <= 5; ++i)
+  for (int i = -5; i <= 5; ++i)
   {
-    x = static_cast<double>(i);
+    double x = static_cast<double>(i);
 
-    value = distributionFunction->EvaluateCDF(x, params[0], params[1]);
+    double value = distributionFunction->EvaluateCDF(x, params[0], params[1]);
 
-    diff = itk::Math::abs(value - expected4[i + 5]);
+    double diff = itk::Math::abs(value - expected4[i + 5]);
 
     std::cout << "Gaussian cdf at ";
     std::cout.width(2);
@@ -250,11 +245,11 @@ itkGaussianDistributionTest(int, char *[])
   std::cout << "Inverse Gaussian CDF" << std::endl;
   // put the parameters back
   distributionFunction->SetParameters(params);
-  for (i = -5; i <= 5; ++i)
+  for (int i = -5; i <= 5; ++i)
   {
-    value = distributionFunction->EvaluateInverseCDF(expected2[i + 5]);
+    double value = distributionFunction->EvaluateInverseCDF(expected2[i + 5]);
 
-    diff = itk::Math::abs(value - static_cast<double>(i));
+    double diff = itk::Math::abs(value - static_cast<double>(i));
 
     std::cout << "Inverse Gaussian cdf at ";
     std::cout.width(22);
@@ -284,7 +279,7 @@ itkGaussianDistributionTest(int, char *[])
   parameters[0] = mean1;
   parameters[1] = variance1;
   distributionFunction->SetParameters(parameters);
-  x = .1;
+  double x = .1;
   std::cout << "Parameters = " << parameters << std::endl;
   std::cout << "Variance() = " << distributionFunction->GetVariance() << std::endl;
   std::cout << "PDF(x,p) = " << distributionFunction->PDF(x, parameters) << std::endl;

--- a/Modules/Numerics/Statistics/test/itkGaussianMixtureModelComponentTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkGaussianMixtureModelComponentTest.cxx
@@ -75,9 +75,8 @@ itkGaussianMixtureModelComponentTest(int argc, char * argv[])
   pointSet->SetPoints(pointsContainer);
 
   PointSetType::PointsContainerIterator p_iter = pointsContainer->Begin();
-  PointSetType::PointType               point;
-  double                                temp;
-  std::ifstream                         dataStream(dataFileName);
+
+  std::ifstream dataStream(dataFileName);
   if (!dataStream)
   {
     std::cout << "ERROR: fail to open the data file." << std::endl;
@@ -86,8 +85,10 @@ itkGaussianMixtureModelComponentTest(int argc, char * argv[])
 
   while (p_iter != pointsContainer->End())
   {
+    PointSetType::PointType point;
     for (unsigned int i = 0; i < PointSetType::PointDimension; ++i)
     {
+      double temp = NAN;
       dataStream >> temp;
       point[i] = temp;
     }

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleAdaptorTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleAdaptorTest2.cxx
@@ -64,20 +64,19 @@ itkImageToListSampleAdaptorTest2(int, char *[])
   adaptor->SetImage(image);
 
   ImageType::IndexType index;
-  ImageType::PixelType pixel;
-
-  ImageToListSampleAdaptorType::InstanceIdentifier id;
 
   for (unsigned int i = 0; i < size[2]; ++i)
+  {
     for (unsigned int j = 0; j < size[1]; ++j)
+    {
       for (unsigned int k = 0; k < size[0]; ++k)
       {
         index[0] = k;
         index[1] = j;
         index[2] = i;
 
-        pixel = image->GetPixel(index);
-        id = image->ComputeOffset(index);
+        ImageType::PixelType                             pixel = image->GetPixel(index);
+        ImageToListSampleAdaptorType::InstanceIdentifier id = image->ComputeOffset(index);
         for (unsigned int m = 0; m < adaptor->GetMeasurementVectorSize(); ++m)
         {
           if (adaptor->GetMeasurementVector(id)[m] != pixel[m])
@@ -87,6 +86,8 @@ itkImageToListSampleAdaptorTest2(int, char *[])
           }
         }
       }
+    }
+  }
 
   //
   // Exercise the iterators
@@ -159,7 +160,7 @@ itkImageToListSampleAdaptorTest2(int, char *[])
   VariableLengthImageType::IndexType vIndex;
   VariableLengthImageType::PixelType vPixel;
 
-  VariableLengthImageToListSampleAdaptorType::InstanceIdentifier vId;
+  VariableLengthImageToListSampleAdaptorType::InstanceIdentifier vId = 0;
 
   for (unsigned int i = 0; i < size[2]; ++i)
   {
@@ -235,7 +236,7 @@ itkImageToListSampleAdaptorTest2(int, char *[])
   RGBImageType::IndexType rgbIndex;
   RGBImageType::PixelType rgbPixel;
 
-  RGBImageToListSampleAdaptorType::InstanceIdentifier rgbId;
+  RGBImageToListSampleAdaptorType::InstanceIdentifier rgbId = 0;
 
   for (unsigned int i = 0; i < size[2]; ++i)
   {

--- a/Modules/Numerics/Statistics/test/itkJointDomainImageToListSampleAdaptorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkJointDomainImageToListSampleAdaptorTest.cxx
@@ -141,12 +141,8 @@ itkJointDomainImageToListSampleAdaptorTest(int, char *[])
   adaptor->Print(std::cout);
 
   ImageType::IndexType index;
-  ImageType::PixelType pixel;
 
-  JointDomainImageToListSampleAdaptorType::InstanceIdentifier iid;
   using MeasurementVectorType = JointDomainImageToListSampleAdaptorType::MeasurementVectorType;
-  JointDomainImageToListSampleAdaptorType::PointType tempPoint;
-
 
   MeasurementVectorType measurementVector;
 
@@ -160,9 +156,10 @@ itkJointDomainImageToListSampleAdaptorTest(int, char *[])
         index[1] = j;
         index[2] = i;
 
+        JointDomainImageToListSampleAdaptorType::PointType tempPoint;
         adaptor->GetImage()->TransformIndexToPhysicalPoint(index, tempPoint);
 
-        pixel = adaptor->GetImage()->GetPixel(index);
+        ImageType::PixelType pixel = adaptor->GetImage()->GetPixel(index);
 
         measurementVector[0] = tempPoint[0];
         measurementVector[1] = tempPoint[1];
@@ -171,7 +168,7 @@ itkJointDomainImageToListSampleAdaptorTest(int, char *[])
         measurementVector[4] = pixel[1];
         measurementVector[5] = pixel[2];
 
-        iid = adaptor->GetImage()->ComputeOffset(index);
+        JointDomainImageToListSampleAdaptorType::InstanceIdentifier iid = adaptor->GetImage()->ComputeOffset(index);
 
         MeasurementVectorType measurementVectorFromAdaptor = adaptor->GetMeasurementVector(iid);
         for (unsigned int m = 0; m < 5; ++m)

--- a/Modules/Numerics/Statistics/test/itkKdTreeBasedKmeansEstimatorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkKdTreeBasedKmeansEstimatorTest.cxx
@@ -66,7 +66,7 @@ itkKdTreeBasedKmeansEstimatorTest(int argc, char * argv[])
 
   PointSetType::PointsContainerIterator pIter = pointsContainer->Begin();
   PointSetType::PointType               point;
-  double                                temp;
+  double                                temp = NAN;
   std::ifstream                         dataStream(dataFileName);
   while (pIter != pointsContainer->End())
   {
@@ -128,7 +128,6 @@ itkKdTreeBasedKmeansEstimatorTest(int argc, char * argv[])
   Estimator::ParametersType estimatedMeans = estimator->GetParameters();
 
   bool               passed = true;
-  int                index;
   const unsigned int numberOfMeasurements = sample->GetMeasurementVectorSize();
   const unsigned int numberOfClasses = trueMeans.size() / numberOfMeasurements;
   for (unsigned int i = 0; i < numberOfClasses; ++i)
@@ -137,7 +136,7 @@ itkKdTreeBasedKmeansEstimatorTest(int argc, char * argv[])
     double displacement = 0.0;
     std::cout << "    true mean :" << std::endl;
     std::cout << "        ";
-    index = numberOfMeasurements * i;
+    int index = numberOfMeasurements * i;
     for (unsigned int j = 0; j < numberOfMeasurements; ++j)
     {
       std::cout << trueMeans[index] << ' ';

--- a/Modules/Numerics/Statistics/test/itkKdTreeGeneratorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkKdTreeGeneratorTest.cxx
@@ -73,8 +73,8 @@ itkKdTreeGeneratorTest(int, char *[])
       std::cout << "Root node is not a terminal node." << std::endl;
     }
 
-    unsigned int partitionDimension;
-    float        partitionValue;
+    unsigned int partitionDimension = 0;
+    float        partitionValue = NAN;
     root->GetParameters(partitionDimension, partitionValue);
     std::cout << "Dimension chosen to split the space = " << partitionDimension << std::endl;
     std::cout << "Split point on the partition dimension = " << partitionValue << std::endl;
@@ -164,8 +164,8 @@ itkKdTreeGeneratorTest(int, char *[])
       std::cout << "Root node is not a terminal node." << std::endl;
     }
 
-    unsigned int partitionDimension;
-    float        partitionValue;
+    unsigned int partitionDimension = 0;
+    float        partitionValue = NAN;
     root->GetParameters(partitionDimension, partitionValue);
     std::cout << "Dimension chosen to split the space = " << partitionDimension << std::endl;
     std::cout << "Split point on the partition dimension = " << partitionValue << std::endl;

--- a/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthFeaturesFilterTest.cxx
@@ -95,11 +95,8 @@ itkScalarImageToRunLengthFeaturesFilterTest(int, char *[])
   //--------------------------------------------------------------------------
   // Test the texFilter
   //--------------------------------------------------------------------------
-  bool passed = true;
-
   try
   {
-
     using RunLengthFilterType = itk::Statistics::ScalarImageToRunLengthFeaturesFilter<InputImageType>;
 
     // First test: just use the defaults.
@@ -107,6 +104,7 @@ itkScalarImageToRunLengthFeaturesFilterTest(int, char *[])
 
     // Invoke update before adding an input. An exception should be
     // thrown.
+    bool passed = true;
     try
     {
       texFilter->Update();
@@ -200,32 +198,33 @@ itkScalarImageToRunLengthFeaturesFilterTest(int, char *[])
     RunLengthFilterType::FeatureValueVectorPointer stds = texFilter->GetFeatureStandardDeviations();
 
     constexpr double expectedMeans[10] = { 0.76, 7, 10.4, 20, 0.0826667, 15.4, 0.0628267, 11.704, 0.578667, 107.8 };
-    constexpr double expectedDeviations[10] = { 0.415692, 10.3923,   4.50333, 8.66025,  0,
-                                                0,        0.0343639, 6.40166, 0.859097, 160.041494 };
-    RunLengthFilterType::FeatureValueVector::ConstIterator mIt;
-    RunLengthFilterType::FeatureValueVector::ConstIterator sIt;
 
-    int counter;
-    for (counter = 0, mIt = means->Begin(); mIt != means->End(); ++mIt, counter++)
     {
-      if (itk::Math::abs(expectedMeans[counter] - mIt.Value()) > 0.0001)
+      RunLengthFilterType::FeatureValueVector::ConstIterator mIt = means->Begin();
+      for (int counter = 0; mIt != means->End(); ++mIt, counter++)
       {
-        std::cerr << "Error. Mean for feature " << counter << " is " << mIt.Value() << ", expected "
-                  << expectedMeans[counter] << '.' << std::endl;
-        passed = false;
+        if (itk::Math::abs(expectedMeans[counter] - mIt.Value()) > 0.0001)
+        {
+          std::cerr << "Error. Mean for feature " << counter << " is " << mIt.Value() << ", expected "
+                    << expectedMeans[counter] << '.' << std::endl;
+          passed = false;
+        }
       }
     }
-
-    for (counter = 0, sIt = stds->Begin(); sIt != stds->End(); ++sIt, counter++)
     {
-      if (itk::Math::abs(expectedDeviations[counter] - sIt.Value()) > 0.0001)
+      constexpr double expectedDeviations[10] = { 0.415692, 10.3923,   4.50333, 8.66025,  0,
+                                                  0,        0.0343639, 6.40166, 0.859097, 160.041494 };
+      RunLengthFilterType::FeatureValueVector::ConstIterator sIt = stds->Begin();
+      for (int counter = 0; sIt != stds->End(); ++sIt, counter++)
       {
-        std::cerr << "Error. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
-                  << expectedDeviations[counter] << '.' << std::endl;
-        passed = false;
+        if (itk::Math::abs(expectedDeviations[counter] - sIt.Value()) > 0.0001)
+        {
+          std::cerr << "Error. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
+                    << expectedDeviations[counter] << '.' << std::endl;
+          passed = false;
+        }
       }
     }
-
     // Rerun the feature generation with fast calculations on
     texFilter->FastCalculationsOn();
     texFilter->Update();
@@ -235,26 +234,30 @@ itkScalarImageToRunLengthFeaturesFilterTest(int, char *[])
     constexpr double expectedMeans2[10] = { 1, 1, 13, 25, 0.0826667, 15.4, 0.0826667, 15.4, 0.0826667, 15.4 };
     constexpr double expectedDeviations2[10] = { 0 };
 
-    for (counter = 0, mIt = means->Begin(); mIt != means->End(); ++mIt, counter++)
     {
-      if (itk::Math::abs(expectedMeans2[counter] - mIt.Value()) > 0.0001)
+      RunLengthFilterType::FeatureValueVector::ConstIterator mIt = means->Begin();
+      for (int counter = 0; mIt != means->End(); ++mIt, counter++)
       {
-        std::cerr << "Error2. Mean for feature " << counter << " is " << mIt.Value() << ", expected "
-                  << expectedMeans2[counter] << '.' << std::endl;
-        passed = false;
+        if (itk::Math::abs(expectedMeans2[counter] - mIt.Value()) > 0.0001)
+        {
+          std::cerr << "Error2. Mean for feature " << counter << " is " << mIt.Value() << ", expected "
+                    << expectedMeans2[counter] << '.' << std::endl;
+          passed = false;
+        }
       }
     }
-
-    for (counter = 0, sIt = stds->Begin(); sIt != stds->End(); ++sIt, counter++)
     {
-      if (itk::Math::abs(expectedDeviations2[counter] - sIt.Value()) > 0.0001)
+      RunLengthFilterType::FeatureValueVector::ConstIterator sIt = stds->Begin();
+      for (int counter = 0; sIt != stds->End(); ++sIt, counter++)
       {
-        std::cerr << "Error2. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
-                  << expectedDeviations2[counter] << '.' << std::endl;
-        passed = false;
+        if (itk::Math::abs(expectedDeviations2[counter] - sIt.Value()) > 0.0001)
+        {
+          std::cerr << "Error2. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
+                    << expectedDeviations2[counter] << '.' << std::endl;
+          passed = false;
+        }
       }
     }
-
     //    //Rerun the feature generation setting an offset
     RunLengthFilterType::OffsetType offset;
     offset[0] = -1;
@@ -269,10 +272,9 @@ itkScalarImageToRunLengthFeaturesFilterTest(int, char *[])
 
     const RunLengthFilterType::OffsetVector * offsets2 = texFilter->GetOffsets();
 
-    RunLengthFilterType::OffsetVector::ConstIterator vIt;
-    RunLengthFilterType::OffsetVector::ConstIterator vIt2;
-
-    for (vIt = offsets->Begin(), vIt2 = offsets2->Begin(); vIt != offsets->End(); ++vIt, ++vIt2)
+    for (RunLengthFilterType::OffsetVector::ConstIterator vIt = offsets->Begin(), vIt2 = offsets2->Begin();
+         vIt != offsets->End();
+         ++vIt, ++vIt2)
     {
       if (vIt.Value() != vIt2.Value())
       {
@@ -295,24 +297,29 @@ itkScalarImageToRunLengthFeaturesFilterTest(int, char *[])
 
     constexpr double expectedMeans3[10] = { 1, 1, 13, 25, 0.0826667, 15.4, 0.0826667, 15.4, 0.0826667, 15.4 };
     constexpr double expectedDeviations3[10] = { 0 };
-
-    for (counter = 0, mIt = means->Begin(); mIt != means->End(); ++mIt, counter++)
     {
-      if (itk::Math::abs(expectedMeans3[counter] - mIt.Value()) > 0.0001)
+      RunLengthFilterType::FeatureValueVector::ConstIterator mIt = means->Begin();
+      for (int counter = 0; mIt != means->End(); ++mIt, counter++)
       {
-        std::cerr << "Error3. Mean for feature " << counter << " is " << mIt.Value() << ", expected "
-                  << expectedMeans3[counter] << '.' << std::endl;
-        passed = false;
+        if (itk::Math::abs(expectedMeans3[counter] - mIt.Value()) > 0.0001)
+        {
+          std::cerr << "Error3. Mean for feature " << counter << " is " << mIt.Value() << ", expected "
+                    << expectedMeans3[counter] << '.' << std::endl;
+          passed = false;
+        }
       }
     }
 
-    for (counter = 0, sIt = stds->Begin(); sIt != stds->End(); ++sIt, counter++)
     {
-      if (itk::Math::abs(expectedDeviations3[counter] - sIt.Value()) > 0.0001)
+      RunLengthFilterType::FeatureValueVector::ConstIterator sIt = stds->Begin();
+      for (int counter = 0; sIt != stds->End(); ++sIt, counter++)
       {
-        std::cerr << "Error3. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
-                  << expectedDeviations3[counter] << '.' << std::endl;
-        passed = false;
+        if (itk::Math::abs(expectedDeviations3[counter] - sIt.Value()) > 0.0001)
+        {
+          std::cerr << "Error3. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
+                    << expectedDeviations3[counter] << '.' << std::endl;
+          passed = false;
+        }
       }
     }
 
@@ -328,15 +335,13 @@ itkScalarImageToRunLengthFeaturesFilterTest(int, char *[])
 
     const RunLengthFilterType::FeatureNameVector * requestedFeatures2 = texFilter->GetRequestedFeatures();
 
-    RunLengthFilterType::FeatureNameVector::ConstIterator fIt;
-
-    fIt = requestedFeatures2->Begin();
+    RunLengthFilterType::FeatureNameVector::ConstIterator fIt = requestedFeatures2->Begin();
     if (fIt.Value() != static_cast<uint8_t>(itk::Statistics::RunLengthFeatureEnum::ShortRunEmphasis))
     {
       std::cerr << "Requested feature name not correctly set" << std::endl;
       passed = false;
     }
-    fIt++;
+    ++fIt;
 
     if (fIt.Value() != static_cast<uint8_t>(itk::Statistics::RunLengthFeatureEnum::GreyLevelNonuniformity))
     {

--- a/Modules/Numerics/Statistics/test/itkScalarImageToTextureFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToTextureFeaturesFilterTest.cxx
@@ -98,8 +98,6 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
   //--------------------------------------------------------------------------
   // Test the texFilter
   //--------------------------------------------------------------------------
-  bool passed = true;
-
   try
   {
 
@@ -108,7 +106,7 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
 
     // First test: just use the defaults.
     auto texFilter = TextureFilterType::New();
-
+    bool passed = true;
     // Invoke update before adding an input. An exception should be
     // thrown.
     try
@@ -201,27 +199,30 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
     constexpr double expectedMeans[6] = { 0.505, 0.992738, 0.625, 0.75, 0.0959999, 0.2688 };
     constexpr double expectedDeviations[6] = { 0.00866027, 0.0125788, 0.216506351, 0.433012702, 0.166277, 0.465575 };
 
-    TextureFilterType::FeatureValueVector::ConstIterator mIt;
-    TextureFilterType::FeatureValueVector::ConstIterator sIt;
 
-    int counter;
-    for (counter = 0, mIt = means->Begin(); mIt != means->End(); ++mIt, counter++)
     {
-      if (itk::Math::abs(expectedMeans[counter] - mIt.Value()) > 0.0001)
+      TextureFilterType::FeatureValueVector::ConstIterator mIt = means->Begin();
+      for (int counter = 0; mIt != means->End(); ++mIt, counter++)
       {
-        std::cerr << "Error. Mean for feature " << counter << " is " << mIt.Value() << ", expected "
-                  << expectedMeans[counter] << '.' << std::endl;
-        passed = false;
+        if (itk::Math::abs(expectedMeans[counter] - mIt.Value()) > 0.0001)
+        {
+          std::cerr << "Error. Mean for feature " << counter << " is " << mIt.Value() << ", expected "
+                    << expectedMeans[counter] << '.' << std::endl;
+          passed = false;
+        }
       }
     }
 
-    for (counter = 0, sIt = stds->Begin(); sIt != stds->End(); ++sIt, counter++)
     {
-      if (itk::Math::abs(expectedDeviations[counter] - sIt.Value()) > 0.0001)
+      TextureFilterType::FeatureValueVector::ConstIterator sIt = stds->Begin();
+      for (int counter = 0; sIt != stds->End(); ++sIt, counter++)
       {
-        std::cerr << "Error. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
-                  << expectedDeviations[counter] << '.' << std::endl;
-        passed = false;
+        if (itk::Math::abs(expectedDeviations[counter] - sIt.Value()) > 0.0001)
+        {
+          std::cerr << "Error. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
+                    << expectedDeviations[counter] << '.' << std::endl;
+          passed = false;
+        }
       }
     }
 
@@ -234,23 +235,29 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
     constexpr double expectedMeans2[6] = { 0.5, 1.0, 0.5, 1.0, 0.0, 0.0 };
     constexpr double expectedDeviations2[6] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
-    for (counter = 0, mIt = means->Begin(); mIt != means->End(); ++mIt, counter++)
     {
-      if (itk::Math::abs(expectedMeans2[counter] - mIt.Value()) > 0.0001)
+      TextureFilterType::FeatureValueVector::ConstIterator mIt = means->Begin();
+      for (int counter = 0; mIt != means->End(); ++mIt, counter++)
       {
-        std::cerr << "Error. Mean for feature " << counter << " is " << mIt.Value() << ", expected "
-                  << expectedMeans2[counter] << '.' << std::endl;
-        passed = false;
+        if (itk::Math::abs(expectedMeans2[counter] - mIt.Value()) > 0.0001)
+        {
+          std::cerr << "Error. Mean for feature " << counter << " is " << mIt.Value() << ", expected "
+                    << expectedMeans2[counter] << '.' << std::endl;
+          passed = false;
+        }
       }
     }
 
-    for (counter = 0, sIt = stds->Begin(); sIt != stds->End(); ++sIt, counter++)
     {
-      if (itk::Math::abs(expectedDeviations2[counter] - sIt.Value()) > 0.0001)
+      TextureFilterType::FeatureValueVector::ConstIterator sIt = stds->Begin();
+      for (int counter = 0; sIt != stds->End(); ++sIt, counter++)
       {
-        std::cerr << "Error. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
-                  << expectedDeviations2[counter] << '.' << std::endl;
-        passed = false;
+        if (itk::Math::abs(expectedDeviations2[counter] - sIt.Value()) > 0.0001)
+        {
+          std::cerr << "Error. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
+                    << expectedDeviations2[counter] << '.' << std::endl;
+          passed = false;
+        }
       }
     }
 
@@ -268,10 +275,9 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
 
     const TextureFilterType::OffsetVector * offsets2 = texFilter->GetOffsets();
 
-    TextureFilterType::OffsetVector::ConstIterator vIt;
-    TextureFilterType::OffsetVector::ConstIterator vIt2;
-
-    for (vIt = offsets->Begin(), vIt2 = offsets2->Begin(); vIt != offsets->End(); ++vIt, ++vIt2)
+    for (TextureFilterType::OffsetVector::ConstIterator vIt = offsets->Begin(), vIt2 = offsets2->Begin();
+         vIt != offsets->End();
+         ++vIt, ++vIt2)
     {
       if (vIt.Value() != vIt2.Value())
       {
@@ -288,23 +294,29 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
     constexpr double expectedMeans3[6] = { 0.5, 1.0, 0.5, 1.0, 0.0, 0.0 };
     constexpr double expectedDeviations3[6] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
-    for (counter = 0, mIt = means->Begin(); mIt != means->End(); ++mIt, counter++)
     {
-      if (itk::Math::abs(expectedMeans3[counter] - mIt.Value()) > 0.0001)
+      TextureFilterType::FeatureValueVector::ConstIterator mIt = means->Begin();
+      for (int counter = 0; mIt != means->End(); ++mIt, counter++)
       {
-        std::cerr << "Error. Mean for feature " << counter << " is " << mIt.Value() << ", expected "
-                  << expectedMeans3[counter] << '.' << std::endl;
-        passed = false;
+        if (itk::Math::abs(expectedMeans3[counter] - mIt.Value()) > 0.0001)
+        {
+          std::cerr << "Error. Mean for feature " << counter << " is " << mIt.Value() << ", expected "
+                    << expectedMeans3[counter] << '.' << std::endl;
+          passed = false;
+        }
       }
     }
 
-    for (counter = 0, sIt = stds->Begin(); sIt != stds->End(); ++sIt, counter++)
     {
-      if (itk::Math::abs(expectedDeviations3[counter] - sIt.Value()) > 0.0001)
+      TextureFilterType::FeatureValueVector::ConstIterator sIt = stds->Begin();
+      for (int counter = 0; sIt != stds->End(); ++sIt, counter++)
       {
-        std::cerr << "Error. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
-                  << expectedDeviations3[counter] << '.' << std::endl;
-        passed = false;
+        if (itk::Math::abs(expectedDeviations3[counter] - sIt.Value()) > 0.0001)
+        {
+          std::cerr << "Error. Deviation for feature " << counter << " is " << sIt.Value() << ", expected "
+                    << expectedDeviations3[counter] << '.' << std::endl;
+          passed = false;
+        }
       }
     }
 
@@ -328,7 +340,7 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
       std::cerr << "Requested feature name not correctly set" << std::endl;
       passed = false;
     }
-    fIt++;
+    ++fIt;
 
     if (fIt.Value() !=
         static_cast<uint8_t>(itk::Statistics::HistogramToTextureFeaturesFilterEnums::TextureFeature::ClusterShade))

--- a/Modules/Numerics/Statistics/test/itkTDistributionTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkTDistributionTest.cxx
@@ -39,16 +39,7 @@ itkTDistributionTest(int, char *[])
   std::cout << "Number of parameters = " << distributionFunction->GetNumberOfParameters() << std::endl;
 
   distributionFunction->Print(std::cout);
-
-  int    i;
-  double x;
-  double value;
-  double diff;
-
   int status = EXIT_SUCCESS;
-
-  // Tolerance for the values.
-  double tol;
 
   // expected values for Student-t cdf with 1 degree of freedom at
   // values of -5:1:5
@@ -61,19 +52,21 @@ itkTDistributionTest(int, char *[])
   std::cout << "Testing distribution with 1 degree of freedom" << std::endl;
 
   std::cout << "Student-t CDF" << std::endl;
-  tol = 1e-15;
+  // Tolerance for the values.
+  double tol = 1e-15;
   std::cout << "Tolerance used for test: ";
   std::cout.width(20);
   std::cout.precision(15);
   std::cout << tol << std::endl;
   distributionFunction->SetDegreesOfFreedom(1);
-  for (i = -5; i <= 5; ++i)
+
+  for (int i = -5; i <= 5; ++i)
   {
-    x = static_cast<double>(i);
+    double x = static_cast<double>(i);
 
-    value = distributionFunction->EvaluateCDF(x);
+    double value = distributionFunction->EvaluateCDF(x);
 
-    diff = itk::Math::abs(value - expected1[i + 5]);
+    double diff = itk::Math::abs(value - expected1[i + 5]);
 
     std::cout << "Student-t cdf at ";
     std::cout.width(2);
@@ -104,12 +97,12 @@ itkTDistributionTest(int, char *[])
   std::cout.width(20);
   std::cout.precision(15);
   std::cout << tol << std::endl;
-  for (i = -5; i <= 5; ++i)
+  for (int i = -5; i <= 5; ++i)
   {
 
-    value = distributionFunction->EvaluateInverseCDF(expected1[i + 5]);
+    double value = distributionFunction->EvaluateInverseCDF(expected1[i + 5]);
 
-    diff = itk::Math::abs(value - static_cast<double>(i));
+    double diff = itk::Math::abs(value - static_cast<double>(i));
 
     std::cout << "Student-t cdf at ";
     std::cout.width(20);
@@ -152,13 +145,13 @@ itkTDistributionTest(int, char *[])
   std::cout.precision(15);
   std::cout << tol << std::endl;
   distributionFunction->SetDegreesOfFreedom(11);
-  for (i = -5; i <= 5; ++i)
+  for (int i = -5; i <= 5; ++i)
   {
-    x = static_cast<double>(i);
+    double x = static_cast<double>(i);
 
-    value = distributionFunction->EvaluateCDF(x);
+    double value = distributionFunction->EvaluateCDF(x);
 
-    diff = itk::Math::abs(value - expected11[i + 5]);
+    double diff = itk::Math::abs(value - expected11[i + 5]);
 
     std::cout << "Student-t cdf at ";
     std::cout.width(2);
@@ -189,12 +182,12 @@ itkTDistributionTest(int, char *[])
   std::cout.width(20);
   std::cout.precision(15);
   std::cout << tol << std::endl;
-  for (i = -5; i <= 5; ++i)
+  for (int i = -5; i <= 5; ++i)
   {
 
-    value = distributionFunction->EvaluateInverseCDF(expected11[i + 5]);
+    double value = distributionFunction->EvaluateInverseCDF(expected11[i + 5]);
 
-    diff = itk::Math::abs(value - static_cast<double>(i));
+    double diff = itk::Math::abs(value - static_cast<double>(i));
 
     std::cout << "Student-t cdf at ";
     std::cout.width(20);
@@ -235,13 +228,13 @@ itkTDistributionTest(int, char *[])
   DistributionType::ParametersType params(1);
   params[0] = 11;
 
-  for (i = -5; i <= 5; ++i)
+  for (int i = -5; i <= 5; ++i)
   {
-    x = static_cast<double>(i);
+    double x = static_cast<double>(i);
 
-    value = distributionFunction->EvaluateCDF(x, params);
+    double value = distributionFunction->EvaluateCDF(x, params);
 
-    diff = itk::Math::abs(value - expected11[i + 5]);
+    double diff = itk::Math::abs(value - expected11[i + 5]);
 
     std::cout << "Student-t cdf at ";
     std::cout.width(2);
@@ -273,12 +266,12 @@ itkTDistributionTest(int, char *[])
   std::cout.width(20);
   std::cout.precision(15);
   std::cout << tol << std::endl;
-  for (i = -5; i <= 5; ++i)
+  for (int i = -5; i <= 5; ++i)
   {
 
-    value = distributionFunction->EvaluateInverseCDF(expected11[i + 5], params);
+    double value = distributionFunction->EvaluateInverseCDF(expected11[i + 5], params);
 
-    diff = itk::Math::abs(value - static_cast<double>(i));
+    double diff = itk::Math::abs(value - static_cast<double>(i));
 
     std::cout << "Student-t cdf at ";
     std::cout.width(20);
@@ -315,8 +308,10 @@ itkTDistributionTest(int, char *[])
   std::cout.width(20);
   std::cout.precision(15);
   std::cout << tol << std::endl;
-
-  for (i = -5; i <= 5; ++i)
+  double x = NAN;
+  double value = NAN;
+  double diff = NAN;
+  for (int i = -5; i <= 5; ++i)
   {
     x = static_cast<double>(i);
 
@@ -354,7 +349,7 @@ itkTDistributionTest(int, char *[])
   std::cout.width(20);
   std::cout.precision(15);
   std::cout << tol << std::endl;
-  for (i = -5; i <= 5; ++i)
+  for (int i = -5; i <= 5; ++i)
   {
 
     value = distributionFunction->EvaluateInverseCDF(expected11[i + 5], static_cast<itk::SizeValueType>(params[0]));

--- a/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
@@ -198,11 +198,10 @@ void
 BlockMatchingImageFilter<TFixedImage, TMovingImage, TFeatures, TDisplacements, TSimilarities>::
   AfterThreadedGenerateData()
 {
-  const FeaturePointsConstPointer                     featurePoints = this->GetFeaturePoints();
-  const typename FeaturePointsType::PointsContainer * points;
+  const FeaturePointsConstPointer featurePoints = this->GetFeaturePoints();
   if (featurePoints)
   {
-    points = featurePoints->GetPoints();
+    const typename FeaturePointsType::PointsContainer * points = featurePoints->GetPoints();
 
     const DisplacementsPointer displacements = this->GetDisplacements();
 

--- a/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
@@ -33,11 +33,9 @@ namespace itk
 template <typename TFixedImage, typename TMovingImage>
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GradientDifferenceImageToImageMetric()
 {
-  unsigned int iDimension;
-
   m_TransformMovingImageFilter = nullptr;
 
-  for (iDimension = 0; iDimension < FixedImageDimension; ++iDimension)
+  for (unsigned int iDimension = 0; iDimension < FixedImageDimension; ++iDimension)
   {
     m_MinFixedGradient[iDimension] = 0;
     m_MaxFixedGradient[iDimension] = 0;
@@ -45,7 +43,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GradientDiffere
     m_Variance[iDimension] = 0;
   }
 
-  for (iDimension = 0; iDimension < MovedImageDimension; ++iDimension)
+  for (unsigned int iDimension = 0; iDimension < MovedImageDimension; ++iDimension)
   {
     m_MinMovedGradient[iDimension] = 0;
     m_MaxMovedGradient[iDimension] = 0;
@@ -58,8 +56,6 @@ template <typename TFixedImage, typename TMovingImage>
 void
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
 {
-  unsigned int iFilter; // Index of Sobel filters for each dimension
-
   if (!this->GetComputeGradient())
   {
     itkExceptionMacro("Gradients must be calculated");
@@ -92,7 +88,8 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
   m_CastFixedImageFilter = CastFixedImageFilterType::New();
   m_CastFixedImageFilter->SetInput(this->m_FixedImage);
 
-  for (iFilter = 0; iFilter < FixedImageDimension; ++iFilter)
+  // Index of Sobel filters for each dimension
+  for (unsigned int iFilter = 0; iFilter < FixedImageDimension; ++iFilter)
   {
     m_FixedSobelOperators[iFilter].SetDirection(iFilter);
     m_FixedSobelOperators[iFilter].CreateDirectional();
@@ -114,7 +111,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
   m_CastMovedImageFilter = CastMovedImageFilterType::New();
   m_CastMovedImageFilter->SetInput(m_TransformMovingImageFilter->GetOutput());
 
-  for (iFilter = 0; iFilter < MovedImageDimension; ++iFilter)
+  for (unsigned int iFilter = 0; iFilter < MovedImageDimension; ++iFilter)
   {
     m_MovedSobelOperators[iFilter].SetDirection(iFilter);
     m_MovedSobelOperators[iFilter].CreateDirectional();
@@ -180,7 +177,7 @@ template <typename TFixedImage, typename TMovingImage>
 void
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMovedGradientRange() const
 {
-  unsigned int           iDimension;
+  unsigned int           iDimension = 0;
   MovedGradientPixelType gradient;
 
   for (iDimension = 0; iDimension < FixedImageDimension; ++iDimension)
@@ -217,8 +214,8 @@ template <typename TFixedImage, typename TMovingImage>
 void
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeVariance() const
 {
-  unsigned int           iDimension;
-  SizeValueType          nPixels;
+  unsigned int           iDimension = 0;
+  SizeValueType          nPixels = 0;
   FixedGradientPixelType mean[FixedImageDimension];
   FixedGradientPixelType gradient;
 
@@ -292,7 +289,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMeasure(
   const TransformParametersType & parameters,
   const double *                  subtractionFactor) const -> MeasureType
 {
-  unsigned int iDimension;
+  unsigned int iDimension = 0;
 
   this->SetTransformParameters(parameters);
   m_TransformMovingImageFilter->UpdateLargestPossibleRegion();
@@ -351,9 +348,9 @@ auto
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
   const TransformParametersType & parameters) const -> MeasureType
 {
-  unsigned int iFilter; // Index of Sobel filters for
-                        // each dimension
-  unsigned int iDimension;
+  unsigned int iFilter = 0; // Index of Sobel filters for
+                            // each dimension
+  unsigned int iDimension = 0;
 
   this->SetTransformParameters(parameters);
   m_TransformMovingImageFilter->UpdateLargestPossibleRegion();

--- a/Modules/Registration/Common/include/itkImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethod.hxx
@@ -55,44 +55,44 @@ ModifiedTimeType
 ImageRegistrationMethod<TFixedImage, TMovingImage>::GetMTime() const
 {
   ModifiedTimeType mtime = Superclass::GetMTime();
-  ModifiedTimeType m;
 
   // Some of the following should be removed once ivars are put in the
   // input and output lists
 
+
   if (m_Transform)
   {
-    m = m_Transform->GetMTime();
+    ModifiedTimeType m = m_Transform->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_Interpolator)
   {
-    m = m_Interpolator->GetMTime();
+    ModifiedTimeType m = m_Interpolator->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_Metric)
   {
-    m = m_Metric->GetMTime();
+    ModifiedTimeType m = m_Metric->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_Optimizer)
   {
-    m = m_Optimizer->GetMTime();
+    ModifiedTimeType m = m_Optimizer->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_FixedImage)
   {
-    m = m_FixedImage->GetMTime();
+    ModifiedTimeType m = m_FixedImage->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_MovingImage)
   {
-    m = m_MovingImage->GetMTime();
+    ModifiedTimeType m = m_MovingImage->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -513,7 +513,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImageRegion(FixedImage
 
       if (m_FixedImageMask.IsNotNull())
       {
-        double val;
+        double val = NAN;
         if (m_FixedImageMask->ValueAtInWorldSpace(inputPoint, val))
         {
           if (Math::AlmostEquals(val, 0.0))
@@ -727,7 +727,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PreComputeTransformValues()
   // Cycle through each sampled fixed image point
   BSplineTransformWeightsType    weights;
   BSplineTransformIndexArrayType indices;
-  bool                           valid;
+  bool                           valid = false;
   MovingImagePointType           mappedPoint;
 
   // Declare iterators for iteration over the sample container
@@ -762,7 +762,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::TransformPoint(unsigned int      
                                                               ThreadIdType           threadId) const
 {
   sampleOk = true;
-  TransformType * transform;
+  TransformType * transform = nullptr;
 
   if (threadId > 0)
   {
@@ -809,8 +809,8 @@ ImageToImageMetric<TFixedImage, TMovingImage>::TransformPoint(unsigned int      
     }
     else
     {
-      BSplineTransformWeightsType *    weightsHelper;
-      BSplineTransformIndexArrayType * indicesHelper;
+      BSplineTransformWeightsType *    weightsHelper = nullptr;
+      BSplineTransformIndexArrayType * indicesHelper = nullptr;
 
       if (threadId > 0)
       {
@@ -870,7 +870,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::TransformPointWithDerivatives(uns
                                                                              ImageDerivativesType & movingImageGradient,
                                                                              ThreadIdType           threadId) const
 {
-  TransformType * transform;
+  TransformType * transform = nullptr;
 
   sampleOk = true;
 
@@ -919,8 +919,8 @@ ImageToImageMetric<TFixedImage, TMovingImage>::TransformPointWithDerivatives(uns
     }
     else
     {
-      BSplineTransformWeightsType *    weightsHelper;
-      BSplineTransformIndexArrayType * indicesHelper;
+      BSplineTransformWeightsType *    weightsHelper = nullptr;
+      BSplineTransformIndexArrayType * indicesHelper = nullptr;
 
       if (threadId > 0)
       {
@@ -1072,8 +1072,8 @@ ImageToImageMetric<TFixedImage, TMovingImage>::GetValueThread(ThreadIdType threa
   for (int count = 0; count < chunkSize; ++count, ++fixedImageSample)
   {
     MovingImagePointType mappedPoint;
-    bool                 sampleOk;
-    double               movingImageValue;
+    bool                 sampleOk = false;
+    double               movingImageValue = NAN;
     // Get moving image value
     this->TransformPoint(fixedImageSample, mappedPoint, sampleOk, movingImageValue, threadId);
 
@@ -1169,8 +1169,8 @@ ImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeThread(Threa
 
   // Process the samples
   MovingImagePointType mappedPoint;
-  bool                 sampleOk;
-  double               movingImageValue;
+  bool                 sampleOk = false;
+  double               movingImageValue = NAN;
   ImageDerivativesType movingImageGradientValue;
   for (int count = 0; count < chunkSize; ++count, ++fixedImageSample)
   {

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectRegistrationMethod.hxx
@@ -173,44 +173,43 @@ ModifiedTimeType
 ImageToSpatialObjectRegistrationMethod<TFixedImage, TMovingSpatialObject>::GetMTime() const
 {
   ModifiedTimeType mtime = Superclass::GetMTime();
-  ModifiedTimeType m;
 
   // Some of the following should be removed once ivars are put in the
   // input and output lists
 
   if (m_Transform)
   {
-    m = m_Transform->GetMTime();
+    ModifiedTimeType m = m_Transform->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_Interpolator)
   {
-    m = m_Interpolator->GetMTime();
+    ModifiedTimeType m = m_Interpolator->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_Metric)
   {
-    m = m_Metric->GetMTime();
+    ModifiedTimeType m = m_Metric->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_Optimizer)
   {
-    m = m_Optimizer->GetMTime();
+    ModifiedTimeType m = m_Optimizer->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_FixedImage)
   {
-    m = m_FixedImage->GetMTime();
+    ModifiedTimeType m = m_FixedImage->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_MovingSpatialObject)
   {
-    m = m_MovingSpatialObject->GetMTime();
+    ModifiedTimeType m = m_MovingSpatialObject->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -923,14 +923,10 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::ComputePDF
     // Use a raw pointer here to avoid the overhead of smart pointers.
     // For instance, Register and UnRegister have mutex locks around
     // the reference counts.
-    TransformType * transform;
+    TransformType * transform = this->m_Transform;
     if (threadId > 0)
     {
       transform = this->m_ThreaderTransform[threadId - 1];
-    }
-    else
-    {
-      transform = this->m_Transform;
     }
 
     // Compute the transform Jacobian.
@@ -1003,8 +999,8 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::ComputePDF
          * (because for each parameter the Jacobian is non-zero in only 1 of the
          * possible dimensions) which is multiplied by the moving image
          * gradient. */
-        PDFValueType innerProduct;
-        int          parameterIndex;
+        PDFValueType innerProduct = NAN;
+        int          parameterIndex = 0;
         if (this->m_UseCachingOfBSplineWeights)
         {
           innerProduct = movingImageGradientValue[dim] * weights[mu];

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
@@ -53,10 +53,6 @@ MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Get
   {
     itkExceptionMacro("Fixed image has not been assigned");
   }
-
-  double MovingValue;
-  double FixedValue;
-
   using FixedIteratorType = itk::ImageRegionConstIteratorWithIndex<FixedImageType>;
 
   FixedIteratorType ti(fixedImage, this->GetFixedImageRegion());
@@ -93,8 +89,8 @@ MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Get
 
     if (this->m_Interpolator->IsInsideBuffer(transformedPoint))
     {
-      MovingValue = this->m_Interpolator->Evaluate(transformedPoint);
-      FixedValue = ti.Get();
+      double MovingValue = this->m_Interpolator->Evaluate(transformedPoint);
+      double FixedValue = ti.Get();
       this->m_NumberOfPixelsCounted++;
       const double diff = MovingValue - FixedValue;
       measure += 1.0f / (1.0f + m_Lambda * (diff * diff));

--- a/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.hxx
@@ -153,15 +153,11 @@ MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivativeT
   // Use a raw pointer here to avoid the overhead of smart pointers.
   // For instance, Register and UnRegister have mutex locks around
   // the reference counts.
-  TransformType * transform;
+  TransformType * transform = this->m_Transform;
 
   if (threadId > 0)
   {
     transform = this->m_ThreaderTransform[threadId - 1];
-  }
-  else
-  {
-    transform = this->m_Transform;
   }
 
   if (this->m_BSplineTransform && this->m_UseCachingOfBSplineWeights)

--- a/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
@@ -375,44 +375,43 @@ ModifiedTimeType
 MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::GetMTime() const
 {
   ModifiedTimeType mtime = Superclass::GetMTime();
-  ModifiedTimeType m;
 
   // Some of the following should be removed once ivars are put in the
   // input and output lists
 
   if (m_Transform)
   {
-    m = m_Transform->GetMTime();
+    ModifiedTimeType m = m_Transform->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_Interpolator)
   {
-    m = m_Interpolator->GetMTime();
+    ModifiedTimeType m = m_Interpolator->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_Metric)
   {
-    m = m_Metric->GetMTime();
+    ModifiedTimeType m = m_Metric->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_Optimizer)
   {
-    m = m_Optimizer->GetMTime();
+    ModifiedTimeType m = m_Optimizer->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_FixedImage)
   {
-    m = m_FixedImage->GetMTime();
+    ModifiedTimeType m = m_FixedImage->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_MovingImage)
   {
-    m = m_MovingImage->GetMTime();
+    ModifiedTimeType m = m_MovingImage->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 

--- a/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.hxx
@@ -215,13 +215,10 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const P
     dSumJoint += m_MinProbability;
     for (aiter = m_SampleA.begin(); aiter != aend; ++aiter)
     {
-      double valueFixed;
-      double valueMoving;
-
-      valueFixed = (biter->FixedImageValue - aiter->FixedImageValue) / m_FixedImageStandardDeviation;
+      double valueFixed = (biter->FixedImageValue - aiter->FixedImageValue) / m_FixedImageStandardDeviation;
       valueFixed = m_KernelFunction->Evaluate(valueFixed);
 
-      valueMoving = (biter->MovingImageValue - aiter->MovingImageValue) / m_MovingImageStandardDeviation;
+      double valueMoving = (biter->MovingImageValue - aiter->MovingImageValue) / m_MovingImageStandardDeviation;
       valueMoving = m_KernelFunction->Evaluate(valueMoving);
 
       dSumFixed += valueFixed;
@@ -324,13 +321,10 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDeriv
     dSumFixed += m_MinProbability;
     for (aiter = m_SampleA.begin(); aiter != aend; ++aiter)
     {
-      double valueFixed;
-      double valueMoving;
-
-      valueFixed = (biter->FixedImageValue - aiter->FixedImageValue) / m_FixedImageStandardDeviation;
+      double valueFixed = (biter->FixedImageValue - aiter->FixedImageValue) / m_FixedImageStandardDeviation;
       valueFixed = m_KernelFunction->Evaluate(valueFixed);
 
-      valueMoving = (biter->MovingImageValue - aiter->MovingImageValue) / m_MovingImageStandardDeviation;
+      double valueMoving = (biter->MovingImageValue - aiter->MovingImageValue) / m_MovingImageStandardDeviation;
       valueMoving = m_KernelFunction->Evaluate(valueMoving);
 
       dDenominatorMoving += valueMoving;
@@ -358,22 +352,16 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDeriv
     SumType totalWeight;
     for (aiter = m_SampleA.begin(), aditer = sampleADerivatives.begin(); aiter != aend; ++aiter, ++aditer)
     {
-      double valueFixed;
-      double valueMoving;
-      double weightMoving;
-      double weightJoint;
-      double weight;
-
-      valueFixed = (biter->FixedImageValue - aiter->FixedImageValue) / m_FixedImageStandardDeviation;
+      double valueFixed = (biter->FixedImageValue - aiter->FixedImageValue) / m_FixedImageStandardDeviation;
       valueFixed = m_KernelFunction->Evaluate(valueFixed);
 
-      valueMoving = (biter->MovingImageValue - aiter->MovingImageValue) / m_MovingImageStandardDeviation;
+      double valueMoving = (biter->MovingImageValue - aiter->MovingImageValue) / m_MovingImageStandardDeviation;
       valueMoving = m_KernelFunction->Evaluate(valueMoving);
 
-      weightMoving = valueMoving / dDenominatorMoving.GetSum();
-      weightJoint = valueMoving * valueFixed / dDenominatorJoint.GetSum();
+      double weightMoving = valueMoving / dDenominatorMoving.GetSum();
+      double weightJoint = valueMoving * valueFixed / dDenominatorJoint.GetSum();
 
-      weight = (weightMoving - weightJoint);
+      double weight = (weightMoving - weightJoint);
       weight *= biter->MovingImageValue - aiter->MovingImageValue;
 
       totalWeight += weight;

--- a/Modules/Registration/Common/include/itkPointSetToImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToImageRegistrationMethod.hxx
@@ -169,44 +169,43 @@ ModifiedTimeType
 PointSetToImageRegistrationMethod<TFixedPointSet, TMovingImage>::GetMTime() const
 {
   ModifiedTimeType mtime = Superclass::GetMTime();
-  ModifiedTimeType m;
 
   // Some of the following should be removed once ivars are put in the
   // input and output lists
 
   if (m_Transform)
   {
-    m = m_Transform->GetMTime();
+    ModifiedTimeType m = m_Transform->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_Interpolator)
   {
-    m = m_Interpolator->GetMTime();
+    ModifiedTimeType m = m_Interpolator->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_Metric)
   {
-    m = m_Metric->GetMTime();
+    ModifiedTimeType m = m_Metric->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_Optimizer)
   {
-    m = m_Optimizer->GetMTime();
+    ModifiedTimeType m = m_Optimizer->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_FixedPointSet)
   {
-    m = m_FixedPointSet->GetMTime();
+    ModifiedTimeType m = m_FixedPointSet->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_MovingImage)
   {
-    m = m_MovingImage->GetMTime();
+    ModifiedTimeType m = m_MovingImage->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 

--- a/Modules/Registration/Common/include/itkPointSetToPointSetRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToPointSetRegistrationMethod.hxx
@@ -163,38 +163,37 @@ ModifiedTimeType
 PointSetToPointSetRegistrationMethod<TFixedPointSet, TMovingPointSet>::GetMTime() const
 {
   ModifiedTimeType mtime = Superclass::GetMTime();
-  ModifiedTimeType m;
 
   // Some of the following should be removed once ivars are put in the
   // input and output lists
 
   if (m_Transform)
   {
-    m = m_Transform->GetMTime();
+    ModifiedTimeType m = m_Transform->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_Metric)
   {
-    m = m_Metric->GetMTime();
+    ModifiedTimeType m = m_Metric->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_Optimizer)
   {
-    m = m_Optimizer->GetMTime();
+    ModifiedTimeType m = m_Optimizer->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_FixedPointSet)
   {
-    m = m_FixedPointSet->GetMTime();
+    ModifiedTimeType m = m_FixedPointSet->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 
   if (m_MovingPointSet)
   {
-    m = m_MovingPointSet->GetMTime();
+    ModifiedTimeType m = m_MovingPointSet->GetMTime();
     mtime = (m > mtime ? m : mtime);
   }
 

--- a/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.hxx
@@ -245,7 +245,7 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateO
     requestedSize = requestedRegion.GetSize();
     requestedIndex = requestedRegion.GetIndex();
 
-    for (int idim = 0; idim < int{ ImageDimension }; ++idim)
+    for (unsigned int idim = 0; idim < ImageDimension; ++idim)
     {
       factors[idim] = this->GetSchedule()[ilevel - 1][idim] / this->GetSchedule()[ilevel][idim];
 
@@ -282,7 +282,7 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateO
     requestedSize = requestedRegion.GetSize();
     requestedIndex = requestedRegion.GetIndex();
 
-    for (int idim = 0; idim < int{ ImageDimension }; ++idim)
+    for (unsigned int idim = 0; idim < ImageDimension; ++idim)
     {
       factors[idim] = this->GetSchedule()[ilevel][idim] / this->GetSchedule()[ilevel + 1][idim];
 
@@ -344,8 +344,7 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateI
   SizeType     baseSize = this->GetOutput(refLevel)->GetRequestedRegion().GetSize();
   IndexType    baseIndex = this->GetOutput(refLevel)->GetRequestedRegion().GetIndex();
 
-  unsigned int idim;
-  for (idim = 0; idim < ImageDimension; ++idim)
+  for (unsigned int idim = 0; idim < ImageDimension; ++idim)
   {
     const unsigned int factor = this->GetSchedule()[refLevel][idim];
     baseIndex[idim] *= static_cast<IndexValueType>(factor);
@@ -364,7 +363,7 @@ RecursiveMultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::GenerateI
   RegionType inputRequestedRegion = baseRegion;
   refLevel = 0;
 
-  for (idim = 0; idim < TInputImage::ImageDimension; ++idim)
+  for (unsigned int idim = 0; idim < TInputImage::ImageDimension; ++idim)
   {
     oper.SetDirection(idim);
     oper.SetVariance(itk::Math::sqr(0.5 * static_cast<float>(this->GetSchedule()[refLevel][idim])));

--- a/Modules/Registration/Common/test/itkGradientDifferenceImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkGradientDifferenceImageToImageMetricTest.cxx
@@ -121,14 +121,14 @@ itkGradientDifferenceImageToImageMetricTest(int, char *[])
     metric->Initialize();
 
     // Do some work
-    DerivativeType          derivatives(numberOfParameters);
-    MetricType::MeasureType value;
+    DerivativeType derivatives(numberOfParameters);
     for (double y = -10.0; y <= 10.0; y += 5.0)
     {
       parameters[1] = y;
       for (double x = -10.0; x <= 10.0; x += 5.0)
       {
         parameters[0] = x;
+        MetricType::MeasureType value = NAN;
         metric->GetValueAndDerivative(parameters, value, derivatives);
         std::cout << "Parameters: " << parameters << ", Value: " << value << ", Derivatives: " << derivatives
                   << std::endl;

--- a/Modules/Registration/Common/test/itkHistogramImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkHistogramImageToImageMetricTest.cxx
@@ -163,7 +163,7 @@ itkHistogramImageToImageMetricTest(int, char *[])
 
     // Do some work
     DerivativeType          derivatives(numberOfParameters);
-    MetricType::MeasureType value;
+    MetricType::MeasureType value = NAN;
     for (double y = -50.0; y <= 50.0; y += 25.0)
     {
       parameters[1] = y;

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest.cxx
@@ -36,8 +36,6 @@ itkImageRegistrationMethodTest(int, char *[])
 
   itk::OutputWindow::SetInstance(itk::TextOutput::New().GetPointer());
 
-  bool pass;
-
   constexpr unsigned int dimension = 3;
 
   // Fixed Image Type
@@ -112,7 +110,7 @@ itkImageRegistrationMethodTest(int, char *[])
   /****************************************************
    * Test out initialization errors
    ****************************************************/
-
+  bool pass = false;
 #define TEST_INITIALIZATION_ERROR(ComponentName, badComponent, goodComponent) \
   registration->Set##ComponentName(badComponent);                             \
   try                                                                         \

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_13.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_13.cxx
@@ -99,7 +99,6 @@ itkImageRegistrationMethodTest_13(int, char *[])
   bool pass = true;
 
   constexpr unsigned int dimension = 3;
-  unsigned int           j;
 
   using PixelType = float;
 
@@ -155,7 +154,7 @@ itkImageRegistrationMethodTest_13(int, char *[])
   using FixedImageIterator = itk::ImageRegionIterator<FixedImageType>;
 
   itk::Point<double, dimension> center;
-  for (j = 0; j < dimension; ++j)
+  for (unsigned int j = 0; j < dimension; ++j)
   {
     center[j] = 0.5 * static_cast<double>(region.GetSize()[j]);
   }
@@ -168,7 +167,7 @@ itkImageRegistrationMethodTest_13(int, char *[])
 
   while (!mIter.IsAtEnd())
   {
-    for (j = 0; j < dimension; ++j)
+    for (unsigned int j = 0; j < dimension; ++j)
     {
       p[j] = mIter.GetIndex()[j];
     }
@@ -177,7 +176,7 @@ itkImageRegistrationMethodTest_13(int, char *[])
 
     fIter.Set((PixelType)F(d));
 
-    for (j = 0; j < dimension; ++j)
+    for (unsigned int j = 0; j < dimension; ++j)
     {
       d[j] = d[j] * scale[j] + displacement[j];
     }
@@ -190,7 +189,7 @@ itkImageRegistrationMethodTest_13(int, char *[])
 
   // set the image origin to be center of the image
   double transCenter[dimension];
-  for (j = 0; j < dimension; ++j)
+  for (unsigned int j = 0; j < dimension; ++j)
   {
     transCenter[j] = -0.5 * static_cast<double>(size[j]);
   }
@@ -209,7 +208,7 @@ itkImageRegistrationMethodTest_13(int, char *[])
 
   parametersScales.Fill(1.0);
 
-  for (j = 9; j < 12; ++j)
+  for (unsigned int j = 9; j < 12; ++j)
   {
     parametersScales[j] = 0.001;
   }
@@ -256,7 +255,7 @@ itkImageRegistrationMethodTest_13(int, char *[])
   constexpr unsigned int iter[numberOfLoops] = { 300, 300, 350 };
   constexpr double       rates[numberOfLoops] = { 1e-3, 5e-4, 1e-4 };
 
-  for (j = 0; j < numberOfLoops; ++j)
+  for (unsigned int j = 0; j < numberOfLoops; ++j)
   {
 
     try
@@ -296,7 +295,7 @@ itkImageRegistrationMethodTest_13(int, char *[])
 
   std::cout << "True solution is: " << trueParameters << std::endl;
 
-  for (j = 0; j < 9; ++j)
+  for (unsigned int j = 0; j < 9; ++j)
   {
     if (itk::Math::abs(solution[j] - trueParameters[j]) > 0.025)
     {
@@ -304,7 +303,7 @@ itkImageRegistrationMethodTest_13(int, char *[])
       pass = false;
     }
   }
-  for (j = 9; j < 12; ++j)
+  for (unsigned int j = 9; j < 12; ++j)
   {
     if (itk::Math::abs(solution[j] - trueParameters[j]) > 1.0)
     {

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_15.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_15.cxx
@@ -83,7 +83,6 @@ itkImageRegistrationMethodTest_15(int, char *[])
   bool pass = true;
 
   constexpr unsigned int dimension = 3;
-  unsigned int           j;
 
   using PixelType = float;
 
@@ -139,7 +138,7 @@ itkImageRegistrationMethodTest_15(int, char *[])
   using FixedImageIterator = itk::ImageRegionIterator<FixedImageType>;
 
   itk::Point<double, dimension> center;
-  for (j = 0; j < dimension; ++j)
+  for (unsigned int j = 0; j < dimension; ++j)
   {
     center[j] = 0.5 * static_cast<double>(region.GetSize()[j]);
   }
@@ -152,7 +151,7 @@ itkImageRegistrationMethodTest_15(int, char *[])
 
   while (!mIter.IsAtEnd())
   {
-    for (j = 0; j < dimension; ++j)
+    for (unsigned int j = 0; j < dimension; ++j)
     {
       p[j] = mIter.GetIndex()[j];
     }
@@ -161,7 +160,7 @@ itkImageRegistrationMethodTest_15(int, char *[])
 
     fIter.Set((PixelType)F(d));
 
-    for (j = 0; j < dimension; ++j)
+    for (unsigned int j = 0; j < dimension; ++j)
     {
       d[j] = d[j] * scale[j] + displacement[j];
     }
@@ -174,7 +173,7 @@ itkImageRegistrationMethodTest_15(int, char *[])
 
   // set the image origin to be center of the image
   double transCenter[dimension];
-  for (j = 0; j < dimension; ++j)
+  for (unsigned int j = 0; j < dimension; ++j)
   {
     transCenter[j] = -0.5 * static_cast<double>(size[j]);
   }
@@ -193,7 +192,7 @@ itkImageRegistrationMethodTest_15(int, char *[])
 
   parametersScales.Fill(1.0);
 
-  for (j = 9; j < 12; ++j)
+  for (unsigned int j = 9; j < 12; ++j)
   {
     parametersScales[j] = 0.0001;
   }
@@ -256,7 +255,7 @@ itkImageRegistrationMethodTest_15(int, char *[])
   constexpr double       rates[numberOfLoops] = { 1e-3, 5e-4 };
 
 
-  for (j = 0; j < numberOfLoops; ++j)
+  for (unsigned int j = 0; j < numberOfLoops; ++j)
   {
 
     try
@@ -296,14 +295,14 @@ itkImageRegistrationMethodTest_15(int, char *[])
 
   std::cout << "True solution is: " << trueParameters << std::endl;
 
-  for (j = 0; j < 9; ++j)
+  for (unsigned int j = 0; j < 9; ++j)
   {
     if (itk::Math::abs(solution[j] - trueParameters[j]) > 0.025)
     {
       pass = false;
     }
   }
-  for (j = 9; j < 12; ++j)
+  for (unsigned int j = 9; j < 12; ++j)
   {
     if (itk::Math::abs(solution[j] - trueParameters[j]) > 1.0)
     {

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_17.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_17.cxx
@@ -89,7 +89,6 @@ itkImageRegistrationMethodTest_17(int, char *[])
   bool pass = true;
 
   constexpr unsigned int dimension = 3;
-  unsigned int           j;
 
   using PixelType = float;
 
@@ -145,7 +144,7 @@ itkImageRegistrationMethodTest_17(int, char *[])
   using FixedImageIterator = itk::ImageRegionIterator<FixedImageType>;
 
   itk::Point<double, dimension> center;
-  for (j = 0; j < dimension; ++j)
+  for (unsigned int j = 0; j < dimension; ++j)
   {
     center[j] = 0.5 * static_cast<double>(region.GetSize()[j]);
   }
@@ -158,7 +157,7 @@ itkImageRegistrationMethodTest_17(int, char *[])
 
   while (!mIter.IsAtEnd())
   {
-    for (j = 0; j < dimension; ++j)
+    for (unsigned int j = 0; j < dimension; ++j)
     {
       p[j] = mIter.GetIndex()[j];
     }
@@ -167,7 +166,7 @@ itkImageRegistrationMethodTest_17(int, char *[])
 
     fIter.Set((PixelType)F(d));
 
-    for (j = 0; j < dimension; ++j)
+    for (unsigned int j = 0; j < dimension; ++j)
     {
       d[j] = d[j] * scale[j] + displacement[j];
     }
@@ -180,7 +179,7 @@ itkImageRegistrationMethodTest_17(int, char *[])
 
   // set the image origin to be center of the image
   double transCenter[dimension];
-  for (j = 0; j < dimension; ++j)
+  for (unsigned int j = 0; j < dimension; ++j)
   {
     transCenter[j] = -0.5 * static_cast<double>(size[j]);
   }
@@ -199,7 +198,7 @@ itkImageRegistrationMethodTest_17(int, char *[])
 
   parametersScales.Fill(1.0);
 
-  for (j = 9; j < 12; ++j)
+  for (unsigned int j = 9; j < 12; ++j)
   {
     parametersScales[j] = 0.0001;
   }
@@ -264,7 +263,7 @@ itkImageRegistrationMethodTest_17(int, char *[])
   constexpr double       rates[numberOfLoops] = { 1e-3, 5e-4 };
 
 
-  for (j = 0; j < numberOfLoops; ++j)
+  for (unsigned int j = 0; j < numberOfLoops; ++j)
   {
 
     try
@@ -304,14 +303,14 @@ itkImageRegistrationMethodTest_17(int, char *[])
 
   std::cout << "True solution is: " << trueParameters << std::endl;
 
-  for (j = 0; j < 9; ++j)
+  for (unsigned int j = 0; j < 9; ++j)
   {
     if (itk::Math::abs(solution[j] - trueParameters[j]) > 0.025)
     {
       pass = false;
     }
   }
-  for (j = 9; j < 12; ++j)
+  for (unsigned int j = 9; j < 12; ++j)
   {
     if (itk::Math::abs(solution[j] - trueParameters[j]) > 1.0)
     {

--- a/Modules/Registration/Common/test/itkKullbackLeiblerCompareHistogramImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkKullbackLeiblerCompareHistogramImageToImageMetricTest.cxx
@@ -265,7 +265,7 @@ itkKullbackLeiblerCompareHistogramImageToImageMetricTest(int, char *[])
   // for parameters[4] = {-10,10}
   //---------------------------------------------------------
 
-  MetricType::MeasureType    measure;
+  MetricType::MeasureType    measure = NAN;
   MetricType::DerivativeType derivative(numberOfParameters);
 
   itk::TimeProbesCollectorBase collector;

--- a/Modules/Registration/Common/test/itkMeanReciprocalSquareDifferenceImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMeanReciprocalSquareDifferenceImageMetricTest.cxx
@@ -190,7 +190,7 @@ itkMeanReciprocalSquareDifferenceImageMetricTest(int, char *[])
   // for parameters[1] = {-10,10}  (arbitrary choice...)
   //---------------------------------------------------------
 
-  MetricType::MeasureType    measure;
+  MetricType::MeasureType    measure = NAN;
   MetricType::DerivativeType derivative;
 
   std::cout << "param[1]   Metric    d(Metric)/d(param[1] " << std::endl;

--- a/Modules/Registration/Common/test/itkMeanReciprocalSquareDifferencePointSetToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMeanReciprocalSquareDifferencePointSetToImageMetricTest.cxx
@@ -227,7 +227,7 @@ itkMeanReciprocalSquareDifferencePointSetToImageMetricTest(int, char *[])
   // for parameters[1] = {-10,10}  (arbitrary choice...)
   //---------------------------------------------------------
 
-  MetricType::MeasureType    measure;
+  MetricType::MeasureType    measure = NAN;
   MetricType::DerivativeType derivative;
 
   std::cout << "param[1]   Metric    d(Metric)/d(param[1] " << std::endl;

--- a/Modules/Registration/Common/test/itkMeanSquaresImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMeanSquaresImageMetricTest.cxx
@@ -179,7 +179,7 @@ itkMeanSquaresImageMetricTest(int, char *[])
   // for parameters[1] = {-10,10}  (arbitrary choice...)
   //---------------------------------------------------------
 
-  MetricType::MeasureType    measure;
+  MetricType::MeasureType    measure = NAN;
   MetricType::DerivativeType derivative;
 
   std::cout << "param[1]   Metric    d(Metric)/d(param[1]) " << std::endl;
@@ -416,7 +416,7 @@ itkMeanSquaresImageMetricTest(int, char *[])
     std::cout << "Test for exception throwing... PASSED ! " << std::endl;
   }
 
-  bool pass;
+  bool pass = false;
 #define TEST_INITIALIZATION_ERROR(ComponentName, badComponent, goodComponent) \
   metric->Set##ComponentName(badComponent);                                   \
   try                                                                         \

--- a/Modules/Registration/Common/test/itkMeanSquaresPointSetToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMeanSquaresPointSetToImageMetricTest.cxx
@@ -221,7 +221,7 @@ itkMeanSquaresPointSetToImageMetricTest(int, char *[])
   // for parameters[1] = {-10,10}  (arbitrary choice...)
   //---------------------------------------------------------
 
-  MetricType::MeasureType    measure;
+  MetricType::MeasureType    measure = NAN;
   MetricType::DerivativeType derivative;
 
   std::cout << "param[1]   Metric    d(Metric)/d(param[1] " << std::endl;

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest.cxx
@@ -38,8 +38,6 @@ itkMultiResolutionImageRegistrationMethodTest(int, char *[])
 
   itk::OutputWindow::SetInstance(itk::TextOutput::New().GetPointer());
 
-  bool pass;
-
   constexpr unsigned int dimension = 3;
 
   // Fixed Image Type
@@ -147,7 +145,7 @@ itkMultiResolutionImageRegistrationMethodTest(int, char *[])
   /****************************************************
    * Test out initialization errors
    ****************************************************/
-
+  bool pass = false;
 #define TEST_INITIALIZATION_ERROR(ComponentName, badComponent, goodComponent) \
   registration->Set##ComponentName(badComponent);                             \
   try                                                                         \

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_1.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_1.cxx
@@ -81,7 +81,6 @@ itkMultiResolutionImageRegistrationMethodTest_1(int, char *[])
   bool pass = true;
 
   constexpr unsigned int dimension = 3;
-  unsigned int           j;
 
   using PixelType = float;
 
@@ -137,7 +136,7 @@ itkMultiResolutionImageRegistrationMethodTest_1(int, char *[])
   using FixedImageIterator = itk::ImageRegionIterator<FixedImageType>;
 
   itk::Point<double, dimension> center;
-  for (j = 0; j < dimension; ++j)
+  for (unsigned int j = 0; j < dimension; ++j)
   {
     center[j] = 0.5 * static_cast<double>(region.GetSize()[j]);
   }
@@ -150,7 +149,7 @@ itkMultiResolutionImageRegistrationMethodTest_1(int, char *[])
 
   while (!mIter.IsAtEnd())
   {
-    for (j = 0; j < dimension; ++j)
+    for (unsigned int j = 0; j < dimension; ++j)
     {
       p[j] = mIter.GetIndex()[j];
     }
@@ -159,7 +158,7 @@ itkMultiResolutionImageRegistrationMethodTest_1(int, char *[])
 
     fIter.Set((PixelType)F(d));
 
-    for (j = 0; j < dimension; ++j)
+    for (unsigned int j = 0; j < dimension; ++j)
     {
       d[j] = d[j] * scale[j] + displacement[j];
     }
@@ -172,7 +171,7 @@ itkMultiResolutionImageRegistrationMethodTest_1(int, char *[])
 
   // set the image origin to be center of the image
   double transCenter[dimension];
-  for (j = 0; j < dimension; ++j)
+  for (unsigned int j = 0; j < dimension; ++j)
   {
     transCenter[j] = -0.5 * static_cast<double>(size[j]);
   }
@@ -205,7 +204,7 @@ itkMultiResolutionImageRegistrationMethodTest_1(int, char *[])
 
     parametersScales.Fill(1.0);
 
-    for (j = 9; j < 12; ++j)
+    for (unsigned int j = 9; j < 12; ++j)
     {
       parametersScales[j] = 0.0001;
     }
@@ -300,14 +299,14 @@ itkMultiResolutionImageRegistrationMethodTest_1(int, char *[])
 
     std::cout << "True solution is: " << trueParameters << std::endl;
 
-    for (j = 0; j < 9; ++j)
+    for (unsigned int j = 0; j < 9; ++j)
     {
       if (itk::Math::abs(solution[j] - trueParameters[j]) > 0.025)
       {
         pass = false;
       }
     }
-    for (j = 9; j < 12; ++j)
+    for (unsigned int j = 9; j < 12; ++j)
     {
       if (itk::Math::abs(solution[j] - trueParameters[j]) > 1.0)
       {
@@ -429,7 +428,7 @@ itkMultiResolutionImageRegistrationMethodTest_1(int, char *[])
 
     parametersScales.Fill(1.0);
 
-    for (j = 9; j < 12; ++j)
+    for (unsigned int j = 9; j < 12; ++j)
     {
       parametersScales[j] = 0.0001;
     }
@@ -528,14 +527,14 @@ itkMultiResolutionImageRegistrationMethodTest_1(int, char *[])
 
     std::cout << "True solution is: " << trueParameters << std::endl;
 
-    for (j = 0; j < 9; ++j)
+    for (unsigned int j = 0; j < 9; ++j)
     {
       if (itk::Math::abs(solution[j] - trueParameters[j]) > 0.025)
       {
         pass = false;
       }
     }
-    for (j = 9; j < 12; ++j)
+    for (unsigned int j = 9; j < 12; ++j)
     {
       if (itk::Math::abs(solution[j] - trueParameters[j]) > 1.0)
       {

--- a/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
@@ -212,11 +212,10 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
   pyramid->SetUseShrinkImageFilter(useShrinkFilter);
   pyramid->SetInput(imgTarget);
 
-  unsigned int                              numLevels;
   itk::Vector<unsigned int, ImageDimension> factors;
 
   // set schedule by specifying the number of levels;
-  numLevels = 3;
+  unsigned int numLevels = 3;
   factors.Fill(1 << (numLevels - 1));
   pyramid->SetNumberOfLevels(numLevels);
 

--- a/Modules/Registration/Common/test/itkMutualInformationMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMutualInformationMetricTest.cxx
@@ -187,7 +187,7 @@ itkMutualInformationMetricTest(int, char *[])
   // for parameters[4] = {-10,10}
   //---------------------------------------------------------
 
-  MetricType::MeasureType    measure;
+  MetricType::MeasureType    measure = NAN;
   MetricType::DerivativeType derivative(numberOfParameters);
 
   itk::TimeProbesCollectorBase collector;

--- a/Modules/Registration/Common/test/itkNormalizedCorrelationImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkNormalizedCorrelationImageMetricTest.cxx
@@ -177,7 +177,7 @@ itkNormalizedCorrelationImageMetricTest(int, char *[])
   // for parameters[1] = {-10,10}  (arbitrary choice...)
   //---------------------------------------------------------
 
-  MetricType::MeasureType    measure;
+  MetricType::MeasureType    measure = NAN;
   MetricType::DerivativeType derivative;
 
   std::cout << "param[1]   Metric    d(Metric)/d(param[1] " << std::endl;

--- a/Modules/Registration/Common/test/itkNormalizedCorrelationPointSetToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkNormalizedCorrelationPointSetToImageMetricTest.cxx
@@ -214,7 +214,7 @@ itkNormalizedCorrelationPointSetToImageMetricTest(int, char *[])
   // for parameters[1] = {-10,10}  (arbitrary choice...)
   //---------------------------------------------------------
 
-  MetricType::MeasureType    measure;
+  MetricType::MeasureType    measure = NAN;
   MetricType::DerivativeType derivative;
 
   std::cout << "param[1]   Metric    d(Metric)/d(param[1] " << std::endl;

--- a/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -44,7 +44,7 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<TDo
   VirtualPointType   virtualPoint;
   MeasureType        metricValueResult{};
   MeasureType        metricValueSum{};
-  bool               pointIsValid;
+  bool               pointIsValid = false;
   ScanIteratorType   scanIt;
   ScanParametersType scanParameters;
   ScanMemType        scanMem;
@@ -446,7 +446,7 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<
   MovingImagePointType    mappedMovingPoint;
   MovingImagePixelType    movingImageValue;
   MovingImageGradientType movingImageGradient;
-  bool                    pointIsValid;
+  bool                    pointIsValid = false;
 
   this->m_ANTSAssociate->TransformVirtualIndexToPhysicalPoint(oindex, virtualPoint);
 
@@ -591,7 +591,7 @@ ANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader<TDo
 {
 
   MeasureType        metricValueResult{};
-  bool               pointIsValid;
+  bool               pointIsValid = false;
   ScanIteratorType   scanIt;
   ScanParametersType scanParameters;
   ScanMemType        scanMem;

--- a/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -63,18 +63,13 @@ DemonsImageToImageMetricv4GetValueAndDerivativeThreader<TDomainPartitioner, TIma
 
   /* Derivative */
   InternalComputationValueType   gradientSquaredMagnitude = 0;
-  const FixedImageGradientType * gradient;
-  SizeValueType                  numberOfDimensions;
+  const FixedImageGradientType * gradient = &movingImageGradient;
+  SizeValueType                  numberOfDimensions = ImageToImageMetricv4Type::MovingImageDimension;
 
   if (this->m_DemonsAssociate->GetGradientSourceIncludesFixed())
   {
     gradient = &fixedImageGradient;
     numberOfDimensions = ImageToImageMetricv4Type::FixedImageDimension;
-  }
-  else
-  {
-    gradient = &movingImageGradient;
-    numberOfDimensions = ImageToImageMetricv4Type::MovingImageDimension;
   }
 
   for (ImageDimensionType j = 0; j < numberOfDimensions; ++j)

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
@@ -84,8 +84,7 @@ JointHistogramMutualInformationComputeJointPDFThreaderBase<TDomainPartitioner, T
         if (this->m_JointHistogramMIPerThreadVariables[threadId].JointHistogram->GetBufferedRegion().IsInside(
               jointPDFIndex))
         {
-          typename JointHistogramType::PixelType jointHistogramPixel;
-          jointHistogramPixel =
+          typename JointHistogramType::PixelType jointHistogramPixel =
             this->m_JointHistogramMIPerThreadVariables[threadId].JointHistogram->GetPixel(jointPDFIndex);
           ++jointHistogramPixel;
           this->m_JointHistogramMIPerThreadVariables[threadId].JointHistogram->SetPixel(jointPDFIndex,
@@ -138,7 +137,7 @@ JointHistogramMutualInformationComputeJointPDFThreaderBase<TDomainPartitioner,
     jointHistogramPerThreadIts[i].GoToBegin();
   }
 
-  JointHistogramPixelType jointHistogramPixel;
+  JointHistogramPixelType jointHistogramPixel = 0;
   while (!jointPDFIt.IsAtEnd())
   {
     jointHistogramPixel = JointHistogramPixelType{};

--- a/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
@@ -255,7 +255,7 @@ itkANTSNeighborhoodCorrelationImageToImageMetricv4Test(int, char ** const)
 
 
   // Evaluate
-  MetricType::MeasureType    valueReturn1;
+  MetricType::MeasureType    valueReturn1 = NAN;
   MetricType::DerivativeType derivativeReturn;
   ITK_TRY_EXPECT_NO_EXCEPTION(metric->GetValueAndDerivative(valueReturn1, derivativeReturn));
 
@@ -264,7 +264,7 @@ itkANTSNeighborhoodCorrelationImageToImageMetricv4Test(int, char ** const)
 
 
   // Evaluate with GetValue
-  MetricType::MeasureType valueReturn2;
+  MetricType::MeasureType valueReturn2 = NAN;
   ITK_TRY_EXPECT_NO_EXCEPTION(valueReturn2 = metric->GetValue());
 
 
@@ -322,7 +322,7 @@ itkANTSNeighborhoodCorrelationImageToImageMetricv4Test(int, char ** const)
   ITK_TRY_EXPECT_NO_EXCEPTION(metricSparse->Initialize());
 
 
-  MetricType::MeasureType    valueReturnSparse;
+  MetricType::MeasureType    valueReturnSparse = NAN;
   MetricType::DerivativeType derivativeReturnSparse;
   ITK_TRY_EXPECT_NO_EXCEPTION(metricSparse->GetValueAndDerivative(valueReturnSparse, derivativeReturnSparse));
 
@@ -358,7 +358,7 @@ itkANTSNeighborhoodCorrelationImageToImageMetricv4Test(int, char ** const)
   transformMdisplacement->SetParameters(parameters);
   constexpr MetricType::MeasureType expectedMetricMax = itk::NumericTraits<MetricType::MeasureType>::max();
   std::cout << "Testing non-overlapping images. Expect a warning:" << std::endl;
-  MetricType::MeasureType valueReturn;
+  MetricType::MeasureType valueReturn = NAN;
   metric->GetValueAndDerivative(valueReturn, derivativeReturn);
   if (metric->GetNumberOfValidPoints() != 0 || itk::Math::NotExactlyEquals(valueReturn, expectedMetricMax))
   {

--- a/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
@@ -207,7 +207,7 @@ itkCorrelationImageToImageMetricv4Test(int, char ** const)
 
   metric->SetMaximumNumberOfWorkUnits(1);
   std::cerr << "Setting number of metric threads to " << metric->GetMaximumNumberOfWorkUnits() << std::endl;
-  MetricType::MeasureType    value1;
+  MetricType::MeasureType    value1 = NAN;
   MetricType::DerivativeType derivative1;
 
   int ret = itkCorrelationImageToImageMetricv4Test_WithSpecifiedThreads(metric, value1, derivative1);
@@ -215,7 +215,7 @@ itkCorrelationImageToImageMetricv4Test(int, char ** const)
   {
     result = EXIT_FAILURE;
   }
-  MetricType::MeasureType    value2;
+  MetricType::MeasureType    value2 = NAN;
   MetricType::DerivativeType derivative2;
   metric->SetMaximumNumberOfWorkUnits(8);
   std::cerr << "Setting number of metric threads to " << metric->GetMaximumNumberOfWorkUnits() << std::endl;
@@ -250,7 +250,7 @@ itkCorrelationImageToImageMetricv4Test(int, char ** const)
   movingTransform->SetParameters(parameters);
   constexpr MetricType::MeasureType expectedMetricMax = itk::NumericTraits<MetricType::MeasureType>::max();
   std::cout << "Testing non-overlapping images. Expect a warning:" << std::endl;
-  MetricType::MeasureType    valueReturn;
+  MetricType::MeasureType    valueReturn = NAN;
   MetricType::DerivativeType derivativeReturn;
   metric->GetValueAndDerivative(valueReturn, derivativeReturn);
   if (metric->GetNumberOfValidPoints() != 0 || itk::Math::NotExactlyEquals(valueReturn, expectedMetricMax))

--- a/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
@@ -127,7 +127,7 @@ itkDemonsImageToImageMetricv4Test(int, char ** const)
   }
 
   // Evaluate with GetValueAndDerivative
-  MetricType::MeasureType    valueReturn1;
+  MetricType::MeasureType    valueReturn1 = NAN;
   MetricType::DerivativeType derivativeReturn;
   try
   {
@@ -151,7 +151,7 @@ itkDemonsImageToImageMetricv4Test(int, char ** const)
     std::cerr << "Caught unexpected exception during re-initialize: " << exc << std::endl;
     return EXIT_FAILURE;
   }
-  MetricType::MeasureType valueReturn2;
+  MetricType::MeasureType valueReturn2 = NAN;
   try
   {
     std::cout << "Calling GetValue..." << std::endl;

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
@@ -204,7 +204,7 @@ ImageToImageMetricv4TestComputeIdentityTruthValues(const ImageToImageMetricv4Tes
   std::cout << "truth values: Initialize" << std::endl;
   metric->Initialize();
   // Call once to setup gradient images if applicable
-  ImageToImageMetricv4TestMetricType::MeasureType    tempValue;
+  ImageToImageMetricv4TestMetricType::MeasureType    tempValue = NAN;
   ImageToImageMetricv4TestMetricType::DerivativeType tempDerivative;
 
   metric->GetValueAndDerivative(tempValue, tempDerivative);
@@ -319,14 +319,14 @@ ImageToImageMetricv4TestRunSingleTest(const ImageToImageMetricv4TestMetricPointe
   ITK_TRY_EXPECT_NO_EXCEPTION(metric->Initialize());
 
   // Evaluate using GetValue
-  ImageToImageMetricv4TestMetricType::MeasureType valueReturn1;
+  ImageToImageMetricv4TestMetricType::MeasureType valueReturn1 = NAN;
   ITK_TRY_EXPECT_NO_EXCEPTION(valueReturn1 = metric->GetValue());
 
   // Re-initialize.
   ITK_TRY_EXPECT_NO_EXCEPTION(metric->Initialize());
 
   // Evaluate using GetValueAndDerivative
-  ImageToImageMetricv4TestMetricType::MeasureType    valueReturn2;
+  ImageToImageMetricv4TestMetricType::MeasureType    valueReturn2 = NAN;
   ImageToImageMetricv4TestMetricType::DerivativeType derivativeReturn;
   ITK_TRY_EXPECT_NO_EXCEPTION(metric->GetValueAndDerivative(valueReturn2, derivativeReturn));
 
@@ -458,7 +458,7 @@ itkImageToImageMetricv4Test(int, char ** const)
   // Evaluate the metric and verify results, using identity transforms.
   // Test with different numbers of threads.
   // Run through all the permutations image gradient calculation method.
-  ImageToImageMetricv4TestMetricType::MeasureType    truthValue;
+  ImageToImageMetricv4TestMetricType::MeasureType    truthValue = NAN;
   ImageToImageMetricv4TestMetricType::DerivativeType truthDerivative;
   for (itk::ThreadIdType numberOfThreads = 1; numberOfThreads < 6; ++numberOfThreads)
   {
@@ -519,7 +519,7 @@ itkImageToImageMetricv4Test(int, char ** const)
   parameters[0] = 1000;
   parameters[1] = 1000;
   movingTransform->SetParameters(parameters);
-  ImageToImageMetricv4TestMetricType::MeasureType expectedMetricMax;
+  ImageToImageMetricv4TestMetricType::MeasureType expectedMetricMax = NAN;
   expectedMetricMax = itk::NumericTraits<ImageToImageMetricv4TestMetricType::MeasureType>::max();
   std::cout << "Testing non-overlapping images. Expect a warning:" << std::endl;
   if (ImageToImageMetricv4TestRunSingleTest(metric, truthValue, truthDerivative, 0, true) != EXIT_SUCCESS ||

--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
@@ -101,10 +101,10 @@ itkJointHistogramMutualInformationImageToImageMetricv4Test(int, char *[])
   ITK_TRY_EXPECT_NO_EXCEPTION(metric->Initialize());
 
   // Evaluate
-  MetricType::MeasureType valueReturn1;
+  MetricType::MeasureType valueReturn1 = NAN;
   ITK_TRY_EXPECT_NO_EXCEPTION(valueReturn1 = metric->GetValue());
 
-  MetricType::MeasureType    valueReturn2;
+  MetricType::MeasureType    valueReturn2 = NAN;
   MetricType::DerivativeType derivativeReturn;
   ITK_TRY_EXPECT_NO_EXCEPTION(metric->GetValueAndDerivative(valueReturn2, derivativeReturn));
 

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
@@ -121,7 +121,7 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest(int, char ** const)
   std::cout << "Initialized" << std::endl;
 
   /* Evaluate with GetValueAndDerivative */
-  MetricType::MeasureType    valueReturn1;
+  MetricType::MeasureType    valueReturn1 = NAN;
   MetricType::DerivativeType derivativeReturn;
   try
   {
@@ -145,7 +145,7 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest(int, char ** const)
     std::cerr << "Caught unexpected exception during re-initialize: " << exc << std::endl;
     return EXIT_FAILURE;
   }
-  MetricType::MeasureType valueReturn2;
+  MetricType::MeasureType valueReturn2 = NAN;
   try
   {
     std::cout << "Calling GetValue..." << std::endl;

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
@@ -103,7 +103,7 @@ itkMeanSquaresImageToImageMetricv4SpeedTest(int argc, char * argv[])
   metric->Initialize();
 
   // Evaluate with GetValueAndDerivative
-  MetricType::MeasureType    valueReturn1;
+  MetricType::MeasureType    valueReturn1 = NAN;
   MetricType::DerivativeType derivativeReturn;
 
   MetricType::MeasureType sum{};

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4Test.cxx
@@ -106,7 +106,7 @@ itkMeanSquaresImageToImageMetricv4Test(int, char ** const)
   }
 
   // Evaluate with GetValueAndDerivative
-  MetricType::MeasureType    valueReturn1;
+  MetricType::MeasureType    valueReturn1 = NAN;
   MetricType::DerivativeType derivativeReturn;
   try
   {
@@ -131,7 +131,7 @@ itkMeanSquaresImageToImageMetricv4Test(int, char ** const)
     return EXIT_FAILURE;
   }
 
-  MetricType::MeasureType valueReturn2;
+  MetricType::MeasureType valueReturn2 = NAN;
   try
   {
     std::cout << "Calling GetValue..." << std::endl;

--- a/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4Test.cxx
@@ -462,11 +462,10 @@ itkObjectToObjectMultiMetricv4TestRun(bool useDisplacementTransform)
   shiftScaleEstimator->EstimateScales(scales);
   std::cout << "Estimated scales: " << scales << std::endl;
 
-  ScalesEstimatorMultiType::FloatType      stepScale;
   ScalesEstimatorMultiType::ParametersType step;
   step.SetSize(multiVariateMetric->GetNumberOfParameters());
   step.Fill(itk::NumericTraits<ScalesEstimatorMultiType::ParametersType::ValueType>::OneValue());
-  stepScale = shiftScaleEstimator->EstimateStepScale(step);
+  ScalesEstimatorMultiType::FloatType stepScale = shiftScaleEstimator->EstimateStepScale(step);
   std::cout << "Estimated stepScale: " << stepScale << std::endl;
 
   //

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.hxx
@@ -161,7 +161,7 @@ DemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Compu
     mappedPoint[j] += it.GetCenterPixel()[j];
   }
 
-  double movingValue;
+  double movingValue = NAN;
   if (m_MovingImageInterpolator->IsInsideBuffer(mappedPoint))
   {
     movingValue = m_MovingImageInterpolator->Evaluate(mappedPoint);

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
@@ -353,16 +353,12 @@ ESMDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Co
   const double speedValue = fixedValue - movingValue;
   if (itk::Math::abs(speedValue) >= m_IntensityDifferenceThreshold)
   {
-    double denom;
+    // least square solution of the system
+    double denom = usedGradientTimes2SquaredMagnitude;
     if (m_Normalizer > 0.0)
     {
       // "ITK-Thirion" normalization
       denom = usedGradientTimes2SquaredMagnitude + (itk::Math::sqr(speedValue) / m_Normalizer);
-    }
-    else
-    {
-      // least square solution of the system
-      denom = usedGradientTimes2SquaredMagnitude;
     }
 
     if (denom >= m_DenominatorThreshold)

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.hxx
@@ -219,7 +219,7 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
     mappedPoint[j] += it.GetCenterPixel()[j];
   }
   PixelType update;
-  double    movingValue;
+  double    movingValue = NAN;
   if (m_MovingImageInterpolator->IsInsideBuffer(mappedPoint))
   {
     movingValue = m_MovingImageInterpolator->Evaluate(mappedPoint);

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
@@ -58,8 +58,7 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
   m_FixedImagePyramid->SetNumberOfLevels(m_NumberOfLevels);
   m_MovingImagePyramid->SetNumberOfLevels(m_NumberOfLevels);
 
-  unsigned int ilevel;
-  for (ilevel = 0; ilevel < m_NumberOfLevels; ++ilevel)
+  for (unsigned int ilevel = 0; ilevel < m_NumberOfLevels; ++ilevel)
   {
     m_NumberOfIterations[ilevel] = 10;
   }
@@ -276,8 +275,8 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
   os << indent << "CurrentLevel: " << m_CurrentLevel << std::endl;
 
   os << indent << "NumberOfIterations: [";
-  unsigned int ilevel;
-  for (ilevel = 0; ilevel < m_NumberOfLevels - 1; ++ilevel)
+  unsigned int ilevel = 0;
+  for (; ilevel < m_NumberOfLevels - 1; ++ilevel)
   {
     os << m_NumberOfIterations[ilevel] << ", ";
   }

--- a/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
@@ -203,14 +203,13 @@ itkMultiResolutionPDEDeformableRegistrationTest(int argc, char * argv[])
   initField->SetSpacing(spacing);
 
   double              center[ImageDimension];
-  double              radius;
   constexpr PixelType fgnd = 250;
   constexpr PixelType bgnd = 15;
 
   // fill moving with circle
   center[0] = 128;
   center[1] = 128;
-  radius = 60;
+  double radius = 60;
   FillWithCircle<ImageType>(moving, center, radius, fgnd, bgnd);
 
   // fill fixed with circle
@@ -250,8 +249,8 @@ itkMultiResolutionPDEDeformableRegistrationTest(int argc, char * argv[])
   numIterations[0] = 64;
   numIterationsArray[0] = numIterations[0];
 
-  unsigned int ilevel;
-  for (ilevel = 1; ilevel < numLevel; ++ilevel)
+
+  for (unsigned int ilevel = 1; ilevel < numLevel; ++ilevel)
   {
     numIterations[ilevel] = numIterations[ilevel - 1] / 2;
     numIterationsArray[ilevel] = numIterations[ilevel];
@@ -273,7 +272,7 @@ itkMultiResolutionPDEDeformableRegistrationTest(int argc, char * argv[])
   // Set the number of iterations to a different value and try the overloaded method with the desired value
   unsigned int numIterations2[numLevel];
   numIterations2[0] = 8;
-  for (ilevel = 1; ilevel < numLevel; ++ilevel)
+  for (unsigned int ilevel = 1; ilevel < numLevel; ++ilevel)
   {
     numIterations2[ilevel] = numIterations2[ilevel - 1] / 2;
   }
@@ -373,7 +372,7 @@ itkMultiResolutionPDEDeformableRegistrationTest(int argc, char * argv[])
   }
 
   // Exercise error handling
-  bool passed;
+  bool passed = false;
 
   using InternalRegistrationType = RegistrationType::RegistrationType;
   const InternalRegistrationType::Pointer demons = registrator->GetModifiableRegistrationFilter();

--- a/Modules/Segmentation/Classifiers/include/itkImageClassifierBase.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageClassifierBase.hxx
@@ -72,8 +72,6 @@ ImageClassifierBase<TInputImage, TClassifiedImage>::Classify()
 
   std::vector<double> discriminantScores;
   discriminantScores.resize(numberOfClasses);
-  unsigned int classLabel;
-  unsigned int classIndex;
 
   // support progress methods/callbacks
   const SizeValueType totalPixels = inputImage->GetBufferedRegion().GetNumberOfPixels();
@@ -93,12 +91,12 @@ ImageClassifierBase<TInputImage, TClassifiedImage>::Classify()
 
     // Read the input vector
     inputImagePixel = inIt.Get();
-    for (classIndex = 0; classIndex < numberOfClasses; ++classIndex)
+    for (unsigned int classIndex = 0; classIndex < numberOfClasses; ++classIndex)
     {
       discriminantScores[classIndex] = (this->GetMembershipFunction(classIndex))->Evaluate(inputImagePixel);
     }
 
-    classLabel = static_cast<unsigned int>(this->GetDecisionRule()->Evaluate(discriminantScores));
+    unsigned int classLabel = static_cast<unsigned int>(this->GetDecisionRule()->Evaluate(discriminantScores));
 
     outputClassifiedLabel = ClassifiedImagePixelType(classLabel);
     classifiedIt.Set(outputClassifiedLabel);

--- a/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
@@ -282,7 +282,7 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::WithCodebookUseGLA(
   int pass = 0; // no empty cells have been found yet
   m_CurrentNumberOfCodewords = m_Codebook.rows();
 
-  double distortion;
+  double distortion = NAN;
   do
   {
     // Encode all of the input vectors using the given codebook

--- a/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest7.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest7.cxx
@@ -113,7 +113,7 @@ itkSampleClassifierFilterTest7(int argc, char * argv[])
   {
     for (unsigned int i = 0; i < PointSetType::PointDimension; ++i)
     {
-      double temp;
+      double temp = NAN;
       dataStream >> temp;
       point[i] = temp;
     }
@@ -260,7 +260,7 @@ itkSampleClassifierFilterTest7(int argc, char * argv[])
   {
     for (unsigned int i = 0; i < PointSetType::PointDimension; ++i)
     {
-      double temp;
+      double temp = NAN;
       dataTargetStream >> temp;
       point[i] = temp;
     }

--- a/Modules/Segmentation/Classifiers/test/itkSupervisedImageClassifierTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSupervisedImageClassifierTest.cxx
@@ -193,13 +193,12 @@ itkSupervisedImageClassifierTest(int, char *[])
 
   ClassImageIterator classoutIt(classImage, classImage->GetBufferedRegion());
 
-  ClassImagePixelType outputPixel;
   //--------------------------------------------------------------------------
   // Manually create and store each vector
   //--------------------------------------------------------------------------
   // Slice 1
   // Pixel no. 1
-  outputPixel = 2;
+  ClassImagePixelType outputPixel = 2;
   classoutIt.Set(outputPixel);
   ++classoutIt;
 

--- a/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
@@ -30,24 +30,16 @@ template <typename TInputImage, typename TOutputImage>
 void
 HardConnectedComponentImageFilter<TInputImage, TOutputImage>::GenerateData()
 {
-  unsigned int i;
-  int          p;
-  int          q;
-  int          m;
-
   using LabelType = unsigned short;
 
   const auto equivalenceTable = make_unique_for_overwrite<LabelType[]>(NumericTraits<LabelType>::max());
-  LabelType  label = 0;
-  LabelType  maxLabel = 0;
-  SizeType   size;
 
-  typename ListType::iterator iter;
+  LabelType maxLabel = 0;
 
   TOutputImage *      output = this->GetOutput();
   const TInputImage * input = this->GetInput();
 
-  size = input->GetLargestPossibleRegion().GetSize();
+  SizeType         size = input->GetLargestPossibleRegion().GetSize();
   const RegionType region(size);
   output->SetRegions(region);
   output->Allocate();
@@ -75,15 +67,12 @@ HardConnectedComponentImageFilter<TInputImage, TOutputImage>::GenerateData()
   {
     if (ot.Get())
     {
-      for (i = 0; i < ImageDimension; ++i)
+      for (unsigned int i = 0; i < ImageDimension; ++i)
       {
         IndexType currentIndex = ot.GetIndex();
         currentIndex[i] = currentIndex[i] - 1;
-        if (currentIndex[i] < 0)
-        {
-          label = 0;
-        }
-        else
+        LabelType label = 0;
+        if (currentIndex[i] >= 0)
         {
           label = static_cast<LabelType>(output->GetPixel(currentIndex));
         }
@@ -98,8 +87,8 @@ HardConnectedComponentImageFilter<TInputImage, TOutputImage>::GenerateData()
           {
             if (equivalenceTable[static_cast<LabelType>(ot.Get())] > equivalenceTable[label])
             {
-              q = equivalenceTable[static_cast<LabelType>(ot.Get())];
-              for (p = q; p <= maxLabel; ++p)
+              int q = equivalenceTable[static_cast<LabelType>(ot.Get())];
+              for (int p = q; p <= maxLabel; ++p)
               {
                 if (equivalenceTable[p] == q)
                 {
@@ -109,8 +98,8 @@ HardConnectedComponentImageFilter<TInputImage, TOutputImage>::GenerateData()
             }
             else
             {
-              q = equivalenceTable[label];
-              for (p = q; p <= maxLabel; ++p)
+              int q = equivalenceTable[label];
+              for (int p = q; p <= maxLabel; ++p)
               {
                 if (equivalenceTable[p] == q)
                 {
@@ -135,9 +124,10 @@ HardConnectedComponentImageFilter<TInputImage, TOutputImage>::GenerateData()
     progress.CompletedPixel();
   }
 
-  for (p = 1; p <= maxLabel; ++p)
+  for (int p = 1; p <= maxLabel; ++p)
   {
-    for (m = p; (m <= maxLabel) && (equivalenceTable[m] != p); ++m)
+    int m = p;
+    for (; (m <= maxLabel) && (equivalenceTable[m] != p); ++m)
     {
     }
     if (m > maxLabel)
@@ -147,7 +137,7 @@ HardConnectedComponentImageFilter<TInputImage, TOutputImage>::GenerateData()
       }
       if (m <= maxLabel)
       {
-        for (i = m; i <= maxLabel; ++i)
+        for (unsigned int i = m; i <= maxLabel; ++i)
         {
           if (equivalenceTable[i] == m)
           {
@@ -160,11 +150,11 @@ HardConnectedComponentImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   const auto flags = make_unique_for_overwrite<unsigned char[]>(NumericTraits<LabelType>::max());
   memset(flags.get(), 0, maxLabel + 1);
-  for (iter = m_Seeds.begin(); iter != m_Seeds.end(); ++iter)
+  for (typename ListType::iterator iter = m_Seeds.begin(); iter != m_Seeds.end(); ++iter)
   {
     const IndexType currentIndex = *iter;
-    m = equivalenceTable[static_cast<LabelType>(output->GetPixel(currentIndex))];
-    for (i = m; i <= maxLabel; ++i)
+    int             m = equivalenceTable[static_cast<LabelType>(output->GetPixel(currentIndex))];
+    for (unsigned int i = m; i <= maxLabel; ++i)
     {
       if (equivalenceTable[i] == m)
       {

--- a/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.hxx
@@ -277,21 +277,20 @@ RelabelComponentImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream &
   os << indent << "MinimumObjectSizes: " << m_MinimumObjectSize << std::endl;
   os << indent << "SortByObjectSize: " << m_SortByObjectSize << std::endl;
 
-  typename ObjectSizeInPixelsContainerType::const_iterator it;
-  ObjectSizeInPhysicalUnitsContainerType::const_iterator   fit;
-  SizeValueType                                            i;
-
   // limit the number of objects to print
-  const SizeValueType numPrint = std::min<SizeValueType>(m_NumberOfObjectsToPrint, m_SizeOfObjectsInPixels.size());
+  {
+    const SizeValueType numPrint = std::min<SizeValueType>(m_NumberOfObjectsToPrint, m_SizeOfObjectsInPixels.size());
 
-  for (i = 0, it = m_SizeOfObjectsInPixels.begin(), fit = m_SizeOfObjectsInPhysicalUnits.begin(); i < numPrint;
-       ++it, ++fit, ++i)
-  {
-    os << indent << "Object #" << i + 1 << ": " << *it << " pixels, " << *fit << " physical units" << std::endl;
-  }
-  if (numPrint < m_SizeOfObjectsInPixels.size())
-  {
-    os << indent << "..." << std::endl;
+    ObjectSizeInPixelsContainerType::const_iterator        it = m_SizeOfObjectsInPixels.begin();
+    ObjectSizeInPhysicalUnitsContainerType::const_iterator fit = m_SizeOfObjectsInPhysicalUnits.begin();
+    for (SizeValueType i = 0; i < numPrint; ++it, ++fit, ++i)
+    {
+      os << indent << "Object #" << i + 1 << ": " << *it << " pixels, " << *fit << " physical units" << std::endl;
+    }
+    if (numPrint < m_SizeOfObjectsInPixels.size())
+    {
+      os << indent << "..." << std::endl;
+    }
   }
 }
 } // end namespace itk

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
@@ -114,9 +114,8 @@ DeformableSimplexMesh3DFilter<TInputMesh, TOutputMesh>::GenerateData()
 
   while (pointItr != points->End())
   {
-    SimplexMeshGeometry * data;
     const IdentifierType  idx = pointItr.Index();
-    data = this->m_Data->GetElement(idx);
+    SimplexMeshGeometry * data = this->m_Data->GetElement(idx);
     delete data->neighborSet;
     data->neighborSet = nullptr;
     ++pointItr;
@@ -165,10 +164,9 @@ DeformableSimplexMesh3DFilter<TInputMesh, TOutputMesh>::Initialize()
 
   while (pointItr != points->End())
   {
-    SimplexMeshGeometry * data;
-    const IdentifierType  idx = pointItr.Index();
+    const IdentifierType idx = pointItr.Index();
 
-    data = this->m_Data->GetElement(idx);
+    SimplexMeshGeometry * data = this->m_Data->GetElement(idx);
     data->pos = pointItr.Value();
 
     //        InputMeshType::ArrayType neighbors =

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
@@ -116,7 +116,7 @@ DeformableSimplexMesh3DGradientConstraintForceFilter<TInputMesh, TOutputMesh>::N
 {
   const double dp[3]{ pp[0], pp[1], pp[2] };
 
-  double dlx;
+  double dlx = NAN;
   if (dp[0] >= 0.0)
   {
     dlx = ((ic[0] + 1) * 1 - *x) / dp[0];
@@ -133,7 +133,7 @@ DeformableSimplexMesh3DGradientConstraintForceFilter<TInputMesh, TOutputMesh>::N
       dlx = ((ic[0] - 1) * 1 - *x) / dp[0];
     }
   }
-  double dly;
+  double dly = NAN;
   if (dp[1] >= 0.0)
   {
     dly = ((ic[1] + 1) * 1 - *y) / dp[1];
@@ -151,7 +151,7 @@ DeformableSimplexMesh3DGradientConstraintForceFilter<TInputMesh, TOutputMesh>::N
     }
   }
 
-  double dlz;
+  double dlz = NAN;
   if (dp[2] >= 0.0)
   {
     dlz = ((ic[2] + 1) * 1 - *z) / dp[2];
@@ -169,7 +169,7 @@ DeformableSimplexMesh3DGradientConstraintForceFilter<TInputMesh, TOutputMesh>::N
     }
   }
 
-  double d;
+  double d = NAN;
   if ((dlx < dly) && (dlx < dlz))
   {
     d = dlx;

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
@@ -593,11 +593,8 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::MergeRegions()
   }
 
   // Two regions are associated with the candidate border
-  KLMSegmentationRegion * pRegion1;
-  KLMSegmentationRegion * pRegion2;
-
-  pRegion1 = m_BorderCandidate->m_Pointer->GetRegion1();
-  pRegion2 = m_BorderCandidate->m_Pointer->GetRegion2();
+  KLMSegmentationRegion * pRegion1 = m_BorderCandidate->m_Pointer->GetRegion1();
+  KLMSegmentationRegion * pRegion2 = m_BorderCandidate->m_Pointer->GetRegion2();
 
   // For consistency, always assign smaller label: this affects
   // GenerateOutputImage and GenerateLabelledImage

--- a/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
@@ -154,7 +154,7 @@ test_RegionGrowKLMExceptionHandling()
 
   std::cout << "Test error handling" << std::endl;
 
-  bool passed;
+  bool passed = false;
 
 #undef LOCAL_TEST_EXCEPTION_MACRO
 #define LOCAL_TEST_EXCEPTION_MACRO(MSG, FILTER)         \
@@ -345,20 +345,17 @@ test_regiongrowKLM1D()
   const LabelledImageType::Pointer labelledImage = KLMFilter->GetLabelledImage();
 
   using OutputImageData = OutputImageType::PixelType::VectorType;
-  ImageData       pixelIn;
-  OutputImageData pixelOut;
 
   using LabelImageIterator = itk::ImageRegionIterator<LabelledImageType>;
   LabelImageIterator labelIt(labelledImage, labelledImage->GetBufferedRegion());
-  LabelType          pixelLabel;
   LabelType          m = 1;
 
   inIt.GoToBegin();
   while (!inIt.IsAtEnd())
   {
-    pixelOut = outIt.Get();
-    pixelIn = inIt.Get();
-    pixelLabel = labelIt.Get();
+    OutputImageData pixelOut = outIt.Get();
+    ImageData       pixelIn = inIt.Get();
+    LabelType       pixelLabel = labelIt.Get();
 
     if (itk::Math::NotAlmostEquals(pixelOut[0], pixelIn[0]) || itk::Math::NotAlmostEquals(pixelOut[1], pixelIn[1]) ||
         itk::Math::NotAlmostEquals(pixelOut[2], pixelIn[2]) || pixelLabel != m)
@@ -452,8 +449,8 @@ test_regiongrowKLM1D()
   k = 0;
   while (!outIt2.IsAtEnd())
   {
-    pixelOut = outIt2.Get();
-    pixelLabel = labelIt2.Get();
+    OutputImageData pixelOut = outIt2.Get();
+    LabelType       pixelLabel = labelIt2.Get();
 
     if (k < numPixelsHalf)
     {
@@ -591,8 +588,8 @@ test_regiongrowKLM1D()
   k = 0;
   while (!outIt3.IsAtEnd())
   {
-    pixelOut = outIt3.Get();
-    pixelLabel = labelIt3.Get();
+    OutputImageData pixelOut = outIt3.Get();
+    LabelType       pixelLabel = labelIt3.Get();
 
     if (k < numPixelsHalf / 2)
     {
@@ -755,12 +752,12 @@ test_regiongrowKLM1D()
     pixelOut5in[2] = 0;
     for (int idx = 0; idx < gridWidth; ++idx)
     {
-      pixelIn = inIt.Get();
+      ImageData pixelIn = inIt.Get();
       pixelOut5in[0] += pixelIn[0];
       pixelOut5in[1] += pixelIn[1];
       pixelOut5in[2] += pixelIn[2];
 
-      pixelLabel = labelIt5.Get();
+      LabelType pixelLabel = labelIt5.Get();
 
       if (pixelLabel != k)
       {
@@ -991,7 +988,7 @@ test_regiongrowKLM2D()
 
   LabelImageIterator labelIt(labelledImage, labelledImage->GetBufferedRegion());
 
-  LabelType pixelLabel;
+  LabelType pixelLabel = 0;
   LabelType m = 1;
   while (!labelIt.IsAtEnd())
   {
@@ -1498,7 +1495,7 @@ test_regiongrowKLM3D()
 
   LabelImageIterator labelIt(labelledImage, labelledImage->GetBufferedRegion());
 
-  LabelType pixelLabel;
+  LabelType pixelLabel = 0;
   LabelType m = 1;
   while (!labelIt.IsAtEnd())
   {
@@ -1898,7 +1895,7 @@ test_regiongrowKLM4D()
 
   LabelImageIterator labelIt(labelledImage, labelledImage->GetBufferedRegion());
 
-  LabelType pixelLabel;
+  LabelType pixelLabel = 0;
   LabelType m = 1;
   while (!labelIt.IsAtEnd())
   {

--- a/Modules/Segmentation/LevelSets/include/itkExtensionVelocitiesImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkExtensionVelocitiesImageFilter.hxx
@@ -190,8 +190,6 @@ ExtensionVelocitiesImageFilter<TLevelSet, TAuxValue, VAuxDimension>::GenerateDat
     auxTempIt[k] = AuxIteratorType(ptr, ptr->GetBufferedRegion());
   }
 
-  double value;
-
   inputIt.GoToBegin();
   outputIt.GoToBegin();
   tempIt.GoToBegin();
@@ -203,7 +201,7 @@ ExtensionVelocitiesImageFilter<TLevelSet, TAuxValue, VAuxDimension>::GenerateDat
 
   while (!inputIt.IsAtEnd())
   {
-    value = static_cast<double>(inputIt.Get());
+    const double value = static_cast<double>(inputIt.Get());
     if (value - levelSetValue > 0)
     {
       outputIt.Set(tempIt.Get());
@@ -242,7 +240,7 @@ ExtensionVelocitiesImageFilter<TLevelSet, TAuxValue, VAuxDimension>::GenerateDat
 
   while (!inputIt.IsAtEnd())
   {
-    value = static_cast<double>(inputIt.Get());
+    double value = static_cast<double>(inputIt.Get());
     if (value - levelSetValue <= 0)
     {
       value = static_cast<double>(tempIt.Get());
@@ -297,14 +295,12 @@ ExtensionVelocitiesImageFilter<TLevelSet, TAuxValue, VAuxDimension>::GenerateDat
 
   // set all internal pixels to minus infinity and
   // all external pixels to positive infinity
-  double value;
-
   inputIt.GoToBegin();
   outputIt.GoToBegin();
 
   while (!inputIt.IsAtEnd())
   {
-    value = static_cast<double>(inputIt.Get());
+    const double value = static_cast<double>(inputIt.Get());
     if (value - levelSetValue <= 0)
     {
       outputIt.Set(negInfinity);
@@ -401,7 +397,7 @@ ExtensionVelocitiesImageFilter<TLevelSet, TAuxValue, VAuxDimension>::GenerateDat
     node = pointsIt.Value();
     inPixel = inputPtr->GetPixel(node.GetIndex());
 
-    value = static_cast<double>(inPixel);
+    const double value = static_cast<double>(inPixel);
     if (value - levelSetValue > 0)
     {
       inPixel = tempLevelSet->GetPixel(node.GetIndex());
@@ -431,7 +427,7 @@ ExtensionVelocitiesImageFilter<TLevelSet, TAuxValue, VAuxDimension>::GenerateDat
     node = pointsIt.Value();
     inPixel = inputPtr->GetPixel(node.GetIndex());
 
-    value = static_cast<double>(inPixel);
+    double value = static_cast<double>(inPixel);
     if (value - levelSetValue <= 0)
     {
       inPixel = tempLevelSet->GetPixel(node.GetIndex());

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
@@ -211,7 +211,7 @@ LevelSetFunction<TImageType>::ComputeGlobalTimeStep(void * GlobalData) const -> 
 
   d->m_MaxAdvectionChange += d->m_MaxPropagationChange;
 
-  TimeStepType dt;
+  TimeStepType dt = NAN;
   if (itk::Math::abs(d->m_MaxCurvatureChange) > 0.0)
   {
     if (d->m_MaxAdvectionChange > 0.0)

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
@@ -208,18 +208,15 @@ LevelSetNeighborhoodExtractor<TLevelSet>::CalculateDistance(IndexType & index)
 
   const bool inside = (centerValue <= 0.0);
 
-  IndexType                             neighIndex = index;
-  typename LevelSetImageType::PixelType neighValue;
-  NodeType                              neighNode;
-  SpacePrecisionType                    distance;
-  SpacePrecisionType                    spacing;
+  IndexType neighIndex = index;
+  NodeType  neighNode;
 
   // In each dimension, find the distance to the zero set
   // by linear interpolating along the grid line.
   for (unsigned int j = 0; j < SetDimension; ++j)
   {
     neighNode.SetValue(m_LargeValue);
-    spacing = m_InputLevelSet->GetSpacing()[j];
+    SpacePrecisionType spacing = m_InputLevelSet->GetSpacing()[j];
 
     for (int s = -1; s < 2; s = s + 2)
     {
@@ -231,12 +228,12 @@ LevelSetNeighborhoodExtractor<TLevelSet>::CalculateDistance(IndexType & index)
       }
 
       inputPixel = m_InputLevelSet->GetPixel(neighIndex);
-      neighValue = inputPixel;
+      typename LevelSetImageType::PixelType neighValue = inputPixel;
       neighValue -= m_LevelSetValue;
 
       if ((neighValue > 0 && inside) || (neighValue < 0 && !inside))
       {
-        distance = centerValue / (centerValue - neighValue) * spacing;
+        SpacePrecisionType distance = centerValue / (centerValue - neighValue) * spacing;
 
         if (neighNode.GetValue() > distance)
         {
@@ -258,7 +255,7 @@ LevelSetNeighborhoodExtractor<TLevelSet>::CalculateDistance(IndexType & index)
 
   // The final distance is given by the minimum distance to the plane
   // crossing formed by the zero set crossing points.
-  distance = 0.0;
+  SpacePrecisionType distance = 0.0;
   for (unsigned int j = 0; j < SetDimension; ++j)
   {
     neighNode = m_NodesUsed[j];

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -427,7 +427,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ConstructLaye
     {
       if (statusIt.GetPixel(m_NeighborList.GetArrayIndex(i)) == m_StatusNull)
       {
-        bool boundary_status;
+        bool boundary_status = false;
         statusIt.SetPixel(m_NeighborList.GetArrayIndex(i), to, boundary_status);
 
         if (boundary_status) // in bounds
@@ -897,11 +897,10 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::DeallocateDat
     for (unsigned int i = 0; i < 2 * static_cast<unsigned int>(m_NumberOfLayers) + 1; ++i)
     {
       // return all the nodes in layer i to the main node pool
-      LayerNodeType *        nodePtr = nullptr;
       const LayerPointerType layerPtr = m_Layers[i];
       while (!layerPtr->Empty())
       {
-        nodePtr = layerPtr->Front();
+        LayerNodeType * nodePtr = layerPtr->Front();
         layerPtr->PopFront();
         m_LayerNodeStore->Return(nodePtr);
       }
@@ -930,11 +929,10 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::DeallocateDat
       for (unsigned int i = 0; i < 2 * static_cast<unsigned int>(m_NumberOfLayers) + 1; ++i)
       {
         // return all the nodes in layer i to thread-i's node pool
-        LayerNodeType *        nodePtr;
         const LayerPointerType layerPtr = m_Data[ThreadId].m_Layers[i];
         while (!layerPtr->Empty())
         {
-          nodePtr = layerPtr->Front();
+          LayerNodeType * nodePtr = layerPtr->Front();
           layerPtr->PopFront();
           m_Data[ThreadId].m_LayerNodeStore->Return(nodePtr);
         }
@@ -953,12 +951,11 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::DeallocateDat
             continue;
           }
 
-          LayerNodeType *        nodePtr;
           const LayerPointerType layerPtr = m_Data[ThreadId].m_LoadTransferBufferLayers[i][tid];
 
           while (!layerPtr->Empty())
           {
-            nodePtr = layerPtr->Front();
+            LayerNodeType * nodePtr = layerPtr->Front();
             layerPtr->PopFront();
             m_Data[ThreadId].m_LayerNodeStore->Return(nodePtr);
           }
@@ -971,7 +968,6 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::DeallocateDat
       // m_InterNeighborNodeTransferBufferLayers (if any)
       for (unsigned int i = 0; i < m_NumOfWorkUnits; ++i)
       {
-        LayerNodeType * nodePtr;
         for (unsigned int InOrOut = 0; InOrOut < 2; ++InOrOut)
         {
           const LayerPointerType layerPtr =
@@ -979,7 +975,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::DeallocateDat
 
           while (!layerPtr->Empty())
           {
-            nodePtr = layerPtr->Front();
+            LayerNodeType * nodePtr = layerPtr->Front();
             layerPtr->PopFront();
             m_Data[ThreadId].m_LayerNodeStore->Return(nodePtr);
           }
@@ -1927,10 +1923,9 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedProce
 
   // Push each index in the input list into its appropriate status layer
   // (ChangeToStatus) and ... ... update the status image value at that index
-  LayerNodeType * nodePtr;
   while (!OutsideList->Empty())
   {
-    nodePtr = OutsideList->Front();
+    LayerNodeType * nodePtr = OutsideList->Front();
     OutsideList->PopFront();
 
     m_StatusImage->SetPixel(nodePtr->m_Index, ChangeToStatus);
@@ -2171,10 +2166,8 @@ template <typename TInputImage, typename TOutputImage>
 void
 ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedLoadBalance1(ThreadIdType ThreadId)
 {
-  unsigned int i;
-
   // cleanup the layers first
-  for (i = 0; i < 2 * static_cast<unsigned int>(m_NumberOfLayers) + 1; ++i)
+  for (unsigned int i = 0; i < 2 * static_cast<unsigned int>(m_NumberOfLayers) + 1; ++i)
   {
     for (ThreadIdType tid = 0; tid < m_NumOfWorkUnits; ++tid)
     {
@@ -2188,16 +2181,15 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedLoadB
     }
   }
 
-  LayerNodeType * nodePtr;
   // for all layers
-  for (i = 0; i < 2 * static_cast<unsigned int>(m_NumberOfLayers) + 1; ++i)
+  for (unsigned int i = 0; i < 2 * static_cast<unsigned int>(m_NumberOfLayers) + 1; ++i)
   {
     typename LayerType::Iterator       layerIt = m_Data[ThreadId].m_Layers[i]->Begin();
     const typename LayerType::Iterator layerEnd = m_Data[ThreadId].m_Layers[i]->End();
 
     while (layerIt != layerEnd)
     {
-      nodePtr = layerIt.GetPointer();
+      LayerNodeType * nodePtr = layerIt.GetPointer();
       ++layerIt;
 
       // use the latest (just updated in CheckLoadBalance) boundaries to

--- a/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
@@ -144,8 +144,6 @@ ReinitializeLevelSetImageFilter<TLevelSet>::GenerateDataFull()
   ConstIteratorType inputIt(inputPtr, inputPtr->GetBufferedRegion());
   IteratorType      outputIt(outputPtr, outputPtr->GetBufferedRegion());
 
-  IteratorType tempIt;
-
   this->UpdateProgress(0.0);
 
   // locate the level set
@@ -159,13 +157,10 @@ ReinitializeLevelSetImageFilter<TLevelSet>::GenerateDataFull()
   m_Marcher->SetTrialPoints(m_Locator->GetOutsidePoints());
   m_Marcher->Update();
 
-  tempIt = IteratorType(tempLevelSet, tempLevelSet->GetBufferedRegion());
-
-  double value;
-
+  IteratorType tempIt = IteratorType(tempLevelSet, tempLevelSet->GetBufferedRegion());
   while (!inputIt.IsAtEnd())
   {
-    value = static_cast<double>(inputIt.Get());
+    double value = static_cast<double>(inputIt.Get());
     if (value - m_LevelSetValue > 0)
     {
       outputIt.Set(tempIt.Get());
@@ -188,7 +183,7 @@ ReinitializeLevelSetImageFilter<TLevelSet>::GenerateDataFull()
 
   while (!inputIt.IsAtEnd())
   {
-    value = static_cast<double>(inputIt.Get());
+    double value = static_cast<double>(inputIt.Get());
     if (value - m_LevelSetValue <= 0)
     {
       value = static_cast<double>(tempIt.Get());
@@ -217,19 +212,14 @@ ReinitializeLevelSetImageFilter<TLevelSet>::GenerateDataNarrowBand()
 
   IteratorType outputIt(outputPtr, outputPtr->GetBufferedRegion());
 
-  PixelType posInfinity;
-  PixelType negInfinity;
-
-  posInfinity = NumericTraits<PixelType>::max();
-  negInfinity = NumericTraits<PixelType>::NonpositiveMin();
+  PixelType posInfinity = NumericTraits<PixelType>::max();
+  PixelType negInfinity = NumericTraits<PixelType>::NonpositiveMin();
 
   // set all internal pixels to minus infinity and
   // all external pixels to positive infinity
-  double value;
-
   while (!inputIt.IsAtEnd())
   {
-    value = static_cast<double>(inputIt.Get());
+    double value = static_cast<double>(inputIt.Get());
     if (value - m_LevelSetValue <= 0)
     {
       outputIt.Set(negInfinity);
@@ -276,21 +266,13 @@ ReinitializeLevelSetImageFilter<TLevelSet>::GenerateDataNarrowBand()
 
   NodeContainerPointer procPoints = m_Marcher->GetProcessedPoints();
 
-  typename NodeContainer::ConstIterator pointsIt;
-  typename NodeContainer::ConstIterator pointsEnd;
-
-  pointsIt = procPoints->Begin();
-  pointsEnd = procPoints->End();
-
-  NodeType  node;
-  PixelType inPixel;
-
-  for (; pointsIt != pointsEnd; ++pointsIt)
+  typename NodeContainer::ConstIterator pointsEnd = procPoints->End();
+  for (typename NodeContainer::ConstIterator pointsIt = procPoints->Begin(); pointsIt != pointsEnd; ++pointsIt)
   {
-    node = pointsIt.Value();
-    inPixel = inputPtr->GetPixel(node.GetIndex());
+    NodeType  node = pointsIt.Value();
+    PixelType inPixel = inputPtr->GetPixel(node.GetIndex());
 
-    value = static_cast<double>(inPixel);
+    double value = static_cast<double>(inPixel);
     if (value - m_LevelSetValue > 0)
     {
       inPixel = tempLevelSet->GetPixel(node.GetIndex());
@@ -306,15 +288,13 @@ ReinitializeLevelSetImageFilter<TLevelSet>::GenerateDataNarrowBand()
   m_Marcher->Update();
 
   procPoints = m_Marcher->GetProcessedPoints();
-  pointsIt = procPoints->Begin();
   pointsEnd = procPoints->End();
-
-  for (; pointsIt != pointsEnd; ++pointsIt)
+  for (typename NodeContainer::ConstIterator pointsIt = procPoints->Begin(); pointsIt != pointsEnd; ++pointsIt)
   {
-    node = pointsIt.Value();
-    inPixel = inputPtr->GetPixel(node.GetIndex());
+    NodeType  node = pointsIt.Value();
+    PixelType inPixel = inputPtr->GetPixel(node.GetIndex());
 
-    value = static_cast<double>(inPixel);
+    double value = static_cast<double>(inPixel);
     if (value - m_LevelSetValue <= 0)
     {
       inPixel = tempLevelSet->GetPixel(node.GetIndex());

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -204,14 +204,12 @@ void
 SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ProcessOutsideList(LayerType * OutsideList,
                                                                               StatusType  ChangeToStatus)
 {
-  LayerNodeType * node;
-
   // Push each index in the input list into its appropriate status layer
   // (ChangeToStatus) and update the status image value at that index.
   while (!OutsideList->Empty())
   {
     m_StatusImage->SetPixel(OutsideList->Front()->m_Value, ChangeToStatus);
-    node = OutsideList->Front();
+    LayerNodeType * node = OutsideList->Front();
     OutsideList->PopFront();
     m_Layers[ChangeToStatus]->PushFront(node);
   }
@@ -259,7 +257,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ProcessStatusList(Lay
 
       if (neighbor_status == SearchForStatus)
       { // mark this pixel so we don't add it twice.
-        bool bounds_status;
+        bool bounds_status = false;
         statusIt.SetPixel(m_NeighborList.GetArrayIndex(i), m_StatusChanging, bounds_status);
         if (bounds_status)
         {
@@ -689,7 +687,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ConstructActiveLayer(
           // Assign to first inside layer --> 1
           // Assign to first inside layer --  2
           const StatusType layer_number = (value < m_ValueZero) ? 1 : 2;
-          bool             bounds_status;
+          bool             bounds_status = false;
           statusIt.SetPixel(m_NeighborList.GetArrayIndex(i), layer_number, bounds_status);
           if (bounds_status) // In bounds.
           {
@@ -722,7 +720,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ConstructLayer(Status
     {
       if (statusIt.GetPixel(m_NeighborList.GetArrayIndex(i)) == m_StatusNull)
       {
-        bool boundary_status;
+        bool boundary_status = false;
         statusIt.SetPixel(m_NeighborList.GetArrayIndex(i), to, boundary_status);
         if (boundary_status) // in bounds
         {

--- a/Modules/Segmentation/LevelSets/test/itkExtensionVelocitiesImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkExtensionVelocitiesImageFilterTest.cxx
@@ -66,7 +66,7 @@ SimpleVelocity(const TPoint & p)
 {
   auto center = itk::MakeFilled<TPoint>(50);
 
-  double       value;
+  double       value = 0.0;
   const double x = p[0] - center[0];
   const double y = p[1] - center[1];
 

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest.cxx
@@ -384,7 +384,7 @@ itkGeodesicActiveContourShapePriorLevelSetImageFilterTest(int, char *[])
   //
   // Exercise error handling testing.
   //
-  bool pass;
+  bool pass = false;
 
 #define TEST_INITIALIZATION_ERROR(ComponentName, badComponent, goodComponent) \
   filter->Set##ComponentName(badComponent);                                   \

--- a/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
@@ -57,15 +57,13 @@ square(unsigned int x, unsigned int y)
 {
   const float X = itk::Math::abs(x - float{ WIDTH } / 2.0);
   const float Y = itk::Math::abs(y - float{ HEIGHT } / 2.0);
-  float       dis;
+  float       dis = -std::sqrt((X - RADIUS) * (X - RADIUS) + (Y - RADIUS) * (Y - RADIUS));
+
   if (!((X > RADIUS) && (Y > RADIUS)))
   {
     dis = RADIUS - std::max(X, Y);
   }
-  else
-  {
-    dis = -std::sqrt((X - RADIUS) * (X - RADIUS) + (Y - RADIUS) * (Y - RADIUS));
-  }
+
   return dis;
 }
 

--- a/Modules/Segmentation/LevelSets/test/itkLevelSetNeighborhoodExtractorTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLevelSetNeighborhoodExtractorTest.cxx
@@ -89,7 +89,7 @@ itkLevelSetNeighborhoodExtractorTest(int, char *[])
   std::cout << "InputNarrowBand: " << extractor->GetInputNarrowBand() << std::endl;
 
   // exercise error handling
-  bool passed;
+  bool passed = false;
   std::cout << "Testing nullptr inputs" << std::endl;
 
   try

--- a/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
@@ -62,14 +62,10 @@ cube(unsigned int x, unsigned int y, unsigned int z)
   const float X = itk::Math::abs(x - float{ WIDTH } / 2.0);
   const float Y = itk::Math::abs(y - float{ HEIGHT } / 2.0);
   const float Z = itk::Math::abs(z - float{ DEPTH } / 2.0);
-  float       dis;
+  float       dis = -sqrt((X - RADIUS) * (X - RADIUS) + (Y - RADIUS) * (Y - RADIUS) + (Z - RADIUS) * (Z - RADIUS));
   if (!((X > RADIUS) && (Y > RADIUS) && (Z > RADIUS)))
   {
     dis = RADIUS - (std::max(std::max(X, Y), Z));
-  }
-  else
-  {
-    dis = -sqrt((X - RADIUS) * (X - RADIUS) + (Y - RADIUS) * (Y - RADIUS) + (Z - RADIUS) * (Z - RADIUS));
   }
   return (-dis);
 }

--- a/Modules/Segmentation/LevelSets/test/itkShapePriorMAPCostFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkShapePriorMAPCostFunctionTest.cxx
@@ -220,7 +220,7 @@ itkShapePriorMAPCostFunctionTest(int, char *[])
 
   // exercise error testing
 
-  bool pass;
+  bool pass = false;
 
 #define TEST_INITIALIZATION_ERROR(ComponentName, badComponent, goodComponent) \
   costFunction->Set##ComponentName(badComponent);                             \

--- a/Modules/Segmentation/LevelSets/test/itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
@@ -52,14 +52,10 @@ square(unsigned int x, unsigned int y)
 {
   const float X = itk::Math::abs(x - float{ WIDTH } / 2.0);
   const float Y = itk::Math::abs(y - float{ HEIGHT } / 2.0);
-  float       dis;
+  float       dis = -std::sqrt((X - RADIUS) * (X - RADIUS) + (Y - RADIUS) * (Y - RADIUS));
   if (!((X > RADIUS) && (Y > RADIUS)))
   {
     dis = RADIUS - std::max(X, Y);
-  }
-  else
-  {
-    dis = -std::sqrt((X - RADIUS) * (X - RADIUS) + (Y - RADIUS) * (Y - RADIUS));
   }
   return (dis);
 }

--- a/Modules/Segmentation/LevelSets/test/itkUnsharpMaskLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkUnsharpMaskLevelSetImageFilterTest.cxx
@@ -30,14 +30,10 @@ square(unsigned int x, unsigned int y)
 {
   const float X = itk::Math::abs(x - float{ WIDTH } / 2.0);
   const float Y = itk::Math::abs(y - float{ HEIGHT } / 2.0);
-  float       dis;
+  float       dis = -std::sqrt((X - RADIUS) * (X - RADIUS) + (Y - RADIUS) * (Y - RADIUS));
   if (!((X > RADIUS) && (Y > RADIUS)))
   {
     dis = RADIUS - std::max(X, Y);
-  }
-  else
-  {
-    dis = -std::sqrt((X - RADIUS) * (X - RADIUS) + (Y - RADIUS) * (Y - RADIUS));
   }
   return (dis);
 }

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetChanAndVeseInternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetChanAndVeseInternalTermTest.cxx
@@ -140,12 +140,11 @@ itkMultiLevelSetChanAndVeseInternalTermTest(int, char *[])
   level_set[2]->SetImage(input2);
 
   // Insert the levelsets in a levelset container
-  bool levelSetNotYetAdded;
   auto lscontainer = LevelSetContainerType::New();
   lscontainer->SetHeaviside(heaviside);
   lscontainer->SetDomainMapFilter(domainMapFilter);
 
-  levelSetNotYetAdded = lscontainer->AddLevelSet(0, level_set[1], false);
+  bool levelSetNotYetAdded = lscontainer->AddLevelSet(0, level_set[1], false);
   if (!levelSetNotYetAdded)
   {
     return EXIT_FAILURE;

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageTest.cxx
@@ -107,17 +107,14 @@ itkMultiLevelSetDenseImageTest(int, char *[])
 
   it.GoToBegin();
 
-  CacheImageType::IndexType out_index;
-  CacheImageType::PixelType out_id;
-
   using DomainMapType = DomainMapImageFilterType::DomainMapType;
   const DomainMapType           domainMap = filter->GetDomainMap();
   DomainMapType::const_iterator mapIt;
   const auto                    mapEnd = domainMap.end();
   while (!it.IsAtEnd())
   {
-    out_index = it.GetIndex();
-    out_id = it.Get();
+    CacheImageType::IndexType out_index = it.GetIndex();
+    CacheImageType::PixelType out_id = it.Get();
 
     IdListType solution;
     if ((out_index[0] < 5) && (out_index[1] < 5))

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
@@ -331,7 +331,7 @@ MRFImageFilter<TInputImage, TClassifiedImage>::Allocate()
   InputImageSizeType inputImageSize = this->GetInput()->GetBufferedRegion().GetSize();
 
   // Get the number of valid pixels in the output MRF image
-  int tmp;
+  int tmp = 0;
   for (unsigned int i = 0; i < InputImageDimension; ++i)
   {
     tmp = static_cast<int>(inputImageSize[i]);
@@ -488,8 +488,6 @@ MRFImageFilter<TInputImage, TClassifiedImage>::DoNeighborhoodOperation(
   LabelledImageNeighborhoodIterator &    labelledIter,
   LabelStatusImageNeighborhoodIterator & labelStatusIter)
 {
-  unsigned int index;
-
   // Read the pixel of interest and get its corresponding membership value
   InputImagePixelType * inputPixelVec = imageIter.GetCenterValue();
 
@@ -497,6 +495,7 @@ MRFImageFilter<TInputImage, TClassifiedImage>::DoNeighborhoodOperation(
 
   // Reinitialize the neighborhood influence at the beginning of the
   // neighborhood operation
+  unsigned int index = 0;
   for (index = 0; index < m_NeighborInfluence.size(); ++index)
   {
     m_NeighborInfluence[index] = 0;
@@ -521,7 +520,7 @@ MRFImageFilter<TInputImage, TClassifiedImage>::DoNeighborhoodOperation(
   // Determine the maximum possible distance
   double maximumDistance = -1e+20;
   int    pixLabel = -1;
-  double tmpPixDistance;
+  double tmpPixDistance = NAN;
   for (index = 0; index < m_NumberOfClasses; ++index)
   {
     tmpPixDistance = m_MahalanobisDistance[index];

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
@@ -87,18 +87,12 @@ template <typename TInputImage, typename TClassifiedImage>
 void
 RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GreyScalarBoundary(LabelledImageIndexType Index3D)
 {
-  int       change;
   int       signs[4];
-  int       x;
-  int       numx;
-  LabelType origin;
-  LabelType neighbors[4];
-
-  neighbors[0] = neighbors[1] = neighbors[2] = neighbors[3] = 0;
+  LabelType neighbors[4] = { 0, 0, 0, 0 };
 
   for (unsigned int rgb = 0; rgb < m_VecDim; ++rgb)
   {
-    origin = static_cast<LabelType>(m_InputImage->GetPixel(Index3D)[rgb]);
+    LabelType    origin = static_cast<LabelType>(m_InputImage->GetPixel(Index3D)[rgb]);
     unsigned int j = 0;
 
     for (unsigned int i = 0; i < ImageDimension - 1; ++i)
@@ -121,9 +115,9 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GreyScalarBoundary(LabelledI
 
     // Compute the minimum points of piecewise smoothness.
     m_LowPoint[rgb] = origin;
-    change = 1;
-    x = origin;
-    numx = 1;
+    int change = 1;
+    int x = origin;
+    int numx = 1;
 
     while (change > 0)
     {
@@ -196,12 +190,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GibbsTotalEnergy(int i)
   int rowsize = m_ImageWidth;
 
   double       energy[2];
-  double       difenergy;
-  LabelType    label;
-  LabelType    originlabel;
   LabelType    f[8];
-  unsigned int j;
-  unsigned int k;
   unsigned int neighborcount = 0;
 
   offsetIndex3D[2] = i / frame;
@@ -236,8 +225,8 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GibbsTotalEnergy(int i)
     f[neighborcount] = static_cast<int>(m_LabelledImage->GetPixel(offsetIndex3D));
   }
 
-  k = 0;
-  for (j = 0; j < 8; ++j)
+  unsigned int k = 0;
+  for (unsigned int j = 0; j < 8; ++j)
   {
     if (f[j] == m_ObjectLabel)
     {
@@ -268,17 +257,13 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GibbsTotalEnergy(int i)
       energy[jj] += 3;
     }
   }
-
+  LabelType label = 1;
   if (energy[0] < energy[1])
   {
     label = 0;
   }
-  else
-  {
-    label = 1;
-  }
 
-  originlabel = m_LabelledImage->GetPixel(offsetIndex3D);
+  LabelType originlabel = m_LabelledImage->GetPixel(offsetIndex3D);
   if (originlabel != label)
   {
     m_LabelledImage->SetPixel(offsetIndex3D, label);
@@ -288,7 +273,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GibbsTotalEnergy(int i)
   {
     if (changeflag)
     {
-      difenergy = energy[label] - energy[1 - label];
+      double       difenergy = energy[label] - energy[1 - label];
       const double rand_num{ rand() / (RAND_MAX + 1.0) };
       double       energy_num{ std::exp(static_cast<double>(difenergy * 0.5 * size / (2 * size - m_Temp))) };
       if (rand_num < energy_num)
@@ -306,11 +291,9 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GibbsEnergy(unsigned int i, 
   LabelledImageRegionIterator labelledImageIt(m_LabelledImage, m_LabelledImage->GetBufferedRegion());
 
   LabelType    f[8];
-  int          j;
   unsigned int neighborcount = 0;
   int          simnum = 0;
   int          changenum = 0;
-  bool         changeflag;
   double       res = 0.0;
 
   LabelledImageIndexType offsetIndex3D{};
@@ -372,10 +355,10 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GibbsEnergy(unsigned int i, 
     labelledPixel = k1;
   }
 
-  changeflag = (f[0] == labelledPixel);
+  bool changeflag = (f[0] == labelledPixel);
 
   // Assuming we are segmenting objects with smooth boundaries, we give weight to local characteristics.
-  for (j = 0; j < 8; ++j)
+  for (unsigned int j = 0; j < 8; ++j)
   {
     if ((f[j] == labelledPixel) != changeflag)
     {
@@ -560,14 +543,10 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::ApplyGibbsLabeller()
 
     const std::vector<double> & distValue = m_ClassifierPtr->GetPixelMembershipValue(changedPixelVec);
 
-    LabelType pixLabel;
+    LabelType pixLabel = 1;
     if (distValue[1] > m_ObjectThreshold)
     {
       pixLabel = 0;
-    }
-    else
-    {
-      pixLabel = 1;
     }
     labelledImageIt.Set(pixLabel);
 
@@ -599,13 +578,11 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::RegionEraser()
   LabelType i{};
   LabelType k{};
   LabelType l{};
-  LabelType label;
-
   while (!labelledImageIt.IsAtEnd())
   {
     if (m_Region[i] == 0)
     {
-      label = labelledImageIt.Get();
+      LabelType label = labelledImageIt.Get();
       if (this->LabelRegion(i, ++l, label) > m_ClusterSize)
       {
         valid_region_counter[k] = l;
@@ -618,7 +595,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::RegionEraser()
   }
 
   i = 0;
-  unsigned int j;
+  unsigned int j = 0;
   labelledImageIt.GoToBegin();
 
   while (!labelledImageIt.IsAtEnd())
@@ -631,7 +608,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::RegionEraser()
 
     if (j == k)
     {
-      label = labelledImageIt.Get();
+      LabelType label = labelledImageIt.Get();
       labelledImageIt.Set(1 - label);
     }
     ++i;
@@ -644,7 +621,6 @@ unsigned int
 RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::LabelRegion(int i, int l, int change)
 {
   unsigned int       count = 1;
-  int                m;
   const unsigned int frame = m_ImageWidth * m_ImageHeight;
   const unsigned int rowsize = m_ImageWidth;
 
@@ -659,7 +635,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::LabelRegion(int i, int l, in
   if (offsetIndex3D[0] > 0)
   {
     offsetIndex3D[0]--;
-    m = m_LabelledImage->GetPixel(offsetIndex3D);
+    int m = m_LabelledImage->GetPixel(offsetIndex3D);
     if ((m == change) && (m_Region[i - 1] == 0))
     {
       count += this->LabelRegion(i - 1, l, change);
@@ -670,7 +646,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::LabelRegion(int i, int l, in
   if (offsetIndex3D[0] < static_cast<IndexValueType>(m_ImageWidth - 1))
   {
     offsetIndex3D[0]++;
-    m = m_LabelledImage->GetPixel(offsetIndex3D);
+    int m = m_LabelledImage->GetPixel(offsetIndex3D);
     if ((m == change) && (m_Region[i + 1] == 0))
     {
       count += this->LabelRegion(i + 1, l, change);
@@ -681,7 +657,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::LabelRegion(int i, int l, in
   if (offsetIndex3D[1] > 0)
   {
     offsetIndex3D[1]--;
-    m = m_LabelledImage->GetPixel(offsetIndex3D);
+    int m = m_LabelledImage->GetPixel(offsetIndex3D);
     if ((m == change) && (m_Region[i - rowsize] == 0))
     {
       count += this->LabelRegion(i - rowsize, l, change);
@@ -692,7 +668,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::LabelRegion(int i, int l, in
   if (offsetIndex3D[1] < static_cast<IndexValueType>(m_ImageHeight - 1))
   {
     offsetIndex3D[1]++;
-    m = m_LabelledImage->GetPixel(offsetIndex3D);
+    int m = m_LabelledImage->GetPixel(offsetIndex3D);
     if ((m == change) && (m_Region[i + rowsize] == 0))
     {
       count += this->LabelRegion(i + rowsize, l, change);

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkRGBGibbsPriorFilterTest.cxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkRGBGibbsPriorFilterTest.cxx
@@ -352,7 +352,6 @@ itkRGBGibbsPriorFilterTest(int, char *[])
   //  fclose(output);
   // Verify if the results were as per expectation
 
-  bool passTest;
   /*  int j = 0;
     i = 0;
     labeloutIt.GoToBegin();
@@ -365,16 +364,13 @@ itkRGBGibbsPriorFilterTest(int, char *[])
     ++labeloutIt;
     }
   */
-  passTest = ((j1 > 285) && (j1 < 315));
-  if (passTest)
-  {
-    std::cout << "Gibbs Prior Test Passed" << std::endl;
-  }
-  else
+
+  const bool passTest = ((j1 > 285) && (j1 < 315));
+  if (!passTest)
   {
     std::cout << "Gibbs Prior Test failed" << std::endl;
     return EXIT_FAILURE;
   }
-
+  std::cout << "Gibbs Prior Test Passed" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
@@ -119,8 +119,6 @@ VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   using IteratorType = FloodFilledImageFunctionConditionalIterator<OutputImageType, DistanceThresholdFunctionType>;
   using SecondIteratorType = FloodFilledImageFunctionConditionalConstIterator<InputImageType, SecondFunctionType>;
 
-  unsigned int loop;
-
   const typename Superclass::InputImageConstPointer inputImage = this->GetInput();
   const typename Superclass::OutputImagePointer     outputImage = this->GetOutput();
 
@@ -249,8 +247,7 @@ VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
   }
 
   ProgressReporter progress(this, 0, region.GetNumberOfPixels() * m_NumberOfIterations);
-
-  for (loop = 0; loop < m_NumberOfIterations; ++loop)
+  for (unsigned int loop = 0; loop < m_NumberOfIterations; ++loop)
   {
     // Now that we have an initial segmentation, let's recalculate the
     // statistics.  Since we have already labelled the output, we visit

--- a/Modules/Segmentation/SignedDistanceFunction/test/itkPCAShapeSignedDistanceFunctionTest.cxx
+++ b/Modules/Segmentation/SignedDistanceFunction/test/itkPCAShapeSignedDistanceFunctionTest.cxx
@@ -36,7 +36,6 @@
 int
 itkPCAShapeSignedDistanceFunctionTest(int, char *[])
 {
-  unsigned int i;
   using CoordRep = double;
   constexpr unsigned int Dimension = 2;
   constexpr unsigned int ImageWidth = 3;
@@ -69,8 +68,6 @@ itkPCAShapeSignedDistanceFunctionTest(int, char *[])
 
   // set up the random number generator
   vnl_sample_reseed();
-  ImageType::PixelType randomPixel;
-
 
   // set up the mean image
   auto meanImage = ImageType::New();
@@ -82,7 +79,7 @@ itkPCAShapeSignedDistanceFunctionTest(int, char *[])
 
   for (meanImageIt.GoToBegin(); !meanImageIt.IsAtEnd(); ++meanImageIt)
   {
-    randomPixel = vnl_sample_normal(0, 1);
+    ImageType::PixelType randomPixel = vnl_sample_normal(0, 1);
     meanImageIt.Set(randomPixel);
   }
 
@@ -94,7 +91,7 @@ itkPCAShapeSignedDistanceFunctionTest(int, char *[])
   using ImageIteratorVector = std::vector<ImageIterator>;
   ImageIteratorVector pcImageIts(NumberOfPCs);
 
-  for (i = 0; i < NumberOfPCs; ++i)
+  for (unsigned int i = 0; i < NumberOfPCs; ++i)
   {
     pcImages[i] = ImageType::New();
     pcImages[i]->SetRegions(region);
@@ -104,7 +101,7 @@ itkPCAShapeSignedDistanceFunctionTest(int, char *[])
 
     for (pcImageIts[i].GoToBegin(); !pcImageIts[i].IsAtEnd(); ++pcImageIts[i])
     {
-      randomPixel = vnl_sample_normal(0, 1);
+      ImageType::PixelType randomPixel = vnl_sample_normal(0, 1);
       pcImageIts[i].Set(randomPixel);
     }
   }
@@ -115,7 +112,7 @@ itkPCAShapeSignedDistanceFunctionTest(int, char *[])
   // set up the standard deviation for each principal component images
   ShapeFunction::ParametersType pcStandardDeviations(NumberOfPCs);
 
-  for (i = 0; i < NumberOfPCs; ++i)
+  for (unsigned int i = 0; i < NumberOfPCs; ++i)
   {
     pcStandardDeviations[i] = vnl_sample_normal(0, 1);
   }
@@ -129,7 +126,7 @@ itkPCAShapeSignedDistanceFunctionTest(int, char *[])
   const unsigned int            numberOfParameters = numberOfShapeParameters + numberOfPoseParameters;
   ShapeFunction::ParametersType parameters(numberOfParameters);
 
-  for (i = 0; i < numberOfParameters; ++i)
+  for (unsigned int i = 0; i < numberOfParameters; ++i)
   {
     parameters[i] = vnl_sample_normal(0, 1);
   }
@@ -141,10 +138,7 @@ itkPCAShapeSignedDistanceFunctionTest(int, char *[])
   shape->Initialize();
 
   // check pca shape calculation
-  ShapeFunction::PointType  point;
-  ImageType::IndexType      index;
-  ShapeFunction::OutputType output;
-  ShapeFunction::OutputType expected;
+  ShapeFunction::PointType point;
 
   std::cout << "check results:" << std::endl;
   constexpr unsigned int numberOfRotationParameters = Dimension * (Dimension - 1) / 2;
@@ -156,7 +150,7 @@ itkPCAShapeSignedDistanceFunctionTest(int, char *[])
   for (meanImageIt.GoToBegin(); !meanImageIt.IsAtEnd(); ++meanImageIt)
   {
     // from index to physical point
-    index = meanImageIt.GetIndex();
+    ImageType::IndexType index = meanImageIt.GetIndex();
     meanImage->TransformIndexToPhysicalPoint(index, point);
 
     // inverse Euler2DTransform: first translation then rotation
@@ -168,11 +162,11 @@ itkPCAShapeSignedDistanceFunctionTest(int, char *[])
     q[1] = p[0] * std::sin(-angle) + p[1] * std::cos(-angle);
 
     // evaluate shape function
-    output = shape->Evaluate(q);
+    ShapeFunction::OutputType output = shape->Evaluate(q);
 
     // calculate expected function value
-    expected = meanImage->GetPixel(index);
-    for (i = 0; i < NumberOfPCs; ++i)
+    ShapeFunction::OutputType expected = meanImage->GetPixel(index);
+    for (unsigned int i = 0; i < NumberOfPCs; ++i)
     {
       expected += pcImages[i]->GetPixel(index) * pcStandardDeviations[i] * parameters[i];
     }
@@ -190,7 +184,7 @@ itkPCAShapeSignedDistanceFunctionTest(int, char *[])
   // Evaluate at a point outside the image domain
   std::cout << "Evaluate at point outside image domain" << std::endl;
   q.Fill(5.0);
-  output = shape->Evaluate(q);
+  ShapeFunction::OutputType output = shape->Evaluate(q);
   std::cout << "f(" << q << ") = " << output << std::endl;
 
   // Exercise other methods for test coverage
@@ -204,7 +198,7 @@ itkPCAShapeSignedDistanceFunctionTest(int, char *[])
   std::cout << "Parameters: " << shape->GetParameters() << std::endl;
 
   // Exercise error testing
-  bool pass;
+  bool pass = false;
 
 #define TEST_INITIALIZATION_ERROR(ComponentName, badComponent, goodComponent) \
   shape->Set##ComponentName(badComponent);                                    \

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
@@ -323,7 +323,6 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::ThreadedPerturbClust
 
 
   auto          radius = itk::Size<ImageDimension>::Filled(1);
-  unsigned long center;
   unsigned long stride[ImageDimension];
 
 
@@ -334,7 +333,7 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::ThreadedPerturbClust
 
   // get center and dimension strides for iterator neighborhoods
   NeighborhoodType it(radius, inputImage, inputImage->GetLargestPossibleRegion());
-  center = it.Size() / 2;
+  unsigned long    center = it.Size() / 2;
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     stride[i] = it.GetStride(i);
@@ -758,7 +757,6 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::RelabelConnectedRegi
   lbc.SetConstant(NumericTraits<typename OutputImageType::PixelType>::max());
 
   auto          radius = itk::Size<ImageDimension>::Filled(1);
-  unsigned long center;
   unsigned long stride[ImageDimension];
 
   using NeighborhoodType = NeighborhoodIterator<TOutputImage, ConstantBoundaryCondition<TOutputImage>>;
@@ -766,7 +764,7 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::RelabelConnectedRegi
   NeighborhoodType labelIt(radius, outputImage, outputImage->GetRequestedRegion());
   labelIt.OverrideBoundaryCondition(&lbc);
 
-  center = labelIt.Size() / 2;
+  unsigned long center = labelIt.Size() / 2;
   for (unsigned int j = 0; j < ImageDimension; ++j)
   {
     stride[j] = labelIt.GetStride(j);

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -42,13 +42,12 @@ template <typename TCoordinate>
 void
 VoronoiDiagram2DGenerator<TCoordinate>::SetRandomSeeds(int num)
 {
-  PointType curr;
-
   m_Seeds.clear();
   const double ymax{ m_VorBoundary[1] };
   const double xmax{ m_VorBoundary[0] };
   for (int i = 0; i < num; ++i)
   {
+    PointType curr;
     curr[0] = (CoordinateType)(vnl_sample_uniform(0, xmax));
     curr[1] = (CoordinateType)(vnl_sample_uniform(0, ymax));
     m_Seeds.push_back(curr);
@@ -264,19 +263,13 @@ VoronoiDiagram2DGenerator<TCoordinate>::ConstructDiagram()
   ++m_Nvert;
   m_OutputVD->AddVert(corner[3]);
 
-  std::list<EdgeInfo>                    buildEdges;
-  typename std::list<EdgeInfo>::iterator BEiter;
-  EdgeInfo                               curr;
-  EdgeInfo                               curr1;
-  EdgeInfo                               curr2;
+  std::list<EdgeInfo> buildEdges;
 
-  unsigned char                     frontbnd;
-  unsigned char                     backbnd;
   const std::vector<IdentifierType> cellPoints;
   for (unsigned int i = 0; i < m_NumberOfSeeds; ++i)
   {
     buildEdges.clear();
-    curr = rawEdges[i].front();
+    EdgeInfo curr = rawEdges[i].front();
     rawEdges[i].pop_front();
     buildEdges.push_back(curr);
     EdgeInfo front = curr;
@@ -285,8 +278,8 @@ VoronoiDiagram2DGenerator<TCoordinate>::ConstructDiagram()
     {
       curr = rawEdges[i].front();
       rawEdges[i].pop_front();
-      frontbnd = Pointonbnd(front[0]);
-      backbnd = Pointonbnd(back[1]);
+      unsigned char frontbnd = Pointonbnd(front[0]);
+      unsigned char backbnd = Pointonbnd(back[1]);
       if (curr[0] == back[1])
       {
         buildEdges.push_back(curr);
@@ -299,6 +292,7 @@ VoronoiDiagram2DGenerator<TCoordinate>::ConstructDiagram()
       }
       else if (curr[1] == back[1])
       {
+        EdgeInfo curr1;
         curr1[1] = curr[0];
         curr1[0] = curr[1];
         buildEdges.push_back(curr1);
@@ -306,6 +300,7 @@ VoronoiDiagram2DGenerator<TCoordinate>::ConstructDiagram()
       }
       else if (curr[0] == front[0])
       {
+        EdgeInfo curr1;
         curr1[0] = curr[1];
         curr1[1] = curr[0];
         buildEdges.push_front(curr1);
@@ -318,6 +313,7 @@ VoronoiDiagram2DGenerator<TCoordinate>::ConstructDiagram()
 
         if ((cfrontbnd == backbnd) && (backbnd))
         {
+          EdgeInfo curr1;
           curr1[0] = back[1];
           curr1[1] = curr[0];
           buildEdges.push_back(curr1);
@@ -326,6 +322,7 @@ VoronoiDiagram2DGenerator<TCoordinate>::ConstructDiagram()
         }
         else if ((cbackbnd == frontbnd) && (frontbnd))
         {
+          EdgeInfo curr1;
           curr1[0] = curr[1];
           curr1[1] = front[0];
           buildEdges.push_front(curr1);
@@ -334,6 +331,7 @@ VoronoiDiagram2DGenerator<TCoordinate>::ConstructDiagram()
         }
         else if ((cfrontbnd == frontbnd) && (frontbnd))
         {
+          EdgeInfo curr1;
           curr1[0] = curr[0];
           curr1[1] = front[0];
           buildEdges.push_front(curr1);
@@ -344,6 +342,7 @@ VoronoiDiagram2DGenerator<TCoordinate>::ConstructDiagram()
         }
         else if ((cbackbnd == backbnd) && (backbnd))
         {
+          EdgeInfo curr1;
           curr1[0] = back[1];
           curr1[1] = curr[1];
           buildEdges.push_back(curr1);
@@ -364,21 +363,23 @@ VoronoiDiagram2DGenerator<TCoordinate>::ConstructDiagram()
     }
 
     curr = buildEdges.front();
-    curr1 = buildEdges.back();
+    EdgeInfo curr1 = buildEdges.back();
     if (curr[0] != curr1[1])
     {
-      frontbnd = Pointonbnd(curr[0]);
-      backbnd = Pointonbnd(curr1[1]);
+      unsigned char frontbnd = Pointonbnd(curr[0]);
+      unsigned char backbnd = Pointonbnd(curr1[1]);
       if ((frontbnd != 0) && (backbnd != 0))
       {
         if (frontbnd == backbnd)
         {
+          EdgeInfo curr2;
           curr2[0] = curr1[1];
           curr2[1] = curr[0];
           buildEdges.push_back(curr2);
         }
         else if ((frontbnd == backbnd + 1) || (frontbnd == backbnd - 3))
         {
+          EdgeInfo curr2;
           curr2[0] = cornerID[frontbnd - 1];
           curr2[1] = curr[0];
           buildEdges.push_front(curr2);
@@ -388,6 +389,7 @@ VoronoiDiagram2DGenerator<TCoordinate>::ConstructDiagram()
         }
         else if ((frontbnd == backbnd - 1) || (frontbnd == backbnd + 3))
         {
+          EdgeInfo curr2;
           curr2[0] = cornerID[backbnd - 1];
           curr2[1] = curr[0];
           buildEdges.push_front(curr2);
@@ -402,13 +404,12 @@ VoronoiDiagram2DGenerator<TCoordinate>::ConstructDiagram()
       }
     }
 
-    EdgeInfo pp;
 
     m_OutputVD->ClearRegion(i);
 
-    for (BEiter = buildEdges.begin(); BEiter != buildEdges.end(); ++BEiter)
+    for (typename std::list<EdgeInfo>::iterator BEiter = buildEdges.begin(); BEiter != buildEdges.end(); ++BEiter)
     {
-      pp = *BEiter;
+      EdgeInfo pp = *BEiter;
       m_OutputVD->VoronoiRegionAddPointId(i, pp[0]);
     }
     m_OutputVD->BuildEdge(i);
@@ -433,8 +434,8 @@ VoronoiDiagram2DGenerator<TCoordinate>::right_of(FortuneHalfEdge * el, PointType
   {
     return (false);
   }
-  bool above;
-  bool fast;
+  bool above = false;
+  bool fast = false;
   if (e->m_A == 1.0)
   {
     const double dyp = ((*p)[1]) - (topsite->m_Coord[1]);
@@ -504,7 +505,7 @@ template <typename TCoordinate>
 void
 VoronoiDiagram2DGenerator<TCoordinate>::deletePQ(FortuneHalfEdge * task)
 {
-  FortuneHalfEdge * last;
+  FortuneHalfEdge * last = nullptr;
 
   if ((task->m_Vert) != nullptr)
   {
@@ -555,7 +556,7 @@ VoronoiDiagram2DGenerator<TCoordinate>::insertPQ(FortuneHalfEdge * he, FortuneSi
   he->m_Vert = v;
   he->m_Ystar = (v->m_Coord[1]) + offset;
   FortuneHalfEdge * last = &(m_PQHash[PQbucket(he)]);
-  FortuneHalfEdge * enext;
+  FortuneHalfEdge * enext = nullptr;
 
   while (((enext = (last->m_Next)) != nullptr) &&
          (((he->m_Ystar) > (enext->m_Ystar)) ||
@@ -608,7 +609,7 @@ template <typename TCoordinate>
 auto
 VoronoiDiagram2DGenerator<TCoordinate>::findLeftHE(PointType * p) -> FortuneHalfEdge *
 {
-  int  i;
+  int  i = 0;
   auto bucket = static_cast<int>((((*p)[0]) - m_Pxmin) / m_Deltax * m_ELhashsize);
 
   if (bucket < 0)
@@ -745,8 +746,8 @@ VoronoiDiagram2DGenerator<TCoordinate>::intersect(FortuneSite * newV, FortuneHal
 {
   FortuneEdge *     e1 = el1->m_Edge;
   FortuneEdge *     e2 = el2->m_Edge;
-  FortuneHalfEdge * saveHE;
-  FortuneEdge *     saveE;
+  FortuneHalfEdge * saveHE = nullptr;
+  FortuneEdge *     saveE = nullptr;
 
   if (e1 == nullptr)
   {
@@ -814,8 +815,8 @@ void
 VoronoiDiagram2DGenerator<TCoordinate>::clip_line(FortuneEdge * task)
 {
   // Clip line
-  FortuneSite * s1;
-  FortuneSite * s2;
+  FortuneSite * s1 = nullptr;
+  FortuneSite * s2 = nullptr;
   if (((task->m_A) == 1.0) && ((task->m_B) >= 0.0))
   {
     s1 = task->m_Ep[1];
@@ -828,12 +829,12 @@ VoronoiDiagram2DGenerator<TCoordinate>::clip_line(FortuneEdge * task)
   }
 
 
-  double x1;
-  double y1;
-  double x2;
-  double y2;
-  int    id1;
-  int    id2;
+  double x1 = NAN;
+  double y1 = NAN;
+  double x2 = NAN;
+  double y2 = NAN;
+  int    id1 = 0;
+  int    id2 = 0;
   if ((task->m_A) == 1.0)
   {
     if ((s1 != nullptr) && ((s1->m_Coord[1]) > m_Pymin))
@@ -1088,7 +1089,7 @@ VoronoiDiagram2DGenerator<TCoordinate>::GenerateVDFortune()
   unsigned int      i = 2;
   bool              ok = true;
   PointType         currentCircle{};
-  FortuneHalfEdge * leftHalfEdge;
+  FortuneHalfEdge * leftHalfEdge = nullptr;
   while (ok)
   {
     if (m_PQcount != 0)

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.hxx
@@ -163,14 +163,10 @@ VoronoiPartitioningImageFilter<TInputImage, TOutputImage>::TestHomogeneity(Index
     addpp = addpp + getp * getp;
   }
 
-  double savevar;
+  double savevar = -1;
   if (num > 1)
   {
     savevar = std::sqrt((addpp - (addp * addp) / static_cast<double>(num)) / (static_cast<double>(num) - 1.0));
-  }
-  else
-  {
-    savevar = -1;
   }
 
   return (savevar >= 0 && std::sqrt(savevar) < m_SigmaThreshold);

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.hxx
@@ -44,7 +44,7 @@ bool
 VoronoiSegmentationImageFilter<TInputImage, TOutputImage, TBinaryPriorImage>::TestHomogeneity(IndexList & Plist)
 {
   auto   num = static_cast<int>(Plist.size());
-  double getp;
+  double getp = NAN;
   double addp = 0;
   double addpp = 0;
 
@@ -57,17 +57,12 @@ VoronoiSegmentationImageFilter<TInputImage, TOutputImage, TBinaryPriorImage>::Te
     addpp = addpp + getp * getp;
   }
 
-  double savemean;
-  double saveSTD;
+  double savemean = 0;
+  double saveSTD = -1;
   if (num > 1)
   {
     savemean = addp / num;
     saveSTD = std::sqrt((addpp - (addp * addp) / (num)) / (num - 1));
-  }
-  else
-  {
-    savemean = 0;
-    saveSTD = -1;
   }
 
   //   // jvm - Mahalanobis distance
@@ -101,7 +96,7 @@ VoronoiSegmentationImageFilter<TInputImage, TOutputImage, TBinaryPriorImage>::Ta
   int   num = 0;
   float addp = 0;
   float addpp = 0;
-  float currp;
+  float currp = NAN;
 
   unsigned int minx = 0;
   unsigned int miny = 0;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
@@ -239,7 +239,7 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::TakeAPrior(const B
 
   ait.GoToBegin();
   iit.GoToBegin();
-  unsigned int k;
+
   for (unsigned int i = 0; i < miny; ++i)
   {
     for (unsigned int j = 0; j < this->GetSize()[0]; ++j)
@@ -261,7 +261,7 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::TakeAPrior(const B
       if (ait.Get())
       {
         ++objnum;
-        for (k = 0; k < 6; ++k)
+        for (unsigned int k = 0; k < 6; ++k)
         {
           objaddp[k] += currp[k];
           objaddpp[k] += currp[k] * currp[k];
@@ -270,7 +270,7 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::TakeAPrior(const B
       else
       {
         ++bkgnum;
-        for (k = 0; k < 6; ++k)
+        for (unsigned int k = 0; k < 6; ++k)
         {
           bkgaddp[k] += currp[k];
           bkgaddpp[k] += currp[k] * currp[k];
@@ -359,7 +359,7 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::TakeAPrior(const B
   unsigned char tmp[6] = { 0, 1, 2, 3, 4, 5 };
   for (unsigned int j = 0; j < 3; ++j)
   {
-    k = 0;
+    unsigned int k = 0;
     for (unsigned int i = 1; i < 6 - j; ++i)
     {
       if (diffMean[tmp[i]] > diffMean[tmp[k]])
@@ -373,7 +373,7 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::TakeAPrior(const B
   unsigned char tmp1[6] = { 0, 1, 2, 3, 4, 5 };
   for (unsigned int j = 0; j < 3; ++j)
   {
-    k = 0;
+    unsigned int k = 0;
     for (unsigned int i = 1; i < 6 - j; ++i)
     {
       if (diffSTD[tmp1[i]] > diffSTD[tmp1[k]])

--- a/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationImageFilterTest.cxx
+++ b/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationImageFilterTest.cxx
@@ -70,22 +70,20 @@ itkVoronoiSegmentationImageFilterTest(int argc, char * argv[])
 
   // Object (2): random field with mean: 520, std: 20
   std::cout << "Defining object #2" << std::endl;
-  unsigned int i;
-  unsigned int j;
-  for (i = 30; i < 94; ++i)
+  for (unsigned int i = 30; i < 94; ++i)
   {
     index[0] = i;
-    for (j = 30; j < 94; ++j)
+    for (unsigned int j = 30; j < 94; ++j)
     {
       index[1] = j;
       inputImage->SetPixel(index, static_cast<unsigned short>(vnl_sample_uniform(500, 540)));
     }
   }
 
-  for (i = 150; i < 214; ++i)
+  for (unsigned int i = 150; i < 214; ++i)
   {
     index[0] = i;
-    for (j = 150; j < 214; ++j)
+    for (unsigned int j = 150; j < 214; ++j)
     {
       index[1] = j;
       inputImage->SetPixel(index, static_cast<unsigned short>(vnl_sample_uniform(500, 540)));

--- a/Modules/Segmentation/Watersheds/include/itkIsolatedWatershedImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkIsolatedWatershedImageFilter.hxx
@@ -151,13 +151,12 @@ IsolatedWatershedImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   const IdentifierType seed1Label = m_Watershed->GetOutput()->GetPixel(m_Seed1);
   const IdentifierType seed2Label = m_Watershed->GetOutput()->GetPixel(m_Seed2);
-  IdentifierType       value;
 
   it.GoToBegin();
   ot.GoToBegin();
   while (!it.IsAtEnd())
   {
-    value = it.Get();
+    IdentifierType value = it.Get();
     if (value == seed1Label)
     {
       ot.Set(m_ReplaceValue1);

--- a/Modules/Segmentation/Watersheds/include/itkWatershedBoundary.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedBoundary.hxx
@@ -28,8 +28,6 @@ namespace watershed
 template <typename TScalar, unsigned int TDimension>
 Boundary<TScalar, TDimension>::Boundary()
 {
-  unsigned int      i;
-  FacePointer       p;
   const flat_hash_t f;
 
   std::pair<FacePointer, FacePointer> i_pair;
@@ -37,9 +35,9 @@ Boundary<TScalar, TDimension>::Boundary()
   std::pair<bool, bool>               v_pair;
 
   // Initialize all the members of the lists, etc.
-  for (i = 0; i < Dimension; ++i)
+  for (unsigned int i = 0; i < Dimension; ++i)
   {
-    p = face_t::New();
+    FacePointer p = face_t::New();
     i_pair.first = p;
     c_pair.first = flat_hash_t();
     v_pair.first = false;

--- a/Modules/Segmentation/Watersheds/include/itkWatershedEquivalenceRelabeler.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedEquivalenceRelabeler.hxx
@@ -18,6 +18,7 @@
 #ifndef itkWatershedEquivalenceRelabeler_hxx
 #define itkWatershedEquivalenceRelabeler_hxx
 #include "itkImageRegionIterator.h"
+
 namespace itk
 {
 namespace watershed
@@ -84,18 +85,16 @@ EquivalenceRelabeler<TScalar, TImageDimension>::GenerateOutputRequestedRegion(Da
   // No choice but to use RTTI here.
   // All Image outputs set to the same RequestedRegion  other
   // outputs ignored.
-  ImageBase<ImageDimension> * imgData;
-  ImageBase<ImageDimension> * op;
-  imgData = dynamic_cast<ImageBase<ImageDimension> *>(output);
+  ImageBase<ImageDimension> * imgData = dynamic_cast<ImageBase<ImageDimension> *>(output);
 
   if (imgData)
   {
-    std::vector<ProcessObject::DataObjectPointer>::size_type idx;
+    std::vector<ProcessObject::DataObjectPointer>::size_type idx = 0;
     for (idx = 0; idx < this->GetNumberOfIndexedOutputs(); ++idx)
     {
       if (this->GetOutput(idx) && this->GetOutput(idx) != output)
       {
-        op = dynamic_cast<ImageBase<ImageDimension> *>(this->GetOutput(idx));
+        ImageBase<ImageDimension> * op = dynamic_cast<ImageBase<ImageDimension> *>(this->GetOutput(idx));
         if (op)
         {
           this->GetOutput(idx)->SetRequestedRegion(output);

--- a/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.hxx
@@ -122,18 +122,16 @@ Relabeler<TScalar, TImageDimension>::GenerateOutputRequestedRegion(DataObject * 
   // No choice but to use RTTI here.
   // All Image outputs set to the same RequestedRegion  other
   // outputs ignored.
-  ImageBase<ImageDimension> * imgData;
-  ImageBase<ImageDimension> * op;
-  imgData = dynamic_cast<ImageBase<ImageDimension> *>(output);
 
+  ImageBase<ImageDimension> * imgData = dynamic_cast<ImageBase<ImageDimension> *>(output);
   if (imgData)
   {
-    std::vector<ProcessObject::DataObjectPointer>::size_type idx;
+    std::vector<ProcessObject::DataObjectPointer>::size_type idx = 0;
     for (idx = 0; idx < this->GetNumberOfIndexedOutputs(); ++idx)
     {
       if (this->GetOutput(idx) && this->GetOutput(idx) != output)
       {
-        op = dynamic_cast<ImageBase<ImageDimension> *>(this->GetOutput(idx));
+        ImageBase<ImageDimension> * op = dynamic_cast<ImageBase<ImageDimension> *>(this->GetOutput(idx));
         if (op)
         {
           this->GetOutput(idx)->SetRequestedRegion(output);

--- a/Modules/Video/Core/include/itkVideoSource.hxx
+++ b/Modules/Video/Core/include/itkVideoSource.hxx
@@ -297,14 +297,9 @@ VideoSource<TOutputVideoStream>::SplitRequestedSpatialRegion(
   // determine the actual number of pieces that will be generated
   const typename TOutputVideoStream::SizeType::SizeValueType range = requestedRegionSize[splitAxis];
 
-  int valuesPerThread;
-  int maxThreadIdUsed;
-  if (range == 0)
-  {
-    valuesPerThread = 0;
-    maxThreadIdUsed = 0;
-  }
-  else
+  int valuesPerThread = 0;
+  int maxThreadIdUsed = 0;
+  if (range != 0)
   {
     valuesPerThread = Math::Ceil<int>(range / static_cast<double>(num));
     maxThreadIdUsed = Math::Ceil<int>(range / static_cast<double>(valuesPerThread)) - 1;


### PR DESCRIPTION
Checks whether there are local variables that are declared without an initial value. These may lead to unexpected behaviour if there is a code path that reads the variable before assigning to it.

Only integers, booleans, floats, doubles, and pointers are checked. The fix option initializes all detected values to zero. An exception is float and double types, which are initialized to NaN.

cd
run-clang-tidy.py -extra-arg=-D__clang__ -checks=-*,cppcoreguidelines-init-variables  -header-filter=.* -fix

Initialize non-initialized variables to default values (e.g., NaN, nullptr, zero, etc.). Manually review and prefer initialization to assignment of default values.  Place variable initialization in a smaller scope.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)