### PR TITLE
PERF: Replace itkExceptionMacro("...") w/ itkExceptionStringMacro("...")

### DIFF
--- a/Modules/Core/Common/include/itkDomainThreader.hxx
+++ b/Modules/Core/Common/include/itkDomainThreader.hxx
@@ -82,7 +82,7 @@ DomainThreader<TDomainPartitioner, TAssociate>::DetermineNumberOfWorkUnitsUsed()
 
   if (this->m_NumberOfWorkUnitsUsed > numberOfWorkUnits)
   {
-    itkExceptionMacro(
+    itkExceptionStringMacro(
       "A subclass of ThreadedDomainPartitioner::PartitionDomain returned more subdomains than were requested");
   }
 }

--- a/Modules/Core/Common/include/itkImageSource.hxx
+++ b/Modules/Core/Common/include/itkImageSource.hxx
@@ -247,8 +247,8 @@ ImageSource<TOutputImage>::ThreadedGenerateData(const OutputImageRegionType &
 #if !defined(ITK_LEGACY_REMOVE)
   this->DynamicThreadedGenerateData(region);
 #else
-  itkExceptionMacro("With DynamicMultiThreadingOff subclass should override this method. The signature of "
-                    "ThreadedGenerateData() has been changed in ITK v4 to use the new ThreadIdType.");
+  itkExceptionStringMacro("With DynamicMultiThreadingOff subclass should override this method. The signature of "
+                          "ThreadedGenerateData() has been changed in ITK v4 to use the new ThreadIdType.");
 #endif
 }
 

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -976,7 +976,7 @@ compilers.
       itkDynamicCastInDebugMode<const DecoratorType *>(this->ProcessObject::GetInput(#name));                        \
     if (input == nullptr)                                                                                            \
     {                                                                                                                \
-      itkExceptionMacro("input" #name " is not set");                                                                \
+      itkExceptionStringMacro("input" #name " is not set");                                                          \
     }                                                                                                                \
     return input->Get();                                                                                             \
   }                                                                                                                  \
@@ -1462,7 +1462,7 @@ ContainerCopyWithCheck(MemberContainerType & m, const CopyFromContainerType & c,
       itkDynamicCastInDebugMode<const DecoratorType *>(this->ProcessObject::GetOutput(#name));                        \
     if (output == nullptr)                                                                                            \
     {                                                                                                                 \
-      itkExceptionMacro("output" #name " is not set");                                                                \
+      itkExceptionStringMacro("output" #name " is not set");                                                          \
     }                                                                                                                 \
     return output->Get();                                                                                             \
   }                                                                                                                   \

--- a/Modules/Core/Common/include/itkSobelOperator.hxx
+++ b/Modules/Core/Common/include/itkSobelOperator.hxx
@@ -73,8 +73,9 @@ SobelOperator<TPixel, VDimension, TAllocator>::Fill(const CoefficientVector & co
   }
   else
   {
-    itkExceptionMacro("The ND version of the Sobel operator is not yet implemented.  Currently only the 2D and 3D "
-                      "versions are available.");
+    itkExceptionStringMacro(
+      "The ND version of the Sobel operator is not yet implemented.  Currently only the 2D and 3D "
+      "versions are available.");
   }
 }
 
@@ -207,8 +208,8 @@ SobelOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> Coeffic
   }
   else
   {
-    itkExceptionMacro("The ND version of the Sobel operator has not been implemented.  Currently only 2D and 3D "
-                      "versions are available.");
+    itkExceptionStringMacro("The ND version of the Sobel operator has not been implemented.  Currently only 2D and 3D "
+                            "versions are available.");
   }
 
   return coeff;

--- a/Modules/Core/Transform/include/itkRigid3DPerspectiveTransform.h
+++ b/Modules/Core/Transform/include/itkRigid3DPerspectiveTransform.h
@@ -207,8 +207,8 @@ public:
   OutputCovariantVectorType
   TransformCovariantVector(const InputCovariantVectorType &) const override
   {
-    itkExceptionMacro("TransformCovariantVector(const InputCovariantVectorType &) is not implemented for "
-                      "Rigid3DPerspectiveTransform");
+    itkExceptionStringMacro("TransformCovariantVector(const InputCovariantVectorType &) is not implemented for "
+                            "Rigid3DPerspectiveTransform");
   }
 
   /** Return the rotation matrix */

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.h
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.h
@@ -222,7 +222,7 @@ public:
     if (m_GradientImageTypeEnumeration ==
         DiffusionTensor3DReconstructionImageFilterEnums::GradientImageFormat::GradientIsInASingleImage)
     {
-      itkExceptionMacro(
+      itkExceptionStringMacro(
         "Cannot call both methods:AddGradientImage and SetGradientImage. Please call only one of them.");
     }
 

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.h
@@ -229,22 +229,22 @@ public:
   OutputVectorType
   TransformVector(const InputVectorType &) const override
   {
-    itkExceptionMacro("TransformVector(Vector) unimplemented, use "
-                      "TransformVector(Vector,Point)");
+    itkExceptionStringMacro("TransformVector(Vector) unimplemented, use "
+                            "TransformVector(Vector,Point)");
   }
 
   OutputVectorPixelType
   TransformVector(const InputVectorPixelType &) const override
   {
-    itkExceptionMacro("TransformVector(Vector) unimplemented, use "
-                      "TransformVector(Vector,Point)");
+    itkExceptionStringMacro("TransformVector(Vector) unimplemented, use "
+                            "TransformVector(Vector,Point)");
   }
 
   OutputVnlVectorType
   TransformVector(const InputVnlVectorType &) const override
   {
-    itkExceptionMacro("TransformVector(Vector) unimplemented, use "
-                      "TransformVector(Vector,Point)");
+    itkExceptionStringMacro("TransformVector(Vector) unimplemented, use "
+                            "TransformVector(Vector,Point)");
   }
   /** @ITKEndGrouping */
 
@@ -254,15 +254,15 @@ public:
   OutputDiffusionTensor3DType
   TransformDiffusionTensor(const InputDiffusionTensor3DType &) const
   {
-    itkExceptionMacro("TransformDiffusionTensor(Tensor) unimplemented, use "
-                      "TransformDiffusionTensor(Tensor,Point)");
+    itkExceptionStringMacro("TransformDiffusionTensor(Tensor) unimplemented, use "
+                            "TransformDiffusionTensor(Tensor,Point)");
   }
 
   OutputVectorPixelType
   TransformDiffusionTensor(const InputVectorPixelType &) const
   {
-    itkExceptionMacro("TransformDiffusionTensor(Tensor) unimplemented, use "
-                      "TransformDiffusionTensor(Tensor,Point)");
+    itkExceptionStringMacro("TransformDiffusionTensor(Tensor) unimplemented, use "
+                            "TransformDiffusionTensor(Tensor,Point)");
   }
   /** @ITKEndGrouping */
 
@@ -272,15 +272,15 @@ public:
   OutputCovariantVectorType
   TransformCovariantVector(const InputCovariantVectorType &) const override
   {
-    itkExceptionMacro("TransformCovariantVector(CovariantVector) "
-                      "unimplemented, use TransformCovariantVector(CovariantVector,Point)");
+    itkExceptionStringMacro("TransformCovariantVector(CovariantVector) "
+                            "unimplemented, use TransformCovariantVector(CovariantVector,Point)");
   }
 
   OutputVectorPixelType
   TransformCovariantVector(const InputVectorPixelType &) const override
   {
-    itkExceptionMacro("TransformCovariantVector(CovariantVector) "
-                      "unimplemented, use TransformCovariantVector(CovariantVector,Point)");
+    itkExceptionStringMacro("TransformCovariantVector(CovariantVector) "
+                            "unimplemented, use TransformCovariantVector(CovariantVector,Point)");
   }
   /** @ITKEndGrouping */
 

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -104,8 +104,8 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
   const ReferenceImageBaseType * const referenceImage = this->GetReferenceImage();
   if (this->m_Size[0] == 0 && referenceImage && !m_UseReferenceImage)
   {
-    itkExceptionMacro("Output image size is zero in all dimensions.  Consider using UseReferenceImageOn()."
-                      "or SetUseReferenceImage(true) to define the resample output from the ReferenceImage.");
+    itkExceptionStringMacro("Output image size is zero in all dimensions.  Consider using UseReferenceImageOn()."
+                            "or SetUseReferenceImage(true) to define the resample output from the ReferenceImage.");
   }
 }
 

--- a/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.hxx
@@ -140,8 +140,9 @@ SliceBySliceImageFilter<TInputImage,
   if (outputFilter == nullptr && filter != nullptr)
   {
     // TODO: can it be replaced by a concept check ?
-    itkExceptionMacro("Wrong output filter type. Use SetOutputFilter() and SetInputFilter() instead of SetFilter() "
-                      "when input and output filter types are different.");
+    itkExceptionStringMacro(
+      "Wrong output filter type. Use SetOutputFilter() and SetInputFilter() instead of SetFilter() "
+      "when input and output filter types are different.");
   }
   this->SetInputFilter(filter);
   this->SetOutputFilter(outputFilter);

--- a/Modules/Filtering/LabelMap/include/itkObjectByObjectLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkObjectByObjectLabelMapFilter.hxx
@@ -103,8 +103,9 @@ ObjectByObjectLabelMapFilter<TInputImage,
   if (outputFilter == nullptr && filter != nullptr)
   {
     // TODO: can it be replaced by a concept check ?
-    itkExceptionMacro("Wrong output filter type. Use SetOutputFilter() and SetInputFilter() instead of SetFilter() "
-                      "when input and output filter types are different.");
+    itkExceptionStringMacro(
+      "Wrong output filter type. Use SetOutputFilter() and SetInputFilter() instead of SetFilter() "
+      "when input and output filter types are different.");
   }
   this->SetInputFilter(filter);
   this->SetOutputFilter(outputFilter);

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -1224,8 +1224,8 @@ GDCMImageIO::Write(const void * buffer)
     }
     else
     {
-      itkExceptionMacro("A Floating point buffer was passed but the stored pixel type was not specified."
-                        "This is currently not supported");
+      itkExceptionStringMacro("A Floating point buffer was passed but the stored pixel type was not specified."
+                              "This is currently not supported");
     }
   }
   else if (this->GetInternalComponentType() != IOComponentEnum::UNKNOWNCOMPONENTTYPE)

--- a/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
+++ b/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
@@ -107,7 +107,7 @@ OFFMeshIO::ReadMeshInformation()
   std::getline(m_InputFile, line, '\n'); // delimiter is '\n'
   if (line.find("OFF") == std::string::npos)
   {
-    itkExceptionMacro("Error, the file doesn't begin with keyword \"OFF\" ");
+    itkExceptionStringMacro("Error, the file doesn't begin with keyword \"OFF\" ");
   }
 
   // If the file is binary file, it contains "BINARY"

--- a/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
+++ b/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
@@ -421,8 +421,8 @@ NrrdImageIO::ReadImageInformation()
 
     if (nrrdTypeBlock == nrrd->type)
     {
-      itkExceptionMacro("ReadImageInformation: Cannot currently "
-                        "handle nrrdTypeBlock");
+      itkExceptionStringMacro("ReadImageInformation: Cannot currently "
+                              "handle nrrdTypeBlock");
     }
     if (nio->endian == airEndianLittle)
     {
@@ -624,14 +624,14 @@ NrrdImageIO::ReadImageInformation()
           break;
         default:
         case nrrdSpacingStatusUnknown:
-          itkExceptionMacro("ReadImageInformation: Error interpreting "
-                            "nrrd spacing (nrrdSpacingStatusUnknown)");
+          itkExceptionStringMacro("ReadImageInformation: Error interpreting "
+                                  "nrrd spacing (nrrdSpacingStatusUnknown)");
         case nrrdSpacingStatusScalarWithSpace:
           // Both "spacings" and "space origin" fields are specified. This is an unusual combination, no need to support
           // it. Either use space fields ("space directions" and "space origin") or use older convention of just
           // "spacings".
-          itkExceptionMacro("ReadImageInformation: Error interpreting "
-                            "nrrd spacing (nrrdSpacingStatusScalarWithSpace)");
+          itkExceptionStringMacro("ReadImageInformation: Error interpreting "
+                                  "nrrd spacing (nrrdSpacingStatusScalarWithSpace)");
       }
     }
 
@@ -701,7 +701,7 @@ NrrdImageIO::ReadImageInformation()
       {
         // this should never happen, as numberOfDomainAxes is obtained by calling a same method earlier
         // but it is safer to check than just assume they match
-        itkExceptionMacro("ReadImageInformation: internal error, mismatch in number of domain axes.");
+        itkExceptionStringMacro("ReadImageInformation: internal error, mismatch in number of domain axes.");
       }
 
       int originStatus =
@@ -721,8 +721,8 @@ NrrdImageIO::ReadImageInformation()
           default:
           case nrrdOriginStatusUnknown:
           case nrrdOriginStatusDirection:
-            itkExceptionMacro("ReadImageInformation: Error interpreting "
-                              "nrrd origin status");
+            itkExceptionStringMacro("ReadImageInformation: Error interpreting "
+                                    "nrrd origin status");
         }
       }
     }

