### PR TITLE
STYLE: Don't call static TypeAsString functions via instances, in tests

### DIFF
--- a/Modules/IO/BMP/test/itkBMPImageIOTest.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTest.cxx
@@ -44,10 +44,10 @@ itkBMPImageIOTest(int argc, char * argv[])
 
   reader->UpdateOutputInformation();
 
-  std::cout << "PixelType: " << reader->GetImageIO()->GetPixelTypeAsString(reader->GetImageIO()->GetPixelType())
+  std::cout << "PixelType: " << itk::ImageIOBase::GetPixelTypeAsString(reader->GetImageIO()->GetPixelType())
             << std::endl;
-  std::cout << "ComponentType: "
-            << reader->GetImageIO()->GetComponentTypeAsString(reader->GetImageIO()->GetComponentType()) << std::endl;
+  std::cout << "ComponentType: " << itk::ImageIOBase::GetComponentTypeAsString(reader->GetImageIO()->GetComponentType())
+            << std::endl;
   std::cout << "NumberOfComponents: " << reader->GetImageIO()->GetNumberOfComponents() << std::endl;
 
   ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());

--- a/Modules/IO/BMP/test/itkBMPImageIOTest2.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTest2.cxx
@@ -46,10 +46,10 @@ itkBMPImageIOTest2(int argc, char * argv[])
   reader->SetFileName(argv[1]);
   reader->UpdateOutputInformation();
 
-  std::cout << "PixelType: " << reader->GetImageIO()->GetPixelTypeAsString(reader->GetImageIO()->GetPixelType())
+  std::cout << "PixelType: " << itk::ImageIOBase::GetPixelTypeAsString(reader->GetImageIO()->GetPixelType())
             << std::endl;
-  std::cout << "ComponentType: "
-            << reader->GetImageIO()->GetComponentTypeAsString(reader->GetImageIO()->GetComponentType()) << std::endl;
+  std::cout << "ComponentType: " << itk::ImageIOBase::GetComponentTypeAsString(reader->GetImageIO()->GetComponentType())
+            << std::endl;
   std::cout << "NumberOfComponents: " << reader->GetImageIO()->GetNumberOfComponents() << std::endl;
 
   ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());

--- a/Modules/IO/GDCM/test/itkGDCMImageReadWriteTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageReadWriteTest.cxx
@@ -68,20 +68,21 @@ internalMain(const std::string &       inputImage,
   {
     case IOPixelType::SCALAR:
       ITK_TEST_EXPECT_EQUAL(numberOfComponents, 1);
-      ITK_TEST_EXPECT_EQUAL(gdcmImageIO->GetPixelTypeAsString(pixelType), expectedPixelType);
+      ITK_TEST_EXPECT_EQUAL(itk::ImageIOBase::GetPixelTypeAsString(pixelType), expectedPixelType);
       return ReadWrite<itk::Image<float, Dimension>>(inputImage, outputImage);
 
     case IOPixelType::RGB:
       ITK_TEST_EXPECT_EQUAL(numberOfComponents, 3);
-      ITK_TEST_EXPECT_EQUAL(gdcmImageIO->GetPixelTypeAsString(pixelType), expectedPixelType);
+      ITK_TEST_EXPECT_EQUAL(itk::ImageIOBase::GetPixelTypeAsString(pixelType), expectedPixelType);
       return ReadWrite<itk::Image<itk::RGBPixel<unsigned char>, Dimension>>(inputImage, outputImage);
 
     case IOPixelType::VECTOR:
-      ITK_TEST_EXPECT_EQUAL(gdcmImageIO->GetPixelTypeAsString(pixelType), expectedPixelType);
+      ITK_TEST_EXPECT_EQUAL(itk::ImageIOBase::GetPixelTypeAsString(pixelType), expectedPixelType);
       return ReadWrite<itk::VectorImage<float, Dimension>>(inputImage, outputImage);
 
     default:
-      std::cerr << "Test does not support pixel type of " << gdcmImageIO->GetPixelTypeAsString(pixelType) << std::endl;
+      std::cerr << "Test does not support pixel type of " << itk::ImageIOBase::GetPixelTypeAsString(pixelType)
+                << std::endl;
       return EXIT_FAILURE;
   }
 }

--- a/Modules/IO/ImageBase/test/itkImageIOBaseTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageIOBaseTest.cxx
@@ -210,97 +210,48 @@ itkImageIOBaseTest(int, char *[])
 
     constexpr size_t listComponentSize = std::size(listComponentType);
     constexpr size_t listPixelSize = std::size(listIOPixelType);
