### PR TITLE
STYLE: Remove unnecessary parentheses around dereferenced variables

### DIFF
--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
@@ -506,7 +506,7 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::operator++()
       m_Loop[i] = m_BeginIndex[i];
       for (Iterator it = Superclass::Begin(); it < _end; ++it)
       {
-        (*it) += m_WrapOffset[i];
+        *it += m_WrapOffset[i];
       }
     }
     else
@@ -541,7 +541,7 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::operator--()
       m_Loop[i] = m_Bound[i] - 1;
       for (Iterator it = Superclass::Begin(); it < _end; ++it)
       {
-        (*it) -= m_WrapOffset[i];
+        *it -= m_WrapOffset[i];
       }
     }
     else
@@ -713,7 +713,7 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::operator+=(const OffsetTy
   // Increment pointers.
   for (Iterator it = this->Begin(); it < _end; ++it)
   {
-    (*it) += accumulator;
+    *it += accumulator;
   }
 
   // Update loop counter values
@@ -750,7 +750,7 @@ ConstNeighborhoodIterator<TImage, TBoundaryCondition>::operator-=(const OffsetTy
   // Increment pointers.
   for (Iterator it = this->Begin(); it < _end; ++it)
   {
-    (*it) -= accumulator;
+    *it -= accumulator;
   }
 
   // Update loop counter values

--- a/Modules/Core/Common/include/itkNeighborhoodAccessorFunctor.h
+++ b/Modules/Core/Common/include/itkNeighborhoodAccessorFunctor.h
@@ -61,14 +61,14 @@ public:
 
   /** Method to dereference a pixel pointer. This is used from the
    * ConstNeighborhoodIterator as the equivalent operation to (*it).
-   * This method should be preferred over the former (*it) notation.
+   * This method should be preferred over the former *it notation.
    * The reason is that dereferencing a pointer to a location of
    * VectorImage pixel involves a different operation that simply
    * dereferencing the pointer.  */
   inline PixelType
   Get(const InternalPixelType * pixelPointer) const
   {
-    return (*pixelPointer);
+    return *pixelPointer;
   }
 
   /** Method to set the pixel value at a certain pixel pointer */

--- a/Modules/Core/Common/include/itkPriorityQueueContainer.hxx
+++ b/Modules/Core/Common/include/itkPriorityQueueContainer.hxx
@@ -61,7 +61,7 @@ ElementWrapperPointerInterface<TElementWrapperPointer, TElementIdentifier>::is_l
   const ElementWrapperPointerType & element1,
   const ElementWrapperPointerType & element2) const
 {
-  return (element1->is_less((*element1), (*element2)));
+  return (element1->is_less(*element1, *element2));
 }
 // -----------------------------------------------------------------------------
 
@@ -72,7 +72,7 @@ ElementWrapperPointerInterface<TElementWrapperPointer, TElementIdentifier>::is_g
   const ElementWrapperPointerType & element1,
   const ElementWrapperPointerType & element2) const
 {
-  return (element1->is_greater((*element1), (*element2)));
+  return (element1->is_greater(*element1, *element2));
 }
 // -----------------------------------------------------------------------------
 

