### PR TITLE
STYLE: Use C++17 nested namespace syntax

### DIFF
--- a/Modules/Core/Common/include/itkBinaryOperationConcept.h
+++ b/Modules/Core/Common/include/itkBinaryOperationConcept.h
@@ -22,11 +22,8 @@
 #include "itkPromoteType.h"
 
 /// \cond HIDE_META_PROGRAMMING
-namespace itk
-{
-namespace Details
-{
-namespace op
+
+namespace itk::Details::op
 {
 /** Root Binary Operation Concept.
  * All binary operations are expected to inherit from this type.
@@ -99,9 +96,7 @@ struct Div : BinaryOperationConcept
   }
 };
 
-} // namespace op
-} // namespace Details
-} // namespace itk
+} // namespace itk::Details::op
 /// \endcond
 
 #endif // itkBinaryOperationConcept_h

--- a/Modules/Core/Common/include/itkConceptChecking.h
+++ b/Modules/Core/Common/include/itkConceptChecking.h
@@ -107,11 +107,10 @@
 
 #endif
 
-namespace itk
-{
+
 /** All concept class definitions are contained in the "itk::Concept"
     namespace. */
-namespace Concept
+namespace itk::Concept
 {
 
 /**
@@ -978,7 +977,6 @@ struct IsFixedPoint
 
   itkConceptConstraintsMacro();
 };
-} // end namespace Concept
-} // end namespace itk
+} // namespace itk::Concept
 
 #endif

--- a/Modules/Core/Common/include/itkExtractImageFilterRegionCopier.h
+++ b/Modules/Core/Common/include/itkExtractImageFilterRegionCopier.h
@@ -30,9 +30,7 @@
 
 #include "itkImageToImageFilterDetail.h"
 
-namespace itk
-{
-namespace ImageToImageFilterDetail
+namespace itk::ImageToImageFilterDetail
 {
 /**
  *  Call the base class version: ImageToImageFilterDefaultCopyRegion
@@ -156,7 +154,6 @@ public:
     ImageRegionCopier<T1, T2>::operator()(destRegion, srcRegion);
   }
 };
-} // end namespace ImageToImageFilterDetail
-} // end namespace itk
+} // namespace itk::ImageToImageFilterDetail
 
 #endif

--- a/Modules/Core/Common/include/itkImageToImageFilterDetail.h
+++ b/Modules/Core/Common/include/itkImageToImageFilterDetail.h
@@ -31,8 +31,7 @@
 #include "itkImageRegion.h"
 #include "itkSmartPointer.h"
 
-namespace itk
-{
+
 /** ImageToImageFilterDetail namespace to house implementations of
  * functions that are dependent on dimension. These functions are
  * overloaded based on type unique for each different dimension.
@@ -41,7 +40,7 @@ namespace itk
  * ImageToImageFilter would force the instantiation of all versions of
  * these overloaded functions.
  */
-namespace ImageToImageFilterDetail
+namespace itk::ImageToImageFilterDetail
 {
 
 /** \struct  DispatchBase
@@ -448,7 +447,6 @@ public:
 };
 
 
-} // end of namespace ImageToImageFilterDetail
-} // end namespace itk
+} // namespace itk::ImageToImageFilterDetail
 
 #endif

--- a/Modules/Core/Common/include/itkIsNumber.h
+++ b/Modules/Core/Common/include/itkIsNumber.h
@@ -22,10 +22,9 @@
 #include "itkMetaProgrammingLibrary.h"
 #include "itkIntTypes.h"
 
-namespace itk
-{
+
 /// \cond HIDE_META_PROGRAMMING
-namespace mpl
+namespace itk::mpl
 {
 /** Tells whether a type is a number.
  * \c TrueType for all kinds of numbers from \c short to `long long`,
@@ -79,8 +78,7 @@ struct IsNumber<long double> : TrueType
 {};
 /// \endcond
 
-} // end namespace mpl
+} // namespace itk::mpl
 /// \endcond
-} // end namespace itk
 
 #endif // itkIsNumber_h

--- a/Modules/Core/Common/include/itkLexicographicCompare.h
+++ b/Modules/Core/Common/include/itkLexicographicCompare.h
@@ -23,15 +23,13 @@
 #include <iterator> // For std::begin, std::end, and reverse_iterator.
 #include "itkMacro.h"
 
-namespace itk
-{
 
 /*
 The  Functor was only used in one spot in the
 LevelSet class,  It does not exist in Slicer, BRAINSTools, Remote modules,
 ANTs, or any other project that I could find.
 */
-namespace Functor
+namespace itk::Functor
 {
 /** \class LexicographicCompare
  * \brief Order Index instances lexicographically.
@@ -84,7 +82,6 @@ public:
 };
 
 
-} // end namespace Functor
-} // end namespace itk
+} // namespace itk::Functor
 
 #endif

--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -41,10 +41,7 @@
  */
 #include <vxl_version.h>
 
-
-namespace itk
-{
-namespace Math
+namespace itk::Math
 {
 // These constants originate from VXL's vnl_math.h. They have been
 // moved here to improve visibility, and to ensure that the constants
@@ -881,7 +878,6 @@ abs(unsigned long long x)
 
 using std::abs;
 
-} // end namespace Math
-} // end namespace itk
+} // namespace itk::Math
 
 #endif // end of itkMath.h

--- a/Modules/Core/Common/include/itkMathDetail.h
+++ b/Modules/Core/Common/include/itkMathDetail.h
@@ -74,9 +74,8 @@
 
 namespace itk
 {
-namespace Math
-{
-namespace Detail
+
+namespace Math::Detail
 {
 // The functions defined in this namespace are not meant to be used directly
 // and thus do not adhere to the standard backward-compatibility
@@ -515,8 +514,8 @@ union FloatIEEE
   }
 };
 
-} // end namespace Detail
-} // end namespace Math
+} // namespace Math::Detail
+// end namespace Math
 
 // move to itkConceptChecking?
 namespace Concept

--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -31,9 +31,7 @@
 #include <ctime>
 #include <limits>
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class MersenneTwisterRandomVariateGenerator
  * \brief MersenneTwisterRandom random variate generator
@@ -425,7 +423,6 @@ MersenneTwisterRandomVariateGenerator::GetUniformVariate(const double a, const d
 //      - Fixed out-of-range number generation on 64-bit machines
 //      - Improved portability by substituting literal constants for long enum's
 //      - Changed license from GNU LGPL to BSD
-} // end namespace Statistics
-} // end namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Core/Common/include/itkMetaDataObjectDetail.h
+++ b/Modules/Core/Common/include/itkMetaDataObjectDetail.h
@@ -23,11 +23,9 @@
 #include <utility>
 #include <iosfwd>
 
-namespace itk
-{
 
 // Implementation details for MetaDataObject meta programming
-namespace MetaDataObjectDetail
+namespace itk::MetaDataObjectDetail
 {
 template <class T, class = void>
 struct has_Print : std::false_type
@@ -45,7 +43,7 @@ template <class T>
 struct has_output_operator<T, std::void_t<decltype(std::declval<std::ostream &>() << std::declval<T>())>>
   : std::true_type
 {};
-} // namespace MetaDataObjectDetail
-} // namespace itk
+} // namespace itk::MetaDataObjectDetail
+
 
 #endif

--- a/Modules/Core/Common/include/itkNeighborhoodAlgorithm.h
+++ b/Modules/Core/Common/include/itkNeighborhoodAlgorithm.h
@@ -23,9 +23,7 @@
 #include "itkNeighborhoodOperator.h"
 #include "itkNeighborhoodIterator.h"
 
-namespace itk
-{
-namespace NeighborhoodAlgorithm
+namespace itk::NeighborhoodAlgorithm
 {
 /** \class ImageBoundaryFacesCalculator
  *   \brief Splits an image into a main region and several "face" regions
@@ -138,8 +136,7 @@ struct CalculateOutputWrapOffsetModifiers
   OffsetType
   operator()(TImage *, TImage *) const;
 };
-} // end namespace NeighborhoodAlgorithm
-} // end namespace itk
+} // namespace itk::NeighborhoodAlgorithm
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkNeighborhoodAlgorithm.hxx"

--- a/Modules/Core/Common/include/itkNeighborhoodAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodAlgorithm.hxx
@@ -22,9 +22,7 @@
 #include "itkConstSliceIterator.h"
 #include <algorithm> // For min.
 
-namespace itk
-{
-namespace NeighborhoodAlgorithm
+namespace itk::NeighborhoodAlgorithm
 {
 template <typename TImage>
 auto
@@ -188,7 +186,6 @@ CalculateOutputWrapOffsetModifiers<TImage>::operator()(TImage * input, TImage * 
   }
   return ans;
 }
-} // end namespace NeighborhoodAlgorithm
-} // end namespace itk
+} // namespace itk::NeighborhoodAlgorithm
 
 #endif

--- a/Modules/Core/Common/include/itkPrintHelper.h
+++ b/Modules/Core/Common/include/itkPrintHelper.h
@@ -33,10 +33,7 @@
 #  undef ITK_CASTXML_GCC_VECTOR_WORKAROUND
 #endif
 
-namespace itk
-{
-
-namespace print_helper
+namespace itk::print_helper
 {
 
 template <typename T>
@@ -53,7 +50,6 @@ operator<<(std::ostream & os, const std::vector<T> & v)
   return os << v.back() << ')';
 }
 
-} // end namespace print_helper
-} // end namespace itk
+} // namespace itk::print_helper
 
 #endif // itkPrintHelper_h

--- a/Modules/Core/Common/include/itkPromoteType.h
+++ b/Modules/Core/Common/include/itkPromoteType.h
@@ -21,11 +21,10 @@
 #include "itkMacro.h"
 
 // Simplification of boost::common_type
-namespace itk
-{
+
 
 /// \cond HIDE_META_PROGRAMMING
-namespace mpl
+namespace itk::mpl
 {
 
 namespace Details
@@ -154,9 +153,8 @@ public:
    */
   using Type = typename Details::SizeToType<sizeof Check(a + b, 0), TA, TB>::Type;
 };
-} // end namespace mpl
+} // namespace itk::mpl
 
 /// \endcond
-} // end namespace itk
 
 #endif // itkPromoteType_h

--- a/Modules/Core/Common/include/itkRandomVariateGeneratorBase.h
+++ b/Modules/Core/Common/include/itkRandomVariateGeneratorBase.h
@@ -20,9 +20,7 @@
 
 #include "itkObject.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class RandomVariateGeneratorBase
  * \brief Defines common interfaces for random variate generators.
@@ -52,7 +50,6 @@ protected:
 
 private:
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Core/Common/src/itkMath.cxx
+++ b/Modules/Core/Common/src/itkMath.cxx
@@ -17,9 +17,7 @@
  *=========================================================================*/
 #include "itkMath.h"
 
-namespace itk
-{
-namespace Math
+namespace itk::Math
 {
 
 namespace
@@ -115,5 +113,4 @@ GreatestPrimeFactor(unsigned long long n)
   return GreatestPrimeFactor<unsigned long long>(n);
 }
 
-} // end namespace Math
-} // end namespace itk
+} // namespace itk::Math

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -21,9 +21,7 @@
 
 #include <atomic>
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 namespace
 {
@@ -286,5 +284,4 @@ MersenneTwisterRandomVariateGenerator::PrintSelf(std::ostream & os, Indent inden
   os << indent << "Values left before next reload: " << m_Left << std::endl;
 }
 
-} // end namespace Statistics
-} // end namespace itk
+} // namespace itk::Statistics

--- a/Modules/Core/Common/src/itkRandomVariateGeneratorBase.cxx
+++ b/Modules/Core/Common/src/itkRandomVariateGeneratorBase.cxx
@@ -17,11 +17,8 @@
  *=========================================================================*/
 #include "itkRandomVariateGeneratorBase.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 RandomVariateGeneratorBase::RandomVariateGeneratorBase() = default;
 RandomVariateGeneratorBase::~RandomVariateGeneratorBase() = default;
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics

--- a/Modules/Core/Common/test/itkLogTester.h
+++ b/Modules/Core/Common/test/itkLogTester.h
@@ -21,9 +21,7 @@
 #include "itkLoggerBase.h"
 #include "itkTestingMacros.h"
 
-namespace itk
-{
-namespace Testing
+namespace itk::Testing
 {
 
 class LogTester
@@ -64,7 +62,7 @@ public:
 private:
   itk::LoggerBase * m_Logger{ nullptr };
 };
-} // namespace Testing
-} // namespace itk
+} // namespace itk::Testing
+
 
 #endif // itkLogTester_h

--- a/Modules/Core/Common/test/itkPromoteType.cxx
+++ b/Modules/Core/Common/test/itkPromoteType.cxx
@@ -20,9 +20,7 @@
 #include <complex>
 #include <type_traits>
 
-namespace itk
-{
-namespace mpl
+namespace itk::mpl
 {
 
 template <typename TA, typename TB>
@@ -30,8 +28,8 @@ struct PromoteType<std::complex<TA>, std::complex<TB>>
 {
   using Type = std::complex<typename PromoteType<TA, TB>::Type>;
 };
-} // namespace mpl
-} // namespace itk
+} // namespace itk::mpl
+
 
 int
 itkPromoteType(int, char *[])

--- a/Modules/Core/ImageAdaptors/include/itkAddPixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkAddPixelAccessor.h
@@ -20,9 +20,7 @@
 
 #include "itkNumericTraits.h"
 
-namespace itk
-{
-namespace Accessor
+namespace itk::Accessor
 {
 /**
  * \class AddPixelAccessor
@@ -100,7 +98,6 @@ public:
 private:
   TPixel m_Value;
 };
-} // end namespace Accessor
-} // end namespace itk
+} // namespace itk::Accessor
 
 #endif

--- a/Modules/Core/ImageAdaptors/include/itkRGBToVectorPixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkRGBToVectorPixelAccessor.h
@@ -21,9 +21,7 @@
 #include "itkRGBPixel.h"
 #include "itkVector.h"
 
-namespace itk
-{
-namespace Accessor
+namespace itk::Accessor
 {
 /**
  * \class RGBToVectorPixelAccessor
@@ -73,7 +71,6 @@ public:
 
 private:
 };
-} // end namespace Accessor
-} // end namespace itk
+} // namespace itk::Accessor
 
 #endif

--- a/Modules/Core/ImageAdaptors/include/itkVectorToRGBPixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkVectorToRGBPixelAccessor.h
@@ -21,9 +21,7 @@
 #include "itkRGBPixel.h"
 #include "itkVector.h"
 
-namespace itk
-{
-namespace Accessor
+namespace itk::Accessor
 {
 /**
  * \class VectorToRGBPixelAccessor
@@ -74,7 +72,6 @@ public:
 
 private:
 };
-} // end namespace Accessor
-} // end namespace itk
+} // namespace itk::Accessor
 
 #endif

--- a/Modules/Core/TestKernel/include/itkGTest.h
+++ b/Modules/Core/TestKernel/include/itkGTest.h
@@ -23,8 +23,6 @@
 #include "itkGTestPredicate.h"
 #include "itkGTestTypedefsAndConstructors.h"
 
-namespace itk
-{
 
 /** \namespace itk::GTest
  * \brief The GTest namespace contains GTest extensions for ITK, and
@@ -32,9 +30,8 @@ namespace itk
  * results and values.
  *
  */
-namespace GTest
-{} // end namespace GTest
 
-} // end namespace itk
+
+// end namespace itk
 
 #endif // itkGTest_h

--- a/Modules/Core/TestKernel/include/itkGTestPredicate.h
+++ b/Modules/Core/TestKernel/include/itkGTestPredicate.h
@@ -34,17 +34,11 @@
   EXPECT_PRED_FORMAT3(itk::GTest::Predicate::VectorDoubleRMSPredFormat, val1, val2, rmsError)
 
 
-namespace itk
-{
-
-namespace GTest
-{
-
 /** \namespace itk::GTest::Predicate
  *  \brief The Predicate namespace contains functions used to
  *  implement custom GTest Predicate-Formatters.
  */
-namespace Predicate
+namespace itk::GTest::Predicate
 {
 
 /** Implements GTest Predicate Formatter for ITK_EXPECT_VECTOR_NEAR
@@ -89,8 +83,7 @@ VectorDoubleRMSPredFormat(const char * expr1,
                                        << rmsErrorExpr << " evaluates to " << rmsError << '.';
 }
 
-} // end namespace Predicate
-} // end namespace GTest
-} // end namespace itk
+} // namespace itk::GTest::Predicate
+// end namespace GTest
 
 #endif // itkGTestPredicate_h

--- a/Modules/Core/TestKernel/include/itkGTestTypedefsAndConstructors.h
+++ b/Modules/Core/TestKernel/include/itkGTestTypedefsAndConstructors.h
@@ -24,14 +24,7 @@
 
 #include "itkImageBase.h"
 
-
-namespace itk
-{
-
-namespace GTest
-{
-
-namespace TypedefsAndConstructors
+namespace itk::GTest::TypedefsAndConstructors
 {
 
 /** \namespace itk::GTest::TypedefsAndConstructors::Dimension2
@@ -77,9 +70,8 @@ using RegionType = ImageBaseType::RegionType;
 
 } // end namespace Dimension3
 
-} // end namespace TypedefsAndConstructors
-} // end namespace GTest
-} // end namespace itk
+} // namespace itk::GTest::TypedefsAndConstructors
+// end namespace GTest
 
 
 #endif // itkGTestTypedefsAndConstructors_h

--- a/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.h
@@ -23,9 +23,7 @@
 #include "itkImageToImageFilter.h"
 #include <mutex>
 
-namespace itk
-{
-namespace Testing
+namespace itk::Testing
 {
 /**
  * \class ComparisonImageFilter
@@ -144,8 +142,7 @@ private:
 
   std::mutex m_Mutex;
 };
-} // end namespace Testing
-} // end namespace itk
+} // namespace itk::Testing
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkTestingComparisonImageFilter.hxx"

--- a/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.hxx
@@ -26,9 +26,7 @@
 
 #include <cmath> // For abs.
 
-namespace itk
-{
-namespace Testing
+namespace itk::Testing
 {
 //----------------------------------------------------------------------------
 template <typename TInputImage, typename TOutputImage>
@@ -236,7 +234,6 @@ ComparisonImageFilter<TInputImage, TOutputImage>::VerifyInputInformation() const
 }
 
 
-} // end namespace Testing
-} // end namespace itk
+} // namespace itk::Testing
 
 #endif

--- a/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.h
@@ -22,9 +22,7 @@
 #include "itkImageSource.h"
 #include "itkExtractImageFilterRegionCopier.h"
 
-namespace itk
-{
-namespace Testing
+namespace itk::Testing
 {
 /** \class ExtractSliceImageFilterEnums
  * \brief Contains all enum classes used by the ExtractSliceImageFilterEnums class.
@@ -305,8 +303,7 @@ private:
     TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOUNKOWN
   };
 };
-} // end namespace Testing
-} // end namespace itk
+} // namespace itk::Testing
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkTestingExtractSliceImageFilter.hxx"

--- a/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
@@ -22,9 +22,7 @@
 #include "itkObjectFactory.h"
 #include "itkTotalProgressReporter.h"
 
-namespace itk
-{
-namespace Testing
+namespace itk::Testing
 {
 
 template <typename TInputImage, typename TOutputImage>
@@ -287,7 +285,6 @@ ExtractSliceImageFilter<TInputImage, TOutputImage>::GetInput() const
   return itkDynamicCastInDebugMode<const TInputImage *>(this->GetPrimaryInput());
 }
 
-} // end namespace Testing
-} // end namespace itk
+} // namespace itk::Testing
 
 #endif

--- a/Modules/Core/TestKernel/include/itkTestingHashImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkTestingHashImageFilter.h
@@ -22,9 +22,7 @@
 #include "itkSimpleDataObjectDecorator.h"
 #include "itkInPlaceImageFilter.h"
 
-namespace itk
-{
-namespace Testing
+namespace itk::Testing
 {
 /** \class HashImageFilterEnums
  * \brief Enum classes for HashImageFilter
@@ -156,8 +154,7 @@ private:
   HashFunctionEnum m_HashFunction{ HashFunctionEnum::MD5 };
 };
 
-} // end namespace Testing
-} // end namespace itk
+} // namespace itk::Testing
 
 
 #include "itkTestingHashImageFilter.hxx"

--- a/Modules/Core/TestKernel/include/itkTestingHashImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingHashImageFilter.hxx
@@ -22,9 +22,7 @@
 
 #include "itksys/MD5.h"
 
-namespace itk
-{
-namespace Testing
+namespace itk::Testing
 {
 
 template <typename TImageType>
@@ -140,7 +138,6 @@ HashImageFilter<TImageType>::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "HashFunction: " << m_HashFunction << std::endl;
 }
 
-} // end namespace Testing
-} // end namespace itk
+} // namespace itk::Testing
 
 #endif // itkTestingHashImageFilter_hxx

--- a/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.h
@@ -20,9 +20,7 @@
 
 #include "itkUnaryFunctorImageFilter.h"
 
-namespace itk
-{
-namespace Testing
+namespace itk::Testing
 {
 
 /**
@@ -124,8 +122,7 @@ private:
   OutputPixelType m_OutputMinimum{};
   OutputPixelType m_OutputMaximum{};
 };
-} // end namespace Testing
-} // end namespace itk
+} // namespace itk::Testing
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkTestingStretchIntensityImageFilter.hxx"

--- a/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.hxx
@@ -34,9 +34,7 @@
 #include "itkMath.h"
 #include "itkTotalProgressReporter.h"
 
-namespace itk
-{
-namespace Testing
+namespace itk::Testing
 {
 
 template <typename TInputImage, typename TOutputImage>
@@ -163,7 +161,6 @@ StretchIntensityImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream &
   os << indent << "Output Maximum: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_OutputMaximum)
      << std::endl;
 }
-} // end namespace Testing
-} // end namespace itk
+} // namespace itk::Testing
 
 #endif

--- a/Modules/Core/TestKernel/src/itkTestingExtractSliceImageFilter.cxx
+++ b/Modules/Core/TestKernel/src/itkTestingExtractSliceImageFilter.cxx
@@ -17,9 +17,7 @@
  *=========================================================================*/
 #include "itkTestingExtractSliceImageFilter.h"
 
-namespace itk
-{
-namespace Testing
+namespace itk::Testing
 {
 /** Print enum values */
 std::ostream &
@@ -45,5 +43,4 @@ operator<<(std::ostream & out, const ExtractSliceImageFilterEnums::TestExtractSl
     }
   }();
 }
-} // end namespace Testing
-} // end namespace itk
+} // namespace itk::Testing

--- a/Modules/Core/TestKernel/src/itkTestingHashImageFilter.cxx
+++ b/Modules/Core/TestKernel/src/itkTestingHashImageFilter.cxx
@@ -28,9 +28,7 @@
 
 #include "itkTestingHashImageFilter.h"
 
-namespace itk
-{
-namespace Testing
+namespace itk::Testing
 {
 /** Print enum values */
 std::ostream &
@@ -46,5 +44,4 @@ operator<<(std::ostream & out, const HashImageFilterEnums::HashFunction value)
     }
   }();
 }
-} // namespace Testing
-} // namespace itk
+} // namespace itk::Testing

--- a/Modules/Core/Transform/include/itkv3Rigid3DTransform.h
+++ b/Modules/Core/Transform/include/itkv3Rigid3DTransform.h
@@ -22,9 +22,7 @@
 #include "itkRigid3DTransform.h"
 #include "itkVersor.h"
 