-    { // Test the static version of the string <-> type conversions
-      for (size_t i = 0; i < listComponentSize; ++i)
-      {
-        const std::string componentTypeString = itk::ImageIOBase::GetComponentTypeAsString(listComponentType[i]);
-        if (componentTypeString.compare(listComponentTypeString[i]) != 0)
-        {
-          std::cerr << "GetComponentTypeAsString(" << listComponentType[i] << ") should return '"
-                    << listComponentTypeString[i] << '\'' << std::endl;
-          return EXIT_FAILURE;
-        }
-      }
-      for (size_t i = 0; i < listPixelSize; ++i)
-      {
-        const std::string pixelTypeString = itk::ImageIOBase::GetPixelTypeAsString(listIOPixelType[i]);
-        if (pixelTypeString.compare(listIOPixelTypeString[i]) != 0)
-        {
-          std::cerr << "GetPixelTypeAsString(" << listIOPixelType[i] << ") should return '" << listIOPixelTypeString[i]
-                    << '\'' << std::endl;
-          return EXIT_FAILURE;
-        }
-      }
-      for (size_t i = 0; i < listComponentSize; ++i)
-      {
-        const itk::IOComponentEnum componentType =
-          itk::ImageIOBase::GetComponentTypeFromString(listComponentTypeString[i]);
-        if (componentType != listComponentType[i])
-        {
-          std::cerr << "GetComponentTypeFromString('" << listComponentTypeString[i] << "') should return "
-                    << listComponentType[i] << std::endl;
-          return EXIT_FAILURE;
-        }
-      }
-      for (size_t i = 0; i < listPixelSize; ++i)
-      {
-        const itk::IOPixelEnum pixelType = itk::ImageIOBase::GetPixelTypeFromString(listIOPixelTypeString[i]);
-        if (pixelType != listIOPixelType[i])
-        {
-          std::cerr << "GetPixelTypeFromString('" << listIOPixelTypeString[i] << "') should return "
-                    << listIOPixelType[i] << std::endl;
-          return EXIT_FAILURE;
-        }
-      }
-    } // end Test the static version of the string <-> type conversions
 
