### PR TITLE
STYLE: Remove unnecessary parentheses when doing "address-of" by `(&x)`

### DIFF
--- a/Modules/Core/GPUFiniteDifference/include/itkGPUDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUDenseFiniteDifferenceImageFilter.hxx
@@ -134,7 +134,7 @@ GPUDenseFiniteDifferenceImageFilter<TInputImage, TOutputImage, TParentImageFilte
   int argidx = 0;
   this->m_GPUKernelManager->SetKernelArgWithImage(m_ApplyUpdateGPUKernelHandle, argidx++, bfPtr->GetGPUDataManager());
   this->m_GPUKernelManager->SetKernelArgWithImage(m_ApplyUpdateGPUKernelHandle, argidx++, otPtr->GetGPUDataManager());
-  this->m_GPUKernelManager->SetKernelArg(m_ApplyUpdateGPUKernelHandle, argidx++, sizeof(float), &(timeStep));
+  this->m_GPUKernelManager->SetKernelArg(m_ApplyUpdateGPUKernelHandle, argidx++, sizeof(float), &timeStep);
   for (int i = 0; i < ImageDim; ++i)
   {
     this->m_GPUKernelManager->SetKernelArg(m_ApplyUpdateGPUKernelHandle, argidx++, sizeof(int), &(imgSize[i]));

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientNDAnisotropicDiffusionFunction.hxx
@@ -159,7 +159,7 @@ GPUGradientNDAnisotropicDiffusionFunction<TImage>::GPUComputeUpdate(const typena
   this->m_GPUKernelManager->SetKernelArgWithImage(
     this->m_ComputeUpdateGPUKernelHandle, argidx++, bfPtr->GetGPUDataManager());
   this->m_GPUKernelManager->SetKernelArg(
-    this->m_ComputeUpdateGPUKernelHandle, argidx++, sizeof(typename TImage::PixelType), &(m_K));
+    this->m_ComputeUpdateGPUKernelHandle, argidx++, sizeof(typename TImage::PixelType), &m_K);
 
   // filter scale parameter
   for (int i = 0; i < ImageDim; ++i)

--- a/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.h
+++ b/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.h
@@ -69,10 +69,10 @@ public:
   int
   SetGPUKernelArguments(GPUKernelManager::Pointer KernelManager, int KernelHandle) override
   {
-    KernelManager->SetKernelArg(KernelHandle, 0, sizeof(TInput), &(m_LowerThreshold));
-    KernelManager->SetKernelArg(KernelHandle, 1, sizeof(TInput), &(m_UpperThreshold));
-    KernelManager->SetKernelArg(KernelHandle, 2, sizeof(TOutput), &(m_InsideValue));
-    KernelManager->SetKernelArg(KernelHandle, 3, sizeof(TOutput), &(m_OutsideValue));
+    KernelManager->SetKernelArg(KernelHandle, 0, sizeof(TInput), &m_LowerThreshold);
+    KernelManager->SetKernelArg(KernelHandle, 1, sizeof(TInput), &m_UpperThreshold);
+    KernelManager->SetKernelArg(KernelHandle, 2, sizeof(TOutput), &m_InsideValue);
+    KernelManager->SetKernelArg(KernelHandle, 3, sizeof(TOutput), &m_OutsideValue);
     return 4;
   }
 

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -706,11 +706,11 @@ GiplImageIO::Write(const void * buffer)
       if (m_IsCompressed)
       {
         gzwrite(
-          m_Internal->m_GzFile, reinterpret_cast<char *>(&(value)), static_cast<unsigned int>(sizeof(unsigned short)));
+          m_Internal->m_GzFile, reinterpret_cast<char *>(&value), static_cast<unsigned int>(sizeof(unsigned short)));
       }
       else
       {
-        m_Ofstream.write(reinterpret_cast<char *>(&(value)), sizeof(unsigned short));
+        m_Ofstream.write(reinterpret_cast<char *>(&value), sizeof(unsigned short));
       }
     }
     else