-namespace itk
-{
-namespace v3
+namespace itk::v3
 {
 /** \class Rigid3DTransform
  * \brief ITK3.x compatible Rigid3DTransform of a vector space (e.g. space coordinates)
@@ -130,8 +128,8 @@ public:
 protected:
   Rigid3DTransform() = default;
 }; // class Rigid3DTransform
-} // namespace v3
-} // namespace itk
+} // namespace itk::v3
+
 
 #if !defined(ITK_LEGACY_REMOVE)
 #  define itkv3 itk::v3

--- a/Modules/Core/Transform/test/itkTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformTest.cxx
@@ -21,9 +21,7 @@
 #include "itkTestingMacros.h"
 #include "itkTransform.h"
 
-namespace itk
-{
-namespace itkTransformTestHelpers
+namespace itk::itkTransformTestHelpers
 {
 
 template <typename TScalar, unsigned int VInputDimension, unsigned int VOutputDimension>
@@ -328,8 +326,8 @@ public:
 };
 
 
-} // namespace itkTransformTestHelpers
-} // namespace itk
+} // namespace itk::itkTransformTestHelpers
+
 
 int
 itkTransformTest(int, char *[])

--- a/Modules/Filtering/Colormap/include/itkAutumnColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkAutumnColormapFunction.h
@@ -20,9 +20,7 @@
 
 #include "itkColormapFunction.h"
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 /**
  * \class AutumnColormapFunction
@@ -64,8 +62,7 @@ protected:
   AutumnColormapFunction() = default;
   ~AutumnColormapFunction() override = default;
 };
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkAutumnColormapFunction.hxx"

--- a/Modules/Filtering/Colormap/include/itkAutumnColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkAutumnColormapFunction.hxx
@@ -18,10 +18,7 @@
 #ifndef itkAutumnColormapFunction_hxx
 #define itkAutumnColormapFunction_hxx
 
-
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 template <typename TScalar, typename TRGBPixel>
 auto
@@ -47,7 +44,6 @@ AutumnColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const 
 
   return pixel;
 }
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #endif

--- a/Modules/Filtering/Colormap/include/itkBlueColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkBlueColormapFunction.h
@@ -20,9 +20,7 @@
 
 #include "itkColormapFunction.h"
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 /**
  * \class BlueColormapFunction
@@ -64,8 +62,7 @@ protected:
   BlueColormapFunction() = default;
   ~BlueColormapFunction() override = default;
 };
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkBlueColormapFunction.hxx"

--- a/Modules/Filtering/Colormap/include/itkBlueColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkBlueColormapFunction.hxx
@@ -18,10 +18,7 @@
 #ifndef itkBlueColormapFunction_hxx
 #define itkBlueColormapFunction_hxx
 
-
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 template <typename TScalar, typename TRGBPixel>
 auto
@@ -40,7 +37,6 @@ BlueColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const ->
 
   return pixel;
 }
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #endif

--- a/Modules/Filtering/Colormap/include/itkColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkColormapFunction.h
@@ -23,9 +23,7 @@
 #include "itkNumericTraits.h"
 #include "itkRGBPixel.h"
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 /**
  * \class ColormapFunction
@@ -136,7 +134,6 @@ private:
   RGBComponentType m_MinimumRGBComponentValue{};
   RGBComponentType m_MaximumRGBComponentValue{};
 };
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #endif

--- a/Modules/Filtering/Colormap/include/itkCoolColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkCoolColormapFunction.h
@@ -20,9 +20,7 @@
 
 #include "itkColormapFunction.h"
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 /**
  * \class CoolColormapFunction
@@ -64,8 +62,7 @@ protected:
   CoolColormapFunction() = default;
   ~CoolColormapFunction() override = default;
 };
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkCoolColormapFunction.hxx"

--- a/Modules/Filtering/Colormap/include/itkCoolColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkCoolColormapFunction.hxx
@@ -18,10 +18,7 @@
 #ifndef itkCoolColormapFunction_hxx
 #define itkCoolColormapFunction_hxx
 
-
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 template <typename TScalar, typename TRGBPixel>
 auto
@@ -47,7 +44,6 @@ CoolColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const ->
 
   return pixel;
 }
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #endif

--- a/Modules/Filtering/Colormap/include/itkCopperColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkCopperColormapFunction.h
@@ -20,9 +20,7 @@
 
 #include "itkColormapFunction.h"
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 /**
  * \class CopperColormapFunction
@@ -64,8 +62,7 @@ protected:
   CopperColormapFunction() = default;
   ~CopperColormapFunction() override = default;
 };
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkCopperColormapFunction.hxx"

--- a/Modules/Filtering/Colormap/include/itkCopperColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkCopperColormapFunction.hxx
@@ -18,10 +18,7 @@
 #ifndef itkCopperColormapFunction_hxx
 #define itkCopperColormapFunction_hxx
 
-
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 template <typename TScalar, typename TRGBPixel>
 auto
@@ -49,7 +46,6 @@ CopperColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const 
 
   return pixel;
 }
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #endif

--- a/Modules/Filtering/Colormap/include/itkCustomColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkCustomColormapFunction.h
@@ -22,9 +22,7 @@
 
 #include <vector>
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 /**
  * \class CustomColormapFunction
@@ -113,8 +111,7 @@ private:
   ChannelType m_GreenChannel{};
   ChannelType m_BlueChannel{};
 };
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkCustomColormapFunction.hxx"

--- a/Modules/Filtering/Colormap/include/itkCustomColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkCustomColormapFunction.hxx
@@ -18,10 +18,7 @@
 #ifndef itkCustomColormapFunction_hxx
 #define itkCustomColormapFunction_hxx
 
-
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 template <typename TScalar, typename TRGBPixel>
 auto
@@ -69,7 +66,6 @@ CustomColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const 
 
   return pixel;
 }
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #endif

--- a/Modules/Filtering/Colormap/include/itkGreenColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkGreenColormapFunction.h
@@ -20,9 +20,7 @@
 
 #include "itkColormapFunction.h"
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 /**
  * \class GreenColormapFunction
@@ -64,8 +62,7 @@ protected:
   GreenColormapFunction() = default;
   ~GreenColormapFunction() override = default;
 };
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkGreenColormapFunction.hxx"

--- a/Modules/Filtering/Colormap/include/itkGreenColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkGreenColormapFunction.hxx
@@ -18,10 +18,7 @@
 #ifndef itkGreenColormapFunction_hxx
 #define itkGreenColormapFunction_hxx
 
-
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 template <typename TScalar, typename TRGBPixel>
 auto
@@ -40,7 +37,6 @@ GreenColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -
 
   return pixel;
 }
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #endif

--- a/Modules/Filtering/Colormap/include/itkGreyColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkGreyColormapFunction.h
@@ -20,9 +20,7 @@
 
 #include "itkColormapFunction.h"
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 /**
  * \class GreyColormapFunction
@@ -65,8 +63,7 @@ protected:
   GreyColormapFunction() = default;
   ~GreyColormapFunction() override = default;
 };
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkGreyColormapFunction.hxx"

--- a/Modules/Filtering/Colormap/include/itkGreyColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkGreyColormapFunction.hxx
@@ -18,10 +18,7 @@
 #ifndef itkGreyColormapFunction_hxx
 #define itkGreyColormapFunction_hxx
 
-
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 template <typename TScalar, typename TRGBPixel>
 auto
@@ -40,7 +37,6 @@ GreyColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const ->
 
   return pixel;
 }
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #endif

--- a/Modules/Filtering/Colormap/include/itkHSVColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkHSVColormapFunction.h
@@ -20,9 +20,7 @@
 
 #include "itkColormapFunction.h"
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 /**
  * \class HSVColormapFunction
@@ -65,8 +63,7 @@ protected:
   HSVColormapFunction() = default;
   ~HSVColormapFunction() override = default;
 };
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkHSVColormapFunction.hxx"

--- a/Modules/Filtering/Colormap/include/itkHSVColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkHSVColormapFunction.hxx
@@ -18,10 +18,7 @@
 #ifndef itkHSVColormapFunction_hxx
 #define itkHSVColormapFunction_hxx
 
-
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 template <typename TScalar, typename TRGBPixel>
 auto
@@ -51,7 +48,6 @@ HSVColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> 
 
   return pixel;
 }
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #endif

--- a/Modules/Filtering/Colormap/include/itkHotColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkHotColormapFunction.h
@@ -20,9 +20,7 @@
 
 #include "itkColormapFunction.h"
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 /**
  * \class HotColormapFunction
@@ -65,8 +63,7 @@ protected:
   HotColormapFunction() = default;
   ~HotColormapFunction() override = default;
 };
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkHotColormapFunction.hxx"

--- a/Modules/Filtering/Colormap/include/itkHotColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkHotColormapFunction.hxx
@@ -18,10 +18,7 @@
 #ifndef itkHotColormapFunction_hxx
 #define itkHotColormapFunction_hxx
 
-
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 template <typename TScalar, typename TRGBPixel>
 auto
@@ -50,7 +47,6 @@ HotColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> 
 
   return pixel;
 }
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #endif

--- a/Modules/Filtering/Colormap/include/itkJetColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkJetColormapFunction.h
@@ -20,9 +20,7 @@
 
 #include "itkColormapFunction.h"
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 /**
  * \class JetColormapFunction
@@ -69,8 +67,7 @@ protected:
   JetColormapFunction() = default;
   ~JetColormapFunction() override = default;
 };
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkJetColormapFunction.hxx"

--- a/Modules/Filtering/Colormap/include/itkJetColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkJetColormapFunction.hxx
@@ -18,10 +18,7 @@
 #ifndef itkJetColormapFunction_hxx
 #define itkJetColormapFunction_hxx
 
-
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 template <typename TScalar, typename TRGBPixel>
 auto
@@ -50,7 +47,6 @@ JetColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> 
 
   return pixel;
 }
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #endif

--- a/Modules/Filtering/Colormap/include/itkOverUnderColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkOverUnderColormapFunction.h
@@ -20,9 +20,7 @@
 
 #include "itkColormapFunction.h"
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 /**
  * \class OverUnderColormapFunction
@@ -65,8 +63,7 @@ protected:
   OverUnderColormapFunction() = default;
   ~OverUnderColormapFunction() override = default;
 };
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkOverUnderColormapFunction.hxx"

--- a/Modules/Filtering/Colormap/include/itkOverUnderColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkOverUnderColormapFunction.hxx
@@ -18,10 +18,7 @@
 #ifndef itkOverUnderColormapFunction_hxx
 #define itkOverUnderColormapFunction_hxx
 
-
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 template <typename TScalar, typename TRGBPixel>
 auto
@@ -60,7 +57,6 @@ OverUnderColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) con
 
   return pixel;
 }
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #endif

--- a/Modules/Filtering/Colormap/include/itkRedColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkRedColormapFunction.h
@@ -20,9 +20,7 @@
 
 #include "itkColormapFunction.h"
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 /**
  * \class RedColormapFunction
@@ -65,8 +63,7 @@ protected:
   RedColormapFunction() = default;
   ~RedColormapFunction() override = default;
 };
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkRedColormapFunction.hxx"

--- a/Modules/Filtering/Colormap/include/itkRedColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkRedColormapFunction.hxx
@@ -18,10 +18,7 @@
 #ifndef itkRedColormapFunction_hxx
 #define itkRedColormapFunction_hxx
 
-
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 template <typename TScalar, typename TRGBPixel>
 auto
@@ -40,7 +37,6 @@ RedColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const -> 
 
   return pixel;
 }
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #endif

--- a/Modules/Filtering/Colormap/include/itkSpringColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkSpringColormapFunction.h
@@ -20,9 +20,7 @@
 
 #include "itkColormapFunction.h"
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 /**
  * \class SpringColormapFunction
@@ -65,8 +63,7 @@ protected:
   SpringColormapFunction() = default;
   ~SpringColormapFunction() override = default;
 };
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkSpringColormapFunction.hxx"

--- a/Modules/Filtering/Colormap/include/itkSpringColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkSpringColormapFunction.hxx
@@ -18,10 +18,7 @@
 #ifndef itkSpringColormapFunction_hxx
 #define itkSpringColormapFunction_hxx
 
-
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 template <typename TScalar, typename TRGBPixel>
 auto
@@ -47,7 +44,6 @@ SpringColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const 
 
   return pixel;
 }
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #endif

--- a/Modules/Filtering/Colormap/include/itkSummerColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkSummerColormapFunction.h
@@ -20,9 +20,7 @@
 
 #include "itkColormapFunction.h"
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 /**
  * \class SummerColormapFunction
@@ -65,8 +63,7 @@ protected:
   SummerColormapFunction() = default;
   ~SummerColormapFunction() override = default;
 };
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkSummerColormapFunction.hxx"

--- a/Modules/Filtering/Colormap/include/itkSummerColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkSummerColormapFunction.hxx
@@ -18,10 +18,7 @@
 #ifndef itkSummerColormapFunction_hxx
 #define itkSummerColormapFunction_hxx
 
-
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 template <typename TScalar, typename TRGBPixel>
 auto
@@ -47,7 +44,6 @@ SummerColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const 
 
   return pixel;
 }
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #endif

--- a/Modules/Filtering/Colormap/include/itkWinterColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkWinterColormapFunction.h
@@ -20,9 +20,7 @@
 
 #include "itkColormapFunction.h"
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 /**
  * \class WinterColormapFunction
@@ -65,8 +63,7 @@ protected:
   WinterColormapFunction() = default;
   ~WinterColormapFunction() override = default;
 };
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkWinterColormapFunction.hxx"

--- a/Modules/Filtering/Colormap/include/itkWinterColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkWinterColormapFunction.hxx
@@ -18,10 +18,7 @@
 #ifndef itkWinterColormapFunction_hxx
 #define itkWinterColormapFunction_hxx
 
-
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 template <typename TScalar, typename TRGBPixel>
 auto
@@ -47,7 +44,6 @@ WinterColormapFunction<TScalar, TRGBPixel>::operator()(const TScalar & v) const 
 
   return pixel;
 }
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #endif

--- a/Modules/Filtering/Colormap/test/itkCustomColormapFunctionTest.cxx
+++ b/Modules/Filtering/Colormap/test/itkCustomColormapFunctionTest.cxx
@@ -21,10 +21,7 @@
 #include "itkImageFileReader.h"
 #include "itkTestingMacros.h"
 
-
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 
 /**
@@ -99,8 +96,7 @@ public:
 protected:
 };
 
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 
 int

--- a/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.h
@@ -22,9 +22,8 @@
 #include "itkSubtractImageFilter.h"
 
 // Simple functor to invert an image for Outside Danielsson distance map
-namespace itk
-{
-namespace Functor
+
+namespace itk::Functor
 {
 template <typename InputPixelType>
 class ITK_TEMPLATE_EXPORT InvertIntensityFunctor{ public: InputPixelType operator()(InputPixelType input)
@@ -35,8 +34,7 @@ return NumericTraits<InputPixelType>::OneValue();
 } // namespace itk
 }
 ;
-} // namespace Functor
-} // namespace itk
+} // namespace itk::Functor
 
 namespace itk
 {

--- a/Modules/Filtering/FFT/include/itkFFTWCommonExtended.h
+++ b/Modules/Filtering/FFT/include/itkFFTWCommonExtended.h
@@ -29,10 +29,7 @@
 
 #include <mutex>
 
-namespace itk
-{
-
-namespace fftw
+namespace itk::fftw
 {
 /**
  * \class Interface
@@ -361,6 +358,6 @@ public:
 };
 
 #endif
-} // namespace fftw
-} // namespace itk
+} // namespace itk::fftw
+
 #endif

--- a/Modules/Filtering/ImageFusion/include/itkLabelOverlayFunctor.h
+++ b/Modules/Filtering/ImageFusion/include/itkLabelOverlayFunctor.h
@@ -21,9 +21,7 @@
 #include "itkLabelToRGBFunctor.h"
 #include "itkMath.h"
 
-namespace itk
-{
-namespace Functor
+namespace itk::Functor
 {
 /**
  * \class LabelOverlayFunctor
@@ -138,7 +136,6 @@ private:
 
   typename Functor::LabelToRGBFunctor<TLabel, TRGBPixel> m_RGBFunctor;
 };
-} // end namespace Functor
-} // end namespace itk
+} // namespace itk::Functor
 
 #endif

--- a/Modules/Filtering/ImageFusion/include/itkLabelToRGBFunctor.h
+++ b/Modules/Filtering/ImageFusion/include/itkLabelToRGBFunctor.h
@@ -21,9 +21,7 @@
 #include <vector>
 #include "itkNumericTraits.h"
 
-namespace itk
-{
-namespace Functor
+namespace itk::Functor
 {
 /**
  * \class LabelToRGBFunctor
@@ -162,7 +160,6 @@ public:
 
   TLabel m_BackgroundValue;
 };
-} // end namespace Functor
-} // end namespace itk
+} // namespace itk::Functor
 
 #endif

--- a/Modules/Filtering/ImageFusion/include/itkScalarToRGBPixelFunctor.h
+++ b/Modules/Filtering/ImageFusion/include/itkScalarToRGBPixelFunctor.h
@@ -20,9 +20,7 @@
 
 #include "itkRGBPixel.h"
 
-namespace itk
-{
-namespace Functor
+namespace itk::Functor
 {
 /**
  * \class ScalarToRGBPixelFunctor
@@ -95,8 +93,7 @@ private:
   bool         m_UseMSBForHashing;
   unsigned int m_ColorIndex[3];
 };
-} // end namespace Functor
-} // end namespace itk
+} // namespace itk::Functor
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkScalarToRGBPixelFunctor.hxx"

--- a/Modules/Filtering/ImageFusion/include/itkScalarToRGBPixelFunctor.hxx
+++ b/Modules/Filtering/ImageFusion/include/itkScalarToRGBPixelFunctor.hxx
@@ -20,9 +20,7 @@
 
 #include "itkByteSwapper.h"
 
-namespace itk
-{
-namespace Functor
+namespace itk::Functor
 {
 template <typename TScalar>
 ScalarToRGBPixelFunctor<TScalar>::ScalarToRGBPixelFunctor()
@@ -71,7 +69,6 @@ ScalarToRGBPixelFunctor<TScalar>::operator()(const TScalar & v) const -> RGBPixe
 
   return ans;
 }
-} // end namespace Functor
-} // end namespace itk
+} // namespace itk::Functor
 
 #endif

--- a/Modules/Filtering/ImageIntensity/include/itkArithmeticOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkArithmeticOpsFunctors.h
@@ -20,9 +20,7 @@
 
 #include "itkMath.h"
 
-namespace itk
-{
-namespace Functor
+namespace itk::Functor
 {
 
 /**
@@ -361,7 +359,7 @@ public:
     return (TOutput)(-A);
   }
 };
-} // namespace Functor
-} // namespace itk
+} // namespace itk::Functor
+
 
 #endif

--- a/Modules/Filtering/ImageIntensity/include/itkBitwiseOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkBitwiseOpsFunctors.h
@@ -20,9 +20,7 @@
 
 #include "itkMacro.h"
 
-namespace itk
-{
-namespace Functor
+namespace itk::Functor
 {
 
 /**
@@ -123,7 +121,6 @@ public:
     return static_cast<TOutput>(~A);
   }
 };
-} // namespace Functor
-} // namespace itk
+} // namespace itk::Functor
 
 #endif

--- a/Modules/Filtering/ImageIntensity/include/itkLogicOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkLogicOpsFunctors.h
@@ -21,10 +21,7 @@
 #include "itkNumericTraits.h"
 #include "itkMath.h"
 
-
-namespace itk
-{
-namespace Functor
+namespace itk::Functor
 {
 
 /**
@@ -370,7 +367,7 @@ public:
   }
 };
 
-} // namespace Functor
-} // namespace itk
+} // namespace itk::Functor
+
 
 #endif

--- a/Modules/Filtering/ImageIntensity/src/itkSymmetricEigenAnalysisImageFilter.cxx
+++ b/Modules/Filtering/ImageIntensity/src/itkSymmetricEigenAnalysisImageFilter.cxx
@@ -17,9 +17,7 @@
  *=========================================================================*/
 #include "itkSymmetricEigenAnalysisImageFilter.h"
 
-namespace itk
-{
-namespace Functor
+namespace itk::Functor
 {
 /** Define how to print enumerations */
 std::ostream &
@@ -39,5 +37,4 @@ operator<<(std::ostream & out, const EigenValueOrderEnum value)
     }
   }();
 }
-} // namespace Functor
-} // end namespace itk
+} // namespace itk::Functor

--- a/Modules/Filtering/ImageStatistics/include/itkAdaptiveEqualizationHistogram.h
+++ b/Modules/Filtering/ImageStatistics/include/itkAdaptiveEqualizationHistogram.h
@@ -22,9 +22,8 @@
 #include "itkStructHashFunction.h"
 #include "itkMath.h"
 #include <cmath>
-namespace itk
-{
-namespace Function
+
+namespace itk::Function
 {
 
 /* \class AdaptiveEqualizationHistogram
@@ -156,7 +155,6 @@ private:
   size_t  m_BoundaryCount{ 0 };
 };
 
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #endif // itkAdaptiveHistogramHistogram_h

--- a/Modules/Filtering/ImageStatistics/test/itkProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkProjectionImageFilterTest.cxx
@@ -24,11 +24,7 @@
 #include "itkProjectionImageFilter.h"
 #include "itkTestingMacros.h"
 
-namespace itk
-{
-namespace ProjectionImageFilterNamespace
-{
-namespace Function
+namespace itk::ProjectionImageFilterNamespace::Function
 {
 
 template <typename TInputPixel, typename TOutputPixel>
@@ -66,10 +62,9 @@ public:
 
   bool m_IsForeground{ false };
 };
-} // end namespace Function
+} // namespace itk::ProjectionImageFilterNamespace::Function
 
-} // end namespace ProjectionImageFilterNamespace
-} // end namespace itk
+// end namespace ProjectionImageFilterNamespace
 
 int
 itkProjectionImageFilterTest(int argc, char * argv[])

--- a/Modules/Filtering/LabelMap/include/itkLabelObjectAccessors.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelObjectAccessors.h
@@ -29,9 +29,7 @@
  *
  */
 
-namespace itk
-{
-namespace Functor
+namespace itk::Functor
 {
 template <typename TLabelObject>
 class LabelLabelObjectAccessor
@@ -102,7 +100,6 @@ public:
 private:
   AttributeAccessorType m_Accessor;
 };
-} // namespace Functor
-} // end namespace itk
+} // namespace itk::Functor
 
 #endif

--- a/Modules/Filtering/LabelMap/include/itkLabelObjectLineComparator.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelObjectLineComparator.h
@@ -18,9 +18,7 @@
 #ifndef itkLabelObjectLineComparator_h
 #define itkLabelObjectLineComparator_h
 
-namespace itk
-{
-namespace Functor
+namespace itk::Functor
 {
 
 /**
@@ -62,7 +60,6 @@ public:
   }
 };
 
-} // end namespace Functor
-} // end namespace itk
+} // namespace itk::Functor
 
 #endif

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelObjectAccessors.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelObjectAccessors.h
@@ -30,9 +30,7 @@
  *
  */
 
-namespace itk
-{
-namespace Functor
+namespace itk::Functor
 {
 template <typename TLabelObject>
 class NumberOfPixelsLabelObjectAccessor
@@ -272,7 +270,6 @@ public:
   }
 };
 
-} // namespace Functor
-} // end namespace itk
+} // namespace itk::Functor
 
 #endif

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelObjectAccessors.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelObjectAccessors.h
@@ -28,9 +28,7 @@
  *
  */
 
