### PR TITLE
BUG: MINCImageIO should use `signed char` for `CHAR` and `MI_TYPE_BYTE`

### DIFF
--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -1396,7 +1396,7 @@ MINCImageIO::Write(const void * buffer)
       break;
     case IOComponentEnum::CHAR:
       volume_data_type = MI_TYPE_BYTE;
-      get_buffer_min_max<char>(buffer, buffer_length, buffer_min, buffer_max);
+      get_buffer_min_max<signed char>(buffer, buffer_length, buffer_min, buffer_max);
       break;
     case IOComponentEnum::USHORT:
       volume_data_type = MI_TYPE_USHORT;


### PR DESCRIPTION
`MINCImageIO::Write` should use `signed char` for the estimation of the min and the max pixel value, when the pixel component type is `IOComponentEnum::CHAR`. Both `IOComponentEnum::CHAR` and `MI_TYPE_BYTE` specify a _signed_ type, whereas the default `char` might be unsigned (for example, when using GCC compiler option `-funsigned-char`).

Obviously the estimation of min and max pixel value may go wrong when the pixels are incorrectly assumed to be unsigned.

---

@blowekamp This little bug fix is still a spinoff from [your suggestion](https://github.com/InsightSoftwareConsortium/ITK/pull/5450#issuecomment-3048788622) to try to build ITK using `-funsigned-char`  😃 