### PR TITLE
STYLE: Use range-based loops from C++11

### DIFF
--- a/Examples/Filtering/DiffusionTensor3DReconstructionImageFilter.cxx
+++ b/Examples/Filtering/DiffusionTensor3DReconstructionImageFilter.cxx
@@ -142,13 +142,14 @@ main(int argc, char * argv[])
       GradientDirectionContainerType::New();
 
 
-  for (auto itKey = imgMetaKeys.begin(); itKey != imgMetaKeys.end(); ++itKey)
+  for (auto & imgMetaKey : imgMetaKeys)
   {
     std::string metaString;
-    itk::ExposeMetaData<std::string>(imgMetaDictionary, *itKey, metaString);
-    if (itKey->find("DWMRI_gradient") != std::string::npos)
+    itk::ExposeMetaData<std::string>(
+      imgMetaDictionary, imgMetaKey, metaString);
+    if (imgMetaKey.find("DWMRI_gradient") != std::string::npos)
     {
-      std::cout << *itKey << " ---> " << metaString << std::endl;
+      std::cout << imgMetaKey << " ---> " << metaString << std::endl;
       sscanf(metaString.c_str(),
              "%lf %lf %lf\n",
              &(vect3d[0]),
@@ -163,9 +164,9 @@ main(int argc, char * argv[])
       }
       ++numberOfGradientImages;
     }
-    else if (itKey->find("DWMRI_b-value") != std::string::npos)
+    else if (imgMetaKey.find("DWMRI_b-value") != std::string::npos)
     {
-      std::cout << *itKey << " ---> " << metaString << std::endl;
+      std::cout << imgMetaKey << " ---> " << metaString << std::endl;
       readb0 = true;
       b0 = std::stod(metaString.c_str());
     }

--- a/Examples/IO/IOPlugin.cxx
+++ b/Examples/IO/IOPlugin.cxx
@@ -82,9 +82,10 @@ main(int argc, char * argv[])
         auto n = names.begin();
         auto d = descriptions.begin();
         auto e = enableflags.begin();
-        for (auto o = overrides.begin(); o != overrides.end(); ++o)
+        for (auto & override : overrides)
         {
-          std::cout << "    Override " << *o << " with " << *n << std::endl
+          std::cout << "    Override " << override << " with " << *n
+                    << std::endl
                     << "      described as \"" << *d << "\"" << std::endl
                     << "      enabled " << *e << std::endl;
           ++n, ++d, ++e;
@@ -174,9 +175,10 @@ main(int argc, char * argv[])
         auto n = names.begin();
         auto d = descriptions.begin();
         auto e = enableflags.begin();
-        for (auto o = overrides.begin(); o != overrides.end(); ++o)
+        for (auto & override : overrides)
         {
-          std::cout << "    Override " << *o << " with " << *n << std::endl
+          std::cout << "    Override " << override << " with " << *n
+                    << std::endl
                     << "      described as \"" << *d << "\"" << std::endl
                     << "      enabled " << *e << std::endl;
           ++n, ++d, ++e;

--- a/Examples/Segmentation/HoughTransform2DCirclesImageFilter.cxx
+++ b/Examples/Segmentation/HoughTransform2DCirclesImageFilter.cxx
@@ -214,12 +214,11 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
   // Software Guide : BeginCodeSnippet
 
-  for (auto itCircles = circles.begin(); itCircles != circles.end();
-       ++itCircles)
+  for (auto & circle : circles)
   {
     std::cout << "Center: ";
-    std::cout << (*itCircles)->GetCenterInObjectSpace() << std::endl;
-    std::cout << "Radius: " << (*itCircles)->GetRadiusInObjectSpace()[0]
+    std::cout << circle->GetCenterInObjectSpace() << std::endl;
+    std::cout << "Radius: " << circle->GetRadiusInObjectSpace()[0]
               << std::endl;
     // Software Guide : EndCodeSnippet
 
@@ -234,14 +233,14 @@ main(int argc, char * argv[])
          angle += itk::Math::pi / 60.0)
     {
       const HoughTransformFilterType::CircleType::PointType centerPoint =
-        (*itCircles)->GetCenterInObjectSpace();
+        circle->GetCenterInObjectSpace();
       using IndexValueType = ImageType::IndexType::IndexValueType;
       localIndex[0] = itk::Math::Round<IndexValueType>(
         centerPoint[0] +
-        (*itCircles)->GetRadiusInObjectSpace()[0] * std::cos(angle));
+        circle->GetRadiusInObjectSpace()[0] * std::cos(angle));
       localIndex[1] = itk::Math::Round<IndexValueType>(
         centerPoint[1] +
-        (*itCircles)->GetRadiusInObjectSpace()[0] * std::sin(angle));
+        circle->GetRadiusInObjectSpace()[0] * std::sin(angle));
       const OutputImageType::RegionType outputRegion =
         localOutputImage->GetLargestPossibleRegion();
 

--- a/Examples/Segmentation/HoughTransform2DLinesImageFilter.cxx
+++ b/Examples/Segmentation/HoughTransform2DLinesImageFilter.cxx
@@ -230,7 +230,7 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  for (auto itLines = lines.begin(); itLines != lines.end(); ++itLines)
+  for (auto & line : lines)
   {
     // Software Guide : EndCodeSnippet
 
@@ -246,7 +246,7 @@ main(int argc, char * argv[])
     using LinePointListType =
       HoughTransformFilterType::LineType::LinePointListType;
 
-    LinePointListType pointsList = (*itLines)->GetPoints();
+    LinePointListType pointsList = line->GetPoints();
     auto              itPoints = pointsList.begin();
 
     double u[2];

--- a/Examples/SpatialObjects/BlobSpatialObject.cxx
+++ b/Examples/SpatialObjects/BlobSpatialObject.cxx
@@ -143,12 +143,11 @@ main(int, char *[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  for (auto it = blob->GetPoints().begin(); it != blob->GetPoints().end();
-       ++it)
+  for (auto & currentPoint : blob->GetPoints())
   {
-    std::cout << "Position = " << (*it).GetPositionInWorldSpace()
+    std::cout << "Position = " << currentPoint.GetPositionInWorldSpace()
               << std::endl;
-    std::cout << "Color = " << (*it).GetColor() << std::endl;
+    std::cout << "Color = " << currentPoint.GetColor() << std::endl;
   }
   // Software Guide : EndCodeSnippet
 

--- a/Examples/SpatialObjects/DTITubeSpatialObject.cxx
+++ b/Examples/SpatialObjects/DTITubeSpatialObject.cxx
@@ -148,37 +148,41 @@ main(int, char *[])
   // Software Guide : BeginCodeSnippet
   {
     unsigned int i = 0;
-    for (auto it = dtiTube->GetPoints().begin();
-         it != dtiTube->GetPoints().end();
-         ++it)
+    for (auto & currentPoint : dtiTube->GetPoints())
     {
       std::cout << std::endl;
       std::cout << "Point #" << i << std::endl;
-      std::cout << "Position: " << (*it).GetPositionInObjectSpace()
+      std::cout << "Position: " << currentPoint.GetPositionInObjectSpace()
                 << std::endl;
-      std::cout << "Radius: " << (*it).GetRadiusInObjectSpace() << std::endl;
+      std::cout << "Radius: " << currentPoint.GetRadiusInObjectSpace()
+                << std::endl;
       std::cout << "FA: "
-                << (*it).GetField(itk::DTITubeSpatialObjectPointEnums::
-                                    DTITubeSpatialObjectPointField::FA)
+                << currentPoint.GetField(itk::DTITubeSpatialObjectPointEnums::
+                                           DTITubeSpatialObjectPointField::FA)
                 << std::endl;
       std::cout << "ADC: "
-                << (*it).GetField(itk::DTITubeSpatialObjectPointEnums::
-                                    DTITubeSpatialObjectPointField::ADC)
+                << currentPoint.GetField(
+                     itk::DTITubeSpatialObjectPointEnums::
+                       DTITubeSpatialObjectPointField::ADC)
                 << std::endl;
       std::cout << "GA: "
-                << (*it).GetField(itk::DTITubeSpatialObjectPointEnums::
-                                    DTITubeSpatialObjectPointField::GA)
+                << currentPoint.GetField(itk::DTITubeSpatialObjectPointEnums::
+                                           DTITubeSpatialObjectPointField::GA)
                 << std::endl;
-      std::cout << "Lambda1: " << (*it).GetField("Lambda1") << std::endl;
-      std::cout << "Lambda2: " << (*it).GetField("Lambda2") << std::endl;
-      std::cout << "Lambda3: " << (*it).GetField("Lambda3") << std::endl;
-      std::cout << "TensorMatrix: " << (*it).GetTensorMatrix()[0] << " : ";
-      std::cout << (*it).GetTensorMatrix()[1] << " : ";
-      std::cout << (*it).GetTensorMatrix()[2] << " : ";
-      std::cout << (*it).GetTensorMatrix()[3] << " : ";
-      std::cout << (*it).GetTensorMatrix()[4] << " : ";
-      std::cout << (*it).GetTensorMatrix()[5] << std::endl;
-      std::cout << "Color = " << (*it).GetColor() << std::endl;
+      std::cout << "Lambda1: " << currentPoint.GetField("Lambda1")
+                << std::endl;
+      std::cout << "Lambda2: " << currentPoint.GetField("Lambda2")
+                << std::endl;
+      std::cout << "Lambda3: " << currentPoint.GetField("Lambda3")
+                << std::endl;
+      std::cout << "TensorMatrix: " << currentPoint.GetTensorMatrix()[0]
+                << " : ";
+      std::cout << currentPoint.GetTensorMatrix()[1] << " : ";
+      std::cout << currentPoint.GetTensorMatrix()[2] << " : ";
+      std::cout << currentPoint.GetTensorMatrix()[3] << " : ";
+      std::cout << currentPoint.GetTensorMatrix()[4] << " : ";
+      std::cout << currentPoint.GetTensorMatrix()[5] << std::endl;
+      std::cout << "Color = " << currentPoint.GetColor() << std::endl;
 
       ++i;
     }

--- a/Examples/SpatialObjects/LandmarkSpatialObject.cxx
+++ b/Examples/SpatialObjects/LandmarkSpatialObject.cxx
@@ -108,13 +108,11 @@ main(int, char *[])
   std::cout << "Number of Points in the landmark: " << nPoints << std::endl;
 
 
-  for (auto it = landmark->GetPoints().begin();
-       it != landmark->GetPoints().end();
-       ++it)
+  for (auto & currentPoint : landmark->GetPoints())
   {
-    std::cout << "Position: " << (*it).GetPositionInObjectSpace()
+    std::cout << "Position: " << currentPoint.GetPositionInObjectSpace()
               << std::endl;
-    std::cout << "Color: " << (*it).GetColor() << std::endl;
+    std::cout << "Color: " << currentPoint.GetColor() << std::endl;
   }
   // Software Guide : EndCodeSnippet
 

--- a/Examples/SpatialObjects/LineSpatialObject.cxx
+++ b/Examples/SpatialObjects/LineSpatialObject.cxx
@@ -138,15 +138,14 @@ main(int, char *[])
 
   // Software Guide : BeginCodeSnippet
 
-  for (auto it = Line->GetPoints().begin(); it != Line->GetPoints().end();
-       ++it)
+  for (auto & currentPoint : Line->GetPoints())
   {
-    std::cout << "Position = " << (*it).GetPositionInObjectSpace()
+    std::cout << "Position = " << currentPoint.GetPositionInObjectSpace()
               << std::endl;
-    std::cout << "Color = " << (*it).GetColor() << std::endl;
-    std::cout << "First normal = " << (*it).GetNormalInObjectSpace(0)
+    std::cout << "Color = " << currentPoint.GetColor() << std::endl;
+    std::cout << "First normal = " << currentPoint.GetNormalInObjectSpace(0)
               << std::endl;
-    std::cout << "Second normal = " << (*it).GetNormalInObjectSpace(1)
+    std::cout << "Second normal = " << currentPoint.GetNormalInObjectSpace(1)
               << std::endl;
     std::cout << std::endl;
   }

--- a/Examples/SpatialObjects/SpatialObjectHierarchy.cxx
+++ b/Examples/SpatialObjects/SpatialObjectHierarchy.cxx
@@ -105,10 +105,10 @@ main(int, char *[])
             << std::endl;
 
 
-  for (auto it = childrenList->begin(); it != childrenList->end(); ++it)
+  for (auto & currentChild : *childrenList)
   {
     std::cout << "Name of the child of the object 1: ";
-    std::cout << (*it)->GetProperty().GetName() << std::endl;
+    std::cout << currentChild->GetProperty().GetName() << std::endl;
   }
   // Software Guide : EndCodeSnippet
 

--- a/Examples/SpatialObjects/SurfaceSpatialObject.cxx
+++ b/Examples/SpatialObjects/SurfaceSpatialObject.cxx
@@ -127,14 +127,13 @@ main(int, char *[])
   // Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  for (auto it = surface->GetPoints().begin();
-       it != surface->GetPoints().end();
-       ++it)
+  for (auto & currentPoint : surface->GetPoints())
   {
-    std::cout << "Position = " << (*it).GetPositionInObjectSpace()
+    std::cout << "Position = " << currentPoint.GetPositionInObjectSpace()
               << std::endl;
-    std::cout << "Normal = " << (*it).GetNormalInObjectSpace() << std::endl;
-    std::cout << "Color = " << (*it).GetColor() << std::endl;
+    std::cout << "Normal = " << currentPoint.GetNormalInObjectSpace()
+              << std::endl;
+    std::cout << "Color = " << currentPoint.GetColor() << std::endl;
     std::cout << std::endl;
   }
   // Software Guide : EndCodeSnippet

--- a/Examples/SpatialObjects/TubeSpatialObject.cxx
+++ b/Examples/SpatialObjects/TubeSpatialObject.cxx
@@ -152,21 +152,21 @@ main(int, char *[])
   // Software Guide : BeginCodeSnippet
   {
     unsigned int i = 0;
-    for (auto it = tube->GetPoints().begin(); it != tube->GetPoints().end();
-         ++it)
+    for (auto & currentPoint : tube->GetPoints())
     {
       std::cout << std::endl;
       std::cout << "Point #" << i << std::endl;
-      std::cout << "Position: " << (*it).GetPositionInObjectSpace()
+      std::cout << "Position: " << currentPoint.GetPositionInObjectSpace()
                 << std::endl;
-      std::cout << "Radius: " << (*it).GetRadiusInObjectSpace() << std::endl;
-      std::cout << "Tangent: " << (*it).GetTangentInObjectSpace()
+      std::cout << "Radius: " << currentPoint.GetRadiusInObjectSpace()
                 << std::endl;
-      std::cout << "First Normal: " << (*it).GetNormal1InObjectSpace()
+      std::cout << "Tangent: " << currentPoint.GetTangentInObjectSpace()
                 << std::endl;
-      std::cout << "Second Normal: " << (*it).GetNormal2InObjectSpace()
+      std::cout << "First Normal: " << currentPoint.GetNormal1InObjectSpace()
                 << std::endl;
-      std::cout << "Color = " << (*it).GetColor() << std::endl;
+      std::cout << "Second Normal: " << currentPoint.GetNormal2InObjectSpace()
+                << std::endl;
+      std::cout << "Color = " << currentPoint.GetColor() << std::endl;
       ++i;
     }
   }

--- a/Examples/SpatialObjects/VesselTubeSpatialObject.cxx
+++ b/Examples/SpatialObjects/VesselTubeSpatialObject.cxx
@@ -137,22 +137,23 @@ main(int, char *[])
   // Software Guide : BeginCodeSnippet
   {
     unsigned int i = 0;
-    for (auto it = vesselTube->GetPoints().begin();
-         it != vesselTube->GetPoints().end();
-         ++it)
+    for (auto & currentPoint : vesselTube->GetPoints())
     {
       std::cout << std::endl;
       std::cout << "Point #" << i << std::endl;
-      std::cout << "Position: " << (*it).GetPositionInObjectSpace()
+      std::cout << "Position: " << currentPoint.GetPositionInObjectSpace()
                 << std::endl;
-      std::cout << "Radius: " << (*it).GetRadiusInObjectSpace() << std::endl;
-      std::cout << "Medialness: " << (*it).GetMedialness() << std::endl;
-      std::cout << "Ridgeness: " << (*it).GetRidgeness() << std::endl;
-      std::cout << "Branchness: " << (*it).GetBranchness() << std::endl;
-      std::cout << "Alpha1: " << (*it).GetAlpha1() << std::endl;
-      std::cout << "Alpha2: " << (*it).GetAlpha2() << std::endl;
-      std::cout << "Alpha3: " << (*it).GetAlpha3() << std::endl;
-      std::cout << "Color = " << (*it).GetColor() << std::endl;
+      std::cout << "Radius: " << currentPoint.GetRadiusInObjectSpace()
+                << std::endl;
+      std::cout << "Medialness: " << currentPoint.GetMedialness()
+                << std::endl;
+      std::cout << "Ridgeness: " << currentPoint.GetRidgeness() << std::endl;
+      std::cout << "Branchness: " << currentPoint.GetBranchness()
+                << std::endl;
+      std::cout << "Alpha1: " << currentPoint.GetAlpha1() << std::endl;
+      std::cout << "Alpha2: " << currentPoint.GetAlpha2() << std::endl;
+      std::cout << "Alpha3: " << currentPoint.GetAlpha3() << std::endl;
+      std::cout << "Color = " << currentPoint.GetColor() << std::endl;
       ++i;
     }
   }

--- a/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
@@ -117,9 +117,9 @@ itkWarpVectorImageFilterTest(int, char *[])
 
   ImagePattern<ImageDimension> pattern;
   pattern.m_Offset = 64;
-  for (unsigned int j = 0; j < ImageDimension; ++j)
+  for (double & currentCoefficient : pattern.m_Coeff)
   {
-    pattern.m_Coeff[j] = 1.0;
+    currentCoefficient = 1.0;
   }
 
   using Iterator = itk::ImageRegionIteratorWithIndex<ImageType>;

--- a/Modules/IO/PhilipsREC/src/itkPhilipsPAR.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsPAR.cxx
@@ -1939,9 +1939,9 @@ PhilipsPAR::GetRECRescaleValues(std::string                             parFile,
   // Must match size of image_types
   rescaleValues->resize(PAR_DEFAULT_IMAGE_TYPES_SIZE);
   const PhilipsPAR::PARRescaleValues zero(0.0);
-  for (unsigned int zeroIndex = 0; zeroIndex < rescaleValues->size(); ++zeroIndex)
+  for (auto & rescaleValue : *rescaleValues)
   {
-    (*rescaleValues)[zeroIndex] = zero; // Zero out everything
+    rescaleValue = zero; // Zero out everything
   }
 
   // Check version of PAR file.

--- a/Modules/Nonunit/Review/include/itkScalarRegionBasedLevelSetFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkScalarRegionBasedLevelSetFunction.hxx
@@ -83,17 +83,17 @@ ScalarRegionBasedLevelSetFunction<TInputImage, TFeatureImage, TSharedData>::Upda
   UpdateSharedDataInsideParameters(fId, featureVal, change);
 
   // Compute the product factor
-  ListPixelType   L = this->m_SharedData->m_NearestNeighborListImage->GetPixel(globalIndex);
+  ListPixelType   pixelList = this->m_SharedData->m_NearestNeighborListImage->GetPixel(globalIndex);
   InputIndexType  itInputIndex;
   ScalarValueType hVal;
 
   InputPixelType product = 1;
-  for (auto it = L.begin(); it != L.end(); ++it)
+  for (unsigned int & pixel : pixelList)
   {
-    if (*it != fId)
+    if (pixel != fId)
     {
-      itInputIndex = this->m_SharedData->m_LevelSetDataPointerVector[*it]->GetIndex(globalIndex);
-      hVal = this->m_SharedData->m_LevelSetDataPointerVector[*it]->m_HeavisideFunctionOfLevelSetImage->GetPixel(
+      itInputIndex = this->m_SharedData->m_LevelSetDataPointerVector[pixel]->GetIndex(globalIndex);
+      hVal = this->m_SharedData->m_LevelSetDataPointerVector[pixel]->m_HeavisideFunctionOfLevelSetImage->GetPixel(
         itInputIndex);
       product *= (1 - hVal);
     }
@@ -102,9 +102,9 @@ ScalarRegionBasedLevelSetFunction<TInputImage, TFeatureImage, TSharedData>::Upda
   ScalarValueType productChange = -(product * change);
 
   // update the background constant of all level-set functions
-  for (auto it = L.begin(); it != L.end(); ++it)
+  for (unsigned int & pixel : pixelList)
   {
-    UpdateSharedDataOutsideParameters(*it, featureVal, productChange);
+    UpdateSharedDataOutsideParameters(pixel, featureVal, productChange);
   }
 
   this->m_SharedData->m_LevelSetDataPointerVector[fId]->m_HeavisideFunctionOfLevelSetImage->SetPixel(inputIndex, newH);

--- a/Modules/Nonunit/Review/src/itkVoxBoCUBImageIO.cxx
+++ b/Modules/Nonunit/Review/src/itkVoxBoCUBImageIO.cxx
@@ -835,9 +835,9 @@ VoxBoCUBImageIO::InitializeOrientationMap()
   m_OrientationMap["AIL"] = SpatialOrientationEnums::ValidCoordinateOrientations::ITK_COORDINATE_ORIENTATION_AIL;
   m_OrientationMap["ASL"] = SpatialOrientationEnums::ValidCoordinateOrientations::ITK_COORDINATE_ORIENTATION_ASL;
 
-  for (auto it = m_OrientationMap.begin(); it != m_OrientationMap.end(); ++it)
+  for (auto & orientationElement : m_OrientationMap)
   {
-    m_InverseOrientationMap[it->second] = it->first;
+    m_InverseOrientationMap[orientationElement.second] = orientationElement.first;
   }
 }
 

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapper.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapper.cxx
@@ -169,9 +169,9 @@ LinearSystemWrapper::OptimizeMatrixStorage(unsigned int matrixIndex, unsigned in
   {
     ColumnArray currentRow;
     this->GetColumnsOfNonZeroMatrixElementsInRow(i, currentRow, tempMatrixIndex);
-    for (unsigned int j = 0; j < currentRow.size(); ++j)
+    for (unsigned int rowElement : currentRow)
     {
-      this->SetMatrixValue(i, currentRow[j], this->GetMatrixValue(i, currentRow[j], tempMatrixIndex), matrixIndex);
+      this->SetMatrixValue(i, rowElement, this->GetMatrixValue(i, rowElement, tempMatrixIndex), matrixIndex);
     }
   }
 
@@ -336,16 +336,16 @@ LinearSystemWrapper::FollowConnectionsCuthillMckeeOrdering(unsigned int  rowNumb
   while ((!nextRows.empty()) && (nextRowNumber < this->m_Order))
   {
     bufferArray.clear();
-    for (int i = 0; i < static_cast<int>(nextRows.size()); ++i)
+    for (unsigned int nextRow : nextRows)
     {
-      reverseMapping[nextRows[i]] = nextRowNumber++;
+      reverseMapping[nextRow] = nextRowNumber++;
     }
     /* renumber rows in nextRows */
-    for (int i = 0; i < static_cast<int>(nextRows.size()); ++i)
+    for (unsigned int nextRow : nextRows)
     {
       /* connections of current row */
       ColumnArray rowBuffer;
-      this->GetColumnsOfNonZeroMatrixElementsInRow(nextRows[i], rowBuffer, matrixIndex);
+      this->GetColumnsOfNonZeroMatrixElementsInRow(nextRow, rowBuffer, matrixIndex);
       /* remove previously renumbered rows */
       for (auto rowBufferIt = rowBuffer.begin(); rowBufferIt != rowBuffer.end(); ++rowBufferIt)
       {
@@ -373,12 +373,12 @@ LinearSystemWrapper::FollowConnectionsCuthillMckeeOrdering(unsigned int  rowNumb
       }
 
       /* add rows in rowBuffer to bufferArray (don't add repeats) */
-      for (int k = 0; k < static_cast<int>(rowBuffer.size()); ++k)
+      for (unsigned int k : rowBuffer)
       {
         unsigned int repeatFlag = 0;
-        for (int j = 0; j < static_cast<int>(bufferArray.size()); ++j)
+        for (unsigned int j : bufferArray)
         {
-          if (bufferArray[j] == rowBuffer[k])
+          if (j == k)
           {
             repeatFlag = 1;
           }
@@ -386,7 +386,7 @@ LinearSystemWrapper::FollowConnectionsCuthillMckeeOrdering(unsigned int  rowNumb
 
         if (!repeatFlag)
         {
-          bufferArray.push_back(rowBuffer[k]);
+          bufferArray.push_back(k);
         }
       }
     }

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
@@ -190,7 +190,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GibbsTotalEnergy(int i)
   int rowsize = m_ImageWidth;
 
   double       energy[2];
-  LabelType    f[8];
+  LabelType    eightNeighbors[8];
   unsigned int neighborcount = 0;
 
   offsetIndex3D[2] = i / frame;
@@ -201,34 +201,34 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::GibbsTotalEnergy(int i)
   {
     offsetIndex3D[0]--;
     offsetIndex3D[1]--;
-    f[neighborcount++] = static_cast<int>(m_LabelledImage->GetPixel(offsetIndex3D));
+    eightNeighbors[neighborcount++] = static_cast<int>(m_LabelledImage->GetPixel(offsetIndex3D));
 
     offsetIndex3D[0]++;
-    f[neighborcount++] = static_cast<int>(m_LabelledImage->GetPixel(offsetIndex3D));
+    eightNeighbors[neighborcount++] = static_cast<int>(m_LabelledImage->GetPixel(offsetIndex3D));
 
     offsetIndex3D[0]++;
-    f[neighborcount++] = static_cast<int>(m_LabelledImage->GetPixel(offsetIndex3D));
+    eightNeighbors[neighborcount++] = static_cast<int>(m_LabelledImage->GetPixel(offsetIndex3D));
 
     offsetIndex3D[1]++;
-    f[neighborcount++] = static_cast<int>(m_LabelledImage->GetPixel(offsetIndex3D));
+    eightNeighbors[neighborcount++] = static_cast<int>(m_LabelledImage->GetPixel(offsetIndex3D));
 
     offsetIndex3D[1]++;
-    f[neighborcount++] = static_cast<int>(m_LabelledImage->GetPixel(offsetIndex3D));
+    eightNeighbors[neighborcount++] = static_cast<int>(m_LabelledImage->GetPixel(offsetIndex3D));
 
     offsetIndex3D[0]--;
-    f[neighborcount++] = static_cast<int>(m_LabelledImage->GetPixel(offsetIndex3D));
+    eightNeighbors[neighborcount++] = static_cast<int>(m_LabelledImage->GetPixel(offsetIndex3D));
 
     offsetIndex3D[0]--;
-    f[neighborcount++] = static_cast<int>(m_LabelledImage->GetPixel(offsetIndex3D));
+    eightNeighbors[neighborcount++] = static_cast<int>(m_LabelledImage->GetPixel(offsetIndex3D));
 
     offsetIndex3D[1]--;
-    f[neighborcount] = static_cast<int>(m_LabelledImage->GetPixel(offsetIndex3D));
+    eightNeighbors[neighborcount] = static_cast<int>(m_LabelledImage->GetPixel(offsetIndex3D));
   }
 
   unsigned int k = 0;
-  for (unsigned int j = 0; j < 8; ++j)
+  for (unsigned int currentELement : eightNeighbors)
   {
-    if (f[j] == m_ObjectLabel)
+    if (currentELement == m_ObjectLabel)
     {
       ++k;
     }


### PR DESCRIPTION
C++11 Range based for loops can be used in

Used as a more readable equivalent to the traditional for loop operating over a range of values, such as all elements in a container, in the forward direction..

Range based loopes are more explicit for only computing the end location once for containers.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
