### PR TITLE
COMP: Replace np.bool with np.bool_

### DIFF
--- a/Wrapping/Generators/Python/itk/support/types.py
+++ b/Wrapping/Generators/Python/itk/support/types.py
@@ -140,7 +140,7 @@ class itkCType:
         _SS: "itkCType" = itkCType("signed short", "SS", np.dtype(np.int16))
         _SI: "itkCType" = itkCType("signed int", "SI", np.dtype(np.int32))
         _SLL: "itkCType" = itkCType("signed long long", "SLL", np.dtype(np.int64))
-        _B: "itkCType" = itkCType("bool", "B", np.dtype(np.bool))
+        _B: "itkCType" = itkCType("bool", "B", np.dtype(np.bool_))
         return _F, _D, _UC, _US, _UI, _UL, _SL, _LD, _ULL, _SC, _SS, _SI, _SLL, _B
 
 


### PR DESCRIPTION
For:

E   AttributeError: module 'numpy' has no attribute 'bool'.
E   `np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
E   The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
E       https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
