### PR TITLE
STYLE: Remove accidentally duplicated words from comments

### DIFF
--- a/Modules/Core/Common/include/itkBuildInformation.h
+++ b/Modules/Core/Common/include/itkBuildInformation.h
@@ -32,7 +32,7 @@ namespace itk
  * std::map< std::string, std::string> of key value pairs
  * that describe this version of ITK.
  *
- * Values in in the map provide information about
+ * Values in the map provide information about
  * the ITK (i.e. its version, the build options,
  * configuration options, the home URL for the project,
  * and other static information) that can be gathered

--- a/Modules/Core/Common/include/itkDataObject.h
+++ b/Modules/Core/Common/include/itkDataObject.h
@@ -515,7 +515,7 @@ public:
    * will copy meta-data from the first input to all of its
    * outputs. See ProcessObject::GenerateOutputInformation().  Each
    * subclass of DataObject is responsible for being able to copy
-   * whatever meta-data it needs from from another DataObject.
+   * whatever meta-data it needs from another DataObject.
    * The default implementation of this method is empty. If a subclass
    * overrides this method, it should always call its superclass'
    * version. */

--- a/Modules/Core/Common/include/itkDefaultConvertPixelTraits.h
+++ b/Modules/Core/Common/include/itkDefaultConvertPixelTraits.h
@@ -33,7 +33,7 @@ namespace itk
  *  by the templated static function Convert.
  *
  *  This implementation, does a simple assignment operator, so if you are
