### PR TITLE
ENH: Change language of commit message pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,7 +103,7 @@ repos:
     - id: kw-commit-msg
       name: 'kw commit-msg'
       entry: 'Utilities/Hooks/kw-commit-msg.py'
-      language: system
+      language: python
       stages: [commit-msg]
       exclude: "\\/ThirdParty\\/"
     - id: kw-pre-commit


### PR DESCRIPTION
Avoids the following error message on Windows:
```log
kw commit-msg............................................................Failed
- hook id: kw-commit-msg
- exit code: 9009

Python was not found; run without arguments to install from the Microsoft Store, or disable this shortcut from Settings > Apps > Advanced app settings > App execution aliases.
```
## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

Supersedes and closes #5442.