### PR TITLE
BUG: Include vtkVersionvtkVersionMacros to ensure that direction is propagated

### DIFF
--- a/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.hxx
+++ b/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.hxx
@@ -18,6 +18,8 @@
 #ifndef itkImageToVTKImageFilter_hxx
 #define itkImageToVTKImageFilter_hxx
 
+#include "vtkVersionMacros.h"
+
 
 namespace itk
 {


### PR DESCRIPTION
The ImageToVTKImageFilter code depends on VTK_MAJOR_VERSION.  Include the relevant header so that it is defined.
