### PR TITLE
STYLE: Remove variadic arguments (`...`) from ExceptionObject constructor

### DIFF
--- a/Modules/Core/Common/include/itkExceptionObject.h
+++ b/Modules/Core/Common/include/itkExceptionObject.h
@@ -62,17 +62,16 @@ public:
   ExceptionObject() noexcept = default;
 
   explicit ExceptionObject(std::string         file,
-                           unsigned int        lineNumber = 0,
-                           std::string         description = "None",
-                           std::string         location = {},
-                           const LightObject * thrower = nullptr);
+                           unsigned int        lineNumber,
+                           std::string         description,
+                           std::string         location,
+                           const LightObject * thrower);
 
   explicit ExceptionObject(std::string  file,
-                           unsigned int lineNumber,
-                           std::string  description,
-                           std::string  location,
-                           const void * thrower,
-                           ...);
+                           unsigned int lineNumber = 0,
+                           std::string  description = "None",
+                           std::string  location = {},
+                           const void * thrower = nullptr);
 
   /** Copy-constructor. */
   ExceptionObject(const ExceptionObject &) noexcept = default;

--- a/Modules/Core/Common/src/itkExceptionObject.cxx
+++ b/Modules/Core/Common/src/itkExceptionObject.cxx
@@ -89,8 +89,7 @@ ExceptionObject::ExceptionObject(std::string  file,
                                  unsigned int lineNumber,
                                  std::string  description,
                                  std::string  location,
-                                 const void *,
-                                 ...)
+                                 const void *)
   : m_ExceptionData(
       std::make_shared<const ExceptionData>(std::move(file), lineNumber, std::move(description), std::move(location)))
 {}


### PR DESCRIPTION
Dropped support for an arbitrary number of arguments from this constructor. These variadic arguments were not necessary, and they were ignored anyway.

These variadic arguments were introduced with:
pull request https://github.com/InsightSoftwareConsortium/ITK/pull/5477 commit 868adae78a206e43b7f0c29b2c8fe89262bbd688
"ENH: Add object and class name to ExceptionObject constructor"