### PR TITLE
COMP: Avoid PySequence_Fast_GET_ITEM - ITK 6

### DIFF
--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -78,8 +78,9 @@ PyBuffer<TImage>::_get_image_view_from_contiguous_array(PyObject * arr, PyObject
 
   for (unsigned int i = 0; i < dimension; ++i)
   {
-    PyObject * const item = PySequence_Fast_GET_ITEM(shapeseq, i);
+    PyObject * const item = PySequence_GetItem(shapeseq, i);
     size[i] = static_cast<SizeValueType>(PyInt_AsLong(item));
+    Py_DECREF(item);
   }
 
   const SizeValueType numberOfPixels = size.CalculateProductOfElements();

--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
@@ -66,8 +66,9 @@ PyVectorContainer<TElementIdentifier, TElement>::_vector_container_from_array(Py
   PyObject * const   shapeseq = PySequence_Fast(shape, "expected sequence");
   const unsigned int dimension = PySequence_Size(shape);
 
-  PyObject *   item = PySequence_Fast_GET_ITEM(shapeseq, 0); // Only one dimension
+  PyObject *   item = PySequence_GetItem(shapeseq, 0); // Only one dimension
   const size_t numberOfElements = static_cast<size_t>(PyInt_AsLong(item));
+  Py_DECREF(item);
 
   const size_t len = numberOfElements * sizeof(DataType);
   if (bufferLength < 0 || static_cast<size_t>(bufferLength) != len)

--- a/Modules/Bridge/NumPy/include/itkPyVnl.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.hxx
@@ -65,8 +65,9 @@ PyVnl<TElement>::_GetVnlVectorFromArray(PyObject * arr, PyObject * const shape) 
   PyObject * const   shapeseq = PySequence_Fast(shape, "expected sequence");
   const unsigned int dimension = PySequence_Size(shape);
 
-  PyObject * const item = PySequence_Fast_GET_ITEM(shapeseq, 0); // Only one dimension
+  PyObject * const item = PySequence_GetItem(shapeseq, 0); // Only one dimension
   const size_t     numberOfElements = static_cast<size_t>(PyInt_AsLong(item));
+  Py_DECREF(item);
 
   const size_t len = numberOfElements * sizeof(DataType);
   if (bufferLength < 0 || static_cast<size_t>(bufferLength) != len)
@@ -125,8 +126,9 @@ PyVnl<TElement>::_GetVnlMatrixFromArray(PyObject * arr, PyObject * const shape) 
 
   for (unsigned int i = 0; i < 2; ++i)
   {
-    PyObject * const item = PySequence_Fast_GET_ITEM(shapeseq, i);
+    PyObject * const item = PySequence_GetItem(shapeseq, i);
     size[i] = static_cast<unsigned int>(PyInt_AsLong(item));
+    Py_DECREF(item);
     numberOfElements *= size[i];
   }
 


### PR DESCRIPTION
No longer available in Python 3.14.

Use PySequence_GetItem. This returns a reference. In the use cases
(image dimensions), the performance impact is negligible.
