### PR TITLE
COMP: removed workarounds for old Apple stuff

### DIFF
--- a/Modules/Core/Common/include/itkImageRegion.h
+++ b/Modules/Core/Common/include/itkImageRegion.h
@@ -428,13 +428,6 @@ operator<<(std::ostream & os, const ImageRegion<VImageDimension> & region);
 
 namespace std
 {
-#if defined(__clang__) && defined(__apple_build_version__) && (__clang_major__ <= 10)
-#  pragma clang diagnostic push
-// Old AppleClang 10.0.0 (Xcode 10.1, newest on macOS 10.13) produced some unimportant warnings, like:
-// "warning: 'tuple_size' defined as a struct template here but previously declared as a class template"
-#  pragma clang diagnostic ignored "-Wmismatched-tags"
-#endif
-
 // NOLINTBEGIN(cert-dcl58-cpp)
 // Locally suppressed the following warning from Clang-Tidy (LLVM 17.0.1), as it appears undeserved.
 // > warning: modification of 'std' namespace can result in undefined behavior [cert-dcl58-cpp]
@@ -460,9 +453,6 @@ struct tuple_element<VTupleIndex, itk::ImageRegion<VImageDimension>>
 
 // NOLINTEND(cert-dcl58-cpp)
 
-#if defined(__clang__) && defined(__apple_build_version__) && (__clang_major__ <= 10)
-#  pragma clang diagnostic pop
-#endif
 } // namespace std
 
 #undef itkRegionOverrideMacro

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -216,10 +216,8 @@ namespace itk
 // define a minimum __sgi version that will work.
 #  error "The SGI compiler is not supported"
 #endif
-#if defined(__APPLE__)
-#  if defined(__clang__) && (__cplusplus < 201703L)
-#    error "Apple LLVM compiling with a standard less than C++17 is not supported"
-#  endif
+#if defined(__apple_build_version__) && (__apple_build_version__ < 12000032)
+#  error "AppleClang < Xcode 12.4 is not supported"
 #elif defined(__clang__) && (__clang_major__ < 5)
 #  error "Clang < 5 is not supported"
 #endif

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -303,12 +303,7 @@ ImageIOBase::ReadBufferAsBinary(std::istream & is, void * buffer, ImageIOBase::S
 
   const std::streamsize numberOfBytesRead = is.gcount();
 
-#ifdef __APPLE_CC__
-  // fail() is broken in the Mac. It returns true when reaches eof().
-  if (numberOfBytesRead != numberOfBytesToBeRead)
-#else
   if ((numberOfBytesRead != numberOfBytesToBeRead) || is.fail())
-#endif
   {
     return false; // read failed
   }


### PR DESCRIPTION
- removed workaround for Xcode 10
- emit #error for AppleClang less than Xcode 12.4
- removed workaround for broken fail() added in 1fcd00774bf65728cc4c9e2e7f10750a48334ca2 in 2003. Hopefully the workaround is no longer needed. I'm not sure, but all tests pass on my arm64 macOS 15.5.

Related to issue #5369.