@@ -727,7 +727,7 @@ GiplImageIO::Write(const void * buffer)
       if (m_IsCompressed)
       {
         gzwrite(
-          m_Internal->m_GzFile, reinterpret_cast<char *>(&(value)), static_cast<unsigned int>(sizeof(unsigned short)));
+          m_Internal->m_GzFile, reinterpret_cast<char *>(&value), static_cast<unsigned int>(sizeof(unsigned short)));
       }
       else
       {

--- a/Modules/IO/MRC/src/itkMRCImageIO.cxx
+++ b/Modules/IO/MRC/src/itkMRCImageIO.cxx
@@ -459,7 +459,7 @@ MRCImageIO::WriteImageInformation(const void * buffer)
 
   // write the header
   const MRCHeaderObject::Header & header = m_MRCHeader->GetHeader();
-  file.write(static_cast<const char *>((const void *)&(header)), 1024);
+  file.write(static_cast<const char *>((const void *)&header), 1024);
 }
 
 void

--- a/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
+++ b/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
@@ -368,15 +368,15 @@ OFFMeshIO::WriteMeshInformation()
   {
     // Write number of points
     auto numberOfPoints = static_cast<itk::uint32_t>(this->m_NumberOfPoints);
-    this->WriteBufferAsBinary<itk::uint32_t>(&(numberOfPoints), outputFile, 1);
+    this->WriteBufferAsBinary<itk::uint32_t>(&numberOfPoints, outputFile, 1);
 
     // Write number of cells
     auto numberOfCells = static_cast<itk::uint32_t>(this->m_NumberOfCells);
-    this->WriteBufferAsBinary<itk::uint32_t>(&(numberOfCells), outputFile, 1);
+    this->WriteBufferAsBinary<itk::uint32_t>(&numberOfCells, outputFile, 1);
 
     // Write number of edges
     itk::uint32_t numberOfEdges = 0;
-    this->WriteBufferAsBinary<itk::uint32_t>(&(numberOfEdges), outputFile, 1);
+    this->WriteBufferAsBinary<itk::uint32_t>(&numberOfEdges, outputFile, 1);
   }
 
   outputFile.close();

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
@@ -254,7 +254,7 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::GP
   this->m_GPUKernelManager->SetKernelArgWithImage(
     m_ComputeUpdateGPUKernelHandle, argidx++, m_GPUSquaredDifference->GetGPUDataManager());
 
