### PR TITLE
ENH: Backport AnatomicalOrientation to ITKv5

### DIFF
--- a/Modules/Core/Common/include/itkAnatomicalOrientation.h
+++ b/Modules/Core/Common/include/itkAnatomicalOrientation.h
@@ -1,0 +1,584 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkAnatomicalOrientation_h
+#define itkAnatomicalOrientation_h
+
+#include "ITKCommonExport.h"
+#include "itkImageBase.h"
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+#  include "itkSpatialOrientation.h"
+#endif
+#include <map>
+#include <string>
+
+namespace itk
+{
+
+/** \class AnatomicalOrientation
+ * \brief Representations of anatomical orientations and methods to convert between conventions.
+ *
+ *  Defines patient specific anatomical names to the XYZ axes of a 3D image.
+ *
+ * A class instances holds the patient orientation stored as an enumerated type. Conversion to different representations
+ * such as strings and direction cosine matrices are supported.
+ *
+ * The use of unambiguous anatomical orientation names such as "RightToLeft" is preferred, where "Right" is the
+ * "from direction" and the negative direction of the coordinates, while "Left" is the "to direction" and the positive
+ * direction. The following is an unambiguous construction of an AnatomicalOrientation object:
+ *
+ * \code
+ *  AnatomicalOrientation(AnatomicalOrientation::CoordinateEnum::RightToLeft,
+ *                        AnatomicalOrientation::CoordinateEnum::AnteriorToPosterior,
+ *                        AnatomicalOrientation::CoordinateEnum::InferiorToSuperior);
+ * \endcode
+ *
+ *
+ * \ingroup ITKCommon
+ */
+class ITKCommon_EXPORT AnatomicalOrientation
+{
+public:
+  static constexpr unsigned int Dimension = 3;
+  using DirectionType = typename ImageBase<Dimension>::DirectionType;
+  static constexpr unsigned int ImageDimension = Dimension;
+
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  using LegacyOrientationType = SpatialOrientationEnums::ValidCoordinateOrientations;
+#endif
+
+  // Anatomical names for an axis.
+  //
+  enum class CoordinateEnum : uint8_t
+  {
+    UNKNOWN = 0,
+    RightToLeft = 2, ///< 0b0010
+    LeftToRight = 3,
+    PosteriorToAnterior = 4, ///< to front - 0b0100
+    AnteriorToPosterior = 5, ///< to back
+    InferiorToSuperior = 8,  ///< to head - 0b1000
+    SuperiorToInferior = 9,  ///< to foot
+  };
+
+protected:
+  enum class CoordinateMajornessTermsEnum : uint8_t
+  {
+    PrimaryMinor = 0,
+    SecondaryMinor = 8,
+    TertiaryMinor = 16
+  };
+
+  template <CoordinateEnum VPrimary, CoordinateEnum VSecondary, CoordinateEnum VTertiary>
+  static constexpr uint32_t m_OrientationValue =
+    (static_cast<uint32_t>(VPrimary) << static_cast<uint8_t>(CoordinateMajornessTermsEnum::PrimaryMinor)) +
+    (static_cast<uint32_t>(VSecondary) << static_cast<uint8_t>(CoordinateMajornessTermsEnum::SecondaryMinor)) +
+    (static_cast<uint32_t>(VTertiary) << static_cast<uint8_t>(CoordinateMajornessTermsEnum::TertiaryMinor));
+
+  [[nodiscard]] CoordinateEnum
+  GetCoordinateTerm(CoordinateMajornessTermsEnum cmt) const;
+
+public:
+  // Enumerated acronyms based on the positive or "To" direction of the anatomical coordinates.
+  enum class PositiveEnum : uint32_t
+
+  {
+    INVALID = 0,
+
+    RIP = m_OrientationValue<CoordinateEnum::LeftToRight,
+                             CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::AnteriorToPosterior>,
+    LIP = m_OrientationValue<CoordinateEnum::RightToLeft,
+                             CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::AnteriorToPosterior>,
+    RSP = m_OrientationValue<CoordinateEnum::LeftToRight,
+                             CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::AnteriorToPosterior>,
+    LSP = m_OrientationValue<CoordinateEnum::RightToLeft,
+                             CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::AnteriorToPosterior>,
+    RIA = m_OrientationValue<CoordinateEnum::LeftToRight,
+                             CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::PosteriorToAnterior>,
+    LIA = m_OrientationValue<CoordinateEnum::RightToLeft,
+                             CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::PosteriorToAnterior>,
+    RSA = m_OrientationValue<CoordinateEnum::LeftToRight,
+                             CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::PosteriorToAnterior>,
+    LSA = m_OrientationValue<CoordinateEnum::RightToLeft,
+                             CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::PosteriorToAnterior>,
+
+    IRP = m_OrientationValue<CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::LeftToRight,
+                             CoordinateEnum::AnteriorToPosterior>,
+    ILP = m_OrientationValue<CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::RightToLeft,
+                             CoordinateEnum::AnteriorToPosterior>,
+    SRP = m_OrientationValue<CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::LeftToRight,
+                             CoordinateEnum::AnteriorToPosterior>,
+    SLP = m_OrientationValue<CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::RightToLeft,
+                             CoordinateEnum::AnteriorToPosterior>,
+    IRA = m_OrientationValue<CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::LeftToRight,
+                             CoordinateEnum::PosteriorToAnterior>,
+    ILA = m_OrientationValue<CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::RightToLeft,
+                             CoordinateEnum::PosteriorToAnterior>,
+    SRA = m_OrientationValue<CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::LeftToRight,
+                             CoordinateEnum::PosteriorToAnterior>,
+    SLA = m_OrientationValue<CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::RightToLeft,
+                             CoordinateEnum::PosteriorToAnterior>,
+
+    RPI = m_OrientationValue<CoordinateEnum::LeftToRight,
+                             CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::SuperiorToInferior>,
+    LPI = m_OrientationValue<CoordinateEnum::RightToLeft,
+                             CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::SuperiorToInferior>,
+    RAI = m_OrientationValue<CoordinateEnum::LeftToRight,
+                             CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::SuperiorToInferior>,
+    LAI = m_OrientationValue<CoordinateEnum::RightToLeft,
+                             CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::SuperiorToInferior>,
+    RPS = m_OrientationValue<CoordinateEnum::LeftToRight,
+                             CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::InferiorToSuperior>,
+    LPS = m_OrientationValue<CoordinateEnum::RightToLeft,
+                             CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::InferiorToSuperior>,
+    RAS = m_OrientationValue<CoordinateEnum::LeftToRight,
+                             CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::InferiorToSuperior>,
+    LAS = m_OrientationValue<CoordinateEnum::RightToLeft,
+                             CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::InferiorToSuperior>,
+
+    PRI = m_OrientationValue<CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::LeftToRight,
+                             CoordinateEnum::SuperiorToInferior>,
+    PLI = m_OrientationValue<CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::RightToLeft,
+                             CoordinateEnum::SuperiorToInferior>,
+    ARI = m_OrientationValue<CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::LeftToRight,
+                             CoordinateEnum::SuperiorToInferior>,
+    ALI = m_OrientationValue<CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::RightToLeft,
+                             CoordinateEnum::SuperiorToInferior>,
+    PRS = m_OrientationValue<CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::LeftToRight,
+                             CoordinateEnum::InferiorToSuperior>,
+    PLS = m_OrientationValue<CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::RightToLeft,
+                             CoordinateEnum::InferiorToSuperior>,
+    ARS = m_OrientationValue<CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::LeftToRight,
+                             CoordinateEnum::InferiorToSuperior>,
+    ALS = m_OrientationValue<CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::RightToLeft,
+                             CoordinateEnum::InferiorToSuperior>,
+
+    IPR = m_OrientationValue<CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::LeftToRight>,
+    SPR = m_OrientationValue<CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::LeftToRight>,
+    IAR = m_OrientationValue<CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::LeftToRight>,
+    SAR = m_OrientationValue<CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::LeftToRight>,
+    IPL = m_OrientationValue<CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::RightToLeft>,
+    SPL = m_OrientationValue<CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::RightToLeft>,
+    IAL = m_OrientationValue<CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::RightToLeft>,
+    SAL = m_OrientationValue<CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::RightToLeft>,
+
+    PIR = m_OrientationValue<CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::LeftToRight>,
+    PSR = m_OrientationValue<CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::LeftToRight>,
+    AIR = m_OrientationValue<CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::LeftToRight>,
+    ASR = m_OrientationValue<CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::LeftToRight>,
+    PIL = m_OrientationValue<CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::RightToLeft>,
+    PSL = m_OrientationValue<CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::RightToLeft>,
+    AIL = m_OrientationValue<CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::RightToLeft>,
+    ASL = m_OrientationValue<CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::RightToLeft>
+  };
+
+  // Enumerated acronyms based on the negative or "From" direction of the anatomical coordinates.
+  enum class NegativeEnum : uint32_t
+
+  {
+    INVALID = 0,
+
+    RIP = m_OrientationValue<CoordinateEnum::RightToLeft,
+                             CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::PosteriorToAnterior>,
+    LIP = m_OrientationValue<CoordinateEnum::LeftToRight,
+                             CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::PosteriorToAnterior>,
+    RSP = m_OrientationValue<CoordinateEnum::RightToLeft,
+                             CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::PosteriorToAnterior>,
+    LSP = m_OrientationValue<CoordinateEnum::LeftToRight,
+                             CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::PosteriorToAnterior>,
+    RIA = m_OrientationValue<CoordinateEnum::RightToLeft,
+                             CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::AnteriorToPosterior>,
+    LIA = m_OrientationValue<CoordinateEnum::LeftToRight,
+                             CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::AnteriorToPosterior>,
+    RSA = m_OrientationValue<CoordinateEnum::RightToLeft,
+                             CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::AnteriorToPosterior>,
+    LSA = m_OrientationValue<CoordinateEnum::LeftToRight,
+                             CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::AnteriorToPosterior>,
+
+    IRP = m_OrientationValue<CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::RightToLeft,
+                             CoordinateEnum::PosteriorToAnterior>,
+    ILP = m_OrientationValue<CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::LeftToRight,
+                             CoordinateEnum::PosteriorToAnterior>,
+    SRP = m_OrientationValue<CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::RightToLeft,
+                             CoordinateEnum::PosteriorToAnterior>,
+    SLP = m_OrientationValue<CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::LeftToRight,
+                             CoordinateEnum::PosteriorToAnterior>,
+    IRA = m_OrientationValue<CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::RightToLeft,
+                             CoordinateEnum::AnteriorToPosterior>,
+    ILA = m_OrientationValue<CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::LeftToRight,
+                             CoordinateEnum::AnteriorToPosterior>,
+    SRA = m_OrientationValue<CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::RightToLeft,
+                             CoordinateEnum::AnteriorToPosterior>,
+    SLA = m_OrientationValue<CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::LeftToRight,
+                             CoordinateEnum::AnteriorToPosterior>,
+
+    RPI = m_OrientationValue<CoordinateEnum::RightToLeft,
+                             CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::InferiorToSuperior>,
+    LPI = m_OrientationValue<CoordinateEnum::LeftToRight,
+                             CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::InferiorToSuperior>,
+    RAI = m_OrientationValue<CoordinateEnum::RightToLeft,
+                             CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::InferiorToSuperior>,
+    LAI = m_OrientationValue<CoordinateEnum::LeftToRight,
+                             CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::InferiorToSuperior>,
+    RPS = m_OrientationValue<CoordinateEnum::RightToLeft,
+                             CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::SuperiorToInferior>,
+    LPS = m_OrientationValue<CoordinateEnum::LeftToRight,
+                             CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::SuperiorToInferior>,
+    RAS = m_OrientationValue<CoordinateEnum::RightToLeft,
+                             CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::SuperiorToInferior>,
+    LAS = m_OrientationValue<CoordinateEnum::LeftToRight,
+                             CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::SuperiorToInferior>,
+
+    PRI = m_OrientationValue<CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::RightToLeft,
+                             CoordinateEnum::InferiorToSuperior>,
+    PLI = m_OrientationValue<CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::LeftToRight,
+                             CoordinateEnum::InferiorToSuperior>,
+    ARI = m_OrientationValue<CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::RightToLeft,
+                             CoordinateEnum::InferiorToSuperior>,
+    ALI = m_OrientationValue<CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::LeftToRight,
+                             CoordinateEnum::InferiorToSuperior>,
+    PRS = m_OrientationValue<CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::RightToLeft,
+                             CoordinateEnum::SuperiorToInferior>,
+    PLS = m_OrientationValue<CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::LeftToRight,
+                             CoordinateEnum::SuperiorToInferior>,
+    ARS = m_OrientationValue<CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::RightToLeft,
+                             CoordinateEnum::SuperiorToInferior>,
+    ALS = m_OrientationValue<CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::LeftToRight,
+                             CoordinateEnum::SuperiorToInferior>,
+
+    IPR = m_OrientationValue<CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::RightToLeft>,
+    SPR = m_OrientationValue<CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::RightToLeft>,
+    IAR = m_OrientationValue<CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::RightToLeft>,
+    SAR = m_OrientationValue<CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::RightToLeft>,
+    IPL = m_OrientationValue<CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::LeftToRight>,
+    SPL = m_OrientationValue<CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::LeftToRight>,
+    IAL = m_OrientationValue<CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::LeftToRight>,
+    SAL = m_OrientationValue<CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::LeftToRight>,
+
+    PIR = m_OrientationValue<CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::RightToLeft>,
+    PSR = m_OrientationValue<CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::RightToLeft>,
+    AIR = m_OrientationValue<CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::RightToLeft>,
+    ASR = m_OrientationValue<CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::RightToLeft>,
+    PIL = m_OrientationValue<CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::LeftToRight>,
+    PSL = m_OrientationValue<CoordinateEnum::PosteriorToAnterior,
+                             CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::LeftToRight>,
+    AIL = m_OrientationValue<CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::InferiorToSuperior,
+                             CoordinateEnum::LeftToRight>,
+    ASL = m_OrientationValue<CoordinateEnum::AnteriorToPosterior,
+                             CoordinateEnum::SuperiorToInferior,
+                             CoordinateEnum::LeftToRight>
+
+  };
+
+
+  /** \brief Initialize with CoordinateEnum's from separate axes.
+   *
+   * If multiple CoordinateEnums are from the same axes then the Orientation value is INVALID.
+   */
+  constexpr AnatomicalOrientation(CoordinateEnum primary, CoordinateEnum secondary, CoordinateEnum tertiary)
+    : m_Value(
+        SameOrientationAxes(primary, secondary) || SameOrientationAxes(primary, tertiary) ||
+            SameOrientationAxes(secondary, tertiary)
+          ? PositiveEnum::INVALID
+          : static_cast<PositiveEnum>(
+              (static_cast<uint32_t>(primary) << static_cast<uint8_t>(CoordinateMajornessTermsEnum::PrimaryMinor)) +
+              (static_cast<uint32_t>(secondary) << static_cast<uint8_t>(CoordinateMajornessTermsEnum::SecondaryMinor)) +
+              (static_cast<uint32_t>(tertiary) << static_cast<uint8_t>(CoordinateMajornessTermsEnum::TertiaryMinor))))
+  {}
+
+
+  constexpr AnatomicalOrientation(PositiveEnum toOrientation)
+    : m_Value(toOrientation)
+  {}
+
+
+  constexpr AnatomicalOrientation(NegativeEnum fromOrientation)
+    : m_Value(PositiveEnum(static_cast<uint32_t>(fromOrientation)))
+  {}
+
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+  /** \brief Conversion from Legacy SpatialOrientation
+   *
+   * @param legacyOrientation
+   */
+#  if defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT) && !defined(ITK_WRAPPING)
+  [[deprecated("Use the AnatomicalOrientation::FromEnum type instead.")]]
+#  endif
+  AnatomicalOrientation(LegacyOrientationType legacyOrientation);
+#endif
+
+  /** Conversion for a Direction Cosine Matrix to the closest anatomical orientation. Any partial axis rotations are
+   *  rounded to the nearest axis, and lost in this conversion.
+   */
+  explicit AnatomicalOrientation(const DirectionType & d)
+    : m_Value(ConvertDirectionToPositiveEnum(d))
+  {}
+
+  /** Creates a AnatomicalOrientation from a string with the PositiveEnum encoding. The string is case-insensitive. If
+   * the string is not a valid encoding then the orientation is set to INVALID.
+   */
+  static AnatomicalOrientation
+  CreateFromPositiveStringEncoding(std::string str);
+
+  // Same as CreateFromPositiveStringEncoding but for the NegativeEnum encoding.
+  static AnatomicalOrientation
+  CreateFromNegativeStringEncoding(std::string str);
+
+  operator PositiveEnum() const { return m_Value; }
+
+  /** Returns the PositiveEnum encoding as a string. The string is always upper case. */
+  [[nodiscard]] std::string
+  GetAsPositiveStringEncoding() const;
+
+  /** Returns the NegativeEnum encoding as a string. The string is always upper case. */
+  [[nodiscard]] std::string
+  GetAsNegativeStringEncoding() const;
+
+  /** An involution to convert between "positive" and "negative" single character encoding strings.
+   *
+   * For example the string "RAS" is converted to "LPI" and vice versa.
+   *
+   * The input maybe upper or lower case, while the output is always upper case.
+   * There is no check that the input is a valid encoding.
+   *
+   * */
+  static std::string
+  ConvertStringEncoding(std::string str);
+
+  /** \brief Return the direction cosine matrix for the orientation. */
+  [[nodiscard]] DirectionType
+  GetAsDirection() const
+  {
+    return ConvertPositiveEnumToDirection(m_Value);
+  }
+
+  [[nodiscard]] PositiveEnum
+  GetAsPositiveOrientation() const
+  {
+    return m_Value;
+  }
+
+  [[nodiscard]] NegativeEnum
+  GetAsNegativeOrientation() const
+  {
+    return NegativeEnum(static_cast<uint32_t>(this->m_Value));
+  }
+
+  [[nodiscard]] CoordinateEnum
+  GetPrimaryTerm() const
+  {
+    return GetCoordinateTerm(CoordinateMajornessTermsEnum::PrimaryMinor);
+  }
+
+  [[nodiscard]] CoordinateEnum
+  GetSecondaryTerm() const
+  {
+    return GetCoordinateTerm(CoordinateMajornessTermsEnum::SecondaryMinor);
+  }
+
+  [[nodiscard]] CoordinateEnum
+  GetTertiaryTerm() const
+  {
+    return GetCoordinateTerm(CoordinateMajornessTermsEnum::TertiaryMinor);
+  }
+
+  [[nodiscard]] std::array<CoordinateEnum, 3>
+  GetTerms() const
+  {
+    return { GetPrimaryTerm(), GetSecondaryTerm(), GetTertiaryTerm() };
+  }
+
+  static constexpr bool
+  SameOrientationAxes(CoordinateEnum a, CoordinateEnum b)
+  {
+    const uint8_t AxisField = ~1; // mask the lowest bit
+    return (static_cast<uint8_t>(a) & AxisField) == (static_cast<uint8_t>(b) & AxisField);
+  }
+
+
+  friend ITKCommon_EXPORT std::ostream &
+                          operator<<(std::ostream & out, PositiveEnum value);
+
+protected:
+  /** \brief Return the direction cosine matrix for a orientation. */
+  static DirectionType ConvertPositiveEnumToDirection(PositiveEnum);
+
+
+  /** \brief Return the closest orientation for a direction cosine matrix. */
+  static PositiveEnum
+  ConvertDirectionToPositiveEnum(const DirectionType & dir);
+
+
+  /** \brief Return the global instance of the map from orientation enum to strings.
+   *
+   * The implementation uses a function static local variable so the global is created only if needed, only once.
+   */
+  static const std::map<PositiveEnum, std::string> &
+  GetCodeToString();
+
+  /** \brief Return the global instance of the map from string to orientation enum.
+   */
+  static const std::map<std::string, PositiveEnum> &
+  GetStringToCode();
+
+  PositiveEnum m_Value;
+};
+
+/** Outputs unambiguous anatomical orientation names such as "right-to-left". */
+ITKCommon_EXPORT std::ostream &
+                 operator<<(std::ostream & out, typename AnatomicalOrientation::CoordinateEnum value);
+
+/** Outputs the PositiveEnum encoding as a string such as "LPS". */
+ITKCommon_EXPORT std::ostream &
+                 operator<<(std::ostream & out, typename AnatomicalOrientation::PositiveEnum value);
+
+
+/** Outputs the NegativeEnum encoding as a string such as "RAI" */
+ITKCommon_EXPORT std::ostream &
+                 operator<<(std::ostream & out, typename AnatomicalOrientation::NegativeEnum value);
+
+ITKCommon_EXPORT std::ostream &
+                 operator<<(std::ostream & out, const AnatomicalOrientation & orientation);
+
+
+} // end namespace itk
+
+
+#endif

