### PR TITLE
STYLE: ITK_LEGACY_REMOVE/deprecate `ImageIOBase::GetComponentTypeInfo()`

### DIFF
--- a/Modules/IO/ImageBase/include/itkImageIOBase.h
+++ b/Modules/IO/ImageBase/include/itkImageIOBase.h
@@ -249,13 +249,16 @@ public:
   itkSetEnumMacro(ComponentType, IOComponentEnum);
   itkGetEnumMacro(ComponentType, IOComponentEnum);
 
+#ifndef ITK_LEGACY_REMOVE
   /** get the type_info for the current pixel component type.
    * This function is DEPRECATED and only provided for backwards
    * compatibility.  There is no use for this method that can't
    * be satisfied by calling GetComponentType.
+   *
+   * \deprecated This member function is intended to be removed from ITK 6.
    */
-  virtual const std::type_info &
-  GetComponentTypeInfo() const;
+  itkLegacyMacro(virtual const std::type_info & GetComponentTypeInfo() const);
+#endif
 
   /** Set/Get the number of components per pixel in the image. This may
    * be set by the reading process. For SCALAR pixel types,

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -161,6 +161,8 @@ ImageIOBase::SetDirection(unsigned int i, const vnl_vector<double> & direction)
   m_Direction[i] = v;
 }
 
+
+#ifndef ITK_LEGACY_REMOVE
 const std::type_info &
 ImageIOBase::GetComponentTypeInfo() const
 {
@@ -195,6 +197,8 @@ ImageIOBase::GetComponentTypeInfo() const
       itkExceptionMacro("Unknown component type: " << m_ComponentType);
   }
 }
+#endif
+
 
 void
 ImageIOBase::ComputeStrides()


### PR DESCRIPTION
This member function was already deprecated according to its documentation, as was committed by 6ff5fc7f01148bd11070c5ecfe0d56f643f62565, Kent Williams, Feb 9, 2011.

----

`GetComponentTypeInfo()` is somewhat redundant, because the `std::type_info` of the currently selected Component Type can be retrieved by calling `GetComponentType()` (which returns an `IOComponentEnum` value), and then figuring out which C++ type is mapped to this `IOComponentEnum` value, using `MapPixelType<TPixel>::CType` from https://github.com/InsightSoftwareConsortium/ITK/blob/7bb595b2b554a0083095022db6aae5188dbc30b2/Modules/IO/ImageBase/include/itkImageIOBase.h#L577-L580 
It's not really straightforward, but it works, most of the times.

- Aims to supersede pull request #5393
