### PR TITLE
STYLE: Remove `constexpr IndexType start{ 0, 0, 0 }` from tests

### DIFF
--- a/Modules/Filtering/DisplacementField/test/itkExponentialDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkExponentialDisplacementFieldImageFilterTest.cxx
@@ -35,10 +35,6 @@ itkExponentialDisplacementFieldImageFilterTest(int, char *[])
   // Declare Iterator types appropriate for each image
   using IteratorType = itk::ImageRegionIteratorWithIndex<ImageType>;
 
-
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -48,10 +44,9 @@ itkExponentialDisplacementFieldImageFilterTest(int, char *[])
   // Create two images
   auto inputImage = ImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageCompare/test/itkCheckerBoardImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkCheckerBoardImageFilterTest.cxx
@@ -40,9 +40,6 @@ itkCheckerBoardImageFilterTest(int argc, char * argv[])
   // Declare the types of the images
   using ImageType = itk::Image<PixelType, Dimension>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<Dimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<Dimension>;
 
@@ -61,10 +58,9 @@ itkCheckerBoardImageFilterTest(int argc, char * argv[])
   auto inputImageA = ImageType::New();
   auto inputImageB = ImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 40, 40, 40 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 40, 40, 40 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageCompare/test/itkConstrainedValueDifferenceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkConstrainedValueDifferenceImageFilterTest.cxx
@@ -43,9 +43,6 @@ itkConstrainedValueDifferenceImageFilterTest(int argc, char * argv[])
   using InputImage2Type = itk::Image<InputImage2PixelType, Dimension>;
   using OutputImageType = itk::Image<OutputImagePixelType, Dimension>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<Dimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<Dimension>;
 
@@ -56,10 +53,9 @@ itkConstrainedValueDifferenceImageFilterTest(int argc, char * argv[])
   auto inputImageA = InputImage1Type::New();
   auto inputImageB = InputImage2Type::New();
 
-  // Define their size and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageCompose/test/itkCompose3DVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkCompose3DVectorImageFilterTest.cxx
@@ -34,7 +34,6 @@ itkCompose3DVectorImageFilterTest(int, char *[])
 
   using RegionType = InputImageType::RegionType;
   using SizeType = InputImageType::SizeType;
-  using IndexType = InputImageType::IndexType;
 
   auto filter = FilterType::New();
 
@@ -42,9 +41,8 @@ itkCompose3DVectorImageFilterTest(int, char *[])
   auto oneImage = InputImageType::New();
   auto twoImage = InputImageType::New();
 
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   zeroImage->SetRegions(region);
   oneImage->SetRegions(region);

--- a/Modules/Filtering/ImageCompose/test/itkComposeRGBImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkComposeRGBImageFilterTest.cxx
@@ -35,7 +35,6 @@ itkComposeRGBImageFilterTest(int, char *[])
 
   using RegionType = InputImageType::RegionType;
   using SizeType = InputImageType::SizeType;
-  using IndexType = InputImageType::IndexType;
 
   auto filter = FilterType::New();
 
@@ -43,9 +42,8 @@ itkComposeRGBImageFilterTest(int, char *[])
   auto greenImage = InputImageType::New();
   auto blueImage = InputImageType::New();
 
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   redImage->SetRegions(region);
   greenImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkAbsImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAbsImageFilterAndAdaptorTest.cxx
@@ -40,9 +40,6 @@ itkAbsImageFilterAndAdaptorTest(int, char *[])
   using InputIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -52,10 +49,9 @@ itkAbsImageFilterAndAdaptorTest(int, char *[])
   // Create two images
   auto inputImage = InputImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkAcosImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAcosImageFilterAndAdaptorTest.cxx
@@ -43,9 +43,6 @@ itkAcosImageFilterAndAdaptorTest(int, char *[])
 
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -55,10 +52,9 @@ itkAcosImageFilterAndAdaptorTest(int, char *[])
   // Create the input image
   auto inputImage = InputImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkAddImageAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAddImageAdaptorTest.cxx
