### PR TITLE
COMP: Disable limited Python API for itkVtkGlue module wrapping

### DIFF
--- a/Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt
+++ b/Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt
@@ -16,6 +16,12 @@ if("${VTK_VERSION}" VERSION_LESS 7.0.0)
     WARNING
     "The ITKVtkGlue module can only built with Python 3 and VTK >= 7."
   )
+elseif(ITK_USE_PYTHON_LIMITED_API)
+  message(
+    FATAL_ERROR
+    "The ITKVtkGlue module can only built without Python limited API due to VTK limitations."
+    "Please set `ITK_USE_PYTHON_LIMITED_API` to `FALSE`."
+  )
 else()
   list(
     APPEND

--- a/Wrapping/macro_files/itk_end_wrap_module.cmake
+++ b/Wrapping/macro_files/itk_end_wrap_module.cmake
@@ -489,7 +489,6 @@ ${DO_NOT_WAIT_FOR_THREADS_CALLS}
     ${use_python_limited_api_default}
     CACHE BOOL
     "Use Python's limited API for Python minor version compatibility."
-    FORCE
   )
   mark_as_advanced(ITK_USE_PYTHON_LIMITED_API)
   unset(use_python_limited_api_default)


### PR DESCRIPTION
This is my proposition to fix the build issue introduced by #5502.
In short, it disables Python stable "limited" API when wrapping itkVtkGlue module wrapping.
Other modules are not affected by this change.

WDYT @dzenanz @hjmjohnson @thewtex 

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

