### PR TITLE
STYLE: Don't call static TypeAsString functions via instances (Examples)

### DIFF
--- a/Examples/Filtering/FFTImageFilter.cxx
+++ b/Examples/Filtering/FFTImageFilter.cxx
@@ -327,7 +327,7 @@ main(int argc, char * argv[])
   // A way of testing the pixel type of an image in file is to
   // invoke the ImageIO object from the reader and then call
   // \code{GetPixelTypeAsString()}
-  complexReader->GetImageIO()->GetPixelTypeAsString(
+  itk::ImageIOBase::GetPixelTypeAsString(
     complexReader->GetImageIO()->GetPixelType());
 
 

--- a/Examples/IO/DicomImageReadPrintTags.cxx
+++ b/Examples/IO/DicomImageReadPrintTags.cxx
@@ -369,10 +369,9 @@ main(int argc, char * argv[])
   const itk::IOComponentEnum componentType =
     reader->GetImageIO()->GetComponentType();
   std::cout << "PixelType: "
-            << reader->GetImageIO()->GetPixelTypeAsString(pixelType)
-            << std::endl;
+            << itk::ImageIOBase::GetPixelTypeAsString(pixelType) << std::endl;
   std::cout << "Component Type: "
-            << reader->GetImageIO()->GetComponentTypeAsString(componentType)
+            << itk::ImageIOBase::GetComponentTypeAsString(componentType)
             << std::endl;
   // Software Guide : EndCodeSnippet
 


### PR DESCRIPTION
Replaced function calls of the form `instance->MemberFunction(x)` with `itk::T::MemberFunction(x)`, for the static member functions `GetPixelTypeAsString` and `GetComponentTypeAsString`, in Examples.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/5391 commit 45e93bbde02a67dcaa5ed3fdb51bd6599b7a95e3