- *  going from from a higher bit representation to a lower bit one (int to
+ *  going from a higher bit representation to a lower bit one (int to
  *  char), you may want to specialize and add some sort of transfer function.
  * \ingroup ITKCommon
  */

--- a/Modules/Core/Common/include/itkImageBase.h
+++ b/Modules/Core/Common/include/itkImageBase.h
@@ -721,7 +721,7 @@ public:
    * will copy meta-data from the first input to all of its
    * outputs. See ProcessObject::GenerateOutputInformation().  Each
    * subclass of DataObject is responsible for being able to copy
-   * whatever meta-data it needs from from another DataObject.
+   * whatever meta-data it needs from another DataObject.
    * ImageBase has more meta-data than its DataObject.  Thus, it must
    * provide its own version of CopyInformation() in order to copy the
    * LargestPossibleRegion from the input parameter. */

--- a/Modules/Core/Common/include/itkImageSource.h
+++ b/Modules/Core/Common/include/itkImageSource.h
@@ -326,7 +326,7 @@ protected:
   {}
 
   /** If an imaging filter needs to perform processing after all
-   * processing threads have completed, the filter can can provide an
+   * processing threads have completed, the filter can provide an
    * implementation for AfterThreadedGenerateData(). The execution
    * flow in the default GenerateData() method will be:
    *      1) Allocate the output buffer

--- a/Modules/Core/Common/include/itkVectorNeighborhoodInnerProduct.h
+++ b/Modules/Core/Common/include/itkVectorNeighborhoodInnerProduct.h
@@ -33,7 +33,7 @@ namespace itk
  * template specialization of NeighborhoodInnerProduct for itkVector.
  *
  * This class defines the inner product operation between an itk::Neighborhood
- * and and itk::NeighborhoodOperator.  The operator() method is overloaded
+ * and itk::NeighborhoodOperator.  The operator() method is overloaded
  * to support various types of neighborhoods as well as inner products with
  * slices of neighborhoods.
  *

--- a/Modules/Core/Common/test/itkConstantBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkConstantBoundaryConditionTest.cxx
@@ -79,7 +79,7 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
 
       std::cout << pixel1 << ' ';
 
-      // Check agreement of output from three three methods of accessing pixel values.
+      // Check agreement of output from three methods of accessing pixel values.
       if (pixel1 != pixel2 || pixel2 != pixel3)
       {
         success = false;

--- a/Modules/Core/Common/test/itkImageDuplicatorTest.cxx
+++ b/Modules/Core/Common/test/itkImageDuplicatorTest.cxx
@@ -38,7 +38,7 @@ itkImageDuplicatorTest(int, char *[])
   region.SetIndex(index);
 
   {
-    /** Create an image image */
+    /** Create an image */
     std::cout << "Creating simulated image: ";
     auto m_Image = ImageType::New();
     m_Image->SetRegions(region);
@@ -141,7 +141,7 @@ itkImageDuplicatorTest(int, char *[])
   }
 
   {
-    /** Create an RGB image image */
+    /** Create an RGB image */
     using RGBImageType = itk::Image<itk::RGBPixel<unsigned char>, 3>;
     std::cout << "Creating simulated image: ";
     auto m_RGBImage = RGBImageType::New();

--- a/Modules/Core/Common/test/itkPeriodicBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkPeriodicBoundaryConditionTest.cxx
@@ -80,7 +80,7 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
 
       std::cout << pixel1 << ' ';
 
-      // Check agreement of output from three three methods of accessing pixel values.
+      // Check agreement of output from three methods of accessing pixel values.
       if (pixel1 != pixel2)
       {
         success = false;

--- a/Modules/Core/Common/test/itkZeroFluxBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkZeroFluxBoundaryConditionTest.cxx
@@ -80,7 +80,7 @@ TestPrintNeighborhood(IteratorType & p, VectorIteratorType & v)
 
       std::cout << pixel1 << ' ';
 
-      // Check agreement of output from three three methods of accessing pixel values.
+      // Check agreement of output from three methods of accessing pixel values.
       if (pixel1 != pixel2 || pixel2 != pixel3)
       {
         success = false;

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -662,7 +662,7 @@ public:
    * will copy meta-data from the first input to all of its
    * outputs. See ProcessObject::GenerateOutputInformation().  Each
    * subclass of DataObject is responsible for being able to copy
-   * whatever meta-data it needs from from another DataObject.
+   * whatever meta-data it needs from another DataObject.
    * ImageBase has more meta-data than its DataObject.  Thus, it must
    * provide its own version of CopyInformation() in order to copy the
    * LargestPossibleRegion from the input parameter. */

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.h
@@ -382,7 +382,7 @@ protected:
   InsideValidRegion(ContinuousIndexType &) const = 0;
 
   // NOTE:  There is a natural duality between the
-  //       two representations of of the coefficients
+  //       two representations of the coefficients
   //       whereby the m_InternalParametersBuffer is
   //       needed to fit into the optimization framework
   //       and the m_CoefficientImages is needed for

--- a/Modules/Core/Transform/include/itkKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkKernelTransform.hxx
@@ -90,7 +90,7 @@ KernelTransform<TParametersValueType, VDimension>::ComputeDeformationContributio
                                                                                   OutputPointType &      result) const
 {
   /*
-   * Default implementation of the the method. This can be overloaded
+   * Default implementation of the method. This can be overloaded
    * in transforms whose kernel produce diagonal G matrices.
    */
   const PointIdentifier numberOfLandmarks = this->m_SourceLandmarks->GetNumberOfPoints();

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientAnisotropicDiffusionImageFilter.h
@@ -27,7 +27,7 @@ namespace itk
 /** \class VectorGradientAnisotropicDiffusionImageFilter
  *
  * This filter performs anisotropic diffusion on a vector itk::Image using the
- * anisotropic diffusion function implemented implemented in
+ * anisotropic diffusion function implemented in
  * itkVectorGradientNDAnisotropicDiffusionFunction.  For detailed information on
  * anisotropic diffusion see itkAnisotropicDiffusionFunction,
  * itkVectorGradientNDAnisotropicDiffusionFunction, and

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.h
@@ -72,7 +72,7 @@ namespace itk
  * results from fewer than the product of this fraction and the internally computed maximum
  * number of overlapping pixels will be set to zero.
  * The value ranges between 0.0 and 1.0.
- * This is very useful when the user does does not know beforehand the maximum number of pixels
+ * This is very useful when the user does not know beforehand the maximum number of pixels
  * of the masks that will overlap.
  * For example, when the masks have strange shapes, it is difficult to predict
  * how the correlation of the masks will interact and what the maximum overlap will be.

--- a/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
@@ -177,7 +177,7 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GenerateDataND()
     m_NarrowBand->Clear();
   }
 
-  /** Precomputing the neighbor neighbor types */
+  /** Precomputing the neighbor types */
   neighbor_start = 0;
   neighbor_end = center_voxel - 1;
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingQuadEdgeMeshFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingQuadEdgeMeshFilterBase.hxx
@@ -337,7 +337,7 @@ FastMarchingQuadEdgeMeshFilterBase<TInput, TOutput>::ComputeUpdate(const OutputV
     {
       t = (-f1 - std::sqrt(delta)) / f2;
 
-      // test if we must must choose the other solution
+      // test if we must choose the other solution
       if ((t < u) || (iNorm2 * (t - u) / t < iNorm1 * CosAngle) || (iNorm1 / CosAngle < iNorm2 * (t - u) / t))
       {
         t = (-f1 + std::sqrt(delta)) / f2;

--- a/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
@@ -211,7 +211,7 @@ TestCastFromTo()
       //         << outValue << " may not equal " << expectedValue
       //         << "  Casting out of range floating point values to integers is 'undefined' behavior."
       //         << std::flush << std::endl;
-      continue; // Simply skip the case where where the conversion is undefined.
+      continue; // Simply skip the case where the conversion is undefined.
     }
 
 

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
@@ -225,7 +225,7 @@ private:
   // when computing the derivatives.
   bool m_UseImageDirection{ true };
 
-  // allow setting the the m_BoundaryCondition
+  // allow setting the m_BoundaryCondition
   std::unique_ptr<ImageBoundaryCondition<TInputImage, TInputImage>> m_BoundaryCondition{
     std::make_unique<ZeroFluxNeumannBoundaryCondition<TInputImage>>()
   };

--- a/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
@@ -285,7 +285,7 @@ BinShrinkImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
 
     outputStartIndex[i] = Math::Ceil<SizeValueType>(inputStartIndex[i] / static_cast<double>(m_ShrinkFactors[i]));
 
-    // Round down so that all output pixels fit input input region
+    // Round down so that all output pixels fit input region
     outputSize[i] = Math::Floor<SizeValueType>(
       static_cast<double>(inputSize[i] - outputStartIndex[i] * m_ShrinkFactors[i] + inputStartIndex[i]) /
       static_cast<double>(m_ShrinkFactors[i]));

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
@@ -220,7 +220,7 @@ public:
   itkGetConstReferenceMacro(Size, SizeType);
   /** @ITKEndGrouping */
   /** Get/Set the pixel value when a transformed pixel is outside of the
-   * image.  The default default pixel value is 0. */
+   * image.  The default pixel value is 0. */
   /** @ITKStartGrouping */
   itkSetMacro(DefaultPixelValue, PixelType);
   itkGetConstReferenceMacro(DefaultPixelValue, PixelType);

--- a/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
@@ -261,7 +261,7 @@ ShrinkImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   {
     outputSpacing[i] = inputSpacing[i] * static_cast<double>(m_ShrinkFactors[i]);
 
-    // Round down so that all output pixels fit input input region
+    // Round down so that all output pixels fit input region
     outputSize[i] = static_cast<SizeValueType>(
       std::floor(static_cast<double>(inputSize[i]) / static_cast<double>(m_ShrinkFactors[i])));
 

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.h
@@ -113,7 +113,7 @@ public:
   itkGetConstMacro(Layout, LayoutArrayType);
   /** @ITKEndGrouping */
   /** Set the pixel value for locations that are not covered by an
-   * input image. The default default pixel value is Zero. */
+   * input image. The default pixel value is Zero. */
   itkSetMacro(DefaultPixelValue, OutputPixelType);
 
   /** Get the pixel value for locations that are not covered by an

--- a/Modules/Filtering/ImageStatistics/include/itkHistogramAlgorithmBase.h
+++ b/Modules/Filtering/ImageStatistics/include/itkHistogramAlgorithmBase.h
@@ -46,7 +46,7 @@ public:
   /**Standard Macros */
   itkOverrideGetNameOfClassMacro(HistogramAlgorithmBase);
 
-  /** Histogram type alias alias */
+  /** Histogram type alias */
   using InputHistogramType = TInputHistogram;
 
   /** Stores the histogram pointer */

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.h
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.h
@@ -144,7 +144,7 @@ public:
    * invokes start and end events and handles releasing data. It
    * eventually calls GenerateData() which does the actual writing.
    * Note: the write method will write data specified by the
-   * IORegion. If not set, then then the whole image is written.  Note
+   * IORegion. If not set, then the whole image is written.  Note
    * that the region will be cropped to fit the input image's
    * LargestPossibleRegion. */
   virtual void

--- a/Modules/IO/MeshBase/include/itkMeshConvertPixelTraits.h
+++ b/Modules/IO/MeshBase/include/itkMeshConvertPixelTraits.h
@@ -38,7 +38,7 @@ namespace itk
  *  by the templated static function Convert.
  *
  *  This implementation, does a simple assignment operator, so if you are
- *  going from from a higher bit representation to a lower bit one (int to
+ *  going from a higher bit representation to a lower bit one (int to
  *  char), you may want to specialize and add some sort of transfer function.
  *  \ingroup ITKIOMeshBase
  */

--- a/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapper.h
+++ b/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapper.h
@@ -172,7 +172,7 @@ public:
 
   /**
    * Initialization of the A matrix. First any existing data for matrix A
-   * must be be destroyed, and then a new matrix is created in the memory. All
+   * must be destroyed, and then a new matrix is created in the memory. All
    * elements in A must be set to zero.
    *
    * \param matrixIndex index of matrix to initialize

--- a/Modules/Numerics/FEM/include/itkFEMPArray.h
+++ b/Modules/Numerics/FEM/include/itkFEMPArray.h
@@ -99,7 +99,7 @@ public:
 };
 
 /**
- * Find function for for non-const objects
+ * Find function for non-const objects
  */
 template <typename T>
 auto
@@ -131,7 +131,7 @@ FEMPArray<T>::Find(int gn) -> ClassTypePointer
 }
 
 /**
- * Find function for for const objects
+ * Find function for const objects
  */
 template <typename T>
 auto

--- a/Modules/Numerics/FEM/include/itkFEMSolverCrankNicolson.h
+++ b/Modules/Numerics/FEM/include/itkFEMSolverCrankNicolson.h
@@ -54,7 +54,7 @@ namespace itk::fem
  * choice of time step, dt.  This class inherits and uses most of the Solver class
  * functionality.
  *
- * Updated: The calls to to AssembleKandM (or AssembleK) and
+ * Updated: The calls to AssembleKandM (or AssembleK) and
  * AssembleFforTimeStep (or AssembleF) are now handled internally
  * by calling Update().
  *

--- a/Modules/Numerics/FEM/include/itkFEMSolverCrankNicolson.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMSolverCrankNicolson.hxx
@@ -137,10 +137,10 @@ SolverCrankNicolson<VDimension>::AssembleKandM()
     int Ne = this->m_FEMObject->GetElement(e)->GetNumberOfDegreesOfFreedom();
 
     Me = Me * m_Rho;
-    // Step over all rows in in element matrix
+    // Step over all rows in element matrix
     for (int j = 0; j < Ne; ++j)
     {
-      // Step over all columns in in element matrix
+      // Step over all columns in element matrix
       for (int k = 0; k < Ne; ++k)
       {
         // Error checking. all GFN should be =>0 and <NGFN

--- a/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.h
@@ -62,7 +62,7 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
-  /** type alias alias for the source data container */
+  /** type alias for the source data container */
   using typename Superclass::SampleType;
   using typename Superclass::SampleConstPointer;
   using typename Superclass::MeasurementVectorType;

--- a/Modules/Numerics/Statistics/include/itkKdTree.h
+++ b/Modules/Numerics/Statistics/include/itkKdTree.h
@@ -547,7 +547,7 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
-  /** type alias alias for the source data container */
+  /** type alias for the source data container */
   using SampleType = TSample;
   using MeasurementVectorType = typename TSample::MeasurementVectorType;
   using MeasurementType = typename TSample::MeasurementType;

--- a/Modules/Numerics/Statistics/include/itkKdTreeGenerator.h
+++ b/Modules/Numerics/Statistics/include/itkKdTreeGenerator.h
@@ -83,7 +83,7 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
-  /** type alias alias for the source data container */
+  /** type alias for the source data container */
   using MeasurementVectorType = typename TSample::MeasurementVectorType;
   using MeasurementType = typename TSample::MeasurementType;
 

--- a/Modules/Numerics/Statistics/include/itkRegionConstrainedSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkRegionConstrainedSubsampler.h
@@ -64,7 +64,7 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(RegionConstrainedSubsampler);
 
-  /** type alias alias for the source data container */
+  /** type alias for the source data container */
   using SampleType = TSample;
   using SampleConstPointer = typename SampleType::ConstPointer;
   using MeasurementVectorType = typename TSample::MeasurementVectorType;

--- a/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.h
@@ -64,7 +64,7 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
-  /** type alias alias for the source data container */
+  /** type alias for the source data container */
   using typename Superclass::SampleType;
   using typename Superclass::SampleConstPointer;
   using typename Superclass::MeasurementVectorType;

--- a/Modules/Numerics/Statistics/include/itkSubsamplerBase.h
+++ b/Modules/Numerics/Statistics/include/itkSubsamplerBase.h
@@ -62,7 +62,7 @@ public:
   /** implement type-specific clone method */
   itkCloneMacro(Self);
 
-  /** type alias alias for the source data container */
+  /** type alias for the source data container */
   using SampleType = TSample;
   using SampleConstPointer = typename SampleType::ConstPointer;
   using MeasurementVectorType = typename TSample::MeasurementVectorType;

--- a/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.h
@@ -62,7 +62,7 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
-  /** type alias alias for the source data container */
+  /** type alias for the source data container */
   using typename Superclass::SampleType;
   using typename Superclass::SampleConstPointer;
   using typename Superclass::MeasurementVectorType;

--- a/Modules/Numerics/Statistics/include/itkWeightedCentroidKdTreeGenerator.h
+++ b/Modules/Numerics/Statistics/include/itkWeightedCentroidKdTreeGenerator.h
@@ -79,7 +79,7 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
-  /** type alias alias for the source data container */
+  /** type alias for the source data container */
   using typename Superclass::MeasurementVectorType;
   using typename Superclass::MeasurementType;
   using typename Superclass::SubsampleType;

--- a/Modules/Segmentation/LevelSets/include/itkBinaryMaskToNarrowBandPointSetFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkBinaryMaskToNarrowBandPointSetFilter.h
@@ -99,7 +99,7 @@ public:
 
   /** The ReinitializeLevelSet filter is used to evaluate the distance from
       every pixel to the border of the binary mask. It uses internally a
-      FastMarching filter for propagating a from from the edges of the binary
+      FastMarching filter for propagating a from the edges of the binary
       mask.  */
   using DistanceFilterType = ReinitializeLevelSetImageFilter<RealImageType>;
   using DistanceFilterPointer = typename DistanceFilterType::Pointer;

--- a/Modules/Segmentation/LevelSets/include/itkNarrowBandLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkNarrowBandLevelSetImageFilter.h
@@ -62,7 +62,7 @@ namespace itk
  * \par INPUTS
  * The input to any subclass of this filter is the seed image for the initial
  * level set embedding.  As with other subclasses of the
- * SparseLevelSetImageFilter, the type of the input image is is not important.
+ * SparseLevelSetImageFilter, the type of the input image is not important.
  * The (RequestedRegion) size of the seed image must, however, match the
  * (RequestedRegion) size of the feature image.
  *

--- a/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.h
@@ -58,7 +58,7 @@ namespace itk
  * \par INPUTS
  * The input to any subclass of this filter is the seed image for the initial
  * level set embedding.  As with other subclasses of the
- * SparseLevelSetImageFilter, the type of the input image is is not important.
+ * SparseLevelSetImageFilter, the type of the input image is not important.
  * The (RequestedRegion) size of the seed image must, however, match the
  * (RequestedRegion) size of the feature image.
  *

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -980,7 +980,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::PropagateLayerValues(
     for (unsigned int i = 0; i < m_NeighborList.GetSize(); ++i)
     {
       // If this neighbor is in the "from" list, compare its absolute value
-      // to to any previous values found in the "from" list.  Keep the value
+      // to any previous values found in the "from" list.  Keep the value
       // that will cause the next layer to be closest to the zero level set.
 
       if (statusIt.GetPixel(m_NeighborList.GetArrayIndex(i)) == from)

--- a/Modules/Segmentation/Watersheds/include/itkWatershedImageFilter.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedImageFilter.h
@@ -111,7 +111,7 @@ namespace itk
  * value used during processing. Raising this threshold percentage effectively
  * decreases the number of local minima in the input, resulting in an initial
  * segmentation with fewer regions.  The assumption is that the shallow regions
- * that thresholding removes are of of less interest.
+ * that thresholding removes are of less interest.
  *
  * \par
  * The Level parameter controls the depth of metaphorical flooding of the
@@ -241,7 +241,7 @@ public:
     return m_Segmenter->GetOutputImage();
   }
 
-  /** Get the segmentation tree from from the TreeGenerator member filter. */
+  /** Get the segmentation tree from the TreeGenerator member filter. */
   typename watershed::SegmentTreeGenerator<ScalarType>::SegmentTreeType *
   GetSegmentTree()
   {

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
@@ -236,7 +236,7 @@ SegmentTreeGenerator<TScalar>::ExtractMergeHierarchy(SegmentTableTypePointer seg
     const IdentifierType toSegLabel = m_MergedSegmentsTable->RecursiveLookup(topMerge.to);
 
     // If the two segments do not resolve to the same segment and the
-    // "TO" segment has never been merged, then then merge them.
+    // "TO" segment has never been merged, then merge them.
     // Otherwise, ignore this particular entry.
     if (fromSegLabel == topMerge.from && fromSegLabel != toSegLabel)
     {

--- a/Modules/ThirdParty/TIFF/src/itktiff/libtiff/itk_tiff_mangle.h.in
+++ b/Modules/ThirdParty/TIFF/src/itktiff/libtiff/itk_tiff_mangle.h.in
@@ -37,7 +37,7 @@ The fifth command only prints out those symbols which have not been mangled with
 The sixth command removes duplicates
 The seventh and eighth commmands mangles the symbols and formats the output in such a way to be easily copy and pasted below.
 
-The developer will then need to *MANUALLY* add the symbols to the list below. Please try to keep the symbols in a sorted order (you can use sort utility, in Linux don't forget to to set environmental variable LC_COLLATE=POSIX to deal with the underscores correctly)
+The developer will then need to *MANUALLY* add the symbols to the list below. Please try to keep the symbols in a sorted order (you can use sort utility, in Linux don't forget to set environmental variable LC_COLLATE=POSIX to deal with the underscores correctly)
 */
 
 #define TIFFAccessTagMethods @MANGLE_PREFIX@_TIFFAccessTagMethods


### PR DESCRIPTION
Found by the regular expression ` (\w\w+) \1 `. Avoided removing intended duplicates, like "long long", "really really", and "very very". Skipped comments that may need other adjustments than just removing a duplicate word.