-namespace itk
-{
-namespace Functor
+namespace itk::Functor
 {
 template <typename TLabelObject>
 class MinimumLabelObjectAccessor
@@ -285,7 +283,6 @@ public:
     return labelObject->GetWeightedFlatness();
   }
 };
-} // namespace Functor
-} // end namespace itk
+} // namespace itk::Functor
 
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkMorphologyHistogram.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMorphologyHistogram.h
@@ -23,9 +23,7 @@
 #include "itkIntTypes.h"
 #include "itkNumericTraits.h"
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 template <typename TInputPixel, typename TCompare>
 class MorphologyHistogram
@@ -222,7 +220,6 @@ class MorphologyHistogram<bool, TCompare> : public VectorMorphologyHistogram<boo
 
 /// \endcond
 
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkRankHistogram.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRankHistogram.h
@@ -25,9 +25,7 @@
 #include <map>
 #include <vector>
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 
 /* \class RankHistogram
@@ -409,6 +407,5 @@ class ITK_TEMPLATE_EXPORT RankHistogram<bool> : public VectorRankHistogram<bool>
 
 /// \endcond
 
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 #endif

--- a/Modules/IO/ImageBase/include/itkInternationalizationIOHelpers.h
+++ b/Modules/IO/ImageBase/include/itkInternationalizationIOHelpers.h
@@ -62,9 +62,7 @@
 #  include "itkfdstream/fdstream.hxx"
 #endif
 
-namespace itk
-{
-namespace i18n
+namespace itk::i18n
 {
 // Check if the string is correctly encoded
 #if LOCAL_USE_WIN32_WOPEN
@@ -291,8 +289,8 @@ public:
 using I18nOfstream = std::ofstream;
 using I18nIfstream = std::ifstream;
 #endif
-} // namespace i18n
-} // namespace itk
+} // namespace itk::i18n
+
 
 #undef LOCAL_USE_WIN32_WOPEN
 #undef LOCAL_USE_FDSTREAM

--- a/Modules/IO/MeshBase/include/itkMeshIOTestHelper.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOTestHelper.h
@@ -367,9 +367,7 @@ TestBaseClassMethodsMeshIO(typename TMeshIO::Pointer meshIO)
   return EXIT_SUCCESS;
 }
 
-namespace itk
-{
-namespace MeshIOTestHelper
+namespace itk::MeshIOTestHelper
 {
 
 template <typename T>
@@ -419,7 +417,7 @@ AllocateBuffer(itk::IOComponentEnum componentType, itk::SizeValueType bufferSize
   return nullptr;
 }
 
-} // namespace MeshIOTestHelper
-} // namespace itk
+} // namespace itk::MeshIOTestHelper
+
 
 #endif

--- a/Modules/Numerics/FEM/include/itkFEMElement1DStress.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement1DStress.h
@@ -22,9 +22,7 @@
 #include "itkFEMElementBase.h"
 #include "itkFEMMaterialLinearElasticity.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element1DStress
@@ -127,8 +125,7 @@ protected:
   const MaterialLinearElasticity * m_mat{ nullptr };
 
 }; // class Element1DStress
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkFEMElement1DStress.hxx"

--- a/Modules/Numerics/FEM/include/itkFEMElement1DStress.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMElement1DStress.hxx
@@ -21,9 +21,7 @@
 
 #include "itkFEMMaterialLinearElasticity.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 template <typename TBaseClass>
 Element1DStress<TBaseClass>::Element1DStress()
@@ -97,7 +95,6 @@ Element1DStress<TBaseClass>::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Young Modulus: " << this->m_mat << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearLine.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearLine.h
@@ -22,9 +22,7 @@
 #include "itkFEMElementStd.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element2DC0LinearLine
@@ -116,7 +114,6 @@ protected:
                               // hierarchy. Sometimes it is,
                               // sometimes it is not.
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement2DC0LinearLine_h

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearLineStress.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearLineStress.h
@@ -23,9 +23,7 @@
 #include "itkFEMElement1DStress.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element2DC0LinearLineStress
@@ -75,7 +73,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 }; // class Element2DC0LinearLineStress
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement2DC0LinearLineStress_h

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateral.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateral.h
@@ -22,9 +22,7 @@
 #include "itkFEMElementStd.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element2DC0LinearQuadrilateral
@@ -123,7 +121,6 @@ protected:
 
 private:
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement2DC0LinearQuadrilateral_h

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateralMembrane.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateralMembrane.h
@@ -23,9 +23,7 @@
 #include "itkFEMElement2DMembrane.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element2DC0LinearQuadrilateralMembrane
@@ -95,7 +93,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 }; // class Element2DC0LinearQuadrilateralMembrane
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement2DC0LinearQuadrilateralMembrane_h

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateralStrain.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateralStrain.h
@@ -23,9 +23,7 @@
 #include "itkFEMElement2DStrain.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element2DC0LinearQuadrilateralStrain
@@ -94,7 +92,6 @@ protected:
 
 private:
 }; // class Element2DC0LinearQuadrilateralStrain
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement2DC0LinearQuadrilateralStrain_h

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateralStress.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateralStress.h
@@ -23,9 +23,7 @@
 #include "itkFEMElement2DStress.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element2DC0LinearQuadrilateralStress
@@ -95,7 +93,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 }; // class Element2DC0LinearQuadrilateralStress
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement2DC0LinearQuadrilateralStress_h

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangular.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangular.h
@@ -22,9 +22,7 @@
 #include "itkFEMElementStd.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element2DC0LinearTriangular
@@ -130,7 +128,6 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement2DC0LinearTriangular_h

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangularMembrane.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangularMembrane.h
@@ -23,9 +23,7 @@
 #include "itkFEMElement2DMembrane.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element2DC0LinearTriangularMembrane
@@ -95,7 +93,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 }; // class Element2DC0LinearTriangularMembrane
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement2DC0LinearTriangularMembrane_h

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangularStrain.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangularStrain.h
@@ -23,9 +23,7 @@
 #include "itkFEMElement2DStrain.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element2DC0LinearTriangularStrain
@@ -93,7 +91,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 }; // class Element2DC0LinearTriangularStrain
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement2DC0LinearTriangularStrain_h

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangularStress.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangularStress.h
@@ -23,9 +23,7 @@
 #include "itkFEMElement2DStress.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element2DC0LinearTriangularStress
@@ -77,7 +75,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 }; // class Element2DC0LinearTriangularStress
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement2DC0LinearTriangularStress_h

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0QuadraticTriangular.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0QuadraticTriangular.h
@@ -22,9 +22,7 @@
 #include "itkFEMElementStd.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element2DC0QuadraticTriangular
@@ -119,7 +117,6 @@ protected:
   void
   PopulateEdgeIds() override;
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement2DC0QuadraticTriangular_h

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0QuadraticTriangularStrain.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0QuadraticTriangularStrain.h
@@ -23,9 +23,7 @@
 #include "itkFEMElement2DStrain.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element2DC0QuadraticTriangularStrain
@@ -101,7 +99,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 }; // class Element2DC0QuadraticTriangularStrain
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement2DC0QuadraticTriangularStrain_h

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0QuadraticTriangularStress.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0QuadraticTriangularStress.h
@@ -23,9 +23,7 @@
 #include "itkFEMElement2DStress.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element2DC0QuadraticTriangularStress
@@ -98,7 +96,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 }; // class Element2DC0QuadraticTriangularStress
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement2DC0QuadraticTriangularStress_h

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC1Beam.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC1Beam.h
@@ -24,9 +24,7 @@
 #include "itkFEMMaterialLinearElasticity.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element2DC1Beam
@@ -170,7 +168,6 @@ private:
    */
   const MaterialLinearElasticity * m_mat{ nullptr };
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement2DC1Beam_h

--- a/Modules/Numerics/FEM/include/itkFEMElement2DMembrane.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DMembrane.h
@@ -22,9 +22,7 @@
 #include "itkFEMElementBase.h"
 #include "itkFEMMaterialLinearElasticity.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element2DMembrane
@@ -129,8 +127,7 @@ protected:
   const MaterialLinearElasticity * m_mat{ nullptr };
 
 }; // class Element2DMembrane
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkFEMElement2DMembrane.hxx"

--- a/Modules/Numerics/FEM/include/itkFEMElement2DMembrane.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DMembrane.hxx
@@ -19,10 +19,7 @@
 #ifndef itkFEMElement2DMembrane_hxx
 #define itkFEMElement2DMembrane_hxx
 
-
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 template <typename TBaseClass>
 Element2DMembrane<TBaseClass>::Element2DMembrane()
@@ -102,7 +99,6 @@ Element2DMembrane<TBaseClass>::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Materials: " << this->m_mat << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif

--- a/Modules/Numerics/FEM/include/itkFEMElement2DStrain.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DStrain.h
@@ -22,9 +22,7 @@
 #include "itkFEMElementBase.h"
 #include "itkFEMMaterialLinearElasticity.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element2DStrain
@@ -126,8 +124,7 @@ protected:
    */
   const MaterialLinearElasticity * m_mat{ nullptr };
 }; // class Element2DStrain
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkFEMElement2DStrain.hxx"

--- a/Modules/Numerics/FEM/include/itkFEMElement2DStrain.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DStrain.hxx
@@ -19,10 +19,7 @@
 #ifndef itkFEMElement2DStrain_hxx
 #define itkFEMElement2DStrain_hxx
 
-
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 template <typename TBaseClass>
 Element2DStrain<TBaseClass>::Element2DStrain()
@@ -102,7 +99,6 @@ Element2DStrain<TBaseClass>::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Materials: " << this->m_mat << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif

--- a/Modules/Numerics/FEM/include/itkFEMElement2DStress.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DStress.h
@@ -22,9 +22,7 @@
 #include "itkFEMElementBase.h"
 #include "itkFEMMaterialLinearElasticity.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element2DStress
@@ -131,8 +129,7 @@ protected:
   }
 };
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkFEMElement2DStress.hxx"

--- a/Modules/Numerics/FEM/include/itkFEMElement2DStress.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DStress.hxx
@@ -19,10 +19,7 @@
 #ifndef itkFEMElement2DStress_hxx
 #define itkFEMElement2DStress_hxx
 
-
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 template <typename TBaseClass>
 Element2DStress<TBaseClass>::Element2DStress()
@@ -101,7 +98,6 @@ Element2DStress<TBaseClass>::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Materials: " << this->m_mat << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearHexahedron.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearHexahedron.h
@@ -22,9 +22,7 @@
 #include "itkFEMElementStd.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element3DC0LinearHexahedron
@@ -121,7 +119,6 @@ protected:
   void
   PopulateEdgeIds() override;
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement3DC0LinearHexahedron_h

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearHexahedronMembrane.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearHexahedronMembrane.h
@@ -23,9 +23,7 @@
 #include "itkFEMElement3DMembrane.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element3DC0LinearHexahedronMembrane
@@ -80,7 +78,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 };
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement3DC0LinearHexahedronMembrane_h

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearHexahedronStrain.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearHexahedronStrain.h
@@ -23,9 +23,7 @@
 #include "itkFEMElement3DStrain.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element3DC0LinearHexahedronStrain
@@ -80,7 +78,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 }; // class Element3DC0LinearHexahedronStrain
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement3DC0LinearHexahedronStrain_h

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTetrahedron.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTetrahedron.h
@@ -24,9 +24,7 @@
 #include <vnl/vnl_matrix.h>
 #include <vnl/algo/vnl_matrix_inverse.h>
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element3DC0LinearTetrahedron
@@ -114,7 +112,6 @@ protected:
   void
   PopulateEdgeIds() override;
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement3DC0LinearTetrahedron_h

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTetrahedronMembrane.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTetrahedronMembrane.h
@@ -23,9 +23,7 @@
 #include "itkFEMElement3DMembrane.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element3DC0LinearTetrahedronMembrane
@@ -79,7 +77,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 }; // class Element3DC0LinearTetrahedronMembrane
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement3DC0LinearTetrahedronMembrane_h

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTetrahedronStrain.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTetrahedronStrain.h
@@ -23,9 +23,7 @@
 #include "itkFEMElement3DStrain.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element3DC0LinearTetrahedronStrain
@@ -77,7 +75,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 }; // class Element3DC0LinearTetrahedronStrain
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement3DC0LinearTetrahedronStrain_h

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTriangular.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTriangular.h
@@ -22,9 +22,7 @@
 #include "itkFEMElementStd.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element3DC0LinearTriangular
@@ -143,7 +141,6 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement3DC0LinearTriangular_h

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTriangularLaplaceBeltrami.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTriangularLaplaceBeltrami.h
@@ -24,9 +24,7 @@
 #include "itkFEMElement3DMembrane1DOF.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element3DC0LinearTriangularLaplaceBeltrami
@@ -87,7 +85,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 }; // class Element3DC0LinearTriangularLaplaceBeltrami
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement3DC0LinearTriangularLaplaceBeltrami_h

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTriangularMembrane.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTriangularMembrane.h
@@ -24,9 +24,7 @@
 #include "itkFEMElement3DMembrane1DOF.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element3DC0LinearTriangularMembrane
@@ -74,7 +72,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 }; // class Element3DC0LinearTriangularMembrane
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElement3DC0LinearTriangularMembrane_h

--- a/Modules/Numerics/FEM/include/itkFEMElement3DMembrane.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DMembrane.h
@@ -22,9 +22,7 @@
 #include "itkFEMElementBase.h"
 #include "itkFEMMaterialLinearElasticity.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element3DMembrane
@@ -126,8 +124,7 @@ protected:
   const MaterialLinearElasticity * m_mat{ nullptr };
 
 }; // class Element3DMembrane
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkFEMElement3DMembrane.hxx"

--- a/Modules/Numerics/FEM/include/itkFEMElement3DMembrane.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DMembrane.hxx
@@ -19,10 +19,7 @@
 #ifndef itkFEMElement3DMembrane_hxx
 #define itkFEMElement3DMembrane_hxx
 
-
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 template <typename TBaseClass>
 Element3DMembrane<TBaseClass>::Element3DMembrane()
@@ -129,7 +126,6 @@ Element3DMembrane<TBaseClass>::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Materials: " << this->m_mat << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif

--- a/Modules/Numerics/FEM/include/itkFEMElement3DMembrane1DOF.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DMembrane1DOF.h
@@ -22,9 +22,7 @@
 #include "itkFEMElementBase.h"
 #include "itkFEMMaterialLinearElasticity.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element3DMembrane1DOF
@@ -125,8 +123,7 @@ protected:
   MaterialLinearElasticity::ConstPointer m_Mat{};
 };
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkFEMElement3DMembrane1DOF.hxx"

--- a/Modules/Numerics/FEM/include/itkFEMElement3DMembrane1DOF.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DMembrane1DOF.hxx
@@ -19,10 +19,7 @@
 #ifndef itkFEMElement3DMembrane1DOF_hxx
 #define itkFEMElement3DMembrane1DOF_hxx
 
-
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 template <typename TBaseClass>
 Element3DMembrane1DOF<TBaseClass>::Element3DMembrane1DOF()
@@ -89,7 +86,6 @@ Element3DMembrane1DOF<TBaseClass>::PrintSelf(std::ostream & os, Indent indent) c
   os << indent << "Materials: " << this->m_Mat << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif

--- a/Modules/Numerics/FEM/include/itkFEMElement3DStrain.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DStrain.h
@@ -22,9 +22,7 @@
 #include "itkFEMElementBase.h"
 #include "itkFEMMaterialLinearElasticity.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element3DStrain
@@ -117,8 +115,7 @@ protected:
   const MaterialLinearElasticity * m_mat{ nullptr };
 
 }; // class Element3DStrain
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkFEMElement3DStrain.hxx"

--- a/Modules/Numerics/FEM/include/itkFEMElement3DStrain.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DStrain.hxx
@@ -19,10 +19,7 @@
 #ifndef itkFEMElement3DStrain_hxx
 #define itkFEMElement3DStrain_hxx
 
-
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 template <typename TBaseClass>
 Element3DStrain<TBaseClass>::Element3DStrain()
@@ -134,7 +131,6 @@ Element3DStrain<TBaseClass>::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Materials: " << this->m_mat << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif

--- a/Modules/Numerics/FEM/include/itkFEMElementBase.h
+++ b/Modules/Numerics/FEM/include/itkFEMElementBase.h
@@ -31,9 +31,7 @@
 #include <set>
 #include <vector>
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Element
@@ -723,7 +721,6 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 };
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMElementBase_h

--- a/Modules/Numerics/FEM/include/itkFEMElementStd.h
+++ b/Modules/Numerics/FEM/include/itkFEMElementStd.h
@@ -21,9 +21,7 @@
 
 #include "itkFEMElementBase.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class ElementStd
@@ -159,8 +157,7 @@ protected:
   const Node * m_node[NumberOfNodes]{};
 };
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkFEMElementStd.hxx"

--- a/Modules/Numerics/FEM/include/itkFEMElementStd.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMElementStd.hxx
@@ -19,10 +19,7 @@
 #ifndef itkFEMElementStd_hxx
 #define itkFEMElementStd_hxx
 
-
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 template <unsigned int VNumberOfNodes, unsigned int VNumberOfSpatialDimensions, typename TBaseClass>
 ElementStd<VNumberOfNodes, VNumberOfSpatialDimensions, TBaseClass>::ElementStd()
@@ -46,7 +43,6 @@ ElementStd<VNumberOfNodes, VNumberOfSpatialDimensions, TBaseClass>::PrintSelf(st
   }
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif

--- a/Modules/Numerics/FEM/include/itkFEMException.h
+++ b/Modules/Numerics/FEM/include/itkFEMException.h
@@ -23,9 +23,7 @@
 
 #include "itkMacro.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \file itkFEMException.h
@@ -166,7 +164,6 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(FEMExceptionSolution);
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMException_h

--- a/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.h
+++ b/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.h
@@ -36,9 +36,7 @@
 #include <itkMeanSquaresImageToImageMetric.h>
 #include <itkNormalizedCorrelationImageToImageMetric.h>
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class ImageMetricLoad
@@ -378,8 +376,7 @@ private:
 
 private:
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkFEMImageMetricLoad.hxx"

--- a/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.hxx
@@ -18,10 +18,7 @@
 #ifndef itkFEMImageMetricLoad_hxx
 #define itkFEMImageMetricLoad_hxx
 
-
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 // Overload the CreateAnother() method.
 template <typename TMoving, typename TFixed>
@@ -837,7 +834,6 @@ ImageMetricLoad<TMoving, TFixed>::PrintSelf(std::ostream & os, Indent indent) co
   os << indent << "Energy: " << this->m_Energy << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif

--- a/Modules/Numerics/FEM/include/itkFEMItpackSparseMatrix.h
+++ b/Modules/Numerics/FEM/include/itkFEMItpackSparseMatrix.h
@@ -22,9 +22,7 @@
 #include "itkFEMException.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class ItpackSparseMatrix
@@ -347,7 +345,6 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(FEMExceptionItpackSparseMatrixSbsij);
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMItpackSparseMatrix_h

--- a/Modules/Numerics/FEM/include/itkFEMLightObject.h
+++ b/Modules/Numerics/FEM/include/itkFEMLightObject.h
@@ -28,9 +28,7 @@
 #include "itkFEMException.h"
 #include <iostream>
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class FEMLightObject
@@ -99,7 +97,6 @@ protected:
    */
   int m_GlobalNumber{ -1 };
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMLightObject_h

--- a/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapper.h
+++ b/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapper.h
@@ -28,9 +28,7 @@
 #include <typeinfo>
 #include <string>
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class LinearSystemWrapper
@@ -585,7 +583,6 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(FEMExceptionLinearSystemBounds);
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMLinearSystemWrapper_h

--- a/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapperDenseVNL.h
+++ b/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapperDenseVNL.h
@@ -26,9 +26,7 @@
 #include "ITKFEMExport.h"
 #include <vector>
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class LinearSystemWrapperDenseVNL
@@ -181,7 +179,6 @@ private:
   /** vector of pointers to VNL vectors */
   std::vector<vnl_vector<Float> *> * m_Solutions{ nullptr };
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMLinearSystemWrapperDenseVNL_h

--- a/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapperItpack.h
+++ b/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapperItpack.h
@@ -46,9 +46,7 @@ extern "C"
                                           integer *);
 }
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class LinearSystemWrapperItpack
@@ -778,7 +776,6 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(FEMExceptionItpackSolver);
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMLinearSystemWrapperItpack_h

--- a/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapperVNL.h
+++ b/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapperVNL.h
@@ -25,9 +25,7 @@
 #include <vector>
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class LinearSystemWrapperVNL
@@ -175,7 +173,6 @@ private:
   /** vector of pointers to VNL vectors */
   std::vector<vnl_vector<Float> *> * m_Solutions{ nullptr };
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMLinearSystemWrapperVNL_h

--- a/Modules/Numerics/FEM/include/itkFEMLoadBC.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadBC.h
@@ -21,9 +21,7 @@
 #include "itkFEMLoadBase.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class LoadBC
@@ -92,7 +90,6 @@ protected:
    */
   vnl_vector<Element::Float> m_Value{};
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMLoadBC_h

--- a/Modules/Numerics/FEM/include/itkFEMLoadBCMFC.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadBCMFC.h
@@ -23,9 +23,7 @@
 #include "itkFEMLoadBase.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class LoadBCMFC
@@ -198,7 +196,6 @@ protected:
    */
   vnl_vector<Element::Float> m_RightHandSide{};
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMLoadBCMFC_h

--- a/Modules/Numerics/FEM/include/itkFEMLoadBase.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadBase.h
@@ -23,9 +23,7 @@
 #include "itkFEMPArray.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Load
@@ -101,7 +99,6 @@ protected:
    */
   Element::ConstPointer m_Element{};
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMLoadBase_h

--- a/Modules/Numerics/FEM/include/itkFEMLoadEdge.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadEdge.h
@@ -23,9 +23,7 @@
 #include "ITKFEMExport.h"
 #include "vnl/vnl_matrix.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class LoadEdge
@@ -115,7 +113,6 @@ protected:
    */
   vnl_matrix<Float> m_Force{};
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMLoadEdge_h

--- a/Modules/Numerics/FEM/include/itkFEMLoadElementBase.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadElementBase.h
@@ -22,9 +22,7 @@
 #include "itkFEMLoadBase.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class LoadElement
@@ -119,7 +117,6 @@ protected:
   ElementPointersVectorType m_Element{}; /** pointers to element objects on which the
                                   load acts */
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMLoadElementBase_h

--- a/Modules/Numerics/FEM/include/itkFEMLoadGrav.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadGrav.h
@@ -23,9 +23,7 @@
 #include "ITKFEMExport.h"
 #include "vnl/vnl_vector.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class LoadGrav
@@ -110,7 +108,6 @@ protected:
 
   vnl_vector<Float> m_GravityForce{};
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMLoadGrav_h

--- a/Modules/Numerics/FEM/include/itkFEMLoadLandmark.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadLandmark.h
@@ -24,9 +24,7 @@
 
 #include "vnl/vnl_vector.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class LoadLandmark
