### PR TITLE
COMP: Replace deprecated itkTypeMacro in ExceptionObjectGTest

### DIFF
--- a/Modules/Core/Common/test/itkExceptionObjectGTest.cxx
+++ b/Modules/Core/Common/test/itkExceptionObjectGTest.cxx
@@ -35,7 +35,7 @@ public:
   using Self = TestLightObject;
   using Superclass = itk::LightObject;
   itkNewMacro(Self);
-  itkTypeMacro(TestLightObject, LightObject);
+  itkOverrideGetNameOfClassMacro(TestLightObject);
 };
 } // end anonymous namespace
 


### PR DESCRIPTION
## Summary
Fix compilation error in `itkExceptionObjectGTest.cxx` when `ITK_FUTURE_LEGACY_REMOVE` is enabled.

## Description
The `itkTypeMacro(TestLightObject, LightObject)` macro is deprecated and triggers a static_assert failure when `ITK_FUTURE_LEGACY_REMOVE` is defined. This was causing the following build error in nightly builds:

```
/Users/builder/externalModules/Core/Common/test/itkExceptionObjectGTest.cxx:38:3: error: static_assert failed "In a future revision of ITK, the macro `itkTypeMacro(thisClass, superclass)` will be removed. Please call `itkOverrideGetNameOfClassMacro(thisClass)` instead!"
```

## Changes
- Replaced `itkTypeMacro(TestLightObject, LightObject)` with `itkOverrideGetNameOfClassMacro(TestLightObject)` in the test class
- This follows the current ITK recommendations for class type identification

## Testing
- All ExceptionObject.* tests pass (10/10)
- Build completes successfully with this change
- No functional changes to the test behavior