@@ -45,10 +45,9 @@ itkAddImageAdaptorTest(int, char *[])
   // Create input image
   auto inputImage = ImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkAddImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAddImageFilterTest.cxx
@@ -41,9 +41,6 @@ itkAddImageFilterTest(int, char *[])
   // Declare appropriate Iterator types for each image
   using OutputImageIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<Dimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<Dimension>;
 
@@ -54,10 +51,9 @@ itkAddImageFilterTest(int, char *[])
   auto inputImageA = InputImageType1::New();
   auto inputImageB = InputImageType2::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkAndImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAndImageFilterTest.cxx
@@ -41,9 +41,6 @@ itkAndImageFilterTest(int argc, char * argv[])
   using InputImage2Type = itk::Image<PixelType, Dimension>;
   using OutputImageType = itk::Image<PixelType, Dimension>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<Dimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<Dimension>;
 
@@ -54,10 +51,9 @@ itkAndImageFilterTest(int argc, char * argv[])
   auto inputImageA = InputImage1Type::New();
   auto inputImageB = InputImage2Type::New();
 
-  // Define their size and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkAsinImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAsinImageFilterAndAdaptorTest.cxx
@@ -41,9 +41,6 @@ itkAsinImageFilterAndAdaptorTest(int, char *[])
   using InputIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -53,10 +50,9 @@ itkAsinImageFilterAndAdaptorTest(int, char *[])
   // Create the input image
   auto inputImage = InputImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkAtan2ImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAtan2ImageFilterTest.cxx
@@ -41,9 +41,6 @@ itkAtan2ImageFilterTest(int, char *[])
 
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -54,10 +51,9 @@ itkAtan2ImageFilterTest(int, char *[])
   auto sinImage = InputImageType::New();
   auto cosImage = InputImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Sine Image
   sinImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkAtanImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAtanImageFilterAndAdaptorTest.cxx
@@ -41,9 +41,6 @@ itkAtanImageFilterAndAdaptorTest(int, char *[])
   using InputIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -53,10 +50,9 @@ itkAtanImageFilterAndAdaptorTest(int, char *[])
   // Create the input image
   auto inputImage = InputImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkBinaryMagnitudeImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkBinaryMagnitudeImageFilterTest.cxx
@@ -37,9 +37,6 @@ itkBinaryMagnitudeImageFilterTest(int, char *[])
   using InputImageType2 = itk::Image<PixelType, Dimension>;
   using OutputImageType = itk::Image<PixelType, Dimension>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<Dimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<Dimension>;
 
@@ -50,10 +47,9 @@ itkBinaryMagnitudeImageFilterTest(int, char *[])
   auto inputImageA = InputImageType1::New();
   auto inputImageB = InputImageType2::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkComplexToImaginaryFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkComplexToImaginaryFilterAndAdaptorTest.cxx
@@ -40,9 +40,6 @@ itkComplexToImaginaryFilterAndAdaptorTest(int, char *[])
   using InputIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -52,10 +49,9 @@ itkComplexToImaginaryFilterAndAdaptorTest(int, char *[])
   // Create two images
   auto inputImage = InputImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkComplexToModulusFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkComplexToModulusFilterAndAdaptorTest.cxx
@@ -40,9 +40,6 @@ itkComplexToModulusFilterAndAdaptorTest(int, char *[])
   using InputIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -52,10 +49,9 @@ itkComplexToModulusFilterAndAdaptorTest(int, char *[])
   // Create two images
   auto inputImage = InputImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkComplexToPhaseFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkComplexToPhaseFilterAndAdaptorTest.cxx
@@ -40,9 +40,6 @@ itkComplexToPhaseFilterAndAdaptorTest(int, char *[])
   using InputIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -52,10 +49,9 @@ itkComplexToPhaseFilterAndAdaptorTest(int, char *[])
   // Create two images
   auto inputImage = InputImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkComplexToRealFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkComplexToRealFilterAndAdaptorTest.cxx
