### PR TITLE
Igenerator swig format

### DIFF
--- a/Wrapping/Generators/SwigInterface/igenerator.py
+++ b/Wrapping/Generators/SwigInterface/igenerator.py
@@ -93,7 +93,7 @@ def argument_parser():
         default=[],
         metavar="FILE",
         help=(
-            "File to be included by swig (%include) in the generated " "interface file."
+            "File to be included by swig (%%include) in the generated interface file."
         ),
     )
     cmdln_arg_parser.add_argument(


### PR DESCRIPTION
The help string contains a %-format specifier (like %i or similar) that Python's help string expansion tries to interpret as an old-style printf format.

Escape with %%.

Addresses:

  Traceback (most recent call last):
    File "/opt/python/cp314-cp314/lib/python3.14/argparse.py", line 1747, in _check_help
      formatter._expand_help(action)
      ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
    File "/opt/python/cp314-cp314/lib/python3.14/argparse.py", line 678, in _expand_help
      return help_string % params
             ~~~~~~~~~~~~^~~~~~~~
  TypeError: %i format: a real number is required, not dict

  The above exception was the direct cause of the following exception:

  Traceback (most recent call last):
    File "/ITK/Wrapping/Generators/SwigInterface/igenerator.py", line 220, in <module>
      glb_options = argument_parser()
    File "/ITK/Wrapping/Generators/SwigInterface/igenerator.py", line 89, in argument_parser
      cmdln_arg_parser.add_argument(
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
          "--swig-include",
          ^^^^^^^^^^^^^^^^^
      ...<6 lines>...
          ),
          ^^
      )
      ^
    File "/opt/python/cp314-cp314/lib/python3.14/argparse.py", line 1561, in add_argument
      self._check_help(action)
      ~~~~~~~~~~~~~~~~^^^^^^^^
    File "/opt/python/cp314-cp314/lib/python3.14/argparse.py", line 1749, in _check_help
      raise ValueError('badly formed help string') from exc
  ValueError: badly formed help string

