### PR TITLE
COMP: Fix error made by bcb6876: module vtkvtksys not available

### DIFF
--- a/Modules/Bridge/VtkGlue/itk-module-init.cmake
+++ b/Modules/Bridge/VtkGlue/itk-module-init.cmake
@@ -45,8 +45,10 @@ if(NOT VTK_RENDERING_BACKEND)
   endif()
 endif()
 set(_target_prefix "vtk")
+set(_vtk_sys_name "sys")
 if(VTK_VERSION VERSION_GREATER_EQUAL 8.90.0)
   set(_target_prefix "VTK::")
+  set(_vtk_sys_name "vtksys")
 endif()
 set(_target_freetypeopengl)
 if(TARGET ${_target_prefix}RenderingFreeType${VTK_RENDERING_BACKEND})
@@ -61,7 +63,7 @@ set(
   ${_target_prefix}IOImage
   ${_target_prefix}ImagingSources
   ${_target_prefix}kwiml
-  ${_target_prefix}vtksys
+  ${_target_prefix}${_vtk_sys_name}
 )
 if(ITK_WRAP_PYTHON)
   list(


### PR DESCRIPTION
Commit bcb6876c7d9ed3315ed8cd2d3cdf9f0b11f3f951 introduced a configure error:
```log
CMake Error at C:/Libs/VTK-8.2.0/CMake/vtkModuleAPI.cmake:140 (message):
  Requested modules not available:

    vtkvtksys
Call Stack (most recent call first):
  Modules/Bridge/VtkGlue/itk-module-init.cmake:93 (vtk_module_config)
  CMake/ITKModuleEnablement.cmake:436 (include)
  CMakeLists.txt:754 (include)

-- Configuring incomplete, errors occurred!
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
