### PR TITLE
COMP: Prefer new style cast to old

### DIFF
--- a/Modules/Core/Common/include/itkAnatomicalOrientation.h
+++ b/Modules/Core/Common/include/itkAnatomicalOrientation.h
@@ -498,7 +498,7 @@ public:
   NegativeEnum
   GetAsNegativeOrientation() const
   {
-    return NegativeEnum(uint32_t(this->m_Value));
+    return NegativeEnum(static_cast<uint32_t>(this->m_Value));
   }
 
   CoordinateEnum

--- a/Modules/Core/Common/include/itkColorTable.hxx
+++ b/Modules/Core/Common/include/itkColorTable.hxx
@@ -207,7 +207,7 @@ ColorTable<TComponent>::UseHeatColors(unsigned int n)
     }
     auto g = static_cast<TComponent>(((i + 1) / (n / 2.0 + 1)) * scale + shift);
     auto b = static_cast<TComponent>(((i + 1) / (n / 2.0 + 1)) * scale + shift);
-    m_Color[(size_t)(i + n / 2.0)].Set(r, g, b);
+    m_Color[static_cast<size_t>(i + n / 2.0)].Set(r, g, b);
     std::ostringstream name;
     name << "Heat" << std::fixed << std::setprecision(2) << (i + n / 2.0) / static_cast<float>(n);
     m_ColorName[static_cast<size_t>((i + n / 2.0))] = name.str();

--- a/Modules/Core/Common/src/itkDynamicLoader.cxx
+++ b/Modules/Core/Common/src/itkDynamicLoader.cxx
@@ -43,7 +43,7 @@ DynamicLoader::CloseLibrary(LibHandle lib)
 void *
 DynamicLoader::GetSymbolAddress(LibHandle lib, const char * sym)
 {
-  return (void *)itksys::DynamicLoader::GetSymbolAddress(lib, sym);
+  return reinterpret_cast<void *>(itksys::DynamicLoader::GetSymbolAddress(lib, sym));
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -419,7 +419,7 @@ ObjectFactoryBase::LoadLibrariesInPath(const char * path)
           /**
            * initialize class members if load worked
            */
-          newfactory->m_LibraryHandle = (void *)lib;
+          newfactory->m_LibraryHandle = static_cast<void *>(lib);
           newfactory->m_LibraryPath = fullpath;
           newfactory->m_LibraryDate = 0; // unused for now...
 

--- a/Modules/Core/Common/test/itkAnatomicalOrientationGTest.cxx
+++ b/Modules/Core/Common/test/itkAnatomicalOrientationGTest.cxx
@@ -231,12 +231,12 @@ TEST(AntomicalOrientation, ToFromEnumInteroperability)
   using FromOE = itk::AnatomicalOrientation::NegativeEnum;
   using CE = itk::AnatomicalOrientation::CoordinateEnum;
 
-  static_assert(int(OE::RAI) == int(FromOE::LPS));
-  static_assert(int(OE::LPS) == int(FromOE::RAI));
-  static_assert(int(OE::RAS) == int(FromOE::LPI));
-  static_assert(int(OE::LPI) == int(FromOE::RAS));
-  static_assert(int(OE::PIR) == int(FromOE::ASL));
-  static_assert(int(OE::ASL) == int(FromOE::PIR));
+  static_assert(static_cast<int>(OE::RAI) == static_cast<int>(FromOE::LPS));
+  static_assert(static_cast<int>(OE::LPS) == static_cast<int>(FromOE::RAI));
+  static_assert(static_cast<int>(OE::RAS) == static_cast<int>(FromOE::LPI));
+  static_assert(static_cast<int>(OE::LPI) == static_cast<int>(FromOE::RAS));
+  static_assert(static_cast<int>(OE::PIR) == static_cast<int>(FromOE::ASL));
+  static_assert(static_cast<int>(OE::ASL) == static_cast<int>(FromOE::PIR));
 
   constexpr itk::AnatomicalOrientation itk_rai(FromOE::RAI);
 
@@ -256,10 +256,10 @@ TEST(AnatomicalOrientation, LegacyInteroperability)
   using SOE = itk::SpatialOrientationEnums::ValidCoordinateOrientations;
 
   // byte for byte compatibility, may assist with migration of bindings when types are not strictly enforced.
-  static_assert(int(SOE::ITK_COORDINATE_ORIENTATION_RAI) == int(OE::LPS));
-  static_assert(int(SOE::ITK_COORDINATE_ORIENTATION_LPS) == int(OE::RAI));
-  static_assert(int(SOE::ITK_COORDINATE_ORIENTATION_RSA) == int(OE::LIP));
-  static_assert(int(SOE::ITK_COORDINATE_ORIENTATION_ASL) == int(OE::PIR));
+  static_assert(static_cast<int>(SOE::ITK_COORDINATE_ORIENTATION_RAI) == static_cast<int>(OE::LPS));
+  static_assert(static_cast<int>(SOE::ITK_COORDINATE_ORIENTATION_LPS) == static_cast<int>(OE::RAI));
+  static_assert(static_cast<int>(SOE::ITK_COORDINATE_ORIENTATION_RSA) == static_cast<int>(OE::LIP));
+  static_assert(static_cast<int>(SOE::ITK_COORDINATE_ORIENTATION_ASL) == static_cast<int>(OE::PIR));
 
   const itk::AnatomicalOrientation itk_rai(SOE::ITK_COORDINATE_ORIENTATION_RAI);
   EXPECT_EQ(itk_rai, OE::LPS);

--- a/Modules/Core/Common/test/itkImageFillBufferTest.cxx
+++ b/Modules/Core/Common/test/itkImageFillBufferTest.cxx
@@ -35,7 +35,7 @@ itkImageFillBufferTest(int argc, char * argv[])
   auto image = ImageType::New();
 
   ImageType::SizeType size;
-  size[0] = (ImageType::SizeValueType)(std::stod(argv[1]) * 1024);
+  size[0] = static_cast<ImageType::SizeValueType>(std::stod(argv[1]) * 1024);
   size[1] = 1024;
   size[2] = 1024;
 

--- a/Modules/Core/Common/test/itkMersenneTwisterRandomVariateGeneratorTest.cxx
+++ b/Modules/Core/Common/test/itkMersenneTwisterRandomVariateGeneratorTest.cxx
@@ -63,11 +63,11 @@ itkMersenneTwisterRandomVariateGeneratorTest(int, char *[])
   }
 
   // Ensure we get the same series of numbers
-  constexpr Twister::IntegerType expected[5] = { Twister::IntegerType(3294740812u),
-                                                 Twister::IntegerType(4175194053u),
-                                                 Twister::IntegerType(3041332341u),
-                                                 Twister::IntegerType(199851601u),
-                                                 Twister::IntegerType(3422518480u) };
+  constexpr Twister::IntegerType expected[5] = { static_cast<Twister::IntegerType>(3294740812u),
+                                                 static_cast<Twister::IntegerType>(4175194053u),
+                                                 static_cast<Twister::IntegerType>(3041332341u),
+                                                 static_cast<Twister::IntegerType>(199851601u),
+                                                 static_cast<Twister::IntegerType>(3422518480u) };
 
   bool sameSequence = true;
   for (const auto i : expected)

--- a/Modules/Core/Common/test/itkPointSetTest.cxx
+++ b/Modules/Core/Common/test/itkPointSetTest.cxx
@@ -67,9 +67,9 @@ itkPointSetTest(int, char *[])
   {
     for (int i = 0; i < numOfPoints; ++i)
     {
-      testPointCoords[0] = (PointSet::CoordinateType)vnl_sample_uniform(-1.0, 1.0);
-      testPointCoords[1] = (PointSet::CoordinateType)vnl_sample_uniform(-1.0, 1.0);
-      testPointCoords[2] = (PointSet::CoordinateType)vnl_sample_uniform(-1.0, 1.0);
+      testPointCoords[0] = static_cast<PointSet::CoordinateType>(vnl_sample_uniform(-1.0, 1.0));
+      testPointCoords[1] = static_cast<PointSet::CoordinateType>(vnl_sample_uniform(-1.0, 1.0));
+      testPointCoords[2] = static_cast<PointSet::CoordinateType>(vnl_sample_uniform(-1.0, 1.0));
       pset->SetPoint(i, PointType(testPointCoords));
     }
   }

--- a/Modules/Core/Common/test/itkVariableLengthVectorTest.cxx
+++ b/Modules/Core/Common/test/itkVariableLengthVectorTest.cxx
@@ -59,7 +59,7 @@ itkVariableLengthVectorTest(int, char *[])
 
   std::cout << h << std::endl; // should be [-1.1 -1.1 -1.1]
 
