### PR TITLE
ENH: Upgrade CudaCommon remote module to v2.0.0

### DIFF
--- a/Modules/Remote/CudaCommon.remote.cmake
+++ b/Modules/Remote/CudaCommon.remote.cmake
@@ -42,5 +42,5 @@ itk_fetch_module(
   "Framework for processing images with Cuda."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/RTKConsortium/ITKCudaCommon.git
-  GIT_TAG 455173a72e06bae6272d3d91162dd6f7661e7943
+  GIT_TAG 6feb4a7eb5a7db6dd462bfbcd14c7d8964dc1597
   )


### PR DESCRIPTION
This is the list of changes from the release notes:
- Modified `itk::CudaDataManager::GetGPUBufferPointer` to actually return the GPU buffer pointer and not a pointer to the pointer (647af6cc787460d98a0e952b74d0b18c03c0dcde). This is the only **backward incompatible change** which motivated the increment of the major version number. The pointer to the buffer pointer can now be accessed with `itk::CudaDataManager::GetGPUBufferPointerPtr` (3940961a5fce2c7da43135ef49a65fa8ef8c3945).
- Added a `__cuda_array_interface__` to the Python wrapping of `itk::CudaImage`. See [cuda_array_interface.md](cuda_array_interface.md) for more information and examples (now included in [RTK documentation](https://docs.openrtk.org/en/latest/cuda_array_interface.html) as well).
- Various style improvements (C++, Python and CMake) now checked by the CI with [pre-commit](https://pre-commit.com/).
- Renamed the `master` branch to `main`.
- Added `itk::CudaImage::RebindImageType` for facilitating the definition of images with the same type (`Image` or `CudaImage`) but different pixel types. See e.g. RTKConsortium/RTK#799.
- Added Python tests to the CI, improving C++ coverage.
- Added `itk::CudaImageFromImageFilter` to converting an `itk::CudaImage` from an `itk::Image` in a processing pipeline.
- Improved documentation.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
