### PR TITLE
STYLE: Remove accidentally duplicated `[[nodiscard]]` attributes

### DIFF
--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
@@ -510,7 +510,7 @@ private:
    * `TMatrix` (which is the case when `TMatrix` = `itk::Array2D`).
    */
   template <typename QMatrix = TMatrix>
-  [[nodiscard]] [[nodiscard]] auto
+  [[nodiscard]] auto
   GetMatrixValueType(bool) const -> typename QMatrix::element_type
   {
     return QMatrix::element_type();

--- a/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.h
@@ -176,38 +176,38 @@ public:
   /** @ITKStartGrouping */
   // ORIENTATION_NOTE: this definition of GetLeft (or GetRight)
   // implicitly assumes that the Onext order is counter-clockwise !
-  [[nodiscard]] [[nodiscard]] inline const OriginRefType
+  [[nodiscard]] inline const OriginRefType
   GetOrigin() const
   {
     return (m_Origin);
   }
-  [[nodiscard]] [[nodiscard]] inline const OriginRefType
+  [[nodiscard]] inline const OriginRefType
   GetDestination() const
   {
     return (GetSym()->GetOrigin());
   }
-  [[nodiscard]] [[nodiscard]] inline const DualOriginRefType
+  [[nodiscard]] inline const DualOriginRefType
   GetRight() const
   {
     return (GetRot()->GetOrigin());
   }
-  [[nodiscard]] [[nodiscard]] inline const DualOriginRefType
+  [[nodiscard]] inline const DualOriginRefType
   GetLeft() const
   {
     return (GetInvRot()->GetOrigin());
   }
   /** @ITKEndGrouping */
   /** Boolean accessors. */
-  [[nodiscard]] [[nodiscard]] bool
+  [[nodiscard]] bool
   IsOriginSet() const;
 
-  [[nodiscard]] [[nodiscard]] bool
+  [[nodiscard]] bool
   IsDestinationSet() const;
 
-  [[nodiscard]] [[nodiscard]] bool
+  [[nodiscard]] bool
   IsRightSet() const;
 
-  [[nodiscard]] [[nodiscard]] bool
+  [[nodiscard]] bool
   IsLeftSet() const;
 
   /** Extra data set methods. */
@@ -297,13 +297,13 @@ public:
    * @return Returns true when "this" has faces set on both sides.
    *         Return false otherwise.
    */
-  [[nodiscard]] [[nodiscard]] inline bool
+  [[nodiscard]] inline bool
   IsInternal() const
   {
     return (this->IsLeftSet() && this->IsRightSet());
   }
 
-  [[nodiscard]] [[nodiscard]] bool
+  [[nodiscard]] bool
   IsOriginInternal() const;
 
   bool

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdge.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdge.h
@@ -200,12 +200,12 @@ public:
   {
     return this->m_Rot;
   }
-  [[nodiscard]] [[nodiscard]] inline const Self *
+  [[nodiscard]] inline const Self *
   GetOnext() const
   {
     return this->m_Onext;
   }
-  [[nodiscard]] [[nodiscard]] inline const Self *
+  [[nodiscard]] inline const Self *
   GetRot() const
   {
     return this->m_Rot;
@@ -261,7 +261,7 @@ public:
     return nullptr;
   }
 
-  [[nodiscard]] [[nodiscard]] inline const Self *
+  [[nodiscard]] inline const Self *
   GetSym() const
   {
     if (this->m_Rot)
@@ -277,7 +277,7 @@ public:
   Self *
   GetLnext();
 
-  [[nodiscard]] [[nodiscard]] const Self *
+  [[nodiscard]] const Self *
   GetLnext() const;
 
   /** Returns next edge with same Right face. The first edge
@@ -286,7 +286,7 @@ public:
   Self *
   GetRnext();
 
-  [[nodiscard]] [[nodiscard]] const Self *
+  [[nodiscard]] const Self *
   GetRnext() const;
 
   /** Returns next edge with same right face and same Destination. The
@@ -295,7 +295,7 @@ public:
   Self *
   GetDnext();
 
-  [[nodiscard]] [[nodiscard]] const Self *
+  [[nodiscard]] const Self *
   GetDnext() const;
 
   /** Returns previous edge with same Origin
@@ -303,7 +303,7 @@ public:
   Self *
   GetOprev();
 
-  [[nodiscard]] [[nodiscard]] const Self *
+  [[nodiscard]] const Self *
   GetOprev() const;
 
   /** Returns previous edge with same Left face. The first edge
@@ -312,7 +312,7 @@ public:
   Self *
   GetLprev();
 
-  [[nodiscard]] [[nodiscard]] const Self *
+  [[nodiscard]] const Self *
   GetLprev() const;
 
   /** Returns the previous edge with same Right face. The first edge
@@ -321,7 +321,7 @@ public:
   Self *
   GetRprev();
 
-  [[nodiscard]] [[nodiscard]] const Self *
+  [[nodiscard]] const Self *
   GetRprev() const;
 
   /** Returns the previous edge with same Right face and same Destination.
@@ -330,7 +330,7 @@ public:
   Self *
   GetDprev();
 
-  [[nodiscard]] [[nodiscard]] const Self *
+  [[nodiscard]] const Self *
   GetDprev() const;
 
   /** Inverse operators */
@@ -380,7 +380,7 @@ public:
   {
     return this->GetDprev();
   }
-  [[nodiscard]] [[nodiscard]] inline const Self *
+  [[nodiscard]] inline const Self *
   GetInvRot() const
   {
 #ifdef NDEBUG
@@ -405,22 +405,22 @@ public:
 #endif
   }
 
-  [[nodiscard]] [[nodiscard]] inline const Self *
+  [[nodiscard]] inline const Self *
   GetInvOnext() const
   {
     return this->GetOprev();
   }
-  [[nodiscard]] [[nodiscard]] inline const Self *
+  [[nodiscard]] inline const Self *
   GetInvLnext() const
   {
     return this->GetLprev();
   }
-  [[nodiscard]] [[nodiscard]] inline const Self *
+  [[nodiscard]] inline const Self *
   GetInvRnext() const
   {
     return this->GetRprev();
   }
-  [[nodiscard]] [[nodiscard]] inline const Self *
+  [[nodiscard]] inline const Self *
   GetInvDnext() const
   {
     return this->GetDprev();
@@ -429,23 +429,23 @@ public:
 
   /** Queries. */
   /** @ITKStartGrouping */
-  [[nodiscard]] [[nodiscard]] inline bool
+  [[nodiscard]] inline bool
   IsHalfEdge() const
   {
     return ((m_Onext == this) || (m_Rot == nullptr));
   }
-  [[nodiscard]] [[nodiscard]] inline bool
+  [[nodiscard]] inline bool
   IsIsolated() const
   {
     return (this == this->GetOnext());
   }
   bool
   IsEdgeInOnextRing(Self * testEdge) const;
-  [[nodiscard]] [[nodiscard]] bool
+  [[nodiscard]] bool
   IsLnextGivenSizeCyclic(const int size) const;
   /** @ITKEndGrouping */
 
-  [[nodiscard]] [[nodiscard]] unsigned int
+  [[nodiscard]] unsigned int
   GetOrder() const;
 
 private:

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h
@@ -108,22 +108,22 @@ public:
     return (*this);
   }
 
-  [[nodiscard]] [[nodiscard]] QuadEdgeType *
+  [[nodiscard]] QuadEdgeType *
   GetStartEdge() const
   {
     return (m_StartEdge);
   }
-  [[nodiscard]] [[nodiscard]] QuadEdgeType *
+  [[nodiscard]] QuadEdgeType *
   GetIterator() const
   {
     return (m_Iterator);
   }
-  [[nodiscard]] [[nodiscard]] int
+  [[nodiscard]] int
   GetOpType() const
   {
     return (m_OpType);
   }
-  [[nodiscard]] [[nodiscard]] bool
+  [[nodiscard]] bool
   GetStart() const
   {
     return (m_Start);
@@ -250,7 +250,7 @@ public:
   {
     return (this->m_Iterator);
   }
-  [[nodiscard]] [[nodiscard]] const QuadEdgeType *
+  [[nodiscard]] const QuadEdgeType *
   Value() const
   {
     return (this->m_Iterator);
@@ -326,7 +326,7 @@ public:
     return (*this);
   }
 
-  [[nodiscard]] [[nodiscard]] const QuadEdgeType *
+  [[nodiscard]] const QuadEdgeType *
   Value() const
   {
     return (this->m_Iterator);

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.h
@@ -90,13 +90,13 @@ public:
   TQuadEdge *
   GetEdge();
 
-  [[nodiscard]] [[nodiscard]] TQuadEdge *
+  [[nodiscard]] TQuadEdge *
   GetEdge() const;
 
   /** Return IsOriginalInternal of the edge.
    * @sa GeometricalQuadEdge::isOriginInternal
    */
-  [[nodiscard]] [[nodiscard]] bool
+  [[nodiscard]] bool
   IsInternal() const;
 
   /** Return the valence of this QuadEdgeMeshPoint i.e. the number of edges constituting
@@ -104,7 +104,7 @@ public:
    *  @return the valence when an entry in the Onext ring is present,
    *          and -1 otherwise.
    */
-  [[nodiscard]] [[nodiscard]] int
+  [[nodiscard]] int
   GetValence() const;
 
 protected:


### PR DESCRIPTION
Replaced `[[nodiscard]] [[nodiscard]]` with `[[nodiscard]]`.

- Follow-up to pull request #5404 commit 85aa7bddf8d04b46cfdbfc8416301ddc301407f3 "STYLE: Use C++17 [[nodiscard]] attribute"
