### PR TITLE
COMP: Prefer splitting comma-separated pre-increment statements

### DIFF
--- a/Examples/IO/IOPlugin.cxx
+++ b/Examples/IO/IOPlugin.cxx
@@ -88,7 +88,9 @@ main(int argc, char * argv[])
                     << std::endl
                     << "      described as \"" << *d << "\"" << std::endl
                     << "      enabled " << *e << std::endl;
-          ++n, ++d, ++e;
+          ++n;
+          ++d;
+          ++e;
         }
       }
     }
@@ -181,7 +183,9 @@ main(int argc, char * argv[])
                     << std::endl
                     << "      described as \"" << *d << "\"" << std::endl
                     << "      enabled " << *e << std::endl;
-          ++n, ++d, ++e;
+          ++n;
+          ++d;
+          ++e;
         }
       }
     }


### PR DESCRIPTION
Prefer splitting comma-separated pre-increment statements across different lines.

Fixes:
```
[CTest: warning matched]
 /Users/builder/externalExamples/IO/IOPlugin.cxx:91:14:
 warning: possible misuse of comma operator here [-Wcomma]
          ++n, ++d, ++e;
             ^
[CTest: warning matched]
 /Users/builder/externalExamples/IO/IOPlugin.cxx:91:11:
 note: cast expression to void to silence warning
          ++n, ++d, ++e;
          ^~~
          static_cast<void>( )
[CTest: warning matched]
 /Users/builder/externalExamples/IO/IOPlugin.cxx:91:19:
 warning: possible misuse of comma operator here [-Wcomma]
          ++n, ++d, ++e;
                  ^
[CTest: warning matched]
 /Users/builder/externalExamples/IO/IOPlugin.cxx:91:16:
 note: cast expression to void to silence warning
          ++n, ++d, ++e;
               ^~~
               static_cast<void>( )
[CTest: warning matched]
 /Users/builder/externalExamples/IO/IOPlugin.cxx:184:14:
 warning: possible misuse of comma operator here [-Wcomma]
          ++n, ++d, ++e;
             ^
```

raised for example in:
https://open.cdash.org/viewBuildError.php?type=1&buildid=10478727

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)