### PR TITLE
COMP: Silence duplicate warning flags on MSVS

### DIFF
--- a/Modules/ThirdParty/ZLIB/src/itkzlib-ng/CMakeLists.txt
+++ b/Modules/ThirdParty/ZLIB/src/itkzlib-ng/CMakeLists.txt
@@ -197,8 +197,13 @@ elseif(MSVC)
     # (who'd use cmake from an IDE...) but checking for ICC before checking for MSVC should
     # avoid mistakes.
     # /Oi ?
+    #[[ ITK--start
     set(WARNFLAGS /W3 /w34242 /WX)
     set(WARNFLAGS_MAINTAINER /W4)
+    #]]
+    set(WARNFLAGS /w34242 /WX)
+    set(WARNFLAGS_MAINTAINER)
+    #ITK --stop
     set(WARNFLAGS_DISABLE /wd4206 /wd4054 /wd4324)
     if(BASEARCH_ARM_FOUND)
         add_definitions(-D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE)


### PR DESCRIPTION
40+ warnings are issued when building on MSVS
```
[775/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\gzwrite.c.obj
cl : Command line warning D9025 : overriding '/W0' with '/W3'
```

Silence the warnings by removing duplicate compiler warning flags
from being used.


```
2025-09-20T17:57:47.1348993Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:47.1393019Z [728/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\generic\adler32_fold_c.c.obj
2025-09-20T17:57:47.1595199Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:47.1604309Z [729/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\generic\chunkset_c.c.obj
2025-09-20T17:57:47.1612323Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:47.1630008Z [730/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\generic\compare256_c.c.obj
2025-09-20T17:57:47.1648579Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:47.1661307Z [731/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\generic\crc32_braid_c.c.obj
2025-09-20T17:57:47.1696274Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:47.1713898Z [732/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\generic\crc32_fold_c.c.obj
2025-09-20T17:57:47.1722597Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:47.2343449Z [733/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\generic\slide_hash_c.c.obj
2025-09-20T17:57:47.2405540Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:47.5393596Z [734/6352] Building CXX object Modules\Core\Common\src\CMakeFiles\ITKCommon.dir\itkDynamicLoader.cxx.obj
2025-09-20T17:57:47.7425377Z [735/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\compress.c.obj
2025-09-20T17:57:47.8254541Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:47.8272582Z [736/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\adler32.c.obj
2025-09-20T17:57:47.8409533Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:47.8445401Z [737/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\crc32.c.obj
2025-09-20T17:57:47.8668183Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:47.8703116Z [738/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\crc32_braid_comb.c.obj
2025-09-20T17:57:47.9065684Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:47.9098156Z [739/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\deflate_fast.c.obj
2025-09-20T17:57:48.2723066Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:48.3187440Z [740/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\deflate_huff.c.obj
2025-09-20T17:57:48.4643527Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:48.5326079Z [741/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\deflate.c.obj
2025-09-20T17:57:48.5827729Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:48.5844970Z [742/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\deflate_medium.c.obj
2025-09-20T17:57:48.5999786Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:48.6395967Z [743/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\deflate_quick.c.obj
2025-09-20T17:57:48.6504579Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:48.6543372Z [744/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\deflate_rle.c.obj
2025-09-20T17:57:48.6643534Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:48.6687720Z [745/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\deflate_slow.c.obj
2025-09-20T17:57:48.8860451Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:49.0804223Z [746/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\deflate_stored.c.obj
2025-09-20T17:57:49.2779160Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:49.4240625Z [747/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\functable.c.obj
2025-09-20T17:57:49.4439341Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:49.4508811Z [748/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\infback.c.obj
2025-09-20T17:57:49.6212458Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:49.6712168Z [749/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\inftrees.c.obj
2025-09-20T17:57:49.8706286Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:49.9312927Z [750/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\insert_string.c.obj
2025-09-20T17:57:49.9337633Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:50.0714679Z [751/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\insert_string_roll.c.obj
2025-09-20T17:57:50.0837918Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:50.0910612Z [752/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\inflate.c.obj
2025-09-20T17:57:50.2096491Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:50.2205545Z [753/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\uncompr.c.obj
2025-09-20T17:57:50.2377037Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:50.4687057Z [754/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\trees.c.obj
2025-09-20T17:57:50.7482763Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:50.9275827Z [755/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\cpu_features.c.obj
2025-09-20T17:57:50.9312453Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:50.9328622Z [756/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\zutil.c.obj
2025-09-20T17:57:50.9339606Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:51.1368801Z [757/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\x86\x86_features.c.obj
2025-09-20T17:57:51.2746178Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:51.2852908Z [758/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\x86\chunkset_sse2.c.obj
2025-09-20T17:57:51.2880625Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:51.2950874Z [759/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\x86\slide_hash_sse2.c.obj
2025-09-20T17:57:51.3121485Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:51.5333668Z [760/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\x86\compare256_sse2.c.obj
2025-09-20T17:57:51.7307799Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:51.9338800Z [761/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\x86\adler32_ssse3.c.obj
2025-09-20T17:57:51.9897984Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:51.9922168Z [762/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\x86\adler32_sse42.c.obj
2025-09-20T17:57:51.9969518Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:52.2775624Z [763/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\x86\chunkset_ssse3.c.obj
2025-09-20T17:57:52.5486670Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:52.7805411Z [764/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\x86\crc32_pclmulqdq.c.obj
2025-09-20T17:57:52.7806797Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:52.7984365Z [765/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\x86\slide_hash_avx2.c.obj
2025-09-20T17:57:52.9625185Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:53.1570102Z [766/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\x86\chunkset_avx2.c.obj
2025-09-20T17:57:53.3560713Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:53.4673787Z [767/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\x86\adler32_avx2.c.obj
2025-09-20T17:57:53.4732498Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:53.4766977Z [768/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\x86\compare256_avx2.c.obj
2025-09-20T17:57:53.4916692Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:53.5138650Z [769/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\x86\adler32_avx512.c.obj
2025-09-20T17:57:53.6375108Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:53.6436659Z [770/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\x86\adler32_avx512_vnni.c.obj
2025-09-20T17:57:53.6780712Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:53.6803049Z [771/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\x86\chunkset_avx512.c.obj
2025-09-20T17:57:53.8776895Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:54.0534896Z [772/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\arch\x86\crc32_vpclmulqdq.c.obj
2025-09-20T17:57:54.2748484Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:54.2833284Z [773/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\gzlib.c.obj
2025-09-20T17:57:54.3012460Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:54.3049129Z [774/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\gzread.c.obj
2025-09-20T17:57:54.4911312Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
2025-09-20T17:57:54.4951950Z [775/6352] Building C object Modules\ThirdParty\ZLIB\src\itkzlib-ng\CMakeFiles\zlib.dir\gzwrite.c.obj
2025-09-20T17:57:54.5011840Z cl : Command line warning D9025 : overriding '/W0' with '/W3'
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
