### PR TITLE
Use `std::array` instead of `std::vector` for local variables

### DIFF
--- a/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkNeighborhoodIteratorTestCommon.hxx"
 #include "itkConstNeighborhoodIterator.h"
+#include <array>
 
 void
 println(const char * s)
@@ -356,17 +357,8 @@ itkConstNeighborhoodIteratorTest(int, char *[])
     using NeighborhoodIteratorType = itk::ConstNeighborhoodIterator<ChangeRegionTestImageType>;
     NeighborhoodIteratorType neighborhoodIterator(neighborhoodRadius, image, region1);
 
-    std::vector<int> expectedValuesRegion1(9);
-    expectedValuesRegion1[0] = 0;
-    expectedValuesRegion1[1] = 255;
-    expectedValuesRegion1[2] = 255;
-    expectedValuesRegion1[3] = 0;
-    expectedValuesRegion1[4] = 255;
-    expectedValuesRegion1[5] = 255;
-    expectedValuesRegion1[6] = 0;
-    expectedValuesRegion1[7] = 255;
-    expectedValuesRegion1[8] = 255;
-    unsigned int counter = 0;
+    static constexpr std::array<int, 9> expectedValuesRegion1{ 0, 255, 255, 0, 255, 255, 0, 255, 255 };
+    unsigned int                        counter = 0;
 
     for (NeighborhoodIteratorType::ConstIterator pixelIterator = neighborhoodIterator.Begin();
          pixelIterator < neighborhoodIterator.End();
@@ -387,16 +379,7 @@ itkConstNeighborhoodIteratorTest(int, char *[])
     neighborhoodIterator.SetRegion(region2);
     neighborhoodIterator.GoToBegin();
 
-    std::vector<int> expectedValuesRegion2(9);
-    expectedValuesRegion2[0] = 255;
-    expectedValuesRegion2[1] = 255;
-    expectedValuesRegion2[2] = 255;
-    expectedValuesRegion2[3] = 255;
-    expectedValuesRegion2[4] = 255;
-    expectedValuesRegion2[5] = 255;
-    expectedValuesRegion2[6] = 255;
-    expectedValuesRegion2[7] = 255;
-    expectedValuesRegion2[8] = 255;
+    static constexpr std::array<int, 9> expectedValuesRegion2{ 255, 255, 255, 255, 255, 255, 255, 255, 255 };
     counter = 0;
     for (NeighborhoodIteratorType::ConstIterator pixelIterator = neighborhoodIterator.Begin();
          pixelIterator < neighborhoodIterator.End();

--- a/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkNeighborhoodIteratorTestCommon.hxx"
 #include "itkConstShapedNeighborhoodIterator.h"
+#include <array>
 
 void
 PrintShapedNeighborhood(const itk::ConstShapedNeighborhoodIterator<TestImageType> & n)
@@ -470,9 +471,7 @@ itkConstShapedNeighborhoodIteratorTest(int, char *[])
       shapedNeighborhoodIterator.ActivateOffset(offset_item);
     }
 
-    std::vector<int> expectedValuesRegion1(2);
-    expectedValuesRegion1[0] = 0;
-    expectedValuesRegion1[1] = 255;
+    static constexpr std::array<int, 2> expectedValuesRegion1{ 0, 255 };
 
     unsigned int counter = 0;
     // while(!shapedNeighborhoodIterator.IsAtEnd()) // no need for this loop as we are only iterating over a 1x1 region
@@ -500,9 +499,7 @@ itkConstShapedNeighborhoodIteratorTest(int, char *[])
     shapedNeighborhoodIterator.SetRegion(region2);
     shapedNeighborhoodIterator.GoToBegin();
 
-    std::vector<int> expectedValuesRegion2(2);
-    expectedValuesRegion2[0] = 255;
-    expectedValuesRegion2[1] = 255;
+    static constexpr std::array<int, 2> expectedValuesRegion2{ 255, 255 };
 
     counter = 0;
     // while(!shapedNeighborhoodIterator.IsAtEnd()) // no need for this loop as we are only iterating over a 1x1 region

--- a/Modules/Core/Common/test/itkImageRegionIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionIteratorTest.cxx
@@ -19,6 +19,7 @@
 #include <iostream>
 
 #include "itkImageRegionIterator.h"
+#include <array>
 
 
 // This routine is used to make sure that we call the "const" version
@@ -172,12 +173,8 @@ itkImageRegionIteratorTest(int, char *[])
 
     itk::ImageRegionConstIterator<TestImageType> imageIterator(image, region1);
 
-    std::vector<int> expectedValuesRegion1(4);
-    expectedValuesRegion1[0] = 0;
-    expectedValuesRegion1[1] = 255;
-    expectedValuesRegion1[2] = 0;
-    expectedValuesRegion1[3] = 255;
-    unsigned int counter = 0;
+    static constexpr std::array<int, 4> expectedValuesRegion1{ 0, 255, 0, 255 };
+    unsigned int                        counter = 0;
     while (!imageIterator.IsAtEnd())
     {
       if (imageIterator.Get() != expectedValuesRegion1[counter])
@@ -196,11 +193,7 @@ itkImageRegionIteratorTest(int, char *[])
     imageIterator.SetRegion(region2);
     imageIterator.GoToBegin();
 
-    std::vector<int> expectedValuesRegion2(4);
-    expectedValuesRegion2[0] = 255;
-    expectedValuesRegion2[1] = 255;
-    expectedValuesRegion2[2] = 255;
-    expectedValuesRegion2[3] = 255;
+    static constexpr std::array<int, 4> expectedValuesRegion2{ 255, 255, 255, 255 };
     counter = 0;
     while (!imageIterator.IsAtEnd())
     {

--- a/Modules/Core/Common/test/itkImageScanlineIteratorTest1.cxx
+++ b/Modules/Core/Common/test/itkImageScanlineIteratorTest1.cxx
@@ -19,6 +19,7 @@
 #include <iostream>
 
 #include "itkImageScanlineIterator.h"
+#include <array>
 
 
 // This routine is used to make sure that we call the "const" version
@@ -188,12 +189,8 @@ itkImageScanlineIteratorTest1(int, char *[])
 
     itk::ImageScanlineConstIterator<TestImageType> imageIterator(image, region1);
 
-    std::vector<int> expectedValuesRegion1(4);
-    expectedValuesRegion1[0] = 0;
-    expectedValuesRegion1[1] = 255;
-    expectedValuesRegion1[2] = 0;
-    expectedValuesRegion1[3] = 255;
-    unsigned int counter = 0;
+    static constexpr std::array<int, 4> expectedValuesRegion1{ 0, 255, 0, 255 };
+    unsigned int                        counter = 0;
     while (!imageIterator.IsAtEnd())
     {
       while (!imageIterator.IsAtEndOfLine())
@@ -216,11 +213,7 @@ itkImageScanlineIteratorTest1(int, char *[])
     imageIterator.SetRegion(region2);
     imageIterator.GoToBegin();
 
-    std::vector<int> expectedValuesRegion2(4);
-    expectedValuesRegion2[0] = 255;
-    expectedValuesRegion2[1] = 255;
-    expectedValuesRegion2[2] = 255;
-    expectedValuesRegion2[3] = 255;
+    static constexpr std::array<int, 4> expectedValuesRegion2{ 255, 255, 255, 255 };
     counter = 0;
     while (!imageIterator.IsAtEnd())
     {

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorsTestHelper.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorsTestHelper.h
@@ -20,6 +20,7 @@
 
 #include "itkQuadEdgeMeshTopologyChecker.h"
 #include "itkQuadEdgeMeshPolygonCell.h"
+#include <array>
 
 using IdentifierType = unsigned long;
 
@@ -178,7 +179,7 @@ CreateTetraedronMesh(typename TMesh::Pointer mesh)
   const int     simpleSquareCells[12] = { 0, 1, 2, 1, 0, 3, 1, 3, 2, 2, 3, 0 };
 
   using PointType = typename TMesh::PointType;
-  std::vector<PointType> pts(4);
+  std::array<PointType, 4> pts{};
   {
     int i(0);
     pts[i][0] = 0.;
@@ -235,7 +236,7 @@ CreateSamosa(typename TMesh::Pointer mesh)
   const int     simpleSquareCells[6] = { 0, 1, 2, 1, 0, 2 };
 
   using PointType = typename TMesh::PointType;
-  std::vector<PointType> pts(3);
+  std::array<PointType, 3> pts{};
   {
     int i(0);
     pts[i][0] = 0.;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDelaunayConformingQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDelaunayConformingQuadEdgeMeshFilter.hxx
@@ -18,6 +18,7 @@
 #ifndef itkDelaunayConformingQuadEdgeMeshFilter_hxx
 #define itkDelaunayConformingQuadEdgeMeshFilter_hxx
 
+#include <array>
 
 namespace itk
 {
@@ -124,8 +125,7 @@ DelaunayConformingQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::Process()
 
   m_FlipEdge->SetInput(output);
 
-  typename std::vector<OutputQEType *>           list_qe(5);
-  typename std::vector<OutputQEType *>::iterator it;
+  std::array<OutputQEType *, 5> list_qe{};
 
   while (!m_PriorityQueue->Empty())
   {
@@ -161,9 +161,8 @@ DelaunayConformingQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::Process()
       ++this->m_NumberOfEdgeFlips;
       list_qe[4] = qe;
 
-      for (it = list_qe.begin(); it != list_qe.end(); ++it)
+      for (OutputQEType * e_it : list_qe)
       {
-        OutputQEType * e_it = *it;
         if (e_it)
         {
           CriterionValueType value = Dyer07Criterion(output, e_it);

--- a/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
+++ b/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
@@ -20,6 +20,8 @@
 #include "itksys/SystemTools.hxx"
 
 #include "itk_jpeg.h"
+
+#include <array>
 #include <csetjmp>
 
 #define JPEGIO_JPEG_MESSAGES 1
@@ -542,13 +544,11 @@ JPEGImageIO::WriteSlice(const std::string & fileName, const void * const buffer)
   {
     // store the spacing information as pixels per inch or cm, depending on which option
     // retains as much precision as possible
-    std::vector<UINT16> densityPerInch(2);
-    densityPerInch[0] = static_cast<UINT16>(25.4 / m_Spacing[0] + 0.5);
-    densityPerInch[1] = static_cast<UINT16>(25.4 / m_Spacing[1] + 0.5);
+    const std::array<UINT16, 2> densityPerInch{ static_cast<UINT16>(25.4 / m_Spacing[0] + 0.5),
+                                                static_cast<UINT16>(25.4 / m_Spacing[1] + 0.5) };
 
-    std::vector<UINT16> densityPerCm(2);
-    densityPerCm[0] = static_cast<UINT16>(10.0 / m_Spacing[0] + 0.5);
-    densityPerCm[1] = static_cast<UINT16>(10.0 / m_Spacing[1] + 0.5);
+    const std::array<UINT16, 2> densityPerCm{ static_cast<UINT16>(10.0 / m_Spacing[0] + 0.5),
+                                              static_cast<UINT16>(10.0 / m_Spacing[1] + 0.5) };
 
     if (itk::Math::abs(25.4 / m_Spacing[0] - densityPerInch[0]) +
           itk::Math::abs(25.4 / m_Spacing[1] - densityPerInch[1]) <=

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -27,6 +27,7 @@
 
 #include "itk_minc2.h"
 
+#include <array>
 #include <memory> // For unique_ptr.
 
 
@@ -481,7 +482,7 @@ MINCImageIO::ReadImageInformation()
 
       double _sep = NAN;
       miget_dimension_separation(m_MINCPImpl->m_MincApparentDims[usableDimensions], MI_ORDER_APPARENT, &_sep);
-      std::vector<double> _dir(3);
+      std::array<double, 3> _dir{};
       miget_dimension_cosines(m_MINCPImpl->m_MincApparentDims[usableDimensions], &_dir[0]);
       double _start = NAN;
       miget_dimension_start(m_MINCPImpl->m_MincApparentDims[usableDimensions], MI_ORDER_APPARENT, &_start);


### PR DESCRIPTION
When an std::vector is initialized by a compile-time constant, specifying its size, and the std::vector isn't resized afterwards, it appears clearer to use std::array instead. (And it may produce faster code, of course, when using std::array.) 

Cases found by the following regular expression (using Visual Studio, Find in Files...):

     std::vector<[^=]+>[^=]+\([1-9][0-9]*\);