### PR TITLE
Remove `itkSetMacro2` from itkVTKImageImport.h

### DIFF
--- a/Modules/Bridge/VTK/include/itkVTKImageImport.h
+++ b/Modules/Bridge/VTK/include/itkVTKImageImport.h
@@ -180,7 +180,7 @@ public:
   /** @ITKEndGrouping */
   /** Specify callback data. */
   /** @ITKStartGrouping */
-  itkSetMacro2(CallbackUserData, void *);
+  itkSetMacro(CallbackUserData, void *);
   itkGetConstMacro(CallbackUserData, void *);
   /** @ITKEndGrouping */
 protected:

--- a/Modules/Bridge/VTK/include/itkVTKImageImport.h
+++ b/Modules/Bridge/VTK/include/itkVTKImageImport.h
@@ -22,17 +22,20 @@
 #include "itkImageSource.h"
 #include "itkImportImageContainer.h"
 
-#define itkSetMacro2(name, type)                    \
-  virtual void Set##name(type _arg)                 \
-  {                                                 \
-    itkDebugMacro("setting " #name " to " << _arg); \
-    if (this->m_##name != _arg)                     \
-    {                                               \
-      this->m_##name = _arg;                        \
-      this->Modified();                             \
-    }                                               \
-  }                                                 \
-  ITK_MACROEND_NOOP_STATEMENT
+#ifndef ITK_LEGACY_REMOVE
+// This macro is intended to be removed from ITK 6. Please use `itkSetMacro` instead!
+#  define itkSetMacro2(name, type)                    \
+    virtual void Set##name(type _arg)                 \
+    {                                                 \
+      itkDebugMacro("setting " #name " to " << _arg); \
+      if (this->m_##name != _arg)                     \
+      {                                               \
+        this->m_##name = _arg;                        \
+        this->Modified();                             \
+      }                                               \
+    }                                                 \
+    ITK_MACROEND_NOOP_STATEMENT
+#endif
 
 namespace itk
 {


### PR DESCRIPTION
`itkSetMacro2` was introduced with commit be7ed583913b1a919d3d1d4b20fe9f56c1551cfc (Oct 25, 2001), but it looks like it was redundant already at that time 🤷 

The original version (Oct 25, 2001) is at https://github.com/InsightSoftwareConsortium/ITK/blob/be7ed583913b1a919d3d1d4b20fe9f56c1551cfc/Code/BasicFilters/itkVTKImageImport.h#L48-L57

This pull request is a follow-up to my comment on a pull request from @seanm, at https://github.com/InsightSoftwareConsortium/ITK/pull/5458#discussion_r2198507243

@bradking Do you still remember why `itkSetMacro2` was added, originally?