-  h = (FloatVariableLengthVectorType)g;
+  h = FloatVariableLengthVectorType(g);
   if (h != static_cast<FloatVariableLengthVectorType>(g))
   {
     std::cerr << "Casts: [FAILED]" << std::endl;

--- a/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
@@ -98,10 +98,10 @@ template <typename TInputImage, typename TOutputImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::ApplyUpdateThreaderCallback(void * arg)
 {
-  const ThreadIdType workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
-  const ThreadIdType workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
+  const ThreadIdType workUnitID = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->WorkUnitID;
+  const ThreadIdType workUnitCount = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->NumberOfWorkUnits;
 
-  auto * str = (DenseFDThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
+  auto * str = (DenseFDThreadStruct *)((static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->UserData);
 
   // Execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.
@@ -160,10 +160,10 @@ template <typename TInputImage, typename TOutputImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::CalculateChangeThreaderCallback(void * arg)
 {
-  const ThreadIdType workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
-  const ThreadIdType workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
+  const ThreadIdType workUnitID = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->WorkUnitID;
+  const ThreadIdType workUnitCount = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->NumberOfWorkUnits;
 
-  auto * str = (DenseFDThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
+  auto * str = (DenseFDThreadStruct *)((static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->UserData);
 
   // Execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.hxx
@@ -89,9 +89,9 @@ template <typename TInputImageType, typename TSparseOutputImageType>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::ApplyUpdateThreaderCallback(void * arg)
 {
-  const ThreadIdType workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
-  const ThreadIdType workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
-  auto *             str = (FDThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
+  const ThreadIdType workUnitID = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->WorkUnitID;
+  const ThreadIdType workUnitCount = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->NumberOfWorkUnits;
+  auto *             str = (FDThreadStruct *)((static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->UserData);
 
   // Execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.
@@ -176,10 +176,10 @@ template <typename TInputImageType, typename TSparseOutputImageType>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::CalculateChangeThreaderCallback(void * arg)
 {
-  const ThreadIdType workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
-  const ThreadIdType workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
+  const ThreadIdType workUnitID = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->WorkUnitID;
+  const ThreadIdType workUnitCount = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->NumberOfWorkUnits;
 
-  auto * str = (FDThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
+  auto * str = (FDThreadStruct *)((static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->UserData);
 
   // Execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.
@@ -202,10 +202,10 @@ ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::PrecalculateChangeThreaderCallback(
   void * arg)
 {
-  const ThreadIdType workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
-  const ThreadIdType workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
+  const ThreadIdType workUnitID = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->WorkUnitID;
+  const ThreadIdType workUnitCount = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->NumberOfWorkUnits;
 
-  auto * str = (FDThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
+  auto * str = (FDThreadStruct *)((static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->UserData);
 
   // Execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.

--- a/Modules/Core/ImageAdaptors/test/itkVectorImageToImageAdaptorTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkVectorImageToImageAdaptorTest.cxx
@@ -46,7 +46,7 @@ itkVectorImageToImageAdaptorTest(int, char *[])
   VectorImageType::SizeType            size;
   for (unsigned int i = 0; i < VectorLength; ++i)
   {
-    f[i] = PixelType(i);
+    f[i] = static_cast<PixelType>(i);
   }
   start.Fill(0);
   size.Fill(50);
@@ -75,7 +75,7 @@ itkVectorImageToImageAdaptorTest(int, char *[])
   while (!adaptIt.IsAtEnd())
   {
     const PixelType pixelV = adaptIt.Get();
-    if (itk::Math::NotAlmostEquals(pixelV, PixelType(componentToExtract)))
+    if (itk::Math::NotAlmostEquals(pixelV, static_cast<PixelType>(componentToExtract)))
     {
       std::cout << "Wrong Pixel Value: adaptIt(" << adaptIt.GetIndex() << ") = " << adaptIt.Get() << std::endl;
 

--- a/Modules/Core/ImageFunction/test/itkImageAdaptorInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkImageAdaptorInterpolateImageFunctionTest.cxx
@@ -216,7 +216,7 @@ itkImageAdaptorInterpolateImageFunctionTest(int, char *[])
   {
     itk::SpacePrecisionType darray[3] = { 10, 20, 40 };
     constexpr double        temp = 70.0;
-    output = OutputType(temp);
+    output = static_cast<OutputType>(temp);
     cindex = ContinuousIndexType(darray);
     passed = ImageAdaptorInterpolate::TestContinuousIndex(interp, cindex, true, output);
   }
@@ -238,7 +238,7 @@ itkImageAdaptorInterpolateImageFunctionTest(int, char *[])
   {
     itk::SpacePrecisionType darray[3] = { 0, 20, 40 };
     constexpr double        temp = 60.0;
-    output = OutputType(temp);
+    output = static_cast<OutputType>(temp);
     cindex = ContinuousIndexType(darray);
     passed = ImageAdaptorInterpolate::TestContinuousIndex(interp, cindex, true, output);
   }
@@ -261,7 +261,7 @@ itkImageAdaptorInterpolateImageFunctionTest(int, char *[])
     constexpr itk::SpacePrecisionType epsilon = 1.0e-10;
     itk::SpacePrecisionType           darray[3] = { 19 - epsilon, 20, 40 };
     constexpr double                  temp = 79.0;
-    output = OutputType(temp);
+    output = static_cast<OutputType>(temp);
     cindex = ContinuousIndexType(darray);
     passed = ImageAdaptorInterpolate::TestContinuousIndex(interp, cindex, true, output);
   }
@@ -283,7 +283,7 @@ itkImageAdaptorInterpolateImageFunctionTest(int, char *[])
   {
     itk::SpacePrecisionType darray[3] = { 20, 20, 40 };
     constexpr double        temp = 1.0;
-    output = OutputType(temp);
+    output = static_cast<OutputType>(temp);
     cindex = ContinuousIndexType(darray);
     passed = ImageAdaptorInterpolate::TestContinuousIndex(interp, cindex, false, output);
   }
@@ -305,7 +305,7 @@ itkImageAdaptorInterpolateImageFunctionTest(int, char *[])
   {
     itk::SpacePrecisionType darray[3] = { 5.25, 12.5, 42.0 };
     constexpr double        temp = 59.75;
-    output = OutputType(temp);
+    output = static_cast<OutputType>(temp);
     cindex = ContinuousIndexType(darray);
     passed = ImageAdaptorInterpolate::TestContinuousIndex(interp, cindex, true, output);
   }

--- a/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
@@ -64,7 +64,7 @@ itkRayCastInterpolateImageFunctionTest(int itkNotUsed(argc), char * itkNotUsed(a
       for (unsigned int col = 0; col < size[0]; ++col)
       {
         index[0] = col;
-        auto value = (PixelType)(slice + row + col);
+        auto value = static_cast<PixelType>(slice + row + col);
         image->SetPixel(index, value);
       }
     }

--- a/Modules/Core/ImageFunction/test/itkWindowedSincInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkWindowedSincInterpolateImageFunctionTest.cxx
@@ -200,7 +200,7 @@ itkWindowedSincInterpolateImageFunctionTest(int, char *[])
   // an integer position inside the image
   {
     CoordinateType darray[3] = { 10, 20, 40 };
-    output = OutputType(70);
+    output = static_cast<OutputType>(70);
     cindex = ContinuousIndexType(darray);
     passed = SincInterpolate::TestContinuousIndex(interp, cindex, true, output);
   }
@@ -221,7 +221,7 @@ itkWindowedSincInterpolateImageFunctionTest(int, char *[])
   // position at the image border
   {
     CoordinateType darray[3] = { 0, 20, 40 };
-    output = OutputType(60);
+    output = static_cast<OutputType>(60);
     cindex = ContinuousIndexType(darray);
     passed = SincInterpolate::TestContinuousIndex(interp, cindex, true, output);
   }
@@ -243,7 +243,7 @@ itkWindowedSincInterpolateImageFunctionTest(int, char *[])
   {
     constexpr double epsilon = 1.0e-10;
     CoordinateType   darray[3] = { 19 - epsilon, 20, 40 };
-    output = OutputType(79);
+    output = static_cast<OutputType>(79);
     cindex = ContinuousIndexType(darray);
     passed = SincInterpolate::TestContinuousIndex(interp, cindex, true, output);
   }
@@ -264,7 +264,7 @@ itkWindowedSincInterpolateImageFunctionTest(int, char *[])
   // position outside the image
   {
     CoordinateType darray[3] = { 20, 20, 40 };
-    output = OutputType(1);
+    output = static_cast<OutputType>(1);
     cindex = ContinuousIndexType(darray);
     passed = SincInterpolate::TestContinuousIndex(interp, cindex, false, output);
   }
@@ -285,7 +285,7 @@ itkWindowedSincInterpolateImageFunctionTest(int, char *[])
   // at non-integer position
   {
     CoordinateType darray[3] = { 5.25, 12.5, 42.0 };
-    output = OutputType(59.75);
+    output = static_cast<OutputType>(59.75);
     cindex = ContinuousIndexType(darray);
     passed = SincInterpolate::TestContinuousIndex(interp, cindex, true, output);
   }

--- a/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
@@ -1048,10 +1048,10 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::CreateMesh()
     }
     free(m_CurrentRow);
   }
-  m_CurrentRow = (IdentifierType **)malloc(200 * sizeof(IdentifierType *));
+  m_CurrentRow = static_cast<IdentifierType **>(malloc(200 * sizeof(IdentifierType *)));
   for (int i = 0; i < 200; ++i)
   {
-    m_CurrentRow[i] = (IdentifierType *)malloc(2 * sizeof(IdentifierType));
+    m_CurrentRow[i] = static_cast<IdentifierType *>(malloc(2 * sizeof(IdentifierType)));
   }
 
   if (m_CurrentFrame)
@@ -1063,11 +1063,11 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::CreateMesh()
     free(m_CurrentFrame);
   }
 
-  m_CurrentFrame = (IdentifierType **)malloc(2000 * sizeof(IdentifierType *));
+  m_CurrentFrame = static_cast<IdentifierType **>(malloc(2000 * sizeof(IdentifierType *)));
 
   for (int i = 0; i < 2000; ++i)
   {
-    m_CurrentFrame[i] = (IdentifierType *)malloc(2 * sizeof(IdentifierType));
+    m_CurrentFrame[i] = static_cast<IdentifierType *>(malloc(2 * sizeof(IdentifierType)));
   }
 
   {
@@ -1166,17 +1166,17 @@ template <typename TInputImage, typename TOutputMesh>
 void
 BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltype, unsigned char celltran, int index)
 {
-  IdentifierType ** currentrowtmp = (IdentifierType **)malloc(4 * sizeof(IdentifierType *));
+  IdentifierType ** currentrowtmp = static_cast<IdentifierType **>(malloc(4 * sizeof(IdentifierType *)));
   for (int i = 0; i < 4; ++i)
   {
-    currentrowtmp[i] = (IdentifierType *)malloc(2 * sizeof(IdentifierType));
+    currentrowtmp[i] = static_cast<IdentifierType *>(malloc(2 * sizeof(IdentifierType)));
     currentrowtmp[i][0] = 0;
     currentrowtmp[i][1] = 0;
   }
-  IdentifierType ** currentframetmp = (IdentifierType **)malloc(4 * sizeof(IdentifierType *));
+  IdentifierType ** currentframetmp = static_cast<IdentifierType **>(malloc(4 * sizeof(IdentifierType *)));
   for (int i = 0; i < 4; ++i)
   {
-    currentframetmp[i] = (IdentifierType *)malloc(2 * sizeof(IdentifierType));
+    currentframetmp[i] = static_cast<IdentifierType *>(malloc(2 * sizeof(IdentifierType)));
     currentframetmp[i][0] = 0;
     currentframetmp[i][1] = 0;
   }
@@ -1236,7 +1236,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       {
         if (i > m_LastRowNum - 1)
         {
-          m_LastRow[i] = (IdentifierType *)malloc(2 * sizeof(IdentifierType));
+          m_LastRow[i] = static_cast<IdentifierType *>(malloc(2 * sizeof(IdentifierType)));
         }
         m_LastRow[i][0] = m_CurrentRow[i][0];
         m_LastRow[i][1] = m_CurrentRow[i][1];
@@ -1285,7 +1285,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
       {
         if (i > m_LastFrameNum - 1)
         {
-          m_LastFrame[i] = (IdentifierType *)malloc(2 * sizeof(IdentifierType));
+          m_LastFrame[i] = static_cast<IdentifierType *>(malloc(2 * sizeof(IdentifierType)));
         }
         m_LastFrame[i][0] = m_CurrentFrame[i][0];
         m_LastFrame[i][1] = m_CurrentFrame[i][1];
@@ -1351,9 +1351,9 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
 
   typename TriCell::CellAutoPointer        insertCell;
   typename OutputMeshType::PointIdentifier tripoints[3];
-  auto *                                   tp = (unsigned char *)malloc(3 * sizeof(unsigned char));
+  auto *                                   tp = static_cast<unsigned char *>(malloc(3 * sizeof(unsigned char)));
 
-  auto * tpl = (IdentifierType *)malloc(3 * sizeof(IdentifierType));
+  auto * tpl = static_cast<IdentifierType *>(malloc(3 * sizeof(IdentifierType)));
 
   switch (static_cast<int>(celltype))
   {
@@ -2288,7 +2288,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
           m_CurrentRow = (IdentifierType **)realloc(m_CurrentRow, sizeof(IdentifierType *) * m_CurrentRowNum);
           for (int j = m_CurrentRowIndex; j < m_CurrentRowNum; ++j)
           {
-            m_CurrentRow[j] = (IdentifierType *)malloc(sizeof(IdentifierType) * 2);
+            m_CurrentRow[j] = static_cast<IdentifierType *>(malloc(sizeof(IdentifierType) * 2));
           }
         }
       }
@@ -2303,7 +2303,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::AddCells(unsigned char celltyp
           m_CurrentFrame = (IdentifierType **)realloc(m_CurrentFrame, sizeof(IdentifierType *) * m_CurrentFrameNum);
           for (int j = m_CurrentFrameIndex; j < m_CurrentFrameNum; ++j)
           {
-            m_CurrentFrame[j] = (IdentifierType *)malloc(sizeof(IdentifierType) * 2);
+            m_CurrentFrame[j] = static_cast<IdentifierType *>(malloc(sizeof(IdentifierType) * 2));
           }
         }
       }

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTopologyChecker.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTopologyChecker.hxx
@@ -78,8 +78,8 @@ QuadEdgeMeshTopologyChecker<TMesh>::ValidateEulerCharacteristic() const
   // hence ( 2 - numBounds - numFaces + numEdges - numPoints ) must
   // be an odd number. Let's check it out:
   // Note that genus can take a negative value...
-  const OffsetValueType twiceGenus = OffsetValueType(2) - OffsetValueType(numBounds) - OffsetValueType(numFaces) +
-                                     OffsetValueType(numEdges) - OffsetValueType(numPoints);
+  const OffsetValueType twiceGenus = static_cast<OffsetValueType>(2) - OffsetValueType(numBounds) -
+                                     OffsetValueType(numFaces) + OffsetValueType(numEdges) - OffsetValueType(numPoints);
 
   if (twiceGenus % 2)
   {

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshPolygonCellTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshPolygonCellTest.cxx
@@ -119,7 +119,7 @@ itkQuadEdgeMeshPolygonCellTest(int, char *[])
    * Assign the points to the tetrahedron through their identifiers.
    */
   testCell->SetPointIds(polygon1Points);
-  if (newcell->GetPointId(18) != PointIdentifier(-1))
+  if (newcell->GetPointId(18) != static_cast<PointIdentifier>(-1))
   {
     std::cerr << "Get Point should have failed !" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.hxx
@@ -127,7 +127,7 @@ GaussianSpatialObject<TDimension>::ValueAtInObjectSpace(const PointType &   poin
     if (IsInsideInObjectSpace(point))
     {
       const double zsq = this->SquaredZScoreInObjectSpace(point);
-      value = m_Maximum * (ScalarType)std::exp(-zsq / 2.0);
+      value = m_Maximum * static_cast<ScalarType>(std::exp(-zsq / 2.0));
       return true;
     }
   }

--- a/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.hxx
@@ -83,7 +83,7 @@ MetaMeshConverter<VDimension, PixelType, TMeshTraits>::MetaObjectToSpatialObject
   for (unsigned int celltype = 0; celltype < MET_NUM_CELL_TYPES; ++celltype)
   {
     using CellListType = typename MetaMesh::CellListType;
-    const CellListType cells = _mesh->GetCells((MET_CellGeometry)celltype);
+    const CellListType cells = _mesh->GetCells(static_cast<MET_CellGeometry>(celltype));
     auto               it_cells = cells.begin();
 
     using CellInterfaceType = typename MeshType::CellType;
@@ -101,7 +101,7 @@ MetaMeshConverter<VDimension, PixelType, TMeshTraits>::MetaObjectToSpatialObject
     {
       CellAutoPointer cell;
 
-      switch ((MET_CellGeometry)celltype)
+      switch (static_cast<MET_CellGeometry>(celltype))
       {
         case MET_VERTEX_CELL:
           cell.TakeOwnership(new VertexCellType);

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.hxx
@@ -200,7 +200,7 @@ SurfaceSpatialObject<TDimension, TSurfacePointType>::ComputeNormals()
         const double cob = -(v1[2] * (v2[0] - v3[0]) + v2[2] * (v3[0] - v1[0]) + v3[2] * (v1[0] - v2[0]));
         const double coc = -(v1[0] * (v2[1] - v3[1]) + v2[0] * (v3[1] - v1[1]) + v3[0] * (v1[1] - v2[1]));
 
-        absvec = -std::sqrt((double)((coa * coa) + (cob * cob) + (coc * coc)));
+        absvec = -std::sqrt(((coa * coa) + (cob * cob) + (coc * coc)));
 
         if (Math::AlmostEquals(absvec, 0.0))
         {
@@ -220,7 +220,7 @@ SurfaceSpatialObject<TDimension, TSurfacePointType>::ComputeNormals()
         const double coa = -(v1[1] * (v2[0] - v3[0]) + v2[1] * (v3[0] - v1[0]) + v3[1] * (v1[0] - v2[0]));
         const double cob = -(v1[0] * (v2[1] - v3[1]) + v2[0] * (v3[1] - v1[1]) + v3[0] * (v1[1] - v2[1]));
 
-        absvec = -std::sqrt((double)((coa * coa) + (cob * cob)));
+        absvec = -std::sqrt(((coa * coa) + (cob * cob)));
 
         if (Math::AlmostEquals(absvec, 0.0))
         {

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.hxx
@@ -55,7 +55,7 @@ CurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,
   IdentifierType stride[ImageDimension];
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
-    stride[i] = it.GetStride((IdentifierType)i);
+    stride[i] = it.GetStride(static_cast<IdentifierType>(i));
   }
 
   // get the center pixel position

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
@@ -128,7 +128,7 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const DispatchBase &, cons
   PixelType gradMagnitude = PixelType{};
   for (unsigned int j = 0; j < ImageDimension; ++j)
   {
-    SizeValueType stride = it.GetStride((SizeValueType)j);
+    SizeValueType stride = it.GetStride(static_cast<SizeValueType>(j));
     gradient[j] = 0.5 * (it.GetPixel(center + stride) - it.GetPixel(center - stride));
     gradient[j] *= this->m_ScaleCoefficients[j];
 

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -632,10 +632,11 @@ template <typename TInputImage, typename TOutputImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::RiemannianMinMaxThreaderCallback(void * arg)
 {
-  const unsigned int workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
-  const unsigned int workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
+  const unsigned int workUnitID = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->WorkUnitID;
+  const unsigned int workUnitCount = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->NumberOfWorkUnits;
 
-  const ThreadFilterStruct * str = (ThreadFilterStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
+  const ThreadFilterStruct * str =
+    (ThreadFilterStruct *)((static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->UserData);
 
   // Execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.
@@ -1340,10 +1341,11 @@ template <typename TInputImage, typename TOutputImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ApplyUpdateThreaderCallback(void * arg)
 {
-  const unsigned int workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
-  const unsigned int workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
+  const unsigned int workUnitID = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->WorkUnitID;
+  const unsigned int workUnitCount = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->NumberOfWorkUnits;
 
-  const ThreadFilterStruct * str = (ThreadFilterStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
+  const ThreadFilterStruct * str =
+    (ThreadFilterStruct *)((static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->UserData);
 
   // Execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.
@@ -1452,10 +1454,11 @@ template <typename TInputImage, typename TOutputImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ComputeSigmaUpdateThreaderCallback(void * arg)
 {
-  const unsigned int workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
-  const unsigned int workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
+  const unsigned int workUnitID = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->WorkUnitID;
+  const unsigned int workUnitCount = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->NumberOfWorkUnits;
 
-  const ThreadFilterStruct * str = (ThreadFilterStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
+  const ThreadFilterStruct * str =
+    (ThreadFilterStruct *)((static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->UserData);
 
   // Execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.
@@ -1882,10 +1885,11 @@ template <typename TInputImage, typename TOutputImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ComputeImageUpdateThreaderCallback(void * arg)
 {
-  const unsigned int workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
-  const unsigned int workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
+  const unsigned int workUnitID = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->WorkUnitID;
+  const unsigned int workUnitCount = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->NumberOfWorkUnits;
 
-  const ThreadFilterStruct * str = (ThreadFilterStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
+  const ThreadFilterStruct * str =
+    (ThreadFilterStruct *)((static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->UserData);
 
   // Execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.

--- a/Modules/Filtering/DisplacementField/test/itkBSplineExponentialDiffeomorphicTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkBSplineExponentialDiffeomorphicTransformTest.cxx
@@ -126,7 +126,7 @@ itkBSplineExponentialDiffeomorphicTransformTest(int, char *[])
   {
     for (int j = -2; j < 3; ++j)
     {
-      const unsigned int index = outlier + static_cast<unsigned int>(i * (int)(dimLength * dimensions) + j);
+      const unsigned int index = outlier + static_cast<unsigned int>(i * static_cast<int>(dimLength * dimensions) + j);
       std::cout << params(index) << ' ';
       if (itk::Math::AlmostEquals(params(index), paramsFillValue))
       {
@@ -199,7 +199,7 @@ itkBSplineExponentialDiffeomorphicTransformTest(int, char *[])
   {
     for (int j = -2; j < 3; ++j)
     {
-      const unsigned int index = outlier + static_cast<unsigned int>(i * (int)(dimLength * dimensions) + j);
+      const unsigned int index = outlier + static_cast<unsigned int>(i * static_cast<int>(dimLength * dimensions) + j);
       std::cout << params(index) << ' ';
       if (itk::Math::AlmostEquals(params(index), paramsFillValue))
       {

--- a/Modules/Filtering/DisplacementField/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest.cxx
@@ -143,7 +143,7 @@ itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest(int, char *[])
   {
     for (int j = -2; j < 3; ++j)
     {
-      const unsigned int index = outlier + static_cast<unsigned int>(i * (int)(dimLength * dimensions) + j);
+      const unsigned int index = outlier + static_cast<unsigned int>(i * static_cast<int>(dimLength * dimensions) + j);
       std::cout << params(index) << ' ';
       if (itk::Math::AlmostEquals(params(index), paramsFillValue))
       {
@@ -216,7 +216,7 @@ itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest(int, char *[])
   {
     for (int j = -2; j < 3; ++j)
     {
-      const unsigned int index = outlier + static_cast<unsigned int>(i * (int)(dimLength * dimensions) + j);
+      const unsigned int index = outlier + static_cast<unsigned int>(i * static_cast<int>(dimLength * dimensions) + j);
       std::cout << params(index) << ' ';
       if (itk::Math::AlmostEquals(params(index), paramsFillValue))
       {

--- a/Modules/Filtering/DisplacementField/test/itkGaussianExponentialDiffeomorphicTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkGaussianExponentialDiffeomorphicTransformTest.cxx
@@ -117,7 +117,7 @@ itkGaussianExponentialDiffeomorphicTransformTest(int, char *[])
   {
     for (int j = -2; j < 3; ++j)
     {
-      const unsigned int index = outlier + static_cast<unsigned int>(i * (int)(dimLength * dimensions) + j);
+      const unsigned int index = outlier + static_cast<unsigned int>(i * static_cast<int>(dimLength * dimensions) + j);
       std::cout << params(index) << ' ';
     }
     std::cout << std::endl;
@@ -181,7 +181,7 @@ itkGaussianExponentialDiffeomorphicTransformTest(int, char *[])
   {
     for (int j = -2; j < 3; ++j)
     {
-      const unsigned int index = outlier + static_cast<unsigned int>(i * (int)(dimLength * dimensions) + j);
+      const unsigned int index = outlier + static_cast<unsigned int>(i * static_cast<int>(dimLength * dimensions) + j);
       std::cout << params(index) << ' ';
       if (itk::Math::AlmostEquals(params(index), paramsFillValue))
       {

--- a/Modules/Filtering/DisplacementField/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest.cxx
@@ -109,7 +109,7 @@ itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest(int, char *[])
   {
     for (int j = -2; j < 3; ++j)
     {
-      const unsigned int index = outlier + static_cast<unsigned int>(i * (int)(dimLength * dimensions) + j);
+      const unsigned int index = outlier + static_cast<unsigned int>(i * static_cast<int>(dimLength * dimensions) + j);
       std::cout << params(index) << ' ';
     }
     std::cout << std::endl;
@@ -170,7 +170,7 @@ itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest(int, char *[])
   {
     for (int j = -2; j < 3; ++j)
     {
-      const unsigned int index = outlier + static_cast<unsigned int>(i * (int)(dimLength * dimensions) + j);
+      const unsigned int index = outlier + static_cast<unsigned int>(i * static_cast<int>(dimLength * dimensions) + j);
       std::cout << params(index) << ' ';
       if (itk::Math::AlmostEquals(params(index), paramsFillValue))
       {

--- a/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.hxx
@@ -184,13 +184,13 @@ FFTWComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::ThreadedGenerat
     else // m_TransformDirection == INVERSE
     {
       // copy the output from the buffer into our line
-      outputBufferIt = reinterpret_cast<typename OutputIteratorType::PixelType *>(m_OutputBufferArray[threadID]);
+      inputBufferIt = reinterpret_cast<typename OutputIteratorType::PixelType *>(m_OutputBufferArray[threadID]);
       outputIt.GoToBeginOfLine();
       while (!outputIt.IsAtEndOfLine())
       {
-        outputIt.Set(*outputBufferIt / static_cast<typename OutputIteratorType::PixelType>(lineSize));
+        outputIt.Set(*inputBufferIt / static_cast<typename OutputIteratorType::PixelType>(lineSize));
         ++outputIt;
-        ++outputBufferIt;
+        ++inputBufferIt;
       }
     }
   }

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
@@ -326,8 +326,8 @@ HoughTransform2DLinesImageFilter<TInputPixelType, TOutputPixelType>::GetLines() 
           {
             for (double length = 0; length < m_DiscRadius; length += 1)
             {
-              index[0] = (IndexValueType)(it_input.GetIndex()[0] + length * std::cos(angle));
-              index[1] = (IndexValueType)(it_input.GetIndex()[1] + length * std::sin(angle));
+              index[0] = static_cast<IndexValueType>(it_input.GetIndex()[0] + length * std::cos(angle));
+              index[1] = static_cast<IndexValueType>(it_input.GetIndex()[1] + length * std::sin(angle));
               if (postProcessImage->GetBufferedRegion().IsInside(index))
               {
                 postProcessImage->SetPixel(index, 0);

--- a/Modules/Filtering/ImageFeature/test/itkUnsharpMaskImageFilterTestSimple.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkUnsharpMaskImageFilterTestSimple.cxx
@@ -68,7 +68,7 @@ itkUnsharpMaskImageFilterTestSimple(int, char *[])
   // Initialize the contents of the input image
   while (!it.IsAtEnd())
   {
-    if (it.GetIndex()[0] > itk::IndexValueType(size[0] / 2))
+    if (it.GetIndex()[0] > static_cast<itk::IndexValueType>(size[0] / 2))
     {
       it.Set(1.0);
     }

--- a/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
@@ -147,7 +147,7 @@ BinShrinkImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   }
 
   const size_t numSamples = std::accumulate(
-    this->GetShrinkFactors().cbegin(), this->GetShrinkFactors().cend(), size_t(1), std::multiplies<size_t>());
+    this->GetShrinkFactors().cbegin(), this->GetShrinkFactors().cend(), size_t{ 1 }, std::multiplies<size_t>());
   const double inumSamples = 1.0 / static_cast<double>(numSamples);
 
   TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());

--- a/Modules/Filtering/ImageGrid/test/itkConstantPadImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkConstantPadImageTest.cxx
@@ -89,7 +89,8 @@ itkConstantPadImageTest(int, char *[])
   bool passed = true;
   size = requestedRegion.GetSize();
   index = requestedRegion.GetIndex();
-  if ((index[0] != (0 - (IndexValueType)lowerFactors[0])) || (index[1] != (0 - (IndexValueType)lowerFactors[1])) ||
+  if ((index[0] != (0 - static_cast<IndexValueType>(lowerFactors[0]))) ||
+      (index[1] != (0 - static_cast<IndexValueType>(lowerFactors[1]))) ||
       (size[0] != (8 + lowerFactors[0] + upperFactors[0])) || (size[1] != (12 + lowerFactors[1] + upperFactors[1])))
   {
     passed = false;
@@ -161,7 +162,8 @@ itkConstantPadImageTest(int, char *[])
     passed = true;
     size = requestedRegion.GetSize();
     index = requestedRegion.GetIndex();
-    if ((index[0] != (0 - (IndexValueType)lowerFactors[0])) || (index[1] != (0 - (IndexValueType)lowerFactors[1])) ||
+    if ((index[0] != (0 - static_cast<IndexValueType>(lowerFactors[0]))) ||
+        (index[1] != (0 - static_cast<IndexValueType>(lowerFactors[1]))) ||
         (size[0] != (8 + lowerFactors[0] + upperFactors[0])) || (size[1] != (12 + lowerFactors[1] + upperFactors[1])))
     {
       passed = false;

--- a/Modules/Filtering/ImageGrid/test/itkFlipImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkFlipImageFilterTest.cxx
@@ -137,9 +137,10 @@ itkFlipImageFilterTest(int argc, char * argv[])
       passed = false;
       std::cout << "Mismatch at index: in: " << inputIndex;
       std::cout << "; out: " << outputIndex << std::endl;
-      std::cout << "Expected pixel value: " << itk::NumericTraits<IteratorType::PixelType>::PrintType(inputIter.Get())
-                << ", but got: "
-                << itk::NumericTraits<IteratorType::PixelType>::PrintType(outputImage->GetPixel(outputIndex))
+      std::cout << "Expected pixel value: "
+                << static_cast<itk::NumericTraits<IteratorType::PixelType>::PrintType>(inputIter.Get()) << ", but got: "
+                << static_cast<itk::NumericTraits<IteratorType::PixelType>::PrintType>(
+                     outputImage->GetPixel(outputIndex))
                 << std::endl;
     }
 

--- a/Modules/Filtering/ImageGrid/test/itkMirrorPadImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkMirrorPadImageTest.cxx
@@ -148,7 +148,8 @@ itkMirrorPadImageTest(int, char *[])
   bool passed = true;
   size = requestedRegion.GetSize();
   index = requestedRegion.GetIndex();
-  if ((index[0] != (0 - (IndexValueType)lowerfactors[0])) || (index[1] != (0 - (IndexValueType)lowerfactors[1])) ||
+  if ((index[0] != (0 - static_cast<IndexValueType>(lowerfactors[0]))) ||
+      (index[1] != (0 - static_cast<IndexValueType>(lowerfactors[1]))) ||
       (size[0] != (8 + lowerfactors[0] + upperfactors[0])) || (size[1] != (12 + lowerfactors[1] + upperfactors[1])))
   {
     passed = false;
@@ -200,7 +201,8 @@ itkMirrorPadImageTest(int, char *[])
     passed = true;
     size = requestedRegion.GetSize();
     index = requestedRegion.GetIndex();
-    if ((index[0] != (0 - (IndexValueType)lowerfactors[0])) || (index[1] != (0 - (IndexValueType)lowerfactors[1])) ||
+    if ((index[0] != (0 - static_cast<IndexValueType>(lowerfactors[0]))) ||
+        (index[1] != (0 - static_cast<IndexValueType>(lowerfactors[1]))) ||
         (size[0] != (8 + lowerfactors[0] + upperfactors[0])) || (size[1] != (12 + lowerfactors[1] + upperfactors[1])))
     {
       passed = false;
@@ -259,7 +261,8 @@ itkMirrorPadImageTest(int, char *[])
     passed = true;
     size = requestedRegion.GetSize();
     index = requestedRegion.GetIndex();
-    if ((index[0] != (0 - (IndexValueType)lowerfactors[0])) || (index[1] != (0 - (IndexValueType)lowerfactors[1])) ||
+    if ((index[0] != (0 - static_cast<IndexValueType>(lowerfactors[0]))) ||
+        (index[1] != (0 - static_cast<IndexValueType>(lowerfactors[1]))) ||
         (size[0] != (8 + lowerfactors[0] + upperfactors[0])) || (size[1] != (12 + lowerfactors[1] + upperfactors[1])))
     {
       passed = false;

--- a/Modules/Filtering/ImageGrid/test/itkSliceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkSliceImageFilterTest.cxx
@@ -150,8 +150,8 @@ TEST(SliceImageFilterTests, PhysicalPoint2)
 
   for (start[0] = 0; start[0] < 10; ++start[0])
     for (start[1] = 0; start[1] < 10; ++start[1])
-      for (stop[0] = size[0]; stop[0] > (ImageType::IndexValueType)(size[0] - 10); --stop[0])
-        for (stop[1] = size[1]; stop[1] > (ImageType::IndexValueType)(size[1] - 10); --stop[1])
+      for (stop[0] = size[0]; stop[0] > static_cast<ImageType::IndexValueType>(size[0] - 10); --stop[0])
+        for (stop[1] = size[1]; stop[1] > static_cast<ImageType::IndexValueType>(size[1] - 10); --stop[1])
         {
 
           ImageType::Pointer img;

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -296,8 +296,8 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
   ProjectionImageSizeType projectionSize;
   const IndexValueType    pad = 5;
 
-  projectionSize[0] = (IndexValueType)(bounds[1] - bounds[0]) + pad;
-  projectionSize[1] = (IndexValueType)(bounds[3] - bounds[2]) + pad;
+  projectionSize[0] = static_cast<IndexValueType>(bounds[1] - bounds[0]) + pad;
+  projectionSize[1] = static_cast<IndexValueType>(bounds[3] - bounds[2]) + pad;
 
   const ProjectionImageRegionType projectionRegion(projectionStart, projectionSize);
 

--- a/Modules/Filtering/ImageIntensity/test/itkAbsImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAbsImageFilterAndAdaptorTest.cxx
@@ -168,7 +168,7 @@ itkAbsImageFilterAndAdaptorTest(int, char *[])
     std::cout.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
     std::cout << dt.Get() << std::endl;
     const OutputImageType::PixelType diff = dt.Get();
-    if (!itk::Math::FloatAlmostEqual(diff, (OutputImageType::PixelType)0, 10, epsilon))
+    if (!itk::Math::FloatAlmostEqual(diff, OutputImageType::PixelType{ 0 }, 10, epsilon))
     {
       std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
       std::cerr << "Error in itkAbsImageFilterTest " << std::endl;

--- a/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
@@ -52,7 +52,7 @@ AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateDat
     indSeed += outputRegionForThread.GetIndex(d);
   }
   auto           randn = Statistics::NormalVariateGenerator::New();
-  const uint32_t seed = Self::Hash(this->GetSeed(), uint32_t(indSeed));
+  const uint32_t seed = Self::Hash(this->GetSeed(), static_cast<uint32_t>(indSeed));
   // Convert the seed bit for bit to int32_t
   randn->Initialize(bit_cast<int32_t>(seed));
 

--- a/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.hxx
@@ -50,7 +50,7 @@ SaltAndPepperNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
     indSeed += outputRegionForThread.GetIndex(d);
   }
   auto           rand = Statistics::MersenneTwisterRandomVariateGenerator::New();
-  const uint32_t seed = Self::Hash(this->GetSeed(), uint32_t(indSeed));
+  const uint32_t seed = Self::Hash(this->GetSeed(), static_cast<uint32_t>(indSeed));
   rand->SetSeed(seed);
 
   // Define the portion of the input to walk for this thread, using

--- a/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
@@ -51,7 +51,7 @@ ShotNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
     indSeed += outputRegionForThread.GetIndex(d);
   }
   auto           rand = Statistics::MersenneTwisterRandomVariateGenerator::New();
-  const uint32_t seed = Self::Hash(this->GetSeed(), uint32_t(indSeed));
+  const uint32_t seed = Self::Hash(this->GetSeed(), static_cast<uint32_t>(indSeed));
   rand->SetSeed(seed);
   auto randn = Statistics::NormalVariateGenerator::New();
   randn->Initialize(bit_cast<int32_t>(seed));

--- a/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
@@ -50,7 +50,7 @@ SpeckleNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
     indSeed += outputRegionForThread.GetIndex(d);
   }
   auto           rand = Statistics::MersenneTwisterRandomVariateGenerator::New();
-  const uint32_t seed = Self::Hash(this->GetSeed(), uint32_t(indSeed));
+  const uint32_t seed = Self::Hash(this->GetSeed(), static_cast<uint32_t>(indSeed));
   rand->SetSeed(seed);
 
   // Define the portion of the input to walk for this thread, using

--- a/Modules/Filtering/ImageStatistics/test/itkImageMomentsTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImageMomentsTest.cxx
@@ -84,7 +84,7 @@ itkImageMomentsTest(int argc, char * argv[])
   tpm[2] = 2.0; // Principal moments
 
   MatrixType tpa;
-  tpa.GetVnlMatrix().set((double *)pad);
+  tpa.GetVnlMatrix().set(reinterpret_cast<double *>(pad));
 
   /* Allocate a simple test image */
   auto image = ImageType::New();

--- a/Modules/Filtering/LabelMap/test/itkShapeLabelObjectAccessorsTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeLabelObjectAccessorsTest1.cxx
@@ -97,7 +97,8 @@ itkShapeLabelObjectAccessorsTest1(int argc, char * argv[])
   for (unsigned int n = 0; n < labelMap->GetNumberOfLabelObjects(); ++n)
   {
     ShapeLabelObjectType * labelObject = labelMap->GetNthLabelObject(n);
-    std::cout << "Label: " << itk::NumericTraits<LabelMapType::LabelType>::PrintType(labelObject->GetLabel())
+    std::cout << "Label: "
+              << static_cast<itk::NumericTraits<LabelMapType::LabelType>::PrintType>(labelObject->GetLabel())
               << std::endl;
     std::cout << "    BoundingBox: " << labelObject->GetBoundingBox() << std::endl;
     std::cout << "    NumberOfPixels: " << labelObject->GetNumberOfPixels() << std::endl;

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
@@ -1078,12 +1078,14 @@ FlatStructuringElement<VDimension>::Annulus(RadiusType   radius,
     if (result.GetRadiusIsParametric())
     {
       axesOuter[i] = 2 * result.GetRadius(i);
-      axesInner[i] = std::max(2 * (OffsetValueType)radius[i] - 2 * (OffsetValueType)thickness, (OffsetValueType)1);
+      axesInner[i] = std::max(2 * (OffsetValueType)radius[i] - 2 * static_cast<OffsetValueType>(thickness),
+                              static_cast<OffsetValueType>(1));
     }
     else
     {
       axesOuter[i] = result.GetSize(i);
-      axesInner[i] = std::max(2 * (OffsetValueType)radius[i] + 1 - 2 * (OffsetValueType)thickness, (OffsetValueType)1);
+      axesInner[i] = std::max(2 * (OffsetValueType)radius[i] + 1 - 2 * static_cast<OffsetValueType>(thickness),
+                              static_cast<OffsetValueType>(1));
     }
   }
   ellipsoidOuter->SetAxes(axesOuter);

--- a/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanUtilities.hxx
@@ -82,7 +82,7 @@ FillReverseExt(std::vector<PixelType> & pixbuffer,
                const unsigned int       KernLen,
                unsigned int             len)
 {
-  auto                 size = (IndexValueType)(len);
+  auto                 size = static_cast<IndexValueType>(len);
   const IndexValueType blocks = size / static_cast<int>(KernLen);
   IndexValueType       i = size - 1;
   TFunction            m_TF;

--- a/Modules/Filtering/Path/test/itkChainCodePathTest.cxx
+++ b/Modules/Filtering/Path/test/itkChainCodePathTest.cxx
@@ -90,7 +90,8 @@ itkChainCodePathTest(int, char *[])
   index = path->GetStart();
   std::cout << "Starting at index: " << index << std::endl;
   const PathType::InputType endOfInput = path->EndOfInput();
-  std::cout << "End of input: " << itk::NumericTraits<PathType::InputType>::PrintType(endOfInput) << std::endl;
+  std::cout << "End of input: " << static_cast<itk::NumericTraits<PathType::InputType>::PrintType>(endOfInput)
+            << std::endl;
 
   for (unsigned int input = 0;;)
   {

--- a/Modules/Filtering/Thresholding/test/itkHuangMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkHuangMaskedThresholdImageFilterTest.cxx
@@ -98,9 +98,10 @@ itkHuangMaskedThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkHuangThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkHuangThresholdImageFilterTest.cxx
@@ -102,9 +102,10 @@ itkHuangThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkIntermodesMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkIntermodesMaskedThresholdImageFilterTest.cxx
@@ -106,9 +106,10 @@ itkIntermodesMaskedThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkIntermodesThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkIntermodesThresholdImageFilterTest.cxx
@@ -116,9 +116,10 @@ itkIntermodesThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkIsoDataMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkIsoDataMaskedThresholdImageFilterTest.cxx
@@ -98,9 +98,10 @@ itkIsoDataMaskedThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkIsoDataThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkIsoDataThresholdImageFilterTest.cxx
@@ -101,9 +101,10 @@ itkIsoDataThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkKappaSigmaThresholdImageCalculatorTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkKappaSigmaThresholdImageCalculatorTest.cxx
@@ -80,8 +80,10 @@ itkKappaSigmaThresholdImageCalculatorTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetOutput()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<CalculatorType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<CalculatorType::InputPixelType>::PrintType(resultThreshold)
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<CalculatorType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<CalculatorType::InputPixelType>::PrintType>(resultThreshold)
               << std::endl;
     return EXIT_FAILURE;
   }

--- a/Modules/Filtering/Thresholding/test/itkKappaSigmaThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkKappaSigmaThresholdImageFilterTest.cxx
@@ -97,9 +97,10 @@ itkKappaSigmaThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkKittlerIllingworthMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkKittlerIllingworthMaskedThresholdImageFilterTest.cxx
@@ -98,9 +98,10 @@ itkKittlerIllingworthMaskedThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkKittlerIllingworthThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkKittlerIllingworthThresholdImageFilterTest.cxx
@@ -101,9 +101,10 @@ itkKittlerIllingworthThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkLiMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkLiMaskedThresholdImageFilterTest.cxx
@@ -98,9 +98,10 @@ itkLiMaskedThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkLiThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkLiThresholdImageFilterTest.cxx
@@ -101,9 +101,10 @@ itkLiThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkMaximumEntropyMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkMaximumEntropyMaskedThresholdImageFilterTest.cxx
@@ -100,9 +100,10 @@ itkMaximumEntropyMaskedThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkMaximumEntropyThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkMaximumEntropyThresholdImageFilterTest.cxx
@@ -102,9 +102,10 @@ itkMaximumEntropyThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkMomentsMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkMomentsMaskedThresholdImageFilterTest.cxx
@@ -100,9 +100,10 @@ itkMomentsMaskedThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkMomentsThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkMomentsThresholdImageFilterTest.cxx
@@ -102,9 +102,10 @@ itkMomentsThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkOtsuMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuMaskedThresholdImageFilterTest.cxx
@@ -99,9 +99,10 @@ itkOtsuMaskedThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsImageFilterTest.cxx
@@ -104,7 +104,7 @@ itkOtsuMultipleThresholdsImageFilterTest(int argc, char * argv[])
   std::cout << "filter->GetThresholds(): ";
   for (const double threshold : thresholds)
   {
-    std::cout << itk::NumericTraits<FilterType::InputPixelType>::PrintType(threshold) << ' ';
+    std::cout << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(threshold) << ' ';
   }
   std::cout << std::endl;
 

--- a/Modules/Filtering/Thresholding/test/itkOtsuThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuThresholdImageFilterTest.cxx
@@ -110,9 +110,10 @@ itkOtsuThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkRenyiEntropyMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkRenyiEntropyMaskedThresholdImageFilterTest.cxx
@@ -98,9 +98,10 @@ itkRenyiEntropyMaskedThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkRenyiEntropyThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkRenyiEntropyThresholdImageFilterTest.cxx
@@ -102,9 +102,10 @@ itkRenyiEntropyThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkShanbhagMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkShanbhagMaskedThresholdImageFilterTest.cxx
@@ -99,9 +99,10 @@ itkShanbhagMaskedThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkShanbhagThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkShanbhagThresholdImageFilterTest.cxx
@@ -102,9 +102,10 @@ itkShanbhagThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkTriangleMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkTriangleMaskedThresholdImageFilterTest.cxx
@@ -99,9 +99,10 @@ itkTriangleMaskedThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkTriangleThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkTriangleThresholdImageFilterTest.cxx
@@ -100,9 +100,10 @@ itkTriangleThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkYenMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkYenMaskedThresholdImageFilterTest.cxx
@@ -99,9 +99,10 @@ itkYenMaskedThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/Filtering/Thresholding/test/itkYenThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkYenThresholdImageFilterTest.cxx
@@ -101,9 +101,10 @@ itkYenThresholdImageFilterTest(int argc, char * argv[])
   {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetThreshold()" << std::endl;
-    std::cerr << "Expected: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(expectedThreshold)
-              << ", but got: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(resultThreshold)
-              << std::endl;
+    std::cerr << "Expected: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(expectedThreshold)
+              << ", but got: "
+              << static_cast<itk::NumericTraits<FilterType::InputPixelType>::PrintType>(resultThreshold) << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Modules/IO/BMP/src/itkBMPImageIO.cxx
+++ b/Modules/IO/BMP/src/itkBMPImageIO.cxx
@@ -83,9 +83,9 @@ BMPImageIO::CanReadFile(const char * filename)
   }
   {
     char magic_number1 = 0;
-    inputStream.read((char *)&magic_number1, sizeof(char));
+    inputStream.read(&magic_number1, sizeof(char));
     char magic_number2 = 0;
-    inputStream.read((char *)&magic_number2, sizeof(char));
+    inputStream.read(&magic_number2, sizeof(char));
 
     if ((magic_number1 != 'B') || (magic_number2 != 'M'))
     {
@@ -100,27 +100,27 @@ BMPImageIO::CanReadFile(const char * filename)
   if (sizeLong == 4)
   {
     long tmp = 0;
-    inputStream.read((char *)&tmp, 4);
+    inputStream.read(reinterpret_cast<char *>(&tmp), 4);
     // skip 4 bytes
-    inputStream.read((char *)&tmp, 4);
+    inputStream.read(reinterpret_cast<char *>(&tmp), 4);
     // read the offset
-    inputStream.read((char *)&tmp, 4);
+    inputStream.read(reinterpret_cast<char *>(&tmp), 4);
   }
   else
   {
     int itmp = 0; // in case we are on a 64bit machine
-    inputStream.read((char *)&itmp, 4);
+    inputStream.read(reinterpret_cast<char *>(&itmp), 4);
     // skip 4 bytes
-    inputStream.read((char *)&itmp, 4);
+    inputStream.read(reinterpret_cast<char *>(&itmp), 4);
     // read the offset
-    inputStream.read((char *)&itmp, 4);
+    inputStream.read(reinterpret_cast<char *>(&itmp), 4);
   }
 
   // get size of header
   if (sizeLong == 4) // if we are on a 32 bit machine
   {
     long infoSize = 0;
-    inputStream.read((char *)&infoSize, sizeof(long));
+    inputStream.read(reinterpret_cast<char *>(&infoSize), sizeof(long));
     ByteSwapper<long>::SwapFromSystemToLittleEndian(&infoSize);
     // error checking
     if ((infoSize != 40) && (infoSize != 12))
@@ -132,7 +132,7 @@ BMPImageIO::CanReadFile(const char * filename)
   else // else we are on a 64bit machine
   {
     int iinfoSize = 0; // in case we are on a 64bit machine
-    inputStream.read((char *)&iinfoSize, 4);
+    inputStream.read(reinterpret_cast<char *>(&iinfoSize), 4);
     ByteSwapper<int>::SwapFromSystemToLittleEndian(&iinfoSize);
     const long infoSize = iinfoSize;
 
@@ -348,9 +348,9 @@ BMPImageIO::ReadImageInformation()
 
   {
     char magic_number1 = 0;
-    m_Ifstream.read((char *)&magic_number1, sizeof(char));
+    m_Ifstream.read(&magic_number1, sizeof(char));
     char magic_number2 = 0;
-    m_Ifstream.read((char *)&magic_number2, sizeof(char));
+    m_Ifstream.read(&magic_number2, sizeof(char));
 
     if ((magic_number1 != 'B') || (magic_number2 != 'M'))
     {
@@ -364,22 +364,22 @@ BMPImageIO::ReadImageInformation()
   if (sizeLong == 4)
   {
     long tmp = 0;
-    m_Ifstream.read((char *)&tmp, 4);
+    m_Ifstream.read(reinterpret_cast<char *>(&tmp), 4);
     // skip 4 bytes
-    m_Ifstream.read((char *)&tmp, 4);
+    m_Ifstream.read(reinterpret_cast<char *>(&tmp), 4);
     // read the offset
-    m_Ifstream.read((char *)&tmp, 4);
+    m_Ifstream.read(reinterpret_cast<char *>(&tmp), 4);
     m_BitMapOffset = tmp;
     ByteSwapper<long>::SwapFromSystemToLittleEndian(&m_BitMapOffset);
   }
   else
   {
     int itmp = 0; // in case we are on a 64bit machine
-    m_Ifstream.read((char *)&itmp, 4);
+    m_Ifstream.read(reinterpret_cast<char *>(&itmp), 4);
     // skip 4 bytes
-    m_Ifstream.read((char *)&itmp, 4);
+    m_Ifstream.read(reinterpret_cast<char *>(&itmp), 4);
     // read the offset
-    m_Ifstream.read((char *)&itmp, 4);
+    m_Ifstream.read(reinterpret_cast<char *>(&itmp), 4);
     ByteSwapper<int>::SwapFromSystemToLittleEndian(&itmp);
     m_BitMapOffset = static_cast<long>(itmp);
   }
@@ -390,7 +390,7 @@ BMPImageIO::ReadImageInformation()
   // get size of header
   if (sizeLong == 4) // if we are on a 32 bit machine
   {
-    m_Ifstream.read((char *)&infoSize, 4);
+    m_Ifstream.read(reinterpret_cast<char *>(&infoSize), 4);
     ByteSwapper<long>::SwapFromSystemToLittleEndian(&infoSize);
     // error checking
     if ((infoSize != 40) && (infoSize != 12))
@@ -402,18 +402,18 @@ BMPImageIO::ReadImageInformation()
     if (infoSize == 40)
     {
       // now get the dimensions
-      m_Ifstream.read((char *)&xsize, 4);
+      m_Ifstream.read(reinterpret_cast<char *>(&xsize), 4);
       ByteSwapper<int>::SwapFromSystemToLittleEndian(&xsize);
-      m_Ifstream.read((char *)&ysize, 4);
+      m_Ifstream.read(reinterpret_cast<char *>(&ysize), 4);
       ByteSwapper<int>::SwapFromSystemToLittleEndian(&ysize);
     }
     else
     {
       short stmp = 0;
-      m_Ifstream.read((char *)&stmp, sizeof(short));
+      m_Ifstream.read(reinterpret_cast<char *>(&stmp), sizeof(short));
       ByteSwapper<short>::SwapFromSystemToLittleEndian(&stmp);
       xsize = stmp;
-      m_Ifstream.read((char *)&stmp, sizeof(short));
+      m_Ifstream.read(reinterpret_cast<char *>(&stmp), sizeof(short));
       ByteSwapper<short>::SwapFromSystemToLittleEndian(&stmp);
       ysize = stmp;
     }
@@ -422,7 +422,7 @@ BMPImageIO::ReadImageInformation()
   {
     int iinfoSize = 0; // in case we are on a 64bit machine
 
-    m_Ifstream.read((char *)&iinfoSize, sizeof(int));
+    m_Ifstream.read(reinterpret_cast<char *>(&iinfoSize), sizeof(int));
     ByteSwapper<int>::SwapFromSystemToLittleEndian(&iinfoSize);
     infoSize = iinfoSize;
 
@@ -436,18 +436,18 @@ BMPImageIO::ReadImageInformation()
     if (infoSize == 40)
     {
       // now get the dimensions
-      m_Ifstream.read((char *)&xsize, 4);
+      m_Ifstream.read(reinterpret_cast<char *>(&xsize), 4);
       ByteSwapper<int>::SwapFromSystemToLittleEndian(&xsize);
-      m_Ifstream.read((char *)&ysize, 4);
+      m_Ifstream.read(reinterpret_cast<char *>(&ysize), 4);
       ByteSwapper<int>::SwapFromSystemToLittleEndian(&ysize);
     }
     else
     {
       short stmp = 0;
-      m_Ifstream.read((char *)&stmp, 2);
+      m_Ifstream.read(reinterpret_cast<char *>(&stmp), 2);
       ByteSwapper<short>::SwapFromSystemToLittleEndian(&stmp);
       xsize = stmp;
-      m_Ifstream.read((char *)&stmp, 2);
+      m_Ifstream.read(reinterpret_cast<char *>(&stmp), 2);
       ByteSwapper<short>::SwapFromSystemToLittleEndian(&stmp);
       ysize = stmp;
     }
@@ -470,9 +470,9 @@ BMPImageIO::ReadImageInformation()
 
   // ignore planes
   short stmp = 0;
-  m_Ifstream.read((char *)&stmp, 2);
+  m_Ifstream.read(reinterpret_cast<char *>(&stmp), 2);
   // read depth
-  m_Ifstream.read((char *)&m_Depth, 2);
+  m_Ifstream.read(reinterpret_cast<char *>(&m_Depth), 2);
   ByteSwapper<short>::SwapFromSystemToLittleEndian(&m_Depth);
 
   if ((m_Depth != 8) && (m_Depth != 24) && (m_Depth != 32))
@@ -486,45 +486,45 @@ BMPImageIO::ReadImageInformation()
     if (sizeLong == 4)
     {
       // Compression
-      m_Ifstream.read((char *)&m_BMPCompression, 4);
+      m_Ifstream.read(reinterpret_cast<char *>(&m_BMPCompression), 4);
       ByteSwapper<long>::SwapFromSystemToLittleEndian(&m_BMPCompression);
       // Image Data Size
-      m_Ifstream.read((char *)&m_BMPDataSize, 4);
+      m_Ifstream.read(reinterpret_cast<char *>(&m_BMPDataSize), 4);
       ByteSwapper<unsigned long>::SwapFromSystemToLittleEndian(&m_BMPDataSize);
       // Horizontal Resolution
       long tmp = 0;
-      m_Ifstream.read((char *)&tmp, 4);
+      m_Ifstream.read(reinterpret_cast<char *>(&tmp), 4);
       // Vertical Resolution
-      m_Ifstream.read((char *)&tmp, 4);
+      m_Ifstream.read(reinterpret_cast<char *>(&tmp), 4);
       // Number of colors
-      m_Ifstream.read((char *)&tmp, 4);
+      m_Ifstream.read(reinterpret_cast<char *>(&tmp), 4);
       m_NumberOfColors = static_cast<unsigned short>(tmp);
       // Number of important colors
-      m_Ifstream.read((char *)&tmp, 4);
+      m_Ifstream.read(reinterpret_cast<char *>(&tmp), 4);
     }
     else
     {
       int itmp = 0; // in case we are on a 64bit machine
       // Compression
-      m_Ifstream.read((char *)&itmp, 4);
+      m_Ifstream.read(reinterpret_cast<char *>(&itmp), 4);
       ByteSwapper<int>::SwapFromSystemToLittleEndian(&itmp);
       m_BMPCompression = static_cast<long>(itmp);
       // Image Data Size
-      m_Ifstream.read((char *)&itmp, 4);
+      m_Ifstream.read(reinterpret_cast<char *>(&itmp), 4);
       ByteSwapper<int>::SwapFromSystemToLittleEndian(&itmp);
       m_BMPDataSize = static_cast<unsigned long>(itmp);
       // Horizontal Resolution
-      m_Ifstream.read((char *)&itmp, 4);
+      m_Ifstream.read(reinterpret_cast<char *>(&itmp), 4);
       ByteSwapper<int>::SwapFromSystemToLittleEndian(&itmp);
       // Vertical Resolution
-      m_Ifstream.read((char *)&itmp, 4);
+      m_Ifstream.read(reinterpret_cast<char *>(&itmp), 4);
       ByteSwapper<int>::SwapFromSystemToLittleEndian(&itmp);
       // Number of colors
-      m_Ifstream.read((char *)&itmp, 4);
+      m_Ifstream.read(reinterpret_cast<char *>(&itmp), 4);
       ByteSwapper<int>::SwapFromSystemToLittleEndian(&itmp);
       m_NumberOfColors = static_cast<unsigned short>(itmp);
       // Number of important colors
-      m_Ifstream.read((char *)&itmp, 4);
+      m_Ifstream.read(reinterpret_cast<char *>(&itmp), 4);
     }
   }
 
@@ -556,14 +556,14 @@ BMPImageIO::ReadImageInformation()
   for (unsigned long i = 0; i < m_ColorPaletteSize; ++i)
   {
     RGBPixelType p;
-    m_Ifstream.read((char *)&uctmp, 1);
+    m_Ifstream.read(reinterpret_cast<char *>(&uctmp), 1);
     p.SetRed(uctmp);
-    m_Ifstream.read((char *)&uctmp, 1);
+    m_Ifstream.read(reinterpret_cast<char *>(&uctmp), 1);
     p.SetGreen(uctmp);
-    m_Ifstream.read((char *)&uctmp, 1);
+    m_Ifstream.read(reinterpret_cast<char *>(&uctmp), 1);
     p.SetBlue(uctmp);
     long tmp = 0;
-    m_Ifstream.read((char *)&tmp, 1);
+    m_Ifstream.read(reinterpret_cast<char *>(&tmp), 1);
     m_ColorPalette[i] = p;
   }
 
@@ -613,11 +613,11 @@ BMPImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPixels)
     {
       if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
       {
-        ByteSwapper<char>::SwapRangeFromSystemToLittleEndian((char *)buffer, numberOfPixels);
+        ByteSwapper<char>::SwapRangeFromSystemToLittleEndian(static_cast<char *>(buffer), numberOfPixels);
       }
       else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
       {
-        ByteSwapper<char>::SwapRangeFromSystemToBigEndian((char *)buffer, numberOfPixels);
+        ByteSwapper<char>::SwapRangeFromSystemToBigEndian(static_cast<char *>(buffer), numberOfPixels);
       }
       break;
     }
@@ -625,11 +625,13 @@ BMPImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPixels)
     {
       if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
       {
-        ByteSwapper<unsigned char>::SwapRangeFromSystemToLittleEndian((unsigned char *)buffer, numberOfPixels);
+        ByteSwapper<unsigned char>::SwapRangeFromSystemToLittleEndian(static_cast<unsigned char *>(buffer),
+                                                                      numberOfPixels);
       }
       else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
       {
-        ByteSwapper<unsigned char>::SwapRangeFromSystemToBigEndian((unsigned char *)buffer, numberOfPixels);
+        ByteSwapper<unsigned char>::SwapRangeFromSystemToBigEndian(static_cast<unsigned char *>(buffer),
+                                                                   numberOfPixels);
       }
       break;
     }
@@ -637,11 +639,11 @@ BMPImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPixels)
     {
       if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
       {
-        ByteSwapper<short>::SwapRangeFromSystemToLittleEndian((short *)buffer, numberOfPixels);
+        ByteSwapper<short>::SwapRangeFromSystemToLittleEndian(static_cast<short *>(buffer), numberOfPixels);
       }
       else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
       {
-        ByteSwapper<short>::SwapRangeFromSystemToBigEndian((short *)buffer, numberOfPixels);
+        ByteSwapper<short>::SwapRangeFromSystemToBigEndian(static_cast<short *>(buffer), numberOfPixels);
       }
       break;
     }
@@ -649,11 +651,13 @@ BMPImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPixels)
     {
       if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
       {
-        ByteSwapper<unsigned short>::SwapRangeFromSystemToLittleEndian((unsigned short *)buffer, numberOfPixels);
+        ByteSwapper<unsigned short>::SwapRangeFromSystemToLittleEndian(static_cast<unsigned short *>(buffer),
+                                                                       numberOfPixels);
       }
       else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
       {
-        ByteSwapper<unsigned short>::SwapRangeFromSystemToBigEndian((unsigned short *)buffer, numberOfPixels);
+        ByteSwapper<unsigned short>::SwapRangeFromSystemToBigEndian(static_cast<unsigned short *>(buffer),
+                                                                    numberOfPixels);
       }
       break;
     }

--- a/Modules/IO/BMP/test/itkBMPImageIOTestPalette.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTestPalette.cxx
@@ -164,7 +164,8 @@ itkBMPImageIOTestPalette(int argc, char * argv[])
 
   // Exercise other methods
   const itk::ImageIOBase::SizeType pixelStride = io->GetPixelStride();
-  std::cout << "PixelStride: " << itk::NumericTraits<itk::ImageIOBase::SizeType>::PrintType(pixelStride) << std::endl;
+  std::cout << "PixelStride: " << static_cast<itk::NumericTraits<itk::ImageIOBase::SizeType>::PrintType>(pixelStride)
+            << std::endl;
 
   // ToDo
   // When the palette has made into the Metadata Dictionary (as opposed to the ImageIO):

--- a/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
+++ b/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
@@ -163,7 +163,7 @@ BioRadImageIO::CanReadFile(const char * filename)
   file.seekg(BIORAD_FILE_ID_OFFSET, std::ios::beg);
 
   unsigned short file_id = 0;
-  file.read((char *)(&file_id), 2);
+  file.read(reinterpret_cast<char *>(&file_id), 2);
   ByteSwapper<unsigned short>::SwapFromSystemToLittleEndian(&file_id);
 
   itkDebugMacro("Magic number: " << file_id);
@@ -212,7 +212,7 @@ BioRadImageIO::InternalReadImageInformation(std::ifstream & file)
   }
   file.seekg(0, std::ios::beg);
   bioradheader * p = &h;
-  file.read((char *)p, BIORAD_HEADER_LENGTH);
+  file.read(reinterpret_cast<char *>(p), BIORAD_HEADER_LENGTH);
 
   // byteswap header fields
   ByteSwapper<unsigned short>::SwapFromSystemToLittleEndian(&h.nx);
@@ -297,7 +297,7 @@ BioRadImageIO::InternalReadImageInformation(std::ifstream & file)
     }
     while (!file.eof())
     {
-      file.read((char *)&note, sizeof(note));
+      file.read(reinterpret_cast<char *>(&note), sizeof(note));
       ByteSwapper<short>::SwapFromSystemToLittleEndian(&note.level);
       Aligned4ByteUnion localNext;
       memcpy(localNext.localChar4Array, note.next, 4);
@@ -475,7 +475,7 @@ BioRadImageIO::Write(const void * buffer)
   // Here we copy at most 31 bytes and terminate it explicitly
   strncpy(header.filename, filename.c_str(), sizeof(header.filename) - 1);
   header.filename[sizeof(header.filename) - 1] = '\0';
-  file.write((char *)p, BIORAD_HEADER_LENGTH);
+  file.write(reinterpret_cast<char *>(p), BIORAD_HEADER_LENGTH);
 
   // preparation for writing buffer:
   const auto numberOfBytes = static_cast<SizeValueType>(this->GetImageSizeInBytes());

--- a/Modules/IO/GE/src/itkGE4ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE4ImageIO.cxx
@@ -129,7 +129,7 @@ GE4ImageIO::ReadHeader(const char * FileNameToRead)
   f.seekg(SIGNA_SEHDR_START * 2 + SIGNA_SEHDR_FOV * 2, std::ios::beg);
   IOCHECK();
   int intTmp = 0;
-  f.read((char *)&intTmp, sizeof(intTmp));
+  f.read(reinterpret_cast<char *>(&intTmp), sizeof(intTmp));
   IOCHECK();
   const float tmpFloat = MvtSunf(intTmp);
 
@@ -196,31 +196,33 @@ GE4ImageIO::ReadHeader(const char * FileNameToRead)
   // you read in an integer, but you DON'T byte swap it, and then pass
   // it into the MvtSunf function to get the floating point value.
   // to circumvent byte swapping in GetIntAt, use GetStringAt
-  this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_SLICELOC * 2, (char *)&intTmp, sizeof(int));
+  this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_SLICELOC * 2, reinterpret_cast<char *>(&intTmp), sizeof(int));
 
   hdr->sliceLocation = MvtSunf(intTmp);
 
-  this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_SLICE_THICK * 2, (char *)&intTmp, sizeof(intTmp));
+  this->GetStringAt(
+    f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_SLICE_THICK * 2, reinterpret_cast<char *>(&intTmp), sizeof(intTmp));
 
   hdr->sliceThickness = MvtSunf(intTmp);
 
   /* Get the Slice Spacing from the IMAGE Header */
-  this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_SLICE_SPACING * 2, (char *)&intTmp, sizeof(int));
+  this->GetStringAt(
+    f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_SLICE_SPACING * 2, reinterpret_cast<char *>(&intTmp), sizeof(int));
 
   hdr->sliceGap = MvtSunf(intTmp);
 
   /* Get TR from the IMAGE Header */
-  this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_TR * 2, (char *)&intTmp, sizeof(int));
+  this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_TR * 2, reinterpret_cast<char *>(&intTmp), sizeof(int));
 
   hdr->TR = MvtSunf(intTmp);
 
   /* Get TE from the IMAGE Header */
-  this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_TE * 2, (char *)&intTmp, sizeof(int));
+  this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_TE * 2, reinterpret_cast<char *>(&intTmp), sizeof(int));
 
   hdr->TE = MvtSunf(intTmp);
 
   /* Get TI from the IMAGE Header */
-  this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_TI * 2, (char *)&intTmp, sizeof(int));
+  this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_TI * 2, reinterpret_cast<char *>(&intTmp), sizeof(int));
 
   hdr->TI = MvtSunf(intTmp);
 
@@ -241,13 +243,14 @@ GE4ImageIO::ReadHeader(const char * FileNameToRead)
   this->GetShortAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_Y_DIM * 2, &(hdr->imageYsize));
 
   /* Get Pixel Size from the IMAGE Header */
-  this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_PIXELSIZE * 2, (char *)&intTmp, sizeof(int));
+  this->GetStringAt(
+    f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_PIXELSIZE * 2, reinterpret_cast<char *>(&intTmp), sizeof(int));
 
   hdr->imageXres = MvtSunf(intTmp);
   hdr->imageYres = hdr->imageXres;
 
   /* Get NEX from the IMAGE Header */
-  this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_NEX * 2, (char *)&intTmp, sizeof(int));
+  this->GetStringAt(f, SIGNA_IHDR_START * 2 + SIGNA_IMHDR_NEX * 2, reinterpret_cast<char *>(&intTmp), sizeof(int));
 
   hdr->NEX = static_cast<short>(MvtSunf(intTmp));
 

--- a/Modules/IO/GE/src/itkGE5ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE5ImageIO.cxx
@@ -181,7 +181,7 @@ GE5ImageIO::ReadHeader(const char * FileNameToRead)
   this->OpenFileForReading(f, FileNameToRead);
 
   Ge5xPixelHeader imageHdr; // GE 5x Header
-  f.read((char *)&imageHdr, sizeof(imageHdr));
+  f.read(reinterpret_cast<char *>(&imageHdr), sizeof(imageHdr));
   if (f.fail())
   {
     itkExceptionMacro("GE5ImageIO IO error while reading  " << FileNameToRead << " ." << std::endl

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -122,7 +122,7 @@ GiplImageIO::CanReadFile(const char * filename)
 
     inputStream.seekg(252);
     unsigned int magic_number = 0;
-    inputStream.read((char *)&magic_number, static_cast<std::streamsize>(sizeof(unsigned int)));
+    inputStream.read(reinterpret_cast<char *>(&magic_number), static_cast<std::streamsize>(sizeof(unsigned int)));
 
     if (m_ByteOrder == IOByteOrderEnum::BigEndian)
     {
@@ -151,7 +151,8 @@ GiplImageIO::CanReadFile(const char * filename)
 
     gzseek(m_Internal->m_GzFile, 252, SEEK_SET);
     unsigned int magic_number = 0;
-    gzread(m_Internal->m_GzFile, (char *)&magic_number, static_cast<unsigned int>(sizeof(unsigned int)));
+    gzread(
+      m_Internal->m_GzFile, reinterpret_cast<char *>(&magic_number), static_cast<unsigned int>(sizeof(unsigned int)));
 
     if (m_ByteOrder == IOByteOrderEnum::BigEndian)
     {
@@ -282,11 +283,12 @@ GiplImageIO::ReadImageInformation()
   {
     if (m_IsCompressed)
     {
-      gzread(m_Internal->m_GzFile, (char *)&dims[i], static_cast<unsigned int>(sizeof(unsigned short)));
+      gzread(
+        m_Internal->m_GzFile, reinterpret_cast<char *>(&dims[i]), static_cast<unsigned int>(sizeof(unsigned short)));
     }
     else
     {
-      m_Ifstream.read((char *)&dims[i], sizeof(unsigned short));
+      m_Ifstream.read(reinterpret_cast<char *>(&dims[i]), sizeof(unsigned short));
     }
     if (m_ByteOrder == IOByteOrderEnum::BigEndian)
     {
@@ -321,11 +323,11 @@ GiplImageIO::ReadImageInformation()
 
   if (m_IsCompressed)
   {
-    gzread(m_Internal->m_GzFile, (char *)&image_type, sizeof(unsigned short));
+    gzread(m_Internal->m_GzFile, reinterpret_cast<char *>(&image_type), sizeof(unsigned short));
   }
   else
   {
-    m_Ifstream.read((char *)&image_type, sizeof(unsigned short));
+    m_Ifstream.read(reinterpret_cast<char *>(&image_type), sizeof(unsigned short));
   }
 
   if (m_ByteOrder == IOByteOrderEnum::BigEndian)
@@ -370,11 +372,11 @@ GiplImageIO::ReadImageInformation()
   {
     if (m_IsCompressed)
     {
-      gzread(m_Internal->m_GzFile, (char *)&pixdim[i], sizeof(float));
+      gzread(m_Internal->m_GzFile, reinterpret_cast<char *>(&pixdim[i]), sizeof(float));
     }
     else
     {
-      m_Ifstream.read((char *)&pixdim[i], sizeof(float));
+      m_Ifstream.read(reinterpret_cast<char *>(&pixdim[i]), sizeof(float));
     }
     if (m_ByteOrder == IOByteOrderEnum::BigEndian)
     {
@@ -396,11 +398,11 @@ GiplImageIO::ReadImageInformation()
   {
     if (m_IsCompressed)
     {
-      gzread(m_Internal->m_GzFile, (char *)&it, static_cast<unsigned int>(sizeof(char)));
+      gzread(m_Internal->m_GzFile, &it, static_cast<unsigned int>(sizeof(char)));
     }
     else
     {
-      m_Ifstream.read((char *)&it, sizeof(char));
+      m_Ifstream.read(&it, sizeof(char));
     }
   }
 
@@ -409,11 +411,11 @@ GiplImageIO::ReadImageInformation()
   {
     if (m_IsCompressed)
     {
-      gzread(m_Internal->m_GzFile, (char *)&it, static_cast<unsigned int>(sizeof(float)));
+      gzread(m_Internal->m_GzFile, reinterpret_cast<char *>(&it), static_cast<unsigned int>(sizeof(float)));
     }
     else
     {
-      m_Ifstream.read((char *)&it, sizeof(float));
+      m_Ifstream.read(reinterpret_cast<char *>(&it), sizeof(float));
     }
 
     if (m_ByteOrder == IOByteOrderEnum::BigEndian)
@@ -429,11 +431,11 @@ GiplImageIO::ReadImageInformation()
   char flag1 = 0; /*  186    1  Orientation flag (below)    */
   if (m_IsCompressed)
   {
-    gzread(m_Internal->m_GzFile, (char *)&flag1, static_cast<unsigned int>(sizeof(char)));
+    gzread(m_Internal->m_GzFile, &flag1, static_cast<unsigned int>(sizeof(char)));
   }
   else
   {
-    m_Ifstream.read((char *)&flag1, sizeof(char));
+    m_Ifstream.read(&flag1, sizeof(char));
   }
 
   if (m_ByteOrder == IOByteOrderEnum::BigEndian)
@@ -448,11 +450,11 @@ GiplImageIO::ReadImageInformation()
   char flag2 = 0; /*  187    1                              */
   if (m_IsCompressed)
   {
-    gzread(m_Internal->m_GzFile, (char *)&flag2, static_cast<unsigned int>(sizeof(char)));
+    gzread(m_Internal->m_GzFile, &flag2, static_cast<unsigned int>(sizeof(char)));
   }
   else
   {
-    m_Ifstream.read((char *)&flag2, sizeof(char));
+    m_Ifstream.read(&flag2, sizeof(char));
   }
 
   if (m_ByteOrder == IOByteOrderEnum::BigEndian)
@@ -467,21 +469,21 @@ GiplImageIO::ReadImageInformation()
   double min = NAN; /*  188    8  Minimum voxel value         */
   if (m_IsCompressed)
   {
-    gzread(m_Internal->m_GzFile, (char *)&min, static_cast<unsigned int>(sizeof(double)));
+    gzread(m_Internal->m_GzFile, reinterpret_cast<char *>(&min), static_cast<unsigned int>(sizeof(double)));
   }
   else
   {
-    m_Ifstream.read((char *)&min, sizeof(double));
+    m_Ifstream.read(reinterpret_cast<char *>(&min), sizeof(double));
   }
 
   double max = NAN; /*  196    8  Maximum voxel value         */
   if (m_IsCompressed)
   {
-    gzread(m_Internal->m_GzFile, (char *)&max, static_cast<unsigned int>(sizeof(double)));
+    gzread(m_Internal->m_GzFile, reinterpret_cast<char *>(&max), static_cast<unsigned int>(sizeof(double)));
   }
   else
   {
-    m_Ifstream.read((char *)&max, sizeof(double));
+    m_Ifstream.read(reinterpret_cast<char *>(&max), sizeof(double));
   }
 
   double origin[4]; /*  204   32  X,Y,Z,T offset              */
@@ -489,11 +491,11 @@ GiplImageIO::ReadImageInformation()
   {
     if (m_IsCompressed)
     {
-      gzread(m_Internal->m_GzFile, (char *)&origin[i], static_cast<unsigned int>(sizeof(double)));
+      gzread(m_Internal->m_GzFile, reinterpret_cast<char *>(&origin[i]), static_cast<unsigned int>(sizeof(double)));
     }
     else
     {
-      m_Ifstream.read((char *)&origin[i], sizeof(double));
+      m_Ifstream.read(reinterpret_cast<char *>(&origin[i]), sizeof(double));
     }
 
     if (m_ByteOrder == IOByteOrderEnum::BigEndian)
@@ -514,11 +516,11 @@ GiplImageIO::ReadImageInformation()
   float pixval_offset = NAN; /*  236    4                              */
   if (m_IsCompressed)
   {
-    gzread(m_Internal->m_GzFile, (char *)&pixval_offset, static_cast<unsigned int>(sizeof(float)));
+    gzread(m_Internal->m_GzFile, reinterpret_cast<char *>(&pixval_offset), static_cast<unsigned int>(sizeof(float)));
   }
   else
   {
-    m_Ifstream.read((char *)&pixval_offset, sizeof(float));
+    m_Ifstream.read(reinterpret_cast<char *>(&pixval_offset), sizeof(float));
   }
 
   if (m_ByteOrder == IOByteOrderEnum::BigEndian)
@@ -533,11 +535,11 @@ GiplImageIO::ReadImageInformation()
   float pixval_cal = NAN; /*  240    4                              */
   if (m_IsCompressed)
   {
-    gzread(m_Internal->m_GzFile, (char *)&pixval_cal, static_cast<unsigned int>(sizeof(float)));
+    gzread(m_Internal->m_GzFile, reinterpret_cast<char *>(&pixval_cal), static_cast<unsigned int>(sizeof(float)));
   }
   else
   {
-    m_Ifstream.read((char *)&pixval_cal, sizeof(float));
+    m_Ifstream.read(reinterpret_cast<char *>(&pixval_cal), sizeof(float));
   }
 
   if (m_ByteOrder == IOByteOrderEnum::BigEndian)
@@ -552,11 +554,11 @@ GiplImageIO::ReadImageInformation()
   float user_def1 = NAN; /*  244    4  Inter-slice Gap             */
   if (m_IsCompressed)
   {
-    gzread(m_Internal->m_GzFile, (char *)&user_def1, static_cast<unsigned int>(sizeof(float)));
+    gzread(m_Internal->m_GzFile, reinterpret_cast<char *>(&user_def1), static_cast<unsigned int>(sizeof(float)));
   }
   else
   {
-    m_Ifstream.read((char *)&user_def1, sizeof(float));
+    m_Ifstream.read(reinterpret_cast<char *>(&user_def1), sizeof(float));
   }
 
   if (m_ByteOrder == IOByteOrderEnum::BigEndian)
@@ -571,11 +573,11 @@ GiplImageIO::ReadImageInformation()
   float user_def2 = NAN; /*  248    4  User defined field          */
   if (m_IsCompressed)
   {
-    gzread(m_Internal->m_GzFile, (char *)&user_def2, static_cast<unsigned int>(sizeof(float)));
+    gzread(m_Internal->m_GzFile, reinterpret_cast<char *>(&user_def2), static_cast<unsigned int>(sizeof(float)));
   }
   else
   {
-    m_Ifstream.read((char *)&user_def2, sizeof(float));
+    m_Ifstream.read(reinterpret_cast<char *>(&user_def2), sizeof(float));
   }
 
   if (m_ByteOrder == IOByteOrderEnum::BigEndian)
@@ -590,11 +592,12 @@ GiplImageIO::ReadImageInformation()
   unsigned int magic_number = 0; /*  252    4 Magic Number                 */
   if (m_IsCompressed)
   {
-    gzread(m_Internal->m_GzFile, (char *)&magic_number, static_cast<unsigned int>(sizeof(unsigned int)));
+    gzread(
+      m_Internal->m_GzFile, reinterpret_cast<char *>(&magic_number), static_cast<unsigned int>(sizeof(unsigned int)));
   }
   else
   {
-    m_Ifstream.read((char *)&magic_number, sizeof(unsigned int));
+    m_Ifstream.read(reinterpret_cast<char *>(&magic_number), sizeof(unsigned int));
   }
 
   if (m_ByteOrder == IOByteOrderEnum::BigEndian)
@@ -616,11 +619,11 @@ GiplImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPixels)
     {
       if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
       {
-        ByteSwapper<char>::SwapRangeFromSystemToLittleEndian((char *)buffer, numberOfPixels);
+        ByteSwapper<char>::SwapRangeFromSystemToLittleEndian(static_cast<char *>(buffer), numberOfPixels);
       }
       else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
       {
-        ByteSwapper<char>::SwapRangeFromSystemToBigEndian((char *)buffer, numberOfPixels);
+        ByteSwapper<char>::SwapRangeFromSystemToBigEndian(static_cast<char *>(buffer), numberOfPixels);
       }
       break;
     }
@@ -628,11 +631,13 @@ GiplImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPixels)
     {
       if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
       {
-        ByteSwapper<unsigned char>::SwapRangeFromSystemToLittleEndian((unsigned char *)buffer, numberOfPixels);
+        ByteSwapper<unsigned char>::SwapRangeFromSystemToLittleEndian(static_cast<unsigned char *>(buffer),
+                                                                      numberOfPixels);
       }
       else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
       {
-        ByteSwapper<unsigned char>::SwapRangeFromSystemToBigEndian((unsigned char *)buffer, numberOfPixels);
+        ByteSwapper<unsigned char>::SwapRangeFromSystemToBigEndian(static_cast<unsigned char *>(buffer),
+                                                                   numberOfPixels);
       }
       break;
     }
@@ -640,11 +645,11 @@ GiplImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPixels)
     {
       if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
       {
-        ByteSwapper<short>::SwapRangeFromSystemToLittleEndian((short *)buffer, numberOfPixels);
+        ByteSwapper<short>::SwapRangeFromSystemToLittleEndian(static_cast<short *>(buffer), numberOfPixels);
       }
       else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
       {
-        ByteSwapper<short>::SwapRangeFromSystemToBigEndian((short *)buffer, numberOfPixels);
+        ByteSwapper<short>::SwapRangeFromSystemToBigEndian(static_cast<short *>(buffer), numberOfPixels);
       }
       break;
     }
@@ -652,11 +657,13 @@ GiplImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPixels)
     {
       if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
       {
-        ByteSwapper<unsigned short>::SwapRangeFromSystemToLittleEndian((unsigned short *)buffer, numberOfPixels);
+        ByteSwapper<unsigned short>::SwapRangeFromSystemToLittleEndian(static_cast<unsigned short *>(buffer),
+                                                                       numberOfPixels);
       }
       else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
       {
-        ByteSwapper<unsigned short>::SwapRangeFromSystemToBigEndian((unsigned short *)buffer, numberOfPixels);
+        ByteSwapper<unsigned short>::SwapRangeFromSystemToBigEndian(static_cast<unsigned short *>(buffer),
+                                                                    numberOfPixels);
       }
       break;
     }
@@ -664,11 +671,11 @@ GiplImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPixels)
     {
       if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
       {
-        ByteSwapper<float>::SwapRangeFromSystemToLittleEndian((float *)buffer, numberOfPixels);
+        ByteSwapper<float>::SwapRangeFromSystemToLittleEndian(static_cast<float *>(buffer), numberOfPixels);
       }
       else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
       {
-        ByteSwapper<float>::SwapRangeFromSystemToBigEndian((float *)buffer, numberOfPixels);
+        ByteSwapper<float>::SwapRangeFromSystemToBigEndian(static_cast<float *>(buffer), numberOfPixels);
       }
       break;
     }
@@ -676,11 +683,11 @@ GiplImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPixels)
     {
       if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
       {
-        ByteSwapper<double>::SwapRangeFromSystemToLittleEndian((double *)buffer, numberOfPixels);
+        ByteSwapper<double>::SwapRangeFromSystemToLittleEndian(static_cast<double *>(buffer), numberOfPixels);
       }
       else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
       {
-        ByteSwapper<double>::SwapRangeFromSystemToBigEndian((double *)buffer, numberOfPixels);
+        ByteSwapper<double>::SwapRangeFromSystemToBigEndian(static_cast<double *>(buffer), numberOfPixels);
       }
       break;
     }
@@ -737,11 +744,12 @@ GiplImageIO::Write(const void * buffer)
 
       if (m_IsCompressed)
       {
-        gzwrite(m_Internal->m_GzFile, (char *)&(value), static_cast<unsigned int>(sizeof(unsigned short)));
+        gzwrite(
+          m_Internal->m_GzFile, reinterpret_cast<char *>(&(value)), static_cast<unsigned int>(sizeof(unsigned short)));
       }
       else
       {
-        m_Ofstream.write((char *)&(value), sizeof(unsigned short));
+        m_Ofstream.write(reinterpret_cast<char *>(&(value)), sizeof(unsigned short));
       }
     }
     else
@@ -757,11 +765,12 @@ GiplImageIO::Write(const void * buffer)
       }
       if (m_IsCompressed)
       {
-        gzwrite(m_Internal->m_GzFile, (char *)&(value), static_cast<unsigned int>(sizeof(unsigned short)));
+        gzwrite(
+          m_Internal->m_GzFile, reinterpret_cast<char *>(&(value)), static_cast<unsigned int>(sizeof(unsigned short)));
       }
       else
       {
-        m_Ofstream.write((char *)&value, sizeof(unsigned short));
+        m_Ofstream.write(reinterpret_cast<char *>(&value), sizeof(unsigned short));
       }
     }
   }
@@ -799,20 +808,21 @@ GiplImageIO::Write(const void * buffer)
 
   if (m_ByteOrder == IOByteOrderEnum::BigEndian)
   {
-    ByteSwapper<unsigned short>::SwapFromSystemToBigEndian((unsigned short *)&image_type);
+    ByteSwapper<unsigned short>::SwapFromSystemToBigEndian(&image_type);
   }
   if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
   {
-    ByteSwapper<unsigned short>::SwapFromSystemToLittleEndian((unsigned short *)&image_type);
+    ByteSwapper<unsigned short>::SwapFromSystemToLittleEndian(&image_type);
   }
 
   if (m_IsCompressed)
   {
-    gzwrite(m_Internal->m_GzFile, (char *)&image_type, static_cast<unsigned int>(sizeof(unsigned short)));
+    gzwrite(
+      m_Internal->m_GzFile, reinterpret_cast<char *>(&image_type), static_cast<unsigned int>(sizeof(unsigned short)));
   }
   else
   {
-    m_Ofstream.write((char *)&image_type, sizeof(unsigned short));
+    m_Ofstream.write(reinterpret_cast<char *>(&image_type), sizeof(unsigned short));
   }
 
   /*   10   16  X,Y,Z,T pixel dimensions mm */
@@ -823,19 +833,19 @@ GiplImageIO::Write(const void * buffer)
       auto value = static_cast<float>(m_Spacing[i]);
       if (m_ByteOrder == IOByteOrderEnum::BigEndian)
       {
-        ByteSwapper<float>::SwapFromSystemToBigEndian((float *)&value);
+        ByteSwapper<float>::SwapFromSystemToBigEndian(static_cast<float *>(&value));
       }
       if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
       {
-        ByteSwapper<float>::SwapFromSystemToLittleEndian((float *)&value);
+        ByteSwapper<float>::SwapFromSystemToLittleEndian(static_cast<float *>(&value));
       }
       if (m_IsCompressed)
       {
-        gzwrite(m_Internal->m_GzFile, (char *)&value, static_cast<unsigned int>(sizeof(float)));
+        gzwrite(m_Internal->m_GzFile, reinterpret_cast<char *>(&value), static_cast<unsigned int>(sizeof(float)));
       }
       else
       {
-        m_Ofstream.write((char *)&value, sizeof(float));
+        m_Ofstream.write(reinterpret_cast<char *>(&value), sizeof(float));
       }
     }
     else
@@ -843,19 +853,19 @@ GiplImageIO::Write(const void * buffer)
       float value = 1.0f;
       if (m_ByteOrder == IOByteOrderEnum::BigEndian)
       {
-        ByteSwapper<float>::SwapFromSystemToBigEndian((float *)&value);
+        ByteSwapper<float>::SwapFromSystemToBigEndian(&value);
       }
       if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
       {
-        ByteSwapper<float>::SwapFromSystemToLittleEndian((float *)&value);
+        ByteSwapper<float>::SwapFromSystemToLittleEndian(&value);
       }
       if (m_IsCompressed)
       {
-        gzwrite(m_Internal->m_GzFile, (char *)&value, static_cast<unsigned int>(sizeof(float)));
+        gzwrite(m_Internal->m_GzFile, reinterpret_cast<char *>(&value), static_cast<unsigned int>(sizeof(float)));
       }
       else
       {
-        m_Ofstream.write((char *)&value, sizeof(float));
+        m_Ofstream.write(reinterpret_cast<char *>(&value), sizeof(float));
       }
     }
   }
@@ -872,11 +882,11 @@ GiplImageIO::Write(const void * buffer)
   {
     if (m_IsCompressed)
     {
-      gzwrite(m_Internal->m_GzFile, (char *)&i, static_cast<unsigned int>(sizeof(char)));
+      gzwrite(m_Internal->m_GzFile, &i, static_cast<unsigned int>(sizeof(char)));
     }
     else
     {
-      m_Ofstream.write((char *)&i, sizeof(char));
+      m_Ofstream.write(&i, sizeof(char));
     }
   }
 
@@ -886,52 +896,52 @@ GiplImageIO::Write(const void * buffer)
     i = 0; // write zeros
     if (m_IsCompressed)
     {
-      gzwrite(m_Internal->m_GzFile, (char *)&i, static_cast<unsigned int>(sizeof(float)));
+      gzwrite(m_Internal->m_GzFile, reinterpret_cast<char *>(&i), static_cast<unsigned int>(sizeof(float)));
     }
     else
     {
-      m_Ofstream.write((char *)&i, sizeof(float));
+      m_Ofstream.write(reinterpret_cast<char *>(&i), sizeof(float));
     }
   }
 
   char flag1 = 0; /*  186    1  Orientation flag (below)    */
   if (m_IsCompressed)
   {
-    gzwrite(m_Internal->m_GzFile, (char *)&flag1, static_cast<unsigned int>(sizeof(char)));
+    gzwrite(m_Internal->m_GzFile, &flag1, static_cast<unsigned int>(sizeof(char)));
   }
   else
   {
-    m_Ofstream.write((char *)&flag1, sizeof(char));
+    m_Ofstream.write(&flag1, sizeof(char));
   }
 
   char flag2 = 0; /*  187    1                              */
   if (m_IsCompressed)
   {
-    gzwrite(m_Internal->m_GzFile, (char *)&flag2, static_cast<unsigned int>(sizeof(char)));
+    gzwrite(m_Internal->m_GzFile, &flag2, static_cast<unsigned int>(sizeof(char)));
   }
   else
   {
-    m_Ofstream.write((char *)&flag2, sizeof(char));
+    m_Ofstream.write(&flag2, sizeof(char));
   }
 
   double min = 0; /*  188    8  Minimum voxel value         */
   if (m_IsCompressed)
   {
-    gzwrite(m_Internal->m_GzFile, (char *)&min, static_cast<unsigned int>(sizeof(double)));
+    gzwrite(m_Internal->m_GzFile, reinterpret_cast<char *>(&min), static_cast<unsigned int>(sizeof(double)));
   }
   else
   {
-    m_Ofstream.write((char *)&min, sizeof(double));
+    m_Ofstream.write(reinterpret_cast<char *>(&min), sizeof(double));
   }
 
   double max = 0; /*  196    8  Maximum voxel value         */
   if (m_IsCompressed)
   {
-    gzwrite(m_Internal->m_GzFile, (char *)&max, static_cast<unsigned int>(sizeof(double)));
+    gzwrite(m_Internal->m_GzFile, reinterpret_cast<char *>(&max), static_cast<unsigned int>(sizeof(double)));
   }
   else
   {
-    m_Ofstream.write((char *)&max, sizeof(double));
+    m_Ofstream.write(reinterpret_cast<char *>(&max), sizeof(double));
   }
 
   double origin[4]; /*  204   32  X,Y,Z,T offset              */
@@ -948,61 +958,61 @@ GiplImageIO::Write(const void * buffer)
 
     if (m_ByteOrder == IOByteOrderEnum::BigEndian)
     {
-      ByteSwapper<double>::SwapFromSystemToBigEndian((double *)&origin[i]);
+      ByteSwapper<double>::SwapFromSystemToBigEndian(&origin[i]);
     }
     if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
     {
-      ByteSwapper<double>::SwapFromSystemToLittleEndian((double *)&origin[i]);
+      ByteSwapper<double>::SwapFromSystemToLittleEndian(&origin[i]);
     }
 
     if (m_IsCompressed)
     {
-      gzwrite(m_Internal->m_GzFile, (char *)&origin[i], static_cast<unsigned int>(sizeof(double)));
+      gzwrite(m_Internal->m_GzFile, reinterpret_cast<char *>(&origin[i]), static_cast<unsigned int>(sizeof(double)));
     }
     else
     {
-      m_Ofstream.write((char *)&origin[i], sizeof(double));
+      m_Ofstream.write(reinterpret_cast<char *>(&origin[i]), sizeof(double));
     }
   }
 
   float pixval_offset = 0; /*  236    4                            */
   if (m_IsCompressed)
   {
-    gzwrite(m_Internal->m_GzFile, (char *)&pixval_offset, static_cast<unsigned int>(sizeof(float)));
+    gzwrite(m_Internal->m_GzFile, reinterpret_cast<char *>(&pixval_offset), static_cast<unsigned int>(sizeof(float)));
   }
   else
   {
-    m_Ofstream.write((char *)&pixval_offset, sizeof(float));
+    m_Ofstream.write(reinterpret_cast<char *>(&pixval_offset), sizeof(float));
   }
 
   float pixval_cal = 0; /*  240    4                              */
   if (m_IsCompressed)
   {
-    gzwrite(m_Internal->m_GzFile, (char *)&pixval_cal, static_cast<unsigned int>(sizeof(float)));
+    gzwrite(m_Internal->m_GzFile, reinterpret_cast<char *>(&pixval_cal), static_cast<unsigned int>(sizeof(float)));
   }
   else
   {
-    m_Ofstream.write((char *)&pixval_cal, sizeof(float));
+    m_Ofstream.write(reinterpret_cast<char *>(&pixval_cal), sizeof(float));
   }
 
   float user_def1 = 0; /*  244    4  Inter-slice Gap             */
   if (m_IsCompressed)
   {
-    gzwrite(m_Internal->m_GzFile, (char *)&user_def1, static_cast<unsigned int>(sizeof(float)));
+    gzwrite(m_Internal->m_GzFile, reinterpret_cast<char *>(&user_def1), static_cast<unsigned int>(sizeof(float)));
   }
   else
   {
-    m_Ofstream.write((char *)&user_def1, sizeof(float));
+    m_Ofstream.write(reinterpret_cast<char *>(&user_def1), sizeof(float));
   }
 
   float user_def2 = 0; /*  248    4  User defined field          */
   if (m_IsCompressed)
   {
-    gzwrite(m_Internal->m_GzFile, (char *)&user_def2, static_cast<unsigned int>(sizeof(float)));
+    gzwrite(m_Internal->m_GzFile, reinterpret_cast<char *>(&user_def2), static_cast<unsigned int>(sizeof(float)));
   }
   else
   {
-    m_Ofstream.write((char *)&user_def2, sizeof(float));
+    m_Ofstream.write(reinterpret_cast<char *>(&user_def2), sizeof(float));
   }
 
   unsigned int magic_number = GIPL_MAGIC_NUMBER; /*  252    4 Magic Number
@@ -1018,11 +1028,12 @@ GiplImageIO::Write(const void * buffer)
 
   if (m_IsCompressed)
   {
-    gzwrite(m_Internal->m_GzFile, (char *)&magic_number, static_cast<unsigned int>(sizeof(unsigned int)));
+    gzwrite(
+      m_Internal->m_GzFile, reinterpret_cast<char *>(&magic_number), static_cast<unsigned int>(sizeof(unsigned int)));
   }
   else
   {
-    m_Ofstream.write((char *)&magic_number, sizeof(unsigned int));
+    m_Ofstream.write(reinterpret_cast<char *>(&magic_number), sizeof(unsigned int));
   }
 
   // Actually do the writing

--- a/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
+++ b/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
@@ -73,7 +73,7 @@ IPLCommonImageIO::GetComponentSize() const
 void
 IPLCommonImageIO::Read(void * buffer)
 {
-  auto * img_buffer = (short *)buffer;
+  auto * img_buffer = static_cast<short *>(buffer);
   auto   it = m_FilenameList->begin();
   auto   itend = m_FilenameList->end();
 
@@ -339,9 +339,9 @@ IPLCommonImageIO::GetIntAt(std::ifstream & f, std::streamoff Offset, int * ip, b
 {
   int tmp = 0;
 
-  if (this->GetStringAt(f, Offset, (char *)&tmp, sizeof(int), throw_exception) == 0)
+  if (this->GetStringAt(f, Offset, reinterpret_cast<char *>(&tmp), sizeof(int), throw_exception) == 0)
   {
-    *ip = this->hdr2Int((char *)&tmp);
+    *ip = this->hdr2Int(reinterpret_cast<char *>(&tmp));
   }
   else
   {
@@ -355,9 +355,9 @@ IPLCommonImageIO::GetShortAt(std::ifstream & f, std::streamoff Offset, short * i
 {
   short tmp = 0;
 
-  if (this->GetStringAt(f, Offset, (char *)&tmp, sizeof(short), throw_exception) == 0)
+  if (this->GetStringAt(f, Offset, reinterpret_cast<char *>(&tmp), sizeof(short), throw_exception) == 0)
   {
-    *ip = this->hdr2Short((char *)&tmp);
+    *ip = this->hdr2Short(reinterpret_cast<char *>(&tmp));
   }
   else
   {
@@ -371,9 +371,9 @@ IPLCommonImageIO::GetFloatAt(std::ifstream & f, std::streamoff Offset, float * i
 {
   float tmp = NAN;
 
-  if (this->GetStringAt(f, Offset, (char *)&tmp, sizeof(float), throw_exception) == 0)
+  if (this->GetStringAt(f, Offset, reinterpret_cast<char *>(&tmp), sizeof(float), throw_exception) == 0)
   {
-    *ip = this->hdr2Float((char *)&tmp);
+    *ip = this->hdr2Float(reinterpret_cast<char *>(&tmp));
   }
   else
   {
@@ -387,9 +387,9 @@ IPLCommonImageIO::GetDoubleAt(std::ifstream & f, std::streamoff Offset, double *
 {
   double tmp = NAN;
 
-  if (this->GetStringAt(f, Offset, (char *)&tmp, sizeof(double), throw_exception) == 0)
+  if (this->GetStringAt(f, Offset, reinterpret_cast<char *>(&tmp), sizeof(double), throw_exception) == 0)
   {
-    *ip = this->hdr2Double((char *)&tmp);
+    *ip = this->hdr2Double(reinterpret_cast<char *>(&tmp));
   }
   else
   {
@@ -493,7 +493,7 @@ int
 IPLCommonImageIO::statTimeToAscii(void * clock, char * timeString, int len)
 {
 
-  auto               tclock = (time_t)*((int *)clock);
+  auto               tclock = static_cast<time_t>(*(static_cast<int *>(clock)));
   const char * const asciiTime = ctime(&tclock);
 
   strncpy(timeString, asciiTime, len);

--- a/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
+++ b/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
@@ -491,7 +491,7 @@ JPEG2000ImageIO::Read(void * buffer)
 
   OPJ_BOOL l_go_on = true;
 
-  auto * l_data = (OPJ_BYTE *)opj_malloc(1000);
+  auto * l_data = static_cast<OPJ_BYTE *>(opj_malloc(1000));
 
   while (l_go_on)
   {
@@ -538,7 +538,7 @@ JPEG2000ImageIO::Read(void * buffer)
     {
       if (l_data_size > l_max_data_size)
       {
-        l_data = (OPJ_BYTE *)opj_realloc(l_data, l_data_size);
+        l_data = static_cast<OPJ_BYTE *>(opj_realloc(l_data, l_data_size));
 
         if (!l_data)
         {
@@ -598,7 +598,7 @@ JPEG2000ImageIO::Read(void * buffer)
       // tile ROI iteration
       for (unsigned int k = 0; k < numberOfComponents; ++k)
       {
-        auto * charBuffer = (unsigned char *)buffer;
+        auto * charBuffer = static_cast<unsigned char *>(buffer);
         charBuffer += k * sizePerComponentInBytes;
 
         charBuffer += initialStrideInBytes;
@@ -764,7 +764,7 @@ JPEG2000ImageIO::Write(const void * buffer)
     snprintf(parameters.cp_comment, commentLength, "%s%s with JPWL", comment, version);
 #else
     const size_t commentLength = clen + strlen(version) + 11;
-    parameters.cp_comment = (char *)opj_malloc(commentLength);
+    parameters.cp_comment = static_cast<char *>(opj_malloc(commentLength));
     snprintf(parameters.cp_comment, commentLength, "%s%s", comment, version);
 #endif
     /* <<UniPG */
@@ -873,11 +873,11 @@ JPEG2000ImageIO::Write(const void * buffer)
 
   // HERE, copy the buffer
   SizeValueType       index = 0;
-  const SizeValueType numberOfPixels = SizeValueType(w) * SizeValueType(h);
+  const SizeValueType numberOfPixels = static_cast<SizeValueType>(w) * static_cast<SizeValueType>(h);
   itkDebugMacro(" START COPY BUFFER");
   if (this->GetComponentType() == IOComponentEnum::UCHAR)
   {
-    const auto * charBuffer = (const unsigned char *)buffer;
+    const auto * charBuffer = static_cast<const unsigned char *>(buffer);
     for (SizeValueType j = 0; j < numberOfPixels; ++j)
     {
       for (unsigned int k = 0; k < this->GetNumberOfComponents(); ++k)
@@ -890,7 +890,7 @@ JPEG2000ImageIO::Write(const void * buffer)
 
   if (this->GetComponentType() == IOComponentEnum::USHORT)
   {
-    const auto * shortBuffer = (const unsigned short *)buffer;
+    const auto * shortBuffer = static_cast<const unsigned short *>(buffer);
     for (SizeValueType j = 0; j < numberOfPixels; ++j)
     {
       for (unsigned int k = 0; k < this->GetNumberOfComponents(); ++k)

--- a/Modules/IO/LSM/src/itkLSMImageIO.cxx
+++ b/Modules/IO/LSM/src/itkLSMImageIO.cxx
@@ -231,7 +231,7 @@ LSMImageIO::FillZeissStruct(char * cz)
 void
 LSMImageIO::Write(const void * buffer)
 {
-  const auto * outPtr = (const unsigned char *)buffer;
+  const auto * outPtr = static_cast<const unsigned char *>(buffer);
 
   unsigned int pages = 1;
   if (this->GetNumberOfDimensions() < 2)

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -1325,7 +1325,7 @@ MINCImageIO::WriteImageInformation()
 
   // preserve information of MINC PositiveCoordinateOrientation RAS to ITK PositiveCoordinateOrientation LPS conversion
   {
-    int tmp = (int)this->m_RAStoLPS;
+    int tmp = static_cast<int>(this->m_RAStoLPS);
     miset_attr_values(m_MINCPImpl->m_Volume, MI_TYPE_INT, "itk", "RAStoLPS", 1, &tmp);
   }
 

--- a/Modules/IO/MRC/src/itkMRCHeaderObject.cxx
+++ b/Modules/IO/MRC/src/itkMRCHeaderObject.cxx
@@ -159,11 +159,12 @@ MRCHeaderObject::SetExtendedHeader(const void * buffer)
 
     if (this->m_BigEndianHeader)
     {
-      ByteSwapper<float>::SwapRangeFromSystemToBigEndian((float *)this->m_ExtendedHeader, this->m_ExtendedHeaderSize);
+      ByteSwapper<float>::SwapRangeFromSystemToBigEndian(static_cast<float *>(this->m_ExtendedHeader),
+                                                         this->m_ExtendedHeaderSize);
     }
     else
     {
-      ByteSwapper<float>::SwapRangeFromSystemToLittleEndian((float *)this->m_ExtendedHeader,
+      ByteSwapper<float>::SwapRangeFromSystemToLittleEndian(static_cast<float *>(this->m_ExtendedHeader),
                                                             this->m_ExtendedHeaderSize);
     }
   }

--- a/Modules/IO/MRC/src/itkMRCImageIO.cxx
+++ b/Modules/IO/MRC/src/itkMRCImageIO.cxx
@@ -297,14 +297,16 @@ MRCImageIO::Read(void * buffer)
       break;
     case 2:
       this->GetByteOrder() == IOByteOrderEnum::BigEndian
-        ? ByteSwapper<uint16_t>::SwapRangeFromSystemToBigEndian((uint16_t *)buffer, this->GetImageSizeInComponents())
-        : ByteSwapper<uint16_t>::SwapRangeFromSystemToLittleEndian((uint16_t *)buffer,
+        ? ByteSwapper<uint16_t>::SwapRangeFromSystemToBigEndian(static_cast<uint16_t *>(buffer),
+                                                                this->GetImageSizeInComponents())
+        : ByteSwapper<uint16_t>::SwapRangeFromSystemToLittleEndian(static_cast<uint16_t *>(buffer),
                                                                    this->GetImageSizeInComponents());
       break;
     case 4:
       this->GetByteOrder() == IOByteOrderEnum::BigEndian
-        ? ByteSwapper<uint32_t>::SwapRangeFromSystemToBigEndian((uint32_t *)buffer, this->GetImageSizeInComponents())
-        : ByteSwapper<uint32_t>::SwapRangeFromSystemToLittleEndian((uint32_t *)buffer,
+        ? ByteSwapper<uint32_t>::SwapRangeFromSystemToBigEndian(static_cast<uint32_t *>(buffer),
+                                                                this->GetImageSizeInComponents())
+        : ByteSwapper<uint32_t>::SwapRangeFromSystemToLittleEndian(static_cast<uint32_t *>(buffer),
                                                                    this->GetImageSizeInComponents());
       break;
     default:

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
@@ -148,12 +148,12 @@ FreeSurferBinaryMeshIO::ReadMeshInformation()
 
     // Read the number of points and number of cells
     itk::uint32_t numberOfPoints = 0;
-    m_InputFile.read((char *)(&numberOfPoints), sizeof(numberOfPoints));
+    m_InputFile.read(reinterpret_cast<char *>(&numberOfPoints), sizeof(numberOfPoints));
     itk::ByteSwapper<itk::uint32_t>::SwapFromSystemToBigEndian(&numberOfPoints);
     this->m_NumberOfPoints = static_cast<SizeValueType>(numberOfPoints);
 
     itk::uint32_t numberOfCells = 0;
-    m_InputFile.read((char *)(&numberOfCells), sizeof(numberOfCells));
+    m_InputFile.read(reinterpret_cast<char *>(&numberOfCells), sizeof(numberOfCells));
     itk::ByteSwapper<itk::uint32_t>::SwapFromSystemToBigEndian(&numberOfCells);
     this->m_NumberOfCells = static_cast<SizeValueType>(numberOfCells);
 
@@ -191,18 +191,18 @@ FreeSurferBinaryMeshIO::ReadMeshInformation()
 
     // Read numberOfValuesPerPoint and numberOfPoints and numberOfCells
     itk::uint32_t numberOfPoints = 0;
-    m_InputFile.read((char *)(&numberOfPoints), sizeof(numberOfPoints));
+    m_InputFile.read(reinterpret_cast<char *>(&numberOfPoints), sizeof(numberOfPoints));
     itk::ByteSwapper<itk::uint32_t>::SwapFromSystemToBigEndian(&numberOfPoints);
     this->m_NumberOfPoints = static_cast<SizeValueType>(numberOfPoints);
     this->m_NumberOfPointPixels = this->m_NumberOfPoints;
 
     itk::uint32_t numberOfCells = 0;
-    m_InputFile.read((char *)(&numberOfCells), sizeof(numberOfCells));
+    m_InputFile.read(reinterpret_cast<char *>(&numberOfCells), sizeof(numberOfCells));
     itk::ByteSwapper<itk::uint32_t>::SwapFromSystemToBigEndian(&numberOfCells);
     this->m_NumberOfCells = static_cast<SizeValueType>(numberOfCells);
 
     itk::uint32_t numberOfValuesPerPoint = 0;
-    m_InputFile.read((char *)(&numberOfValuesPerPoint), sizeof(numberOfValuesPerPoint));
+    m_InputFile.read(reinterpret_cast<char *>(&numberOfValuesPerPoint), sizeof(numberOfValuesPerPoint));
     itk::ByteSwapper<itk::uint32_t>::SwapFromSystemToBigEndian(&numberOfValuesPerPoint);
 
     m_FilePosition = m_InputFile.tellg();

--- a/Modules/IO/MeshGifti/src/itkGiftiMeshIO.cxx
+++ b/Modules/IO/MeshGifti/src/itkGiftiMeshIO.cxx
@@ -717,8 +717,8 @@ GiftiMeshIO::WriteMeshInformation()
       gifti_clear_LabelTable(&m_GiftiImage->labeltable);
       m_GiftiImage->labeltable.length = labelMap->Size();
 
-      m_GiftiImage->labeltable.key = (int *)malloc(labelMap->Size() * sizeof(int));
-      m_GiftiImage->labeltable.label = (char **)malloc(labelMap->Size() * sizeof(char *));
+      m_GiftiImage->labeltable.key = static_cast<int *>(malloc(labelMap->Size() * sizeof(int)));
+      m_GiftiImage->labeltable.label = static_cast<char **>(malloc(labelMap->Size() * sizeof(char *)));
 
       unsigned int mm = 0;
       for (LabelNameContainer::ConstIterator lt = labelMap->Begin(); lt != labelMap->End(); ++lt)
@@ -734,7 +734,7 @@ GiftiMeshIO::WriteMeshInformation()
     {
       if (colorMap)
       {
-        m_GiftiImage->labeltable.rgba = (float *)malloc(colorMap->Size() * 4 * sizeof(float));
+        m_GiftiImage->labeltable.rgba = static_cast<float *>(malloc(colorMap->Size() * 4 * sizeof(float)));
         unsigned int kk = 0;
         for (LabelColorContainer::ConstIterator lt = colorMap->Begin(); lt != colorMap->End(); ++lt)
         {

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -695,8 +695,8 @@ NiftiImageIO::Read(void * buffer)
   {
     // otherwise nifti is x y z t vec l m 0, itk is
     // vec x y z t l m o
-    const auto * niftibuf = (const char *)data;
-    auto *       itkbuf = (char *)buffer;
+    const auto * niftibuf = static_cast<const char *>(data);
+    auto *       itkbuf = static_cast<char *>(buffer);
     const size_t rowdist = this->m_NiftiImage->dim[1];
     const size_t slicedist = rowdist * this->m_NiftiImage->dim[2];
     const size_t volumedist = slicedist * this->m_NiftiImage->dim[3];
@@ -2414,13 +2414,14 @@ NiftiImageIO::Write(const void * buffer)
         this->m_NiftiImage->dim[i] = 1;
       }
     }
-    const size_t numVoxels = size_t(this->m_NiftiImage->dim[1]) * size_t(this->m_NiftiImage->dim[2]) *
-                             size_t(this->m_NiftiImage->dim[3]) * size_t(this->m_NiftiImage->dim[4]);
+    const size_t numVoxels =
+      static_cast<size_t>(this->m_NiftiImage->dim[1]) * static_cast<size_t>(this->m_NiftiImage->dim[2]) *
+      static_cast<size_t>(this->m_NiftiImage->dim[3]) * static_cast<size_t>(this->m_NiftiImage->dim[4]);
     const size_t buffer_size = numVoxels * numComponents // Number of components
                                * this->m_NiftiImage->nbyper;
 
     const auto         nifti_buf = make_unique_for_overwrite<char[]>(buffer_size);
-    const auto * const itkbuf = (const char *)buffer;
+    const auto * const itkbuf = static_cast<const char *>(buffer);
     // Data must be rearranged to meet nifti organzation.
     // nifti_layout[vec][t][z][y][x] = itk_layout[t][z][y][z][vec]
     const size_t rowdist = m_NiftiImage->dim[1];

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest5.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest5.cxx
@@ -28,7 +28,7 @@ SlopeInterceptTest()
   // fill out a nifti image and write it.
   const char *  filename = "SlopeIntercept.nii";
   nifti_image * niftiImage = nifti_simple_init_nim();
-  niftiImage->fname = (char *)malloc(strlen(filename) + 1);
+  niftiImage->fname = static_cast<char *>(malloc(strlen(filename) + 1));
   if (niftiImage->fname == nullptr)
   {
     std::cerr << "Failed to allocate memory for filename, length requested " << strlen(filename) + 1 << std::endl;
@@ -36,7 +36,7 @@ SlopeInterceptTest()
   }
   strcpy(niftiImage->fname, filename);
   niftiImage->nifti_type = 1;
-  niftiImage->iname = (char *)malloc(strlen(filename) + 1);
+  niftiImage->iname = static_cast<char *>(malloc(strlen(filename) + 1));
   if (niftiImage->iname == nullptr)
   {
     free(niftiImage->fname);

--- a/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
+++ b/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
@@ -592,8 +592,8 @@ NrrdImageIO::ReadImageInformation()
     {
       nrrdKeyValueIndex(nrrd, &keyPtr, &valPtr, kvpi);
       EncapsulateMetaData<std::string>(thisDic, std::string(keyPtr), std::string(valPtr));
-      keyPtr = (char *)airFree(keyPtr);
-      valPtr = (char *)airFree(valPtr);
+      keyPtr = static_cast<char *>(airFree(keyPtr));
+      valPtr = static_cast<char *>(airFree(valPtr));
     }
 
     // save in MetaDataDictionary those important nrrd fields that

--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -682,7 +682,7 @@ PNGImageIO::WriteSlice(const std::string & fileName, const void * const buffer)
 
   {
     const int                      rowInc = width * numComp * bitDepth / 8;
-    const volatile unsigned char * outPtr = ((const unsigned char *)buffer);
+    const volatile unsigned char * outPtr = (static_cast<const unsigned char *>(buffer));
     for (unsigned int ui = 0; ui < height; ++ui)
     {
       row_pointers[ui] = const_cast<png_byte *>(outPtr);

--- a/Modules/IO/PNG/test/itkPNGImageIOTest.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTest.cxx
@@ -146,7 +146,8 @@ itkPNGImageIOTest(int argc, char * argv[])
 
   // Exercise other methods
   const itk::ImageIOBase::SizeType pixelStride = io->GetPixelStride();
-  std::cout << "PixelStride: " << itk::NumericTraits<itk::ImageIOBase::SizeType>::PrintType(pixelStride) << std::endl;
+  std::cout << "PixelStride: " << static_cast<itk::NumericTraits<itk::ImageIOBase::SizeType>::PrintType>(pixelStride)
+            << std::endl;
 
   //
   // Try writing out several kinds of images using png.

--- a/Modules/IO/PNG/test/itkPNGImageIOTest2.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTest2.cxx
@@ -178,7 +178,8 @@ itkPNGImageIOTest2(int argc, char * argv[])
 
   // Exercise other methods
   const itk::ImageIOBase::SizeType pixelStride = io->GetPixelStride();
-  std::cout << "PixelStride: " << itk::NumericTraits<itk::ImageIOBase::SizeType>::PrintType(pixelStride) << std::endl;
+  std::cout << "PixelStride: " << static_cast<itk::NumericTraits<itk::ImageIOBase::SizeType>::PrintType>(pixelStride)
+            << std::endl;
 
 
   const ImageType::Pointer inputImage = reader->GetOutput();

--- a/Modules/IO/PNG/test/itkPNGImageIOTestPalette.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTestPalette.cxx
@@ -237,7 +237,8 @@ itkPNGImageIOTestPalette(int argc, char * argv[])
 
   // Exercise other methods
   const itk::ImageIOBase::SizeType pixelStride = io->GetPixelStride();
-  std::cout << "PixelStride: " << itk::NumericTraits<itk::ImageIOBase::SizeType>::PrintType(pixelStride) << std::endl;
+  std::cout << "PixelStride: " << static_cast<itk::NumericTraits<itk::ImageIOBase::SizeType>::PrintType>(pixelStride)
+            << std::endl;
 
   // ToDo
   // When the palette has made into the Metadata Dictionary (as opposed to the ImageIO):

--- a/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
+++ b/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
@@ -155,23 +155,23 @@ StimulateImageIO::Read(void * buffer)
   switch (this->GetComponentType())
   {
     case IOComponentEnum::CHAR:
-      ByteSwapper<char>::SwapRangeFromSystemToBigEndian((char *)buffer,
+      ByteSwapper<char>::SwapRangeFromSystemToBigEndian(static_cast<char *>(buffer),
                                                         static_cast<SizeValueType>(this->GetImageSizeInComponents()));
       break;
     case IOComponentEnum::SHORT:
-      ByteSwapper<short>::SwapRangeFromSystemToBigEndian((short *)buffer,
+      ByteSwapper<short>::SwapRangeFromSystemToBigEndian(static_cast<short *>(buffer),
                                                          static_cast<SizeValueType>(this->GetImageSizeInComponents()));
       break;
     case IOComponentEnum::INT:
-      ByteSwapper<int>::SwapRangeFromSystemToBigEndian((int *)buffer,
+      ByteSwapper<int>::SwapRangeFromSystemToBigEndian(static_cast<int *>(buffer),
                                                        static_cast<SizeValueType>(this->GetImageSizeInComponents()));
       break;
     case IOComponentEnum::FLOAT:
-      ByteSwapper<float>::SwapRangeFromSystemToBigEndian((float *)buffer,
+      ByteSwapper<float>::SwapRangeFromSystemToBigEndian(static_cast<float *>(buffer),
                                                          static_cast<SizeValueType>(this->GetImageSizeInComponents()));
       break;
     case IOComponentEnum::DOUBLE:
-      ByteSwapper<double>::SwapRangeFromSystemToBigEndian((double *)buffer,
+      ByteSwapper<double>::SwapRangeFromSystemToBigEndian(static_cast<double *>(buffer),
                                                           static_cast<SizeValueType>(this->GetImageSizeInComponents()));
       break;
     default:

--- a/Modules/IO/TIFF/test/itkLargeTIFFImageWriteReadTest.cxx
+++ b/Modules/IO/TIFF/test/itkLargeTIFFImageWriteReadTest.cxx
@@ -56,7 +56,7 @@ itkLargeTIFFImageWriteReadTestHelper(std::string filename, typename TImage::Size
       numberOfPixels *= static_cast<SizeValueType>(region.GetSize(i));
     }
 
-    constexpr SizeValueType oneMebiByte = SizeValueType(1024) * SizeValueType(1024);
+    constexpr SizeValueType oneMebiByte = static_cast<SizeValueType>(1024) * static_cast<SizeValueType>(1024);
 
     const SizeValueType sizeInBytes = sizeof(PixelType) * numberOfPixels;
 

--- a/Modules/IO/TIFF/test/itkTIFFImageIOTestPalette.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOTestPalette.cxx
@@ -236,7 +236,8 @@ itkTIFFImageIOTestPalette(int argc, char * argv[])
 
   // Exercise other methods
   const itk::ImageIOBase::SizeType pixelStride = io->GetPixelStride();
-  std::cout << "PixelStride: " << itk::NumericTraits<itk::ImageIOBase::SizeType>::PrintType(pixelStride) << std::endl;
+  std::cout << "PixelStride: " << static_cast<itk::NumericTraits<itk::ImageIOBase::SizeType>::PrintType>(pixelStride)
+            << std::endl;
 
   // ToDo
   // When the palette has made into the Metadata Dictionary (as opposed to the ImageIO):

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -549,13 +549,16 @@ VTKImageIO::Read(void * buffer)
       case 1:
         break;
       case 2:
-        ByteSwapper<uint16_t>::SwapRangeFromSystemToBigEndian((uint16_t *)buffer, this->GetIORegionSizeInComponents());
+        ByteSwapper<uint16_t>::SwapRangeFromSystemToBigEndian(static_cast<uint16_t *>(buffer),
+                                                              this->GetIORegionSizeInComponents());
         break;
       case 4:
-        ByteSwapper<uint32_t>::SwapRangeFromSystemToBigEndian((uint32_t *)buffer, this->GetIORegionSizeInComponents());
+        ByteSwapper<uint32_t>::SwapRangeFromSystemToBigEndian(static_cast<uint32_t *>(buffer),
+                                                              this->GetIORegionSizeInComponents());
         break;
       case 8:
-        ByteSwapper<uint64_t>::SwapRangeFromSystemToBigEndian((uint64_t *)buffer, this->GetIORegionSizeInComponents());
+        ByteSwapper<uint64_t>::SwapRangeFromSystemToBigEndian(static_cast<uint64_t *>(buffer),
+                                                              this->GetIORegionSizeInComponents());
         break;
       default:
         itkExceptionMacro("Unknown component size" << this->GetComponentSize());
@@ -600,13 +603,16 @@ VTKImageIO::Read(void * buffer)
         case 1:
           break;
         case 2:
-          ByteSwapper<uint16_t>::SwapRangeFromSystemToBigEndian((uint16_t *)buffer, this->GetImageSizeInComponents());
+          ByteSwapper<uint16_t>::SwapRangeFromSystemToBigEndian(static_cast<uint16_t *>(buffer),
+                                                                this->GetImageSizeInComponents());
           break;
         case 4:
-          ByteSwapper<uint32_t>::SwapRangeFromSystemToBigEndian((uint32_t *)buffer, this->GetImageSizeInComponents());
+          ByteSwapper<uint32_t>::SwapRangeFromSystemToBigEndian(static_cast<uint32_t *>(buffer),
+                                                                this->GetImageSizeInComponents());
           break;
         case 8:
-          ByteSwapper<uint64_t>::SwapRangeFromSystemToBigEndian((uint64_t *)buffer, this->GetImageSizeInComponents());
+          ByteSwapper<uint64_t>::SwapRangeFromSystemToBigEndian(static_cast<uint64_t *>(buffer),
+                                                                this->GetImageSizeInComponents());
           break;
         default:
           itkExceptionMacro("Unknown component size" << this->GetComponentSize());

--- a/Modules/IO/XML/src/itkDOMNode.cxx
+++ b/Modules/IO/XML/src/itkDOMNode.cxx
@@ -499,7 +499,7 @@ DOMNode::Find(const std::string & path)
     iss >> i;
     if (!iss.fail())
     {
-      node = this->GetChild(IdentifierType(i));
+      node = this->GetChild(static_cast<IdentifierType>(i));
     }
   }
 
@@ -514,7 +514,7 @@ DOMNode::Find(const std::string & path)
       iss >> i;
       if (!iss.fail())
       {
-        node = this->GetSibling(OffsetType(i));
+        node = this->GetSibling(static_cast<OffsetType>(i));
       }
     }
     else
@@ -534,7 +534,7 @@ DOMNode::Find(const std::string & path)
       iss >> i;
       if (!iss.fail())
       {
-        node = this->GetSibling(-OffsetType(i));
+        node = this->GetSibling(-static_cast<OffsetType>(i));
       }
     }
     else

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -264,7 +264,7 @@ Histogram<TMeasurement, TFrequencyContainer>::GetIndex(const MeasurementVectorTy
       // its ok if we extend the bins to infinity.. not ok if we don't
       if (!m_ClipBinsAtEnds)
       {
-        index[dim] = (IndexValueType)0;
+        index[dim] = static_cast<IndexValueType>(0);
         continue;
       }
 

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
@@ -140,7 +140,7 @@ ScalarImageToRunLengthFeaturesFilter<TImage, THistogramFrequencyContainer>::Full
              ++fnameIt, featureNum++)
         {
           features[offsetNum][featureNum] =
-            runLengthMatrixCalculator->GetFeature((InternalRunLengthFeatureName)fnameIt.Value());
+            runLengthMatrixCalculator->GetFeature(static_cast<InternalRunLengthFeatureName>(fnameIt.Value()));
         }
       }
     }
@@ -228,7 +228,7 @@ ScalarImageToRunLengthFeaturesFilter<TImage, THistogramFrequencyContainer>::Fast
        ++fnameIt)
   {
     this->m_FeatureMeans->push_back(
-      runLengthMatrixCalculator->GetFeature((InternalRunLengthFeatureName)fnameIt.Value()));
+      runLengthMatrixCalculator->GetFeature(static_cast<InternalRunLengthFeatureName>(fnameIt.Value())));
     this->m_FeatureStandardDeviations->push_back(0.0);
   }
 

--- a/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
@@ -134,7 +134,8 @@ ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMa
          fnameIt != m_RequestedFeatures->End();
          ++fnameIt, featureNum++)
     {
-      features[offsetNum][featureNum] = this->m_GLCMCalculator->GetFeature((InternalTextureFeatureName)fnameIt.Value());
+      features[offsetNum][featureNum] =
+        this->m_GLCMCalculator->GetFeature(static_cast<InternalTextureFeatureName>(fnameIt.Value()));
     }
   }
 
@@ -217,7 +218,8 @@ ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMa
   typename FeatureNameVector::ConstIterator fnameIt;
   for (fnameIt = m_RequestedFeatures->Begin(); fnameIt != m_RequestedFeatures->End(); ++fnameIt)
   {
-    m_FeatureMeans->push_back(this->m_GLCMCalculator->GetFeature((InternalTextureFeatureName)fnameIt.Value()));
+    m_FeatureMeans->push_back(
+      this->m_GLCMCalculator->GetFeature(static_cast<InternalTextureFeatureName>(fnameIt.Value())));
     m_FeatureStandardDeviations->push_back(0.0);
   }
 

--- a/Modules/Numerics/Statistics/src/itkChiSquareDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkChiSquareDistribution.cxx
@@ -123,7 +123,7 @@ ChiSquareDistribution::CDF(double x, const ParametersType & p)
     itkGenericExceptionMacro("Invalid number of parameters to describe distribution. Expected 1 parameter, but got "
                              << p.size() << " parameters.");
   }
-  return ChiSquareDistribution::CDF(x, (SizeValueType)p[0]);
+  return ChiSquareDistribution::CDF(x, static_cast<SizeValueType>(p[0]));
 }
 
 double

--- a/Modules/Numerics/Statistics/test/itkCovarianceSampleFilterTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkCovarianceSampleFilterTest3.cxx
@@ -131,7 +131,7 @@ itkCovarianceSampleFilterTest3(int, char *[])
 
     const double MahalanobisDistance2 = MahalanobisDistance * MahalanobisDistance;
 
-    auto frequency = (AbsoluteFrequencyType)std::floor(1e5 * std::exp(-0.5 * MahalanobisDistance2));
+    auto frequency = static_cast<AbsoluteFrequencyType>(std::floor(1e5 * std::exp(-0.5 * MahalanobisDistance2)));
 
     itr.SetFrequency(frequency);
     ++itr;

--- a/Modules/Numerics/Statistics/test/itkMeanSampleFilterTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkMeanSampleFilterTest3.cxx
@@ -92,7 +92,7 @@ itkMeanSampleFilterTest3(int, char *[])
 
     const double MahalanobisDistance2 = MahalanobisDistance * MahalanobisDistance;
 
-    auto frequency = (AbsoluteFrequencyType)std::floor(1e5 * std::exp(-0.5 * MahalanobisDistance2));
+    auto frequency = static_cast<AbsoluteFrequencyType>(std::floor(1e5 * std::exp(-0.5 * MahalanobisDistance2)));
 
     itr.SetFrequency(frequency);
     ++itr;

--- a/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
@@ -252,8 +252,8 @@ ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 BlockMatchingImageFilter<TFixedImage, TMovingImage, TFeatures, TDisplacements, TSimilarities>::ThreaderCallback(
   void * arg)
 {
-  auto *             str = (ThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
-  const ThreadIdType workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
+  auto *             str = (ThreadStruct *)((static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->UserData);
+  const ThreadIdType workUnitID = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->WorkUnitID;
 
   str->Filter->ThreadedGenerateData(workUnitID);
 

--- a/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
@@ -227,10 +227,10 @@ template <typename TFixedImage, typename TMovingImage>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::ThreaderCallback(void * arg)
 {
-  const ThreadIdType workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
-  const ThreadIdType workUnitCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
+  const ThreadIdType workUnitID = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->WorkUnitID;
+  const ThreadIdType workUnitCount = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->NumberOfWorkUnits;
 
-  auto * str = (ThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
+  auto * str = (ThreadStruct *)((static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->UserData);
 
   // execute the actual method with appropriate computation region
   // first find out how many pieces extent can be split into.

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_13.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_13.cxx
@@ -174,14 +174,14 @@ itkImageRegistrationMethodTest_13(int, char *[])
 
     d = p - center;
 
-    fIter.Set((PixelType)F(d));
+    fIter.Set(static_cast<PixelType>(F(d)));
 
     for (unsigned int j = 0; j < dimension; ++j)
     {
       d[j] = d[j] * scale[j] + displacement[j];
     }
 
-    mIter.Set((PixelType)F(d));
+    mIter.Set(static_cast<PixelType>(F(d)));
 
     ++fIter;
     ++mIter;

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_14.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_14.cxx
@@ -178,14 +178,14 @@ itkImageRegistrationMethodTest_14(int, char *[])
 
     itk::Vector<double, dimension> d = p - center;
 
-    fIter.Set((PixelType)F(d));
+    fIter.Set(static_cast<PixelType>(F(d)));
 
     itk::Vector<double, dimension> d2;
     d2[0] = d[0] * std::cos(angle) + d[1] * std::sin(angle) + displacement[0];
     d2[1] = -d[0] * std::sin(angle) + d[1] * std::cos(angle) + displacement[1];
     d2[2] = d[2] + displacement[2];
 
-    mIter.Set((PixelType)F(d2));
+    mIter.Set(static_cast<PixelType>(F(d2)));
 
     ++fIter;
     ++mIter;

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_15.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_15.cxx
@@ -158,14 +158,14 @@ itkImageRegistrationMethodTest_15(int, char *[])
 
     d = p - center;
 
-    fIter.Set((PixelType)F(d));
+    fIter.Set(static_cast<PixelType>(F(d)));
 
     for (unsigned int j = 0; j < dimension; ++j)
     {
       d[j] = d[j] * scale[j] + displacement[j];
     }
 
-    mIter.Set((PixelType)F(d));
+    mIter.Set(static_cast<PixelType>(F(d)));
 
     ++fIter;
     ++mIter;

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_17.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_17.cxx
@@ -164,14 +164,14 @@ itkImageRegistrationMethodTest_17(int, char *[])
 
     d = p - center;
 
-    fIter.Set((PixelType)F(d));
+    fIter.Set(static_cast<PixelType>(F(d)));
 
     for (unsigned int j = 0; j < dimension; ++j)
     {
       d[j] = d[j] * scale[j] + displacement[j];
     }
 
-    mIter.Set((PixelType)F(d));
+    mIter.Set(static_cast<PixelType>(F(d)));
 
     ++fIter;
     ++mIter;

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_1.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_1.cxx
@@ -156,14 +156,14 @@ itkMultiResolutionImageRegistrationMethodTest_1(int, char *[])
 
     d = p - center;
 
-    fIter.Set((PixelType)F(d));
+    fIter.Set(static_cast<PixelType>(F(d)));
 
     for (unsigned int j = 0; j < dimension; ++j)
     {
       d[j] = d[j] * scale[j] + displacement[j];
     }
 
-    mIter.Set((PixelType)F(d));
+    mIter.Set(static_cast<PixelType>(F(d)));
 
     ++fIter;
     ++mIter;

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_2.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_2.cxx
@@ -150,14 +150,14 @@ itkMultiResolutionImageRegistrationMethodTest_2(int, char *[])
 
     itk::Vector<double, dimension> d = p - center;
 
-    fIter.Set((PixelType)F(d));
+    fIter.Set(static_cast<PixelType>(F(d)));
 
     itk::Vector<double, dimension> d2;
     d2[0] = d[0] * std::cos(angle) + d[1] * std::sin(angle) + displacement[0];
     d2[1] = -d[0] * std::sin(angle) + d[1] * std::cos(angle) + displacement[1];
     d2[2] = d[2] + displacement[2];
 
-    mIter.Set((PixelType)F(d2));
+    mIter.Set(static_cast<PixelType>(F(d2)));
 
     ++fIter;
     ++mIter;

--- a/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
@@ -177,7 +177,7 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
     const double x = d[0];
     const double y = d[1];
     const double z = d[2];
-    ti.Set((PixelType)F(x, y, z));
+    ti.Set(static_cast<PixelType>(F(x, y, z)));
     ++ti;
   }
 

--- a/Modules/Registration/Common/test/itkRecursiveMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkRecursiveMultiResolutionPyramidImageFilterTest.cxx
@@ -124,7 +124,7 @@ itkRecursiveMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
     const double           x = d[0];
     const double           y = d[1];
     const double           z = d[2];
-    ti.Set((PixelType)F(x, y, z));
+    ti.Set(static_cast<PixelType>(F(x, y, z)));
     ++ti;
   }
 

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
@@ -204,7 +204,7 @@ typename PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointSet, TI
 
   // Sum per thread
   MultiThreaderBase::New()->ParallelizeArray(
-    (SizeValueType)0, (SizeValueType)ranges.size(), sumNeighborhoodValues, nullptr);
+    static_cast<SizeValueType>(0), (SizeValueType)ranges.size(), sumNeighborhoodValues, nullptr);
   // Join sums
   CompensatedSummation<MeasureType> value = 0;
   for (unsigned int i = 0; i < threadValues.size(); ++i)
@@ -378,7 +378,7 @@ PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointSet, TInternalCo
 
   // Sum per thread
   MultiThreaderBase::New()->ParallelizeArray(
-    (SizeValueType)0, (SizeValueType)ranges.size(), sumNeighborhoodValues, nullptr);
+    static_cast<SizeValueType>(0), (SizeValueType)ranges.size(), sumNeighborhoodValues, nullptr);
 
   // Sum thread results
   CompensatedSummation<MeasureType> value = 0;

--- a/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
@@ -234,7 +234,7 @@ itkCorrelationImageToImageMetricv4Test(int, char ** const)
     result = EXIT_FAILURE;
   }
 
-  const vnl_vector<double> ddiff = (vnl_vector<double>)derivative1 - (vnl_vector<double>)derivative2;
+  const vnl_vector<double> ddiff = vnl_vector<double>(derivative1) - vnl_vector<double>(derivative2);
   if (ddiff.two_norm() > myeps)
   {
     std::cerr << "derivative1: " << derivative1 << std::endl;

--- a/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
@@ -146,7 +146,7 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::Allocate()
 
     // Set the initial and final codebook size
 
-    const auto initCodebookSize = (SizeValueType)1;
+    const auto initCodebookSize = static_cast<SizeValueType>(1);
     m_Codebook.set_size(initCodebookSize, m_VectorDimension);
 
     // Initialize m_Codebook to 0 (it now has only one row)

--- a/Modules/Segmentation/Classifiers/test/itkSupervisedImageClassifierTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSupervisedImageClassifierTest.cxx
@@ -339,7 +339,7 @@ itkSupervisedImageClassifierTest(int, char *[])
   applyClassifier->SetInputImage(vecImage);
 
   // Set the decision rule
-  applyClassifier->SetDecisionRule((DecisionRuleBasePointer)myDecisionRule);
+  applyClassifier->SetDecisionRule(DecisionRuleBasePointer(myDecisionRule));
 
   // Add the membership functions
   for (unsigned int i = 0; i < NUM_CLASSES; ++i)

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkRGBGibbsPriorFilterTest.cxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkRGBGibbsPriorFilterTest.cxx
@@ -241,7 +241,7 @@ itkRGBGibbsPriorFilterTest(int, char *[])
   myClassifier->SetNumberOfClasses(NumClasses);
 
   // Set the decision rule
-  myClassifier->SetDecisionRule((DecisionRuleBasePointer)myDecisionRule);
+  myClassifier->SetDecisionRule(DecisionRuleBasePointer(myDecisionRule));
 
   // Add the membership functions
   for (unsigned int ii = 0; ii < NumClasses; ++ii)

--- a/Modules/Segmentation/RegionGrowing/test/itkNeighborhoodConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkNeighborhoodConnectedImageFilterTest.cxx
@@ -61,11 +61,12 @@ itkNeighborhoodConnectedImageFilterTest(int argc, char * argv[])
 
   // Test GetMacros
   const PixelType lower = filter->GetLower();
-  std::cout << "filter->GetLower(): " << itk::NumericTraits<PixelType>::PrintType(lower) << std::endl;
+  std::cout << "filter->GetLower(): " << static_cast<itk::NumericTraits<PixelType>::PrintType>(lower) << std::endl;
   const PixelType upper = filter->GetUpper();
-  std::cout << "filter->GetUpper(): " << itk::NumericTraits<PixelType>::PrintType(upper) << std::endl;
+  std::cout << "filter->GetUpper(): " << static_cast<itk::NumericTraits<PixelType>::PrintType>(upper) << std::endl;
   const PixelType replaceValue = filter->GetReplaceValue();
-  std::cout << "filter->GetReplaceValue(): " << itk::NumericTraits<PixelType>::PrintType(replaceValue) << std::endl;
+  std::cout << "filter->GetReplaceValue(): " << static_cast<itk::NumericTraits<PixelType>::PrintType>(replaceValue)
+            << std::endl;
 
   // Test GetConstReferenceMacro
   const SizeType & radius2 = filter->GetRadius();

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
@@ -423,7 +423,9 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::ThreadedConnectivity
   const unsigned int     numberOfClusterComponents = numberOfComponents + ImageDimension;
 
   const size_t minSuperSize =
-    std::accumulate(m_SuperGridSize.cbegin(), m_SuperGridSize.cend(), size_t(1), std::multiplies<size_t>()) / 4;
+    std::accumulate(
+      m_SuperGridSize.cbegin(), m_SuperGridSize.cend(), static_cast<size_t>(1), std::multiplies<size_t>()) /
+    4;
 
   ConstantBoundaryCondition<TOutputImage> lbc;
   lbc.SetConstant(NumericTraits<typename OutputImageType::PixelType>::max());
@@ -509,7 +511,9 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::SingleThreadedConnec
   OutputPixelType prevLabel = m_Clusters.size() / numberOfClusterComponents;
 
   const size_t minSuperSize =
-    std::accumulate(m_SuperGridSize.cbegin(), m_SuperGridSize.cend(), size_t(1), std::multiplies<size_t>()) / 4;
+    std::accumulate(
+      m_SuperGridSize.cbegin(), m_SuperGridSize.cend(), static_cast<size_t>(1), std::multiplies<size_t>()) /
+    4;
 
   std::vector<IndexType> indexStack;
 

--- a/Modules/Video/Core/include/itkVideoSource.hxx
+++ b/Modules/Video/Core/include/itkVideoSource.hxx
@@ -334,10 +334,10 @@ template <typename TOutputVideoStream>
 ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 VideoSource<TOutputVideoStream>::ThreaderCallback(void * arg)
 {
-  const int workUnitID = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
-  const int threadCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
+  const int workUnitID = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->WorkUnitID;
+  const int threadCount = (static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->NumberOfWorkUnits;
 
-  auto * str = (ThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
+  auto * str = (ThreadStruct *)((static_cast<MultiThreaderBase::WorkUnitInfo *>(arg))->UserData);
 
   // execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.

--- a/Modules/Video/Core/src/itkTemporalProcessObject.cxx
+++ b/Modules/Video/Core/src/itkTemporalProcessObject.cxx
@@ -456,8 +456,8 @@ TemporalProcessObject::GenerateData()
       bufferedStart = outputStartFrame;
     }
 
-    const OffsetValueType spareFrames = output->GetNumberOfBuffers() - (OffsetValueType)bufferedDuration;
-    if (spareFrames >= (OffsetValueType)m_UnitOutputNumberOfFrames)
+    const OffsetValueType spareFrames = output->GetNumberOfBuffers() - static_cast<OffsetValueType>(bufferedDuration);
+    if (spareFrames >= static_cast<OffsetValueType>(m_UnitOutputNumberOfFrames))
     {
       bufferedDuration += m_UnitOutputNumberOfFrames;
     }

--- a/Modules/Video/Core/test/itkVideoToVideoFilterTest.cxx
+++ b/Modules/Video/Core/test/itkVideoToVideoFilterTest.cxx
@@ -234,7 +234,7 @@ itkVideoToVideoFilterTest(int, char *[])
     const OutputFrameType *                        frame = filter->GetOutput()->GetFrame(i);
     itk::ImageRegionConstIterator<OutputFrameType> iter(frame, frame->GetRequestedRegion());
 
-    const OutputPixelType     expectedVal = ((OutputPixelType)(i)-1.0 + (OutputPixelType)(i)) / 2.0;
+    const OutputPixelType expectedVal = (static_cast<OutputPixelType>(i) - 1.0 + static_cast<OutputPixelType>(i)) / 2.0;
     constexpr OutputPixelType epsilon = .00001;
     while (!iter.IsAtEnd())
     {

--- a/Modules/Video/Filtering/test/itkFrameAverageVideoFilterTest.cxx
+++ b/Modules/Video/Filtering/test/itkFrameAverageVideoFilterTest.cxx
@@ -155,7 +155,7 @@ itkFrameAverageVideoFilterTest(int argc, char * argv[])
     filter->Update();
 
     // Check the results
-    const OutputPixelType expectedVal = (OutputPixelType)(i + (i + 1)) / 2.0;
+    const OutputPixelType expectedVal = static_cast<OutputPixelType>(i + (i + 1)) / 2.0;
     const OutputPixelType actualVal = filter->GetOutput()->GetFrame(i)->GetPixel(checkPx);
     constexpr double      eps = 0.00001;
     if (expectedVal < actualVal - eps || expectedVal > actualVal + eps)
@@ -198,7 +198,7 @@ itkFrameAverageVideoFilterTest(int argc, char * argv[])
   filter->Update();
   for (unsigned int i = outputStart; i < outputStart + outputDuration; ++i)
   {
-    const OutputPixelType expectedVal = (OutputPixelType)(i + (i + 1) + (i + 2)) / 3.0;
+    const OutputPixelType expectedVal = static_cast<OutputPixelType>(i + (i + 1) + (i + 2)) / 3.0;
     const OutputPixelType actualVal = filter->GetOutput()->GetFrame(i)->GetPixel(checkPx);
     constexpr double      eps = 0.00001;
     if (expectedVal < actualVal - eps || expectedVal > actualVal + eps)


### PR DESCRIPTION
This check is similar to -Wold-style-cast, but it suggests automated fixes in some cases. The reported locations should not be different from the ones generated by -Wold-style-cast.

clang-tidy rule google-readability-casting

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
