### PR TITLE
DOC: Prepare for future, doxygen, releases

### DIFF
--- a/Utilities/Doxygen/DoxygenConfig.cmake
+++ b/Utilities/Doxygen/DoxygenConfig.cmake
@@ -100,11 +100,15 @@ set(DOXYGEN_DOCSET_PUBLISHER_NAME "InsightConsortium")
 set(DOXYGEN_ECLIPSE_DOC_ID "org.itk.ITK")
 set(DOXYGEN_ENUM_VALUES_PER_LINE "1")
 set(DOXYGEN_USE_MATHJAX "YES")
-set(DOXYGEN_MATHJAX_VERSION "MathJax_2")
-set(
-  DOXYGEN_MATHJAX_RELPATH
-  "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/"
-)
+if (DOXYGEN_VERSION VERSION_GREATER_EQUAL 1.15.0)
+  set(DOXYGEN_MATHJAX_VERSION "MathJax_4")
+else()
+  set(DOXYGEN_MATHJAX_VERSION "MathJax_2")
+  set(
+    DOXYGEN_MATHJAX_RELPATH
+    "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/"
+  )
+endif()
 if(ITK_DOXYGEN_SERVER_BASED_SEARCH)
   set(DOXYGEN_SERVER_BASED_SEARCH "YES")
 else()
@@ -212,6 +216,11 @@ set(
   DOXYGEN_CITE_BIB_FILES
   "${ITK_SOURCE_DIR}/Documentation/Doxygen/doxygen.bib"
 )
+
+if (DOXYGEN_VERSION VERSION_GREATER_EQUAL 1.15.0)
+  set(DOXYGEN_MARKDOWN_STRICT "NO")
+  set(DOXYGEN_PAGE_OUTLINE_PANEL "NO")
+endif()
 
 foreach(
   _FORMAT


### PR DESCRIPTION
Preparing some settings for future doxygen releases, version 1.15.0 is the current master.
- MathJax support for Mathjax version 4
- Disable right hand side navigation panel (introduced in doxygen 1.14.0)
- Placing doxygen  in non strict markdown mode (markdown handling in respect to backticks has made more conform other markdown handlers, but disabled some doxygen features, e.g. `<backtick><text><apostrophe>`, with `MARKDOWN_STRICT=NO` this remains possible.



## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

