### PR TITLE
BUG: VTKPolyDataMeshIO should use `signed char` for the `SCHAR` cases

### DIFF
--- a/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
+++ b/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
@@ -828,7 +828,7 @@ VTKPolyDataMeshIO::ReadMeshInformation()
   }                                                             \
   case IOComponentEnum::SCHAR:                                  \
   {                                                             \
-    function(param, static_cast<char *>(buffer));               \
+    function(param, static_cast<signed char *>(buffer));        \
     break;                                                      \
   }                                                             \
   case IOComponentEnum::USHORT:                                 \
@@ -1696,7 +1696,7 @@ VTKPolyDataMeshIO::WriteMeshInformation()
   }                                                                                    \
   case IOComponentEnum::SCHAR:                                                         \
   {                                                                                    \
-    function(outputFile, static_cast<char *>(buffer), " char");                        \
+    function(outputFile, static_cast<signed char *>(buffer), " char");                 \
     break;                                                                             \
   }                                                                                    \
   case IOComponentEnum::USHORT:                                                        \
@@ -1819,8 +1819,8 @@ VTKPolyDataMeshIO::WritePoints(void * buffer)
   }                                                                   \
   case IOComponentEnum::SCHAR:                                        \
   {                                                                   \
-    UpdateCellInformation(static_cast<char *>(buffer));               \
-    function(outputFile, static_cast<char *>(buffer));                \
+    UpdateCellInformation(static_cast<signed char *>(buffer));        \
+    function(outputFile, static_cast<signed char *>(buffer));         \
     break;                                                            \
   }                                                                   \
   case IOComponentEnum::USHORT:                                       \


### PR DESCRIPTION
`VTKPolyDataMeshIO` originally casted the `buffer` to plain `char *` for component type `SCHAR`. However, `SCHAR` indicates that the component type is _signed_ char.

Follow-up to pull request #5470 commit 70fbb2b2f1442467e952f660f23df7ea7e546f07 "BUG: MINCImageIO should use `signed char` for `CHAR` and `MI_TYPE_BYTE`"