### PR TITLE
COMP: Use value initialization to zero-initialize thread id variable

### DIFF
--- a/Modules/Core/Common/include/itkThreadSupport.h
+++ b/Modules/Core/Common/include/itkThreadSupport.h
@@ -42,7 +42,7 @@ using FastMutexType = pthread_mutex_t;
 using ThreadFunctionType = void * (*)(void *);
 using ThreadProcessIdType = pthread_t;
 #  if !defined(ITK_FUTURE_LEGACY_REMOVE)
-constexpr ThreadProcessIdType ITK_DEFAULT_THREAD_ID = 0;
+constexpr ThreadProcessIdType ITK_DEFAULT_THREAD_ID = {};
 #  endif
 using ITK_THREAD_RETURN_TYPE = void *;
 /** @ITKEndGrouping */

--- a/Modules/Core/Common/src/itkPlatformMultiThreaderPosix.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreaderPosix.cxx
@@ -169,7 +169,7 @@ ThreadProcessIdType
 PlatformMultiThreader::SpawnDispatchSingleMethodThread(PlatformMultiThreader::WorkUnitInfo * threadInfo)
 {
   // Using POSIX threads
-  pthread_t threadHandle = 0;
+  pthread_t threadHandle = {};
   const int threadError = pthread_create(&threadHandle,
                                          nullptr,
                                          reinterpret_cast<c_void_cast>(this->SingleMethodProxy),


### PR DESCRIPTION
Use value initialization to zero-initialize thread id variable.

Fixes:
```
In file included from
 Core/Common/src/itkPlatformMultiThreader.cxx:35:
[CTest: warning matched]
 Core/Common/src/itkPlatformMultiThreaderPosix.cxx:172:28:
 warning: zero as null pointer constant [-Wzero-as-null-pointer-constant]
  172 |   pthread_t threadHandle = 0;
      |                            ^
      |                            nullptr
[CTest: warning suppressed] 1 warning generated.
```

raised for example in:
https://open.cdash.org/viewBuildError.php?type=1&buildid=10477917

and
```
ITK/Modules/Core/Common/include/itkThreadSupport.h:45:55:
 warning: zero as null pointer constant [-Wzero-as-null-pointer-constant]
   45 | constexpr ThreadProcessIdType ITK_DEFAULT_THREAD_ID = 0;
      |                                                       ^
      |                                                       nullptr
```

reported by a local build.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
