### PR TITLE
DOC: correct documentation warning

### DIFF
--- a/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.h
@@ -88,15 +88,15 @@ namespace itk
  * This filter is a core component of the Symmetric Normalization (SyN) registration
  * algorithm: at each iteration SyN updates forward and inverse velocity/displacement
  * estimates symmetrically and uses this routine to maintain an explicit inverse field,
- * preserving inverse-consistency during optimization \cite{christensen2001}.
+ * preserving inverse-consistency during optimization \cite christensen2001.
  *
  * \author Nick Tustison
  * \author Brian Avants
  *
  * \par References
- * - \cite{christensen2001} Christensen, G. E., & Johnson, H. J. (2001).
+ * - Christensen, G. E., & Johnson, H. J. (2001).
  *   Consistent image registration.
- *   *IEEE Transactions on Medical Imaging*, 20(7), 568–582.
+ *   *IEEE Transactions on Medical Imaging*, 20(7), 568–582.\cite christensen2001
  *
  * \ingroup ITKDisplacementField
  */


### PR DESCRIPTION
Correction of documentation warning so it is doxygen conform.


## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
