### PR TITLE
DOC: Update ITKReleases NumFOCUS Drive

### DIFF
--- a/Documentation/Maintenance/Release.md
+++ b/Documentation/Maintenance/Release.md
@@ -997,7 +997,7 @@ excellent packaging.
 [ITK Software Guide]: https://itk.org/ItkSoftwareGuide.pdf
 [ITK wiki]: https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK
 [ITK Sphinx examples]: https://examples.itk.org/
-[ITKReleases NumFOCUS GDrive]: https://drive.google.com/drive/folders/1-uE7lKAZN4PT52vJJuDqr6KT656r6Dn_?usp=drive_link
+[ITKReleases NumFOCUS GDrive]: https://drive.google.com/drive/u/2/folders/0AKRok0KBkv02Uk9PVA
 [kubo]: https://github.com/ipfs/kubo
 [pinata]: https://pinata.cloud
 [releases page]: https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK/Releases

--- a/Documentation/docs/releases/index.md
+++ b/Documentation/docs/releases/index.md
@@ -59,3 +59,5 @@
 1.8.md
 1.0.md
 ```
+
+The release asset archive is [available here](https://drive.google.com/drive/u/2/folders/0AKRok0KBkv02Uk9PVA).


### PR DESCRIPTION
We now store the ITK release asset archive on an NumFOCUS Insight
Software Consortium Google Workspace Google Shared Drive called
ITKReleases.