--- a/Modules/Core/Common/include/itkVectorImageNeighborhoodAccessorFunctor.h
+++ b/Modules/Core/Common/include/itkVectorImageNeighborhoodAccessorFunctor.h
@@ -79,7 +79,7 @@ public:
 
   /** Method to dereference a pixel pointer. This is used from the
    * ConstNeighborhoodIterator as the equivalent operation to (*it).
-   * This method should be preferred over the former (*it) notation.
+   * This method should be preferred over the former *it notation.
    * The reason is that dereferencing a pointer to a location of
    * VectorImage pixel involves a different operation that simply
    * dereferencing the pointer. Here a PixelType (array of InternalPixelType s)

--- a/Modules/Core/Common/test/itkMathRoundProfileTest1.cxx
+++ b/Modules/Core/Common/test/itkMathRoundProfileTest1.cxx
@@ -204,7 +204,7 @@ itkMathRoundProfileTest1(int, char *[])
 
   while (inpItr != inputEnd)
   {
-    if ((*outItr1) != (*outItr2))
+    if (*outItr1 != *outItr2)
     {
       std::cout << "Warning*** For input: " << *inpItr << " if-round: " << *outItr1
                 << " differs from itk::Math::Round: " << *outItr2 << std::endl;

--- a/Modules/Core/GPUCommon/src/itkOpenCLUtil.cxx
+++ b/Modules/Core/GPUCommon/src/itkOpenCLUtil.cxx
@@ -61,7 +61,7 @@ OpenCLGetAvailableDevices(cl_platform_id platform, cl_device_type devType, cl_ui
   errid = clGetDeviceIDs(platform, devType, totalNumDevices, totalDevices, nullptr);
   OpenCLCheckError(errid, __FILE__, __LINE__, ITK_LOCATION);
 
-  (*numAvailableDevices) = 0;
+  *numAvailableDevices = 0;
 
   // check available devices
   for (cl_uint i = 0; i < totalNumDevices; ++i)
@@ -75,7 +75,7 @@ OpenCLGetAvailableDevices(cl_platform_id platform, cl_device_type devType, cl_ui
     }
   }
 
-  availableDevices = (cl_device_id *)malloc((*numAvailableDevices) * sizeof(cl_device_id));
+  availableDevices = (cl_device_id *)malloc(*numAvailableDevices * sizeof(cl_device_id));
 
   int idx = 0;
   for (cl_uint i = 0; i < totalNumDevices; ++i)

--- a/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
@@ -332,8 +332,8 @@ GaussianBlurImageFunction<TInputImage, TOutput>::RecomputeContinuousGaussianKern
         }
       }
 
-      (*it) = m_GaussianFunction->Evaluate(pt);
-      sum += (*it);
+      *it = m_GaussianFunction->Evaluate(pt);
+      sum += *it;
       ++i;
       ++it;
     }
@@ -342,7 +342,7 @@ GaussianBlurImageFunction<TInputImage, TOutput>::RecomputeContinuousGaussianKern
     it = gaussianNeighborhood.Begin();
     while (it != gaussianNeighborhood.End())
     {
-      (*it) /= sum;
+      *it /= sum;
       ++it;
     }
     m_ContinuousOperatorArray[direction] = gaussianNeighborhood;

--- a/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
@@ -130,7 +130,7 @@ GaussianDerivativeImageFunction<TInputImage, TOutput>::RecomputeGaussianKernel()
       while (it != dogNeighborhood.End())
       {
         pt[0] = dogNeighborhood.GetOffset(i)[direction] * directionSpacing;
-        (*it) = m_GaussianDerivativeSpatialFunction->Evaluate(pt);
+        *it = m_GaussianDerivativeSpatialFunction->Evaluate(pt);
         ++i;
         ++it;
       }
@@ -167,7 +167,7 @@ GaussianDerivativeImageFunction<TInputImage, TOutput>::EvaluateAtIndex(const Ind
 
     for (const TOutput & kernelValue : operatorNeighborhood.GetBufferReference())
     {
-      result += kernelValue * (*neighborhoodRangeIterator);
+      result += kernelValue * *neighborhoodRangeIterator;
       ++neighborhoodRangeIterator;
     }
     gradient[direction] = result;

--- a/Modules/Core/ImageFunction/include/itkMedianImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMedianImageFunction.hxx
@@ -75,7 +75,7 @@ MedianImageFunction<TInputImage, TCoordinate>::EvaluateAtIndex(const IndexType &
   const auto medianIterator = pixels.begin() + (pixels.size() / 2);
   std::nth_element(pixels.begin(), medianIterator, pixels.end());
 
-  return (*medianIterator);
+  return *medianIterator;
 }
 } // namespace itk
 

--- a/Modules/Core/Mesh/include/itkMesh.hxx
+++ b/Modules/Core/Mesh/include/itkMesh.hxx
@@ -634,7 +634,7 @@ Mesh<TPixelType, VDimension, TMeshTraits>::GetCellBoundaryFeatureNeighbors(int  
 
       for (auto usingCell = boundary->UsingCellsBegin(); usingCell != boundary->UsingCellsEnd(); ++usingCell)
       {
-        if ((*usingCell) != cellId)
+        if (*usingCell != cellId)
         {
           cellSet->insert(*usingCell);
         }

--- a/Modules/Core/Mesh/test/itkMeshSpatialObjectIOTest.cxx
+++ b/Modules/Core/Mesh/test/itkMeshSpatialObjectIOTest.cxx
@@ -249,10 +249,10 @@ itkMeshSpatialObjectIOTest(int argc, char * argv[])
     auto         it = (*it_celllinks)->Value().begin();
     while (it != (*it_celllinks)->Value().end())
     {
-      if ((*it) != i)
+      if (*it != i)
       {
         std::cout << " [FAILED]" << std::endl;
-        std::cout << (*it) << " v.s " << i << std::endl;
+        std::cout << *it << " v.s " << i << std::endl;
         return EXIT_FAILURE;
       }
       i++;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h
@@ -105,7 +105,7 @@ public:
       m_OpType = r.m_OpType;
       m_Start = r.m_Start;
     }
-    return (*this);
+    return *this;
   }
 
   [[nodiscard]] [[nodiscard]] QuadEdgeType *
@@ -148,7 +148,7 @@ public:
       m_Start = !(m_Iterator == m_StartEdge);
     }
 
-    return (*this);
+    return *this;
   }
 
   Self &
@@ -159,7 +159,7 @@ public:
       this->GoToNext();
       m_Start = !(m_Iterator == m_StartEdge);
     }
-    return (*this);
+    return *this;
   }
 
 protected:
@@ -323,7 +323,7 @@ public:
     this->m_Iterator = r.GetIterator();
     this->m_OpType = r.GetOpType();
     this->m_Start = r.GetStart();
-    return (*this);
+    return *this;
   }
 
   [[nodiscard]] [[nodiscard]] const QuadEdgeType *
@@ -370,7 +370,7 @@ public:
     this->m_Iterator = r.GetIterator();
     this->m_OpType = r.GetOpType();
     this->m_Start = r.GetStart();
-    return (*this);
+    return *this;
   }
 
   const OriginRefType

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
@@ -161,7 +161,7 @@ public:
       m_IsPointVisited = r.m_IsPointVisited;
       m_CurrentEdge = r.m_CurrentEdge;
     }
-    return (*this);
+    return *this;
   }
 
   // Iteration methods.
@@ -285,7 +285,7 @@ public:
   operator=(const NoConstType & r)
   {
     this->m_Mesh = r.GetMesh();
-    return (*this);
+    return *this;
   }
 
   [[nodiscard]] const QEType *

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.hxx
@@ -69,14 +69,14 @@ QuadEdgeMeshFrontBaseIterator<TMesh, TQE>::operator++()
   // We continue only if not previously marked as finish...
   if (!m_Start)
   {
-    return (*this);
+    return *this;
   }
 
   // ... or until the front is empty:
   if (m_Front->empty())
   {
     m_Start = false;
-    return (*this);
+    return *this;
   }
 
   // Sort on the Cost:
@@ -111,7 +111,7 @@ QuadEdgeMeshFrontBaseIterator<TMesh, TQE>::operator++()
 
     // We still want to handle oEdge
     m_CurrentEdge = oEdge;
-    return (*this);
+    return *this;
   }
 
   // All the edge->Origin() neighbours were already visited. Remove

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.hxx
@@ -46,7 +46,7 @@ QuadEdgeMeshPoint<TCoordinate, VPointDimension, TQuadEdge>::operator=(const Supe
 {
   this->Superclass::operator=(r);
   this->Initialize();
-  return (*this);
+  return *this;
 }
 
 // ---------------------------------------------------------------------
@@ -56,7 +56,7 @@ QuadEdgeMeshPoint<TCoordinate, VPointDimension, TQuadEdge>::operator=(const Valu
 {
   this->Superclass::operator=(r);
   this->Initialize();
-  return (*this);
+  return *this;
 }
 
 template <typename TCoordinate, unsigned int VPointDimension, typename TQuadEdge>

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshToQuadEdgeMeshFilter.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshToQuadEdgeMeshFilter.h
@@ -250,7 +250,7 @@ CopyMeshToMeshCells(const TInputMesh * in, TOutputMesh * out)
 
       while (pIt != pEnd)
       {
-        points.push_back((*pIt));
+        points.push_back(*pIt);
         ++pIt;
       }
       out->AddFaceWithSecurePointList(points, false);

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTopologyChecker.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTopologyChecker.hxx
@@ -49,7 +49,7 @@ QuadEdgeMeshTopologyChecker<TMesh>::ValidateEulerCharacteristic() const
   // Number of USED faces
   const CellIdentifier numFaces = m_Mesh->ComputeNumberOfFaces();
   // Number of Boundaries
-  typename BoundaryEdges::OutputType listOfBoundaries = boundaryEdges->Evaluate((*m_Mesh));
+  typename BoundaryEdges::OutputType listOfBoundaries = boundaryEdges->Evaluate(*m_Mesh);
   auto                               numBounds = static_cast<CellIdentifier>(listOfBoundaries->size());
   delete listOfBoundaries;
 

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
@@ -218,7 +218,7 @@ ContourSpatialObject<TDimension>::Update()
             newPoint[d] = pnt[d] + i * step[d];
           }
         }
-        typename Superclass::SpatialObjectPointType newSOPoint = (*it);
+        typename Superclass::SpatialObjectPointType newSOPoint = *it;
         newSOPoint.SetSpatialObject(this);
         newSOPoint.SetPositionInObjectSpace(newPoint);
         this->m_Points.push_back(newSOPoint);

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
@@ -105,7 +105,7 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::ClosestPointInObje
     const double                                             curdistance = curpos.EuclideanDistanceTo(point);
     if (curdistance < closestPointDistance)
     {
-      closestPoint = (*it);
+      closestPoint = *it;
       closestPointDistance = curdistance;
     }
     ++it;
@@ -134,7 +134,7 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::ClosestPointInWorl
     const double                                             curdistance = curpos.EuclideanDistanceTo(point);
     if (curdistance < closestPointDistance)
     {
-      closestPoint = (*it);
+      closestPoint = *it;
       closestPointDistance = curdistance;
     }
     ++it;

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -123,7 +123,7 @@ SpatialObject<TDimension>::DerivativeAtInObjectSpace(const PointType &          
       DerivativeAtInObjectSpace(p1, order - 1, v1, depth, name, offsetDiv2);
       DerivativeAtInObjectSpace(p2, order - 1, v2, depth, name, offsetDiv2);
 
-      (*it) = ((*it_v2) - (*it_v1)) / 2;
+      *it = (*it_v2 - *it_v1) / 2;
     }
   }
 }

--- a/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
@@ -196,7 +196,7 @@ itkDTITubeSpatialObjectTest(int, char *[])
 
     for (unsigned int i = 0; it != end; ++itTest, ++it, i++)
     {
-      if ((*itTest) != (*it))
+      if (*itTest != *it)
       {
         passed = false;
         break;
@@ -239,7 +239,7 @@ itkDTITubeSpatialObjectTest(int, char *[])
 
     for (unsigned int i = 0; it != end; ++itTest, ++it, i++)
     {
-      if ((*itTest) != (*it))
+      if (*itTest != *it)
       {
         passed = false;
         break;

--- a/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
@@ -211,7 +211,7 @@ itkTubeSpatialObjectTest(int, char *[])
 
     for (unsigned int i = 0; it != end; ++itTest, ++it, i++)
     {
-      if ((*itTest) != (*it))
+      if (*itTest != *it)
       {
         passed = false;
         break;
@@ -254,7 +254,7 @@ itkTubeSpatialObjectTest(int, char *[])
 
     for (unsigned int i = 0; it != end; ++itTest, ++it, i++)
     {
-      if ((*itTest) != (*it))
+      if (*itTest != *it)
       {
         passed = false;
         break;

--- a/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
+++ b/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
@@ -186,7 +186,7 @@ ProcessArguments(int * argc, ArgumentStringType * argv, ProcessedOutputType * pr
         return 1;
       }
       regressionTestParameters.compareList.emplace_back((*argv)[i + 1], (*argv)[i + 2]);
-      (*argv) += 3;
+      *argv += 3;
       *argc -= 3;
     }
     else if (!skip && strcmp((*argv)[i], "--compare-MD5") == 0)
@@ -211,8 +211,8 @@ ProcessArguments(int * argc, ArgumentStringType * argv, ProcessedOutputType * pr
       std::vector<std::string> hashVector;
       hashVector.push_back(md5hash0);
 
-      (*argv) += 3;
-      (*argc) -= 3;
+      *argv += 3;
+      *argc -= 3;
 
       // continue eating hash values
       while (*argc - i > 0)
@@ -291,7 +291,7 @@ ProcessArguments(int * argc, ArgumentStringType * argv, ProcessedOutputType * pr
         return 1;
       }
       regressionTestParameters.radiusTolerance = std::stoi((*argv)[i + 1]);
-      (*argv) += 2;
+      *argv += 2;
       *argc -= 2;
     }
     else if (!skip && strcmp((*argv)[i], "--compareIntensityTolerance") == 0)
@@ -302,7 +302,7 @@ ProcessArguments(int * argc, ArgumentStringType * argv, ProcessedOutputType * pr
         return 1;
       }
       regressionTestParameters.intensityTolerance = std::stod((*argv)[i + 1]);
-      (*argv) += 2;
+      *argv += 2;
       *argc -= 2;
     }
     else if (!skip && strcmp((*argv)[i], "--compareCoordinateTolerance") == 0)
@@ -313,7 +313,7 @@ ProcessArguments(int * argc, ArgumentStringType * argv, ProcessedOutputType * pr
         return 1;
       }
       regressionTestParameters.coordinateTolerance = std::stod((*argv)[i + 1]);
-      (*argv) += 2;
+      *argv += 2;
       *argc -= 2;
     }
     else if (!skip && strcmp((*argv)[i], "--compareDirectionTolerance") == 0)
@@ -324,13 +324,13 @@ ProcessArguments(int * argc, ArgumentStringType * argv, ProcessedOutputType * pr
         return 1;
       }
       regressionTestParameters.directionTolerance = std::stod((*argv)[i + 1]);
-      (*argv) += 2;
+      *argv += 2;
       *argc -= 2;
     }
     else if (!skip && strcmp((*argv)[i], "--ignoreInputInformation") == 0)
     {
       regressionTestParameters.verifyInputInformation = false;
-      (*argv) += 1;
+      *argv += 1;
       *argc -= 1;
     }
     else if (!skip && strcmp((*argv)[i], "--add-before-libpath") == 0)
@@ -344,7 +344,7 @@ ProcessArguments(int * argc, ArgumentStringType * argv, ProcessedOutputType * pr
       {
         processedOutput->add_before_libpath.push_back((*argv)[i + 1]);
       }
-      (*argv) += 2;
+      *argv += 2;
       *argc -= 2;
     }
     else if (!skip && strcmp((*argv)[i], "--add-before-env") == 0)
@@ -359,7 +359,7 @@ ProcessArguments(int * argc, ArgumentStringType * argv, ProcessedOutputType * pr
         processedOutput->add_before_env.push_back((*argv)[i + 1]);
         processedOutput->add_before_env.push_back((*argv)[i + 2]);
       }
-      (*argv) += 3;
+      *argv += 3;
       *argc -= 3;
     }
     else if (!skip && strcmp((*argv)[i], "--add-before-env-with-sep") == 0)
@@ -375,7 +375,7 @@ ProcessArguments(int * argc, ArgumentStringType * argv, ProcessedOutputType * pr
         processedOutput->add_before_env_with_sep.push_back((*argv)[i + 2]);
         processedOutput->add_before_env_with_sep.push_back((*argv)[i + 3]);
       }
-      (*argv) += 4;
+      *argv += 4;
       *argc -= 4;
     }
     else if (!skip && strcmp((*argv)[i], "--remove-env") == 0)
@@ -388,7 +388,7 @@ ProcessArguments(int * argc, ArgumentStringType * argv, ProcessedOutputType * pr
 
       itksys::SystemTools::UnPutEnv((*argv)[i + 1]);
 
-      (*argv) += 2;
+      *argv += 2;
       *argc -= 2;
     }
     else if (!skip && strcmp((*argv)[i], "--full-output") == 0)
@@ -396,7 +396,7 @@ ProcessArguments(int * argc, ArgumentStringType * argv, ProcessedOutputType * pr
       // emit the string to tell ctest that the full output should be
       // passed to cdash.
       std::cout << "CTEST_FULL_OUTPUT" << std::endl;
-      (*argv) += 1;
+      *argv += 1;
       *argc -= 1;
     }
     else if (!skip && strcmp((*argv)[i], "--no-process") == 0)
@@ -407,7 +407,7 @@ ProcessArguments(int * argc, ArgumentStringType * argv, ProcessedOutputType * pr
       {
         processedOutput->externalProcessMustBeCalled = false;
       }
-      (*argv) += 1;
+      *argv += 1;
       *argc -= 1;
     }
     else if (!skip && strcmp((*argv)[i], "--redirectOutput") == 0)

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -990,7 +990,7 @@ CompositeTransform<TParametersValueType, VDimension>::InternalClone() const
        ++tqIt, ++tfIt, ++i)
   {
     clone->AddTransform((*tqIt)->Clone().GetPointer());
-    clone->SetNthTransformToOptimize(i, (*tfIt));
+    clone->SetNthTransformToOptimize(i, *tfIt);
   }
   return loPtr;
 }

--- a/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
@@ -106,8 +106,8 @@ NormalizedCorrelationImageFilter<TInputImage, TMaskImage, TOutputImage, TOperato
          tIt < this->GetOperator().End();
          ++tIt)
     {
-      sum += (*tIt);
-      sumOfSquares += ((*tIt) * (*tIt));
+      sum += *tIt;
+      sumOfSquares += (*tIt * *tIt);
     }
   }
   auto                      num = static_cast<OutputPixelRealType>(this->GetOperator().Size());

--- a/Modules/Filtering/FFT/include/itkVnlComplexToComplex1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlComplexToComplex1DFFTImageFilter.hxx
@@ -103,7 +103,7 @@ VnlComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
           outputIt.GoToBeginOfLine();
           while (!outputIt.IsAtEndOfLine())
           {
-            outputIt.Set((*outputBufferIt) / static_cast<PixelType>(vectorSize));
+            outputIt.Set(*outputBufferIt / static_cast<PixelType>(vectorSize));
             ++outputIt;
             ++outputBufferIt;
           }

--- a/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
@@ -288,7 +288,7 @@ BilateralImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
           // normalization factor so filter integrates to one
           // (product of the domain and the range gaussian)
-          const OutputPixelRealType gaussianProduct = (*k_it) * rangeGaussian;
+          const OutputPixelRealType gaussianProduct = *k_it * rangeGaussian;
           normFactor += gaussianProduct;
 
           // Input Image * Domain Gaussian * Range Gaussian

--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.hxx
@@ -54,7 +54,7 @@ MovingHistogramImageFilter<TInputImage, TOutputImage, TKernel, THistogram>::Dyna
   // initialize the histogram
   for (auto listIt = this->m_KernelOffsets.begin(); listIt != this->m_KernelOffsets.end(); ++listIt)
   {
-    const IndexType idx = outputRegionForThread.GetIndex() + (*listIt);
+    const IndexType idx = outputRegionForThread.GetIndex() + *listIt;
     if (inputRegion.IsInside(idx))
     {
       histogram.AddPixel(inputImage->GetPixel(idx));
@@ -185,11 +185,11 @@ MovingHistogramImageFilter<TInputImage, TOutputImage, TKernel, THistogram>::Push
     // update the histogram
     for (auto addedIt = addedList->begin(); addedIt != addedList->end(); ++addedIt)
     {
-      histogram.AddPixel(inputImage->GetPixel(currentIdx + (*addedIt)));
+      histogram.AddPixel(inputImage->GetPixel(currentIdx + *addedIt));
     }
     for (auto removedIt = removedList->begin(); removedIt != removedList->end(); ++removedIt)
     {
-      histogram.RemovePixel(inputImage->GetPixel(currentIdx + (*removedIt)));
+      histogram.RemovePixel(inputImage->GetPixel(currentIdx + *removedIt));
     }
   }
   else
@@ -197,7 +197,7 @@ MovingHistogramImageFilter<TInputImage, TOutputImage, TKernel, THistogram>::Push
     // update the histogram
     for (auto addedIt = addedList->begin(); addedIt != addedList->end(); ++addedIt)
     {
-      const IndexType idx = currentIdx + (*addedIt);
+      const IndexType idx = currentIdx + *addedIt;
       if (inputRegion.IsInside(idx))
       {
         histogram.AddPixel(inputImage->GetPixel(idx));
@@ -209,7 +209,7 @@ MovingHistogramImageFilter<TInputImage, TOutputImage, TKernel, THistogram>::Push
     }
     for (auto removedIt = removedList->begin(); removedIt != removedList->end(); ++removedIt)
     {
-      const IndexType idx = currentIdx + (*removedIt);
+      const IndexType idx = currentIdx + *removedIt;
       if (inputRegion.IsInside(idx))
       {
         histogram.RemovePixel(inputImage->GetPixel(idx));

--- a/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.hxx
+++ b/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.hxx
@@ -204,7 +204,7 @@ BinaryContourImageFilter<TInputImage, TOutputImage>::ThreadedIntegrateData(const
     {
       for (auto I = this->m_LineOffsets.begin(); I != this->m_LineOffsets.end(); ++I)
       {
-        const OffsetValueType neighIdx = thisIdx + (*I);
+        const OffsetValueType neighIdx = thisIdx + *I;
 
         // check if the neighbor is in the map
         if (neighIdx >= 0 && neighIdx < OffsetValueType(linecount) && !m_BackgroundLineMap[neighIdx].empty())

--- a/Modules/Filtering/ImageLabel/include/itkLabelContourImageFilter.hxx
+++ b/Modules/Filtering/ImageLabel/include/itkLabelContourImageFilter.hxx
@@ -168,7 +168,7 @@ LabelContourImageFilter<TInputImage, TOutputImage>::ThreadedIntegrateData(
     {
       for (auto I = this->m_LineOffsets.begin(); I != this->m_LineOffsets.end(); ++I)
       {
-        const OffsetValueType neighIdx = thisIdx + (*I);
+        const OffsetValueType neighIdx = thisIdx + *I;
 
         // check if the neighbor is in the map
         if (neighIdx >= 0 && neighIdx < linecount)

--- a/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
+++ b/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
@@ -474,7 +474,7 @@ protected:
         auto it = this->m_LineOffsets.begin();
         while (it != this->m_LineOffsets.end())
         {
-          const OffsetValueType neighIdx = thisIdx + (*it);
+          const OffsetValueType neighIdx = thisIdx + *it;
           // check if the neighbor is in the map
           if (neighIdx >= 0 && neighIdx < linecount && !m_LineMap[neighIdx].empty())
           {

--- a/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
@@ -146,7 +146,7 @@ MaskedMovingHistogramImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel,
   // initialize the histogram
   for (auto listIt = this->m_KernelOffsets.begin(); listIt != this->m_KernelOffsets.end(); ++listIt)
   {
-    const IndexType idx = outputRegionForThread.GetIndex() + (*listIt);
+    const IndexType idx = outputRegionForThread.GetIndex() + *listIt;
     if (inputRegion.IsInside(idx) && maskImage->GetPixel(idx) == m_MaskValue)
     {
       histogram.AddPixel(inputImage->GetPixel(idx));
@@ -294,7 +294,7 @@ MaskedMovingHistogramImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel,
     // update the histogram
     for (auto addedIt = addedList->begin(); addedIt != addedList->end(); ++addedIt)
     {
-      const typename InputImageType::IndexType idx = currentIdx + (*addedIt);
+      const typename InputImageType::IndexType idx = currentIdx + *addedIt;
       if (maskImage->GetPixel(idx) == m_MaskValue)
       {
         histogram.AddPixel(inputImage->GetPixel(idx));
@@ -306,7 +306,7 @@ MaskedMovingHistogramImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel,
     }
     for (auto removedIt = removedList->begin(); removedIt != removedList->end(); ++removedIt)
     {
-      const typename InputImageType::IndexType idx = currentIdx + (*removedIt);
+      const typename InputImageType::IndexType idx = currentIdx + *removedIt;
       if (maskImage->GetPixel(idx) == m_MaskValue)
       {
         histogram.RemovePixel(inputImage->GetPixel(idx));
@@ -322,7 +322,7 @@ MaskedMovingHistogramImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel,
     // update the histogram
     for (auto addedIt = addedList->begin(); addedIt != addedList->end(); ++addedIt)
     {
-      const IndexType idx = currentIdx + (*addedIt);
+      const IndexType idx = currentIdx + *addedIt;
       if (inputRegion.IsInside(idx) && maskImage->GetPixel(idx) == m_MaskValue)
       {
         histogram.AddPixel(inputImage->GetPixel(idx));
@@ -334,7 +334,7 @@ MaskedMovingHistogramImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel,
     }
     for (auto removedIt = removedList->begin(); removedIt != removedList->end(); ++removedIt)
     {
-      const IndexType idx = currentIdx + (*removedIt);
+      const IndexType idx = currentIdx + *removedIt;
       if (inputRegion.IsInside(idx) && maskImage->GetPixel(idx) == m_MaskValue)
       {
         histogram.RemovePixel(inputImage->GetPixel(idx));

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkCleanQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkCleanQuadEdgeMeshFilter.hxx
@@ -110,7 +110,7 @@ CleanQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::MergePoints(const InputCoordin
            pit != polygonCell->InternalPointIdsEnd();
            ++pit)
       {
-        points.push_back((*pit));
+        points.push_back(*pit);
       }
       output->AddFaceWithSecurePointList(points);
     }

--- a/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
@@ -110,7 +110,7 @@ isNoPreambleDicom(std::ifstream & file) // NOTE: Similar function is in itkGDCMI
       auto * uilength = reinterpret_cast<unsigned int *>(lengthChars);
       itk::ByteSwapper<unsigned int>::SwapFromSystemToLittleEndian(uilength);
 
-      length = (*uilength);
+      length = *uilength;
     }
     if (length <= 0)
     {

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -164,7 +164,7 @@ readNoPreambleDicom(std::ifstream & file) // NOTE: This file is duplicated in it
       auto * uilength = reinterpret_cast<unsigned int *>(lengthChars);
       ByteSwapper<unsigned int>::SwapFromSystemToLittleEndian(uilength);
 
-      length = (*uilength);
+      length = *uilength;
     }
     if (length <= 0)
     {

--- a/Modules/IO/IPL/src/itkIPLFileNameList.cxx
+++ b/Modules/IO/IPL/src/itkIPLFileNameList.cxx
@@ -147,7 +147,7 @@ IPLFileNameList::~IPLFileNameList()
 
   while (it != itend)
   {
-    delete (*it);
+    delete *it;
     ++it;
   }
 }

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
@@ -282,7 +282,7 @@ ImageSeriesWriter<TInputImage, TOutputImage>::WriteFiles()
                                                  << m_MetaDataDictionaryArray->size() << '.');
         }
         DictionaryRawPointer dictionary = (*m_MetaDataDictionaryArray)[slice];
-        m_ImageIO->SetMetaDataDictionary((*dictionary));
+        m_ImageIO->SetMetaDataDictionary(*dictionary);
       }
       else
       {

--- a/Modules/IO/ImageBase/src/itkArchetypeSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkArchetypeSeriesFileNames.cxx
@@ -127,13 +127,13 @@ ArchetypeSeriesFileNames::Scan()
   for (std::string::iterator sit = fileName.begin(); sit < fileName.end(); ++sit)
   {
     // If the element is a number, find its starting index and length.
-    if ((*sit) >= '0' && (*sit) <= '9')
+    if (*sit >= '0' && *sit <= '9')
     {
       const int sIndex = static_cast<int>(sit - fileName.begin());
       numGroupStart.push_back(sIndex);
 
       // Loop to one past the end of the group of numbers.
-      while (sit != fileName.end() && (*sit) >= '0' && (*sit) <= '9')
+      while (sit != fileName.end() && *sit >= '0' && *sit <= '9')
       {
         ++sit;
       }

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -1515,7 +1515,7 @@ TIFFImageIO::PutPaletteRGB(TType *      to,
   {
     for (unsigned int x = xsize; x-- > 0;)
     {
-      const TFromType index = (*from) % m_TotalColors;
+      const TFromType index = *from % m_TotalColors;
 
       const auto red = static_cast<TType>(*(m_ColorRed + index));
       const auto green = static_cast<TType>(*(m_ColorGreen + index));

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionSharedData.h
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionSharedData.h
@@ -118,7 +118,7 @@ public:
     auto end = m_LevelSetDataPointerVector.end();
     while (it != end)
     {
-      (*it) = LevelSetDataType::New();
+      *it = LevelSetDataType::New();
       ++it;
     }
   }

--- a/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.hxx
@@ -154,7 +154,7 @@ ImageMetricLoad<TMoving, TFixed>::EvaluateMetricGivenSolution(Element::ArrayType
   {
     for (unsigned int i = 0; i < m_NumberOfIntegrationPoints; ++i)
     {
-      static_cast<Element *>((*elt))->GetIntegrationPointAndWeight(i, ip, w, m_NumberOfIntegrationPoints);
+      static_cast<Element *>(*elt)->GetIntegrationPointAndWeight(i, ip, w, m_NumberOfIntegrationPoints);
       // FIXME REMOVE WHEN ELEMENT NEW IS BASE CLASS
       shapef = (*elt)->ShapeFunctions(ip);
 
@@ -222,7 +222,7 @@ ImageMetricLoad<TMoving, TFixed>::EvaluateMetricGivenSolution1(Element::ArrayTyp
   {
     for (unsigned int i = 0; i < m_NumberOfIntegrationPoints; ++i)
     {
-      static_cast<Element *>((*elt))->GetIntegrationPointAndWeight(i, ip, w, m_NumberOfIntegrationPoints);
+      static_cast<Element *>(*elt)->GetIntegrationPointAndWeight(i, ip, w, m_NumberOfIntegrationPoints);
       // FIXME REMOVE WHEN ELEMENT NEW IS BASE CLASS
       shapef = (*elt)->ShapeFunctions(ip);
 

--- a/Modules/Numerics/FEM/include/itkFEMSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.hxx
@@ -401,7 +401,7 @@ Solver<VDimension>::AssembleF(int dim)
         // we apply the load to all elements in that array.
         for (auto i = l1->GetElementArray().begin(); i != l1->GetElementArray().end(); i++)
         {
-          const Element * el0 = (*i);
+          const Element * el0 = *i;
           // Call the Fe() function of the element that we are applying the load
           // to.
           // We pass a pointer to the load object as a parameter and a reference

--- a/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.hxx
+++ b/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.hxx
@@ -64,7 +64,7 @@ MetaFEMObjectConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectTy
 
   while (it_nodes != nodelist.end())
   {
-    FEMObjectNode * node = (*it_nodes);
+    FEMObjectNode * node = *it_nodes;
 
     // create a new object of the correct class
     // a = FEMOF::Create(clID);
@@ -91,7 +91,7 @@ MetaFEMObjectConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectTy
 
   while (it_material != materiallist.end())
   {
-    FEMObjectMaterial * material = (*it_material);
+    FEMObjectMaterial * material = *it_material;
 
     auto o1 = fem::MaterialLinearElasticity::New();
     o1->SetGlobalNumber(material->m_GN);
@@ -113,7 +113,7 @@ MetaFEMObjectConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectTy
 
   while (it_elements != elementlist.end())
   {
-    FEMObjectElement *        element = (*it_elements);
+    FEMObjectElement *        element = *it_elements;
     itk::LightObject::Pointer a = ObjectFactoryBase::CreateInstance(element->m_ElementName);
     a->UnRegister();
     fem::Element::Pointer o1 = dynamic_cast<fem::Element *>(a.GetPointer());
@@ -137,7 +137,7 @@ MetaFEMObjectConverter<VDimension>::MetaObjectToSpatialObject(const MetaObjectTy
 
   while (it_load != loadlist.end())
   {
-    FEMObjectLoad * load = (*it_load);
+    FEMObjectLoad * load = *it_load;
 
     std::string loadname(load->m_LoadName);
     if (loadname == "LoadNode")

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangular.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangular.cxx
@@ -284,7 +284,7 @@ invJ2[1][1]=idet*((*pJ)[0][0]-(*pJ)[2][0]);
 invJ2[1][2]=idet*((*pJ)[1][0]-(*pJ)[0][0]);
 
 std::cout << " pJ " << std::endl;
-std::cout << (*pJ) << std::endl;
+std::cout << *pJ << std::endl;
 
 std::cout << " invJ " << std::endl;
 std::cout << (invJ) << std::endl;

--- a/Modules/Numerics/FEM/src/itkFEMElementBase.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElementBase.cxx
@@ -288,7 +288,7 @@ Element::Jacobian(const VectorType & pt, MatrixType & J, const MatrixType * psha
     coords.set_row(n, p);
   }
 
-  J = (*pshapeD) * coords;
+  J = *pshapeD * coords;
 }
 
 Element::Float
@@ -355,7 +355,7 @@ Element::ShapeFunctionGlobalDerivatives(const VectorType & pt,
   MatrixType invJ;
   this->JacobianInverse(pt, invJ, pJ);
 
-  shapeDgl = invJ * (*pshapeD);
+  shapeDgl = invJ * *pshapeD;
 }
 
 Element::VectorType

--- a/Modules/Numerics/FEM/src/itkFEMLoadLandmark.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadLandmark.cxx
@@ -146,7 +146,7 @@ LoadLandmark::ApplyLoad(Element::ConstPointer element, Element::VectorType & Fe)
 
   // Determine the displacement at point pt
   constexpr unsigned int TotalSolutionIndex = 1;
-  disp = element->InterpolateSolution(pt, (*sol), TotalSolutionIndex);
+  disp = element->InterpolateSolution(pt, *sol, TotalSolutionIndex);
 
   // Convert the source to global coordinates
   new_source = this->GetSource() + disp;

--- a/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
@@ -34,7 +34,7 @@ FRPROptimizer::GetValueAndDerivative(ParametersType & p, double * val, Parameter
   this->m_CostFunction->GetValueAndDerivative(p, *val, *xi);
   if (this->GetMaximize())
   {
-    (*val) *= -1;
+    *val *= -1;
     for (unsigned int i = 0; i < this->GetSpaceDimension(); ++i)
     {
       (*xi)[i] *= -1;
@@ -69,7 +69,7 @@ FRPROptimizer::LineOptimize(ParametersType * p, ParametersType & xi, double * va
   this->SetLine(*p, xi);
 
   double ax = 0.0;
-  double fa = (*val);
+  double fa = *val;
   double xx = this->GetStepLength();
   double fx = NAN;
   double bx = NAN;
@@ -84,8 +84,8 @@ FRPROptimizer::LineOptimize(ParametersType * p, ParametersType & xi, double * va
   this->BracketedLineOptimize(ax, xx, bx, fa, fx, fb, &extX, &extVal, tempCoord);
   this->SetCurrentLinePoint(extX, extVal);
 
-  (*p) = this->GetCurrentPosition();
-  (*val) = extVal;
+  *p = this->GetCurrentPosition();
+  *val = extVal;
 }
 
 void

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
@@ -342,7 +342,7 @@ ParticleSwarmOptimizerBase::ValidateSettings()
     const auto end = this->m_Particles.end();
     for (auto it = this->m_Particles.begin(); it != end; ++it)
     {
-      ParticleData & p = (*it);
+      ParticleData & p = *it;
       for (unsigned int i = 0; i < n; ++i)
       {
         if (p.m_CurrentParameters[i] < m_ParameterBounds[i].first ||

--- a/Modules/Numerics/Optimizersv4/test/itkMultiGradientOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkMultiGradientOptimizerv4Test.cxx
@@ -110,14 +110,14 @@ public:
     const double x = (*m_Parameters)[0];
     const double y = (*m_Parameters)[1];
     const double metric = 0.5 * (3 * x * x + 4 * x * y + 6 * y * y) - 2 * x + 8 * y;
-    std::cout << (*m_Parameters) << " metric " << metric << std::endl;
+    std::cout << *m_Parameters << " metric " << metric << std::endl;
     return metric;
   }
 
   void
   UpdateTransformParameters(const DerivativeType & update, ParametersValueType) override
   {
-    (*m_Parameters) += update;
+    *m_Parameters += update;
   }
 
   unsigned int
@@ -149,7 +149,7 @@ public:
   const ParametersType &
   GetParameters() const override
   {
-    return (*m_Parameters);
+    return *m_Parameters;
   }
 
 private:
@@ -225,7 +225,7 @@ public:
     const double x = (*m_Parameters)[0];
     const double y = (*m_Parameters)[1];
     const double metric = 0.5 * (3 * x * x + 4 * x * y + 6 * y * y) - x + 4 * y;
-    std::cout << (*m_Parameters) << " metric " << metric << std::endl;
+    std::cout << *m_Parameters << " metric " << metric << std::endl;
     return metric;
   }
 
@@ -238,7 +238,7 @@ public:
   void
   UpdateTransformParameters(const DerivativeType & update, ParametersValueType) override
   {
-    (*m_Parameters) += update;
+    *m_Parameters += update;
   }
 
   unsigned int
@@ -264,7 +264,7 @@ public:
   const ParametersType &
   GetParameters() const override
   {
-    return (*m_Parameters);
+    return *m_Parameters;
   }
 
 private:

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
@@ -107,7 +107,7 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
     auto weightIt = this->m_LandmarkWeight.begin();
     for (unsigned int i = 0; weightIt != this->m_LandmarkWeight.end(); ++i, ++weightIt)
     {
-      weights->InsertElement(i, (*weightIt));
+      weights->InsertElement(i, *weightIt);
     }
   }
   else
@@ -126,7 +126,7 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
   auto movingIt = this->m_MovingLandmarks.begin();
   for (size_t i = 0; fixedIt != this->m_FixedLandmarks.end(); ++i, ++fixedIt, ++movingIt)
   {
-    pointSet->SetPoint(static_cast<typename PointSetType::PointIdentifier>(i), (*fixedIt));
+    pointSet->SetPoint(static_cast<typename PointSetType::PointIdentifier>(i), *fixedIt);
     VectorType vectorTmp;
     for (unsigned int d = 0; d < ImageDimension; ++d)
     {
@@ -222,7 +222,7 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
     auto weightIt = this->m_LandmarkWeight.begin();
     for (unsigned int i = 0; weightIt != this->m_LandmarkWeight.end(); ++i, ++weightIt)
     {
-      vnlWeight(i, i) = (*weightIt);
+      vnlWeight(i, i) = *weightIt;
     }
   }
   // Normalize weights.

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -779,7 +779,7 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAn
           for (unsigned int parameter = 0; parameter < this->m_NumberOfParameters; ++parameter, derivPtr++)
           {
             // Ref: eqn 23 of Thevenaz & Unser paper [3]
-            derivative[parameter] -= (*derivPtr) * pRatio;
+            derivative[parameter] -= *derivPtr * pRatio;
           } // end for-loop over parameters
         }
         else

--- a/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.hxx
@@ -304,7 +304,7 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDeriv
   {
     /** FIXME: is there a way to avoid the extra copying step? */
     this->CalculateDerivatives(aiter->FixedImagePointValue, tempDeriv, jacobian);
