### PR TITLE
BUG: `ImageIOBase` should internally use `signed char` for `CHAR`

### DIFF
--- a/Modules/IO/ImageBase/include/itkImageIOBase.h
+++ b/Modules/IO/ImageBase/include/itkImageIOBase.h
@@ -1010,7 +1010,7 @@ private:
   static constexpr ComponentTypeTraits
   GetComponentTypeTraits(const IOComponentEnum componentEnum)
   {
-    return ComponentTypeTraits::Get<char,
+    return ComponentTypeTraits::Get<signed char,
                                     unsigned char,
                                     short,
                                     unsigned short,


### PR DESCRIPTION
`ImageIOBase::GetComponentTypeTraits` incorrectly assumed that the plain `char` type is always mapped to `IOComponentEnum::CHAR`. However, that isn't the case when the default `char` type is an unsigned type (as can be specified by GCC option `-funsigned-char` and MSVC option `/J`).

This bug was introduced with pull request https://github.com/InsightSoftwareConsortium/ITK/pull/5421 commit 3604e0c6c02f6c184cd84c2ce3ad1fbd677c1f73 "ENH: Ease getting type traits of pixel components from ImageIO" (merged to the master branch on June 23, 2025).

The bug caused incorrect return values from the following function calls:

    ImageIOBase::GetNumberOfBitsOfComponentType(IOComponentEnum::INT8);
    ImageIOBase::GetNumberOfBitsOfComponentType(IOComponentEnum::CHAR);
    ImageIOBase::GetComponentTypeFromTypeTraits(false, false, 0);
    ImageIOBase::GetComponentTypeFromTypeTraits(false, false, 8);

As was observed from the static_assert failures in "itkImageIOBaseTest.cxx", when using the compiler option that makes the default `char` unsigned.