### PR TITLE
Remove unnecessary ByteSwapper Swap function calls for char types

### DIFF
--- a/Modules/IO/BMP/src/itkBMPImageIO.cxx
+++ b/Modules/IO/BMP/src/itkBMPImageIO.cxx
@@ -610,29 +610,9 @@ BMPImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPixels)
   switch (m_ComponentType)
   {
     case IOComponentEnum::CHAR:
-    {
-      if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
-      {
-        ByteSwapper<char>::SwapRangeFromSystemToLittleEndian(static_cast<char *>(buffer), numberOfPixels);
-      }
-      else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
-      {
-        ByteSwapper<char>::SwapRangeFromSystemToBigEndian(static_cast<char *>(buffer), numberOfPixels);
-      }
-      break;
-    }
     case IOComponentEnum::UCHAR:
     {
-      if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
-      {
-        ByteSwapper<unsigned char>::SwapRangeFromSystemToLittleEndian(static_cast<unsigned char *>(buffer),
-                                                                      numberOfPixels);
-      }
-      else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
-      {
-        ByteSwapper<unsigned char>::SwapRangeFromSystemToBigEndian(static_cast<unsigned char *>(buffer),
-                                                                   numberOfPixels);
-      }
+      // For CHAR and UCHAR, it is not necessary to swap bytes.
       break;
     }
     case IOComponentEnum::SHORT:

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -437,15 +437,6 @@ GiplImageIO::ReadImageInformation()
     m_Ifstream.read(&flag1, sizeof(char));
   }
 