@@ -40,9 +40,6 @@ itkComplexToRealFilterAndAdaptorTest(int, char *[])
   using InputIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -52,10 +49,9 @@ itkComplexToRealFilterAndAdaptorTest(int, char *[])
   // Create two images
   auto inputImage = InputImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkConstrainedValueAdditionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkConstrainedValueAdditionImageFilterTest.cxx
@@ -43,9 +43,6 @@ itkConstrainedValueAdditionImageFilterTest(int argc, char * argv[])
   using InputImageType2 = itk::Image<InputPixelType, Dimension>;
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<Dimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<Dimension>;
 
@@ -56,10 +53,9 @@ itkConstrainedValueAdditionImageFilterTest(int argc, char * argv[])
   auto inputImageA = InputImageType1::New();
   auto inputImageB = InputImageType2::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkCosImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkCosImageFilterAndAdaptorTest.cxx
@@ -41,9 +41,6 @@ itkCosImageFilterAndAdaptorTest(int, char *[])
   using InputIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -53,10 +50,9 @@ itkCosImageFilterAndAdaptorTest(int, char *[])
   // Create the input image
   auto inputImage = InputImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkDivideImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkDivideImageFilterTest.cxx
@@ -40,9 +40,6 @@ itkDivideImageFilterTest(int, char *[])
   // Declare appropriate Iterator types for each image
   using OutputImageIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<Dimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<Dimension>;
 
@@ -53,10 +50,9 @@ itkDivideImageFilterTest(int, char *[])
   auto inputImageA = InputImageType1::New();
   auto inputImageB = InputImageType2::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkEdgePotentialImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkEdgePotentialImageFilterTest.cxx
@@ -36,10 +36,6 @@ itkEdgePotentialImageFilterTest(int, char *[])
   using InputIteratorType = itk::ImageRegionIterator<InputImageType>;
   using OutputIteratorType = itk::ImageRegionIterator<OutputImageType>;
 
-
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -49,10 +45,9 @@ itkEdgePotentialImageFilterTest(int, char *[])
   // Create two images
   auto inputImage = InputImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize input image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkExpImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkExpImageFilterAndAdaptorTest.cxx
@@ -36,9 +36,6 @@ itkExpImageFilterAndAdaptorTest(int, char *[])
   using InputIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -48,10 +45,9 @@ itkExpImageFilterAndAdaptorTest(int, char *[])
   // Create two images
   auto inputImage = InputImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkExpNegativeImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkExpNegativeImageFilterAndAdaptorTest.cxx
@@ -36,9 +36,6 @@ itkExpNegativeImageFilterAndAdaptorTest(int, char *[])
   using InputIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -48,10 +45,9 @@ itkExpNegativeImageFilterAndAdaptorTest(int, char *[])
   // Create two images
   auto inputImage = InputImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkLog10ImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkLog10ImageFilterAndAdaptorTest.cxx
@@ -39,9 +39,6 @@ itkLog10ImageFilterAndAdaptorTest(int, char *[])
   using InputIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -51,10 +48,9 @@ itkLog10ImageFilterAndAdaptorTest(int, char *[])
   // Create the input images
   auto inputImage = InputImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkLogImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkLogImageFilterAndAdaptorTest.cxx
@@ -40,9 +40,6 @@ itkLogImageFilterAndAdaptorTest(int, char *[])
   using InputIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -52,10 +49,9 @@ itkLogImageFilterAndAdaptorTest(int, char *[])
   // Create the input image
   auto inputImage = InputImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkMaximumImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMaximumImageFilterTest.cxx
@@ -33,9 +33,6 @@ itkMaximumImageFilterTest(int, char *[])
   // Declare the types of the images
   using ImageType = itk::Image<PixelType, Dimension>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<Dimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<Dimension>;
 
