### PR TITLE
COMP: Fix compile error introduced by 3279b33 in OpenCVVideoIOTest

### DIFF
--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoIOTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoIOTest.cxx
@@ -38,7 +38,7 @@ ImageType::Pointer
 itkImageFromBuffer(itk::OpenCVVideoIO::Pointer opencvIO, void * buffer, size_t bufferSize)
 {
   // Set up for incoming image
-  constexpr ImageType::SizeType  size{ opencvIO->GetDimensions(0), opencvIO->GetDimensions(1) };
+  const ImageType::SizeType      size{ opencvIO->GetDimensions(0), opencvIO->GetDimensions(1) };
   constexpr ImageType::IndexType start{};
   ImageType::RegionType          region = { start, size };
   ImageType::PointType           origin;


### PR DESCRIPTION
3279b33f97a3baeeb6999bfe22edf4331afc5bc5 introduced the compile error: `C:\Dev\ITK-git\Modules\Video\BridgeOpenCV\test\itkOpenCVVideoIOTest.cxx(41,38): error C2131: expression did not evaluate to a constant`

Complete build log:
```log
Build started at 13:57...
1>------ Build started: Project: ITKVideoBridgeOpenCVTestDriver, Configuration: Debug x64 ------ 1>itkOpenCVVideoIOTest.cxx
1>C:\Dev\ITK-git\Modules\Video\BridgeOpenCV\test\itkOpenCVVideoIOTest.cxx(41,38): error C2131: expression did not evaluate to a constant
1>    C:\Dev\ITK-git\Modules\Video\BridgeOpenCV\test\itkOpenCVVideoIOTest.cxx(41,40):
1>    failure was caused by call of undefined function or one not declared 'constexpr'
1>    C:\Dev\ITK-git\Modules\Video\BridgeOpenCV\test\itkOpenCVVideoIOTest.cxx(41,40):
1>    see usage of 'itk::SmartPointer<itk::OpenCVVideoIO::Self>::operator ->'
1>    C:\Dev\ITK-git\Modules\Video\BridgeOpenCV\test\itkOpenCVVideoIOTest.cxx(41,38):
1>    the call stack of the evaluation (the oldest call first) is
1>        C:\Dev\ITK-git\Modules\Video\BridgeOpenCV\test\itkOpenCVVideoIOTest.cxx(41,40):
1>        while evaluating function 'itk::OpenCVVideoIO *itk::SmartPointer<itk::OpenCVVideoIO::Self>::operator ->(void) noexcept const'
1>Done building project "ITKVideoBridgeOpenCVTestDriver.vcxproj" -- FAILED.
========== Build: 0 succeeded, 1 failed, 56 up-to-date, 0 skipped ==========
========== Build completed at 13:58 and took 02.868 seconds ==========
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
