### PR TITLE
COMP: Use CastXML Windows-11 built binaries

### DIFF
--- a/Wrapping/Generators/CastXML/CMakeLists.txt
+++ b/Wrapping/Generators/CastXML/CMakeLists.txt
@@ -80,11 +80,11 @@ else()
   )
     set(
       _castxml_hash
-      f3c4639e84cc65d0ba6e608772d07dd32f47ccb0d03e16fcbe182429908ed4f2
+      91b1daf54623b6dc43b333218e1d38b30ce595c481a1e2a307f99b423cfc4e1e
     )
     set(
       _castxml_url
-      "https://github.com/CastXML/CastXMLSuperbuild/releases/download/v${_castxml_version}/castxml-windows-2022-amd64.zip"
+      "https://github.com/CastXML/CastXMLSuperbuild/releases/download/v${_castxml_version}/castxml-windows-win11-amd64.zip"
     )
     set(_download_castxml_binaries 1)
 


### PR DESCRIPTION
These do not have GCC libraries as dependencies like the ones built with
GitHub Actions.