@@ -281,7 +279,7 @@ protected:
   Solution::ConstPointer m_Solution{ nullptr };
 };
 
-} // namespace fem
-} // namespace itk
+} // namespace itk::fem
+
 
 #endif // itkFEMLoadLandmark_h

--- a/Modules/Numerics/FEM/include/itkFEMLoadNode.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadNode.h
@@ -25,9 +25,7 @@
 #include "ITKFEMExport.h"
 #include "vnl/vnl_vector.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class LoadNode
@@ -110,7 +108,6 @@ protected:
    */
   vnl_vector<Float> m_Force{};
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMLoadNode_h

--- a/Modules/Numerics/FEM/include/itkFEMLoadNoisyLandmark.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadNoisyLandmark.h
@@ -22,9 +22,7 @@
 #include "itkFEMLoadLandmark.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class FEMLoadNoisyLandmark
@@ -239,7 +237,6 @@ private:
    */
   MatrixType m_LandmarkTensor{};
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMLoadNoisyLandmark_h

--- a/Modules/Numerics/FEM/include/itkFEMLoadPoint.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadPoint.h
@@ -23,9 +23,7 @@
 #include "ITKFEMExport.h"
 #include "vnl/vnl_vector.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class LoadPoint
@@ -92,7 +90,6 @@ protected:
   /** The actual load vector. */
   vnl_vector<Float> m_ForcePoint{};
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMLoadPoint_h

--- a/Modules/Numerics/FEM/include/itkFEMLoadTest.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadTest.h
@@ -21,9 +21,7 @@
 
 #include "itkFEMLoadElementBase.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class LoadTest
@@ -80,7 +78,6 @@ public:
 
 private:
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMLoadTest_h

--- a/Modules/Numerics/FEM/include/itkFEMMaterialBase.h
+++ b/Modules/Numerics/FEM/include/itkFEMMaterialBase.h
@@ -23,9 +23,7 @@
 #include "itkFEMPArray.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Material
@@ -64,7 +62,6 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMMaterialBase_h

--- a/Modules/Numerics/FEM/include/itkFEMMaterialLinearElasticity.h
+++ b/Modules/Numerics/FEM/include/itkFEMMaterialLinearElasticity.h
@@ -22,9 +22,7 @@
 #include "itkFEMMaterialBase.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class MaterialLinearElasticity
@@ -172,7 +170,6 @@ protected:
    */
   double m_DensityHeatCapacity{ 1.0 };
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMMaterialLinearElasticity_h

--- a/Modules/Numerics/FEM/include/itkFEMObject.h
+++ b/Modules/Numerics/FEM/include/itkFEMObject.h
@@ -35,9 +35,7 @@
 #include "itkVectorContainer.h"
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /** \class FEMObject
  * \brief Implements N-dimensional Finite element (FE) models including
@@ -390,8 +388,8 @@ private:
   AddNextLoadInternal(Load * l);
 };
 
-} // namespace fem
-} // namespace itk
+} // namespace itk::fem
+
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkFEMObject.hxx"

--- a/Modules/Numerics/FEM/include/itkFEMObject.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMObject.hxx
@@ -32,9 +32,7 @@
 
 #include <algorithm>
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 template <unsigned int VDimension>
@@ -645,7 +643,6 @@ FEMObject<VDimension>::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "MaterialContainer: " << this->m_MaterialContainer << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMObject_hxx

--- a/Modules/Numerics/FEM/include/itkFEMP.h
+++ b/Modules/Numerics/FEM/include/itkFEMP.h
@@ -22,9 +22,7 @@
 #include <utility>
 #include "itkMacro.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class FEMP
@@ -165,7 +163,6 @@ FEMP<T>::operator=(const FEMP<T> & rhs)
   return *this;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMP_h

--- a/Modules/Numerics/FEM/include/itkFEMPArray.h
+++ b/Modules/Numerics/FEM/include/itkFEMPArray.h
@@ -23,9 +23,7 @@
 #include "itkFEMException.h"
 #include <vector>
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class FEMPArray
@@ -180,7 +178,6 @@ FEMPArray<T>::Renumber()
   return j;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMPArray_h

--- a/Modules/Numerics/FEM/include/itkFEMRobustSolver.h
+++ b/Modules/Numerics/FEM/include/itkFEMRobustSolver.h
@@ -29,9 +29,7 @@
 
 #include <cmath>
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class FEMRobustSolver
@@ -373,8 +371,7 @@ public:
   }
 };
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkFEMRobustSolver.hxx"

--- a/Modules/Numerics/FEM/include/itkFEMRobustSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMRobustSolver.hxx
@@ -26,9 +26,7 @@
 #include "itkFEMLoadLandmark.h"
 #include "itkMath.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 template <unsigned int VDimension>
@@ -1052,7 +1050,6 @@ RobustSolver<VDimension>::InitializeInterpolationGrid()
   } // next element
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif

--- a/Modules/Numerics/FEM/include/itkFEMScatteredDataPointSetToImageFilter.h
+++ b/Modules/Numerics/FEM/include/itkFEMScatteredDataPointSetToImageFilter.h
@@ -38,9 +38,7 @@
 #include "itkQuadrilateralCell.h"
 #include "itkHexahedronCell.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /** \class FEMScatteredDataPointSetToImageFilter
  * \brief Scattered data approximation to interpolation
@@ -303,8 +301,7 @@ private:
   MaterialPointerType m_Material{};
 };
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkFEMScatteredDataPointSetToImageFilter.hxx"

--- a/Modules/Numerics/FEM/include/itkFEMScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMScatteredDataPointSetToImageFilter.hxx
@@ -30,9 +30,7 @@
 #include "vnl/vnl_vector.h"
 #include <limits>
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 template <typename TInputPointSet,
@@ -783,7 +781,6 @@ FEMScatteredDataPointSetToImageFilter<TInputPointSet,
   os << indent << "  Direction: " << this->m_Direction << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif

--- a/Modules/Numerics/FEM/include/itkFEMSolution.h
+++ b/Modules/Numerics/FEM/include/itkFEMSolution.h
@@ -21,9 +21,7 @@
 
 #include "ITKFEMExport.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Solution
@@ -72,7 +70,6 @@ public:
    */
   virtual ~Solution();
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMSolution_h

--- a/Modules/Numerics/FEM/include/itkFEMSolver.h
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.h
@@ -27,9 +27,7 @@
 
 #include "itkImage.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class Solver
@@ -440,8 +438,7 @@ private:
   InterpolationGridSpacingType   m_Spacing{};
   InterpolationGridDirectionType m_Direction{};
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkFEMSolver.hxx"

--- a/Modules/Numerics/FEM/include/itkFEMSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.hxx
@@ -31,9 +31,7 @@
 #include <algorithm>
 #include "itkMath.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 template <unsigned int VDimension>
@@ -919,7 +917,6 @@ Solver<VDimension>::GetElementAtPoint(const VectorType & pt) const
   }
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif

--- a/Modules/Numerics/FEM/include/itkFEMSolverCrankNicolson.h
+++ b/Modules/Numerics/FEM/include/itkFEMSolverCrankNicolson.h
@@ -33,9 +33,7 @@
 #include <vnl/vnl_sparse_matrix_linear_system.h>
 #include <cmath>
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class SolverCrankNicolson
@@ -276,8 +274,7 @@ protected:
   unsigned int m_SumMatrixIndex{};
   unsigned int m_DiffMatrixBySolutionTMinus1Index{};
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkFEMSolverCrankNicolson.hxx"

--- a/Modules/Numerics/FEM/include/itkFEMSolverCrankNicolson.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMSolverCrankNicolson.hxx
@@ -26,9 +26,7 @@
 #include "itkFEMLoadLandmark.h"
 #include "itkMath.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 #define TOTE
 
@@ -882,7 +880,6 @@ SolverCrankNicolson<VDimension>::PrintForce()
   }
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif

--- a/Modules/Numerics/FEM/include/itkFEMSolverHyperbolic.h
+++ b/Modules/Numerics/FEM/include/itkFEMSolverHyperbolic.h
@@ -21,9 +21,7 @@
 
 #include "itkFEMSolver.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 /**
@@ -155,8 +153,7 @@ protected:
   unsigned int m_NumberOfIterations{};
 };
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkFEMSolverHyperbolic.hxx"

--- a/Modules/Numerics/FEM/include/itkFEMSolverHyperbolic.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMSolverHyperbolic.hxx
@@ -21,9 +21,7 @@
 
 #include "itkMath.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 template <unsigned int VDimension>
@@ -238,7 +236,6 @@ SolverHyperbolic<VDimension>::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Gamma: " << this->m_Gamma << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif

--- a/Modules/Numerics/FEM/include/itkFEMUtility.h
+++ b/Modules/Numerics/FEM/include/itkFEMUtility.h
@@ -25,9 +25,7 @@
 
 class MetaObject;
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \file itkFEMUtility.h
@@ -275,7 +273,6 @@ public:
   Integrate(double (*f)(double), double a, double b, int n = 3);
 };
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif // itkFEMUtility_h

--- a/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.h
+++ b/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.h
@@ -23,9 +23,7 @@
 #include "itkFEMObject.h"
 #include "itkProcessObject.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * \class ImageToRectilinearFEMObjectFilter
@@ -171,8 +169,7 @@ private:
   MaterialPointerType      m_Material{};
   ElementBasePointerType   m_Element{};
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkImageToRectilinearFEMObjectFilter.hxx"

--- a/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.hxx
+++ b/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.hxx
@@ -21,9 +21,8 @@
 #include "itkFEMElement2DC0LinearQuadrilateral.h"
 #include "itkFEMElement3DC0LinearHexahedron.h"
 #include <cmath>
