### PR TITLE
COMP: Fix cannot open 'vtkkwiml.lib' occurring with older VTK

### DIFF
--- a/Modules/Bridge/VtkGlue/itk-module-init.cmake
+++ b/Modules/Bridge/VtkGlue/itk-module-init.cmake
@@ -62,9 +62,19 @@ set(
   _required_vtk_libraries
   ${_target_prefix}IOImage
   ${_target_prefix}ImagingSources
-  ${_target_prefix}kwiml
-  ${_target_prefix}${_vtk_sys_name}
 )
+
+if(VTK_VERSION VERSION_GREATER_EQUAL 8.90.0)
+  list(
+    APPEND
+    _required_vtk_libraries
+    "VTK::vtksys"
+    "VTK::kwiml"
+  )
+else()
+  list(APPEND _required_vtk_libraries "vtksys")
+endif()
+
 if(ITK_WRAP_PYTHON)
   list(
     APPEND


### PR DESCRIPTION
Fixes `vtkkwiml` errors described here: https://github.com/InsightSoftwareConsortium/ITK/pull/5502#issuecomment-3271718823

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