-    (*aditer) = tempDeriv;
+    *aditer = tempDeriv;
   }
 
   DerivativeType derivB(numberOfParameters);
@@ -362,7 +362,7 @@ MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndDeriv
       weight *= biter->MovingImageValue - aiter->MovingImageValue;
 
       totalWeight += weight;
-      derivative -= (*aditer) * weight;
+      derivative -= *aditer * weight;
     } // end of sample A loop
 
     derivative += derivB * totalWeight.GetSum();

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
@@ -400,7 +400,7 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
                    ++parameter, derivPtr++)
               {
                 // Ref: eqn 23 of Thevenaz & Unser paper [3]
-                (*(this->m_DerivativeResult))[parameter] += (*derivPtr) * pRatio;
+                (*(this->m_DerivativeResult))[parameter] += *derivPtr * pRatio;
               } // end for-loop over parameters
             }
             else

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationRegion.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationRegion.cxx
@@ -299,7 +299,7 @@ KLMSegmentationRegion::SpliceRegionBorders(Self * region)
     // Ensure that there are no common borders in the new region
     if (((*thisRegionBordersIt)->GetRegion1() == (*thisRegionBordersIt)->GetRegion2()) ||
         ((*thatRegionBordersIt)->GetRegion1() == (*thatRegionBordersIt)->GetRegion2()) ||
-        ((*thisRegionBordersIt) == (*thatRegionBordersIt)))
+        (*thisRegionBordersIt == *thatRegionBordersIt))
     {
       itkExceptionStringMacro("Invalid region border list");
     }