-namespace itk
-{
-namespace fem
+
+namespace itk::fem
 {
 
 template <typename TInputImage>
@@ -303,6 +302,5 @@ ImageToRectilinearFEMObjectFilter<TInputImage>::PrintSelf(std::ostream & os, Ind
   itkPrintSelfObjectMacro(Element);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 #endif // itkImageToRectilinearFEMObjectFilter_hxx

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearLine.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearLine.cxx
@@ -19,9 +19,7 @@
 #include "itkFEMElement2DC0LinearLine.h"
 #include <cmath> // For abs.
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 void
 Element2DC0LinearLine::GetIntegrationPointAndWeight(unsigned int i,
@@ -199,5 +197,4 @@ Element2DC0LinearLine::PrintSelf(std::ostream & os, Indent indent) const
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearLineStress.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearLineStress.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMElement2DC0LinearLineStress.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 // Overload the CreateAnother() method.
 itk::LightObject::Pointer
@@ -89,5 +87,4 @@ Element2DC0LinearLineStress::PrintSelf(std::ostream & os, Indent indent) const
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateral.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateral.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMElement2DC0LinearQuadrilateral.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 void
 Element2DC0LinearQuadrilateral::GetIntegrationPointAndWeight(unsigned int i,
@@ -240,5 +238,4 @@ Element2DC0LinearQuadrilateral::PrintSelf(std::ostream & os, Indent indent) cons
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralMembrane.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralMembrane.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMElement2DC0LinearQuadrilateralMembrane.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 // Overload the CreateAnother() method.
 itk::LightObject::Pointer
@@ -78,5 +76,4 @@ Element2DC0LinearQuadrilateralMembrane::PrintSelf(std::ostream & os, Indent inde
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralStrain.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralStrain.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMElement2DC0LinearQuadrilateralStrain.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 // Overload the CreateAnother() method.
 itk::LightObject::Pointer
@@ -80,5 +78,4 @@ Element2DC0LinearQuadrilateralStrain::PrintSelf(std::ostream & os, Indent indent
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralStress.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralStress.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMElement2DC0LinearQuadrilateralStress.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 // Overload the CreateAnother() method.
 itk::LightObject::Pointer
@@ -80,5 +78,4 @@ Element2DC0LinearQuadrilateralStress::PrintSelf(std::ostream & os, Indent indent
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangular.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangular.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMElement2DC0LinearTriangular.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 const double Element2DC0LinearTriangular::trigGaussRuleInfo[6][7][4] = {
   { // order=0, never used
@@ -237,5 +235,4 @@ Element2DC0LinearTriangular::PrintSelf(std::ostream & os, Indent indent) const
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularMembrane.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularMembrane.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMElement2DC0LinearTriangularMembrane.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 // Overload the CreateAnother() method.
 itk::LightObject::Pointer
@@ -75,5 +73,4 @@ Element2DC0LinearTriangularMembrane::PrintSelf(std::ostream & os, Indent indent)
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularStrain.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularStrain.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMElement2DC0LinearTriangularStrain.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 // Overload the CreateAnother() method.
 itk::LightObject::Pointer
@@ -75,5 +73,4 @@ Element2DC0LinearTriangularStrain::PrintSelf(std::ostream & os, Indent indent) c
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularStress.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularStress.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMElement2DC0LinearTriangularStress.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 // Overload the CreateAnother() method.
 itk::LightObject::Pointer
@@ -75,5 +73,4 @@ Element2DC0LinearTriangularStress::PrintSelf(std::ostream & os, Indent indent) c
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangular.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangular.cxx
@@ -20,9 +20,7 @@
 
 #include "itkFEMElement2DC0LinearTriangularMembrane.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 void
 Element2DC0QuadraticTriangular::GetIntegrationPointAndWeight(unsigned int i,
@@ -246,5 +244,4 @@ Element2DC0QuadraticTriangular::PrintSelf(std::ostream & os, Indent indent) cons
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangularStrain.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangularStrain.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMElement2DC0QuadraticTriangularStrain.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 // Overload the CreateAnother() method.
 itk::LightObject::Pointer
@@ -84,5 +82,4 @@ Element2DC0QuadraticTriangularStrain::PrintSelf(std::ostream & os, Indent indent
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangularStress.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangularStress.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMElement2DC0QuadraticTriangularStress.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 // Overload the CreateAnother() method.
 itk::LightObject::Pointer
@@ -84,5 +82,4 @@ Element2DC0QuadraticTriangularStress::PrintSelf(std::ostream & os, Indent indent
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC1Beam.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC1Beam.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMElement2DC1Beam.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 // Overload the CreateAnother() method.
 itk::LightObject::Pointer
@@ -348,5 +346,4 @@ Element2DC1Beam::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Materials: " << this->m_mat << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedron.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedron.cxx
@@ -19,9 +19,7 @@
 #include "itkFEMElement3DC0LinearHexahedron.h"
 #include "itkMath.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 void
 Element3DC0LinearHexahedron::GetIntegrationPointAndWeight(unsigned int i,
@@ -430,5 +428,4 @@ Element3DC0LinearHexahedron::PrintSelf(std::ostream & os, Indent indent) const
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedronMembrane.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedronMembrane.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMElement3DC0LinearHexahedronMembrane.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 // Overload the CreateAnother() method
 itk::LightObject::Pointer
@@ -78,5 +76,4 @@ Element3DC0LinearHexahedronMembrane::PrintSelf(std::ostream & os, Indent indent)
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedronStrain.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedronStrain.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMElement3DC0LinearHexahedronStrain.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 // Overload the CreateAnother() method
 itk::LightObject::Pointer
@@ -78,5 +76,4 @@ Element3DC0LinearHexahedronStrain::PrintSelf(std::ostream & os, Indent indent) c
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedron.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedron.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMElement3DC0LinearTetrahedron.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 void
@@ -202,5 +200,4 @@ Element3DC0LinearTetrahedron::PrintSelf(std::ostream & os, Indent indent) const
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedronMembrane.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedronMembrane.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMElement3DC0LinearTetrahedronMembrane.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 // Overload the CreateAnother() method
 itk::LightObject::Pointer
@@ -73,5 +71,4 @@ Element3DC0LinearTetrahedronMembrane::PrintSelf(std::ostream & os, Indent indent
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedronStrain.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedronStrain.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMElement3DC0LinearTetrahedronStrain.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 // Overload the CreateAnother() method
 itk::LightObject::Pointer
@@ -74,5 +72,4 @@ Element3DC0LinearTetrahedronStrain::PrintSelf(std::ostream & os, Indent indent) 
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangular.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangular.cxx
@@ -22,9 +22,7 @@
 
 #include "vnl/algo/vnl_qr.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 const Element3DC0LinearTriangular::Float Element3DC0LinearTriangular::trigGaussRuleInfo[6][7][4] = {
   { // order=0, never used
@@ -379,5 +377,4 @@ Element3DC0LinearTriangular::PrintSelf(std::ostream & os, Indent indent) const
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangularLaplaceBeltrami.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangularLaplaceBeltrami.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMElement3DC0LinearTriangularLaplaceBeltrami.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 // Overload the CreateAnother() method
 itk::LightObject::Pointer
@@ -300,5 +298,4 @@ Element3DC0LinearTriangularLaplaceBeltrami::PrintSelf(std::ostream & os, Indent 
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangularMembrane.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangularMembrane.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMElement3DC0LinearTriangularMembrane.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 // Overload the CreateAnother() method
@@ -166,5 +164,4 @@ Element3DC0LinearTriangularMembrane::PrintSelf(std::ostream & os, Indent indent)
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMElementBase.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElementBase.cxx
@@ -19,9 +19,7 @@
 #include "itkFEMElementBase.h"
 #include "vnl/algo/vnl_qr.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 // ////////////////////////////////////////////////////////////////////////
@@ -540,5 +538,4 @@ Element::GetEdgeIds() const
   return this->m_EdgeIds;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMException.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMException.cxx
@@ -20,9 +20,7 @@
 
 #include <iostream>
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 FEMException::FEMException(std::string file, unsigned int lineNumber, std::string location)
   : ExceptionObject(std::move(file), lineNumber, "Unhandled exception in FEM class!", std::move(location))
@@ -76,5 +74,4 @@ FEMExceptionSolution::FEMExceptionSolution(std::string  file,
 
 FEMExceptionSolution::~FEMExceptionSolution() noexcept = default;
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMItpackSparseMatrix.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMItpackSparseMatrix.cxx
@@ -18,9 +18,7 @@
 #include "itkFEMItpackSparseMatrix.h"
 #include "itpack.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 ItpackSparseMatrix::ItpackSparseMatrix()
   : m_MatrixFinalized(0)
@@ -488,5 +486,4 @@ FEMExceptionItpackSparseMatrixSbsij::FEMExceptionItpackSparseMatrixSbsij(std::st
 
 FEMExceptionItpackSparseMatrixSbsij::~FEMExceptionItpackSparseMatrixSbsij() noexcept = default;
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMLightObject.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLightObject.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMLightObject.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * Here we just read the global number from the stream.
@@ -46,5 +44,4 @@ FEMLightObject::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Global Number: " << this->m_GlobalNumber << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapper.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapper.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMLinearSystemWrapper.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 LinearSystemWrapper::~LinearSystemWrapper() = default;
@@ -436,5 +434,4 @@ FEMExceptionLinearSystemBounds::FEMExceptionLinearSystemBounds(std::string  file
 
 FEMExceptionLinearSystemBounds::~FEMExceptionLinearSystemBounds() noexcept = default;
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperDenseVNL.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperDenseVNL.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMLinearSystemWrapperDenseVNL.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 void
 LinearSystemWrapperDenseVNL::InitializeMatrix(unsigned int matrixIndex)
@@ -288,5 +286,4 @@ LinearSystemWrapperDenseVNL::~LinearSystemWrapperDenseVNL()
   delete m_Solutions;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperItpack.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperItpack.cxx
@@ -19,9 +19,7 @@
 #include "itpack.h"
 #include "itkFEMLinearSystemWrapperItpack.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /**
  * constructor
@@ -1073,5 +1071,4 @@ FEMExceptionItpackSolver::FEMExceptionItpackSolver(std::string  file,
   SetDescription(buf.str().c_str());
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperVNL.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperVNL.cxx
@@ -20,9 +20,7 @@
 #include <vnl/vnl_sparse_matrix_linear_system.h>
 #include <vnl/algo/vnl_lsqr.h>
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 void
 LinearSystemWrapperVNL::InitializeMatrix(unsigned int matrixIndex)
@@ -312,5 +310,4 @@ LinearSystemWrapperVNL::~LinearSystemWrapperVNL()
   delete m_Solutions;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMLoadBC.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadBC.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMLoadBC.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 // Overload the CreateAnother() method.
@@ -74,5 +72,4 @@ LoadBC::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Degree Of Freedom: " << this->m_DegreeOfFreedom << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMLoadBCMFC.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadBCMFC.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMLoadBCMFC.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 // Overload the CreateAnother() method.
 itk::LightObject::Pointer
@@ -147,5 +145,4 @@ LoadBCMFC::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Right HandSide: " << this->m_RightHandSide << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMLoadBase.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadBase.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMLoadBase.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 void
@@ -29,5 +27,4 @@ Load::PrintSelf(std::ostream & os, Indent indent) const
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMLoadEdge.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadEdge.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMLoadEdge.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 // Overload the CreateAnother() method.
@@ -117,5 +115,4 @@ LoadEdge::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Force: " << this->m_Force << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMLoadElementBase.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadElementBase.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMLoadElementBase.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 // Overload the CreateAnother() method
@@ -70,5 +68,4 @@ LoadElement::PrintSelf(std::ostream & os, Indent indent) const
   }
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMLoadGrav.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadGrav.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMLoadGrav.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 void
@@ -133,5 +131,4 @@ LoadGravConst::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Gravity Force: " << this->m_GravityForce << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMLoadLandmark.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadLandmark.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMLoadLandmark.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 // Overload the CreateAnother() method.
@@ -194,5 +192,4 @@ LoadLandmark::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Solution: " << this->m_Solution << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMLoadNode.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadNode.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMLoadNode.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 // Overload the CreateAnother() method.
@@ -73,5 +71,4 @@ LoadNode::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Force: " << this->m_Force << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMLoadNoisyLandmark.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadNoisyLandmark.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMLoadNoisyLandmark.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 void
@@ -40,5 +38,4 @@ LoadNoisyLandmark::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Landmark Tensor: " << this->m_LandmarkTensor << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMLoadPoint.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadPoint.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMLoadPoint.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 itk::LightObject::Pointer
@@ -99,5 +97,4 @@ LoadPoint::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Force Point: " << this->m_ForcePoint << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMMaterialBase.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMMaterialBase.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMMaterialBase.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 void
@@ -29,5 +27,4 @@ Material::PrintSelf(std::ostream & os, Indent indent) const
   Superclass::PrintSelf(os, indent);
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMMaterialLinearElasticity.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMMaterialLinearElasticity.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMMaterialLinearElasticity.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 // Overload the CreateAnother() method
 itk::LightObject::Pointer
@@ -131,5 +129,4 @@ MaterialLinearElasticity::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Density Heat Capacity: " << this->m_DensityHeatCapacity << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMSolution.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMSolution.cxx
@@ -17,12 +17,9 @@
  *=========================================================================*/
 #include "itkFEMSolution.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 Solution::~Solution() = default;
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/FEM/src/itkFEMUtility.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMUtility.cxx
@@ -18,9 +18,7 @@
 
 #include "itkFEMUtility.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 /**
@@ -74,5 +72,4 @@ GaussIntegrate::Integrate(double (*f)(double), double a, double b, int n)
   return scale * sum;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Numerics/Optimizersv4/include/itkConvergenceMonitoringFunction.h
+++ b/Modules/Numerics/Optimizersv4/include/itkConvergenceMonitoringFunction.h
@@ -25,9 +25,7 @@
 
 #include <deque>
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 /**
  * \class ConvergenceMonitoringFunction
@@ -117,7 +115,6 @@ protected:
 
   EnergyValueContainerType m_EnergyValues{};
 };
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #endif

--- a/Modules/Numerics/Optimizersv4/include/itkWindowConvergenceMonitoringFunction.h
+++ b/Modules/Numerics/Optimizersv4/include/itkWindowConvergenceMonitoringFunction.h
@@ -20,9 +20,7 @@
 
 #include "itkConvergenceMonitoringFunction.h"
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 /**
  * \class WindowConvergenceMonitoringFunction
@@ -91,8 +89,7 @@ private:
 
   RealType m_TotalEnergy{};
 };
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkWindowConvergenceMonitoringFunction.hxx"

--- a/Modules/Numerics/Optimizersv4/include/itkWindowConvergenceMonitoringFunction.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkWindowConvergenceMonitoringFunction.hxx
@@ -25,9 +25,7 @@
 #include "itkPointSet.h"
 #include "itkVector.h"
 
-namespace itk
-{
-namespace Function
+namespace itk::Function
 {
 
 template <typename TScalar>
@@ -136,7 +134,6 @@ WindowConvergenceMonitoringFunction<TScalar>::PrintSelf(std::ostream & os, Inden
   os << indent << "Window size: " << this->m_WindowSize << std::endl;
 }
 
-} // end namespace Function
-} // end namespace itk
+} // namespace itk::Function
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkChiSquareDistribution.h
+++ b/Modules/Numerics/Statistics/include/itkChiSquareDistribution.h
@@ -22,9 +22,7 @@
 #include "itkNumericTraits.h"
 #include "ITKStatisticsExport.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class ChiSquareDistribution
  * \brief ChiSquareDistribution class defines the interface for a
@@ -233,7 +231,6 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 }; // end of class
-} // end of namespace Statistics
-} // end namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkCovarianceSampleFilter.h
+++ b/Modules/Numerics/Statistics/include/itkCovarianceSampleFilter.h
@@ -23,9 +23,7 @@
 #include "itkVariableSizeMatrix.h"
 #include "itkSimpleDataObjectDecorator.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class CovarianceSampleFilter
@@ -139,8 +137,7 @@ protected:
   void
   GenerateData() override;
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkCovarianceSampleFilter.hxx"

--- a/Modules/Numerics/Statistics/include/itkCovarianceSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkCovarianceSampleFilter.hxx
@@ -20,9 +20,7 @@
 
 #include "itkMeanSampleFilter.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TSample>
 CovarianceSampleFilter<TSample>::CovarianceSampleFilter()
@@ -218,7 +216,6 @@ CovarianceSampleFilter<TSample>::GetMean() const -> const MeasurementVectorRealT
 {
   return this->GetMeanOutput()->Get();
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkDecisionRule.h
+++ b/Modules/Numerics/Statistics/include/itkDecisionRule.h
@@ -25,9 +25,7 @@
 #include "itkArray.h"
 #include "ITKStatisticsExport.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class DecisionRule
@@ -78,7 +76,6 @@ protected:
   DecisionRule();
   ~DecisionRule() override;
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkDenseFrequencyContainer2.h
+++ b/Modules/Numerics/Statistics/include/itkDenseFrequencyContainer2.h
@@ -23,9 +23,7 @@
 #include "itkMeasurementVectorTraits.h"
 #include "ITKStatisticsExport.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class DenseFrequencyContainer2
@@ -121,7 +119,6 @@ private:
   FrequencyContainerPointer  m_FrequencyContainer{};
   TotalAbsoluteFrequencyType m_TotalFrequency{};
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkDistanceMetric.h
+++ b/Modules/Numerics/Statistics/include/itkDistanceMetric.h
@@ -21,9 +21,7 @@
 #include "itkFunctionBase.h"
 #include "itkMeasurementVectorTraits.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class DistanceMetric
@@ -138,8 +136,7 @@ private:
   /** Number of components in the MeasurementVectorType */
   MeasurementVectorSizeType m_MeasurementVectorSize{};
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkDistanceMetric.hxx"

--- a/Modules/Numerics/Statistics/include/itkDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkDistanceMetric.hxx
@@ -18,10 +18,7 @@
 #ifndef itkDistanceMetric_hxx
 #define itkDistanceMetric_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TVector>
 DistanceMetric<TVector>::DistanceMetric()
@@ -69,7 +66,6 @@ DistanceMetric<TVector>::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Origin: " << this->GetOrigin() << std::endl;
   os << indent << "MeasurementVectorSize: " << this->GetMeasurementVectorSize() << std::endl;
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkDistanceToCentroidMembershipFunction.h
+++ b/Modules/Numerics/Statistics/include/itkDistanceToCentroidMembershipFunction.h
@@ -21,9 +21,7 @@
 #include "itkMembershipFunctionBase.h"
 #include "itkDistanceMetric.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class DistanceToCentroidMembershipFunction
  * \brief DistanceToCentroidMembershipFunction models class membership
@@ -112,8 +110,7 @@ protected:
 private:
   DistanceMetricPointer m_DistanceMetric{};
 };
-} // end of namespace Statistics
-} // end namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkDistanceToCentroidMembershipFunction.hxx"

--- a/Modules/Numerics/Statistics/include/itkDistanceToCentroidMembershipFunction.hxx
+++ b/Modules/Numerics/Statistics/include/itkDistanceToCentroidMembershipFunction.hxx
@@ -20,9 +20,7 @@
 
 #include "itkEuclideanDistanceMetric.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TVector>
 DistanceToCentroidMembershipFunction<TVector>::DistanceToCentroidMembershipFunction()
@@ -90,6 +88,5 @@ DistanceToCentroidMembershipFunction<TVector>::PrintSelf(std::ostream & os, Inde
 
   os << indent << "Distance Metric: " << m_DistanceMetric.GetPointer() << std::endl;
 }
-} // end namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 #endif

--- a/Modules/Numerics/Statistics/include/itkEuclideanDistanceMetric.h
+++ b/Modules/Numerics/Statistics/include/itkEuclideanDistanceMetric.h
@@ -20,9 +20,7 @@
 
 #include "itkDistanceMetric.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class EuclideanDistanceMetric
@@ -72,8 +70,7 @@ protected:
   EuclideanDistanceMetric() = default;
   ~EuclideanDistanceMetric() override = default;
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkEuclideanDistanceMetric.hxx"

--- a/Modules/Numerics/Statistics/include/itkEuclideanDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkEuclideanDistanceMetric.hxx
@@ -18,10 +18,7 @@
 #ifndef itkEuclideanDistanceMetric_hxx
 #define itkEuclideanDistanceMetric_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TVector>
 inline double
@@ -84,7 +81,6 @@ EuclideanDistanceMetric<TVector>::Evaluate(const ValueType & a, const ValueType 
 
   return itk::Math::abs(temp);
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkEuclideanSquareDistanceMetric.h
+++ b/Modules/Numerics/Statistics/include/itkEuclideanSquareDistanceMetric.h
@@ -20,9 +20,7 @@
 
 #include "itkDistanceMetric.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class EuclideanSquareDistanceMetric
@@ -64,8 +62,7 @@ protected:
   EuclideanSquareDistanceMetric() = default;
   ~EuclideanSquareDistanceMetric() override = default;
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkEuclideanSquareDistanceMetric.hxx"

--- a/Modules/Numerics/Statistics/include/itkEuclideanSquareDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkEuclideanSquareDistanceMetric.hxx
@@ -18,10 +18,7 @@
 #ifndef itkEuclideanSquareDistanceMetric_hxx
 #define itkEuclideanSquareDistanceMetric_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TVector>
 inline double
@@ -70,7 +67,6 @@ EuclideanSquareDistanceMetric<TVector>::Evaluate(const MeasurementVectorType & x
   }
   return distance;
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.h
+++ b/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.h
@@ -23,9 +23,7 @@
 #include "itkGaussianMembershipFunction.h"
 #include "itkSimpleDataObjectDecorator.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class ExpectationMaximizationMixtureModelEstimatorEnums
  * \brief Contains all enum classes used by ExpectationMaximizationMixtureModelEstimator class.
@@ -239,8 +237,7 @@ private:
   MembershipFunctionVectorObjectPointer  m_MembershipFunctionsObject{};
   MembershipFunctionsWeightsArrayPointer m_MembershipFunctionsWeightArrayObject{};
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkExpectationMaximizationMixtureModelEstimator.hxx"

--- a/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.hxx
+++ b/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.hxx
@@ -21,9 +21,7 @@
 #include "itkNumericTraits.h"
 #include "itkMath.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TSample>
 ExpectationMaximizationMixtureModelEstimator<TSample>::ExpectationMaximizationMixtureModelEstimator()
@@ -394,7 +392,6 @@ ExpectationMaximizationMixtureModelEstimator<TSample>::Update()
 {
   this->GenerateData();
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkGaussianDistribution.h
+++ b/Modules/Numerics/Statistics/include/itkGaussianDistribution.h
@@ -21,9 +21,7 @@
 #include "itkProbabilityDistribution.h"
 #include "ITKStatisticsExport.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class GaussianDistribution
  * \brief GaussianDistribution class defines the interface for a
@@ -268,7 +266,6 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 }; // end of class
-} // end of namespace Statistics
-} // end namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkGaussianMembershipFunction.h
+++ b/Modules/Numerics/Statistics/include/itkGaussianMembershipFunction.h
@@ -21,9 +21,7 @@
 #include "itkMatrix.h"
 #include "itkMembershipFunctionBase.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class GaussianMembershipFunction
@@ -141,8 +139,7 @@ private:
   /** Boolean to cache whether the covariance is singular or nearly singular */
   bool m_CovarianceNonsingular{ true };
 };
-} // end of namespace Statistics
-} // end namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkGaussianMembershipFunction.hxx"

--- a/Modules/Numerics/Statistics/include/itkGaussianMembershipFunction.hxx
+++ b/Modules/Numerics/Statistics/include/itkGaussianMembershipFunction.hxx
@@ -18,10 +18,7 @@
 #ifndef itkGaussianMembershipFunction_hxx
 #define itkGaussianMembershipFunction_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TMeasurementVector>
 GaussianMembershipFunction<TMeasurementVector>::GaussianMembershipFunction()
@@ -185,7 +182,6 @@ GaussianMembershipFunction<TVector>::InternalClone() const
 
   return loPtr;
 }
-} // end namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkGaussianMixtureModelComponent.h
+++ b/Modules/Numerics/Statistics/include/itkGaussianMixtureModelComponent.h
@@ -23,9 +23,7 @@
 #include "itkWeightedMeanSampleFilter.h"
 #include "itkWeightedCovarianceSampleFilter.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class GaussianMixtureModelComponent
@@ -117,8 +115,7 @@ private:
 
   typename CovarianceEstimatorType::Pointer m_CovarianceEstimator{};
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkGaussianMixtureModelComponent.hxx"

--- a/Modules/Numerics/Statistics/include/itkGaussianMixtureModelComponent.hxx
+++ b/Modules/Numerics/Statistics/include/itkGaussianMixtureModelComponent.hxx
@@ -22,9 +22,7 @@
 
 #include "itkMath.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TSample>
 GaussianMixtureModelComponent<TSample>::GaussianMixtureModelComponent()
@@ -282,7 +280,6 @@ GaussianMixtureModelComponent<TSample>::GenerateData()
 
   Superclass::SetParameters(parameters);
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.h
@@ -20,9 +20,7 @@
 
 #include "itkUniformRandomSpatialNeighborSubsampler.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class GaussianRandomSpatialNeighborSubsampler
@@ -120,8 +118,7 @@ protected:
   RealType m_Variance{};
 }; // end of class GaussianRandomSpatialNeighborSubsampler
 
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkGaussianRandomSpatialNeighborSubsampler.hxx"

--- a/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.hxx
@@ -18,9 +18,7 @@
 #ifndef itkGaussianRandomSpatialNeighborSubsampler_hxx
 #define itkGaussianRandomSpatialNeighborSubsampler_hxx
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 
 template <typename TSample, typename TRegion>
@@ -75,7 +73,6 @@ GaussianRandomSpatialNeighborSubsampler<TSample, TRegion>::PrintSelf(std::ostrea
   os << std::endl;
 }
 
-} // end namespace Statistics
-} // end namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkHistogram.h
+++ b/Modules/Numerics/Statistics/include/itkHistogram.h
@@ -25,9 +25,7 @@
 #include "itkDenseFrequencyContainer2.h"
 #include "itkSparseFrequencyContainer2.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 
 /**
@@ -517,8 +515,7 @@ private:
 
   bool m_ClipBinsAtEnds{ true };
 };
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkHistogram.hxx"

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -22,9 +22,7 @@
 #include "itkMath.h"
 #include "itkPrintHelper.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TMeasurement, typename TFrequencyContainer>
 Histogram<TMeasurement, TFrequencyContainer>::Histogram()
@@ -718,7 +716,6 @@ Histogram<TMeasurement, TFrequencyContainer>::Graft(const DataObject * thatObjec
   }
 }
 
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkHistogramToRunLengthFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToRunLengthFeaturesFilter.h
@@ -23,9 +23,7 @@
 #include "itkProcessObject.h"
 #include "itkSimpleDataObjectDecorator.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class HistogramToRunLengthFeaturesFilterEnums
  * \brief Contains all enum classes used by HistogramToRunLengthFeaturesFilter class.
@@ -237,8 +235,7 @@ private:
   unsigned long m_TotalNumberOfRuns{};
 };
 
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkHistogramToRunLengthFeaturesFilter.hxx"

--- a/Modules/Numerics/Statistics/include/itkHistogramToRunLengthFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogramToRunLengthFeaturesFilter.hxx
@@ -22,9 +22,7 @@
 #include "itkNumericTraits.h"
 #include "itkMath.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 
 // constructor
@@ -352,8 +350,7 @@ HistogramToRunLengthFeaturesFilter<THistogram>::PrintSelf(std::ostream & os, Ind
   Superclass::PrintSelf(os, indent);
 }
 
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.h
@@ -23,9 +23,7 @@
 #include "itkProcessObject.h"
 #include "itkSimpleDataObjectDecorator.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class HistogramToTextureFeaturesFilterEnums
  *\brief This class contains all enum classes used by HistogramToTextureFeaturesFilter class.
@@ -258,8 +256,7 @@ private:
 
   RelativeFrequencyContainerType m_RelativeFrequencyContainer{};
 };
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkHistogramToTextureFeaturesFilter.hxx"

--- a/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.hxx
@@ -23,9 +23,7 @@
 #include "itkMath.h"
 #include <memory> // For make_unique.
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 // constructor
 template <typename THistogram>
@@ -385,7 +383,6 @@ HistogramToTextureFeaturesFilter<THistogram>::PrintSelf(std::ostream & os, Inden
 {
   Superclass::PrintSelf(os, indent);
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkImageClassifierFilter.h
+++ b/Modules/Numerics/Statistics/include/itkImageClassifierFilter.h
@@ -25,9 +25,7 @@
 #include "itkImageToImageFilter.h"
 #include "itkSimpleDataObjectDecorator.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class ImageClassifierFilter
@@ -164,8 +162,7 @@ private:
   /** Decision Rule */
   DecisionRulePointer m_DecisionRule{};
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkImageClassifierFilter.hxx"

--- a/Modules/Numerics/Statistics/include/itkImageClassifierFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageClassifierFilter.hxx
@@ -20,9 +20,7 @@
 
 #include "itkImageRegionIterator.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TSample, typename TInputImage, typename TOutputImage>
 ImageClassifierFilter<TSample, TInputImage, TOutputImage>::ImageClassifierFilter()
@@ -174,7 +172,6 @@ ImageClassifierFilter<TSample, TInputImage, TOutputImage>::GenerateData()
     ++outItr;
   }
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.h
+++ b/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.h
@@ -25,9 +25,7 @@
 #include "itkSimpleDataObjectDecorator.h"
 #include "itkProgressReporter.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class ImageToHistogramFilter
@@ -189,8 +187,7 @@ private:
                      HistogramMeasurementVectorType & max,
                      HistogramSizeType &              size);
 };
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkImageToHistogramFilter.hxx"

--- a/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.hxx
@@ -20,9 +20,7 @@
 
 #include "itkImageRegionConstIterator.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TImage>
 ImageToHistogramFilter<TImage>::ImageToHistogramFilter()
@@ -381,7 +379,6 @@ ImageToHistogramFilter<TImage>::PrintSelf(std::ostream & os, Indent indent) cons
     os << indent << "HistogramSize: " << this->GetHistogramSize() << std::endl;
   }
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.h
@@ -28,9 +28,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkMeasurementVectorTraits.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class ImageToListSampleAdaptor
  *  \brief This class provides ListSample interface to ITK Image
@@ -308,8 +306,7 @@ private:
   mutable MeasurementVectorType m_MeasurementVectorInternal{};
 
 }; // end of class ImageToListSampleAdaptor
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkImageToListSampleAdaptor.hxx"

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.hxx
@@ -18,10 +18,7 @@
 #ifndef itkImageToListSampleAdaptor_hxx
 #define itkImageToListSampleAdaptor_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TImage>
 ImageToListSampleAdaptor<TImage>::ImageToListSampleAdaptor()
@@ -123,7 +120,6 @@ ImageToListSampleAdaptor<TImage>::GetTotalFrequency() const -> TotalAbsoluteFreq
 
   return this->Size();
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleFilter.h
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleFilter.h
@@ -23,9 +23,7 @@
 #include "itkProcessObject.h"
 #include "itkDataObjectDecorator.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class ImageToListSampleFilter
@@ -147,8 +145,7 @@ protected:
 private:
   MaskPixelType m_MaskValue{};
 }; // end of class ImageToListSampleFilter
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkImageToListSampleFilter.hxx"

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleFilter.hxx
@@ -20,9 +20,7 @@
 
 #include "itkImageRegionConstIterator.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TImage, typename TMaskImage>
 ImageToListSampleFilter<TImage, TMaskImage>::ImageToListSampleFilter()
@@ -186,7 +184,6 @@ ImageToListSampleFilter<TImage, TMaskImage>::GetOutput() const -> const ListSamp
 
   return output;
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkJointDomainImageToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkJointDomainImageToListSampleAdaptor.h
@@ -24,9 +24,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkListSample.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class ImageJointDomainTraits
  *  \brief This class provides the type definition for the measurement
@@ -343,8 +341,7 @@ private:
 
   PixelContainerConstPointer m_PixelContainer{};
 }; // end of class JointDomainImageToListSampleAdaptor
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkJointDomainImageToListSampleAdaptor.hxx"

--- a/Modules/Numerics/Statistics/include/itkJointDomainImageToListSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkJointDomainImageToListSampleAdaptor.hxx
@@ -18,10 +18,7 @@
 #ifndef itkJointDomainImageToListSampleAdaptor_hxx
 #define itkJointDomainImageToListSampleAdaptor_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TImage>
 JointDomainImageToListSampleAdaptor<TImage>::JointDomainImageToListSampleAdaptor()
@@ -148,7 +145,6 @@ JointDomainImageToListSampleAdaptor<TImage>::GetMeasurementVector(InstanceIdenti
 
   return m_TempVector;
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkKdTree.h
+++ b/Modules/Numerics/Statistics/include/itkKdTree.h
@@ -30,9 +30,7 @@
 
 #include "itkEuclideanDistanceMetric.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class KdTreeNode
@@ -838,8 +836,7 @@ private:
   /** Measurement vector size */
   MeasurementVectorSizeType m_MeasurementVectorSize{};
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkKdTree.hxx"

--- a/Modules/Numerics/Statistics/include/itkKdTree.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTree.hxx
@@ -18,10 +18,7 @@
 #ifndef itkKdTree_hxx
 #define itkKdTree_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TSample>
 KdTreeNonterminalNode<TSample>::KdTreeNonterminalNode(unsigned int    partitionDimension,
@@ -617,7 +614,6 @@ KdTree<TSample>::PlotTree(KdTreeNodeType * node, std::ostream & os) const
     this->PlotTree(right, os);
   }
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.h
+++ b/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.h
@@ -27,9 +27,7 @@
 #include "itkSimpleDataObjectDecorator.h"
 #include "itkNumericTraitsArrayPixel.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class KdTreeBasedKmeansEstimator
@@ -341,8 +339,7 @@ private:
   MeasurementVectorSizeType             m_MeasurementVectorSize{ 0 };
   MembershipFunctionVectorObjectPointer m_MembershipFunctionsObject{};
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkKdTreeBasedKmeansEstimator.hxx"

--- a/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
@@ -20,9 +20,7 @@
 
 #include "itkStatisticsAlgorithm.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TKdTree>
 KdTreeBasedKmeansEstimator<TKdTree>::KdTreeBasedKmeansEstimator()
@@ -431,7 +429,6 @@ KdTreeBasedKmeansEstimator<TKdTree>::PrintPoint(ParameterType & point)
   }
   std::cout << ']';
 }
-} // end of namespace Statistics
-} // end namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkKdTreeGenerator.h
+++ b/Modules/Numerics/Statistics/include/itkKdTreeGenerator.h
@@ -23,9 +23,7 @@
 #include "itkKdTree.h"
 #include "itkStatisticsAlgorithm.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class KdTreeGenerator
@@ -206,8 +204,7 @@ private:
   /** Length of a measurement vector */
   MeasurementVectorSizeType m_MeasurementVectorSize{};
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkKdTreeGenerator.hxx"

--- a/Modules/Numerics/Statistics/include/itkKdTreeGenerator.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTreeGenerator.hxx
@@ -18,10 +18,7 @@
 #ifndef itkKdTreeGenerator_hxx
 #define itkKdTreeGenerator_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TSample>
 KdTreeGenerator<TSample>::KdTreeGenerator()
@@ -207,7 +204,6 @@ KdTreeGenerator<TSample>::GenerateTreeLoop(unsigned int            beginIndex,
     return this->GenerateNonterminalNode(beginIndex, endIndex, lowerBound, upperBound, level + 1);
   }
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkListSample.h
+++ b/Modules/Numerics/Statistics/include/itkListSample.h
@@ -24,9 +24,7 @@
 
 #include <vector>
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class ListSample
  *  \brief This class is the native implementation of the a Sample with an STL container
@@ -279,8 +277,7 @@ protected:
 private:
   InternalDataContainerType m_InternalContainer{};
 };
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkListSample.hxx"

--- a/Modules/Numerics/Statistics/include/itkListSample.hxx
+++ b/Modules/Numerics/Statistics/include/itkListSample.hxx
@@ -18,10 +18,7 @@
 #ifndef itkListSample_hxx
 #define itkListSample_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TMeasurementVector>
 void
@@ -134,7 +131,6 @@ ListSample<TMeasurementVector>::PrintSelf(std::ostream & os, Indent indent) cons
 
   os << indent << "InternalContainer: " << &m_InternalContainer << std::endl;
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.h
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.h
@@ -23,9 +23,7 @@
 
 #include "itkMembershipFunctionBase.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class MahalanobisDistanceMembershipFunction
  * \brief MahalanobisDistanceMembershipFunction models class
@@ -141,8 +139,7 @@ private:
   /** Boolean to cache whether the covariance is singular or nearly singular */
   bool m_CovarianceNonsingular{};
 };
-} // end of namespace Statistics
-} // end namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkMahalanobisDistanceMembershipFunction.hxx"

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.hxx
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.hxx
@@ -23,9 +23,7 @@
 #include "vnl/vnl_matrix.h"
 #include "vnl/algo/vnl_matrix_inverse.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TVector>
 MahalanobisDistanceMembershipFunction<TVector>::MahalanobisDistanceMembershipFunction()