-    // Test the non-static version of the string <-> type conversions
+    for (size_t i = 0; i < listComponentSize; ++i)
     {
-      // Create an instance of ImageIOBase. It does not matter that 'test' is not a valid image to read,
-      // we just want the ImageIOBase object.
-      const itk::ImageIOBase::Pointer imageIOBase =
-        itk::ImageIOFactory::CreateImageIO("test", itk::ImageIOFactory::IOFileModeEnum::ReadMode);
-      for (size_t i = 0; i < listComponentSize; ++i)
+      const std::string componentTypeString = itk::ImageIOBase::GetComponentTypeAsString(listComponentType[i]);
+      if (componentTypeString.compare(listComponentTypeString[i]) != 0)
       {
-        const std::string componentTypeString = imageIOBase->GetComponentTypeAsString(listComponentType[i]);
-        if (componentTypeString.compare(listComponentTypeString[i]) != 0)
-        {
-          std::cerr << "GetComponentTypeAsString(" << listComponentType[i] << ") should return '"
-                    << listComponentTypeString[i] << '\'' << std::endl;
-          return EXIT_FAILURE;
-        }
+        std::cerr << "GetComponentTypeAsString(" << listComponentType[i] << ") should return '"
+                  << listComponentTypeString[i] << '\'' << std::endl;
+        return EXIT_FAILURE;
       }
-      for (size_t i = 0; i < listPixelSize; ++i)
+    }
+    for (size_t i = 0; i < listPixelSize; ++i)
+    {
+      const std::string pixelTypeString = itk::ImageIOBase::GetPixelTypeAsString(listIOPixelType[i]);
+      if (pixelTypeString.compare(listIOPixelTypeString[i]) != 0)
       {
-        const std::string pixelTypeString = imageIOBase->GetPixelTypeAsString(listIOPixelType[i]);
-        if (pixelTypeString.compare(listIOPixelTypeString[i]) != 0)
-        {
-          std::cerr << "GetPixelTypeAsString(" << listIOPixelType[i] << ") should return " << listIOPixelTypeString[i]
-                    << std::endl;
-          return EXIT_FAILURE;
-        }
+        std::cerr << "GetPixelTypeAsString(" << listIOPixelType[i] << ") should return '" << listIOPixelTypeString[i]
+                  << '\'' << std::endl;
+        return EXIT_FAILURE;
       }
-      for (size_t i = 0; i < listComponentSize; ++i)
+    }
+    for (size_t i = 0; i < listComponentSize; ++i)
+    {
+      const itk::IOComponentEnum componentType =
+        itk::ImageIOBase::GetComponentTypeFromString(listComponentTypeString[i]);
+      if (componentType != listComponentType[i])
       {
-        const itk::IOComponentEnum componentType = imageIOBase->GetComponentTypeFromString(listComponentTypeString[i]);
-        if (componentType != listComponentType[i])
-        {
-          std::cerr << "GetComponentTypeFromString('" << listComponentTypeString[i] << "') should return "
-                    << listComponentType[i] << std::endl;
-          return EXIT_FAILURE;
-        }
+        std::cerr << "GetComponentTypeFromString('" << listComponentTypeString[i] << "') should return "
+                  << listComponentType[i] << std::endl;
+        return EXIT_FAILURE;
       }
-      for (size_t i = 0; i < listPixelSize; ++i)
+    }
+    for (size_t i = 0; i < listPixelSize; ++i)
+    {
+      const itk::IOPixelEnum pixelType = itk::ImageIOBase::GetPixelTypeFromString(listIOPixelTypeString[i]);
+      if (pixelType != listIOPixelType[i])
       {
-        const itk::IOPixelEnum pixelType = imageIOBase->GetPixelTypeFromString(listIOPixelTypeString[i]);
-        if (pixelType != listIOPixelType[i])
-        {
-          std::cerr << "GetPixelTypeFromString('" << listIOPixelTypeString[i] << "') should return "
-                    << listIOPixelType[i] << std::endl;
-          return EXIT_FAILURE;
-        }
+        std::cerr << "GetPixelTypeFromString('" << listIOPixelTypeString[i] << "') should return " << listIOPixelType[i]
+                  << std::endl;
+        return EXIT_FAILURE;
       }
-    } // end Test the non-static version of the string <-> type conversions
+    }
   }
 
   { // Test SetPixelTypeInfo

--- a/Modules/IO/ImageBase/test/itkVectorImageReadWriteTest.cxx
+++ b/Modules/IO/ImageBase/test/itkVectorImageReadWriteTest.cxx
@@ -108,8 +108,9 @@ itkVectorImageReadWriteTest(int argc, char * argv[])
   const itk::ImageIOBase::Pointer io = reader->GetModifiableImageIO();
 
 
-  std::cout << "ImageIO Pixel Information: " << io->GetPixelTypeAsString(io->GetPixelType()) << ' '
-            << io->GetComponentTypeAsString(io->GetComponentType()) << ' ' << io->GetNumberOfComponents() << std::endl;
+  std::cout << "ImageIO Pixel Information: " << itk::ImageIOBase::GetPixelTypeAsString(io->GetPixelType()) << ' '
+            << itk::ImageIOBase::GetComponentTypeAsString(io->GetComponentType()) << ' ' << io->GetNumberOfComponents()
+            << std::endl;
   if (io->GetNumberOfComponents() != 4 || io->GetComponentType() != itk::IOComponentEnum::DOUBLE ||
       io->GetPixelType() != itk::IOPixelEnum::VECTOR)
   {

--- a/Modules/IO/MeshBase/include/itkMeshIOTestHelper.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOTestHelper.h
@@ -300,10 +300,10 @@ TestBaseClassMethodsMeshIO(typename TMeshIO::Pointer meshIO)
   const itk::IOComponentEnum floatComponent = itk::IOComponentEnum::FLOAT;
   std::cout << "ComponentSize: " << meshIO->GetComponentSize(floatComponent) << std::endl;
 
-  std::cout << "ComponentTypeAsString: " << meshIO->GetComponentTypeAsString(floatComponent) << std::endl;
+  std::cout << "ComponentTypeAsString: " << itk::MeshIOBase::GetComponentTypeAsString(floatComponent) << std::endl;
 
   const itk::CommonEnums::IOPixel pixelType = itk::CommonEnums::IOPixel::SCALAR;
-  std::cout << "PixelTypeAsString: " << meshIO->GetPixelTypeAsString(pixelType) << std::endl;
+  std::cout << "PixelTypeAsString: " << itk::MeshIOBase::GetPixelTypeAsString(pixelType) << std::endl;
 
   const itk::CommonEnums::IOComponent pointComponentType = itk::CommonEnums::IOComponent::FLOAT;
   meshIO->SetPointComponentType(pointComponentType);

--- a/Modules/IO/TIFF/test/itkTIFFImageIOCompressionTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOCompressionTest.cxx
@@ -178,10 +178,10 @@ itkTIFFImageIOCompressionTest(int argc, char * argv[])
   std::cout << "Compression: " << argv[3] << std::endl;
   std::cout << "JPEGQuality: " << JPEGQuality << std::endl;
 
-  std::cout << " Pixel type (string): " << imageIO->GetPixelTypeAsString(imageIO->GetPixelType()) << std::endl;
+  std::cout << " Pixel type (string): " << itk::ImageIOBase::GetPixelTypeAsString(imageIO->GetPixelType()) << std::endl;
 
   const ScalarPixelType componentType = imageIO->GetComponentType();
-  std::cout << " Component Type is " << imageIO->GetComponentTypeAsString(componentType) << std::endl;
+  std::cout << " Component Type is " << itk::ImageIOBase::GetComponentTypeAsString(componentType) << std::endl;
 
   std::cout << " Component size: " << imageIO->GetComponentSize() << std::endl;
 


### PR DESCRIPTION
Replaced function calls of the form `instance->MemberFunction(x)` with `itk::T::MemberFunction(x)`, for the static member functions `GetPixelTypeAsString` and `GetComponentTypeAsString`.

Removed the non-static version of the string <-> type conversion tests from itkImageIOBaseTest.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/5391 commit 45e93bbde02a67dcaa5ed3fdb51bd6599b7a95e3