-  if (m_ByteOrder == IOByteOrderEnum::BigEndian)
-  {
-    ByteSwapper<char>::SwapFromSystemToBigEndian(&flag1);
-  }
-  else if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
-  {
-    ByteSwapper<char>::SwapFromSystemToLittleEndian(&flag1);
-  }
-
   char flag2 = 0; /*  187    1                              */
   if (m_IsCompressed)
   {
@@ -454,15 +445,6 @@ GiplImageIO::ReadImageInformation()
   else
   {
     m_Ifstream.read(&flag2, sizeof(char));
-  }
-
-  if (m_ByteOrder == IOByteOrderEnum::BigEndian)
-  {
-    ByteSwapper<char>::SwapFromSystemToBigEndian(&flag2);
-  }
-  else if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
-  {
-    ByteSwapper<char>::SwapFromSystemToLittleEndian(&flag2);
   }
 
   double min = NAN; /*  188    8  Minimum voxel value         */
@@ -615,29 +597,9 @@ GiplImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPixels)
   switch (m_ComponentType)
   {
     case IOComponentEnum::CHAR:
-    {
-      if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
-      {
-        ByteSwapper<char>::SwapRangeFromSystemToLittleEndian(static_cast<char *>(buffer), numberOfPixels);
-      }
-      else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
-      {
-        ByteSwapper<char>::SwapRangeFromSystemToBigEndian(static_cast<char *>(buffer), numberOfPixels);
-      }
-      break;
-    }
     case IOComponentEnum::UCHAR:
     {
-      if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
-      {
-        ByteSwapper<unsigned char>::SwapRangeFromSystemToLittleEndian(static_cast<unsigned char *>(buffer),
-                                                                      numberOfPixels);
-      }
-      else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
-      {
-        ByteSwapper<unsigned char>::SwapRangeFromSystemToBigEndian(static_cast<unsigned char *>(buffer),
-                                                                   numberOfPixels);
-      }
+      // For CHAR and UCHAR, it is not necessary to swap bytes.
       break;
     }
     case IOComponentEnum::SHORT:

--- a/Modules/IO/ImageBase/src/itkRawImageIOUtilities.cxx
+++ b/Modules/IO/ImageBase/src/itkRawImageIOUtilities.cxx
@@ -135,6 +135,7 @@ ReadRawBytesAfterSwapping(IOComponentEnum componentType,
                           SizeValueType   numberOfComponents)
 {
   // Swap bytes if necessary
+  // Note that for CHAR and UCHAR, byte swapping is not necessary.
   if (componentType == IOComponentEnum::USHORT)
   {
     _ReadRawBytesAfterSwappingUtility<unsigned short>(buffer, byteOrder, numberOfComponents);
@@ -142,14 +143,6 @@ ReadRawBytesAfterSwapping(IOComponentEnum componentType,
   else if (componentType == IOComponentEnum::SHORT)
   {
     _ReadRawBytesAfterSwappingUtility<short>(buffer, byteOrder, numberOfComponents);
-  }
-  else if (componentType == IOComponentEnum::CHAR)
-  {
-    _ReadRawBytesAfterSwappingUtility<char>(buffer, byteOrder, numberOfComponents);
-  }
-  else if (componentType == IOComponentEnum::UCHAR)
-  {
-    _ReadRawBytesAfterSwappingUtility<unsigned char>(buffer, byteOrder, numberOfComponents);
   }
   else if (componentType == IOComponentEnum::UINT)
   {

--- a/Modules/IO/ImageBase/src/itkRawImageIOUtilities.cxx
+++ b/Modules/IO/ImageBase/src/itkRawImageIOUtilities.cxx
@@ -81,21 +81,18 @@ WriteRawBytesAfterSwapping(IOComponentEnum componentType,
                            SizeValueType   numberOfComponents)
 {
   // Swap bytes if necessary
-  if (componentType == IOComponentEnum::USHORT)
+  if (componentType == IOComponentEnum::CHAR || componentType == IOComponentEnum::UCHAR)
+  {
+    // For CHAR and UCHAR, byte swapping is not necessary.
+    file.write(static_cast<const char *>(buffer), numberOfBytes);
+  }
+  else if (componentType == IOComponentEnum::USHORT)
   {
     _WriteRawBytesAfterSwappingUtility<unsigned short>(buffer, file, byteOrder, numberOfBytes, numberOfComponents);
   }
   else if (componentType == IOComponentEnum::SHORT)
   {
     _WriteRawBytesAfterSwappingUtility<short>(buffer, file, byteOrder, numberOfBytes, numberOfComponents);
-  }
-  else if (componentType == IOComponentEnum::CHAR)
-  {
-    _WriteRawBytesAfterSwappingUtility<char>(buffer, file, byteOrder, numberOfBytes, numberOfComponents);
-  }
-  else if (componentType == IOComponentEnum::UCHAR)
-  {
-    _WriteRawBytesAfterSwappingUtility<unsigned char>(buffer, file, byteOrder, numberOfBytes, numberOfComponents);
   }
   else if (componentType == IOComponentEnum::UINT)
   {

--- a/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
@@ -299,10 +299,8 @@ PhilipsRECImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPix
     switch (this->m_ComponentType)
     {
       case IOComponentEnum::CHAR:
-        ByteSwapper<char>::SwapRangeFromSystemToLittleEndian((char *)buffer, numberOfPixels);
-        break;
       case IOComponentEnum::UCHAR:
-        ByteSwapper<unsigned char>::SwapRangeFromSystemToLittleEndian((unsigned char *)buffer, numberOfPixels);
+        // For CHAR and UCHAR, it is not necessary to swap bytes.
         break;
       case IOComponentEnum::SHORT:
         ByteSwapper<short>::SwapRangeFromSystemToLittleEndian((short *)buffer, numberOfPixels);
@@ -338,10 +336,8 @@ PhilipsRECImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPix
     switch (this->m_ComponentType)
     {
       case IOComponentEnum::CHAR:
-        ByteSwapper<char>::SwapRangeFromSystemToBigEndian((char *)buffer, numberOfPixels);
-        break;
       case IOComponentEnum::UCHAR:
-        ByteSwapper<unsigned char>::SwapRangeFromSystemToBigEndian((unsigned char *)buffer, numberOfPixels);
+        // For CHAR and UCHAR, it is not necessary to swap bytes.
         break;
       case IOComponentEnum::SHORT:
         ByteSwapper<short>::SwapRangeFromSystemToBigEndian((short *)buffer, numberOfPixels);

--- a/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
+++ b/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
@@ -155,8 +155,7 @@ StimulateImageIO::Read(void * buffer)
   switch (this->GetComponentType())
   {
     case IOComponentEnum::CHAR:
-      ByteSwapper<char>::SwapRangeFromSystemToBigEndian(static_cast<char *>(buffer),
-                                                        static_cast<SizeValueType>(this->GetImageSizeInComponents()));
+      // For CHAR, it is not necessary to swap bytes. (It would not have any effect anyway.)
       break;
     case IOComponentEnum::SHORT:
       ByteSwapper<short>::SwapRangeFromSystemToBigEndian(static_cast<short *>(buffer),
@@ -536,8 +535,7 @@ StimulateImageIO::Write(const void * buffer)
     {
       case IOComponentEnum::CHAR:
         file << "BYTE";
-        ByteSwapper<char>::SwapRangeFromSystemToBigEndian(reinterpret_cast<char *>(tempmemory.get()),
-                                                          numberOfComponents);
+        // For CHAR, it is not necessary to swap bytes. (It would not have any effect anyway.)
         break;
       case IOComponentEnum::SHORT:
         file << "WORD";


### PR DESCRIPTION
When a buffer consists of elements of size `sizeof(char)`, the Swap member functions of `ByteSwapper` don't do anything.