@@ -188,7 +186,6 @@ MahalanobisDistanceMembershipFunction<TVector>::InternalClone() const
   return loPtr;
 }
 
-} // end namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.h
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.h
@@ -28,9 +28,7 @@
 
 #include "itkDistanceMetric.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class MahalanobisDistanceMetric
@@ -137,8 +135,7 @@ private:
   void
   CalculateInverseCovariance();
 };
-} // end of namespace Statistics
-} // end namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkMahalanobisDistanceMetric.hxx"

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.hxx
@@ -18,10 +18,7 @@
 #ifndef itkMahalanobisDistanceMetric_hxx
 #define itkMahalanobisDistanceMetric_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TVector>
 MahalanobisDistanceMetric<TVector>::MahalanobisDistanceMetric()
@@ -210,7 +207,6 @@ MahalanobisDistanceMetric<TVector>::PrintSelf(std::ostream & os, Indent indent) 
   os << indent << "Double max:        " << std::endl;
   os << this->GetDoubleMax() << std::endl;
 }
-} // end namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkManhattanDistanceMetric.h
+++ b/Modules/Numerics/Statistics/include/itkManhattanDistanceMetric.h
@@ -20,9 +20,7 @@
 
 #include "itkDistanceMetric.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class ManhattanDistanceMetric
@@ -66,8 +64,7 @@ protected:
   ManhattanDistanceMetric() = default;
   ~ManhattanDistanceMetric() override = default;
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkManhattanDistanceMetric.hxx"

--- a/Modules/Numerics/Statistics/include/itkManhattanDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkManhattanDistanceMetric.hxx
@@ -18,10 +18,7 @@
 #ifndef itkManhattanDistanceMetric_hxx
 #define itkManhattanDistanceMetric_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TVector>
 inline double
@@ -65,7 +62,6 @@ ManhattanDistanceMetric<TVector>::Evaluate(const MeasurementVectorType & x1, con
   }
   return distance;
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkMaskedImageToHistogramFilter.h
+++ b/Modules/Numerics/Statistics/include/itkMaskedImageToHistogramFilter.h
@@ -22,9 +22,7 @@
 #include "itkImageToHistogramFilter.h"
 #include "itkSimpleDataObjectDecorator.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class MaskedImageToHistogramFilter
@@ -95,8 +93,7 @@ protected:
   void
   ThreadedComputeMinimumAndMaximum(const RegionType & inputRegionForThread) override;
 };
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkMaskedImageToHistogramFilter.hxx"

--- a/Modules/Numerics/Statistics/include/itkMaskedImageToHistogramFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkMaskedImageToHistogramFilter.hxx
@@ -21,9 +21,7 @@
 #include "itkProgressReporter.h"
 #include "itkImageRegionConstIterator.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TImage, typename TMaskImage>
 MaskedImageToHistogramFilter<TImage, TMaskImage>::MaskedImageToHistogramFilter()
@@ -111,7 +109,6 @@ MaskedImageToHistogramFilter<TImage, TMaskImage>::ThreadedStreamedGenerateData(c
   this->ThreadedMergeHistogram(std::move(histogram));
 }
 
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkMaximumDecisionRule.h
+++ b/Modules/Numerics/Statistics/include/itkMaximumDecisionRule.h
@@ -21,9 +21,7 @@
 #include "itkDecisionRule.h"
 #include "ITKStatisticsExport.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class MaximumDecisionRule
@@ -72,7 +70,6 @@ protected:
   ~MaximumDecisionRule() override = default;
 
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkMaximumRatioDecisionRule.h
+++ b/Modules/Numerics/Statistics/include/itkMaximumRatioDecisionRule.h
@@ -25,9 +25,7 @@
 #include "itkDecisionRule.h"
 #include "ITKStatisticsExport.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class MaximumRatioDecisionRule
@@ -114,6 +112,6 @@ private:
   PriorProbabilityVectorType m_PriorProbabilities{};
 
 }; // end of class
-} // namespace Statistics
-} // namespace itk
+} // namespace itk::Statistics
+
 #endif

--- a/Modules/Numerics/Statistics/include/itkMeanSampleFilter.h
+++ b/Modules/Numerics/Statistics/include/itkMeanSampleFilter.h
@@ -22,9 +22,7 @@
 #include "itkArray.h"
 #include "itkSimpleDataObjectDecorator.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class MeanSampleFilter
@@ -119,8 +117,7 @@ protected:
   void
   GenerateData() override;
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkMeanSampleFilter.hxx"

--- a/Modules/Numerics/Statistics/include/itkMeanSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkMeanSampleFilter.hxx
@@ -23,9 +23,7 @@
 #include "itkCompensatedSummation.h"
 #include "itkMeasurementVectorTraits.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TSample>
 MeanSampleFilter<TSample>::MeanSampleFilter()
@@ -158,7 +156,6 @@ MeanSampleFilter<TSample>::GenerateData()
 
   decoratedOutput->Set(output);
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h
+++ b/Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h
@@ -28,9 +28,7 @@
 #include "itkSize.h"
 #include <vector>
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class MeasurementVectorTraits
  * \ingroup Statistics
@@ -530,7 +528,7 @@ public:
 
 /// \endcond
 
-} // namespace Statistics
-} // namespace itk
+} // namespace itk::Statistics
+
 
 #endif // itkMeasurementVectorTraits_h

--- a/Modules/Numerics/Statistics/include/itkMembershipFunctionBase.h
+++ b/Modules/Numerics/Statistics/include/itkMembershipFunctionBase.h
@@ -22,9 +22,7 @@
 #include "itkMeasurementVectorTraits.h"
 #include "itkNumericTraitsCovariantVectorPixel.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class MembershipFunctionBase
@@ -139,7 +137,6 @@ private:
   MeasurementVectorSizeType m_MeasurementVectorSize{};
 
 }; // end of class
-} // end of namespace Statistics
-} // end namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkMembershipSample.h
+++ b/Modules/Numerics/Statistics/include/itkMembershipSample.h
@@ -21,9 +21,7 @@
 #include <unordered_map>
 #include "itkSubsample.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class MembershipSample
@@ -317,8 +315,7 @@ private:
   SampleConstPointer              m_Sample{};
   unsigned int                    m_NumberOfClasses{};
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkMembershipSample.hxx"

--- a/Modules/Numerics/Statistics/include/itkMembershipSample.hxx
+++ b/Modules/Numerics/Statistics/include/itkMembershipSample.hxx
@@ -18,10 +18,7 @@
 #ifndef itkMembershipSample_hxx
 #define itkMembershipSample_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TSample>
 MembershipSample<TSample>::MembershipSample() = default;
@@ -154,7 +151,6 @@ MembershipSample<TSample>::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Sample: " << m_Sample.GetPointer() << std::endl;
   os << indent << "NumberOfClasses: " << this->GetNumberOfClasses() << std::endl;
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkMinimumDecisionRule.h
+++ b/Modules/Numerics/Statistics/include/itkMinimumDecisionRule.h
@@ -21,9 +21,7 @@
 #include "itkDecisionRule.h"
 #include "ITKStatisticsExport.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class MinimumDecisionRule
  *  \brief A decision rule that returns the class label with the
@@ -69,7 +67,6 @@ protected:
   ~MinimumDecisionRule() override = default;
 
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkMixtureModelComponentBase.h
+++ b/Modules/Numerics/Statistics/include/itkMixtureModelComponentBase.h
@@ -25,9 +25,7 @@
 #include "itkObject.h"
 #include "itkMembershipFunctionBase.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class MixtureModelComponentBase
@@ -172,8 +170,7 @@ private:
   /** indicative flag of membership function's parameter changes */
   bool m_ParametersModified{};
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkMixtureModelComponentBase.hxx"

--- a/Modules/Numerics/Statistics/include/itkMixtureModelComponentBase.hxx
+++ b/Modules/Numerics/Statistics/include/itkMixtureModelComponentBase.hxx
@@ -18,10 +18,7 @@
 #ifndef itkMixtureModelComponentBase_hxx
 #define itkMixtureModelComponentBase_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TSample>
 MixtureModelComponentBase<TSample>::MixtureModelComponentBase()
@@ -156,7 +153,6 @@ MixtureModelComponentBase<TSample>::Update()
 {
   this->GenerateData();
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkNeighborhoodSampler.h
+++ b/Modules/Numerics/Statistics/include/itkNeighborhoodSampler.h
@@ -21,9 +21,7 @@
 #include "itkSampleToSubsampleFilter.h"
 #include "itkSimpleDataObjectDecorator.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class NeighborhoodSampler
  * \brief Generates a Subsample out of a Sample, based on a user-provided
@@ -84,8 +82,7 @@ protected:
   void
   GenerateData() override;
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkNeighborhoodSampler.hxx"

--- a/Modules/Numerics/Statistics/include/itkNeighborhoodSampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkNeighborhoodSampler.hxx
@@ -18,10 +18,7 @@
 #ifndef itkNeighborhoodSampler_hxx
 #define itkNeighborhoodSampler_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 
 template <typename TSample>
@@ -56,7 +53,6 @@ NeighborhoodSampler<TSample>::PrintSelf(std::ostream & os, Indent indent) const
   // m_Radius
   os << indent << "Radius: " << this->GetRadiusInput() << std::endl;
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkNormalVariateGenerator.h
+++ b/Modules/Numerics/Statistics/include/itkNormalVariateGenerator.h
@@ -22,9 +22,7 @@
 #include "itkRandomVariateGeneratorBase.h"
 #include "ITKStatisticsExport.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class NormalVariateGenerator
  * \brief Normal random variate generator
@@ -160,6 +158,5 @@ private:
   double m_Chic2{};
   double m_ActualRSD{};
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 #endif

--- a/Modules/Numerics/Statistics/include/itkPointSetToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkPointSetToListSampleAdaptor.h
@@ -24,9 +24,7 @@
 #include "itkListSample.h"
 #include "itkSmartPointer.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class PointSetToListSampleAdaptor
@@ -270,8 +268,7 @@ private:
   /** temporary points for conversions */
   mutable PointType m_TempPoint{};
 }; // end of class PointSetToListSampleAdaptor
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkPointSetToListSampleAdaptor.hxx"

--- a/Modules/Numerics/Statistics/include/itkPointSetToListSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkPointSetToListSampleAdaptor.hxx
@@ -18,10 +18,7 @@
 #ifndef itkPointSetToListSampleAdaptor_hxx
 #define itkPointSetToListSampleAdaptor_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TPointSet>
 PointSetToListSampleAdaptor<TPointSet>::PointSetToListSampleAdaptor()
@@ -118,7 +115,6 @@ PointSetToListSampleAdaptor<TPointSet>::GetTotalFrequency() const -> TotalAbsolu
 
   return this->Size();
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkProbabilityDistribution.h
+++ b/Modules/Numerics/Statistics/include/itkProbabilityDistribution.h
@@ -24,9 +24,7 @@
 #include "itkArray.h"
 #include "ITKStatisticsExport.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class ProbabilityDistribution
  * \brief ProbabilityDistribution class defines common interface for
@@ -166,7 +164,6 @@ protected:
 
   ParametersType m_Parameters{};
 }; // end of class
-} // end of namespace Statistics
-} // end namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkRegionConstrainedSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkRegionConstrainedSubsampler.h
@@ -21,9 +21,7 @@
 #include "itkSubsamplerBase.h"
 #include "itkImageRegion.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class RegionConstrainedSubsampler
@@ -134,8 +132,7 @@ protected:
   bool       m_SampleRegionInitialized{};
 }; // end of class RegionConstrainedSubsampler
 
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkRegionConstrainedSubsampler.hxx"

--- a/Modules/Numerics/Statistics/include/itkRegionConstrainedSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkRegionConstrainedSubsampler.hxx
@@ -18,9 +18,7 @@
 #ifndef itkRegionConstrainedSubsampler_hxx
 #define itkRegionConstrainedSubsampler_hxx
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 
 template <typename TSample, typename TRegion>
@@ -114,7 +112,6 @@ RegionConstrainedSubsampler<TSample, TRegion>::PrintSelf(std::ostream & os, Inde
   os << std::endl;
 }
 
-} // end namespace Statistics
-} // end namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkSample.h
+++ b/Modules/Numerics/Statistics/include/itkSample.h
@@ -23,9 +23,7 @@
 #include "itkMeasurementVectorTraits.h"
 #include <vector> // for the size_type declaration
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class Sample
@@ -184,7 +182,6 @@ protected:
 private:
   MeasurementVectorSizeType m_MeasurementVectorSize{};
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkSampleClassifierFilter.h
+++ b/Modules/Numerics/Statistics/include/itkSampleClassifierFilter.h
@@ -26,9 +26,7 @@
 #include "itkProcessObject.h"
 #include "itkSimpleDataObjectDecorator.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class SampleClassifierFilter
@@ -159,8 +157,7 @@ private:
   /** Decision Rule */
   DecisionRulePointer m_DecisionRule{};
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkSampleClassifierFilter.hxx"

--- a/Modules/Numerics/Statistics/include/itkSampleClassifierFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkSampleClassifierFilter.hxx
@@ -18,10 +18,7 @@
 #ifndef itkSampleClassifierFilter_hxx
 #define itkSampleClassifierFilter_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TSample>
 SampleClassifierFilter<TSample>::SampleClassifierFilter()
@@ -175,7 +172,6 @@ SampleClassifierFilter<TSample>::GetOutput() const -> const MembershipSampleType
 {
   return static_cast<const MembershipSampleType *>(this->ProcessObject::GetOutput(0));
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkSampleToHistogramFilter.h
+++ b/Modules/Numerics/Statistics/include/itkSampleToHistogramFilter.h
@@ -43,9 +43,7 @@ itkDeclareExceptionMacro(HistogramWrongNumberOfComponents,
                          SampleToHistogramFilterException,
                          "Histogram has wrong number of components");
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 
 /**
@@ -197,8 +195,7 @@ private:
   }
 
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkSampleToHistogramFilter.hxx"

--- a/Modules/Numerics/Statistics/include/itkSampleToHistogramFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkSampleToHistogramFilter.hxx
@@ -20,9 +20,7 @@
 
 #include "itkStatisticsAlgorithm.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TSample, typename THistogram>
 SampleToHistogramFilter<TSample, THistogram>::SampleToHistogramFilter()
@@ -278,7 +276,6 @@ SampleToHistogramFilter<TSample, THistogram>::GenerateData()
     ++iter;
   }
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkSampleToSubsampleFilter.h
+++ b/Modules/Numerics/Statistics/include/itkSampleToSubsampleFilter.h
@@ -21,9 +21,7 @@
 #include "itkSubsample.h"
 #include "itkProcessObject.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class SampleToSubsampleFilter
  * \brief Base class of filters intended to select subsamples from samples.
@@ -99,8 +97,7 @@ protected:
   MakeOutput(DataObjectPointerArraySizeType idx) override;
   /** @ITKEndGrouping */
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkSampleToSubsampleFilter.hxx"

--- a/Modules/Numerics/Statistics/include/itkSampleToSubsampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkSampleToSubsampleFilter.hxx
@@ -18,10 +18,7 @@
 #ifndef itkSampleToSubsampleFilter_hxx
 #define itkSampleToSubsampleFilter_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TSample>
 SampleToSubsampleFilter<TSample>::SampleToSubsampleFilter()
@@ -71,7 +68,6 @@ SampleToSubsampleFilter<TSample>::PrintSelf(std::ostream & os, Indent indent) co
 {
   this->Superclass::PrintSelf(os, indent);
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.h
@@ -32,9 +32,7 @@
 #include <algorithm>
 #include <iostream>
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class ScalarImageToCooccurrenceListSampleFilter
@@ -120,8 +118,7 @@ protected:
 private:
   OffsetTable m_OffsetTable{};
 }; // end of class ScalarImageToListSampleFilter
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkScalarImageToCooccurrenceListSampleFilter.hxx"

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.hxx
@@ -18,10 +18,7 @@
 #ifndef itkScalarImageToCooccurrenceListSampleFilter_hxx
 #define itkScalarImageToCooccurrenceListSampleFilter_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TImage>
 ScalarImageToCooccurrenceListSampleFilter<TImage>::ScalarImageToCooccurrenceListSampleFilter()
@@ -163,7 +160,6 @@ ScalarImageToCooccurrenceListSampleFilter<TImage>::UseNeighbor(const OffsetType 
     m_OffsetTable.push_back(offset);
   }
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.h
@@ -24,9 +24,7 @@
 #include "itkNumericTraits.h"
 #include "itkProcessObject.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class ScalarImageToCooccurrenceMatrixFilter
  *  \brief This class computes a co-occurrence matrix (histogram) from
@@ -224,8 +222,7 @@ private:
 
   MaskPixelType m_InsidePixelValue{};
 };
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkScalarImageToCooccurrenceMatrixFilter.hxx"

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.hxx
@@ -22,9 +22,7 @@
 #include "itkConstNeighborhoodIterator.h"
 #include "itkMath.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::
@@ -355,7 +353,6 @@ ScalarImageToCooccurrenceMatrixFilter<TImageType, THistogramFrequencyContainer, 
   os << indent << "Normalize: " << this->GetNormalize() << std::endl;
   os << indent << "InsidePixelValue: " << this->GetInsidePixelValue() << std::endl;
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkScalarImageToHistogramGenerator.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToHistogramGenerator.h
@@ -23,9 +23,7 @@
 #include "itkHistogram.h"
 #include "itkObject.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class ScalarImageToHistogramGenerator
@@ -118,8 +116,7 @@ private:
 
   GeneratorPointer m_HistogramGenerator{};
 };
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkScalarImageToHistogramGenerator.hxx"

--- a/Modules/Numerics/Statistics/include/itkScalarImageToHistogramGenerator.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToHistogramGenerator.hxx
@@ -18,10 +18,7 @@
 #ifndef itkScalarImageToHistogramGenerator_hxx
 #define itkScalarImageToHistogramGenerator_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TImage>
 ScalarImageToHistogramGenerator<TImage>::ScalarImageToHistogramGenerator()
@@ -107,7 +104,6 @@ ScalarImageToHistogramGenerator<TImage>::PrintSelf(std::ostream & os, Indent ind
   itkPrintSelfObjectMacro(ImageToListSampleAdaptor);
   itkPrintSelfObjectMacro(HistogramGenerator);
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.h
@@ -23,9 +23,7 @@
 #include "itkHistogramToRunLengthFeaturesFilter.h"
 #include "itkScalarImageToRunLengthMatrixFilter.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class ScalarImageToRunLengthFeaturesFilter
@@ -225,8 +223,7 @@ private:
   OffsetVectorConstPointer      m_Offsets{};
   bool                          m_FastCalculations{};
 };
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkScalarImageToRunLengthFeaturesFilter.hxx"

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
@@ -22,9 +22,7 @@
 #include "itkMath.h"
 #include "itkMakeUniqueForOverwrite.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TImage, typename THistogramFrequencyContainer>
 ScalarImageToRunLengthFeaturesFilter<TImage, THistogramFrequencyContainer>::ScalarImageToRunLengthFeaturesFilter()