--- a/Modules/Core/Common/src/CMakeLists.txt
+++ b/Modules/Core/Common/src/CMakeLists.txt
@@ -145,7 +145,9 @@ set(ITKCommon_SRCS
     itkFrustumSpatialFunction.cxx
     itkObjectStore.cxx
     itkGaussianDerivativeOperator.cxx
-    itkSpatialOrientation.cxx)
+    itkSpatialOrientation.cxx
+  itkAnatomicalOrientation.cxx
+)
 
 if(WIN32)
   list(APPEND ITKCommon_SRCS itkWin32OutputWindow.cxx)

--- a/Modules/Core/Common/src/itkAnatomicalOrientation.cxx
+++ b/Modules/Core/Common/src/itkAnatomicalOrientation.cxx
@@ -1,0 +1,327 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "itkAnatomicalOrientation.h"
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+#  include "itkSpatialOrientationAdapter.h"
+#endif
+
+namespace itk
+{
+
+
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+AnatomicalOrientation::AnatomicalOrientation(LegacyOrientationType legacyOrientation)
+  : AnatomicalOrientation(SpatialOrientationAdapter().ToDirectionCosines(legacyOrientation))
+{
+  assert(uint32_t(legacyOrientation) == uint32_t(m_Value));
+}
+#endif
+
+
+std::string
+AnatomicalOrientation::GetAsPositiveStringEncoding() const
+{
+
+  // a lambda function to convert a CoordinateEnum to a char
+  auto enumAsChar = [](CoordinateEnum coord) -> char {
+    switch (coord)
+    {
+      case CoordinateEnum::RightToLeft:
+        return 'L';
+      case CoordinateEnum::LeftToRight:
+        return 'R';
+      case CoordinateEnum::AnteriorToPosterior:
+        return 'P';
+      case CoordinateEnum::PosteriorToAnterior:
+        return 'A';
+      case CoordinateEnum::InferiorToSuperior:
+        return 'S';
+      case CoordinateEnum::SuperiorToInferior:
+        return 'I';
+      default:
+        return 'X';
+    }
+  };
+
+  if (m_Value == PositiveEnum::INVALID)
+  {
+    return "INVALID";
+  }
+
+  return std::string({ enumAsChar(GetPrimaryTerm()), enumAsChar(GetSecondaryTerm()), enumAsChar(GetTertiaryTerm()) });
+}
+
+
+std::string
+AnatomicalOrientation::GetAsNegativeStringEncoding() const
+{
+  return ConvertStringEncoding(GetAsPositiveStringEncoding());
+}
+
+
+AnatomicalOrientation
+AnatomicalOrientation::CreateFromPositiveStringEncoding(std::string str)
+{
+  std::transform(str.begin(), str.end(), str.begin(), ::toupper);
+
+  const std::map<std::string, typename AnatomicalOrientation::PositiveEnum> & stringToCode = GetStringToCode();
+  auto                                                                        iter = stringToCode.find(str);
+  if (iter == stringToCode.end())
+  {
+    return { PositiveEnum::INVALID };
+  }
+  return { iter->second };
+}
+
+AnatomicalOrientation
+AnatomicalOrientation::CreateFromNegativeStringEncoding(std::string str)
+{
+  return AnatomicalOrientation::CreateFromPositiveStringEncoding(ConvertStringEncoding(str));
+}
+
+
+std::string
+AnatomicalOrientation::ConvertStringEncoding(std::string str)
+{
+
+  auto flip = [](char c) -> char {
+    switch (::toupper(c))
+    {
+      case 'R':
+        return 'L';
+      case 'L':
+        return 'R';
+      case 'A':
+        return 'P';
+      case 'P':
+        return 'A';
+      case 'S':
+        return 'I';
+      case 'I':
+        return 'S';
+      case 'X':
+        return 'X';
+      default:
+        return c;
+    }
+  };
+
+  for (auto & c : str)
+  {
+    c = flip(c);
+  }
+  return str;
+}
+
+
+AnatomicalOrientation::CoordinateEnum
+AnatomicalOrientation::GetCoordinateTerm(CoordinateMajornessTermsEnum cmt) const
+{
+  return static_cast<CoordinateEnum>(static_cast<uint32_t>(m_Value) >> static_cast<uint8_t>(cmt) & 0xff);
+}
+
+
+const std::map<typename AnatomicalOrientation::PositiveEnum, std::string> &
+AnatomicalOrientation::GetCodeToString()
+{
+  auto createCodeToString = []() -> std::map<PositiveEnum, std::string> {
+    std::map<PositiveEnum, std::string> orientToString;
+
+    for (auto code : { PositiveEnum::RIP, PositiveEnum::LIP, PositiveEnum::RSP, PositiveEnum::LSP,    PositiveEnum::RIA,
+                       PositiveEnum::LIA, PositiveEnum::RSA, PositiveEnum::LSA, PositiveEnum::IRP,    PositiveEnum::ILP,
+                       PositiveEnum::SRP, PositiveEnum::SLP, PositiveEnum::IRA, PositiveEnum::ILA,    PositiveEnum::SRA,
+                       PositiveEnum::SLA, PositiveEnum::RPI, PositiveEnum::LPI, PositiveEnum::RAI,    PositiveEnum::LAI,
+                       PositiveEnum::RPS, PositiveEnum::LPS, PositiveEnum::RAS, PositiveEnum::LAS,    PositiveEnum::PRI,
+                       PositiveEnum::PLI, PositiveEnum::ARI, PositiveEnum::ALI, PositiveEnum::PRS,    PositiveEnum::PLS,
+                       PositiveEnum::ARS, PositiveEnum::ALS, PositiveEnum::IPR, PositiveEnum::SPR,    PositiveEnum::IAR,
+                       PositiveEnum::SAR, PositiveEnum::IPL, PositiveEnum::SPL, PositiveEnum::IAL,    PositiveEnum::SAL,
+                       PositiveEnum::PIR, PositiveEnum::PSR, PositiveEnum::AIR, PositiveEnum::ASR,    PositiveEnum::PIL,
+                       PositiveEnum::PSL, PositiveEnum::AIL, PositiveEnum::ASL, PositiveEnum::INVALID })
+    {
+      orientToString[code] = AnatomicalOrientation(code).GetAsPositiveStringEncoding();
+    }
+
+    return orientToString;
+  };
+  static const std::map<PositiveEnum, std::string> codeToString = createCodeToString();
+  return codeToString;
+}
+
+const std::map<std::string, AnatomicalOrientation::PositiveEnum> &
+AnatomicalOrientation::GetStringToCode()
+{
+
+  auto createStringToCode = []() -> std::map<std::string, PositiveEnum> {
+    std::map<std::string, PositiveEnum>         stringToCode;
+    const std::map<PositiveEnum, std::string> & codeToString = GetCodeToString();
+
+    for (const auto & kv : codeToString)
+    {
+      stringToCode[kv.second] = kv.first;
+    }
+    return stringToCode;
+  };
+
+  static const std::map<std::string, AnatomicalOrientation::PositiveEnum> stringToCode = createStringToCode();
+  return stringToCode;
+}
+
+
+AnatomicalOrientation::PositiveEnum
+AnatomicalOrientation::ConvertDirectionToPositiveEnum(const DirectionType & dir)
+{
+  // NOTE: This method was based off of itk::SpatialObjectAdaptor::FromDirectionCosines
+  // but it is DIFFERENT in the meaning of direction in terms of sign-ness.
+  CoordinateEnum terms[3] = { CoordinateEnum::UNKNOWN, CoordinateEnum::UNKNOWN, CoordinateEnum::UNKNOWN };
+
+  std::multimap<double, std::pair<unsigned, unsigned>> value_to_idx;
+  for (unsigned int c = 0; c < 3; ++c)
+  {
+    for (unsigned int r = 0; r < 3; ++r)
+    {
+      value_to_idx.emplace(std::abs(dir[c][r]), std::make_pair(c, r));
+    }
+  }
+
+  for (unsigned i = 0; i < 3; ++i)
+  {
+
+    auto               max_idx = value_to_idx.rbegin()->second;
+    const unsigned int max_c = max_idx.first;
+    const unsigned int max_r = max_idx.second;
+
+    const int max_sgn = Math::sgn(dir[max_c][max_r]);
+
+    for (auto it = value_to_idx.begin(); it != value_to_idx.end();)
+    {
+      if (it->second.first == max_c || it->second.second == max_r)
+      {
+        value_to_idx.erase(it++);
+      }
+      else
+      {
+        ++it;
+      }
+    }
+
+    switch (max_c)
+    {
+      case 0:
+      {
+        // When the dominant axis sign is positive, assign the coordinate for the direction we are increasing towards.
+        // ITK is in LPS, so that is the positive direction
+        terms[max_r] = (max_sgn == 1) ? CoordinateEnum::RightToLeft : CoordinateEnum::LeftToRight;
+        break;
+      }
+      case 1:
+      {
+        terms[max_r] = (max_sgn == 1) ? CoordinateEnum::AnteriorToPosterior : CoordinateEnum::PosteriorToAnterior;
+        break;
+      }
+      case 2:
+      {
+        terms[max_r] = (max_sgn == 1) ? CoordinateEnum::InferiorToSuperior : CoordinateEnum::SuperiorToInferior;
+        break;
+      }
+      default:
+        itkGenericExceptionMacro("Unexpected Axis");
+    }
+  }
+
+  return AnatomicalOrientation(terms[0], terms[1], terms[2]);
+}
+
+
+typename AnatomicalOrientation::DirectionType
+AnatomicalOrientation::ConvertPositiveEnumToDirection(PositiveEnum orientationEnum)
+{
+  const AnatomicalOrientation o(orientationEnum);
+
+  const CoordinateEnum terms[Dimension] = { o.GetPrimaryTerm(), o.GetSecondaryTerm(), o.GetTertiaryTerm() };
+  DirectionType        direction{};
+
+  for (unsigned int i = 0; i < Dimension; ++i)
+  {
+    const int sign = (static_cast<uint8_t>(terms[i]) & 0x1) ? 1 : -1;
+
+    switch (terms[i])
+    {
+      case CoordinateEnum::LeftToRight:
+      case CoordinateEnum::RightToLeft:
+        direction[0][i] = -1 * sign;
+        break;
+      case CoordinateEnum::AnteriorToPosterior:
+      case CoordinateEnum::PosteriorToAnterior:
+        direction[1][i] = 1 * sign;
+        break;
+      case CoordinateEnum::InferiorToSuperior:
+      case CoordinateEnum::SuperiorToInferior:
+        direction[2][i] = -1 * sign;
+        break;
+      case CoordinateEnum::UNKNOWN:
+        break;
+    }
+  }
+  return direction;
+}
+
+std::ostream &
+operator<<(std::ostream & out, typename AnatomicalOrientation::CoordinateEnum value)
+{
+  switch (value)
+  {
+    case AnatomicalOrientation::CoordinateEnum::RightToLeft:
+      return out << "right-to-left";
+    case AnatomicalOrientation::CoordinateEnum::LeftToRight:
+      return out << "left-to-right";
+    case AnatomicalOrientation::CoordinateEnum::AnteriorToPosterior:
+      return out << "anterior-to-posterior";
+    case AnatomicalOrientation::CoordinateEnum::PosteriorToAnterior:
+      return out << "posterior-to-anterior";
+    case AnatomicalOrientation::CoordinateEnum::InferiorToSuperior:
+      return out << "inferior-to-superior";
+    case AnatomicalOrientation::CoordinateEnum::SuperiorToInferior:
+      return out << "superior-to-inferior";
+    case AnatomicalOrientation::CoordinateEnum::UNKNOWN:
+      return out << "unknown";
+    default:
+      return out << "invalid";
+  }
+}
+
+std::ostream &
+operator<<(std::ostream & out, typename AnatomicalOrientation::PositiveEnum value)
+{
+  return (out << AnatomicalOrientation(value).GetAsPositiveStringEncoding());
+}
+
+std::ostream &
+operator<<(std::ostream & out, typename AnatomicalOrientation::NegativeEnum value)
+{
+  return (out << AnatomicalOrientation(value).GetAsNegativeStringEncoding());
+}
+
+std::ostream &
+operator<<(std::ostream & out, const AnatomicalOrientation & orientation)
+{
+  const auto terms = orientation.GetTerms();
+  static_assert(std::tuple_size<decltype(terms)>{} == 3);
+  return out << terms[0] << " " << terms[1] << " " << terms[2];
+}
+
+} // namespace itk

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -1758,7 +1758,9 @@ set(ITKCommonGTests
     itkWeakPointerGTest.cxx
     itkCommonTypeTraitsGTest.cxx
     itkMetaDataDictionaryGTest.cxx
-    itkSpatialOrientationAdaptorGTest.cxx)
+    itkSpatialOrientationAdaptorGTest.cxx
+    itkAnatomicalOrientationGTest.cxx
+)
 creategoogletestdriver(ITKCommon "${ITKCommon-Test_LIBRARIES}" "${ITKCommonGTests}")
 # If `-static` was passed to CMAKE_EXE_LINKER_FLAGS, compilation fails. No need to
 # test this case.