@@ -321,7 +321,7 @@ KLMSegmentationRegion::SpliceRegionBorders(Self * region)
       // The border's region1 is the neighbor
       if ((*thatRegionBordersIt)->GetRegion2() == this)
       {
-        (*thatRegionBordersIt)->GetRegion1()->DeleteRegionBorder((*thatRegionBordersIt));
+        (*thatRegionBordersIt)->GetRegion1()->DeleteRegionBorder(*thatRegionBordersIt);
       } // end if (the border's region1 is the neighbor )
 
       // The border's region2 is the neighbor
@@ -468,7 +468,7 @@ KLMSegmentationRegion::PrintRegionInfo()
     const int region1label = (*tempVectorIt)->GetRegion1()->GetRegionLabel();
     const int region2label = (*tempVectorIt)->GetRegion2()->GetRegionLabel();
 
-    std::cout << "Border Ptr :" << (*tempVectorIt) << "( " << region1label << " - " << region2label << " )"
+    std::cout << "Border Ptr :" << *tempVectorIt << "( " << region1label << " - " << region2label << " )"
               << " Lambda = " << (*tempVectorIt)->GetLambda() << std::endl;
 
     ++tempVectorIt;

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -425,7 +425,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::UpdateActiveLayerValu
     else
     {
       rms_change_accumulator += itk::Math::sqr(new_value - outputIt.GetCenterPixel());
-      // rms_change_accumulator += (*updateIt) * (*updateIt);
+      // rms_change_accumulator += *updateIt * *updateIt;
       outputIt.SetCenterPixel(new_value);
       ++layerIt;
     }

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.hxx
@@ -41,7 +41,7 @@ VoronoiPartitioningImageFilter<TInputImage, TOutputImage>::ClassifyDiagram()
     VertList.clear();
     for (currPit = currCell->PointIdsBegin(); currPit != currPitEnd; ++currPit)
     {
-      this->m_WorkingVD->GetPoint((*currPit), &(currP));
+      this->m_WorkingVD->GetPoint(*currPit, &(currP));
       VertList.push_back(currP);
     }
 