@@ -351,7 +349,6 @@ ScalarImageToRunLengthFeaturesFilter<TImage, THistogramFrequencyContainer>::Prin
   os << indent << "Offsets: " << this->GetOffsets() << std::endl;
   os << indent << "FeatureMeans: " << this->GetFeatureMeans() << std::endl;
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.h
@@ -24,9 +24,7 @@
 #include "itkVectorContainer.h"
 #include "itkProcessObject.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 
 /**
@@ -267,8 +265,7 @@ private:
   MeasurementVectorType m_UpperBound{};
   OffsetVectorPointer   m_Offsets{};
 };
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkScalarImageToRunLengthMatrixFilter.hxx"

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
@@ -24,9 +24,7 @@
 #include "itkMacro.h"
 #include "itkMath.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 
 template <typename TImageType, typename THistogramFrequencyContainer>
@@ -342,8 +340,7 @@ ScalarImageToRunLengthMatrixFilter<TImageType, THistogramFrequencyContainer>::No
   itkDebugMacro("new  offset = " << offset << std::endl);
 }
 
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.h
@@ -23,9 +23,7 @@
 #include "itkHistogramToTextureFeaturesFilter.h"
 #include "itkScalarImageToCooccurrenceMatrixFilter.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class ScalarImageToTextureFeaturesFilter
  *  \brief This class computes texture descriptions from an image.
@@ -239,8 +237,7 @@ private:
   OffsetVectorConstPointer      m_Offsets{};
   bool                          m_FastCalculations{};
 };
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkScalarImageToTextureFeaturesFilter.hxx"

--- a/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
@@ -21,9 +21,7 @@
 #include "itkNeighborhood.h"
 #include "itkMath.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TImageType, typename THistogramFrequencyContainer, typename TMaskImageType>
 ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMaskImageType>::
@@ -330,7 +328,6 @@ ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMa
   os << indent << "Offsets: " << this->GetOffsets() << std::endl;
   os << indent << "FeatureMeans: " << this->GetFeatureMeans() << std::endl;
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkSparseFrequencyContainer2.h
+++ b/Modules/Numerics/Statistics/include/itkSparseFrequencyContainer2.h
@@ -25,9 +25,7 @@
 #include "itkMeasurementVectorTraits.h"
 #include "ITKStatisticsExport.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class SparseFrequencyContainer2
@@ -115,7 +113,6 @@ private:
   FrequencyContainerType     m_FrequencyContainer{};
   TotalAbsoluteFrequencyType m_TotalFrequency{};
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.h
@@ -21,9 +21,7 @@
 #include "itkRegionConstrainedSubsampler.h"
 #include "itkImageHelper.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class SpatialNeighborSubsampler
@@ -128,8 +126,7 @@ protected:
   bool       m_RadiusInitialized{};
 }; // end of class SpatialNeighborSubsampler
 
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkSpatialNeighborSubsampler.hxx"

--- a/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.hxx
@@ -19,9 +19,7 @@
 #define itkSpatialNeighborSubsampler_hxx
 #include "itkImageRegionConstIteratorWithIndex.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 
 template <typename TSample, typename TRegion>
@@ -198,7 +196,6 @@ SpatialNeighborSubsampler<TSample, TRegion>::PrintSelf(std::ostream & os, Indent
   os << std::endl;
 }
 
-} // end namespace Statistics
-} // end namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkStandardDeviationPerComponentSampleFilter.h
+++ b/Modules/Numerics/Statistics/include/itkStandardDeviationPerComponentSampleFilter.h
@@ -24,9 +24,7 @@
 #include "itkSimpleDataObjectDecorator.h"
 #include "itkNumericTraitsFixedArrayPixel.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class StandardDeviationPerComponentSampleFilter
@@ -121,8 +119,7 @@ protected:
 
 private:
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkStandardDeviationPerComponentSampleFilter.hxx"

--- a/Modules/Numerics/Statistics/include/itkStandardDeviationPerComponentSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkStandardDeviationPerComponentSampleFilter.hxx
@@ -21,9 +21,7 @@
 #include "itkMeasurementVectorTraits.h"
 #include "itkMath.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TSample>
 StandardDeviationPerComponentSampleFilter<TSample>::StandardDeviationPerComponentSampleFilter()
@@ -208,7 +206,6 @@ StandardDeviationPerComponentSampleFilter<TSample>::GetMeanPerComponent() const 
 {
   return this->GetMeanPerComponentOutput()->Get();
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkStatisticsAlgorithm.h
+++ b/Modules/Numerics/Statistics/include/itkStatisticsAlgorithm.h
@@ -20,11 +20,7 @@
 
 #include "itkSubsample.h"
 
-namespace itk
-{
-namespace Statistics
-{
-namespace Algorithm
+namespace itk::Statistics::Algorithm
 {
 template <typename TSize>
 TSize
@@ -177,9 +173,8 @@ template <typename TSubsample>
 void
 IntrospectiveSort(TSubsample * sample, unsigned int activeDimension, int beginIndex, int endIndex, int sizeThreshold);
 
-} // end of namespace Algorithm
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics::Algorithm
+// end of namespace Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkStatisticsAlgorithm.hxx"

--- a/Modules/Numerics/Statistics/include/itkStatisticsAlgorithm.hxx
+++ b/Modules/Numerics/Statistics/include/itkStatisticsAlgorithm.hxx
@@ -20,11 +20,7 @@
 
 #include "itkNumericTraits.h"
 
-namespace itk
-{
-namespace Statistics
-{
-namespace Algorithm
+namespace itk::Statistics::Algorithm
 {
 template <typename TSize>
 inline TSize
@@ -653,8 +649,7 @@ IntrospectiveSort(TSubsample * sample, unsigned int activeDimension, int beginIn
     sample, activeDimension, beginIndex, endIndex, 2 * FloorLog(endIndex - beginIndex), sizeThreshold);
   InsertSort<TSubsample>(sample, activeDimension, beginIndex, endIndex);
 }
-} // end of namespace Algorithm
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics::Algorithm
+// end of namespace Statistics
 
 #endif // #ifndef itkStatisticsAlgorithm_hxx

--- a/Modules/Numerics/Statistics/include/itkSubsample.h
+++ b/Modules/Numerics/Statistics/include/itkSubsample.h
@@ -22,9 +22,7 @@
 #include "itkMacro.h"
 #include "itkObjectFactory.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class Subsample
@@ -291,8 +289,7 @@ private:
   unsigned int               m_ActiveDimension{};
   TotalAbsoluteFrequencyType m_TotalFrequency{};
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkSubsample.hxx"

--- a/Modules/Numerics/Statistics/include/itkSubsample.hxx
+++ b/Modules/Numerics/Statistics/include/itkSubsample.hxx
@@ -21,9 +21,7 @@
 
 #include "itkObject.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TSample>
 Subsample<TSample>::Subsample()
@@ -219,7 +217,6 @@ Subsample<TSample>::Graft(const DataObject * thatObject)
     this->m_TotalFrequency = that->m_TotalFrequency;
   }
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkSubsamplerBase.h
+++ b/Modules/Numerics/Statistics/include/itkSubsamplerBase.h
@@ -22,9 +22,7 @@
 #include "itkSample.h"
 #include "itkSubsample.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class SubsamplerBase
@@ -140,8 +138,7 @@ protected:
   SeedType           m_Seed{};
 }; // end of class SubsamplerBase
 
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkSubsamplerBase.hxx"

--- a/Modules/Numerics/Statistics/include/itkSubsamplerBase.hxx
+++ b/Modules/Numerics/Statistics/include/itkSubsamplerBase.hxx
@@ -18,9 +18,7 @@
 #ifndef itkSubsamplerBase_hxx
 #define itkSubsamplerBase_hxx
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 
 template <typename TSample>
@@ -70,7 +68,6 @@ SubsamplerBase<TSample>::PrintSelf(std::ostream & os, Indent indent) const
   os << std::endl;
 }
 
-} // end namespace Statistics
-} // end namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkTDistribution.h
+++ b/Modules/Numerics/Statistics/include/itkTDistribution.h
@@ -22,9 +22,7 @@
 #include "itkNumericTraits.h"
 #include "ITKStatisticsExport.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class TDistribution
@@ -233,7 +231,6 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 }; // end of class
-} // end of namespace Statistics
-} // end namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.h
@@ -21,9 +21,7 @@
 #include "itkSpatialNeighborSubsampler.h"
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class UniformRandomSpatialNeighborSubsampler
@@ -163,8 +161,7 @@ protected:
   bool                         m_UseClockForSeed{};
 }; // end of class UniformRandomSpatialNeighborSubsampler
 
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkUniformRandomSpatialNeighborSubsampler.hxx"

--- a/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
@@ -19,9 +19,7 @@
 #define itkUniformRandomSpatialNeighborSubsampler_hxx
 #include <set>
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 
 template <typename TSample, typename TRegion>
@@ -193,7 +191,6 @@ UniformRandomSpatialNeighborSubsampler<TSample, TRegion>::PrintSelf(std::ostream
   os << std::endl;
 }
 
-} // end namespace Statistics
-} // end namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.h
@@ -24,9 +24,7 @@
 #include "itkSmartPointer.h"
 #include "itkVectorContainer.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** \class VectorContainerToListSampleAdaptor
  *  \brief This class provides ListSample interface to ITK VectorContainer
@@ -254,8 +252,7 @@ protected:
 private:
   VectorContainerConstPointer m_VectorContainer{};
 }; // end of class VectorContainerToListSampleAdaptor
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkVectorContainerToListSampleAdaptor.hxx"

--- a/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.hxx
@@ -18,10 +18,7 @@
 #ifndef itkVectorContainerToListSampleAdaptor_hxx
 #define itkVectorContainerToListSampleAdaptor_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TVectorContainer>
 VectorContainerToListSampleAdaptor<TVectorContainer>::VectorContainerToListSampleAdaptor()
@@ -83,7 +80,6 @@ VectorContainerToListSampleAdaptor<TVectorContainer>::GetTotalFrequency() const 
   }
   return this->Size();
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkWeightedCentroidKdTreeGenerator.h
+++ b/Modules/Numerics/Statistics/include/itkWeightedCentroidKdTreeGenerator.h
@@ -23,9 +23,7 @@
 #include "itkSubsample.h"
 #include "itkKdTreeGenerator.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class WeightedCentroidKdTreeGenerator
@@ -112,8 +110,7 @@ private:
   MeasurementVectorType m_TempUpperBound{};
   MeasurementVectorType m_TempMean{};
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkWeightedCentroidKdTreeGenerator.hxx"

--- a/Modules/Numerics/Statistics/include/itkWeightedCentroidKdTreeGenerator.hxx
+++ b/Modules/Numerics/Statistics/include/itkWeightedCentroidKdTreeGenerator.hxx
@@ -18,10 +18,7 @@
 #ifndef itkWeightedCentroidKdTreeGenerator_hxx
 #define itkWeightedCentroidKdTreeGenerator_hxx
 
-
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 
 template <typename TSample>
@@ -116,7 +113,6 @@ WeightedCentroidKdTreeGenerator<TSample>::GenerateNonterminalNode(unsigned int  
 
   return nonTerminalNode;
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkWeightedCovarianceSampleFilter.h
+++ b/Modules/Numerics/Statistics/include/itkWeightedCovarianceSampleFilter.h
@@ -22,9 +22,7 @@
 #include "itkCovarianceSampleFilter.h"
 #include "itkDataObjectDecorator.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class WeightedCovarianceSampleFilter
@@ -115,8 +113,7 @@ protected:
   void
   ComputeCovarianceMatrixWithWeights();
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkWeightedCovarianceSampleFilter.hxx"

--- a/Modules/Numerics/Statistics/include/itkWeightedCovarianceSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkWeightedCovarianceSampleFilter.hxx
@@ -20,9 +20,7 @@
 
 #include "itkWeightedMeanSampleFilter.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TSample>
 WeightedCovarianceSampleFilter<TSample>::WeightedCovarianceSampleFilter()
@@ -250,7 +248,6 @@ WeightedCovarianceSampleFilter<TSample>::ComputeCovarianceMatrixWithWeights()
 
   decoratedOutput->Set(output);
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/include/itkWeightedMeanSampleFilter.h
+++ b/Modules/Numerics/Statistics/include/itkWeightedMeanSampleFilter.h
@@ -22,9 +22,7 @@
 #include "itkFunctionBase.h"
 #include "itkDataObjectDecorator.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /**
  * \class WeightedMeanSampleFilter
@@ -110,8 +108,7 @@ protected:
   void
   ComputeMeanWithWeightingFunction();
 }; // end of class
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkWeightedMeanSampleFilter.hxx"

--- a/Modules/Numerics/Statistics/include/itkWeightedMeanSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkWeightedMeanSampleFilter.hxx
@@ -23,9 +23,7 @@
 #include "itkCompensatedSummation.h"
 #include "itkMeasurementVectorTraits.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TSample>
 WeightedMeanSampleFilter<TSample>::WeightedMeanSampleFilter()
@@ -180,7 +178,6 @@ WeightedMeanSampleFilter<TSample>::ComputeMeanWithWeightingFunction()
 
   decoratedOutput->Set(output);
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics
 
 #endif

--- a/Modules/Numerics/Statistics/src/itkChiSquareDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkChiSquareDistribution.cxx
@@ -25,9 +25,7 @@ dgami_(double * a, double * x);
 extern "C" double
 dgamma_(double * x);
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 ChiSquareDistribution::ChiSquareDistribution()
 {
@@ -315,5 +313,4 @@ ChiSquareDistribution::PrintSelf(std::ostream & os, Indent indent) const
     os << indent << "Degrees of freedom: (unknown)" << std::endl;
   }
 }
-} // end of namespace Statistics
-} // end namespace itk
+} // namespace itk::Statistics

--- a/Modules/Numerics/Statistics/src/itkDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkDecisionRule.cxx
@@ -17,13 +17,10 @@
  *=========================================================================*/
 #include "itkDecisionRule.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 DecisionRule::DecisionRule() = default;
 
 DecisionRule::~DecisionRule() = default;
 
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics

--- a/Modules/Numerics/Statistics/src/itkDenseFrequencyContainer2.cxx
+++ b/Modules/Numerics/Statistics/src/itkDenseFrequencyContainer2.cxx
@@ -17,9 +17,7 @@
  *=========================================================================*/
 #include "itkDenseFrequencyContainer2.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 DenseFrequencyContainer2::DenseFrequencyContainer2()
   : m_TotalFrequency(TotalAbsoluteFrequencyType{})
@@ -82,5 +80,4 @@ DenseFrequencyContainer2::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics

--- a/Modules/Numerics/Statistics/src/itkExpectationMaximizationMixtureModelEstimator.cxx
+++ b/Modules/Numerics/Statistics/src/itkExpectationMaximizationMixtureModelEstimator.cxx
@@ -17,9 +17,7 @@
  *=========================================================================*/
 #include "itkExpectationMaximizationMixtureModelEstimator.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** Print enum values */
 std::ostream &
@@ -37,5 +35,4 @@ operator<<(std::ostream & out, const ExpectationMaximizationMixtureModelEstimato
     }
   }();
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics

--- a/Modules/Numerics/Statistics/src/itkGaussianDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkGaussianDistribution.cxx
@@ -19,9 +19,7 @@
 #include "vnl/vnl_erf.h"
 #include "itkMath.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 GaussianDistribution::GaussianDistribution()
 {
@@ -442,5 +440,4 @@ GaussianDistribution::PrintSelf(std::ostream & os, Indent indent) const
     os << indent << "Variance: (unknown)" << std::endl;
   }
 }
-} // end of namespace Statistics
-} // end namespace itk
+} // namespace itk::Statistics

--- a/Modules/Numerics/Statistics/src/itkHistogramToRunLengthFeaturesFilter.cxx
+++ b/Modules/Numerics/Statistics/src/itkHistogramToRunLengthFeaturesFilter.cxx
@@ -17,9 +17,7 @@
  *=========================================================================*/
 #include "itkHistogramToRunLengthFeaturesFilter.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** Print enum values */
 std::ostream &
@@ -53,5 +51,4 @@ operator<<(std::ostream & out, const HistogramToRunLengthFeaturesFilterEnums::Ru
     }
   }();
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics

--- a/Modules/Numerics/Statistics/src/itkHistogramToTextureFeaturesFilter.cxx
+++ b/Modules/Numerics/Statistics/src/itkHistogramToTextureFeaturesFilter.cxx
@@ -17,9 +17,7 @@
  *=========================================================================*/
 #include "itkHistogramToTextureFeaturesFilter.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 /** Print enum values */
 std::ostream &
@@ -51,5 +49,4 @@ operator<<(std::ostream & out, const HistogramToTextureFeaturesFilterEnums::Text
     }
   }();
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics

--- a/Modules/Numerics/Statistics/src/itkMaximumDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkMaximumDecisionRule.cxx
@@ -17,9 +17,7 @@
  *=========================================================================*/
 #include "itkMaximumDecisionRule.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 MaximumDecisionRule::ClassIdentifierType
 MaximumDecisionRule::Evaluate(const MembershipVectorType & discriminantScores) const
@@ -41,5 +39,4 @@ MaximumDecisionRule::Evaluate(const MembershipVectorType & discriminantScores) c
   }
   return maxIndex;
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics

--- a/Modules/Numerics/Statistics/src/itkMaximumRatioDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkMaximumRatioDecisionRule.cxx
@@ -18,9 +18,7 @@
 #include "itkMaximumRatioDecisionRule.h"
 #include "itkMath.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 MaximumRatioDecisionRule::MaximumRatioDecisionRule() = default;
 
@@ -120,5 +118,4 @@ MaximumRatioDecisionRule::Evaluate(const MembershipVectorType & discriminantScor
   }
   return besti;
 }
-} // namespace Statistics
-} // namespace itk
+} // namespace itk::Statistics

--- a/Modules/Numerics/Statistics/src/itkMinimumDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkMinimumDecisionRule.cxx
@@ -17,9 +17,7 @@
  *=========================================================================*/
 #include "itkMinimumDecisionRule.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 MinimumDecisionRule::ClassIdentifierType
 MinimumDecisionRule::Evaluate(const MembershipVectorType & discriminantScores) const
@@ -41,5 +39,4 @@ MinimumDecisionRule::Evaluate(const MembershipVectorType & discriminantScores) c
   }
   return minIndex;
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics

--- a/Modules/Numerics/Statistics/src/itkNormalVariateGenerator.cxx
+++ b/Modules/Numerics/Statistics/src/itkNormalVariateGenerator.cxx
@@ -19,9 +19,7 @@
 
 #include "itkNormalVariateGenerator.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 NormalVariateGenerator::NormalVariateGenerator()
   : m_Scale(30000000.0)
@@ -474,5 +472,4 @@ recalcsumsq:
   m_ActualRSD = 1.0 / ts; /* Reciprocal of actual Standard Devtn */
   goto startpass;
 }
-} // namespace Statistics
-} // namespace itk
+} // namespace itk::Statistics

--- a/Modules/Numerics/Statistics/src/itkProbabilityDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkProbabilityDistribution.cxx
@@ -17,9 +17,7 @@
  *=========================================================================*/
 #include "itkProbabilityDistribution.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 void
 ProbabilityDistribution::SetParameters(const ParametersType & params)
@@ -41,5 +39,4 @@ ProbabilityDistribution::PrintSelf(std::ostream & os, Indent indent) const
   Superclass::PrintSelf(os, indent);
   os << indent << "Parameters: " << m_Parameters << std::endl;
 }
-} // namespace Statistics
-} // namespace itk
+} // namespace itk::Statistics

--- a/Modules/Numerics/Statistics/src/itkSparseFrequencyContainer2.cxx
+++ b/Modules/Numerics/Statistics/src/itkSparseFrequencyContainer2.cxx
@@ -17,9 +17,7 @@
  *=========================================================================*/
 #include "itkSparseFrequencyContainer2.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 SparseFrequencyContainer2::SparseFrequencyContainer2()
   : m_TotalFrequency(TotalAbsoluteFrequencyType{})
@@ -86,5 +84,4 @@ SparseFrequencyContainer2::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 }
-} // end of namespace Statistics
-} // end of namespace itk
+} // namespace itk::Statistics

--- a/Modules/Numerics/Statistics/src/itkTDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkTDistribution.cxx
@@ -26,9 +26,7 @@ dbetai_(double * x, double * pin, double * qin);
 extern "C" double
 dgamma_(double * x);
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 TDistribution::TDistribution()
 {
@@ -364,5 +362,4 @@ TDistribution::PrintSelf(std::ostream & os, Indent indent) const
     os << indent << "Degrees of freedom: (unknown)" << std::endl;
   }
 }
-} // end of namespace Statistics
-} // end namespace itk
+} // namespace itk::Statistics

--- a/Modules/Numerics/Statistics/test/itkCovarianceSampleFilterTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkCovarianceSampleFilterTest3.cxx
@@ -20,9 +20,7 @@
 #include "itkHistogram.h"
 #include "itkMahalanobisDistanceMetric.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TSample>
 class MyCovarianceSampleFilter : public CovarianceSampleFilter<TSample>
@@ -56,8 +54,8 @@ private:
   MyCovarianceSampleFilter() = default;
   ~MyCovarianceSampleFilter() override = default;
 };
-} // namespace Statistics
-} // namespace itk
+} // namespace itk::Statistics
+
 
 int
 itkCovarianceSampleFilterTest3(int, char *[])

--- a/Modules/Numerics/Statistics/test/itkDecisionRuleTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkDecisionRuleTest.cxx
@@ -18,13 +18,8 @@
 
 #include "itkDecisionRule.h"
 
-namespace itk
+namespace itk::Statistics::DecisionRuleTest
 {
-namespace Statistics
-{
-namespace DecisionRuleTest
-{
-
 class MyDecisionRule : public DecisionRule
 {
 public:
@@ -65,10 +60,8 @@ public:
     return maxIndex;
   }
 };
+} // namespace itk::Statistics::DecisionRuleTest
 
-} // namespace DecisionRuleTest
-} // namespace Statistics
-} // namespace itk
 int
 itkDecisionRuleTest(int, char *[])
 {

--- a/Modules/Numerics/Statistics/test/itkDistanceMetricTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkDistanceMetricTest.cxx
@@ -18,11 +18,7 @@
 
 #include "itkDistanceMetric.h"
 
-namespace itk
-{
-namespace Statistics
-{
-namespace DistanceMetricTest
+namespace itk::Statistics::DistanceMetricTest
 {
 
 template <typename TMeasurementVector>
@@ -57,9 +53,8 @@ public:
   }
 };
 
-} // namespace DistanceMetricTest
-} // namespace Statistics
-} // namespace itk
+} // namespace itk::Statistics::DistanceMetricTest
+
 int
 itkDistanceMetricTest(int, char *[])
 {

--- a/Modules/Numerics/Statistics/test/itkDistanceMetricTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkDistanceMetricTest2.cxx
@@ -18,11 +18,7 @@
 
 #include "itkDistanceMetric.h"
 
-namespace itk
-{
-namespace Statistics
-{
-namespace DistanceMetricTest
+namespace itk::Statistics::DistanceMetricTest
 {
 
 template <typename TMeasurementVector>
@@ -57,9 +53,8 @@ public:
   }
 };
 
-} // namespace DistanceMetricTest
-} // namespace Statistics
-} // namespace itk
+} // namespace itk::Statistics::DistanceMetricTest
+
 
 // test DistanceMetric using resizable measurement vector type
 int

--- a/Modules/Numerics/Statistics/test/itkMembershipFunctionBaseTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMembershipFunctionBaseTest.cxx
@@ -19,11 +19,7 @@
 #include <iostream>
 #include "itkMembershipFunctionBase.h"
 
-namespace itk
-{
-namespace Statistics
-{
-namespace MembershipFunctionBaseTest
+namespace itk::Statistics::MembershipFunctionBaseTest
 {
 
 template <typename TMeasurementVector>
@@ -54,9 +50,9 @@ public:
   }
 };
 
-} // namespace MembershipFunctionBaseTest
-} // namespace Statistics
-} // namespace itk
+} // namespace itk::Statistics::MembershipFunctionBaseTest
+
+
 int
 itkMembershipFunctionBaseTest(int, char *[])
 {

--- a/Modules/Numerics/Statistics/test/itkMembershipFunctionBaseTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkMembershipFunctionBaseTest2.cxx
@@ -19,11 +19,7 @@
 #include <iostream>
 #include "itkMembershipFunctionBase.h"
 
-namespace itk
-{
-namespace Statistics
-{
-namespace MembershipFunctionBaseTest
+namespace itk::Statistics::MembershipFunctionBaseTest
 {
 
 template <typename TMeasurementVector>
@@ -54,9 +50,8 @@ public:
   }
 };
 
-} // namespace MembershipFunctionBaseTest
-} // namespace Statistics
-} // namespace itk
+} // namespace itk::Statistics::MembershipFunctionBaseTest
+
 
 /* Test MembershipFunctionBase using a resizable vector type */
 int

--- a/Modules/Numerics/Statistics/test/itkMixtureModelComponentBaseTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMixtureModelComponentBaseTest.cxx
@@ -20,9 +20,7 @@
 #include "itkListSample.h"
 #include "itkTestingMacros.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 
 template <typename TSample>
@@ -59,8 +57,8 @@ protected:
   }
 };
 
-} // namespace Statistics
-} // namespace itk
+} // namespace itk::Statistics
+
 
 int
 itkMixtureModelComponentBaseTest(int, char *[])

--- a/Modules/Numerics/Statistics/test/itkProbabilityDistributionTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkProbabilityDistributionTest.cxx
@@ -18,9 +18,7 @@
 
 #include "itkProbabilityDistribution.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 
 class ProbabilityDistributionTestingHelper : public ProbabilityDistribution
@@ -99,8 +97,8 @@ public:
   }
 };
 
-} // namespace Statistics
-} // namespace itk
+} // namespace itk::Statistics
+
 
 int
 itkProbabilityDistributionTest(int, char *[])

--- a/Modules/Numerics/Statistics/test/itkRandomVariateGeneratorBaseTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkRandomVariateGeneratorBaseTest.cxx
@@ -19,9 +19,7 @@
 #include "itkRandomVariateGeneratorBase.h"
 #include "itkObjectFactory.h"
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 
 class VariateGeneratorTestHelper : public RandomVariateGeneratorBase
@@ -52,8 +50,8 @@ public:
   }
 };
 
-} // namespace Statistics
-} // namespace itk
+} // namespace itk::Statistics
+
 
 int
 itkRandomVariateGeneratorBaseTest(int, char *[])

--- a/Modules/Numerics/Statistics/test/itkSampleTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleTest.cxx
@@ -21,11 +21,7 @@
 #include "itkObjectFactory.h"
 #include "itkMath.h"
 
