### PR TITLE
COMP: Silence warning in Expat config

### DIFF
--- a/Modules/ThirdParty/Expat/src/itkexpat/CMakeLists.txt
+++ b/Modules/ThirdParty/Expat/src/itkexpat/CMakeLists.txt
@@ -237,8 +237,10 @@ if(MSVC)
             message(SEND_ERROR "MSVC_VERSION ${MSVC_VERSION} is TOO OLD to compile Expat without errors.")
             message(SEND_ERROR "Please use officially supported ${_EXPAT_MSVC_SUPPORTED_DISPLAY} or later.  Thank you!")
         else()
+#[[ ITK -- start
             message(WARNING "MSVC_VERSION ${MSVC_VERSION} is NOT OFFICIALLY SUPPORTED by Expat.")
             message(WARNING "Please use ${_EXPAT_MSVC_SUPPORTED_DISPLAY} or later.  Thank you!")
+#]] # ITK --stop
         endif()
     endif()
 endif()


### PR DESCRIPTION
Expat is not tested on pre MSVC=1930 versions. A warning
idicates the lack of testing (not a lack of working).

Silence the configure-time warning.

Resolves: #5534

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