@@ -106,7 +106,7 @@ VoronoiPartitioningImageFilter<TInputImage, TOutputImage>::MakeSegmentBoundary()
     nitend = this->m_WorkingVD->NeighborIdsEnd(i);
     for (nit = this->m_WorkingVD->NeighborIdsBegin(i); nit != nitend; ++nit)
     {
-      if ((*nit) > i)
+      if (*nit > i)
       {
         this->drawLine(this->m_WorkingVD->GetSeed(i), this->m_WorkingVD->GetSeed(*nit));
       }
@@ -138,7 +138,7 @@ VoronoiPartitioningImageFilter<TInputImage, TOutputImage>::MakeSegmentObject()
     VertList.clear();
     for (currPit = currCell->PointIdsBegin(); currPit != currPitEnd; ++currPit)
     {
-      this->m_WorkingVD->GetPoint((*currPit), &(currP));
+      this->m_WorkingVD->GetPoint(*currPit, &(currP));
       VertList.push_back(currP);
     }
     // Need to fill with an segment identifier

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
@@ -337,7 +337,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
     for (PointIdIterator currPit = currCell->PointIdsBegin(); currPit != currPitEnd; ++currPit)
     {
       PointType currP;
-      m_WorkingVD->GetPoint((*currPit), &(currP));
+      m_WorkingVD->GetPoint(*currPit, &(currP));
       VertList.push_back(currP);
     }
     IndexList PixelPool;
@@ -534,7 +534,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
       const auto nitend = m_WorkingVD->NeighborIdsEnd(i);
       for (auto nit = m_WorkingVD->NeighborIdsBegin(i); nit != nitend; ++nit)
       {
-        if (((*nit) > i) && (m_Label[*nit] == 2))
+        if ((*nit > i) && (m_Label[*nit] == 2))
         {
           drawLine(m_WorkingVD->GetSeed(i), m_WorkingVD->GetSeed(*nit));
         }
@@ -567,7 +567,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
       for (PointIdIterator currPit = currCell->PointIdsBegin(); currPit != currPitEnd; ++currPit)
       {
         PointType currP;
-        m_WorkingVD->GetPoint((*currPit), &(currP));
+        m_WorkingVD->GetPoint(*currPit, &(currP));
         VertList.push_back(currP);
       }
       FillPolygon(VertList);


### PR DESCRIPTION
Replaced `([ \(])\(\*(\w+)\)([ \),])` with `$1*$2$3`, using regular expressions.