### PR TITLE
STYLE: Update Azure Pipelines to use `windows-2022`

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
@@ -29,8 +29,8 @@ jobs:
           CTEST_CMAKE_GENERATOR_TOOLSET: v142
           CTEST_CMAKE_GENERATOR_PLATFORM: x64
           CTEST_CONFIGURATION_TYPE: Release
-          CTEST_CMAKE_GENERATOR: "Visual Studio 16 2019"
-          imageName: 'windows-2019'
+          CTEST_CMAKE_GENERATOR: "Visual Studio 17 2022"
+          imageName: 'windows-2022'
     pool:
       vmImage: $(imageName)
     steps:
@@ -81,6 +81,7 @@ jobs:
 
       - script: |
           cmake --version
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           ctest -S $(Agent.BuildDirectory)/ITK-dashboard/dashboard.cmake -VV -j 4
         displayName: 'Build and test'
         env:

--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -31,7 +31,7 @@ jobs:
   timeoutInMinutes: 0
   cancelTimeoutInMinutes: 300
   pool:
-    vmImage: 'windows-2019'
+    vmImage: 'windows-2022'
   steps:
     - checkout: self
       clean: true
@@ -80,7 +80,7 @@ jobs:
 
     - script: |
         cmake --version
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         ctest -S $(Agent.BuildDirectory)/ITK-dashboard/dashboard.cmake -VV -j 4
       displayName: 'Build and test'
       env:

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -31,7 +31,7 @@ jobs:
   timeoutInMinutes: 0
   cancelTimeoutInMinutes: 300
   pool:
-    vmImage: 'windows-2019'
+    vmImage: 'windows-2022'
   steps:
     - checkout: self
       clean: true
@@ -90,7 +90,7 @@ jobs:
 
     - script: |
         cmake --version
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" -vcvars_ver=14.2
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         ctest -S $(Agent.BuildDirectory)/ITK-dashboard/dashboard.cmake -VV -j 4 -L Python
       displayName: 'Build and test'
       env:


### PR DESCRIPTION
Refactored YAML configurations to replace `windows-2019` with `windows-2022` VM image, ensuring compatibility with updated environments. Adjusted formatting for improved readability.

The Azure Windows Server 2019 image will be removed on 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)