### PR TITLE
COMP: Update openjpeg to address cmake < 3.10 warning

### DIFF
--- a/Modules/ThirdParty/OpenJPEG/UpdateFromUpstream.sh
+++ b/Modules/ThirdParty/OpenJPEG/UpdateFromUpstream.sh
@@ -8,7 +8,7 @@ readonly name="openjpeg"
 readonly ownership="OpenJPEG Upstream <kwrobot@kitware.com>"
 readonly subtree="Modules/ThirdParty/OpenJPEG/src/$name"
 readonly repo="https://github.com/uclouvain/openjpeg.git"
-readonly tag="v2.5.3"
+readonly tag="v2.5.4"
 readonly paths="
 CMakeLists.txt
 README.md

--- a/Modules/ThirdParty/OpenJPEG/src/openjpeg/CMakeLists.txt
+++ b/Modules/ThirdParty/OpenJPEG/src/openjpeg/CMakeLists.txt
@@ -7,7 +7,7 @@
 # For this purpose you can define a CMake var: OPENJPEG_NAMESPACE to whatever you like
 # e.g.:
 set(OPENJPEG_NAMESPACE "ITKOPENJPEG")
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...3.31.5)
 
 if(NOT OPENJPEG_NAMESPACE)
   set(OPENJPEG_NAMESPACE "OPENJPEG")
@@ -26,7 +26,7 @@ include_regular_expression("^.*$")
 # OPENJPEG version number, useful for packaging and doxygen doc:
 set(OPENJPEG_VERSION_MAJOR 2)
 set(OPENJPEG_VERSION_MINOR 5)
