### PR TITLE
STYLE: Make Python license headers be consistent in Python scripts

### DIFF
--- a/Examples/DataRepresentation/Image/ImageToArray.py
+++ b/Examples/DataRepresentation/Image/ImageToArray.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 from InsightToolkit import *
 from numarray import *

--- a/Examples/IO/DicomSliceRead.py
+++ b/Examples/IO/DicomSliceRead.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Example on the use of ImageFileReader to reading a single slice (it will read

--- a/Examples/RegistrationITKv4/ImageRegistration3.py
+++ b/Examples/RegistrationITKv4/ImageRegistration3.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import sys
 

--- a/Examples/RegistrationITKv4/ImageRegistration4.py
+++ b/Examples/RegistrationITKv4/ImageRegistration4.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 from sys import argv

--- a/Examples/RegistrationITKv4/ImageRegistration5.py
+++ b/Examples/RegistrationITKv4/ImageRegistration5.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 from sys import argv

--- a/Examples/Segmentation/VoronoiSegmentation.py
+++ b/Examples/Segmentation/VoronoiSegmentation.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Example on the use of the VoronoiSegmentationImageFilter.

--- a/Examples/Segmentation/WatershedSegmentation1.py
+++ b/Examples/Segmentation/WatershedSegmentation1.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import InsightToolkit as itk
 import sys

--- a/Examples/Visualization/CannyEdgeDetectionImageFilterConnectVTKITK.py
+++ b/Examples/Visualization/CannyEdgeDetectionImageFilterConnectVTKITK.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 # This file demonstrates how to connect VTK and ITK pipelines together
 # in scripted languages with the new ConnectVTKITK wrapping functionality.

--- a/Modules/Bridge/NumPy/wrapping/test/itkImageMetaDataSetGetItem.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkImageMetaDataSetGetItem.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import sys
 import numpy as np

--- a/Modules/Bridge/NumPy/wrapping/test/itkPyBufferMemoryLeakTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyBufferMemoryLeakTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 import sys
 import numpy as np
 import itk

--- a/Modules/Bridge/NumPy/wrapping/test/itkPyBufferPipelineTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyBufferPipelineTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import sys
 import numpy as np

--- a/Modules/Bridge/NumPy/wrapping/test/itkPyBufferTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyBufferTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import sys
 import unittest

--- a/Modules/Bridge/NumPy/wrapping/test/itkPyVectorContainerTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyVectorContainerTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 import sys
 import unittest
 import datetime as dt

--- a/Modules/Bridge/NumPy/wrapping/test/itkPyVnlTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyVnlTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import sys
 import unittest

--- a/Modules/Core/Common/wrapping/test/itkDirectoryTest.py
+++ b/Modules/Core/Common/wrapping/test/itkDirectoryTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 

--- a/Modules/Core/Common/wrapping/test/itkImageDuplicatorTest.py
+++ b/Modules/Core/Common/wrapping/test/itkImageDuplicatorTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 

--- a/Modules/Core/Common/wrapping/test/itkImageTest.py
+++ b/Modules/Core/Common/wrapping/test/itkImageTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 import itk
 import numpy as np
 

--- a/Modules/Core/Common/wrapping/test/itkIndexOffsetTest.py
+++ b/Modules/Core/Common/wrapping/test/itkIndexOffsetTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 

--- a/Modules/Core/Common/wrapping/test/itkMatrixTest.py
+++ b/Modules/Core/Common/wrapping/test/itkMatrixTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 import numpy as np

--- a/Modules/Core/Common/wrapping/test/itkMetaDataDictionaryTest.py
+++ b/Modules/Core/Common/wrapping/test/itkMetaDataDictionaryTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 

--- a/Modules/Core/Common/wrapping/test/itkPointSetSerializationTest.py
+++ b/Modules/Core/Common/wrapping/test/itkPointSetSerializationTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 
 import itk

--- a/Modules/Core/Common/wrapping/test/itkPointSetTest.py
+++ b/Modules/Core/Common/wrapping/test/itkPointSetTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 import unittest

--- a/Modules/Core/Common/wrapping/test/itkSpatialOrientationAdapterTest.py
+++ b/Modules/Core/Common/wrapping/test/itkSpatialOrientationAdapterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 

--- a/Modules/Core/Common/wrapping/test/itkVariableLengthVectorTest.py
+++ b/Modules/Core/Common/wrapping/test/itkVariableLengthVectorTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 

--- a/Modules/Core/GPUCommon/wrapping/test/itkGPUImageTest.py
+++ b/Modules/Core/GPUCommon/wrapping/test/itkGPUImageTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 import itk
 
 width = 256

--- a/Modules/Core/GPUCommon/wrapping/test/itkGPUReductionTest.py
+++ b/Modules/Core/GPUCommon/wrapping/test/itkGPUReductionTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 import itk
 
 ElementType = itk.SS

--- a/Modules/Core/Mesh/wrapping/test/itkConnectedRegionsMeshFilterTest.py
+++ b/Modules/Core/Mesh/wrapping/test/itkConnectedRegionsMeshFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 import itk
 import sys
 

--- a/Modules/Core/Mesh/wrapping/test/itkMeshArrayPixelTypeTest.py
+++ b/Modules/Core/Mesh/wrapping/test/itkMeshArrayPixelTypeTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 import itk
 import numpy as np
 

--- a/Modules/Core/Mesh/wrapping/test/itkMeshSerializationTest.py
+++ b/Modules/Core/Mesh/wrapping/test/itkMeshSerializationTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 import numpy as np

--- a/Modules/Core/SpatialObjects/wrapping/test/SpatialObjectTest.py
+++ b/Modules/Core/SpatialObjects/wrapping/test/SpatialObjectTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 

--- a/Modules/Core/Transform/wrapping/test/itkTransformSerializationTest.py
+++ b/Modules/Core/Transform/wrapping/test/itkTransformSerializationTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 import numpy as np

--- a/Modules/Filtering/AnisotropicSmoothing/wrapping/test/CurvatureAnisotropicDiffusionImageFilterTest.py
+++ b/Modules/Filtering/AnisotropicSmoothing/wrapping/test/CurvatureAnisotropicDiffusionImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Example on the use of the CurvatureAnisotropicDiffusionImageFilter

--- a/Modules/Filtering/AnisotropicSmoothing/wrapping/test/GradientAnisotropicDiffusionImageFilterTest.py
+++ b/Modules/Filtering/AnisotropicSmoothing/wrapping/test/GradientAnisotropicDiffusionImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 from sys import argv

--- a/Modules/Filtering/AnisotropicSmoothing/wrapping/test/SmoothingRecursiveGaussianImageFilterTest.py
+++ b/Modules/Filtering/AnisotropicSmoothing/wrapping/test/SmoothingRecursiveGaussianImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Example on the use of the SmoothingRecursiveGaussianImageFilter

--- a/Modules/Filtering/AntiAlias/wrapping/test/AntiAliasBinaryImageFilterTest.py
+++ b/Modules/Filtering/AntiAlias/wrapping/test/AntiAliasBinaryImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 from sys import argv, stderr, exit

--- a/Modules/Filtering/BinaryMathematicalMorphology/wrapping/test/BinaryDilateImageFilterTest.py
+++ b/Modules/Filtering/BinaryMathematicalMorphology/wrapping/test/BinaryDilateImageFilterTest.py
@@ -16,7 +16,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Test BinaryDilateImageFilter

--- a/Modules/Filtering/BinaryMathematicalMorphology/wrapping/test/BinaryErodeImageFilterTest.py
+++ b/Modules/Filtering/BinaryMathematicalMorphology/wrapping/test/BinaryErodeImageFilterTest.py
@@ -16,7 +16,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Test BinaryDilateImageFilter

--- a/Modules/Filtering/Convolution/wrapping/test/FFTConvolutionImageFilterTest.py
+++ b/Modules/Filtering/Convolution/wrapping/test/FFTConvolutionImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Verify FFT-based convolution in Python.

--- a/Modules/Filtering/CurvatureFlow/wrapping/test/CurvatureFlowImageFilterTest.py
+++ b/Modules/Filtering/CurvatureFlow/wrapping/test/CurvatureFlowImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Example on the use of the CurvatureFlowImageFilter

--- a/Modules/Filtering/DisplacementField/wrapping/test/itkDisplacementFieldTransformTest.py
+++ b/Modules/Filtering/DisplacementField/wrapping/test/itkDisplacementFieldTransformTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 import itk
 
 itk.auto_progress(2)

--- a/Modules/Filtering/DisplacementField/wrapping/test/itkTransformToDisplacementFieldTest.py
+++ b/Modules/Filtering/DisplacementField/wrapping/test/itkTransformToDisplacementFieldTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 import numpy as np
 import itk
 

--- a/Modules/Filtering/FFT/wrapping/test/FFTImageFilterTest.py
+++ b/Modules/Filtering/FFT/wrapping/test/FFTImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Example on the use of the MeanImageFilter

--- a/Modules/Filtering/FFT/wrapping/test/FFTObjectFactoryTest.py
+++ b/Modules/Filtering/FFT/wrapping/test/FFTObjectFactoryTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Verify FFT factories are registered and synchronized with ITKCommon

--- a/Modules/Filtering/FastMarching/wrapping/test/FastMarchingImageFilterTest.py
+++ b/Modules/Filtering/FastMarching/wrapping/test/FastMarchingImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #     INPUTS:  BrainProtonDensitySlice.png
 #     OUTPUTS: FastMarchingImageFilterOutput5.png

--- a/Modules/Filtering/GPUAnisotropicSmoothing/wrapping/test/itkGPUGradientAnisotropicDiffusionImageFilterTest.py
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/wrapping/test/itkGPUGradientAnisotropicDiffusionImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 import sys

--- a/Modules/Filtering/GPUImageFilterBase/wrapping/test/itkGPUNeighborhoodOperatorImageFilterTest.py
+++ b/Modules/Filtering/GPUImageFilterBase/wrapping/test/itkGPUNeighborhoodOperatorImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 import itk
 import sys
 

--- a/Modules/Filtering/GPUSmoothing/wrapping/test/itkGPUMeanImageFilterTest.py
+++ b/Modules/Filtering/GPUSmoothing/wrapping/test/itkGPUMeanImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 import itk
 import sys
 

--- a/Modules/Filtering/ImageFeature/wrapping/test/CannyEdgeDetectionImageFilterTest.py
+++ b/Modules/Filtering/ImageFeature/wrapping/test/CannyEdgeDetectionImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #  Example on the use of the CannyEdgeDetectionImageFilter
 

--- a/Modules/Filtering/ImageFeature/wrapping/test/HoughTransform2DLinesImageFilterTest.py
+++ b/Modules/Filtering/ImageFeature/wrapping/test/HoughTransform2DLinesImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Example on the use of the LaplacianImageFilter

--- a/Modules/Filtering/ImageFeature/wrapping/test/LaplacianImageFilterTest.py
+++ b/Modules/Filtering/ImageFeature/wrapping/test/LaplacianImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Example on the use of the LaplacianImageFilter

--- a/Modules/Filtering/ImageFeature/wrapping/test/itkGradientVectorFlowImageFilterTest.py
+++ b/Modules/Filtering/ImageFeature/wrapping/test/itkGradientVectorFlowImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 from sys import argv

--- a/Modules/Filtering/ImageFilterBase/wrapping/test/CastImageFilterTest.py
+++ b/Modules/Filtering/ImageFilterBase/wrapping/test/CastImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Example on the use of the CastImageFilter

--- a/Modules/Filtering/ImageGradient/wrapping/test/GradientMagnitudeRecursiveGaussianImageFilterTest.py
+++ b/Modules/Filtering/ImageGradient/wrapping/test/GradientMagnitudeRecursiveGaussianImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 from sys import argv

--- a/Modules/Filtering/ImageGrid/wrapping/test/OrientImageFilterTest.py
+++ b/Modules/Filtering/ImageGrid/wrapping/test/OrientImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 
 import itk

--- a/Modules/Filtering/ImageGrid/wrapping/test/PhasedArray3DResampleTest.py
+++ b/Modules/Filtering/ImageGrid/wrapping/test/PhasedArray3DResampleTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import math
 import argparse

--- a/Modules/Filtering/ImageGrid/wrapping/test/ResampleImageFilterTest.py
+++ b/Modules/Filtering/ImageGrid/wrapping/test/ResampleImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 
 #     INPUTS: {BrainProtonDensitySlice.png}

--- a/Modules/Filtering/ImageIntensity/wrapping/test/SigmoidImageFilterTest.py
+++ b/Modules/Filtering/ImageIntensity/wrapping/test/SigmoidImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Example on the use of the SigmoidImageFilter

--- a/Modules/Filtering/ImageIntensity/wrapping/test/itkImageFilterNumPyInputsTest.py
+++ b/Modules/Filtering/ImageIntensity/wrapping/test/itkImageFilterNumPyInputsTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 import itkConfig
 
 itkConfig.LazyLoading = False

--- a/Modules/Filtering/ImageIntensity/wrapping/test/itkIntensityWindowingImageFilterTest.py
+++ b/Modules/Filtering/ImageIntensity/wrapping/test/itkIntensityWindowingImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 from sys import argv, stderr, exit

--- a/Modules/Filtering/LabelMap/wrapping/test/BinaryFillholeImageFilterTest.py
+++ b/Modules/Filtering/LabelMap/wrapping/test/BinaryFillholeImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 from sys import argv, stderr, exit

--- a/Modules/Filtering/MathematicalMorphology/wrapping/test/BoxGrayscaleDilateImageFilterTest.py
+++ b/Modules/Filtering/MathematicalMorphology/wrapping/test/BoxGrayscaleDilateImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Example on the use of the GrayscaleDilateImageFilter

--- a/Modules/Filtering/MathematicalMorphology/wrapping/test/FlatStructuringElementTest.py
+++ b/Modules/Filtering/MathematicalMorphology/wrapping/test/FlatStructuringElementTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 from sys import argv, exit

--- a/Modules/Filtering/MathematicalMorphology/wrapping/test/GrayscaleDilateImageFilterTest.py
+++ b/Modules/Filtering/MathematicalMorphology/wrapping/test/GrayscaleDilateImageFilterTest.py
@@ -16,7 +16,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Test GrayscaleDilateImageFilter

--- a/Modules/Filtering/MathematicalMorphology/wrapping/test/GrayscaleErodeImageFilterTest.py
+++ b/Modules/Filtering/MathematicalMorphology/wrapping/test/GrayscaleErodeImageFilterTest.py
@@ -16,7 +16,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Test GrayscaleErodeImageFilter

--- a/Modules/Filtering/Smoothing/wrapping/test/MeanImageFilterFunctionCallTest.py
+++ b/Modules/Filtering/Smoothing/wrapping/test/MeanImageFilterFunctionCallTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Example on the use of the MeanImageFilter with function calls

--- a/Modules/Filtering/Smoothing/wrapping/test/MeanImageFilterTest.py
+++ b/Modules/Filtering/Smoothing/wrapping/test/MeanImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Example on the use of the MeanImageFilter

--- a/Modules/Filtering/Smoothing/wrapping/test/MedianImageFilterFunctionalDocumentationTest.py
+++ b/Modules/Filtering/Smoothing/wrapping/test/MedianImageFilterFunctionalDocumentationTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Example on the use of the MedianImageFilter

--- a/Modules/Filtering/Smoothing/wrapping/test/MedianImageFilterTest.py
+++ b/Modules/Filtering/Smoothing/wrapping/test/MedianImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Example on the use of the MedianImageFilter

--- a/Modules/Filtering/Smoothing/wrapping/test/PythonAutoPipelineTest.py
+++ b/Modules/Filtering/Smoothing/wrapping/test/PythonAutoPipelineTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 from sys import argv

--- a/Modules/Filtering/Thresholding/wrapping/test/BinaryThresholdImageFilterTest.py
+++ b/Modules/Filtering/Thresholding/wrapping/test/BinaryThresholdImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Test BinaryThresholdImageFilter

--- a/Modules/Filtering/Thresholding/wrapping/test/ThresholdImageFilterTest.py
+++ b/Modules/Filtering/Thresholding/wrapping/test/ThresholdImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Example on the use of the ThresholdImageFilter

--- a/Modules/IO/GDCM/wrapping/test/ReadDicomAndReadTagTest.py
+++ b/Modules/IO/GDCM/wrapping/test/ReadDicomAndReadTagTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 # Tests:
 # - Reading dicom files from a directory

--- a/Modules/Nonunit/IntegratedTest/wrapping/test/itkCurvatureFlowTestPython2.py
+++ b/Modules/Nonunit/IntegratedTest/wrapping/test/itkCurvatureFlowTestPython2.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 from InsightToolkit import *
 import itktesting

--- a/Modules/Segmentation/LevelSets/wrapping/test/GeodesicActiveContourImageFilterTest.py
+++ b/Modules/Segmentation/LevelSets/wrapping/test/GeodesicActiveContourImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 # GeodesicActiveContourImageFilter.py
 # Translated by Charl P. Botha <https://cpbotha.net/> from the cxx original.

--- a/Modules/Segmentation/LevelSets/wrapping/test/LazyLoadingImageTest.py
+++ b/Modules/Segmentation/LevelSets/wrapping/test/LazyLoadingImageTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 

--- a/Modules/Segmentation/LevelSets/wrapping/test/ThresholdSegmentationLevelSetImageFilterTest.py
+++ b/Modules/Segmentation/LevelSets/wrapping/test/ThresholdSegmentationLevelSetImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #     INPUTS: {BrainProtonDensitySlice.png}
 #     OUTPUTS: {ThresholdSegmentationLevelSetImageFilterWhiteMatter.png}

--- a/Modules/Segmentation/SignedDistanceFunction/wrapping/test/itkPCAShapeSignedDistanceFunction.py
+++ b/Modules/Segmentation/SignedDistanceFunction/wrapping/test/itkPCAShapeSignedDistanceFunction.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 
 import itk

--- a/Modules/Segmentation/Watersheds/wrapping/test/WatershedSegmentation1Test.py
+++ b/Modules/Segmentation/Watersheds/wrapping/test/WatershedSegmentation1Test.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 import sys

--- a/Utilities/Maintenance/BuildHeaderTest.py
+++ b/Utilities/Maintenance/BuildHeaderTest.py
@@ -16,7 +16,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 
 usage = """usage: BuildHeaderTest.py <module_name> <module_source_path> <module_binary_path> <maximum_number_of_headers>

--- a/Utilities/Maintenance/FindRedundantHeaderIncludes.py
+++ b/Utilities/Maintenance/FindRedundantHeaderIncludes.py
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 
 ## Author: Hans J. Johnson

--- a/Utilities/Maintenance/ParallelStripIncludes.py
+++ b/Utilities/Maintenance/ParallelStripIncludes.py
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 # Author: Pat Marion
 # Modified by Xiaoxiao Liu.
 

--- a/Utilities/Maintenance/StripIncludes.py
+++ b/Utilities/Maintenance/StripIncludes.py
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 ## This script is designed to asssit stripping out the unnecessary header includes
 ## for all modules.

--- a/Utilities/Maintenance/UpdateCopyrightStatementsInITK.py
+++ b/Utilities/Maintenance/UpdateCopyrightStatementsInITK.py
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 # \author Hans J. Johnson

--- a/Wrapping/Generators/Python/Tests/ModifiedTime.py
+++ b/Wrapping/Generators/Python/Tests/ModifiedTime.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 #
 #  Test basic properties of modified times

--- a/Wrapping/Generators/Python/Tests/PyImageFilterTest.py
+++ b/Wrapping/Generators/Python/Tests/PyImageFilterTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 import numpy as np

--- a/Wrapping/Generators/Python/Tests/PythonTemplateTest.py
+++ b/Wrapping/Generators/Python/Tests/PythonTemplateTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 import tempfile

--- a/Wrapping/Generators/Python/Tests/PythonTypeTest.py
+++ b/Wrapping/Generators/Python/Tests/PythonTypeTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 # a short program to check the value returned by the GetNameOfClass() methods
 

--- a/Wrapping/Generators/Python/Tests/PythonTypemapsTest.py
+++ b/Wrapping/Generators/Python/Tests/PythonTypemapsTest.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 import sys

--- a/Wrapping/Generators/Python/Tests/build_options.py
+++ b/Wrapping/Generators/Python/Tests/build_options.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 from itk.support.build_options import ALL_TYPES, DIMS
 

--- a/Wrapping/Generators/Python/Tests/complex.py
+++ b/Wrapping/Generators/Python/Tests/complex.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 

--- a/Wrapping/Generators/Python/Tests/dicomSeries.py
+++ b/Wrapping/Generators/Python/Tests/dicomSeries.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 import os

--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 # also test the import callback feature
 

--- a/Wrapping/Generators/Python/Tests/findEmptyClasses.py
+++ b/Wrapping/Generators/Python/Tests/findEmptyClasses.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 import sys

--- a/Wrapping/Generators/Python/Tests/findSegfaults.py
+++ b/Wrapping/Generators/Python/Tests/findSegfaults.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import sys
 import commands

--- a/Wrapping/Generators/Python/Tests/getNameOfClass.py
+++ b/Wrapping/Generators/Python/Tests/getNameOfClass.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 # a short program to check the value returned by the GetNameOfClass() methods
 

--- a/Wrapping/Generators/Python/Tests/helpers.py
+++ b/Wrapping/Generators/Python/Tests/helpers.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 from itk.support import helpers
 import itk
 

--- a/Wrapping/Generators/Python/Tests/lazy.py
+++ b/Wrapping/Generators/Python/Tests/lazy.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 import itkConfig
 
 # Override environmental variable default to force LazyLoading

--- a/Wrapping/Generators/Python/Tests/module2module.py
+++ b/Wrapping/Generators/Python/Tests/module2module.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 import sys

--- a/Wrapping/Generators/Python/Tests/nodefaultfactories.py
+++ b/Wrapping/Generators/Python/Tests/nodefaultfactories.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 import itkConfig
 
 # Override environmental variable default to ignore factories at load time

--- a/Wrapping/Generators/Python/Tests/nolazy.py
+++ b/Wrapping/Generators/Python/Tests/nolazy.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 import itkConfig
 
 # Override environmental variable default to force non-LazyLoading

--- a/Wrapping/Generators/Python/Tests/readWriteVLV.py
+++ b/Wrapping/Generators/Python/Tests/readWriteVLV.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 import sys

--- a/Wrapping/Generators/Python/Tests/returnedTypeCoverage.py
+++ b/Wrapping/Generators/Python/Tests/returnedTypeCoverage.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 import re

--- a/Wrapping/Generators/Python/Tests/simple_pipeline.py
+++ b/Wrapping/Generators/Python/Tests/simple_pipeline.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 import sys

--- a/Wrapping/Generators/Python/Tests/templated_pipeline.py
+++ b/Wrapping/Generators/Python/Tests/templated_pipeline.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import itk
 from sys import argv

--- a/Wrapping/Generators/Python/Tests/test_metadata.py
+++ b/Wrapping/Generators/Python/Tests/test_metadata.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 # Ensure we can convert all Nifti metadata members to Python
 

--- a/Wrapping/Generators/Python/Tests/test_xarray.py
+++ b/Wrapping/Generators/Python/Tests/test_xarray.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 # also test the import callback feature
 

--- a/Wrapping/Generators/Python/Tests/timing.py
+++ b/Wrapping/Generators/Python/Tests/timing.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import time
 

--- a/Wrapping/Generators/Python/Tests/verifyGetOutputAPIConsistency.py
+++ b/Wrapping/Generators/Python/Tests/verifyGetOutputAPIConsistency.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 # a short program to check that ITK's API is consistent across the library.
 

--- a/Wrapping/Generators/Python/Tests/verifyTTypeAPIConsistency.py
+++ b/Wrapping/Generators/Python/Tests/verifyTTypeAPIConsistency.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 # a short program to check that ITK's API is consistent across the library.
 

--- a/Wrapping/Generators/Python/Tests/wrappingCoverage.py
+++ b/Wrapping/Generators/Python/Tests/wrappingCoverage.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import sys
 import re

--- a/Wrapping/Generators/Python/itk/__init__.py
+++ b/Wrapping/Generators/Python/itk/__init__.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 """itk: Top-level container package for ITK wrappers."""
 

--- a/Wrapping/Generators/Python/itk/support/base.py
+++ b/Wrapping/Generators/Python/itk/support/base.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import os
 import sys

--- a/Wrapping/Generators/Python/itk/support/extras.py
+++ b/Wrapping/Generators/Python/itk/support/extras.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import enum
 import re

--- a/Wrapping/Generators/Python/itk/support/helpers.py
+++ b/Wrapping/Generators/Python/itk/support/helpers.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import importlib
 from importlib.metadata import metadata

--- a/Wrapping/Generators/Python/itk/support/lazy.py
+++ b/Wrapping/Generators/Python/itk/support/lazy.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 import types
 from itk.support import base
 from itkConfig import DefaultFactoryLoading as _DefaultFactoryLoading

--- a/Wrapping/Generators/Python/itk/support/template_class.py
+++ b/Wrapping/Generators/Python/itk/support/template_class.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import inspect
 import os

--- a/Wrapping/Generators/Python/itk/support/types.py
+++ b/Wrapping/Generators/Python/itk/support/types.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import importlib
 from importlib.metadata import metadata

--- a/Wrapping/Generators/Python/itk/support/xarray.py
+++ b/Wrapping/Generators/Python/itk/support/xarray.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-# ==========================================================================*/
+# ==========================================================================
 
 import builtins
 from typing import TYPE_CHECKING


### PR DESCRIPTION
Make Python license headers be consistent in Python scripts: remove the `*/` C multi-line comment style end of comment marker leftover.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)