### PR TITLE
STYLE: Remove template specializations of `MeshIOBase::MapComponentType`

### DIFF
--- a/Modules/IO/MeshBase/include/itkMeshIOBase.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOBase.h
@@ -37,6 +37,7 @@
 #include "itkMakeUniqueForOverwrite.h"
 
 #include <string>
+#include <type_traits> // For is_same_v.
 #include <complex>
 #include <fstream>
 
@@ -200,10 +201,25 @@ public:
   itkSetEnumMacro(CellPixelComponentType, itk::CommonEnums::IOComponent);
   itkGetEnumMacro(CellPixelComponentType, itk::CommonEnums::IOComponent);
   /** @ITKEndGrouping */
-  template <typename T>
+
+  template <typename TComponent>
   struct MapComponentType
   {
-    static constexpr IOComponentEnum CType = IOComponentEnum::UNKNOWNCOMPONENTTYPE;
+    static constexpr IOComponentEnum CType =
+      std::is_same_v<TComponent, unsigned char>        ? IOComponentEnum::UCHAR
+      : std::is_same_v<TComponent, char>               ? IOComponentEnum::CHAR
+      : std::is_same_v<TComponent, short>              ? IOComponentEnum::SHORT
+      : std::is_same_v<TComponent, unsigned short>     ? IOComponentEnum::USHORT
+      : std::is_same_v<TComponent, int>                ? IOComponentEnum::INT
+      : std::is_same_v<TComponent, unsigned int>       ? IOComponentEnum::UINT
+      : std::is_same_v<TComponent, long>               ? IOComponentEnum::LONG
+      : std::is_same_v<TComponent, unsigned long>      ? IOComponentEnum::ULONG
+      : std::is_same_v<TComponent, long long>          ? IOComponentEnum::LONGLONG
+      : std::is_same_v<TComponent, unsigned long long> ? IOComponentEnum::ULONGLONG
+      : std::is_same_v<TComponent, float>              ? IOComponentEnum::FLOAT
+      : std::is_same_v<TComponent, double>             ? IOComponentEnum::DOUBLE
+      : std::is_same_v<TComponent, long double>        ? IOComponentEnum::LDOUBLE
+                                                       : IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   };
 
   template <typename T>
@@ -874,27 +890,6 @@ private:
   ArrayOfExtensionsType m_SupportedReadExtensions{};
   ArrayOfExtensionsType m_SupportedWriteExtensions{};
 };
-#define MESHIOBASE_TYPEMAP(type, ctype)             \
-  template <>                                       \
-  struct MeshIOBase::MapComponentType<type>         \
-  {                                                 \
-    static constexpr IOComponentEnum CType = ctype; \
-  }
-
-MESHIOBASE_TYPEMAP(unsigned char, IOComponentEnum::UCHAR);
-MESHIOBASE_TYPEMAP(char, IOComponentEnum::CHAR);
-MESHIOBASE_TYPEMAP(unsigned short, IOComponentEnum::USHORT);
-MESHIOBASE_TYPEMAP(short, IOComponentEnum::SHORT);
-MESHIOBASE_TYPEMAP(unsigned int, IOComponentEnum::UINT);
-MESHIOBASE_TYPEMAP(int, IOComponentEnum::INT);
-MESHIOBASE_TYPEMAP(unsigned long, IOComponentEnum::ULONG);
-MESHIOBASE_TYPEMAP(long, IOComponentEnum::LONG);
-MESHIOBASE_TYPEMAP(unsigned long long, IOComponentEnum::ULONGLONG);
-MESHIOBASE_TYPEMAP(long long, IOComponentEnum::LONGLONG);
-MESHIOBASE_TYPEMAP(float, IOComponentEnum::FLOAT);
-MESHIOBASE_TYPEMAP(double, IOComponentEnum::DOUBLE);
-MESHIOBASE_TYPEMAP(long double, IOComponentEnum::LDOUBLE);
-#undef MESHIOBASE_TYPEMAP
 } // end namespace itk
 
 #endif


### PR DESCRIPTION
Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/5421 commit b209c1a00f2cc042172996631d8cf5a06658fd1a
"STYLE: Remove template specializations of `ImageIOBase::MapPixelType`"

Note that `MeshIOBase::MapComponentType` supports `long double` as pixel component type, whereas `ImageIOBase::MapPixelType` does not. Moreover, `MeshIOBase::MapComponentType` unconditionally maps `char` to `CHAR`, whereas `ImageIOBase::MapPixelType` maps `char` to either `CHAR` or `UCHAR`, depending on the signedness of `char`.