### PR TITLE
Declare ExceptionThrowingBoundsCheck static, let `Index`, `Offset`, `Size` each have its own `std::out_of_range` text 

### DIFF
--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -500,8 +500,8 @@ public:
 
 
 private:
-  void
-  ExceptionThrowingBoundsCheck(size_type pos) const
+  static void
+  ExceptionThrowingBoundsCheck(size_type pos)
   {
     if (pos >= VDimension)
     {

--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -505,7 +505,8 @@ private:
   {
     if (pos >= VDimension)
     {
-      throw std::out_of_range("array::ExceptionThrowingBoundsCheck");
+      throw std::out_of_range("Out of range: `itk::Index::at` argument `pos` (which is " + std::to_string(pos) +
+                              ") should be less than `Dimension` (which is " + std::to_string(VDimension) + ")!");
     }
   }
 

--- a/Modules/Core/Common/include/itkOffset.h
+++ b/Modules/Core/Common/include/itkOffset.h
@@ -444,7 +444,8 @@ private:
   {
     if (pos >= VDimension)
     {
-      throw std::out_of_range("array::ExceptionThrowingBoundsCheck");
+      throw std::out_of_range("Out of range: `itk::Offset::at` argument `pos` (which is " + std::to_string(pos) +
+                              ") should be less than `Dimension` (which is " + std::to_string(VDimension) + ")!");
     }
   }
 

--- a/Modules/Core/Common/include/itkOffset.h
+++ b/Modules/Core/Common/include/itkOffset.h
@@ -439,8 +439,8 @@ public:
   }
 
 private:
-  void
-  ExceptionThrowingBoundsCheck(size_type pos) const
+  static void
+  ExceptionThrowingBoundsCheck(size_type pos)
   {
     if (pos >= VDimension)
     {

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -414,8 +414,8 @@ public:
   }
 
 private:
-  void
-  ExceptionThrowingBoundsCheck(size_type pos) const
+  static void
+  ExceptionThrowingBoundsCheck(size_type pos)
   {
     if (pos >= VDimension)
     {

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -419,7 +419,8 @@ private:
   {
     if (pos >= VDimension)
     {
-      throw std::out_of_range("array::ExceptionThrowingBoundsCheck");
+      throw std::out_of_range("Out of range: `itk::Size::at` argument `pos` (which is " + std::to_string(pos) +
+                              ") should be less than `Dimension` (which is " + std::to_string(VDimension) + ")!");
     }
   }
 


### PR DESCRIPTION
Improved the error messages from `std::out_of_range` exceptions thrown by the `at` member functions of `itk::Index`, `itk::Offset`, and `itk::Size`.

Example:

    Out of range: `itk::Index::at` argument `pos` (which is 10) should be less than `Dimension` (which is 4)!