### PR TITLE
Remove byte swapping for pixel components of size 1 from Bruker2dseqImageIO and VTKImageIO

### DIFF
--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
@@ -361,10 +361,8 @@ Bruker2dseqImageIO::SwapBytesIfNecessary(void * buff, SizeValueType components)
     switch (this->m_OnDiskComponentType)
     {
       case IOComponentEnum::CHAR:
-        BYTE_SWAP(char);
-        break;
       case IOComponentEnum::UCHAR:
-        BYTE_SWAP(unsigned char);
+        // For CHAR and UCHAR, it is not necessary to swap bytes.
         break;
       case IOComponentEnum::SHORT:
         BYTE_SWAP(short);
@@ -401,10 +399,8 @@ Bruker2dseqImageIO::SwapBytesIfNecessary(void * buff, SizeValueType components)
     switch (this->m_OnDiskComponentType)
     {
       case IOComponentEnum::CHAR:
-        BYTE_SWAP(char);
-        break;
       case IOComponentEnum::UCHAR:
-        BYTE_SWAP(unsigned char);
+        // For CHAR and UCHAR, it is not necessary to swap bytes.
         break;
       case IOComponentEnum::SHORT:
         BYTE_SWAP(short);


### PR DESCRIPTION
- Removed unnecessary `BYTE_SWAP` calls from `Bruker2dseqImageIO::SwapBytesIfNecessary`
- Removed expensive `MACRO(char)` calls from `VTKImageIO::Write`

- Follow-up to pull request #5466