### PR TITLE
DOC: Add documentation for InvertDisplacementFieldImageFilter

### DIFF
--- a/Documentation/Doxygen/doxygen.bib
+++ b/Documentation/Doxygen/doxygen.bib
@@ -223,6 +223,27 @@
   doi          = {10.1109/83.902291},
   url          = {https://doi.org/10.1109/83.902291}
 }
+
+@article{christensen2001,
+  abstract = {This paper presents a new method for image registration based on jointly estimating the forward and reverse transformations between two images while constraining these transforms to be inverses of one another. This approach produces a consistent set of transformations that have less pairwise registration error, i.e., better correspondence, than traditional methods that estimate the forward and reverse transformations independently. The transformations are estimated iteratively and are restricted to preserve topology by constraining them to obey the laws of continuum mechanics. The transformations are parameterized by a Fourier series to diagonalize the covariance structure imposed by the continuum mechanics constraints and to provide a computationally efficient numerical implementation. Results using a linear elastic material constraint are presented using both magnetic resonance and X-ray computed tomography image data. The results show that the joint estimation of a consistent set of forward and reverse transformations constrained by linear-elasticity give better registration results than using either constraint alone or none at all.},
+  author = {Christensen, G E and Johnson, H J},
+  date-added = {2025-08-18 09:14:19 -0700},
+  date-modified = {2025-08-18 09:14:19 -0700},
+  doi = {10.1109/42.932742},
+  journal = {IEEE Trans Med Imaging},
+  journal-full = {IEEE transactions on medical imaging},
+  mesh = {Algorithms; Brain; Fourier Analysis; Humans; Image Interpretation, Computer-Assisted; Image Processing, Computer-Assisted; Magnetic Resonance Imaging; Mathematics; Tomography, X-Ray Computed},
+  month = {Jul},
+  number = {7},
+  pages = {568-82},
+  pmid = {11465464},
+  pst = {ppublish},
+  title = {Consistent image registration},
+  volume = {20},
+  year = {2001},
+  bdsk-url-1 = {https://doi.org/10.1109/42.932742}
+}
+
 @article{chu1990,
   title        = {Use of gray value distribution of run lengths for texture analysis},
   author       = {A. Chu and C.M. Sehgal and J.F. Greenleaf},

--- a/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.h
@@ -28,11 +28,75 @@ namespace itk
 
 /**
  * \class InvertDisplacementFieldImageFilter
+ * \brief Iteratively estimates the inverse of a displacement field by fixed-point composition.
  *
- * \brief Iteratively estimate the inverse field of a displacement field.
+ * \par Overview (implementation)
+ * Given a forward displacement field \f$ \mathbf{u}(\mathbf{x}) \f$ (mapping points
+ * \f$ \mathbf{x} \mapsto \mathbf{x} + \mathbf{u}(\mathbf{x}) \f$), the inverse field
+ * \f$ \mathbf{v}(\mathbf{y}) \f$ satisfies
+ * \f[
+ *    \mathbf{x} + \mathbf{u}(\mathbf{x}) = \mathbf{y}, \quad
+ *    \mathbf{y} + \mathbf{v}(\mathbf{y}) = \mathbf{x}.
+ * \f]
+ * Eliminating \f$\mathbf{x}\f$ yields the fixed-point condition
+ * \f[
+ *    \mathbf{v}(\mathbf{y}) \approx -\,\mathbf{u}\!\left(\mathbf{y} + \mathbf{v}(\mathbf{y})\right).
+ * \f]
+ * This filter solves that condition by iterative composition starting from an initial
+ * inverse estimate (optionally supplied by the user). At each iteration, the forward
+ * field is interpolated at warped locations \f$ \mathbf{y} + \mathbf{v}^{(k)}(\mathbf{y}) \f$
+ * and the inverse is updated to reduce both the mean and max residual norms until
+ * user-specified tolerances or an iteration cap is reached. The implementation supports
+ * multithreading and vector-image interpolation; linear vector interpolation is used by
+ * default.
+ *
+ * \par Algorithmic sketch
+ * For output lattice point \f$\mathbf{y}\f$:
+ *  - Initialize \f$\mathbf{v}^{(0)}(\mathbf{y})\f$ to the provided \c InverseFieldInitialEstimate
+ *    (or zero if none).
+ *  - Iterate \f$k = 0,1,\dots\f$ up to \c MaximumNumberOfIterations (default 20):
+ *    \f[
+ *      \mathbf{r}^{(k)}(\mathbf{y}) = \mathbf{u}\!\left(\mathbf{y} + \mathbf{v}^{(k)}(\mathbf{y})\right)
+ *      + \mathbf{v}^{(k)}(\mathbf{y}),
+ *    \f]
+ *    \f[
+ *      \mathbf{v}^{(k+1)}(\mathbf{y}) = \mathbf{v}^{(k)}(\mathbf{y}) - \mathbf{r}^{(k)}(\mathbf{y}).
+ *    \f]
+ *  - Stop when \f$\max_{\mathbf{y}}\|\mathbf{r}^{(k)}(\mathbf{y})\|\f$ and
+ *    \f$\mathrm{mean}_{\mathbf{y}}\|\mathbf{r}^{(k)}(\mathbf{y})\|\f$ fall below
+ *    \c MaxErrorToleranceThreshold and \c MeanErrorToleranceThreshold.
+ *
+ * \par Designed usage and assumptions
+ *  - Best used inside iterative registration where forward updates are small and
+ *    diffeomorphic at each step; supplying the previous iteration’s inverse as the
+ *    initial estimate greatly accelerates convergence and improves robustness.
+ *  - Not intended to recover a full inverse from identity in one step for large
+ *    deformations; prefer multi-resolution schemes, incremental composition, or
+ *    scaling-and-squaring to stay within the contraction regime of the fixed-point map.
+ *  - The forward field should be (approximately) invertible in the region of interest
+ *    (positive Jacobian determinant). Non-invertible folds will stall or diverge.
+ *  - Boundary handling: when \c EnforceBoundaryCondition=true (default), the inverse is
+ *    clamped to zero at the image boundary to avoid extrapolation artifacts.
+ *
+ * \par Complexity and performance
+ * Each iteration performs one interpolation and vector update per voxel:
+ * \f$O(N \times I)\f$ work for \f$N\f$ voxels and \f$I\f$ iterations. The filter
+ * parallelizes across the output region and reuses an internal composed field to
+ * minimize memory traffic.
+ *
+ * \par Relationship to Symmetric Normalization (SyN)
+ * This filter is a core component of the Symmetric Normalization (SyN) registration
+ * algorithm: at each iteration SyN updates forward and inverse velocity/displacement
+ * estimates symmetrically and uses this routine to maintain an explicit inverse field,
+ * preserving inverse-consistency during optimization \cite{christensen2001}.
  *
  * \author Nick Tustison
  * \author Brian Avants
+ *
+ * \par References
+ * - \cite{christensen2001} Christensen, G. E., & Johnson, H. J. (2001).
+ *   Consistent image registration.
+ *   *IEEE Transactions on Medical Imaging*, 20(7), 568–582.
  *
  * \ingroup ITKDisplacementField
  */


### PR DESCRIPTION
Meant to address [this request](https://discourse.itk.org/t/meanerrornorm-and-maxerrornorm-in-invertdisplacementfieldimagefilter/7492/16).


@blowekamp @hjmjohnson @dzenanz 

## PR Checklist
- [ X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ X] Added test (or behavior not changed)
- [ X] Updated API documentation (or API not changed)
- [ X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