-namespace itk
-{
-namespace Statistics
-{
-namespace SampleTest
+namespace itk::Statistics::SampleTest
 {
 
 template <typename TMeasurementVector>
@@ -113,9 +109,9 @@ private:
   std::vector<AbsoluteFrequencyType> m_Frequencies;
 };
 
-} // namespace SampleTest
-} // namespace Statistics
-} // namespace itk
+} // namespace itk::Statistics::SampleTest
+
+
 int
 itkSampleTest(int, char *[])
 {

--- a/Modules/Numerics/Statistics/test/itkSampleTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleTest2.cxx
@@ -21,11 +21,7 @@
 #include "itkObjectFactory.h"
 #include "itkMath.h"
 
-namespace itk
-{
-namespace Statistics
-{
-namespace SampleTest
+namespace itk::Statistics::SampleTest
 {
 
 template <typename TMeasurementVector>
@@ -120,9 +116,9 @@ private:
   std::vector<AbsoluteFrequencyType> m_Frequencies;
 };
 
-} // namespace SampleTest
-} // namespace Statistics
-} // namespace itk
+} // namespace itk::Statistics::SampleTest
+
+
 int
 itkSampleTest2(int, char *[])
 {

--- a/Modules/Numerics/Statistics/test/itkSampleTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleTest3.cxx
@@ -21,11 +21,7 @@
 #include "itkObjectFactory.h"
 #include "itkMath.h"
 
-namespace itk
-{
-namespace Statistics
-{
-namespace SampleTest
+namespace itk::Statistics::SampleTest
 {
 
 template <typename TMeasurementVector>
@@ -121,9 +117,9 @@ private:
   std::vector<AbsoluteFrequencyType> m_Frequencies;
 };
 
-} // namespace SampleTest
-} // namespace Statistics
-} // namespace itk
+} // namespace itk::Statistics::SampleTest
+
+
 int
 itkSampleTest3(int, char *[])
 {

--- a/Modules/Numerics/Statistics/test/itkSampleTest4.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleTest4.cxx
@@ -21,11 +21,7 @@
 #include "itkObjectFactory.h"
 #include "itkMath.h"
 
-namespace itk
-{
-namespace Statistics
-{
-namespace SampleTest
+namespace itk::Statistics::SampleTest
 {
 
 template <typename TMeasurementVector>
@@ -121,9 +117,9 @@ private:
   std::vector<AbsoluteFrequencyType> m_Frequencies;
 };
 
-} // namespace SampleTest
-} // namespace Statistics
-} // namespace itk
+} // namespace itk::Statistics::SampleTest
+
+
 int
 itkSampleTest4(int, char *[])
 {

--- a/Modules/Numerics/Statistics/test/itkSampleToSubsampleFilterTest1.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleToSubsampleFilterTest1.cxx
@@ -20,11 +20,7 @@
 #include "itkListSample.h"
 #include "itkSampleToSubsampleFilter.h"
 
-namespace itk
-{
-namespace Statistics
-{
-namespace itkSampleToSubsampleFilter1Namespace
+namespace itk::Statistics::itkSampleToSubsampleFilter1Namespace
 {
 
 template <typename TSample>
@@ -60,9 +56,7 @@ protected:
 private:
 };
 
-} // namespace itkSampleToSubsampleFilter1Namespace
-} // namespace Statistics
-} // namespace itk
+} // namespace itk::Statistics::itkSampleToSubsampleFilter1Namespace
 
 
 int

--- a/Modules/Numerics/Statistics/test/itkWeightedCovarianceSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCovarianceSampleFilterTest.cxx
@@ -23,9 +23,7 @@ constexpr unsigned int MeasurementVectorSize = 3;
 
 using MeasurementVectorType = itk::FixedArray<float, MeasurementVectorSize>;
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TSample>
 class MyWeightedCovarianceSampleFilter : public WeightedCovarianceSampleFilter<TSample>
@@ -51,8 +49,8 @@ public:
     Superclass::MakeOutput(index);
   }
 };
-} // namespace Statistics
-} // namespace itk
+} // namespace itk::Statistics
+
 
 int
 itkWeightedCovarianceSampleFilterTest(int, char *[])

--- a/Modules/Numerics/Statistics/test/itkWeightedCovarianceSampleFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCovarianceSampleFilterTest2.cxx
@@ -23,9 +23,7 @@ constexpr unsigned int MeasurementVectorSize2 = 3;
 
 using MeasurementVectorType2 = itk::Array<float>;
 
-namespace itk
-{
-namespace Statistics
+namespace itk::Statistics
 {
 template <typename TSample>
 class MyWeightedCovarianceSampleFilter : public WeightedCovarianceSampleFilter<TSample>
@@ -51,8 +49,7 @@ public:
     Superclass::MakeOutput(index);
   }
 };
-} // namespace Statistics
-} // namespace itk
+} // namespace itk::Statistics
 
 
 int

--- a/Modules/Registration/Common/include/itkImageRegistrationMethodImageSource.h
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethodImageSource.h
@@ -31,10 +31,8 @@
  *
  *  Therefore the solution of the registration is |-7 -3|
  */
-namespace itk
-{
 
-namespace testhelper
+namespace itk::testhelper
 {
 
 template <typename TFixedPixelType, typename TMovingPixelType, unsigned int VDimension>
@@ -154,7 +152,7 @@ private:
   ParametersType m_Parameters{};
 };
 
-} // end namespace testhelper
+} // namespace itk::testhelper
 
-} // end namespace itk
+// end namespace itk
 #endif

--- a/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.h
+++ b/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.h
@@ -37,9 +37,7 @@
 #include "itkNCCRegistrationFunction.h"
 #include "itkMIRegistrationFunction.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 /**
@@ -340,8 +338,7 @@ private:
 
   typename DisplacementFieldType::Pointer m_DisplacementField{};
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkFEMFiniteDifferenceFunctionLoad.hxx"

--- a/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.hxx
+++ b/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.hxx
@@ -18,10 +18,7 @@
 #ifndef itkFEMFiniteDifferenceFunctionLoad_hxx
 #define itkFEMFiniteDifferenceFunctionLoad_hxx
 
-
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 template <typename TMoving, typename TFixed>
@@ -372,7 +369,6 @@ FiniteDifferenceFunctionLoad<TMoving, TFixed>::PrintSelf(std::ostream & os, Inde
   itkPrintSelfObjectMacro(DifferenceFunction);
   itkPrintSelfObjectMacro(DisplacementField);
 }
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
@@ -51,9 +51,7 @@
 #include <iostream>
 #include <string>
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /** \class FEMRegistrationFilterEnums
  * \brief Contains all enum classes used by FEMRegistrationFilter class.
@@ -746,8 +744,7 @@ private:
 
   StandardDeviationsType m_StandardDeviations{};
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkFEMRegistrationFilter.hxx"

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
@@ -33,9 +33,7 @@
 
 #include "vnl/algo/vnl_determinant.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 template <typename TMovingImage, typename TFixedImage, typename TFemObject>
@@ -1522,7 +1520,6 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::PrintSelf(std::ost
      << static_cast<typename NumericTraits<StandardDeviationsType>::PrintType>(m_StandardDeviations) << std::endl;
 }
 
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif

--- a/Modules/Registration/FEM/include/itkPhysicsBasedNonRigidRegistrationMethod.h
+++ b/Modules/Registration/FEM/include/itkPhysicsBasedNonRigidRegistrationMethod.h
@@ -25,10 +25,7 @@
 #include "itkFEMScatteredDataPointSetToImageFilter.h"
 #include "itkConceptChecking.h"
 
-
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 
 /** \class PhysicsBasedNonRigidRegistrationMethod
@@ -170,8 +167,7 @@ private:
   typename BlockMatchingFilterType::Pointer    m_BlockMatchingFilter{};
   typename FEMFilterType::Pointer              m_FEMFilter{};
 };
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkPhysicsBasedNonRigidRegistrationMethod.hxx"

--- a/Modules/Registration/FEM/include/itkPhysicsBasedNonRigidRegistrationMethod.hxx
+++ b/Modules/Registration/FEM/include/itkPhysicsBasedNonRigidRegistrationMethod.hxx
@@ -21,11 +21,7 @@
 #include <iostream>
 #include "itkTimeProbe.h"
 
-
-namespace itk
-{
-
-namespace fem
+namespace itk::fem
 {
 
 template <typename TFixedImage, typename TMovingImage, typename TMaskImage, typename TMesh, typename TDeformationField>
@@ -117,7 +113,6 @@ PhysicsBasedNonRigidRegistrationMethod<TFixedImage, TMovingImage, TMaskImage, TM
   itkPrintSelfObjectMacro(BlockMatchingFilter);
   itkPrintSelfObjectMacro(FEMFilter);
 }
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem
 
 #endif

--- a/Modules/Registration/FEM/src/itkFEMRegistrationFilter.cxx
+++ b/Modules/Registration/FEM/src/itkFEMRegistrationFilter.cxx
@@ -17,9 +17,7 @@
  *=========================================================================*/
 #include "itkFEMRegistrationFilter.h"
 
-namespace itk
-{
-namespace fem
+namespace itk::fem
 {
 /** Print enum values */
 std::ostream &
@@ -37,5 +35,4 @@ operator<<(std::ostream & out, const FEMRegistrationFilterEnums::Sign value)
     }
   }();
 }
-} // end namespace fem
-} // end namespace itk
+} // namespace itk::fem

--- a/Modules/Segmentation/LevelSets/test/itkShapePriorSegmentationLevelSetFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkShapePriorSegmentationLevelSetFunctionTest.cxx
@@ -41,9 +41,8 @@
  * The test fails if the overlap is below a certain threshold.
  *
  */
-namespace itk
-{
-namespace SPSLSF
+
+namespace itk::SPSLSF
 {
 
 template <typename TImage>
@@ -105,8 +104,8 @@ private:
   }
 };
 
-} // namespace SPSLSF
-} // namespace itk
+} // namespace itk::SPSLSF
+
 
 int
 itkShapePriorSegmentationLevelSetFunctionTest(int, char *[])

--- a/Modules/Segmentation/Watersheds/include/itkWatershedBoundary.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedBoundary.h
@@ -25,9 +25,7 @@
 #include "itkProcessObject.h"
 #include <unordered_map>
 
-namespace itk
-{
-namespace watershed
+namespace itk::watershed
 {
 /** \class Boundary
  * \par
@@ -275,8 +273,7 @@ protected:
    * information.    */
   std::vector<std::pair<bool, bool>> m_Valid{};
 };
-} // end namespace watershed
-} // end namespace itk
+} // namespace itk::watershed
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkWatershedBoundary.hxx"

--- a/Modules/Segmentation/Watersheds/include/itkWatershedBoundary.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedBoundary.hxx
@@ -21,9 +21,7 @@
 
 #include "itkImageRegionIterator.h"
 
-namespace itk
-{
-namespace watershed
+namespace itk::watershed
 {
 template <typename TScalar, unsigned int TDimension>
 Boundary<TScalar, TDimension>::Boundary()
@@ -59,6 +57,5 @@ Boundary<TScalar, TDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 }
-} // end namespace watershed
-} // end namespace itk
+} // namespace itk::watershed
 #endif

--- a/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.h
@@ -21,9 +21,7 @@
 
 #include "itkWatershedSegmenter.h"
 
-namespace itk
-{
-namespace watershed
+namespace itk::watershed
 {
 /**
  * \class BoundaryResolver
@@ -162,8 +160,7 @@ protected:
   GenerateOutputRequestedRegion(DataObject * itkNotUsed(output)) override
   {}
 };
-} // end namespace watershed
-} // end namespace itk
+} // namespace itk::watershed
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkWatershedBoundaryResolver.hxx"

--- a/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.hxx
@@ -20,9 +20,7 @@
 
 #include "itkImageRegionIterator.h"
 
-namespace itk
-{
-namespace watershed
+namespace itk::watershed
 {
 template <typename TPixelType, unsigned int TDimension>
 void
@@ -104,7 +102,6 @@ BoundaryResolver<TPixelType, TDimension>::PrintSelf(std::ostream & os, Indent in
 
   os << indent << "Face: " << m_Face << std::endl;
 }
-} // end namespace watershed
-} // end namespace itk
+} // namespace itk::watershed
 
 #endif

--- a/Modules/Segmentation/Watersheds/include/itkWatershedEquivalenceRelabeler.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedEquivalenceRelabeler.h
@@ -20,9 +20,7 @@
 
 #include "itkWatershedSegmenter.h"
 
-namespace itk
-{
-namespace watershed
+namespace itk::watershed
 {
 /**
  * \class EquivalenceRelabeler
@@ -143,8 +141,7 @@ protected:
   void
   GenerateInputRequestedRegion() override;
 };
-} // end namespace watershed
-} // end namespace itk
+} // namespace itk::watershed
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkWatershedEquivalenceRelabeler.hxx"

--- a/Modules/Segmentation/Watersheds/include/itkWatershedEquivalenceRelabeler.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedEquivalenceRelabeler.hxx
@@ -19,9 +19,7 @@
 #define itkWatershedEquivalenceRelabeler_hxx
 #include "itkImageRegionIterator.h"
 
-namespace itk
-{
-namespace watershed
+namespace itk::watershed
 {
 template <typename TScalar, unsigned int TImageDimension>
 void
@@ -117,7 +115,6 @@ EquivalenceRelabeler<TScalar, TImageDimension>::MakeOutput(DataObjectPointerArra
 {
   return ImageType::New().GetPointer();
 }
-} // end namespace watershed
-} // end namespace itk
+} // namespace itk::watershed
 
 #endif

--- a/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.h
@@ -21,9 +21,7 @@
 #include "itkWatershedSegmentTree.h"
 #include "itkWatershedSegmenter.h"
 
-namespace itk
-{
-namespace watershed
+namespace itk::watershed
 {
 /**
  * \class Relabeler
@@ -165,8 +163,7 @@ protected:
   void
   GenerateInputRequestedRegion() override;
 };
-} // end namespace watershed
-} // end namespace itk
+} // namespace itk::watershed
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkWatershedRelabeler.hxx"

--- a/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.hxx
@@ -20,9 +20,7 @@
 
 #include "itkImageRegionIterator.h"
 
-namespace itk
-{
-namespace watershed
+namespace itk::watershed
 {
 template <typename TScalar, unsigned int TImageDimension>
 Relabeler<TScalar, TImageDimension>::Relabeler()
@@ -181,7 +179,6 @@ Relabeler<TScalar, TImageDimension>::PrintSelf(std::ostream & os, Indent indent)
   Superclass::PrintSelf(os, indent);
   os << indent << "FloodLevel: " << m_FloodLevel << std::endl;
 }
-} // end namespace watershed
-} // end namespace itk
+} // namespace itk::watershed
 
 #endif

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.h
@@ -23,9 +23,7 @@
 #include <list>
 #include "itkOneWayEquivalencyTable.h"
 
-namespace itk
-{
-namespace watershed
+namespace itk::watershed
 {
 /**
  * \class SegmentTable
@@ -276,8 +274,7 @@ private:
   operator=(const Self &)
   {}
 };
-} // end namespace watershed
-} // end namespace itk
+} // namespace itk::watershed
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkWatershedSegmentTable.hxx"

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.hxx
@@ -18,10 +18,7 @@
 #ifndef itkWatershedSegmentTable_hxx
 #define itkWatershedSegmentTable_hxx
 
-
-namespace itk
-{
-namespace watershed
+namespace itk::watershed
 {
 template <typename TScalar>
 void
@@ -68,7 +65,6 @@ SegmentTable<TScalar>::Add(IdentifierType a, const segment_t & t)
 
   return true;
 }
-} // end namespace watershed
-} // end namespace itk
+} // namespace itk::watershed
 
 #endif

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTree.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTree.h
@@ -22,9 +22,7 @@
 #include <deque>
 #include <functional>
 
-namespace itk
-{
-namespace watershed
+namespace itk::watershed
 {
 /**
  * \class SegmentTree
@@ -222,8 +220,7 @@ protected:
 
   DequeType m_Deque{};
 };
-} // end namespace watershed
-} // end namespace itk
+} // namespace itk::watershed
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkWatershedSegmentTree.hxx"

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTree.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTree.hxx
@@ -18,10 +18,7 @@
 #ifndef itkWatershedSegmentTree_hxx
 #define itkWatershedSegmentTree_hxx
 
-
-namespace itk
-{
-namespace watershed
+namespace itk::watershed
 {
 
 
@@ -47,7 +44,6 @@ SegmentTree<TScalar>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 }
-} // end namespace watershed
-} // end namespace itk
+} // namespace itk::watershed
 
 #endif

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.h
@@ -25,9 +25,7 @@
 #include <algorithm>
 #include <utility>
 
-namespace itk
-{
-namespace watershed
+namespace itk::watershed
 {
 /**
  * \class SegmentTreeGenerator
@@ -244,8 +242,7 @@ private:
    *  updates. */
   double m_HighestCalculatedFloodLevel{ 0.0 };
 };
-} // end namespace watershed
-} // end namespace itk
+} // namespace itk::watershed
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkWatershedSegmentTreeGenerator.hxx"

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
@@ -21,9 +21,7 @@
 #include <stack>
 #include "itkOneWayEquivalencyTable.h"
 
-namespace itk
-{
-namespace watershed
+namespace itk::watershed
 {
 template <typename TScalar>
 SegmentTreeGenerator<TScalar>::SegmentTreeGenerator()
@@ -580,7 +578,6 @@ SegmentTreeGenerator<TScalar>::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "ConsumeInput: " << m_ConsumeInput << std::endl;
   os << indent << "HighestCalculatedFloodLevel: " << m_HighestCalculatedFloodLevel << std::endl;
 }
-} // end namespace watershed
-} // end namespace itk
+} // namespace itk::watershed
 
 #endif

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.h
@@ -23,9 +23,7 @@
 #include "itkWatershedSegmentTable.h"
 #include "itkEquivalencyTable.h"
 
-namespace itk
-{
-namespace watershed
+namespace itk::watershed
 {
 /**
  * \class Segmenter
@@ -407,8 +405,7 @@ private:
   double         m_MaximumFloodLevel{};
   IdentifierType m_CurrentLabel{};
 };
-} // end namespace watershed
-} // end namespace itk
+} // namespace itk::watershed
 
 #ifndef ITK_MANUAL_INSTANTIATION
 #  include "itkWatershedSegmenter.hxx"

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
@@ -24,9 +24,7 @@
 #include <stack>
 #include <list>
 
-namespace itk
-{
-namespace watershed
+namespace itk::watershed
 {
 
 /*
@@ -1331,7 +1329,6 @@ Segmenter<TInputImage>::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "MaximumFloodLevel: " << m_MaximumFloodLevel << std::endl;
   os << indent << "CurrentLabel: " << m_CurrentLabel << std::endl;
 }
-} // end namespace watershed
-} // end namespace itk
+} // namespace itk::watershed
 
 #endif

--- a/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
+++ b/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
@@ -24,9 +24,8 @@
 /** Set up dummy implementations of TemporalProcessObject and
  * TemporalDataObject for testing
  */
-namespace itk
-{
-namespace TemporalProcessObjectTest
+
+namespace itk::TemporalProcessObjectTest
 {
 
 using SizeValueType = itk::SizeValueType;
@@ -519,8 +518,7 @@ private:
   SizeValueType m_IdNumber{ 0 };
 };
 
-} // end namespace TemporalProcessObjectTest
-} // end namespace itk
+} // namespace itk::TemporalProcessObjectTest
 
 
 int

--- a/Modules/Video/Core/test/itkVideoSourceTest.cxx
+++ b/Modules/Video/Core/test/itkVideoSourceTest.cxx
@@ -27,9 +27,7 @@ using FrameType = itk::Image<PixelType, Dimension>;
 using VideoType = itk::VideoStream<FrameType>;
 using SizeValueType = itk::SizeValueType;
 
-namespace itk
-{
-namespace VideoSourceTest
+namespace itk::VideoSourceTest
 {
 /**
  * \class DummyVideoSource
@@ -136,8 +134,7 @@ CreateEmptyFrame()
   return out;
 }
 
-} // end namespace VideoSourceTest
-} // end namespace itk
+} // namespace itk::VideoSourceTest
 
 /**
  * Test the basic functionality of temporal data objects

--- a/Modules/Video/Core/test/itkVideoToVideoFilterTest.cxx
+++ b/Modules/Video/Core/test/itkVideoToVideoFilterTest.cxx
@@ -30,9 +30,7 @@ using OutputFrameType = itk::Image<OutputPixelType, Dimension>;
 using OutputVideoType = itk::VideoStream<OutputFrameType>;
 using SizeValueType = itk::SizeValueType;
 
-namespace itk
-{
-namespace VideoToVideoFilterTest
+namespace itk::VideoToVideoFilterTest
 {
 
 /**
@@ -155,8 +153,7 @@ protected:
   }
 };
 
-} // end namespace VideoToVideoFilterTest
-} // end namespace itk
+} // namespace itk::VideoToVideoFilterTest
 
 /**
  * Test the basic functionality of temporal data objects

--- a/Modules/Video/Filtering/test/itkDecimateFramesVideoFilterTest.cxx
+++ b/Modules/Video/Filtering/test/itkDecimateFramesVideoFilterTest.cxx
@@ -35,9 +35,7 @@ using FilterType = itk::DecimateFramesVideoFilter<VideoType>;
 using ReaderType = itk::VideoFileReader<VideoType>;
 using WriterType = itk::VideoFileWriter<VideoType>;
 
-namespace itk
-{
-namespace DecimateFramesVideoFilterTest
+namespace itk::DecimateFramesVideoFilterTest
 {
 
 /**
@@ -63,8 +61,7 @@ FramesAreEqual(const FrameType * f1, const FrameType * f2)
   return true;
 }
 
-} // namespace DecimateFramesVideoFilterTest
-} // namespace itk
+} // namespace itk::DecimateFramesVideoFilterTest
 
 
 /**

--- a/Modules/Video/Filtering/test/itkFrameAverageVideoFilterTest.cxx
+++ b/Modules/Video/Filtering/test/itkFrameAverageVideoFilterTest.cxx
@@ -38,9 +38,8 @@ using SizeValueType = itk::SizeValueType;
 /**
  * Helper function
  */
-namespace itk
-{
-namespace FrameAverageVideoFilterTest
+
+namespace itk::FrameAverageVideoFilterTest
 {
 
 /**
@@ -73,8 +72,7 @@ CreateInputFrame(InputPixelType val)
   return out;
 }
 
-} // end namespace FrameAverageVideoFilterTest
-} // end namespace itk
+} // namespace itk::FrameAverageVideoFilterTest
 
 
 /**

--- a/Modules/Video/Filtering/test/itkFrameDifferenceVideoFilterTest.cxx
+++ b/Modules/Video/Filtering/test/itkFrameDifferenceVideoFilterTest.cxx
@@ -38,9 +38,8 @@ using SizeValueType = itk::SizeValueType;
 /**
  * Helper function
  */
-namespace itk
-{
-namespace FrameDifferenceVideoFilterTest
+
+namespace itk::FrameDifferenceVideoFilterTest
 {
 
 /**
@@ -73,8 +72,7 @@ CreateInputFrame(InputPixelType val)
   return out;
 }
 
-} // end namespace FrameDifferenceVideoFilterTest
-} // end namespace itk
+} // namespace itk::FrameDifferenceVideoFilterTest
 
 
 /**

--- a/Utilities/KWStyle/ITK.kws.xml
+++ b/Utilities/KWStyle/ITK.kws.xml
@@ -10,7 +10,7 @@
 <Tabs>1</Tabs>
 <Spaces>3</Spaces>
 <Comments>/**, *, */,true</Comments>
-<Namespace>itk</Namespace>
+<!-- Disable checking namespace, it conflicts with C++17 nested namespaces <Namespace>itk*</Namespace> -->
 <NameOfClass>[NameOfClass],itk</NameOfClass>
 <IfNDefDefine>[NameOfClass]_[Extension]</IfNDefDefine>
 <EmptyLines>2</EmptyLines>


### PR DESCRIPTION
Replace nested namespaces such as 'namespace a { namespace b { ... } }' and changes to the more concise syntax introduced in C++17: 'namespace a::b { ... }'.

Inline namespaces are not modified.

Disabled KWStyle Namespace checking that is incapable of supporting the c++17 nested namespace formatting.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
