### PR TITLE
Let `IOComponent::CHAR` represents `signed char`

### DIFF
--- a/Modules/Core/Common/include/itkCommonEnums.h
+++ b/Modules/Core/Common/include/itkCommonEnums.h
@@ -71,6 +71,8 @@ public:
    * Enums used to manipulate the component type. The component type
    * refers to the actual storage class associated with either a
    * SCALAR pixel type or elements of a compound pixel.
+   *
+   * \note The enum `CHAR` represents `signed char` (not just plain `char`).
    */
   ITK_CLANG_PRAGMA_PUSH
   ITK_CLANG_SUPPRESS_Wduplicate_enum

--- a/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
+++ b/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
@@ -828,7 +828,7 @@ HashTestImage(const char * testImageFilename, const std::vector<std::string> & b
   switch (componentType)
   {
     case itk::IOComponentEnum::CHAR:
-      testMD5 = ComputeHash<itk::VectorImage<char, ITK_TEST_DIMENSION_MAX>>(testImageFilename);
+      testMD5 = ComputeHash<itk::VectorImage<signed char, ITK_TEST_DIMENSION_MAX>>(testImageFilename);
       break;
     case itk::IOComponentEnum::UCHAR:
       testMD5 = ComputeHash<itk::VectorImage<unsigned char, ITK_TEST_DIMENSION_MAX>>(testImageFilename);

--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -482,7 +482,7 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::DoConvertBuffer(const void * 
   {
   }
   ITK_CONVERT_BUFFER_IF_BLOCK(IOComponentEnum::UCHAR, unsigned char)
-  ITK_CONVERT_BUFFER_IF_BLOCK(IOComponentEnum::CHAR, char)
+  ITK_CONVERT_BUFFER_IF_BLOCK(IOComponentEnum::CHAR, signed char)
   ITK_CONVERT_BUFFER_IF_BLOCK(IOComponentEnum::USHORT, unsigned short)
   ITK_CONVERT_BUFFER_IF_BLOCK(IOComponentEnum::SHORT, short)
   ITK_CONVERT_BUFFER_IF_BLOCK(IOComponentEnum::UINT, unsigned int)

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -824,7 +824,7 @@ ImageIOBase::ReadBufferAsASCII(std::istream & is, void * buffer, IOComponentEnum
     break;
     case IOComponentEnum::CHAR:
     {
-      auto * buf = static_cast<char *>(buffer);
+      auto * buf = static_cast<signed char *>(buffer);
       ReadBuffer(is, buf, numComp);
     }
     break;

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
@@ -703,7 +703,7 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Co
   {
   }
   ITK_CONVERT_POINT_PIXEL_BUFFER_IF_BLOCK(IOComponentEnum::UCHAR, unsigned char)
-  ITK_CONVERT_POINT_PIXEL_BUFFER_IF_BLOCK(IOComponentEnum::CHAR, char)
+  ITK_CONVERT_POINT_PIXEL_BUFFER_IF_BLOCK(IOComponentEnum::CHAR, signed char)
   ITK_CONVERT_POINT_PIXEL_BUFFER_IF_BLOCK(IOComponentEnum::USHORT, unsigned short)
   ITK_CONVERT_POINT_PIXEL_BUFFER_IF_BLOCK(IOComponentEnum::SHORT, short)
   ITK_CONVERT_POINT_PIXEL_BUFFER_IF_BLOCK(IOComponentEnum::UINT, unsigned int)
@@ -778,7 +778,7 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Co
   {
   }
   ITK_CONVERT_CELL_PIXEL_BUFFER_IF_BLOCK(IOComponentEnum::UCHAR, unsigned char)
-  ITK_CONVERT_CELL_PIXEL_BUFFER_IF_BLOCK(IOComponentEnum::CHAR, char)
+  ITK_CONVERT_CELL_PIXEL_BUFFER_IF_BLOCK(IOComponentEnum::CHAR, signed char)
   ITK_CONVERT_CELL_PIXEL_BUFFER_IF_BLOCK(IOComponentEnum::USHORT, unsigned short)
   ITK_CONVERT_CELL_PIXEL_BUFFER_IF_BLOCK(IOComponentEnum::SHORT, short)
   ITK_CONVERT_CELL_PIXEL_BUFFER_IF_BLOCK(IOComponentEnum::UINT, unsigned int)

--- a/Modules/IO/TIFF/test/itkTIFFImageIOCompressionTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOCompressionTest.cxx
@@ -200,7 +200,7 @@ itkTIFFImageIOCompressionTest(int argc, char * argv[])
         }
         case itk::IOComponentEnum::CHAR:
         {
-          using PixelType = char;
+          using PixelType = signed char;
           return itkTIFFImageIOCompressionTestHelper<itk::Image<PixelType, 2>>(argc, argv, JPEGQuality);
         }
         case itk::IOComponentEnum::USHORT:

--- a/Modules/Video/IO/include/itkVideoFileReader.hxx
+++ b/Modules/Video/IO/include/itkVideoFileReader.hxx
@@ -274,7 +274,7 @@ VideoFileReader<TOutputVideoStream>::DoConvertBuffer(const void * inputData, Fra
   {
   }
   ITK_CONVERT_BUFFER_IF_BLOCK(IOComponentEnum::UCHAR, unsigned char)
-  ITK_CONVERT_BUFFER_IF_BLOCK(IOComponentEnum::CHAR, char)
+  ITK_CONVERT_BUFFER_IF_BLOCK(IOComponentEnum::CHAR, signed char)
   ITK_CONVERT_BUFFER_IF_BLOCK(IOComponentEnum::USHORT, unsigned short)
   ITK_CONVERT_BUFFER_IF_BLOCK(IOComponentEnum::SHORT, short)
   ITK_CONVERT_BUFFER_IF_BLOCK(IOComponentEnum::UINT, unsigned int)


### PR DESCRIPTION
- Added a note about `IOComponent::CHAR` representing `signed char`
- Let file readers interpret the `CHAR` enum as `signed char` (instead of just plain `char`)
- Adjusted tests accordingly

Triggered by a discussion with Bradley (@blowekamp) at https://discourse.itk.org/t/long-double-support-for-imageio-meshio-pixels/7570/11 and his comment at https://github.com/InsightSoftwareConsortium/ITK/pull/5449#issuecomment-3032091149