--- a/Modules/Core/Common/test/itkAnatomicalOrientationGTest.cxx
+++ b/Modules/Core/Common/test/itkAnatomicalOrientationGTest.cxx
@@ -1,0 +1,269 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include <gtest/gtest.h>
+
+#include "itkGTest.h"
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+#  define ITK_LEGACY_SILENT
+#endif
+#include "itkAnatomicalOrientation.h"
+#include "itkImage.h"
+#include <sstream>
+
+
+TEST(AnatomicalOrientation, ConstructionAndValues)
+{
+  using itk::AnatomicalOrientation;
+  using OE = AnatomicalOrientation::PositiveEnum;
+  using NOE = AnatomicalOrientation::NegativeEnum;
+  using CE = AnatomicalOrientation::CoordinateEnum;
+  using ImageType = itk::Image<float, 3>;
+
+  ImageType::DirectionType d;
+
+  AnatomicalOrientation do1(OE::LPS);
+
+  EXPECT_EQ("LPS", do1.GetAsPositiveStringEncoding());
+  EXPECT_EQ(CE::RightToLeft, do1.GetPrimaryTerm());
+  EXPECT_EQ(CE::AnteriorToPosterior, do1.GetSecondaryTerm());
+  EXPECT_EQ(CE::InferiorToSuperior, do1.GetTertiaryTerm());
+  EXPECT_EQ(OE::LPS, do1.GetAsPositiveOrientation());
+  EXPECT_EQ(NOE::RAI, do1.GetAsNegativeOrientation());
+
+  d.SetIdentity();
+  EXPECT_EQ(d, do1.GetAsDirection());
+
+
+  do1 = AnatomicalOrientation::CreateFromPositiveStringEncoding("RAS");
+
+  EXPECT_EQ("RAS", do1.GetAsPositiveStringEncoding());
+  EXPECT_EQ(CE::LeftToRight, do1.GetPrimaryTerm());
+  EXPECT_EQ(CE::PosteriorToAnterior, do1.GetSecondaryTerm());
+  EXPECT_EQ(CE::InferiorToSuperior, do1.GetTertiaryTerm());
+  EXPECT_EQ(OE::RAS, do1.GetAsPositiveOrientation());
+  EXPECT_EQ(NOE::LPI, do1.GetAsNegativeOrientation());
+
+  d.Fill(0.0);
+  d(0, 0) = -1.0;
+  d(1, 1) = -1.0;
+  d(2, 2) = 1.0;
+  EXPECT_EQ(d, do1.GetAsDirection());
+
+
+  do1 = AnatomicalOrientation::CreateFromPositiveStringEncoding("rai");
+
+  EXPECT_EQ("RAI", do1.GetAsPositiveStringEncoding());
+  EXPECT_EQ(CE::LeftToRight, do1.GetPrimaryTerm());
+  EXPECT_EQ(CE::PosteriorToAnterior, do1.GetSecondaryTerm());
+  EXPECT_EQ(CE::SuperiorToInferior, do1.GetTertiaryTerm());
+  EXPECT_EQ(OE::RAI, do1.GetAsPositiveOrientation());
+  EXPECT_EQ(NOE::LPS, do1.GetAsNegativeOrientation());
+
+
+  do1 = AnatomicalOrientation::CreateFromNegativeStringEncoding("LPI");
+
+  EXPECT_EQ("RAS", do1.GetAsPositiveStringEncoding());
+  EXPECT_EQ("LPI", do1.GetAsNegativeStringEncoding());
+  EXPECT_EQ(CE::LeftToRight, do1.GetPrimaryTerm());
+  EXPECT_EQ(CE::PosteriorToAnterior, do1.GetSecondaryTerm());
+  EXPECT_EQ(CE::InferiorToSuperior, do1.GetTertiaryTerm());
+  EXPECT_EQ(OE::RAS, do1.GetAsPositiveOrientation());
+  EXPECT_EQ(NOE::LPI, do1.GetAsNegativeOrientation());
+
+  do1 = AnatomicalOrientation(OE::PIR);
+
+  EXPECT_EQ("PIR", do1.GetAsPositiveStringEncoding());
+  EXPECT_EQ(CE::AnteriorToPosterior, do1.GetPrimaryTerm());
+  EXPECT_EQ(CE::SuperiorToInferior, do1.GetSecondaryTerm());
+  EXPECT_EQ(CE::LeftToRight, do1.GetTertiaryTerm());
+  EXPECT_EQ(OE::PIR, do1.GetAsPositiveOrientation());
+  EXPECT_EQ(NOE::ASL, do1.GetAsNegativeOrientation());
+
+  d.Fill(0.0);
+  d(1, 0) = 1.0;
+  d(2, 1) = -1.0;
+  d(0, 2) = -1.0;
+  EXPECT_EQ(d, do1.GetAsDirection());
+
+  const AnatomicalOrientation do2(d);
+
+  EXPECT_EQ("PIR", do2.GetAsPositiveStringEncoding());
+  EXPECT_EQ(CE::AnteriorToPosterior, do2.GetPrimaryTerm());
+  EXPECT_EQ(CE::SuperiorToInferior, do2.GetSecondaryTerm());
+  EXPECT_EQ(CE::LeftToRight, do2.GetTertiaryTerm());
+  EXPECT_EQ(OE::PIR, do2.GetAsPositiveOrientation());
+  EXPECT_EQ(NOE::ASL, do2.GetAsNegativeOrientation());
+
+  EXPECT_EQ(d, do2.GetAsDirection());
+
+  const AnatomicalOrientation do3 = AnatomicalOrientation::CreateFromPositiveStringEncoding("something invalid");
+  EXPECT_EQ("INVALID", do3.GetAsPositiveStringEncoding());
+  EXPECT_EQ(CE::UNKNOWN, do3.GetPrimaryTerm());
+  EXPECT_EQ(CE::UNKNOWN, do3.GetSecondaryTerm());
+  EXPECT_EQ(CE::UNKNOWN, do3.GetTertiaryTerm());
+  EXPECT_EQ(OE::INVALID, do3.GetAsPositiveOrientation());
+  EXPECT_EQ(NOE::INVALID, do3.GetAsNegativeOrientation());
+}
+
+
+TEST(AnatomicalOrientation, ConvertDirectionToPositiveEnum)
+{
+  using itk::AnatomicalOrientation;
+  using OE = AnatomicalOrientation::PositiveEnum;
+  using ImageType = itk::Image<float, 3>;
+  ImageType::DirectionType d;
+  d.SetIdentity();
+
+  EXPECT_EQ(OE::LPS, AnatomicalOrientation(d));
+
+  d.Fill(0.0);
+  d(0, 0) = -1.0;
+  d(1, 1) = -1.0;
+  d(2, 2) = -1.0;
+  EXPECT_EQ(OE::RAI, AnatomicalOrientation(d));
+
+  d.Fill(0.0);
+  d(2, 0) = 1;
+  d(0, 1) = 1;
+  d(1, 2) = 1;
+  EXPECT_EQ(OE::SLP, AnatomicalOrientation(d));
+
+  d.Fill(0.0);
+  d(1, 0) = 1;
+  d(2, 1) = 1;
+  d(0, 2) = 1;
+  EXPECT_EQ(OE::PSL, AnatomicalOrientation(d));
+
+  d.Fill(0.0);
+  d(0, 0) = 1;
+  d(2, 1) = 1;
+  d(1, 2) = 1;
+  EXPECT_EQ(OE::LSP, AnatomicalOrientation(d));
+
+  d.Fill(0.0);
+  d(1, 0) = 1;
+  d(0, 1) = 1;
+  d(2, 2) = 1;
+  EXPECT_EQ(OE::PLS, AnatomicalOrientation(d));
+
+  d.Fill(0.0);
+  d(2, 0) = 1;
+  d(1, 1) = 1;
+  d(0, 2) = 1;
+  EXPECT_EQ(OE::SPL, AnatomicalOrientation(d));
+
+  constexpr itk::SpacePrecisionType data[] = { 0.5986634407395047, 0.22716302314740483, -0.768113953548866,
+                                               0.5627936241740271, 0.563067040943212,   0.6051601804419384,
+                                               0.5699696670095713, -0.794576911518317,  0.20924175102261847 };
+  const ImageType::DirectionType::InternalMatrixType m{ data };
+  d.GetVnlMatrix() = m;
+  EXPECT_EQ(OE::PIR, AnatomicalOrientation(d));
+}
+
+TEST(AnatomicalOrientation, ConvertPositiveEnumToDirection)
+{
+  using itk::AnatomicalOrientation;
+  using ImageType = itk::Image<float, 3>;
+  using OE = AnatomicalOrientation::PositiveEnum;
+
+  ImageType::DirectionType d;
+  d.SetIdentity();
+
+  EXPECT_EQ(d, AnatomicalOrientation(OE::LPS).GetAsDirection());
+
+  d.Fill(0.0);
+  d(0, 0) = -1.0;
+  d(1, 1) = -1.0;
+  d(2, 2) = -1.0;
+  EXPECT_EQ(d, AnatomicalOrientation(OE::RAI).GetAsDirection());
+
+  d.Fill(0.0);
+  d(2, 0) = 1;
+  d(0, 1) = 1;
+  d(1, 2) = 1;
+  EXPECT_EQ(d, AnatomicalOrientation(OE::SLP).GetAsDirection());
+
+  d.Fill(0.0);
+  d(1, 0) = 1;
+  d(2, 1) = 1;
+  d(0, 2) = 1;
+  EXPECT_EQ(d, AnatomicalOrientation(OE::PSL).GetAsDirection());
+
+  d.Fill(0.0);
+  d(0, 0) = 1;
+  d(2, 1) = 1;
+  d(1, 2) = 1;
+  EXPECT_EQ(d, AnatomicalOrientation(OE::LSP).GetAsDirection());
+
+  d.Fill(0.0);
+  d(1, 0) = 1;
+  d(0, 1) = 1;
+  d(2, 2) = 1;
+  EXPECT_EQ(d, AnatomicalOrientation(OE::PLS).GetAsDirection());
+
+  d.Fill(0.0);
+  d(2, 0) = 1;
+  d(1, 1) = 1;
+  d(0, 2) = 1;
+  EXPECT_EQ(d, AnatomicalOrientation(OE::SPL).GetAsDirection());
+}
+
+TEST(AntomicalOrientation, ToFromEnumInteroperability)
+{
+
+  using OE = itk::AnatomicalOrientation::PositiveEnum;
+  using FromOE = itk::AnatomicalOrientation::NegativeEnum;
+  using CE = itk::AnatomicalOrientation::CoordinateEnum;
+
+  static_assert(static_cast<int>(OE::RAI) == static_cast<int>(FromOE::LPS));
+  static_assert(static_cast<int>(OE::LPS) == static_cast<int>(FromOE::RAI));
+  static_assert(static_cast<int>(OE::RAS) == static_cast<int>(FromOE::LPI));
+  static_assert(static_cast<int>(OE::LPI) == static_cast<int>(FromOE::RAS));
+  static_assert(static_cast<int>(OE::PIR) == static_cast<int>(FromOE::ASL));
+  static_assert(static_cast<int>(OE::ASL) == static_cast<int>(FromOE::PIR));
+
+  constexpr itk::AnatomicalOrientation itk_rai(FromOE::RAI);
+
+  EXPECT_EQ(itk_rai, itk::AnatomicalOrientation(OE::LPS));
+  EXPECT_EQ(itk_rai.GetAsPositiveOrientation(), OE::LPS);
+  EXPECT_EQ(itk_rai.GetAsPositiveStringEncoding(), "LPS");
+  constexpr std::array<CE, 3> expected_terms = { { CE::RightToLeft, CE::AnteriorToPosterior, CE::InferiorToSuperior } };
+  EXPECT_EQ(itk_rai.GetTerms(), expected_terms);
+}
+
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+#  include "itkSpatialOrientation.h"
+TEST(AnatomicalOrientation, LegacyInteroperability)
+{
+
+  using OE = itk::AnatomicalOrientation::PositiveEnum;
+  using SOE = itk::SpatialOrientationEnums::ValidCoordinateOrientations;
+
+  // byte for byte compatibility, may assist with migration of bindings when types are not strictly enforced.
+  static_assert(static_cast<int>(SOE::ITK_COORDINATE_ORIENTATION_RAI) == static_cast<int>(OE::LPS));
+  static_assert(static_cast<int>(SOE::ITK_COORDINATE_ORIENTATION_LPS) == static_cast<int>(OE::RAI));
+  static_assert(static_cast<int>(SOE::ITK_COORDINATE_ORIENTATION_RSA) == static_cast<int>(OE::LIP));
+  static_assert(static_cast<int>(SOE::ITK_COORDINATE_ORIENTATION_ASL) == static_cast<int>(OE::PIR));
+
+  const itk::AnatomicalOrientation itk_rai(SOE::ITK_COORDINATE_ORIENTATION_RAI);
+  EXPECT_EQ(itk_rai, OE::LPS);
+  EXPECT_EQ(itk_rai.GetAsPositiveOrientation(), OE::LPS);
+  EXPECT_EQ(itk_rai.GetAsPositiveStringEncoding(), "LPS");
+}
+#endif

--- a/Modules/Core/Common/wrapping/itkAnatomicalOrientation.wrap
+++ b/Modules/Core/Common/wrapping/itkAnatomicalOrientation.wrap
@@ -1,0 +1,1 @@
+itk_wrap_simple_class("itk::AnatomicalOrientation")


### PR DESCRIPTION
To simplify the transition to using itkAnatomicalOrientation as recommended in ITKv6 and above, provide support for AnatomicalOrientation from ITKv5.

The files to support itkAnatomicalOrientation were copied from commit d6a0f1e795316f0efa5b74a874cbd8caacb481ba

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
