### PR TITLE
 No longer declare `ImageIOBase::GetComponentTypeInfo()` deprecated, add GoogleTest unit test 

### DIFF
--- a/Modules/IO/ImageBase/include/itkImageIOBase.h
+++ b/Modules/IO/ImageBase/include/itkImageIOBase.h
@@ -250,9 +250,6 @@ public:
   itkGetEnumMacro(ComponentType, IOComponentEnum);
 
   /** get the type_info for the current pixel component type.
-   * This function is DEPRECATED and only provided for backwards
-   * compatibility.  There is no use for this method that can't
-   * be satisfied by calling GetComponentType.
    */
   virtual const std::type_info &
   GetComponentTypeInfo() const;

--- a/Modules/IO/ImageBase/test/CMakeLists.txt
+++ b/Modules/IO/ImageBase/test/CMakeLists.txt
@@ -977,6 +977,8 @@ itk_add_test(
   COMMAND
   itkUnicodeIOTest)
 
-set(ITKIOImageBaseGTests itkWriteImageFunctionGTest.cxx
+set(ITKIOImageBaseGTests
+  itkImageIOBaseGTest.cxx
+  itkWriteImageFunctionGTest.cxx
 )
 creategoogletestdriver(ITKIOImageBase "${ITKIOImageBase-Test_LIBRARIES}" "${ITKIOImageBaseGTests}")

--- a/Modules/IO/ImageBase/test/itkImageIOBaseGTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageIOBaseGTest.cxx
@@ -1,0 +1,115 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkImageIOBase.h"
+#include <gtest/gtest.h>
+
+namespace
+{
+class DummyImageIO : public itk::ImageIOBase
+{
+public:
+  ITK_DISALLOW_COPY_AND_MOVE(DummyImageIO);
+
+  using Self = DummyImageIO;
+  using Superclass = ImageIOBase;
+  using Pointer = itk::SmartPointer<Self>;
+
+  itkNewMacro(Self);
+  itkOverrideGetNameOfClassMacro(DummyImageIO);
+
+protected:
+  DummyImageIO() = default;
+  ~DummyImageIO() override = default;
+
+private:
+  bool
+  CanReadFile(const char *) override
+  {
+    itkExceptionMacro("Unimplemented");
+  }
+
+  void
+  ReadImageInformation() override
+  {
+    itkExceptionMacro("Unimplemented");
+  }
+
+  void
+  Read(void *) override
+  {
+    itkExceptionMacro("Unimplemented");
+  }
+
+  bool
+  CanWriteFile(const char *) override
+  {
+    itkExceptionMacro("Unimplemented");
+  }
+
+  void
+  WriteImageInformation() override
+  {
+    itkExceptionMacro("Unimplemented");
+  }
+
+  void
+  Write(const void *) override
+  {
+    itkExceptionMacro("Unimplemented");
+  }
+};
+
+
+template <typename T>
+void
+Test_GetComponentTypeInfo()
+{
+  const auto imageIO = DummyImageIO::New();
+  imageIO->SetComponentType(itk::ImageIOBase::MapPixelType<T>::CType);
+
+  // Expect the returned type info to correspond with the component type that was set.
+  EXPECT_EQ(imageIO->GetComponentTypeInfo(), typeid(T));
+}
+
+template <typename... T>
+void
+Test_GetComponentTypeInfo_for_multiple_types()
+{
+  (Test_GetComponentTypeInfo<T>(), ...);
+}
+
+} // namespace
+
+// Test that GetComponentTypeInfo() returns the type info of the currently selected component type.
+TEST(ImageIOBase, GetComponentTypeInfo)
+{
+  Test_GetComponentTypeInfo_for_multiple_types<char,
+                                               unsigned char,
+                                               short,
+                                               unsigned short,
+                                               int,
+                                               unsigned int,
+                                               long,
+                                               unsigned long,
+                                               long long,
+                                               unsigned long long,
+                                               float,
+                                               double>();
+}


### PR DESCRIPTION
`ImageIOBase::GetComponentTypeInfo()` was declared "DEPRECATED" by commit 6ff5fc7f01148bd11070c5ecfe0d56f643f62565, Kent Williams, 9 Feb 2011. However, it is still there after all those years, and it still appears useful.

Added a GoogleTest unit test to test this member function.