### PR TITLE
BUG: Use launcher for local Python pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,7 +102,7 @@ repos:
       stages: [pre-commit]
     - id: kw-commit-msg
       name: 'kw commit-msg'
-      entry: 'Utilities/Hooks/kw-commit-msg.py'
+      entry: 'Utilities/Hooks/run-pixi-python.sh Utilities/Hooks/kw-commit-msg.py'
       language: system
       stages: [commit-msg]
       exclude: "\\/ThirdParty\\/"

--- a/Utilities/Hooks/run-pixi-python.sh
+++ b/Utilities/Hooks/run-pixi-python.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Cross-platform launcher for Pixi-Python launched local Python pre-commit hooks
+
+# Determine Python executable path based on OS
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "mingw" || "$OSTYPE" == "win32" ]]; then
+    PYTHON_EXE="./.pixi/envs/pre-commit/python.exe"
+else
+    PYTHON_EXE="./.pixi/envs/pre-commit/bin/python"
+fi
+
+# Verify Python executable exists
+if [[ ! -x "$PYTHON_EXE" ]]; then
+    echo "Error: Python executable not found at $PYTHON_EXE" >&2
+    exit 1
+fi
+
+# Get target script path from first argument
+TARGET_SCRIPT="$1"
+shift  # Remove first arg, leaving remaining args for the target script
+
+# Execute target script with Python
+exec "$PYTHON_EXE" "$TARGET_SCRIPT" "$@"


### PR DESCRIPTION
Python may not be available on Windows systems. Use a launcher script to run local Python pre-commit hooks with the Python executable we generate when bootstrapping our pre-commit hooks. The launcher script uses the local Python, which we know will be available and have a sufficient version. It also allows adjusting the path with Windows vs Unix.