### PR TITLE
COMP: Suppress Eigen3 shadow warnings in CDash reports

### DIFF
--- a/CMake/CTestCustom.cmake.in
+++ b/CMake/CTestCustom.cmake.in
@@ -78,6 +78,7 @@ set(CTEST_CUSTOM_WARNING_EXCEPTION
   "attempted multiple inclusion of file"
   "warning LNK4221: This object file does not define any previously undefined public symbols"
   ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Dd][Ii][Cc][Oo][Mm][Pp]arser[/\\\\].*[Ww]arning.*"
+  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Ee]igen3[/\\\\].*[Ww]arning.*"
   ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Ee]xpat[/\\\\].*[Ww]arning.*"
   ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Jj][Pp][Ee][Gg][/\\\\].*[Ww]arning.*"
   ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Kk][Ww][Ss]ys[/\\\\].*[Ww]arning.*"


### PR DESCRIPTION
## Description
This PR addresses shadow warnings from the third-party Eigen3 library that appear in CDash build reports.

## Changes
- Added CTest warning suppression for `Modules/ThirdParty/Eigen3` warnings
- Specifically targets shadow warnings like `[-Wshadow-uncaptured-local]` from Eigen's `GenericPacketMath.h`

## Background
The warnings originate from Eigen 3.4.90 in lines like:
```cpp
// GenericPacketMath.h:655 - lambda parameter 'a' shadows function parameter 'a'
return pminmax_impl<NaNPropagation, IsInteger>::run(a, b, 
  EIGEN_BINARY_OP_NAN_PROPAGATION(Packet, (pmin<Packet>)));
```

These are third-party library warnings outside ITK's control and should be suppressed to reduce noise in build reports while maintaining strict warning standards for ITK's own code.

## Testing
- Follows existing pattern of suppressing third-party warnings in `CTestCustom.cmake.in`
- No functional changes to ITK code