### PR TITLE
DOC: Fix typos in GitHub issue template files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,8 +24,8 @@ already filed. -->
 3. [and so on...]
 
 Provide a minimal, complete, compilable, and verifiable example (commonly
-abbreviated as MWE, Minimal Working Example, or sometimes referred to as SSEE,
-Short, Self Contained, Correct (Compilable) Example, SSCCE) or code snippet,
+abbreviated as MWE, Minimal Working Example, or sometimes referred to as SSCCE,
+Short, Self Contained, Correct (Compilable) Example) or code snippet,
 either through a GitHub gist (https://gist.github.com/) or providing your own
 files (including your source code, `CMakeLists.txt` file if applicable, and your
 data) reproducing the issue or showing an incorrect result. -->

--- a/.github/ISSUE_TEMPLATE/compiler_support_report.md
+++ b/.github/ISSUE_TEMPLATE/compiler_support_report.md
@@ -24,8 +24,8 @@ already filed. -->
 3. [and so on...]
 
 Provide a minimal, complete, compilable, and verifiable example (commonly
-abbreviated as MWE, Minimal Working Example, or sometimes referred to as SSEE,
-Short, Self Contained, Correct (Compilable) Example, SSCCE) or code snippet,
+abbreviated as MWE, Minimal Working Example, or sometimes referred to as SSCCE,
+Short, Self Contained, Correct (Compilable) Example) or code snippet,
 either through a GitHub gist (https://gist.github.com/) or providing your own
 files (including your source code, and `CMakeLists.txt` file) reproducing the
 build failure. -->

--- a/.github/ISSUE_TEMPLATE/data_addition_request.md
+++ b/.github/ISSUE_TEMPLATE/data_addition_request.md
@@ -25,8 +25,8 @@ data benefits or challenges the toolkit. -->
 3. [and so on...]
 
 Provide a minimal, complete, compilable, and verifiable example (commonly
-abbreviated as MWE, Minimal Working Example, or sometimes referred to as SSEE,
-Short, Self Contained, Correct (Compilable) Example, SSCCE) or code snippet,
+abbreviated as MWE, Minimal Working Example, or sometimes referred to as SSCCE,
+Short, Self Contained, Correct (Compilable) Example) or code snippet,
 either through a GitHub gist (https://gist.github.com/) or providing your own
 files (including your source code, `CMakeLists.txt` file if applicable, and
 your data) showing how the toolkit is challenged by the new data. -->

--- a/.github/ISSUE_TEMPLATE/design_impact_report.md
+++ b/.github/ISSUE_TEMPLATE/design_impact_report.md
@@ -30,8 +30,8 @@ look like. -->
 ```
 
 <!-- Provide a minimal, complete, compilable, and verifiable example (commonly
-abbreviated as MWE, Minimal Working Example, or sometimes referred to as SSEE,
-Short, Self Contained, Correct (Compilable) Example, SSCCE) or code snippet,
+abbreviated as MWE, Minimal Working Example, or sometimes referred to as SSCCE,
+Short, Self Contained, Correct (Compilable) Example) or code snippet,
 either through a GitHub gist (https://gist.github.com/) or providing your own
 files (including your source code, `CMakeLists.txt` file if applicable, and your
 data) showing the benefit of the change. -->

--- a/.github/ISSUE_TEMPLATE/infrastructure_impact_report.md
+++ b/.github/ISSUE_TEMPLATE/infrastructure_impact_report.md
@@ -30,8 +30,8 @@ code would look like. -->
 ```
 
 <!-- Provide a minimal, complete, compilable, and verifiable example (commonly
-abbreviated as MWE, Minimal Working Example, or sometimes referred to as SSEE,
-Short, Self Contained, Correct (Compilable) Example, SSCCE) or code snippet,
+abbreviated as MWE, Minimal Working Example, or sometimes referred to as SSCCE,
+Short, Self Contained, Correct (Compilable) Example) or code snippet,
 either through a GitHub gist (https://gist.github.com/) or providing your own
 files (including your source code, `CMakeLists.txt` file if applicable, and your
 data) showing the benefit of the change. -->

--- a/.github/ISSUE_TEMPLATE/performance_impact_report.md
+++ b/.github/ISSUE_TEMPLATE/performance_impact_report.md
@@ -30,8 +30,8 @@ what the code would look like. -->
 ```
 
 <!-- Provide a minimal, complete, compilable, and verifiable example (commonly
-abbreviated as MWE, Minimal Working Example, or sometimes referred to as SSEE,
-Short, Self Contained, Correct (Compilable) Example, SSCCE) or code snippet,
+abbreviated as MWE, Minimal Working Example, or sometimes referred to as SSCCE,
+Short, Self Contained, Correct (Compilable) Example) or code snippet,
 either through a GitHub gist (https://gist.github.com/) or providing your own
 files (including your source code, `CMakeLists.txt` file if applicable, and your
 data) that shows the performance improvement of the change. -->

--- a/.github/ISSUE_TEMPLATE/regression_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/regression_bug_report.md
@@ -24,8 +24,8 @@ already filed. -->
 3. [and so on...]
 
 Provide a minimal, complete, compilable, and verifiable example (commonly
-abbreviated as MWE, Minimal Working Example, or sometimes referred to as SSEE,
-Short, Self Contained, Correct (Compilable) Example, SSCCE) or code snippet,
+abbreviated as MWE, Minimal Working Example, or sometimes referred to as SSCCE,
+Short, Self Contained, Correct (Compilable) Example) or code snippet,
 either through a GitHub gist (https://gist.github.com/) or providing your own
 files (including your source code, `CMakeLists.txt` file if applicable, and your
 data) reproducing the incorrect regression result. -->


### PR DESCRIPTION
Fix typos in GitHub issues template files: leave `SSCCE` to mean "Short, Self Contained, Correct (Compilable) Example" and remove `SSEE`.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)