-set(OPENJPEG_VERSION_BUILD 3)
+set(OPENJPEG_VERSION_BUILD 4)
 set(OPENJPEG_VERSION
   "${OPENJPEG_VERSION_MAJOR}.${OPENJPEG_VERSION_MINOR}.${OPENJPEG_VERSION_BUILD}")
 set(PACKAGE_VERSION
@@ -55,6 +55,7 @@ set(PACKAGE_VERSION
 #   2.5.1 |  7
 #   2.5.2 |  7
 #   2.5.3 |  7
+#   2.5.4 |  7
 # above is the recommendation by the OPJ team. If you really need to override this default,
 # you can specify your own OPENJPEG_SOVERSION at cmake configuration time:
 # cmake -DOPENJPEG_SOVERSION:STRING=42 /path/to/openjpeg
@@ -362,6 +363,19 @@ set_variable_from_rel_or_absolute_path("docdir" "\\\${prefix}" "${CMAKE_INSTALL_
 set_variable_from_rel_or_absolute_path("libdir" "\\\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
 set_variable_from_rel_or_absolute_path("includedir" "\\\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}/${OPENJPEG_INSTALL_SUBDIR}")
 
+function(get_pkgconfig_deps NAME OUT)
+  get_target_property(link_libs ${NAME} LINK_LIBRARIES)
+  if(NOT link_libs STREQUAL "link_libs-NOTFOUND")
+    foreach(lib ${link_libs})
+      # omit -lopenjp2 from Libs.private because libopenjp2 is in Requires
+      if(NOT ${lib} STREQUAL ${OPENJPEG_LIBRARY_NAME})
+        string(APPEND deps "-l${lib} ")
+      endif()
+    endforeach()
+  endif()
+  set(${OUT} ${deps} PARENT_SCOPE)
+endfunction()
+get_pkgconfig_deps(${OPENJPEG_LIBRARY_NAME} deps)
 # install in lib and not share (CMAKE_INSTALL_LIBDIR takes care of it for multi-arch)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/lib/openjp2/libopenjp2.pc.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/libopenjp2.pc @ONLY)
@@ -369,6 +383,7 @@ install( FILES  ${CMAKE_CURRENT_BINARY_DIR}/libopenjp2.pc DESTINATION
   ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
 #
 if(BUILD_JPIP)
+  get_pkgconfig_deps(openjpip deps)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/lib/openjpip/libopenjpip.pc.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/libopenjpip.pc @ONLY)
   install( FILES  ${CMAKE_CURRENT_BINARY_DIR}/libopenjpip.pc DESTINATION

--- a/Modules/ThirdParty/OpenJPEG/src/openjpeg/src/lib/openjp2/jp2.c
+++ b/Modules/ThirdParty/OpenJPEG/src/openjpeg/src/lib/openjp2/jp2.c
@@ -1987,6 +1987,12 @@ OPJ_BOOL opj_jp2_setup_encoder(opj_jp2_t *jp2,
     if (image->icc_profile_len) {
         jp2->meth = 2;
         jp2->enumcs = 0;
+        jp2->color.icc_profile_buf = (OPJ_BYTE *)opj_malloc(image->icc_profile_len);
+        if (jp2->color.icc_profile_buf) {
+            jp2->color.icc_profile_len = image->icc_profile_len;
+            memcpy(jp2->color.icc_profile_buf, image->icc_profile_buf,
+                   image->icc_profile_len);
+        }
     } else {
         jp2->meth = 1;
         if (image->color_space == OPJ_CLRSPC_SRGB) {
@@ -2873,7 +2879,7 @@ OPJ_BOOL opj_jp2_read_header(opj_stream_private_t *p_stream,
                               p_image,
                               p_manager);
 
-    if (p_image && *p_image) {
+    if (ret && p_image && *p_image) {
         /* Set Image Color Space */
         if (jp2->enumcs == 16) {
             (*p_image)->color_space = OPJ_CLRSPC_SRGB;

--- a/Modules/ThirdParty/OpenJPEG/src/openjpeg/src/lib/openjp2/libopenjp2.pc.cmake.in
+++ b/Modules/ThirdParty/OpenJPEG/src/openjpeg/src/lib/openjp2/libopenjp2.pc.cmake.in
@@ -10,6 +10,6 @@ Description: JPEG2000 library (Part 1 and 2)
 URL: http://www.openjpeg.org/
 Version: @OPENJPEG_VERSION@
 Libs: -L${libdir} -lopenjp2
-Libs.private: -lm
+Libs.private: @deps@
 Cflags: -I${includedir}
 Cflags.private: -DOPJ_STATIC

--- a/Modules/ThirdParty/OpenJPEG/src/openjpeg/src/lib/openjp2/openjpeg.h
+++ b/Modules/ThirdParty/OpenJPEG/src/openjpeg/src/lib/openjp2/openjpeg.h
@@ -641,6 +641,8 @@ typedef void * opj_codec_t;
 
 /*
  * Callback function prototype for read function
+ * @return returns The number of bytes delivered into
+ * \a p_buffer. -1 signals end of stream.
  */
 typedef OPJ_SIZE_T(* opj_stream_read_fn)(void * p_buffer, OPJ_SIZE_T p_nb_bytes,
         void * p_user_data) ;
@@ -1245,7 +1247,6 @@ OPJ_API void OPJ_CALLCONV opj_stream_set_user_data(opj_stream_t* p_stream,
 
 /**
  * Sets the length of the user data for the stream.
- *
  * @param p_stream    the stream to modify
  * @param data_length length of the user_data.
 */
@@ -1442,6 +1443,8 @@ OPJ_API OPJ_BOOL OPJ_CALLCONV opj_set_decoded_components(opj_codec_t *p_codec,
  * The coordinates passed to this function should be expressed in the reference grid,
  * that is to say at the highest resolution level, even if requesting the image at lower
  * resolution levels.
+ *
+ * Note: If p_start_x, p_start_y, p_end_x, p_end_y are all 0, then the whole image is decoded.
  *
  * Generally opj_set_decode_area() should be followed by opj_decode(), and the
  * codec cannot be re-used.


### PR DESCRIPTION

COMP: Update to openjpeg v2.5.4 (2025-09-20)
    
Closed issues:
  CMake configure warning with CMake 3.30 and newer #1579

Merged pull requests:

pkgconfig: drop unused libraries from Libs.private #1591 (bgilbert)
Fix CMake warning: Compatibility with CMake < 3.10 will be removed #1580 (dzenanz)
code documentation updates #1576 (weanti)
Fixed ICC profile copy failure on write #1574 (mircomir)
opj_jp2_read_header: Check for error after parsing header. #1573 (sebras) (CVE-2025-54874)

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
