### PR TITLE
COMP: Include vtkVersionMacros in ImageToVTKImageFilter

### DIFF
--- a/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.hxx
+++ b/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.hxx
@@ -18,6 +18,7 @@
 #ifndef itkImageToVTKImageFilter_hxx
 #define itkImageToVTKImageFilter_hxx
 
+#include "vtkVersionMacros.h"
 
 namespace itk
 {


### PR DESCRIPTION
The ImageToVTKImageFilter code depends on VTK_MAJOR_VERSION. Include the relevant header so that it is defined.

Updated commit log as requested: https://github.com/InsightSoftwareConsortium/ITK/pull/5518