### PR TITLE
DOC: Use new ITKReleases NumFOCUS GDrive link

### DIFF
--- a/Documentation/Maintenance/Release.md
+++ b/Documentation/Maintenance/Release.md
@@ -997,7 +997,7 @@ excellent packaging.
 [ITK Software Guide]: https://itk.org/ItkSoftwareGuide.pdf
 [ITK wiki]: https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK
 [ITK Sphinx examples]: https://examples.itk.org/
-[ITKReleases NumFOCUS GDrive]: https://drive.google.com/drive/u/2/folders/0AKRok0KBkv02Uk9PVA
+[ITKReleases NumFOCUS GDrive]: https://drive.google.com/drive/folders/1NFEZGTs_axoJUXox3JsRKCqw2QQCY_Ri
 [kubo]: https://github.com/ipfs/kubo
 [pinata]: https://pinata.cloud
 [releases page]: https://insightsoftwareconsortium.github.io/ITKWikiArchive/Wiki/ITK/Releases

--- a/Documentation/docs/releases/index.md
+++ b/Documentation/docs/releases/index.md
@@ -60,4 +60,4 @@
 1.0.md
 ```
 
-The release asset archive is [available here](https://drive.google.com/drive/u/2/folders/0AKRok0KBkv02Uk9PVA).
+The release asset archive is [available here](https://drive.google.com/drive/folders/1NFEZGTs_axoJUXox3JsRKCqw2QQCY_Ri).


### PR DESCRIPTION
- Without the user account in the URL
- Use a folder within the Shared Drive (it is not possible to make the
  root of the shared drive publically accessible).
