### PR TITLE
BUG: fix an infinite loop in itk::VoronoiDiagram2DGenerator

### DIFF
--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -274,8 +274,10 @@ VoronoiDiagram2DGenerator<TCoordinate>::ConstructDiagram()
     buildEdges.push_back(curr);
     EdgeInfo front = curr;
     EdgeInfo back = curr;
-    while (!(rawEdges[i].empty()))
+    auto     maxStop = static_cast<int>(rawEdges[i].size());
+    while (!(rawEdges[i].empty()) && (maxStop > 0))
     {
+      --maxStop;
       curr = rawEdges[i].front();
       rawEdges[i].pop_front();
       unsigned char frontbnd = Pointonbnd(front[0]);


### PR DESCRIPTION
The loop exit condition was present in the code, but never wired and removed via https://github.com/InsightSoftwareConsortium/ITK/commit/cd97879e6bfec6cd9a33a3dd374d68cf4ff4303e

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
