### PR TITLE
Fix valgrind warnings

### DIFF
--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
@@ -337,18 +337,21 @@ HistogramMatchingImageFilter<TInputImage, TOutputImage, THistogramMeasurement>::
         break;
       }
     }
-    // Linear interpolate from point[j] and point[j+1].
-    double mappedValue = m_QuantileTable[1][j - 1] + (srcValue - m_QuantileTable[0][j - 1]) * m_Gradients[j - 1];
-    if (j == 0)
-    {
-      // Linear interpolate from min to point[0]
-      mappedValue = m_ReferenceMinValue + (srcValue - m_SourceMinValue) * m_LowerGradient;
-    }
-    else if (j == m_NumberOfMatchPoints + 2)
-    {
-      // Linear interpolate from point[m_NumberOfMatchPoints+1] to max
-      mappedValue = m_ReferenceMaxValue + (srcValue - m_SourceMaxValue) * m_UpperGradient;
-    }
+
+    const double mappedValue = [this, j, srcValue]() -> double {
+      if (j == 0)
+      {
+        // Linearly interpolate from min to point[0]
+        return m_ReferenceMinValue + (srcValue - m_SourceMinValue) * m_LowerGradient;
+      }
+      if (j == m_NumberOfMatchPoints + 2)
+      {
+        // Linearly interpolate from point[m_NumberOfMatchPoints+1] to max
+        return m_ReferenceMaxValue + (srcValue - m_SourceMaxValue) * m_UpperGradient;
+      }
+      // Linearly interpolate from point[j] and point[j+1].
+      return m_QuantileTable[1][j - 1] + (srcValue - m_QuantileTable[0][j - 1]) * m_Gradients[j - 1];
+    }();
     outIter.Set(static_cast<OutputPixelType>(mappedValue));
   }
 }


### PR DESCRIPTION
Fix the two Valgrind-identified failures.

The incorrect manual refactoring of itkHistogramMatchingImageFilter.hxx in  1f374cfa4797cd580e1bbd1d5fbf59d996253297 changed the logic in a way
That would allow for uninitialized memory reads.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)