-  this->m_GPUKernelManager->SetKernelArg(m_ComputeUpdateGPUKernelHandle, argidx++, sizeof(float), &(normalizer));
+  this->m_GPUKernelManager->SetKernelArg(m_ComputeUpdateGPUKernelHandle, argidx++, sizeof(float), &normalizer);
   for (int i = 0; i < ImageDim; ++i)
   {
     this->m_GPUKernelManager->SetKernelArg(m_ComputeUpdateGPUKernelHandle, argidx++, sizeof(int), &(imgSize[i]));

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
@@ -395,8 +395,7 @@ GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField
     // image size
     this->m_GPUKernelManager->SetKernelArgWithImage(
       m_SmoothDisplacementFieldGPUKernelHandle, argidx++, m_GPUImageSizes);
-    this->m_GPUKernelManager->SetKernelArg(
-      m_SmoothDisplacementFieldGPUKernelHandle, argidx++, sizeof(int), &(ImageDim));
+    this->m_GPUKernelManager->SetKernelArg(m_SmoothDisplacementFieldGPUKernelHandle, argidx++, sizeof(int), &ImageDim);
 
     // smoothing kernel
     this->m_GPUKernelManager->SetKernelArgWithImage(
@@ -405,8 +404,8 @@ GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField
       m_SmoothDisplacementFieldGPUKernelHandle, argidx++, sizeof(int), &(GPUSmoothingKernelSizes[indir]));
 
     // indir and outdir
-    this->m_GPUKernelManager->SetKernelArg(m_SmoothDisplacementFieldGPUKernelHandle, argidx++, sizeof(int), &(indir));
-    this->m_GPUKernelManager->SetKernelArg(m_SmoothDisplacementFieldGPUKernelHandle, argidx++, sizeof(int), &(outdir));
+    this->m_GPUKernelManager->SetKernelArg(m_SmoothDisplacementFieldGPUKernelHandle, argidx++, sizeof(int), &indir);
+    this->m_GPUKernelManager->SetKernelArg(m_SmoothDisplacementFieldGPUKernelHandle, argidx++, sizeof(int), &outdir);
 
     // shared memory below
     this->m_GPUKernelManager->SetKernelArg(m_SmoothDisplacementFieldGPUKernelHandle,

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -526,7 +526,7 @@ VoronoiDiagram2DGenerator<TCoordinate>::deleteEdgeList(FortuneHalfEdge * task)
 {
   (task->m_Left)->m_Right = task->m_Right;
   (task->m_Right)->m_Left = task->m_Left;
-  task->m_Edge = &(m_DELETED);
+  task->m_Edge = &m_DELETED;
 }
 
 template <typename TCoordinate>
@@ -1063,14 +1063,14 @@ VoronoiDiagram2DGenerator<TCoordinate>::GenerateVDFortune()
   {
     m_ELHash[i] = nullptr;
   }
-  createHalfEdge(&(m_ELleftend), nullptr, 0);
-  createHalfEdge(&(m_ELrightend), nullptr, 0);
+  createHalfEdge(&m_ELleftend, nullptr, 0);
+  createHalfEdge(&m_ELrightend, nullptr, 0);
   m_ELleftend.m_Left = nullptr;
-  m_ELleftend.m_Right = &(m_ELrightend);
-  m_ELrightend.m_Left = &(m_ELleftend);
+  m_ELleftend.m_Right = &m_ELrightend;
+  m_ELrightend.m_Left = &m_ELleftend;
   m_ELrightend.m_Right = nullptr;
-  m_ELHash[0] = &(m_ELleftend);
-  m_ELHash[m_ELhashsize - 1] = &(m_ELrightend);
+  m_ELHash[0] = &m_ELleftend;
+  m_ELHash[m_ELhashsize - 1] = &m_ELrightend;
 
   m_BottomSite = &(m_SeedSites[0]);
   FortuneSite * currentSite = &(m_SeedSites[1]);

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.hxx
@@ -41,7 +41,7 @@ VoronoiPartitioningImageFilter<TInputImage, TOutputImage>::ClassifyDiagram()
     VertList.clear();
     for (currPit = currCell->PointIdsBegin(); currPit != currPitEnd; ++currPit)
     {
-      this->m_WorkingVD->GetPoint(*currPit, &(currP));
+      this->m_WorkingVD->GetPoint(*currPit, &currP);
       VertList.push_back(currP);
     }
 
@@ -138,7 +138,7 @@ VoronoiPartitioningImageFilter<TInputImage, TOutputImage>::MakeSegmentObject()
     VertList.clear();
     for (currPit = currCell->PointIdsBegin(); currPit != currPitEnd; ++currPit)
     {
-      this->m_WorkingVD->GetPoint(*currPit, &(currP));
+      this->m_WorkingVD->GetPoint(*currPit, &currP);
       VertList.push_back(currP);
     }
     // Need to fill with an segment identifier

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
@@ -337,7 +337,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
     for (PointIdIterator currPit = currCell->PointIdsBegin(); currPit != currPitEnd; ++currPit)
     {
       PointType currP;
-      m_WorkingVD->GetPoint(*currPit, &(currP));
+      m_WorkingVD->GetPoint(*currPit, &currP);
       VertList.push_back(currP);
     }
     IndexList PixelPool;
@@ -567,7 +567,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
       for (PointIdIterator currPit = currCell->PointIdsBegin(); currPit != currPitEnd; ++currPit)
       {
         PointType currP;
-        m_WorkingVD->GetPoint(*currPit, &(currP));
+        m_WorkingVD->GetPoint(*currPit, &currP);
         VertList.push_back(currP);
       }
       FillPolygon(VertList);


### PR DESCRIPTION
Replaced `&\((\w+)\)` with `&$1`, using regular expressions.
