### PR TITLE
Add `IOComponent` enum `SCHAR` for signed char (equivalent to `CHAR`)

### DIFF
--- a/Modules/Core/Common/include/itkCommonEnums.h
+++ b/Modules/Core/Common/include/itkCommonEnums.h
@@ -80,7 +80,8 @@ public:
   {
     UNKNOWNCOMPONENTTYPE,
     UCHAR,
-    CHAR,
+    SCHAR,
+    CHAR = SCHAR,
     USHORT,
     SHORT,
     UINT,

--- a/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
+++ b/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
@@ -737,7 +737,7 @@ RegressionTestImage(const char *       testImageFilename,
                                                         verifyInputInformation,
                                                         coordinateTolerance,
                                                         directionTolerance);
-      case itk::IOComponentEnum::CHAR:
+      case itk::IOComponentEnum::SCHAR:
       case itk::IOComponentEnum::SHORT:
       case itk::IOComponentEnum::INT:
       case itk::IOComponentEnum::LONG:
@@ -827,7 +827,7 @@ HashTestImage(const char * testImageFilename, const std::vector<std::string> & b
   std::string testMD5 = "";
   switch (componentType)
   {
-    case itk::IOComponentEnum::CHAR:
+    case itk::IOComponentEnum::SCHAR:
       testMD5 = ComputeHash<itk::VectorImage<signed char, ITK_TEST_DIMENSION_MAX>>(testImageFilename);
       break;
     case itk::IOComponentEnum::UCHAR:

--- a/Modules/IO/BMP/src/itkBMPImageIO.cxx
+++ b/Modules/IO/BMP/src/itkBMPImageIO.cxx
@@ -609,7 +609,7 @@ BMPImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPixels)
 {
   switch (m_ComponentType)
   {
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
     case IOComponentEnum::UCHAR:
     {
       // For CHAR and UCHAR, it is not necessary to swap bytes.

--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
@@ -360,7 +360,7 @@ Bruker2dseqImageIO::SwapBytesIfNecessary(void * buff, SizeValueType components)
 #define BYTE_SWAP(T) ByteSwapper<T>::SwapRangeFromSystemToLittleEndian((T *)buff, components)
     switch (this->m_OnDiskComponentType)
     {
-      case IOComponentEnum::CHAR:
+      case IOComponentEnum::SCHAR:
       case IOComponentEnum::UCHAR:
         // For CHAR and UCHAR, it is not necessary to swap bytes.
         break;
@@ -398,7 +398,7 @@ Bruker2dseqImageIO::SwapBytesIfNecessary(void * buff, SizeValueType components)
 #define BYTE_SWAP(T) ByteSwapper<T>::SwapRangeFromSystemToBigEndian((T *)buff, components)
     switch (this->m_OnDiskComponentType)
     {
-      case IOComponentEnum::CHAR:
+      case IOComponentEnum::SCHAR:
       case IOComponentEnum::UCHAR:
         // For CHAR and UCHAR, it is not necessary to swap bytes.
         break;
@@ -451,7 +451,7 @@ Bruker2dseqImageIO::Read(void * buffer)
       case IOComponentEnum::UCHAR:
         numberOfBytesOnDisk *= sizeof(unsigned char);
         break;
-      case IOComponentEnum::CHAR:
+      case IOComponentEnum::SCHAR:
         numberOfBytesOnDisk *= sizeof(char);
         break;
       case IOComponentEnum::USHORT:
@@ -496,7 +496,7 @@ Bruker2dseqImageIO::Read(void * buffer)
     auto * floatBuffer = static_cast<float *>(buffer);
     switch (m_OnDiskComponentType)
     {
-      case IOComponentEnum::CHAR:
+      case IOComponentEnum::SCHAR:
         CastCopy<char>(floatBuffer, dataFromDiskBuffer, numberOfComponents);
         break;
       case IOComponentEnum::UCHAR:
@@ -555,7 +555,7 @@ Bruker2dseqImageIO::Read(void * buffer)
 
   switch (this->m_ComponentType)
   {
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
       [[fallthrough]];
     case IOComponentEnum::UCHAR:
       [[fallthrough]];
@@ -606,7 +606,7 @@ Bruker2dseqImageIO::Read(void * buffer)
       const SizeValueType noswap = this->GetDimensions(3) / sizeToSwap;
       switch (this->m_ComponentType)
       {
-        case IOComponentEnum::CHAR:
+        case IOComponentEnum::SCHAR:
           SwapSlicesAndVolumes(static_cast<char *>(buffer), x, y, z, sizeToSwap, noswap);
           break;
         case IOComponentEnum::UCHAR:
@@ -651,7 +651,7 @@ Bruker2dseqImageIO::Read(void * buffer)
     const SizeValueType v = (this->GetNumberOfDimensions() > 3) ? this->GetDimensions(3) : 1;
     switch (this->m_ComponentType)
     {
-      case IOComponentEnum::CHAR:
+      case IOComponentEnum::SCHAR:
         ReverseSliceOrder(static_cast<char *>(buffer), x, y, z, v);
         break;
       case IOComponentEnum::UCHAR:

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -1161,7 +1161,7 @@ GDCMImageIO::Write(const void * buffer)
   gdcm::PixelFormat pixeltype = gdcm::PixelFormat::UNKNOWN;
   switch (this->GetComponentType())
   {
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
       pixeltype = gdcm::PixelFormat::INT8;
       break;
     case IOComponentEnum::UCHAR:
@@ -1240,7 +1240,7 @@ GDCMImageIO::Write(const void * buffer)
       //  already been taken care of. The float case use an Integer internal
       //  storage, and specifies the precision desired for it.
       //
-      case IOComponentEnum::CHAR:
+      case IOComponentEnum::SCHAR:
         outpixeltype = gdcm::PixelFormat::INT8;
         break;
       case IOComponentEnum::UCHAR:

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -596,7 +596,7 @@ GiplImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPixels)
 {
   switch (m_ComponentType)
   {
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
     case IOComponentEnum::UCHAR:
     {
       // For CHAR and UCHAR, it is not necessary to swap bytes.
@@ -739,7 +739,7 @@ GiplImageIO::Write(const void * buffer)
   unsigned short image_type = 0;
   switch (m_ComponentType)
   {
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
       image_type = GIPL_CHAR;
       break;
     case IOComponentEnum::UCHAR:

--- a/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
@@ -165,7 +165,7 @@ ComponentToPredType(IOComponentEnum cType)
   {
     case IOComponentEnum::UCHAR:
       return H5::PredType::NATIVE_UCHAR;
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
       return H5::PredType::NATIVE_CHAR;
     case IOComponentEnum::USHORT:
       return H5::PredType::NATIVE_USHORT;
@@ -204,7 +204,7 @@ ComponentToString(IOComponentEnum cType)
     case IOComponentEnum::UCHAR:
       rval = "UCHAR";
       break;
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
       rval = "CHAR";
       break;
     case IOComponentEnum::USHORT:

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -170,7 +170,7 @@ ImageIOBase::GetComponentTypeInfo() const
   {
     case IOComponentEnum::UCHAR:
       return typeid(unsigned char);
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
       return typeid(char);
     case IOComponentEnum::USHORT:
       return typeid(unsigned short);
@@ -402,7 +402,7 @@ ImageIOBase::GetComponentTypeAsString(IOComponentEnum t)
   {
     case IOComponentEnum::UCHAR:
       return { "unsigned_char" };
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
       return { "char" };
     case IOComponentEnum::USHORT:
       return { "unsigned_short" };
@@ -702,7 +702,7 @@ ImageIOBase::WriteBufferAsASCII(std::ostream &        os,
       WriteBuffer(os, buf, numComp);
     }
     break;
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
     {
       using Type = const char *;
       auto buf = static_cast<Type>(buffer);
@@ -822,7 +822,7 @@ ImageIOBase::ReadBufferAsASCII(std::istream & is, void * buffer, IOComponentEnum
       ReadBuffer(is, buf, numComp);
     }
     break;
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
     {
       auto * buf = static_cast<signed char *>(buffer);
       ReadBuffer(is, buf, numComp);

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -129,7 +129,7 @@ MINCImageIO::Read(void * buffer)
     case IOComponentEnum::UCHAR:
       volume_data_type = MI_TYPE_UBYTE;
       break;
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
       volume_data_type = MI_TYPE_BYTE;
       break;
     case IOComponentEnum::USHORT:
@@ -1022,7 +1022,7 @@ MINCImageIO::WriteImageInformation()
     case IOComponentEnum::UCHAR:
       m_MINCPImpl->m_Volume_type = MI_TYPE_UBYTE;
       break;
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
       m_MINCPImpl->m_Volume_type = MI_TYPE_BYTE;
       break;
     case IOComponentEnum::USHORT:
@@ -1394,7 +1394,7 @@ MINCImageIO::Write(const void * buffer)
       volume_data_type = MI_TYPE_UBYTE;
       get_buffer_min_max<unsigned char>(buffer, buffer_length, buffer_min, buffer_max);
       break;
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
       volume_data_type = MI_TYPE_BYTE;
       get_buffer_min_max<signed char>(buffer, buffer_length, buffer_min, buffer_max);
       break;

--- a/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
+++ b/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
@@ -334,7 +334,7 @@ BYUMeshIO::WritePoints(void * buffer)
       WritePoints(static_cast<unsigned char *>(buffer), outputFile);
       break;
     }
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
     {
       WritePoints(static_cast<char *>(buffer), outputFile);
 
@@ -442,7 +442,7 @@ BYUMeshIO::WriteCells(void * buffer)
       WriteCells(static_cast<unsigned char *>(buffer), outputFile);
       break;
     }
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
     {
       WriteCells(static_cast<unsigned char *>(buffer), outputFile);
       break;

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
@@ -509,7 +509,7 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Ge
   {
     switch (m_MeshIO->GetPointComponentType())
     {
-      case IOComponentEnum::CHAR:
+      case IOComponentEnum::SCHAR:
       {
         Self::ReadPointsUsingMeshIO<char>();
         break;
@@ -587,7 +587,7 @@ MeshFileReader<TOutputMesh, ConvertPointPixelTraits, ConvertCellPixelTraits>::Ge
   {
     switch (m_MeshIO->GetCellComponentType())
     {
-      case IOComponentEnum::CHAR:
+      case IOComponentEnum::SCHAR:
       {
         Self::ReadCellsUsingMeshIO<char>();
         break;

--- a/Modules/IO/MeshBase/include/itkMeshIOTestHelper.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOTestHelper.h
@@ -382,7 +382,7 @@ AllocateBuffer(itk::IOComponentEnum componentType, itk::SizeValueType bufferSize
 {
   switch (componentType)
   {
-    case itk::IOComponentEnum::CHAR:
+    case itk::IOComponentEnum::SCHAR:
       return MakeSharedArray<char>(bufferSize);
     case itk::IOComponentEnum::UCHAR:
       return MakeSharedArray<unsigned char>(bufferSize);

--- a/Modules/IO/MeshBase/src/itkMeshIOBase.cxx
+++ b/Modules/IO/MeshBase/src/itkMeshIOBase.cxx
@@ -59,7 +59,7 @@ MeshIOBase::GetComponentSize(IOComponentEnum componentType) const
   {
     case IOComponentEnum::UCHAR:
       return sizeof(unsigned char);
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
       return sizeof(char);
     case IOComponentEnum::USHORT:
       return sizeof(unsigned short);
@@ -130,7 +130,7 @@ MeshIOBase::GetComponentTypeAsString(IOComponentEnum t)
   {
     case IOComponentEnum::UCHAR:
       return { "unsigned_char" };
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
       return { "char" };
     case IOComponentEnum::USHORT:
       return { "unsigned_short" };

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
@@ -245,7 +245,7 @@ FreeSurferAsciiMeshIO::WritePoints(void * buffer)
       WritePoints(static_cast<unsigned char *>(buffer), outputFile);
       break;
     }
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
     {
       WritePoints(static_cast<char *>(buffer), outputFile);
 
@@ -353,7 +353,7 @@ FreeSurferAsciiMeshIO::WriteCells(void * buffer)
       WriteCells(static_cast<unsigned char *>(buffer), outputFile);
       break;
     }
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
     {
       WriteCells(static_cast<unsigned char *>(buffer), outputFile);
       break;

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
@@ -351,7 +351,7 @@ FreeSurferBinaryMeshIO::WritePoints(void * buffer)
       WritePoints(static_cast<unsigned char *>(buffer), outputFile);
       break;
     }
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
     {
       WritePoints(static_cast<char *>(buffer), outputFile);
 
@@ -459,7 +459,7 @@ FreeSurferBinaryMeshIO::WriteCells(void * buffer)
       WriteCells(static_cast<unsigned char *>(buffer), outputFile);
       break;
     }
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
     {
       WriteCells(static_cast<char *>(buffer), outputFile);
       break;
@@ -555,7 +555,7 @@ FreeSurferBinaryMeshIO::WritePointData(void * buffer)
       WritePointData(static_cast<unsigned char *>(buffer), outputFile);
       break;
     }
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
     {
       WritePointData(static_cast<char *>(buffer), outputFile);
 

--- a/Modules/IO/MeshGifti/src/itkGiftiMeshIO.cxx
+++ b/Modules/IO/MeshGifti/src/itkGiftiMeshIO.cxx
@@ -483,7 +483,7 @@ GiftiMeshIO::ReadCells(void * buffer)
     {
       switch (this->m_CellComponentType)
       {
-        case IOComponentEnum::CHAR:
+        case IOComponentEnum::SCHAR:
         {
           this->WriteCellsBuffer(static_cast<char *>(m_GiftiImage->darray[ii]->data),
                                  static_cast<char *>(buffer),
@@ -1072,7 +1072,7 @@ GiftiMeshIO::WritePoints(void * buffer)
                         pointsBufferSize);
           break;
         }
-        case IOComponentEnum::CHAR:
+        case IOComponentEnum::SCHAR:
         {
           ConvertBuffer(
             static_cast<char *>(buffer), static_cast<float *>(m_GiftiImage->darray[ii]->data), pointsBufferSize);
@@ -1174,7 +1174,7 @@ GiftiMeshIO::WriteCells(void * buffer)
                                 static_cast<int32_t *>(m_GiftiImage->darray[ii]->data));
           break;
         }
-        case IOComponentEnum::CHAR:
+        case IOComponentEnum::SCHAR:
         {
           this->ReadCellsBuffer(static_cast<char *>(buffer), static_cast<int32_t *>(m_GiftiImage->darray[ii]->data));
           break;
@@ -1271,7 +1271,7 @@ GiftiMeshIO::WritePointData(void * buffer)
                           pointDataBufferSize);
             break;
           }
-          case IOComponentEnum::CHAR:
+          case IOComponentEnum::SCHAR:
           {
             ConvertBuffer(
               static_cast<char *>(buffer), static_cast<float *>(m_GiftiImage->darray[ii]->data), pointDataBufferSize);
@@ -1372,7 +1372,7 @@ GiftiMeshIO::WritePointData(void * buffer)
                           pointDataBufferSize);
             break;
           }
-          case IOComponentEnum::CHAR:
+          case IOComponentEnum::SCHAR:
           {
             ConvertBuffer(
               static_cast<char *>(buffer), static_cast<int *>(m_GiftiImage->darray[ii]->data), pointDataBufferSize);
@@ -1482,7 +1482,7 @@ GiftiMeshIO::WriteCellData(void * buffer)
                           cellDataBufferSize);
             break;
           }
-          case IOComponentEnum::CHAR:
+          case IOComponentEnum::SCHAR:
           {
             ConvertBuffer(
               static_cast<char *>(buffer), static_cast<float *>(m_GiftiImage->darray[ii]->data), cellDataBufferSize);
@@ -1583,7 +1583,7 @@ GiftiMeshIO::WriteCellData(void * buffer)
                           cellDataBufferSize);
             break;
           }
-          case IOComponentEnum::CHAR:
+          case IOComponentEnum::SCHAR:
           {
             ConvertBuffer(
               static_cast<char *>(buffer), static_cast<int *>(m_GiftiImage->darray[ii]->data), cellDataBufferSize);

--- a/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
+++ b/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
@@ -394,7 +394,7 @@ OBJMeshIO::WritePoints(void * buffer)
       WritePoints(static_cast<unsigned char *>(buffer), outputFile);
       break;
     }
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
     {
       WritePoints(static_cast<char *>(buffer), outputFile);
 
@@ -503,7 +503,7 @@ OBJMeshIO::WriteCells(void * buffer)
       WriteCells(static_cast<unsigned char *>(buffer), outputFile);
       break;
     }
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
     {
       WriteCells(static_cast<unsigned char *>(buffer), outputFile);
       break;
@@ -607,7 +607,7 @@ OBJMeshIO::WritePointData(void * buffer)
       WritePointData(static_cast<unsigned char *>(buffer), outputFile);
       break;
     }
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
     {
       WritePointData(static_cast<char *>(buffer), outputFile);
 

--- a/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
+++ b/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
@@ -419,7 +419,7 @@ OFFMeshIO::WritePoints(void * buffer)
         WriteBufferAsAscii(static_cast<unsigned char *>(buffer), outputFile, m_NumberOfPoints, m_PointDimension);
         break;
       }
-      case IOComponentEnum::CHAR:
+      case IOComponentEnum::SCHAR:
       {
         WriteBufferAsAscii(static_cast<char *>(buffer), outputFile, m_NumberOfPoints, m_PointDimension);
 
@@ -507,7 +507,7 @@ OFFMeshIO::WritePoints(void * buffer)
           static_cast<unsigned char *>(buffer), outputFile, m_NumberOfPoints * m_PointDimension);
         break;
       }
-      case IOComponentEnum::CHAR:
+      case IOComponentEnum::SCHAR:
       {
         WriteBufferAsBinary<float>(static_cast<char *>(buffer), outputFile, m_NumberOfPoints * m_PointDimension);
 
@@ -631,7 +631,7 @@ OFFMeshIO::WriteCells(void * buffer)
 
         break;
       }
-      case IOComponentEnum::CHAR:
+      case IOComponentEnum::SCHAR:
       {
         WriteCellsAsAscii(static_cast<unsigned char *>(buffer), outputFile);
 
@@ -719,7 +719,7 @@ OFFMeshIO::WriteCells(void * buffer)
 
         break;
       }
-      case IOComponentEnum::CHAR:
+      case IOComponentEnum::SCHAR:
       {
         WriteCellsAsBinary<itk::uint32_t>(static_cast<char *>(buffer), outputFile);
 

--- a/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
+++ b/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
@@ -826,7 +826,7 @@ VTKPolyDataMeshIO::ReadMeshInformation()
     function(param, static_cast<unsigned char *>(buffer));      \
     break;                                                      \
   }                                                             \
-  case IOComponentEnum::CHAR:                                   \
+  case IOComponentEnum::SCHAR:                                  \
   {                                                             \
     function(param, static_cast<char *>(buffer));               \
     break;                                                      \
@@ -1694,7 +1694,7 @@ VTKPolyDataMeshIO::WriteMeshInformation()
     function(outputFile, static_cast<unsigned char *>(buffer), " unsigned_char");      \
     break;                                                                             \
   }                                                                                    \
-  case IOComponentEnum::CHAR:                                                          \
+  case IOComponentEnum::SCHAR:                                                         \
   {                                                                                    \
     function(outputFile, static_cast<char *>(buffer), " char");                        \
     break;                                                                             \
@@ -1817,7 +1817,7 @@ VTKPolyDataMeshIO::WritePoints(void * buffer)
     function(outputFile, static_cast<unsigned char *>(buffer));       \
     break;                                                            \
   }                                                                   \
-  case IOComponentEnum::CHAR:                                         \
+  case IOComponentEnum::SCHAR:                                        \
   {                                                                   \
     UpdateCellInformation(static_cast<char *>(buffer));               \
     function(outputFile, static_cast<char *>(buffer));                \

--- a/Modules/IO/Meta/src/itkMetaImageIO.cxx
+++ b/Modules/IO/Meta/src/itkMetaImageIO.cxx
@@ -563,7 +563,7 @@ MetaImageIO::Write(const void * buffer)
     case IOComponentEnum::UNKNOWNCOMPONENTTYPE:
       eType = MET_OTHER;
       break;
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
       eType = MET_CHAR;
       break;
     case IOComponentEnum::UCHAR:

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -637,7 +637,7 @@ NiftiImageIO::Read(void * buffer)
     auto * _data = static_cast<float *>(malloc(numElts * sizeof(float)));
     switch (this->m_OnDiskComponentType)
     {
-      case IOComponentEnum::CHAR:
+      case IOComponentEnum::SCHAR:
         CastCopy<char>(_data, data, numElts);
         break;
       case IOComponentEnum::UCHAR:
@@ -768,7 +768,7 @@ NiftiImageIO::Read(void * buffer)
   {
     switch (this->m_ComponentType)
     {
-      case IOComponentEnum::CHAR:
+      case IOComponentEnum::SCHAR:
         RescaleFunction(static_cast<char *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts);
         break;
       case IOComponentEnum::UCHAR:
@@ -1650,7 +1650,7 @@ NiftiImageIO::WriteImageInformation()
       m_Holder->ptr->datatype = NIFTI_TYPE_UINT8;
       m_Holder->ptr->nbyper = 1;
       break;
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
       m_Holder->ptr->datatype = NIFTI_TYPE_INT8;
       m_Holder->ptr->nbyper = 1;
       break;

--- a/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
+++ b/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
@@ -155,7 +155,7 @@ NrrdImageIO::ITKToNrrdComponentType(const IOComponentEnum itkComponentType) cons
     case IOComponentEnum::UNKNOWNCOMPONENTTYPE:
       return nrrdTypeUnknown;
 
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
       return nrrdTypeChar;
 
     case IOComponentEnum::UCHAR:

--- a/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
@@ -298,7 +298,7 @@ PhilipsRECImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPix
   {
     switch (this->m_ComponentType)
     {
-      case IOComponentEnum::CHAR:
+      case IOComponentEnum::SCHAR:
       case IOComponentEnum::UCHAR:
         // For CHAR and UCHAR, it is not necessary to swap bytes.
         break;
@@ -335,7 +335,7 @@ PhilipsRECImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPix
   {
     switch (this->m_ComponentType)
     {
-      case IOComponentEnum::CHAR:
+      case IOComponentEnum::SCHAR:
       case IOComponentEnum::UCHAR:
         // For CHAR and UCHAR, it is not necessary to swap bytes.
         break;

--- a/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
+++ b/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
@@ -154,7 +154,7 @@ StimulateImageIO::Read(void * buffer)
   // byte swapping depending on pixel type:
   switch (this->GetComponentType())
   {
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
       // For CHAR, it is not necessary to swap bytes. (It would not have any effect anyway.)
       break;
     case IOComponentEnum::SHORT:
@@ -533,7 +533,7 @@ StimulateImageIO::Write(const void * buffer)
     memcpy(tempmemory.get(), buffer, numberOfBytes);
     switch (this->GetComponentType())
     {
-      case IOComponentEnum::CHAR:
+      case IOComponentEnum::SCHAR:
         file << "BYTE";
         // For CHAR, it is not necessary to swap bytes. (It would not have any effect anyway.)
         break;

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -596,7 +596,7 @@ TIFFImageIO::InternalWrite(const void * buffer)
     case IOComponentEnum::UCHAR:
       bps = 8;
       break;
-    case IOComponentEnum::CHAR:
+    case IOComponentEnum::SCHAR:
       bps = 8;
       break;
     case IOComponentEnum::USHORT:
@@ -813,7 +813,7 @@ TIFFImageIO::InternalWrite(const void * buffer)
       case IOComponentEnum::USHORT:
         rowLength = sizeof(unsigned short);
         break;
-      case IOComponentEnum::CHAR:
+      case IOComponentEnum::SCHAR:
         rowLength = sizeof(char);
         break;
       case IOComponentEnum::SHORT:

--- a/Modules/IO/TIFF/test/itkTIFFImageIOCompressionTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOCompressionTest.cxx
@@ -198,7 +198,7 @@ itkTIFFImageIOCompressionTest(int argc, char * argv[])
           using PixelType = unsigned char;
           return itkTIFFImageIOCompressionTestHelper<itk::Image<PixelType, 2>>(argc, argv, JPEGQuality);
         }
-        case itk::IOComponentEnum::CHAR:
+        case itk::IOComponentEnum::SCHAR:
         {
           using PixelType = signed char;
           return itkTIFFImageIOCompressionTestHelper<itk::Image<PixelType, 2>>(argc, argv, JPEGQuality);
@@ -232,7 +232,7 @@ itkTIFFImageIOCompressionTest(int argc, char * argv[])
           using PixelType = itk::RGBPixel<unsigned char>;
           return itkTIFFImageIOCompressionTestHelper<itk::Image<PixelType, 2>>(argc, argv, JPEGQuality);
         }
-        case itk::IOComponentEnum::CHAR:
+        case itk::IOComponentEnum::SCHAR:
         {
           using PixelType = itk::RGBPixel<char>;
           return itkTIFFImageIOCompressionTestHelper<itk::Image<PixelType, 2>>(argc, argv, JPEGQuality);
@@ -266,7 +266,7 @@ itkTIFFImageIOCompressionTest(int argc, char * argv[])
           using PixelType = itk::RGBAPixel<unsigned char>;
           return itkTIFFImageIOCompressionTestHelper<itk::Image<PixelType, 2>>(argc, argv, JPEGQuality);
         }
-        case itk::IOComponentEnum::CHAR:
+        case itk::IOComponentEnum::SCHAR:
         {
           using PixelType = itk::RGBAPixel<char>;
           return itkTIFFImageIOCompressionTestHelper<itk::Image<PixelType, 2>>(argc, argv, JPEGQuality);

--- a/Modules/Segmentation/LabelVoting/test/itkVotingBinaryImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkVotingBinaryImageFilterTest.cxx
@@ -120,7 +120,7 @@ itkVotingBinaryImageFilterTest(int argc, char * argv[])
 
   switch (componentType)
   {
-    case itk::IOComponentEnum::CHAR:
+    case itk::IOComponentEnum::SCHAR:
     case itk::IOComponentEnum::UCHAR:
     case itk::IOComponentEnum::SHORT:
       if (dimension == 2)


### PR DESCRIPTION
Replaced `CHAR` with `SCHAR` in `IOComponentEnum::CHAR` cases of `switch` statements.

The name `SCHAR` appears clearer than `CHAR`, because it is intended to specify a _signed_ char type. The abbreviation `SCHAR` is already used to denote `signed char` in C and C++ (`SCHAR_MAX`) as well as in HDF5 (`H5T_NATIVE_SCHAR`).