### PR TITLE
STYLE: Replace `char` with `signed char` as itk::Image argument in tests

### DIFF
--- a/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -274,7 +274,7 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
     using KernelType = itk::BSplineKernelFunction<SplineOrder>;
     auto kernel = KernelType::New();
 
-    using ImageType = itk::Image<char, SpaceDimension>;
+    using ImageType = itk::Image<signed char, SpaceDimension>;
     auto                        image = ImageType::New();
     const ImageType::RegionType region{ startIndex, size };
 

--- a/Modules/Core/Common/test/itkConstNeighborhoodIteratorWithOnlyIndexTest.cxx
+++ b/Modules/Core/Common/test/itkConstNeighborhoodIteratorWithOnlyIndexTest.cxx
@@ -452,7 +452,7 @@ int
 itkConstNeighborhoodIteratorWithOnlyIndexTest(int, char *[])
 {
   std::cout << "*** Testing with itk::Image" << std::endl << std::endl;
-  if (itkConstNeighborhoodIteratorWithOnlyIndexTestRun<itk::Image<char, 4>>() == EXIT_FAILURE)
+  if (itkConstNeighborhoodIteratorWithOnlyIndexTestRun<itk::Image<signed char, 4>>() == EXIT_FAILURE)
   {
     std::cerr << "XXX Failed with itk::Image XXX" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Core/Common/test/itkImageAlgorithmCopyTest.cxx
+++ b/Modules/Core/Common/test/itkImageAlgorithmCopyTest.cxx
@@ -118,7 +118,7 @@ AverageTestCopy(typename TImage::SizeType & size)
 int
 itkImageAlgorithmCopyTest(int, char *[])
 {
-  using ImageType3D = itk::Image<char, 3>;
+  using ImageType3D = itk::Image<signed char, 3>;
   auto size3d = ImageType3D::SizeType::Filled(16);
   AverageTestCopy<ImageType3D>(size3d);
 
@@ -131,7 +131,7 @@ itkImageAlgorithmCopyTest(int, char *[])
   size3d.Fill(128);
   AverageTestCopy<ImageType3D>(size3d);
 
-  using ImageType2D = itk::Image<char, 2>;
+  using ImageType2D = itk::Image<signed char, 2>;
   auto size2d = ImageType2D::SizeType::Filled(16);
   AverageTestCopy<ImageType2D>(size2d);
 

--- a/Modules/Core/Common/test/itkImageRegionConstIteratorWithOnlyIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionConstIteratorWithOnlyIndexTest.cxx
@@ -189,7 +189,7 @@ itkImageRegionConstIteratorWithOnlyIndexTest(int, char *[])
 
   {
     std::cout << "Testing with Image< char, 3 >... " << std::endl;
-    itkImageRegionConstIteratorWithOnlyIndexTestIteratorTester<itk::Image<char, 3>> Tester;
+    itkImageRegionConstIteratorWithOnlyIndexTestIteratorTester<itk::Image<signed char, 3>> Tester;
     if (Tester.TestConstIterator() == false)
     {
       testPassed = false;

--- a/Modules/Core/Common/test/itkImageVectorOptimizerParametersHelperTest.cxx
+++ b/Modules/Core/Common/test/itkImageVectorOptimizerParametersHelperTest.cxx
@@ -142,7 +142,7 @@ itkImageVectorOptimizerParametersHelperTest(int, char *[])
   ITK_TRY_EXPECT_EXCEPTION(params.MoveDataPointer(array.data_block()));
 
   // Test setting an image of wrong type
-  using BadImageType = itk::Image<char, 2>;
+  using BadImageType = itk::Image<signed char, 2>;
   auto badImage = BadImageType::New();
   ITK_TRY_EXPECT_EXCEPTION(params.SetParametersObject(badImage));
 

--- a/Modules/Core/Common/test/itkMultiThreaderParallelizeArrayTest.cxx
+++ b/Modules/Core/Common/test/itkMultiThreaderParallelizeArrayTest.cxx
@@ -66,7 +66,7 @@ itkMultiThreaderParallelizeArrayTest(int argc, char * argv[])
   constexpr unsigned int    size = 1029;
   std::vector<unsigned int> vec(size);
 
-  using SomeProcessObject = itk::AbsImageFilter<itk::Image<char>, itk::Image<char>>;
+  using SomeProcessObject = itk::AbsImageFilter<itk::Image<signed char>, itk::Image<signed char>>;
   auto progressPO = SomeProcessObject::New();
   auto showProgress = ShowProgress::New();
   progressPO->AddObserver(itk::ProgressEvent(), showProgress);

--- a/Modules/Core/Common/test/itkSimpleFilterWatcherTest.cxx
+++ b/Modules/Core/Common/test/itkSimpleFilterWatcherTest.cxx
@@ -85,7 +85,7 @@ itkSimpleFilterWatcherTest(int, char *[])
 {
   // Test out the code
   using WatcherType = itk::SimpleFilterWatcher;
-  using ImageType = itk::Image<char, 3>;
+  using ImageType = itk::Image<signed char, 3>;
   using FilterType = itk::TanHelperImageFilter<ImageType, ImageType>;
   auto         filter = FilterType::New();
   const char * comment = "comment";

--- a/Modules/Filtering/AntiAlias/test/itkAntiAliasBinaryImageFilterTest.cxx
+++ b/Modules/Filtering/AntiAlias/test/itkAntiAliasBinaryImageFilterTest.cxx
@@ -48,9 +48,9 @@ sphere(float x, float y, float z)
 }
 
 void
-evaluate_function(itk::Image<char, 3> * im, float (*f)(float, float, float))
+evaluate_function(itk::Image<signed char, 3> * im, float (*f)(float, float, float))
 {
-  itk::Image<char, 3>::IndexType idx;
+  itk::Image<signed char, 3>::IndexType idx;
 
   for (int z = 0; z < V_DEPTH; ++z)
   {
@@ -88,8 +88,7 @@ itkAntiAliasBinaryImageFilterTest(int argc, char * argv[])
   }
   const char * outputImage = argv[1];
 
-  using InputDataType = char;
-  using BinaryImageType = itk::Image<InputDataType, 3>;
+  using BinaryImageType = itk::Image<signed char, 3>;
   using RealImageType = itk::Image<float, 3>;
 
   const itk::AntiAliasBinaryImageFilter<BinaryImageType, RealImageType>::Pointer antialiaser =

--- a/Modules/Filtering/ImageCompose/test/itkJoinImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkJoinImageFilterTest.cxx
@@ -29,7 +29,7 @@ itkJoinImageFilterTest(int, char *[])
   constexpr unsigned int myDimension = 2;
 
   // Declare the types of the images
-  using myImageType1 = itk::Image<char, myDimension>;
+  using myImageType1 = itk::Image<signed char, myDimension>;
   using myImageType2 = itk::Image<itk::Vector<unsigned short, 2>, myDimension>;
   using myImageType3 = itk::Image<itk::RGBAPixel<short>, myDimension>;
 

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyIteratorsGTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyIteratorsGTest.cxx
@@ -105,7 +105,7 @@ template <typename TOutputImageType>
 static typename TOutputImageType::Pointer
 CreateImage(unsigned int size)
 {
-  using ImageType = itk::Image<char, TOutputImageType::ImageDimension>;
+  using ImageType = itk::Image<signed char, TOutputImageType::ImageDimension>;
   auto imageSize = ImageType::SizeType::Filled(size);
   using RandomImageSourceType = itk::RandomImageSource<ImageType>;
   auto randomImageSource = RandomImageSourceType::New();

--- a/Modules/Filtering/ImageIntensity/test/itkShiftScaleImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkShiftScaleImageFilterTest.cxx
@@ -29,7 +29,7 @@ itkShiftScaleImageFilterTest(int, char *[])
 {
   std::cout << "itkShiftScaleImageFilterTest Start" << std::endl;
 
-  using TestInputImage = itk::Image<char, 3>;
+  using TestInputImage = itk::Image<signed char, 3>;
   using TestOutputImage = itk::Image<unsigned char, 3>;
   using RealType = itk::NumericTraits<char>::RealType;
 

--- a/Modules/IO/ImageBase/test/itkImageFileReaderDimensionsTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileReaderDimensionsTest.cxx
@@ -37,7 +37,7 @@ itkImageFileReaderDimensionsTest(int argc, char * argv[])
   using Image2DType = itk::Image<short, 2>;
   using Image3DType = itk::Image<short, 3>;
   using Image4DType = itk::Image<short, 4>;
-  using CharImage2DType = itk::Image<char, 2>;
+  using CharImage2DType = itk::Image<signed char, 2>;
 
   using Reader2DType = itk::ImageFileReader<Image2DType>;
   using Reader3DType = itk::ImageFileReader<Image3DType>;

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest11.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest11.cxx
@@ -42,7 +42,7 @@ itkNiftiImageIOTest11(int argc, char * argv[])
   {
     return EXIT_FAILURE;
   }
-  using ImageType = itk::Image<char, 3>;
+  using ImageType = itk::Image<signed char, 3>;
 
   ImageType::SizeType size;
   size[0] = static_cast<long>(itk::NumericTraits<short>::max()) * 2;

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest.cxx
@@ -42,7 +42,7 @@ itkImageRegistrationMethodTest(int, char *[])
   using FixedImageType = itk::Image<float, dimension>;
 
   // Moving Image Type
-  using MovingImageType = itk::Image<char, dimension>;
+  using MovingImageType = itk::Image<signed char, dimension>;
 
   // Transform Type
   using TransformType = itk::TranslationTransform<double, dimension>;

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_11.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_11.cxx
@@ -39,7 +39,7 @@ itkImageRegistrationMethodTest_11(int, char *[])
   using FixedImageType = itk::Image<float, dimension>;
 
   // Moving Image Type
-  using MovingImageType = itk::Image<char, dimension>;
+  using MovingImageType = itk::Image<signed char, dimension>;
 
   // Transform Type
   using TransformType = itk::TranslationTransform<double, dimension>;

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest.cxx
@@ -44,7 +44,7 @@ itkMultiResolutionImageRegistrationMethodTest(int, char *[])
   using FixedImageType = itk::Image<float, dimension>;
 
   // Moving Image Type
-  //  using MovingImageType = itk::Image<char,dimension>;
+  //  using MovingImageType = itk::Image<signed char,dimension>;
   using MovingImageType = itk::Image<float, dimension>;
 
   // Transform Type

--- a/Modules/Segmentation/LevelSets/test/itkCannySegmentationLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkCannySegmentationLevelSetImageFilterTest.cxx
@@ -23,7 +23,7 @@ namespace CSIFTN
 {
 
 using ImageType = itk::Image<float, 3>;
-using SeedImageType = itk::Image<char, 3>;
+using SeedImageType = itk::Image<signed char, 3>;
 
 constexpr int V_WIDTH = 64;
 constexpr int V_HEIGHT = 64;
@@ -79,9 +79,9 @@ evaluate_float_function(itk::Image<float, 3> * im, float (*f)(float, float, floa
 }
 
 void
-evaluate_function(itk::Image<char, 3> * im, float (*f)(float, float, float))
+evaluate_function(itk::Image<signed char, 3> * im, float (*f)(float, float, float))
 {
-  itk::Image<char, 3>::IndexType idx;
+  itk::Image<signed char, 3>::IndexType idx;
 
   for (int z = 0; z < V_DEPTH; ++z)
   {

--- a/Modules/Segmentation/LevelSets/test/itkLaplacianSegmentationLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLaplacianSegmentationLevelSetImageFilterTest.cxx
@@ -24,7 +24,7 @@ namespace LSIFTN
 {
 
 using ImageType = itk::Image<float, 3>;
-using SeedImageType = itk::Image<char, 3>;
+using SeedImageType = itk::Image<signed char, 3>;
 
 constexpr int V_WIDTH = 64;
 constexpr int V_HEIGHT = 64;
@@ -80,9 +80,9 @@ evaluate_float_function(itk::Image<float, 3> * im, float (*f)(float, float, floa
 }
 
 void
-evaluate_function(itk::Image<char, 3> * im, float (*f)(float, float, float))
+evaluate_function(itk::Image<signed char, 3> * im, float (*f)(float, float, float))
 {
-  itk::Image<char, 3>::IndexType idx;
+  itk::Image<signed char, 3>::IndexType idx;
 
   for (int z = 0; z < V_DEPTH; ++z)
   {

--- a/Modules/Segmentation/LevelSets/test/itkNarrowBandThresholdSegmentationLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkNarrowBandThresholdSegmentationLevelSetImageFilterTest.cxx
@@ -23,7 +23,7 @@ namespace NBTS
 {
 
 using ImageType = itk::Image<float, 3>;
-using SeedImageType = itk::Image<char, 3>;
+using SeedImageType = itk::Image<signed char, 3>;
 
 constexpr int V_WIDTH = 64;
 constexpr int V_HEIGHT = 64;
@@ -40,9 +40,9 @@ sphere(float x, float y, float z)
 }
 
 void
-evaluate_function(itk::Image<char, 3> * im, float (*f)(float, float, float))
+evaluate_function(itk::Image<signed char, 3> * im, float (*f)(float, float, float))
 {
-  itk::Image<char, 3>::IndexType idx;
+  itk::Image<signed char, 3>::IndexType idx;
 
   for (int z = 0; z < V_DEPTH; ++z)
   {

--- a/Modules/Segmentation/LevelSets/test/itkThresholdSegmentationLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkThresholdSegmentationLevelSetImageFilterTest.cxx
@@ -23,7 +23,7 @@ namespace TSIFTN
 {
 
 using ImageType = itk::Image<float, 3>;
-using SeedImageType = itk::Image<char, 3>;
+using SeedImageType = itk::Image<signed char, 3>;
 
 constexpr int V_WIDTH = 64;
 constexpr int V_HEIGHT = 64;
@@ -40,9 +40,9 @@ sphere(float x, float y, float z)
 }
 
 void
-evaluate_function(itk::Image<char, 3> * im, float (*f)(float, float, float))
+evaluate_function(itk::Image<signed char, 3> * im, float (*f)(float, float, float))
 {
-  itk::Image<char, 3>::IndexType idx;
+  itk::Image<signed char, 3>::IndexType idx;
 
   for (int z = 0; z < V_DEPTH; ++z)
   {

--- a/Modules/Segmentation/LevelSetsv4/test/itkBinaryImageToShiSparseLevelSetAdaptorTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkBinaryImageToShiSparseLevelSetAdaptorTest.cxx
@@ -66,7 +66,7 @@ itkBinaryImageToShiSparseLevelSetAdaptorTest(int argc, char * argv[])
 
   const LevelSetType::Pointer sparseLevelSet = adaptor->GetModifiableLevelSet();
 
-  using StatusImageType = itk::Image<char, Dimension>;
+  using StatusImageType = itk::Image<signed char, Dimension>;
   auto statusImage = StatusImageType::New();
   statusImage->SetRegions(input->GetLargestPossibleRegion());
   statusImage->CopyInformation(input);


### PR DESCRIPTION
Replaced `itk::Image<char` with `itk::Image<signed char`, in all `"itk*Test*.cxx"` source files. Removed pixel type alias `InputDataType = char` from itkAntiAliasBinaryImageFilterTest, and directly used `signed char` instead.

The use of `char` as `TPixel` argument in tests appears to triggers test failures, when compiling with an unsigned default `char` type (GCC option `-funsigned-char` or MSVC option `/J`), for example:

    [ RUN      ] FrequencyIterators.Even2D
    Unequal images, with 29 unequal pixels
    test/itkFrequencyIteratorsGTest.cxx:260: Failure
    Value of: fullAndHermitian
    Actual: false
    Expected: true

It appears clearer to explicitly specify that the pixel type should be signed, by using `signed char` instead.

----

- Those test failures appeared with an experimental pull request: #5455 
- This pull request is inspired by a comment from Bradley (@blowekamp) at https://github.com/InsightSoftwareConsortium/ITK/pull/5450#issuecomment-3048788622
- Various coding guidelines recommend using `signed char`, rather than plain `char`, for numeric values, for example https://wiki.sei.cmu.edu/confluence/display/c/INT07-C.+Use+only+explicitly+signed+or+unsigned+char+type+for+numeric+values and https://rules.sonarsource.com/cpp/tag/confusing/RSPEC-810/  