--- a/Modules/IO/TransformBase/src/itkTransformFileWriterSpecializations.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformFileWriterSpecializations.cxx
@@ -103,8 +103,8 @@ TransformFileWriterTemplate<TParametersValueType>::AddTransform(const Object * t
   {
     if (!this->m_TransformList.empty())
     {
-      itkExceptionMacro("Can only write a transform of type CompositeTransform "
-                        "as the first transform in the file.");
+      itkExceptionStringMacro("Can only write a transform of type CompositeTransform "
+                              "as the first transform in the file.");
     }
   }
 

--- a/Modules/IO/TransformInsightLegacy/src/itkTxtTransformIO.cxx
+++ b/Modules/IO/TransformInsightLegacy/src/itkTxtTransformIO.cxx
@@ -211,8 +211,8 @@ TxtTransformIOTemplate<TParametersValueType>::Read()
         itkDebugMacro("Setting Fixed Parameters: " << TmpFixedParameterArray);
         if (!transform)
         {
-          itkExceptionMacro("Please set the transform before parameters"
-                            "or fixed parameters");
+          itkExceptionStringMacro("Please set the transform before parameters"
+                                  "or fixed parameters");
         }
         if (haveParameters)
         {

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
@@ -1046,8 +1046,8 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
     // Throw an exception if we don't have enough layers.
     if (sparsePtr->m_Layers.size() < 3)
     {
-      itkExceptionMacro("Not enough layers have been allocated for the"
-                        "sparse field.  Requires at least one layer.");
+      itkExceptionStringMacro("Not enough layers have been allocated for the"
+                              "sparse field.  Requires at least one layer.");
     }
   }
 

--- a/Modules/Numerics/Optimizers/src/itkLBFGSBOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLBFGSBOptimizer.cxx
@@ -317,8 +317,8 @@ LBFGSBOptimizer::StartOptimization()
   }
   if (this->m_CostFunctionConvergenceFactor == 0.0 && this->m_ProjectedGradientTolerance == 0.0)
   {
-    itkExceptionMacro("LBFGSB Optimizer cannot function if both CostFunctionConvergenceFactor"
-                      " and ProjectedGradienctTolerance are zero.");
+    itkExceptionStringMacro("LBFGSB Optimizer cannot function if both CostFunctionConvergenceFactor"
+                            " and ProjectedGradienctTolerance are zero.");
   }
   this->SetCurrentPosition(this->GetInitialPosition());
 

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
@@ -129,9 +129,9 @@ GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::StartOpti
   if (this->m_ScalesEstimator.IsNotNull() && this->m_DoEstimateLearningRateOnce &&
       this->m_DoEstimateLearningRateAtEachIteration)
   {
-    itkExceptionMacro("Both m_DoEstimateLearningRateOnce and "
-                      "m_DoEstimateLearningRateAtEachIteration "
-                      "are enabled. Not allowed. ");
+    itkExceptionStringMacro("Both m_DoEstimateLearningRateOnce and "
+                            "m_DoEstimateLearningRateAtEachIteration "
+                            "are enabled. Not allowed. ");
   }
 
   // Estimate the parameter scales if requested.

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
@@ -458,8 +458,8 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
   const MovingDisplacementFieldTransformType * displacementTransform = this->GetMovingDisplacementFieldTransform();
   if (displacementTransform == nullptr)
   {
-    itkExceptionMacro("Expected the moving transform to be of type DisplacementFieldTransform or derived, "
-                      "or a CompositeTransform with DisplacementFieldTransform as the last to have been added.");
+    itkExceptionStringMacro("Expected the moving transform to be of type DisplacementFieldTransform or derived, "
+                            "or a CompositeTransform with DisplacementFieldTransform as the last to have been added.");
   }
   using FieldType = typename MovingDisplacementFieldTransformType::DisplacementFieldType;
   const typename FieldType::ConstPointer field = displacementTransform->GetDisplacementField();

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
@@ -306,8 +306,8 @@ RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomain()
 
   if (!this->m_Metric->SupportsArbitraryVirtualDomainSamples() && !this->m_VirtualDomainPointSet)
   {
-    itkExceptionMacro(" The assigned metric does not support arbitrary virtual domain sampling, "
-                      " yet this->m_VirtualDomainPointSet has not been assigned. ");
+    itkExceptionStringMacro(" The assigned metric does not support arbitrary virtual domain sampling, "
+                            " yet this->m_VirtualDomainPointSet has not been assigned. ");
   }
 
   if (m_SamplingStrategy == SamplingStrategyEnum::VirtualDomainPointSetSampling)

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.hxx
@@ -164,7 +164,7 @@ RegistrationParameterScalesFromShiftBase<TMetric>::EstimateLocalStepScales(const
 {
   if (!this->TransformHasLocalSupportForScalesEstimation())
   {
-    itkExceptionMacro(
+    itkExceptionStringMacro(
       "EstimateLocalStepScales: the transform doesn't have local support (displacement field or b-spline).");
   }
 

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSBOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSBOptimizerv4.cxx
@@ -212,8 +212,8 @@ LBFGSBOptimizerv4::StartOptimization(bool /*doOnlyInitialization*/)
 
   if (this->m_CostFunctionConvergenceFactor == 0.0 && this->m_GradientConvergenceTolerance == 0.0)
   {
-    itkExceptionMacro("LBFGSB Optimizer cannot function if both CostFunctionConvergenceFactor"
-                      " and ProjectedGradienctTolerance are zero.");
+    itkExceptionStringMacro("LBFGSB Optimizer cannot function if both CostFunctionConvergenceFactor"
+                            " and ProjectedGradienctTolerance are zero.");
   }
 
   ParametersType parameters(this->GetInitialPosition());

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4Base.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4Base.cxx
@@ -135,8 +135,9 @@ LBFGSOptimizerBasev4<TInternalVnlOptimizerType>::StartOptimization(bool /* doOnl
   // These aren't currently supported, see main class documentation.
   if (this->GetMetric()->HasLocalSupport())
   {
-    itkExceptionMacro("The assigned transform has local-support. This is not supported for this optimizer. See the "
-                      "optimizer documentation.");
+    itkExceptionStringMacro(
+      "The assigned transform has local-support. This is not supported for this optimizer. See the "
+      "optimizer documentation.");
   }
 
   // Perform some verification, check scales,

--- a/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4.hxx
@@ -55,9 +55,9 @@ DemonsImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage, TInternalCo
   // gradients
   if (this->GetGradientSource() == ObjectToObjectMetricBaseTemplateEnums::GradientSource::GRADIENT_SOURCE_BOTH)
   {
-    itkExceptionMacro("GradientSource has been set to GRADIENT_SOURCE_BOTH. "
-                      "You must choose either GRADIENT_SOURCE_MOVING or "
-                      "GRADIENT_SOURCE_FIXED.");
+    itkExceptionStringMacro("GradientSource has been set to GRADIENT_SOURCE_BOTH. "
+                            "You must choose either GRADIENT_SOURCE_MOVING or "
+                            "GRADIENT_SOURCE_FIXED.");
   }
 
   // Verify that the transform has local support, and its number of local

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.hxx
@@ -386,7 +386,7 @@ ImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage, TInternalComputat
   {
     if (!this->GetGradientSourceIncludesFixed())
     {
-      itkExceptionMacro(
+      itkExceptionStringMacro(
         "Attempted to retrieve fixed image gradient from gradient image filter, "
         "but GradientSource does not include 'fixed', and thus the gradient image has not been calculated.");
     }
@@ -412,7 +412,7 @@ ImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage, TInternalComputat
   {
     if (!this->GetGradientSourceIncludesMoving())
     {
-      itkExceptionMacro(
+      itkExceptionStringMacro(
         "Attempted to retrieve moving image gradient from gradient image filter, "
         "but GradientSource does not include 'moving', and thus the gradient image has not been calculated.");
     }
@@ -583,8 +583,8 @@ ImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage, TInternalComputat
     this->m_FixedTransform->GetInverseTransform();
   if (inverseTransform.IsNull())
   {
-    itkExceptionMacro("Unable to get inverse transform for mapping sampled "
-                      " point set.");
+    itkExceptionStringMacro("Unable to get inverse transform for mapping sampled "
+                            " point set.");
   }
 
   this->m_NumberOfSkippedFixedSampledPoints = 0;
@@ -608,9 +608,9 @@ ImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage, TInternalComputat
   }
   if (this->m_VirtualSampledPointSet->GetNumberOfPoints() == 0)
   {
-    itkExceptionMacro("The virtual sampled point set has zero points because "
-                      "no fixed sampled points were within the virtual "
-                      "domain after mapping. There are no points to evaluate.");
+    itkExceptionStringMacro("The virtual sampled point set has zero points because "
+                            "no fixed sampled points were within the virtual "
+                            "domain after mapping. There are no points to evaluate.");
   }
 }
 

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
@@ -115,7 +115,7 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
 
         if (this->m_FixedTransform.IsNull())
         {
-          itkExceptionMacro(
+          itkExceptionStringMacro(
             "Unable to get transform for mapping sampled point set from virtual space to fixed image space.");
         }
 

--- a/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.hxx
@@ -194,10 +194,10 @@ ObjectToObjectMultiMetricv4<TFixedDimension, TMovingDimension, TVirtualImage, TI
     {
       if (transform != firstTransform)
       {
-        itkExceptionMacro("One or more component metrics have different active transforms. "
-                          "Each metric must be using the same transform object. For CompositeTransform, "
-                          "there must be only one transform set to optimize, and it must be the same "
-                          "as other metric transforms.");
+        itkExceptionStringMacro("One or more component metrics have different active transforms. "
+                                "Each metric must be using the same transform object. For CompositeTransform, "
+                                "there must be only one transform set to optimize, and it must be the same "
+                                "as other metric transforms.");
       }
     }
   }

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
@@ -81,8 +81,9 @@ PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointSet, TInternalCo
         this->GetMovingDisplacementFieldTransform();
       if (displacementTransform.IsNull())
       {
-        itkExceptionMacro("Expected the moving transform to be of type DisplacementFieldTransform or derived, "
-                          "or a CompositeTransform with DisplacementFieldTransform as the last to have been added.");
+        itkExceptionStringMacro(
+          "Expected the moving transform to be of type DisplacementFieldTransform or derived, "
+          "or a CompositeTransform with DisplacementFieldTransform as the last to have been added.");
       }
       using DisplacementFieldType = typename DisplacementFieldTransformType::DisplacementFieldType;
       const typename DisplacementFieldType::ConstPointer field = displacementTransform->GetDisplacementField();

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoCapture.h
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoCapture.h
@@ -75,17 +75,17 @@ public:
   virtual bool
   open(const std::string &)
   {
-    itkExceptionMacro("itk::OpenCVVideoCapture::open(filename) -> If you just want "
-                      "to read from a file, use cv::VideoCapture since there is nothing to be "
-                      "gained using itk's version.");
+    itkExceptionStringMacro("itk::OpenCVVideoCapture::open(filename) -> If you just want "
+                            "to read from a file, use cv::VideoCapture since there is nothing to be "
+                            "gained using itk's version.");
   }
 
   virtual bool
   open(int)
   {
-    itkExceptionMacro("itk::OpenCVVideoCapture::open(device) -> If you just want "
-                      "to read from a device, use cv::VideoCapture since there is nothing to be "
-                      "gained using itk's version.");
+    itkExceptionStringMacro("itk::OpenCVVideoCapture::open(device) -> If you just want "
+                            "to read from a device, use cv::VideoCapture since there is nothing to be "
+                            "gained using itk's version.");
   }
 
   /** Add an open method that takes a TemporalDataObject. This checks to make

--- a/Modules/Video/Core/include/itkVideoStream.hxx
+++ b/Modules/Video/Core/include/itkVideoStream.hxx
@@ -598,9 +598,9 @@ VideoStream<TFrameType>::Allocate()
   const SizeValueType numFrames = m_BufferedTemporalRegion.GetFrameDuration();
   if (m_DataObjectBuffer->GetNumberOfBuffers() < numFrames)
   {
-    itkExceptionMacro("itk::VideoStream::SetAllLargestPossibleSpatialRegions "
-                      "not enough frame buffers available. Call InitializeEmptyFrames "
-                      "to prepare the frame buffer correctly.");
+    itkExceptionStringMacro("itk::VideoStream::SetAllLargestPossibleSpatialRegions "
+                            "not enough frame buffers available. Call InitializeEmptyFrames "
+                            "to prepare the frame buffer correctly.");
   }
 
   // Go through the number of required frames, making sure none are empty and

--- a/Modules/Video/IO/src/itkFileListVideoIO.cxx
+++ b/Modules/Video/IO/src/itkFileListVideoIO.cxx
@@ -394,8 +394,8 @@ FileListVideoIO::OpenReader()
   }
   else
   {
-    itkExceptionMacro("FileListVideoIO doesn't support reading from unknown "
-                      "ReadType");
+    itkExceptionStringMacro("FileListVideoIO doesn't support reading from unknown "
+                            "ReadType");
   }
 }
 


### PR DESCRIPTION
Replaced any `itkExceptionMacro` call with `itkExceptionStringMacro`, whenever its argument is just a literal string (possibly taking multiple lines of code).

Using Notepad++, Replace in Files:

    Find what: itkExceptionMacro(\([ \r\n]*"[^<;]*"\);)
    Replace with: itkExceptionStringMacro$1
    Directory: D:\ITK\Modules
    [v] Match case
    (*) Regular expression [v] . matches newline

- Follow-up to pull request #5477 commit 0907661ad4e70a52f9d4a019f5f858d3e485a92e "PERF: Use string macro for exceptions", Bradley Lowekamp (@blowekamp), Aug 11 2025.