### PR TITLE
STYLE: Deprecate `UnknownType` from both ImageIOBase and MeshIOBase

### DIFF
--- a/Modules/IO/ImageBase/include/itkImageIOBase.h
+++ b/Modules/IO/ImageBase/include/itkImageIOBase.h
@@ -99,13 +99,15 @@ public:
   using IndexValueType = itk::IndexValueType;
   using SizeValueType = itk::SizeValueType;
 
+#ifndef ITK_LEGACY_REMOVE
   /**
    * \class UnknownType
-   * Used to return information when types are unknown.
+   * \deprecated This class is intended to be removed from ITK 6.
    * \ingroup ITKIOImageBase
    */
-  class UnknownType
+  class [[deprecated("This class is intended to be removed from ITK 6.")]] UnknownType
   {};
+#endif
 
 #if !defined(ITK_LEGACY_REMOVE)
   /**Exposes enums values for backwards compatibility*/

--- a/Modules/IO/MeshBase/include/itkMeshIOBase.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOBase.h
@@ -89,13 +89,15 @@ public:
 
   using SizeValueType = IdentifierType;
 
+#ifndef ITK_LEGACY_REMOVE
   /**
    * \class UnknownType
-   * Used to return information when types are unknown.
+   * \deprecated This class is intended to be removed from ITK 6.
    * \ingroup ITKIOMeshBase
    */
-  class UnknownType
+  class [[deprecated("This class is intended to be removed from ITK 6.")]] UnknownType
   {};
+#endif
 
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(MeshIOBase);


### PR DESCRIPTION
The empty nested `UnknownType` classes are no longer being used.
