### PR TITLE
STYLE: Remove trailing `std::endl` inserts from itkExceptionMacro calls

### DIFF
--- a/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
+++ b/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
@@ -246,7 +246,7 @@ VTKImageImport<TOutputImage>::GenerateOutputInformation()
                             << "This means that the " << ijk[j] << " data axis has a " << xyz[i]
                             << " component in physical space, but the ITK image can only represent values"
                             << " along " << ijk.substr(0, OutputImageDimension) << " projected on "
-                            << xyz.substr(0, OutputImageDimension) << '.' << std::endl);
+                            << xyz.substr(0, OutputImageDimension) << '.');
         }
       }
     }

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
@@ -126,7 +126,7 @@ BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::UpdateTran
   if (update.Size() != numberOfParameters)
   {
     itkExceptionMacro("Parameter update size, " << update.Size() << ", must  be same as transform parameter size, "
-                                                << numberOfParameters << std::endl);
+                                                << numberOfParameters);
   }
 
   /* Make sure m_Parameters is updated to reflect the current values in

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -837,7 +837,7 @@ CompositeTransform<TParametersValueType, VDimension>::UpdateTransformParameters(
   if (update.Size() != numberOfParameters)
   {
     itkExceptionMacro("Parameter update size, " << update.Size() << ", must  be same as transform parameter size, "
-                                                << numberOfParameters << std::endl);
+                                                << numberOfParameters);
   }
 
   NumberOfParametersType offset{};

--- a/Modules/Core/Transform/include/itkMultiTransform.hxx
+++ b/Modules/Core/Transform/include/itkMultiTransform.hxx
@@ -270,7 +270,7 @@ MultiTransform<TParametersValueType, VDimension, VSubDimensions>::UpdateTransfor
   if (update.Size() != numberOfParameters)
   {
     itkExceptionMacro("Parameter update size, " << update.Size() << ", must  be same as transform parameter size, "
-                                                << numberOfParameters << std::endl);
+                                                << numberOfParameters);
   }
 
   NumberOfParametersType offset{};

--- a/Modules/Core/Transform/include/itkTransform.hxx
+++ b/Modules/Core/Transform/include/itkTransform.hxx
@@ -74,7 +74,7 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::UpdateTransf
   if (update.Size() != numberOfParameters)
   {
     itkExceptionMacro("Parameter update size, " << update.Size() << ", must  be same as transform parameter size, "
-                                                << numberOfParameters << std::endl);
+                                                << numberOfParameters);
   }
 
   /* Make sure m_Parameters is updated to reflect the current values in
@@ -170,7 +170,7 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformVec
 
   if (vector.GetSize() != VInputDimension)
   {
-    itkExceptionMacro("Input Vector is not of size VInputDimension = " << VInputDimension << std::endl);
+    itkExceptionMacro("Input Vector is not of size VInputDimension = " << VInputDimension);
   }
 
   JacobianPositionType jacobian;
@@ -223,7 +223,7 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformCov
 
   if (vector.GetSize() != VInputDimension)
   {
-    itkExceptionMacro("Input Vector is not of size VInputDimension = " << VInputDimension << std::endl);
+    itkExceptionMacro("Input Vector is not of size VInputDimension = " << VInputDimension);
   }
 
   InverseJacobianPositionType jacobian;
@@ -269,7 +269,7 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformDif
 {
   if (inputTensor.GetSize() != 6)
   {
-    itkExceptionMacro("Input DiffusionTensor3D does not have 6 elements" << std::endl);
+    itkExceptionMacro("Input DiffusionTensor3D does not have 6 elements");
   }
 
   InputDiffusionTensor3DType inTensor;
@@ -418,8 +418,7 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::TransformSym
 
   if (inputTensor.GetSize() != (VInputDimension * VInputDimension))
   {
-    itkExceptionMacro("Input DiffusionTensor3D does not have " << VInputDimension * VInputDimension << " elements"
-                                                               << std::endl);
+    itkExceptionMacro("Input DiffusionTensor3D does not have " << VInputDimension * VInputDimension << " elements");
   }
 
   JacobianPositionType jacobian;

--- a/Modules/Core/Transform/include/itkVersorRigid3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkVersorRigid3DTransform.hxx
@@ -131,7 +131,7 @@ VersorRigid3DTransform<TParametersValueType>::UpdateTransformParameters(const De
   if (update.Size() != numberOfParameters)
   {
     itkExceptionMacro("Parameter update size, " << update.Size() << ", must  be same as transform parameter size, "
-                                                << numberOfParameters << std::endl);
+                                                << numberOfParameters);
   }
 
   /* Make sure m_Parameters is updated to reflect the current values in

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingBSplineVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingBSplineVelocityFieldTransform.hxx
@@ -121,7 +121,7 @@ TimeVaryingBSplineVelocityFieldTransform<TParametersValueType, VDimension>::Upda
   if (update.Size() != numberOfParameters)
   {
     itkExceptionMacro("Parameter update size, " << update.Size() << ", must be same as transform parameter size, "
-                                                << numberOfParameters << std::endl);
+                                                << numberOfParameters);
   }
 
   DerivativeType scaledUpdate = update;

--- a/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
+++ b/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
@@ -408,7 +408,7 @@ BYUMeshIO::WritePoints(void * buffer)
     }
     default:
     {
-      itkExceptionMacro("Unknown point pixel component type" << std::endl);
+      itkExceptionMacro("Unknown point pixel component type");
     }
   }
 
@@ -504,7 +504,7 @@ BYUMeshIO::WriteCells(void * buffer)
     }
     default:
     {
-      itkExceptionMacro("Unknown cell pixel component type" << std::endl);
+      itkExceptionMacro("Unknown cell pixel component type");
     }
   }
 

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
@@ -319,7 +319,7 @@ FreeSurferAsciiMeshIO::WritePoints(void * buffer)
     }
     default:
     {
-      itkExceptionMacro("Unknown point pixel component type" << std::endl);
+      itkExceptionMacro("Unknown point pixel component type");
     }
   }
 
@@ -415,7 +415,7 @@ FreeSurferAsciiMeshIO::WriteCells(void * buffer)
     }
     default:
     {
-      itkExceptionMacro("Unknown cell pixel component type" << std::endl);
+      itkExceptionMacro("Unknown cell pixel component type");
     }
   }
 

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
@@ -425,7 +425,7 @@ FreeSurferBinaryMeshIO::WritePoints(void * buffer)
     }
     default:
     {
-      itkExceptionMacro("Unknown point pixel component type" << std::endl);
+      itkExceptionMacro("Unknown point pixel component type");
     }
   }
 
@@ -521,7 +521,7 @@ FreeSurferBinaryMeshIO::WriteCells(void * buffer)
     }
     default:
     {
-      itkExceptionMacro("Unknown cell component type" << std::endl);
+      itkExceptionMacro("Unknown cell component type");
     }
   }
 
@@ -629,7 +629,7 @@ FreeSurferBinaryMeshIO::WritePointData(void * buffer)
     }
     default:
     {
-      itkExceptionMacro("Unknown point data pixel component type" << std::endl);
+      itkExceptionMacro("Unknown point data pixel component type");
     }
   }
 

--- a/Modules/IO/MeshGifti/src/itkGiftiMeshIO.cxx
+++ b/Modules/IO/MeshGifti/src/itkGiftiMeshIO.cxx
@@ -603,7 +603,7 @@ GiftiMeshIO::ReadCells(void * buffer)
         default:
         {
           gifti_free_image(m_GiftiImage);
-          itkExceptionMacro("Unknown cell data pixel component type" << std::endl);
+          itkExceptionMacro("Unknown cell data pixel component type");
         }
       }
     }
@@ -1151,7 +1151,7 @@ GiftiMeshIO::WritePoints(void * buffer)
         default:
         {
           gifti_free_image(m_GiftiImage);
-          itkExceptionMacro("Unknown point component type" << std::endl);
+          itkExceptionMacro("Unknown point component type");
         }
       }
     }
@@ -1243,7 +1243,7 @@ GiftiMeshIO::WriteCells(void * buffer)
         default:
         {
           gifti_free_image(m_GiftiImage);
-          itkExceptionMacro("Unknown cell component type" << std::endl);
+          itkExceptionMacro("Unknown cell component type");
         }
       }
     }
@@ -1352,7 +1352,7 @@ GiftiMeshIO::WritePointData(void * buffer)
           default:
           {
             gifti_free_image(m_GiftiImage);
-            itkExceptionMacro("Unknown point data pixel component type" << std::endl);
+            itkExceptionMacro("Unknown point data pixel component type");
           }
         }
       }
@@ -1453,7 +1453,7 @@ GiftiMeshIO::WritePointData(void * buffer)
           default:
           {
             gifti_free_image(m_GiftiImage);
-            itkExceptionMacro("Unknown point data pixel component type" << std::endl);
+            itkExceptionMacro("Unknown point data pixel component type");
           }
         }
       }
@@ -1563,7 +1563,7 @@ GiftiMeshIO::WriteCellData(void * buffer)
           default:
           {
             gifti_free_image(m_GiftiImage);
-            itkExceptionMacro("Unknown cell data pixel component type" << std::endl);
+            itkExceptionMacro("Unknown cell data pixel component type");
           }
         }
       }
@@ -1663,7 +1663,7 @@ GiftiMeshIO::WriteCellData(void * buffer)
           default:
           {
             gifti_free_image(m_GiftiImage);
-            itkExceptionMacro("Unknown cell data pixel component type" << std::endl);
+            itkExceptionMacro("Unknown cell data pixel component type");
           }
         }
       }

--- a/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
+++ b/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
@@ -468,7 +468,7 @@ OBJMeshIO::WritePoints(void * buffer)
     }
     default:
     {
-      itkExceptionMacro("Unknown point component type" << std::endl);
+      itkExceptionMacro("Unknown point component type");
     }
   }
 
@@ -565,7 +565,7 @@ OBJMeshIO::WriteCells(void * buffer)
     }
     default:
     {
-      itkExceptionMacro("Unknown cell component type" << std::endl);
+      itkExceptionMacro("Unknown cell component type");
     }
   }
 
@@ -681,7 +681,7 @@ OBJMeshIO::WritePointData(void * buffer)
     }
     default:
     {
-      itkExceptionMacro("Unknown point data pixel component type" << std::endl);
+      itkExceptionMacro("Unknown point data pixel component type");
     }
   }
   outputFile.close();

--- a/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
+++ b/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
@@ -493,7 +493,7 @@ OFFMeshIO::WritePoints(void * buffer)
       }
       default:
       {
-        itkExceptionMacro("Unknown point pixel component type" << std::endl);
+        itkExceptionMacro("Unknown point pixel component type");
       }
     }
   }
@@ -585,7 +585,7 @@ OFFMeshIO::WritePoints(void * buffer)
       }
       default:
       {
-        itkExceptionMacro("Unknown point pixel component type" << std::endl);
+        itkExceptionMacro("Unknown point pixel component type");
       }
     }
   }
@@ -705,7 +705,7 @@ OFFMeshIO::WriteCells(void * buffer)
       }
       default:
       {
-        itkExceptionMacro("Unknown cell pixel component type" << std::endl);
+        itkExceptionMacro("Unknown cell pixel component type");
       }
     }
   }
@@ -793,7 +793,7 @@ OFFMeshIO::WriteCells(void * buffer)
       }
       default:
       {
-        itkExceptionMacro("Unknown cell pixel component type" << std::endl);
+        itkExceptionMacro("Unknown cell pixel component type");
       }
     }
   }

--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -248,7 +248,7 @@ PNGImageIO::Read(void * buffer)
   if (setjmp(png_jmpbuf(png_ptr)))
   {
     png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
-    itkExceptionMacro("Error while reading file: " << this->GetFileName() << std::endl);
+    itkExceptionMacro("Error while reading file: " << this->GetFileName());
   }
   png_read_image(png_ptr, row_pointers.get());
   // close the file

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
@@ -469,7 +469,7 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
       "Virtual domain and moving transform displacement field must have the same size and index for BufferedRegion."
       << std::endl
       << "Virtual size/index: " << virtualRegion.GetSize() << " / " << virtualRegion.GetIndex() << std::endl
-      << "Displacement field size/index: " << fieldRegion.GetSize() << " / " << fieldRegion.GetIndex() << std::endl);
+      << "Displacement field size/index: " << fieldRegion.GetSize() << " / " << fieldRegion.GetIndex());
   }
 
   /* check that the image occupy the same physical space, and that

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -853,8 +853,8 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::CommonGetV
 
   if (this->m_NumberOfPixelsCounted < this->m_NumberOfFixedImageSamples / 16)
   {
-    itkExceptionMacro("Too many samples map outside moving image buffer: "
-                      << this->m_NumberOfPixelsCounted << " / " << this->m_NumberOfFixedImageSamples << std::endl);
+    itkExceptionMacro("Too many samples map outside moving image buffer: " << this->m_NumberOfPixelsCounted << " / "
+                                                                           << this->m_NumberOfFixedImageSamples);
   }
 
   // Normalize the fixed image marginal PDF

--- a/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.hxx
@@ -116,8 +116,8 @@ MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const Paramet
 
   if (this->m_NumberOfPixelsCounted < this->m_NumberOfFixedImageSamples / 4)
   {
-    itkExceptionMacro("Too many samples map outside moving image buffer: "
-                      << this->m_NumberOfPixelsCounted << " / " << this->m_NumberOfFixedImageSamples << std::endl);
+    itkExceptionMacro("Too many samples map outside moving image buffer: " << this->m_NumberOfPixelsCounted << " / "
+                                                                           << this->m_NumberOfFixedImageSamples);
   }
 
   double mse = m_PerThread[0].m_MSE;
@@ -232,8 +232,8 @@ MeanSquaresImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDerivative(
 
   if (this->m_NumberOfPixelsCounted < this->m_NumberOfFixedImageSamples / 4)
   {
-    itkExceptionMacro("Too many samples map outside moving image buffer: "
-                      << this->m_NumberOfPixelsCounted << " / " << this->m_NumberOfFixedImageSamples << std::endl);
+    itkExceptionMacro("Too many samples map outside moving image buffer: " << this->m_NumberOfPixelsCounted << " / "
+                                                                           << this->m_NumberOfFixedImageSamples);
   }
 
   value = 0;

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
@@ -304,8 +304,7 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
   {
     itkExceptionMacro("All samples map outside moving image buffer. The images do not sufficiently overlap. They need "
                       "to be initialized to have more overlap before this metric will work. For instance, you can "
-                      "align the image centers by translation."
-                      << std::endl);
+                      "align the image centers by translation.");
   }
   if (this->m_JointPDFSum < itk::NumericTraits<PDFValueType>::epsilon())
   {


### PR DESCRIPTION
It's uncommon and unnecessary to have an extra newline and flush at the end of an exception message. It is the responsibility of the one who prints the exception description to add a line break, if necessary (like `ExceptionObject::Print` does).

Note also that these `std::endl` manipulators were inserted into an `std::ostringstream`, and for `std::ostringstream`, flushing does not have any effect anyway.

Using Notepad++, Replace In Files:

    Find what: (  itkExceptionMacro\([^)]+) << std::endl(\);)
    Find what: (  itkExceptionMacro\([^;]+) << std::endl(\);)
    Replace with: $1$2
    Directory: D:\ITK\Modules\
    [v] Match case
    (*) Regular expression [v] . matches newline