@@ -49,10 +46,9 @@ itkMaximumImageFilterTest(int, char *[])
   auto inputImageA = ImageType::New();
   auto inputImageB = ImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);
@@ -111,7 +107,7 @@ itkMaximumImageFilterTest(int, char *[])
 
   constexpr ImageType::IndexType pixelIndex{ 0, 1, 1 };
 
-  ITK_TEST_EXPECT_EQUAL(outputImage->GetPixel(start), largePixelValue);
+  ITK_TEST_EXPECT_EQUAL(outputImage->GetPixel({}), largePixelValue);
   ITK_TEST_EXPECT_EQUAL(outputImage->GetPixel(pixelIndex), largePixelValue);
 
   // All objects should be automatically destroyed at this point

--- a/Modules/Filtering/ImageIntensity/test/itkMinimumImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMinimumImageFilterTest.cxx
@@ -33,9 +33,6 @@ itkMinimumImageFilterTest(int, char *[])
   // Declare the types of the images
   using ImageType = itk::Image<PixelType, Dimension>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<Dimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<Dimension>;
 
@@ -49,10 +46,9 @@ itkMinimumImageFilterTest(int, char *[])
   auto inputImageA = ImageType::New();
   auto inputImageB = ImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);
@@ -111,7 +107,7 @@ itkMinimumImageFilterTest(int, char *[])
 
   constexpr ImageType::IndexType pixelIndex{ 0, 1, 1 };
 
-  ITK_TEST_EXPECT_EQUAL(outputImage->GetPixel(start), smallPixelValue);
+  ITK_TEST_EXPECT_EQUAL(outputImage->GetPixel({}), smallPixelValue);
   ITK_TEST_EXPECT_EQUAL(outputImage->GetPixel(pixelIndex), smallPixelValue);
 
   // All objects should be automatically destroyed at this point

--- a/Modules/Filtering/ImageIntensity/test/itkMultiplyImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMultiplyImageFilterTest.cxx
@@ -40,9 +40,6 @@ itkMultiplyImageFilterTest(int, char *[])
   // Declare appropriate Iterator types for each image
   using OutputImageIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<Dimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<Dimension>;
 
@@ -53,10 +50,9 @@ itkMultiplyImageFilterTest(int, char *[])
   auto inputImageA = InputImageType1::New();
   auto inputImageB = InputImageType2::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkNaryMaximumImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNaryMaximumImageFilterTest.cxx
@@ -36,9 +36,6 @@ using PixelType = float;
 using InputImageType = itk::Image<PixelType, Dimension>;
 using OutputImageType = itk::Image<PixelType, Dimension>;
 
-// Declare the type of the index to access images
-using IndexType = itk::Index<Dimension>;
-
 // Declare the type of the size
 using SizeType = itk::Size<Dimension>;
 
