### PR TITLE
Remove trailing `std::endl` inserts from various Macro calls

### DIFF
--- a/Modules/Core/Common/include/itkVersor.hxx
+++ b/Modules/Core/Common/include/itkVersor.hxx
@@ -333,7 +333,7 @@ Versor<T>::Set(const MatrixType & mat)
                              << m << std::endl
                              << "det(m * m transpose) is: " << vnl_det(I) << std::endl
                              << "m * m transpose is:" << std::endl
-                             << I << std::endl);
+                             << I);
   }
 
   const double trace = m(0, 0) + m(1, 1) + m(2, 2) + 1.0;

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
@@ -137,9 +137,6 @@ PolylineMask2DImageFilter<TInputImage, TPolyline, TOutputImage>::GenerateData()
     const auto startImageIndex = outputImagePtr->TransformPhysicalPointToIndex(startVertex);
     const auto endImageIndex = outputImagePtr->TransformPhysicalPointToIndex(endVertex);
 
-    // itkDebugMacro(<<"Projection image (index,physical
-    // coordinate):"<<startImageIndex<<","<<startVertex<<std::endl);
-
     if (endImageIndex[1] > startImageIndex[1])
     {
       pflag = true;

--- a/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
@@ -289,7 +289,7 @@ DCMTKSequence::GetElementItem(unsigned short index, DCMTKItem & target, const bo
   DcmItem * itemElement = this->m_DcmSequenceOfItems->getItem(index);
   if (itemElement == nullptr)
   {
-    DCMTKExceptionOrErrorReturn(<< "Can't get item " << index << std::endl);
+    DCMTKExceptionOrErrorReturn(<< "Can't get item " << index);
   }
   target.SetDcmItem(itemElement);
   return EXIT_SUCCESS;

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
@@ -134,7 +134,7 @@ GradientDescentOptimizerv4Template<TInternalComputationValueType>::ResumeOptimiz
       }
       catch (const std::exception & e)
       {
-        itkWarningMacro("GetConvergenceValue() failed with exception: " << e.what() << std::endl);
+        itkWarningMacro("GetConvergenceValue() failed with exception: " << e.what());
       }
     }
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionBase.hxx
@@ -87,7 +87,7 @@ LevelSetEvolutionBase<TEquationContainer, TLevelSet>::CheckSetUp()
     itkGenericExceptionMacro("this->m_LevelSetContainer != this->m_EquationContainer->GetLevelSetContainer()"
                              << std::endl
                              << this->m_LevelSetContainer.GetPointer()
-                             << " != " << this->m_EquationContainer->GetLevelSetContainer() << std::endl);
+                             << " != " << this->m_EquationContainer->GetLevelSetContainer());
   }
 
   // Get the image to be segmented


### PR DESCRIPTION
Follow-up to:
- pull request #5486
- pull request #5491