### PR TITLE
BUG: Replace np.bool with bool

### DIFF
--- a/Wrapping/Generators/Python/itk/support/types.py
+++ b/Wrapping/Generators/Python/itk/support/types.py
@@ -140,7 +140,7 @@ class itkCType:
         _SS: "itkCType" = itkCType("signed short", "SS", np.dtype(np.int16))
         _SI: "itkCType" = itkCType("signed int", "SI", np.dtype(np.int32))
         _SLL: "itkCType" = itkCType("signed long long", "SLL", np.dtype(np.int64))
-        _B: "itkCType" = itkCType("bool", "B", np.dtype(np.bool_))
+        _B: "itkCType" = itkCType("bool", "B", np.dtype(bool))
         return _F, _D, _UC, _US, _UI, _UL, _SL, _LD, _ULL, _SC, _SS, _SI, _SLL, _B
 
 


### PR DESCRIPTION
- The alias np.bool was officially deprecated in NumPy 1.20.0.  ￼
- The removal (i.e. making np.bool inaccessible / raising AttributeError) occurred in NumPy 1.24.0.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