@@ -58,10 +55,9 @@ InitializeImage(InputImageType * image, double value)
 {
   const InputImageType::Pointer inputImage(image);
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   inputImage->SetRegions(region);
   inputImage->Allocate();

--- a/Modules/Filtering/ImageIntensity/test/itkNotImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNotImageFilterTest.cxx
@@ -34,9 +34,6 @@ itkNotImageFilterTest(int, char *[])
   using InputImageType = itk::Image<PixelType, Dimension>;
   using OutputImageType = itk::Image<PixelType, Dimension>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<Dimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<Dimension>;
 
@@ -49,10 +46,9 @@ itkNotImageFilterTest(int, char *[])
   // Create the input image
   auto inputImage = InputImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize input image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkOrImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkOrImageFilterTest.cxx
@@ -42,9 +42,6 @@ itkOrImageFilterTest(int argc, char * argv[])
   using InputImage2Type = itk::Image<PixelType, Dimension>;
   using OutputImageType = itk::Image<PixelType, Dimension>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<Dimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<Dimension>;
 
@@ -58,10 +55,9 @@ itkOrImageFilterTest(int argc, char * argv[])
   auto inputImageA = InputImage1Type::New();
   auto inputImageB = InputImage2Type::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkRGBToLuminanceImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkRGBToLuminanceImageFilterAndAdaptorTest.cxx
@@ -44,9 +44,6 @@ itkRGBToLuminanceImageFilterAndAdaptorTest(int, char *[])
 
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -56,10 +53,9 @@ itkRGBToLuminanceImageFilterAndAdaptorTest(int, char *[])
   // Create the input image
   auto inputImage = InputImageType::New();
 
-  // Define its size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define its size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize the input image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkSigmoidImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSigmoidImageFilterTest.cxx
@@ -39,9 +39,6 @@ itkSigmoidImageFilterTest(int, char *[])
   using InputIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -51,10 +48,9 @@ itkSigmoidImageFilterTest(int, char *[])
   // Create the input images
   auto inputImage = InputImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize the input image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkSinImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSinImageFilterAndAdaptorTest.cxx
@@ -41,9 +41,6 @@ itkSinImageFilterAndAdaptorTest(int, char *[])
   using InputIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -53,10 +50,9 @@ itkSinImageFilterAndAdaptorTest(int, char *[])
   // Create the input image
   auto inputImage = InputImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkSqrtImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSqrtImageFilterAndAdaptorTest.cxx
@@ -41,9 +41,6 @@ itkSqrtImageFilterAndAdaptorTest(int, char *[])
   using InputIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -53,10 +50,9 @@ itkSqrtImageFilterAndAdaptorTest(int, char *[])
   // Create the input image
   auto inputImage = InputImageType::New();
 
-  // Define its size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define its size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize the input image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkSquareImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSquareImageFilterTest.cxx
@@ -38,9 +38,6 @@ itkSquareImageFilterTest(int, char *[])
   using InputIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -50,10 +47,9 @@ itkSquareImageFilterTest(int, char *[])
   // Create two images
   auto inputImage = InputImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkSubtractImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSubtractImageFilterTest.cxx
@@ -40,10 +40,6 @@ itkSubtractImageFilterTest(int, char *[])
   // Declare appropriate Iterator types for each image
   using OutputImageIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<Dimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<Dimension>;
 
@@ -54,10 +50,9 @@ itkSubtractImageFilterTest(int, char *[])
   auto inputImageA = InputImageType1::New();
   auto inputImageB = InputImageType2::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkTanImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkTanImageFilterAndAdaptorTest.cxx
@@ -40,9 +40,6 @@ itkTanImageFilterAndAdaptorTest(int, char *[])
   using InputIteratorType = itk::ImageRegionIteratorWithIndex<InputImageType>;
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -52,10 +49,9 @@ itkTanImageFilterAndAdaptorTest(int, char *[])
   // Create the input image
   auto inputImage = InputImageType::New();
 
-  // Define its size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define its size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize the input image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkTernaryMagnitudeImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkTernaryMagnitudeImageFilterTest.cxx
@@ -42,9 +42,6 @@ itkTernaryMagnitudeImageFilterTest(int argc, char * argv[])
   using InputImage3Type = itk::Image<InputPixelType, Dimension>;
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<Dimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<Dimension>;
 
@@ -56,10 +53,9 @@ itkTernaryMagnitudeImageFilterTest(int argc, char * argv[])
   auto inputImageB = InputImage2Type::New();
   auto inputImageC = InputImage3Type::New();
 
-  // Define their size and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkTernaryMagnitudeSquaredImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkTernaryMagnitudeSquaredImageFilterTest.cxx
@@ -36,9 +36,6 @@ itkTernaryMagnitudeSquaredImageFilterTest(int, char *[])
   using InputImageType3 = itk::Image<PixelType, Dimension>;
   using OutputImageType = itk::Image<PixelType, Dimension>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<Dimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<Dimension>;
 
@@ -50,10 +47,9 @@ itkTernaryMagnitudeSquaredImageFilterTest(int, char *[])
   auto inputImageB = InputImageType2::New();
   auto inputImageC = InputImageType3::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkXorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkXorImageFilterTest.cxx
@@ -40,9 +40,6 @@ itkXorImageFilterTest(int argc, char * argv[])
   using InputImage2Type = itk::Image<PixelType, Dimension>;
   using OutputImageType = itk::Image<PixelType, Dimension>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<Dimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<Dimension>;
 
@@ -56,10 +53,9 @@ itkXorImageFilterTest(int argc, char * argv[])
   auto inputImageA = InputImage1Type::New();
   auto inputImageB = InputImage2Type::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Nonunit/Review/test/itkGridForwardWarpImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkGridForwardWarpImageFilterTest.cxx
@@ -47,10 +47,6 @@ itkGridForwardWarpImageFilterTest(int argc, char * argv[])
   // Declare iterator types appropriate for each image
   using DeformationIteratorType = itk::ImageRegionIteratorWithIndex<DisplacementFieldType>;
 
-
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -60,10 +56,9 @@ itkGridForwardWarpImageFilterTest(int argc, char * argv[])
   // Create an input image
   auto inputDisplacementField = DisplacementFieldType::New();
 
-  // Define its size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define its size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize the input image
   inputDisplacementField->SetRegions(region);

--- a/Modules/Nonunit/Review/test/itkWarpHarmonicEnergyCalculatorTest.cxx
+++ b/Modules/Nonunit/Review/test/itkWarpHarmonicEnergyCalculatorTest.cxx
@@ -43,9 +43,6 @@ itkWarpHarmonicEnergyCalculatorTest(int argc, char * argv[])
   // Declare the types of the images
   using DisplacementFieldType = itk::Image<DeformationPixelType, ImageDimension>;
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -55,10 +52,9 @@ itkWarpHarmonicEnergyCalculatorTest(int argc, char * argv[])
   // Create the input image
   auto inputDisplacementField = DisplacementFieldType::New();
 
-  // Define its size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define its size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize the input image
   inputDisplacementField->SetRegions(region);

--- a/Modules/Nonunit/Review/test/itkWarpJacobianDeterminantFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkWarpJacobianDeterminantFilterTest.cxx
@@ -37,10 +37,6 @@ itkWarpJacobianDeterminantFilterTest(int, char *[])
   using DeformationIteratorType = itk::ImageRegionIteratorWithIndex<DisplacementFieldType>;
   using OutputIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
 
-
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<ImageDimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<ImageDimension>;
 
@@ -50,10 +46,9 @@ itkWarpJacobianDeterminantFilterTest(int, char *[])
   // Create two images
   auto inputDisplacementField = DisplacementFieldType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputDisplacementField->SetRegions(region);

--- a/Modules/Segmentation/LabelVoting/test/itkLabelVotingImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkLabelVotingImageFilterTest.cxx
@@ -43,9 +43,6 @@ itkLabelVotingImageFilterTest(int, char *[])
   const unsigned int combinationAB[8] = { 8, 1, 8, 8, 4, 8, 8, 8 };
   const unsigned int combinationABundecided255[8] = { 255, 1, 255, 255, 4, 255, 255, 255 };
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<Dimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<Dimension>;
 
@@ -63,10 +60,9 @@ itkLabelVotingImageFilterTest(int, char *[])
   auto inputImageB = ImageType::New();
   auto inputImageC = ImageType::New();
 
-  // Define their size, and start index
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{ 0, 0, 0 };
-  RegionType          region{ start, size };
+  // Define their size and region
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);


### PR DESCRIPTION
Using Notepad++, having Search Mode "Extended":

  Find what: `constexpr IndexType start{ 0, 0, 0 };\r\n  RegionType          region{ start, size };`
  Replaced with: `RegionType region{ size };`

Adjusted the comments accordingly.

Rationale: A 3D region already starts at index `(0, 0, 0)` by default.