### PR TITLE
STYLE: Remove `const IndexType start{}` variables from tests

### DIFF
--- a/Modules/Core/Common/test/itkImageIteratorWithIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorWithIndexTest.cxx
@@ -41,9 +41,7 @@ public:
   {
     auto size = ImageType::SizeType::Filled(100);
 
-    const typename ImageType::IndexType start{};
-
-    const typename ImageType::RegionType region{ start, size };
+    const typename ImageType::RegionType region{ size };
 
     m_Image->SetRegions(region);
     m_Image->Allocate();

--- a/Modules/Core/Common/test/itkImageIteratorsForwardBackwardTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorsForwardBackwardTest.cxx
@@ -35,9 +35,7 @@ itkImageIteratorsForwardBackwardTest(int, char *[])
   size[1] = 4;
   size[2] = 4;
 
-  constexpr ImageType::IndexType start{};
-
-  const ImageType::RegionType region{ start, size };
+  const ImageType::RegionType region{ size };
 
   myImage->SetRegions(region);
   myImage->Allocate();

--- a/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
+++ b/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
@@ -52,9 +52,7 @@ itkImageRandomIteratorTest2(int argc, char * argv[])
 
   const unsigned long numberOfSamples = size[0] * size[1];
 
-  constexpr ImageType::IndexType start{};
-
-  const ImageType::RegionType region{ start, size };
+  const ImageType::RegionType region{ size };
 
   image->SetRegions(region);
   image->AllocateInitialized();

--- a/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest2.cxx
+++ b/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest2.cxx
@@ -34,12 +34,11 @@ itkImageRandomNonRepeatingIteratorWithIndexTest2(int, char *[])
   using ImageType = itk::Image<PixelType, ImageDimension>;
 
   using RandomConstIteratorType = itk::ImageRandomNonRepeatingConstIteratorWithIndex<ImageType>;
-  constexpr unsigned long        N{ 10 };
-  constexpr int                  Seed{ 42 };
-  auto                           size = ImageType::SizeType::Filled(N);
-  constexpr ImageType::IndexType start{};
-  const ImageType::RegionType    region{ start, size };
-  auto                           myImage = ImageType::New();
+  constexpr unsigned long     N{ 10 };
+  constexpr int               Seed{ 42 };
+  auto                        size = ImageType::SizeType::Filled(N);
+  const ImageType::RegionType region{ size };
+  auto                        myImage = ImageType::New();
   myImage->SetRegions(region);
   myImage->Allocate();
   using WalkType = std::vector<ImageType::IndexType>;

--- a/Modules/Core/Common/test/itkImageVectorOptimizerParametersHelperTest.cxx
+++ b/Modules/Core/Common/test/itkImageVectorOptimizerParametersHelperTest.cxx
@@ -80,13 +80,11 @@ itkImageVectorOptimizerParametersHelperTest(int, char *[])
 {
   int result = EXIT_SUCCESS;
 
-  constexpr IndexType start{};
-
   SizeType      size;
   constexpr int dimLength{ 3 };
   size.Fill(dimLength);
 
-  const RegionType region{ start, size };
+  const RegionType region{ size };
 
   const ImageVectorPointer imageOfVectors = ImageVectorType::New();
   imageOfVectors->SetRegions(region);

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageReadTest.cxx
@@ -41,9 +41,7 @@ itkSymmetricSecondRankTensorImageReadTest(int argc, char * argv[])
 
   auto size = MatrixImageType::SizeType::Filled(10);
 
-  constexpr MatrixImageType::IndexType start{};
-
-  const MatrixImageType::RegionType region{ start, size };
+  const MatrixImageType::RegionType region{ size };
 
   matrixImage->SetRegions(region);
   matrixImage->Allocate();

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
@@ -39,9 +39,7 @@ itkSymmetricSecondRankTensorImageWriteReadTest(int argc, char * argv[])
 
   auto size = TensorImageType::SizeType::Filled(10);
 
-  constexpr TensorImageType::IndexType start{};
-
-  const TensorImageType::RegionType region{ start, size };
+  const TensorImageType::RegionType region{ size };
 
   tensorImageInput->SetRegions(region);
   tensorImageInput->Allocate();

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorTest.cxx
@@ -142,9 +142,8 @@ itkSymmetricSecondRankTensorTest(int, char *[])
 
   auto dti = ImageType::New();
 
-  constexpr ImageType::SizeType  size{ 128, 128, 128 };
-  constexpr ImageType::IndexType start{};
-  ImageType::RegionType          region = { start, size };
+  constexpr ImageType::SizeType size{ 128, 128, 128 };
+  ImageType::RegionType         region = { size };
 
   dti->SetRegions(region);
   dti->Allocate();

--- a/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
@@ -572,10 +572,9 @@ itkVectorImageTest(int, char * argv[])
     // Create an image using itk::Vector
     using VectorPixelType = itk::Vector<PixelType, VectorLength>;
     using VectorImageType = itk::Image<itk::Vector<PixelType, VectorLength>, Dimension>;
-    auto                                 image = VectorImageType::New();
-    constexpr VectorImageType::IndexType start{};
-    auto                                 size = VectorImageType::SizeType::Filled(5);
-    const VectorImageType::RegionType    region(start, size);
+    auto                              image = VectorImageType::New();
+    auto                              size = VectorImageType::SizeType::Filled(5);
+    const VectorImageType::RegionType region(size);
     image->SetRegions(region);
     image->Allocate();
 

--- a/Modules/Core/ImageFunction/test/itkCovarianceImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCovarianceImageFunctionTest.cxx
@@ -33,11 +33,9 @@ itkCovarianceImageFunctionTest(int, char *[])
   using FunctionType = itk::CovarianceImageFunction<ImageType>;
 
   // Create and allocate the image
-  auto                           image = ImageType::New();
-  constexpr ImageType::SizeType  size{ 20, 20, 20 };
-  constexpr ImageType::IndexType start{};
-
-  ImageType::RegionType region = { start, size };
+  auto                          image = ImageType::New();
+  constexpr ImageType::SizeType size{ 20, 20, 20 };
+  ImageType::RegionType         region = { size };
 
   image->SetRegions(region);
   image->Allocate();

--- a/Modules/Core/ImageFunction/test/itkGaussianBlurImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianBlurImageFunctionTest.cxx
@@ -29,10 +29,9 @@ itkGaussianBlurImageFunctionTest(int, char *[])
   using GFunctionType = itk::GaussianBlurImageFunction<ImageType>;
 
   // Create and allocate the image
-  auto                           image = ImageType::New();
-  constexpr ImageType::SizeType  size{ 50, 50 };
-  constexpr ImageType::IndexType start{};
-  ImageType::RegionType          region = { start, size };
+  auto                          image = ImageType::New();
+  constexpr ImageType::SizeType size{ 50, 50 };
+  ImageType::RegionType         region = { size };
 
   image->SetRegions(region);
   image->AllocateInitialized();

--- a/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
@@ -42,11 +42,9 @@ itkGaussianInterpolateImageFunctionTest(int, char *[])
 
   auto image = ImageType::New();
 
-  constexpr ImageType::IndexType start{};
-
   auto size = ImageType::SizeType::Filled(3);
 
-  const ImageType::RegionType region{ start, size };
+  const ImageType::RegionType region{ size };
 
   image->SetRegions(region);
   image->Allocate();

--- a/Modules/Core/ImageFunction/test/itkLabelImageGaussianInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLabelImageGaussianInterpolateImageFunctionTest.cxx
@@ -41,9 +41,8 @@ itkLabelImageGaussianInterpolateImageFunctionTest(int, char *[])
   constexpr itk::IndexValueType small_ySize{ 3 };
   auto                          small_image = ImageType::New();
   {
-    constexpr IndexType start{};
-    constexpr SizeType  size{ small_xSize, small_ySize };
-    RegionType          region = { start, size };
+    constexpr SizeType size{ small_xSize, small_ySize };
+    RegionType         region = { size };
 
 
     small_image->SetRegions(region);
@@ -107,12 +106,10 @@ itkLabelImageGaussianInterpolateImageFunctionTest(int, char *[])
   {
     RegionType region;
     {
-      constexpr IndexType start{};
-
       SizeType size;
       size[0] = large_xSize;
       size[1] = large_ySize;
-      region = { start, size };
+      region = { size };
     }
 
     large_image->SetRegions(region);

--- a/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
@@ -60,13 +60,11 @@ RunLinearInterpolateTest()
   auto variablevectorimage = VariableVectorImageType::New();
   variablevectorimage->SetVectorLength(VectorDimension);
 
-  constexpr IndexType start{};
-
   SizeType      size;
   constexpr int dimMaxLength{ 3 };
   size.Fill(dimMaxLength);
 
-  const RegionType region{ start, size };
+  const RegionType region{ size };
 
   image->SetRegions(region);
   image->Allocate();

--- a/Modules/Core/ImageFunction/test/itkMeanImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkMeanImageFunctionTest.cxx
@@ -35,9 +35,8 @@ itkMeanImageFunctionTest(int, char *[])
   // Create and allocate the image
   auto image = ImageType::New();
 
-  constexpr ImageType::SizeType  size{ 50, 50, 50 };
-  constexpr ImageType::IndexType start{};
-  ImageType::RegionType          region = { start, size };
+  constexpr ImageType::SizeType size{ 50, 50, 50 };
+  ImageType::RegionType         region = { size };
 
   image->SetRegions(region);
   image->Allocate();

--- a/Modules/Core/ImageFunction/test/itkMedianImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkMedianImageFunctionTest.cxx
@@ -33,11 +33,10 @@ itkMedianImageFunctionTest(int, char *[])
   // Create and allocate the image
   auto image = ImageType::New();
 
-  constexpr int                  sizeDim(50);
-  constexpr int                  centerIndex(sizeDim / 2);
-  constexpr ImageType::SizeType  size{ 50, 50, 50 };
-  constexpr ImageType::IndexType start{};
-  ImageType::RegionType          region = { start, size };
+  constexpr int                 sizeDim(50);
+  constexpr int                 centerIndex(sizeDim / 2);
+  constexpr ImageType::SizeType size{ 50, 50, 50 };
+  ImageType::RegionType         region = { size };
 
   image->SetRegions(region);
   image->Allocate();

--- a/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
@@ -58,11 +58,9 @@ itkNearestNeighborInterpolateImageFunctionTest(int, char *[])
   auto variablevectorimage = VariableVectorImageType::New();
   variablevectorimage->SetVectorLength(VectorDimension);
 
-  constexpr IndexType start{};
-
   auto size = SizeType::Filled(3);
 
-  const RegionType region{ start, size };
+  const RegionType region{ size };
 
   image->SetRegions(region);
   image->Allocate();

--- a/Modules/Core/ImageFunction/test/itkNeighborhoodOperatorImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkNeighborhoodOperatorImageFunctionTest.cxx
@@ -32,10 +32,9 @@ itkNeighborhoodOperatorImageFunctionTest(int, char *[])
   using FunctionType = itk::NeighborhoodOperatorImageFunction<ImageType, PixelType>;
 
   // Create and allocate the image
-  auto                           image = ImageType::New();
-  constexpr ImageType::SizeType  size{ 50, 50, 50 };
-  constexpr ImageType::IndexType start{};
-  ImageType::RegionType          region = { start, size };
+  auto                          image = ImageType::New();
+  constexpr ImageType::SizeType size{ 50, 50, 50 };
+  ImageType::RegionType         region = { size };
 
   image->SetRegions(region);
   image->Allocate();

--- a/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
@@ -40,10 +40,9 @@ itkRayCastInterpolateImageFunctionTest(int itkNotUsed(argc), char * itkNotUsed(a
   using RegionType = ImageType::RegionType;
 
   /* Allocate a simple test image */
-  auto                image = ImageType::New();
-  constexpr IndexType start{};
-  constexpr SizeType  size{ 30, 30, 30 };
-  RegionType          region{ start, size };
+  auto               image = ImageType::New();
+  constexpr SizeType size{ 30, 30, 30 };
+  RegionType         region{ size };
   image->SetRegions(region);
   image->Allocate();
 

--- a/Modules/Core/ImageFunction/test/itkScatterMatrixImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkScatterMatrixImageFunctionTest.cxx
@@ -33,10 +33,9 @@ itkScatterMatrixImageFunctionTest(int, char *[])
   using FunctionType = itk::ScatterMatrixImageFunction<ImageType>;
 
   // Create and allocate the image
-  auto                           image = ImageType::New();
-  constexpr ImageType::SizeType  size{ 20, 20, 20 };
-  constexpr ImageType::IndexType start{};
-  ImageType::RegionType          region = { start, size };
+  auto                          image = ImageType::New();
+  constexpr ImageType::SizeType size{ 20, 20, 20 };
+  ImageType::RegionType         region = { size };
 
   image->SetRegions(region);
   image->Allocate();

--- a/Modules/Core/ImageFunction/test/itkVarianceImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkVarianceImageFunctionTest.cxx
@@ -32,10 +32,9 @@ itkVarianceImageFunctionTest(int, char *[])
   using FunctionType = itk::VarianceImageFunction<ImageType>;
 
   // Create and allocate the image
-  auto                           image = ImageType::New();
-  constexpr ImageType::SizeType  size{ 50, 50, 50 };
-  constexpr ImageType::IndexType start{};
-  ImageType::RegionType          region = { start, size };
+  auto                          image = ImageType::New();
+  constexpr ImageType::SizeType size{ 50, 50, 50 };
+  ImageType::RegionType         region = { size };
 
   image->SetRegions(region);
   image->Allocate();

--- a/Modules/Core/ImageFunction/test/itkVectorMeanImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkVectorMeanImageFunctionTest.cxx
@@ -34,10 +34,9 @@ itkVectorMeanImageFunctionTest(int, char *[])
   using FunctionType = itk::VectorMeanImageFunction<ImageType>;
 
   // Create and allocate the image
-  auto                           image = ImageType::New();
-  constexpr ImageType::SizeType  size{ 20, 20, 20 };
-  constexpr ImageType::IndexType start{};
-  ImageType::RegionType          region = { start, size };
+  auto                          image = ImageType::New();
+  constexpr ImageType::SizeType size{ 20, 20, 20 };
+  ImageType::RegionType         region = { size };
 
   image->SetRegions(region);
   image->Allocate();

--- a/Modules/Core/Mesh/test/itkBinaryMask3DMeshSourceTest.cxx
+++ b/Modules/Core/Mesh/test/itkBinaryMask3DMeshSourceTest.cxx
@@ -80,9 +80,7 @@ itkBinaryMask3DMeshSourceTest(int argc, char * argv[])
   size[1] = 128;
   size[2] = 128;
 
-  constexpr IndexType start{};
-
-  RegionType region{ start, size };
+  RegionType region{ size };
 
   const ImagePointerType image = ImageType::New();
   image->SetRegions(region);

--- a/Modules/Core/Mesh/test/itkImageToParametricSpaceFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkImageToParametricSpaceFilterTest.cxx
@@ -63,12 +63,11 @@ itkImageToParametricSpaceFilterTest(int, char *[])
   const ImagePointer imageY = ImageType::New();
   const ImagePointer imageZ = ImageType::New();
 
-  ImageType::SizeType            size;
-  constexpr ImageType::IndexType start{};
+  ImageType::SizeType size;
   size[0] = 10;
   size[1] = 10;
 
-  const ImageType::RegionType region{ start, size };
+  const ImageType::RegionType region{ size };
 
   imageX->SetRegions(region);
   imageY->SetRegions(region);

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
@@ -133,11 +133,9 @@ itkSpatialObjectToImageStatisticsCalculatorTest(int, char *[])
 
   using RegionType = Image3DType::RegionType;
   using SizeType = Image3DType::SizeType;
-  using IndexType = Image3DType::IndexType;
 
-  SizeType            size3D{ 50, 50, 3 };
-  constexpr IndexType start{};
-  RegionType          region3D{ start, size3D };
+  SizeType   size3D{ 50, 50, 3 };
+  RegionType region3D{ size3D };
   image3D->SetRegions(region3D);
   image3D->Allocate();
   image3D->FillBuffer(255);

--- a/Modules/Core/Transform/test/itkMultiTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkMultiTransformTest.cxx
@@ -324,10 +324,9 @@ itkMultiTransformTest(int, char *[])
   auto field = FieldType::New(); // This is based on itk::Image
 
 
-  constexpr int                  dimLength{ 4 };
-  constexpr auto                 size = itk::MakeFilled<FieldType::SizeType>(dimLength);
-  constexpr FieldType::IndexType start{};
-  FieldType::RegionType          region{ start, size };
+  constexpr int         dimLength{ 4 };
+  constexpr auto        size = itk::MakeFilled<FieldType::SizeType>(dimLength);
+  FieldType::RegionType region{ size };
   field->SetRegions(region);
   field->Allocate();
 

--- a/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DTest.cxx
@@ -152,9 +152,8 @@ itkDiffusionTensor3DTest(int, char *[])
 
   auto dti = ImageType::New();
 
-  constexpr ImageType::SizeType  size{ 128, 128, 128 };
-  constexpr ImageType::IndexType start{};
-  ImageType::RegionType          region = { start, size };
+  constexpr ImageType::SizeType size{ 128, 128, 128 };
+  ImageType::RegionType         region = { size };
 
   dti->SetRegions(region);
   dti->Allocate();

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformCloneTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformCloneTest.cxx
@@ -55,11 +55,9 @@ itkDisplacementFieldTransformCloneTest(int, char *[])
 
   auto field = FieldType::New();
 
-  constexpr int                  dimLength{ 20 };
-  constexpr FieldType::SizeType  size{ dimLength, dimLength, dimLength };
-  constexpr FieldType::IndexType start{};
-
-  FieldType::RegionType region = { start, size };
+  constexpr int                 dimLength{ 20 };
+  constexpr FieldType::SizeType size{ dimLength, dimLength, dimLength };
+  FieldType::RegionType         region = { size };
   field->SetRegions(region);
   field->Allocate();
 

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
@@ -237,10 +237,9 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
 
   auto field = FieldType::New();
 
-  constexpr int                  dimLength{ 20 };
-  auto                           size = itk::MakeFilled<FieldType::SizeType>(dimLength);
-  constexpr FieldType::IndexType start{};
-  FieldType::RegionType          region{ start, size };
+  constexpr int         dimLength{ 20 };
+  auto                  size = itk::MakeFilled<FieldType::SizeType>(dimLength);
+  FieldType::RegionType region{ size };
   field->SetRegions(region);
   field->Allocate();
 

--- a/Modules/Filtering/DisplacementField/test/itkGaussianExponentialDiffeomorphicTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkGaussianExponentialDiffeomorphicTransformTest.cxx
@@ -46,11 +46,9 @@ itkGaussianExponentialDiffeomorphicTransformTest(int, char *[])
   using FieldType = DisplacementTransformType::DisplacementFieldType;
   auto field = FieldType::New(); // This is based on itk::Image
 
-  constexpr int                  dimLength{ 20 };
-  constexpr FieldType::SizeType  size{ dimLength, dimLength };
-  constexpr FieldType::IndexType start{};
-
-  FieldType::RegionType region = { start, size };
+  constexpr int                 dimLength{ 20 };
+  constexpr FieldType::SizeType size{ dimLength, dimLength };
+  FieldType::RegionType         region = { size };
   field->SetRegions(region);
   field->Allocate();
 

--- a/Modules/Filtering/DisplacementField/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest.cxx
@@ -41,10 +41,9 @@ itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest(int, char *[])
   using FieldType = DisplacementTransformType::DisplacementFieldType;
   auto field = FieldType::New(); // This is based on itk::Image
 
-  constexpr int                  dimLength{ 20 };
-  constexpr FieldType::SizeType  size{ dimLength, dimLength };
-  constexpr FieldType::IndexType start{};
-  FieldType::RegionType          region = { start, size };
+  constexpr int                 dimLength{ 20 };
+  constexpr FieldType::SizeType size{ dimLength, dimLength };
+  FieldType::RegionType         region = { size };
   field->SetRegions(region);
   field->Allocate();
 

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
@@ -172,9 +172,7 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int argc, char * argv[])
   size[1] = 3;
   size[2] = 401;
   size[3] = 61;
-  constexpr ImportFilterType::IndexType start{};
-
-  const ImportFilterType::RegionType region{ start, size };
+  const ImportFilterType::RegionType region{ size };
 
   importFilter->SetRegion(region);
 

--- a/Modules/Filtering/DistanceMap/test/itkReflectiveImageRegionIteratorTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkReflectiveImageRegionIteratorTest.cxx
@@ -37,9 +37,7 @@ itkReflectiveImageRegionIteratorTest(int, char *[])
 
   constexpr ImageType::SizeType size{ 4, 4, 4, 4 };
 
-  constexpr ImageType::IndexType start{};
-
-  const ImageType::RegionType region{ start, size };
+  const ImageType::RegionType region{ size };
 
   myImage->SetRegions(region);
   myImage->Allocate();

--- a/Modules/Filtering/ImageCompose/test/itkCompose2DCovariantVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkCompose2DCovariantVectorImageFilterTest.cxx
@@ -34,16 +34,14 @@ itkCompose2DCovariantVectorImageFilterTest(int, char *[])
 
   using RegionType = InputImageType::RegionType;
   using SizeType = InputImageType::SizeType;
-  using IndexType = InputImageType::IndexType;
 
   auto filter = FilterType::New();
 
   auto zeroImage = InputImageType::New();
   auto oneImage = InputImageType::New();
 
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{};
-  RegionType          region{ start, size };
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   zeroImage->SetRegions(region);
   oneImage->SetRegions(region);

--- a/Modules/Filtering/ImageCompose/test/itkCompose2DVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkCompose2DVectorImageFilterTest.cxx
@@ -34,16 +34,14 @@ itkCompose2DVectorImageFilterTest(int, char *[])
 
   using RegionType = InputImageType::RegionType;
   using SizeType = InputImageType::SizeType;
-  using IndexType = InputImageType::IndexType;
 
   auto filter = FilterType::New();
 
   auto zeroImage = InputImageType::New();
   auto oneImage = InputImageType::New();
 
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{};
-  RegionType          region{ start, size };
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   zeroImage->SetRegions(region);
   oneImage->SetRegions(region);

--- a/Modules/Filtering/ImageCompose/test/itkCompose3DCovariantVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkCompose3DCovariantVectorImageFilterTest.cxx
@@ -35,7 +35,6 @@ itkCompose3DCovariantVectorImageFilterTest(int, char *[])
 
   using RegionType = InputImageType::RegionType;
   using SizeType = InputImageType::SizeType;
-  using IndexType = InputImageType::IndexType;
 
   auto filter = FilterType::New();
 
@@ -43,9 +42,8 @@ itkCompose3DCovariantVectorImageFilterTest(int, char *[])
   auto oneImage = InputImageType::New();
   auto twoImage = InputImageType::New();
 
-  constexpr SizeType  size{ 2, 2, 2 };
-  constexpr IndexType start{};
-  RegionType          region{ start, size };
+  constexpr SizeType size{ 2, 2, 2 };
+  RegionType         region{ size };
 
   zeroImage->SetRegions(region);
   oneImage->SetRegions(region);

--- a/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterScaleSpaceTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterScaleSpaceTest.cxx
@@ -41,9 +41,7 @@ itkHessianRecursiveGaussianFilterScaleSpaceTest(int, char *[])
   auto size = SizeType::Filled(21);
   size[0] = 401;
 
-  constexpr IndexType start{};
-
-  RegionType region{ start, size };
+  RegionType region{ size };
 
   auto origin = itk::MakeFilled<PointType>(-1.25);
   origin[0] = -20.0;

--- a/Modules/Filtering/ImageGrid/test/itkRegionOfInterestImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkRegionOfInterestImageFilterTest.cxx
@@ -46,9 +46,8 @@ itkRegionOfInterestImageFilterTest(int, char *[])
 
   auto image = ImageType::New();
 
-  constexpr IndexType start{};
-  constexpr SizeType  size{ 40, 40, 40 };
-  RegionType          region{ start, size };
+  constexpr SizeType size{ 40, 40, 40 };
+  RegionType         region{ size };
 
   image->SetRegions(region);
   image->Allocate();

--- a/Modules/Filtering/ImageIntensity/test/itkImageAdaptorNthElementTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkImageAdaptorNthElementTest.cxx
@@ -77,10 +77,7 @@ itkImageAdaptorNthElementTest(int, char *[])
   size[1] = 2;
   size[2] = 2; // Small size, because we are printing it
 
-  constexpr myIndexType start{};
-
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   float spacing[3];
   spacing[0] = 1.0;

--- a/Modules/Filtering/ImageIntensity/test/itkNaryAddImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNaryAddImageFilterTest.cxx
@@ -34,9 +34,7 @@ InitializeImage(ImageType * image, const typename ImageType::PixelType & value)
   // Define their size, and start index
   auto size = ImageType::SizeType::Filled(2);
 
-  const typename ImageType::IndexType start{};
-
-  const typename ImageType::RegionType region{ start, size };
+  const typename ImageType::RegionType region{ size };
 
   inputImage->SetRegions(region);
   inputImage->Allocate();

--- a/Modules/Filtering/ImageIntensity/test/itkSymmetricEigenAnalysisImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSymmetricEigenAnalysisImageFilterTest.cxx
@@ -101,9 +101,6 @@ public:
 
     using SymmetricEigenAnalysisImageFilterType = SymmetricEigenAnalysisImageFilter<InputImageType, InternalImageType>;
 
-    // Declare the type of the index to access images
-    using IndexType = itk::Index<InputImageType::ImageDimension>;
-
     // Declare the type of the size
     using SizeType = itk::Size<InputImageType::ImageDimension>;
 
@@ -114,9 +111,8 @@ public:
     auto inputImage = InputImageType::New();
 
     // Define its size, and start index
-    SizeType            size{ 8, 8, 8 };
-    constexpr IndexType start{};
-    RegionType          region{ start, size };
+    SizeType   size{ 8, 8, 8 };
+    RegionType region{ size };
 
     // Initialize the input image
     inputImage->SetRegions(region);
@@ -201,9 +197,6 @@ public:
     using SymmetricEigenAnalysisFixedDimensionImageFilterType =
       SymmetricEigenAnalysisFixedDimensionImageFilter<TMatrixDimension, InputImageType, InternalImageType>;
 
-    // Declare the type of the index to access images
-    using IndexType = itk::Index<InputImageType::ImageDimension>;
-
     // Declare the type of the size
     using SizeType = itk::Size<InputImageType::ImageDimension>;
 
@@ -219,9 +212,7 @@ public:
     size[1] = 8;
     size[2] = 8;
 
-    constexpr IndexType start{};
-
-    RegionType region{ start, size };
+    RegionType region{ size };
 
     // Initialize the input image
     inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkVectorMagnitudeImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkVectorMagnitudeImageFilterTest.cxx
@@ -33,9 +33,7 @@ itkVectorMagnitudeImageFilterTest(int, char *[])
   // Define the size start index of the image
   auto size = VectorImageType::SizeType::Filled(3);
 
-  constexpr VectorImageType::IndexType start{};
-
-  const VectorImageType::RegionType region(start, size);
+  const VectorImageType::RegionType region(size);
 
   // Construct an image
   auto image = VectorImageType::New();

--- a/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest3.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest3.cxx
@@ -31,8 +31,6 @@ SEToFile(const TSEType & e, const std::string & fname)
 
   auto img = ImageType::New();
 
-  const typename ImageType::IndexType start{};
-
   typename ImageType::SizeType size;
   for (unsigned int i = 0; i < Dimension; ++i)
   {
@@ -40,7 +38,7 @@ SEToFile(const TSEType & e, const std::string & fname)
   }
 
 
-  const typename ImageType::RegionType region(start, size);
+  const typename ImageType::RegionType region(size);
   img->SetRegions(region);
   img->Allocate();
   img->FillBuffer(0);

--- a/Modules/Filtering/MathematicalMorphology/test/itkShapedIteratorFromStructuringElementTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkShapedIteratorFromStructuringElementTest.cxx
@@ -22,11 +22,9 @@ using LocalImageType = itk::Image<int, 2>;
 void
 CreateImagex(LocalImageType::Pointer & image)
 {
-  constexpr LocalImageType::IndexType start{};
-
   auto size = LocalImageType::SizeType::Filled(10);
 
-  const LocalImageType::RegionType region(start, size);
+  const LocalImageType::RegionType region(size);
 
   image->SetRegions(region);
   image->AllocateInitialized();

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkBinaryMask3DQuadEdgeMeshSourceTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkBinaryMask3DQuadEdgeMeshSourceTest.cxx
@@ -55,9 +55,7 @@ itkBinaryMask3DQuadEdgeMeshSourceTest(int, char *[])
   size[1] = 128;
   size[2] = 128;
 
-  constexpr IndexType start{};
-
-  const RegionType region{ start, size };
+  const RegionType region{ size };
 
   auto image = ImageType::New();
 
@@ -69,7 +67,7 @@ itkBinaryMask3DQuadEdgeMeshSourceTest(int, char *[])
   IteratorType it(image, region);
   it.GoToBegin();
 
-  IndexType centralIndex = start;
+  IndexType centralIndex{};
   centralIndex[0] += size[0] / 2;
   centralIndex[1] += size[1] / 2;
   centralIndex[2] += size[2] / 2;

--- a/Modules/IO/ImageBase/test/itkMatrixImageWriteReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkMatrixImageWriteReadTest.cxx
@@ -38,9 +38,7 @@ itkMatrixImageWriteReadTest(int argc, char * argv[])
 
   constexpr auto size = MatrixImageType::SizeType::Filled(10);
 
-  constexpr MatrixImageType::IndexType start{};
-
-  const MatrixImageType::RegionType region{ start, size };
+  const MatrixImageType::RegionType region{ size };
 
   matrixImage1->SetRegions(region);
   matrixImage1->Allocate();

--- a/Modules/IO/JPEG/test/itkJPEGImageIOTest2.cxx
+++ b/Modules/IO/JPEG/test/itkJPEGImageIOTest2.cxx
@@ -38,9 +38,8 @@ itkJPEGImageIOTest2(int argc, char * argv[])
 
   auto image = ImageType::New();
 
-  constexpr ImageType::IndexType start{};
-  constexpr ImageType::SizeType  size{ 157, 129 };
-  ImageType::RegionType          region = { start, size };
+  constexpr ImageType::SizeType size{ 157, 129 };
+  ImageType::RegionType         region = { size };
 
   image->SetRegions(region);
   image->AllocateInitialized();

--- a/Modules/IO/RAW/test/itkRawImageIOTest5.cxx
+++ b/Modules/IO/RAW/test/itkRawImageIOTest5.cxx
@@ -40,9 +40,8 @@ public:
   {
     m_Image = ImageType::New();
 
-    constexpr typename ImageType::SizeType  size{ 16, 16 };
-    constexpr typename ImageType::IndexType start{};
-    typename ImageType::RegionType          region = { start, size };
+    constexpr typename ImageType::SizeType size{ 16, 16 };
+    typename ImageType::RegionType         region = { size };
 
     m_Image->SetRegions(region);
     m_Image->Allocate();

--- a/Modules/IO/TransformHDF5/test/itkIOTransformHDF5Test.cxx
+++ b/Modules/IO/TransformHDF5/test/itkIOTransformHDF5Test.cxx
@@ -51,8 +51,7 @@ ReadWriteTest(const std::string & fileName, const bool isRealDisplacementField, 
   {
     constexpr int                        dimLength{ 20 };
     auto                                 size = FieldType::SizeType::Filled(dimLength);
-    const typename FieldType::IndexType  start{};
-    const typename FieldType::RegionType region{ start, size };
+    const typename FieldType::RegionType region{ size };
     knownField->SetRegions(region);
 
     auto spacing = itk::MakeFilled<typename FieldType::SpacingType>(requiredSpacing);

--- a/Modules/Numerics/Eigen/test/itkEigenAnalysis2DImageFilterTest.cxx
+++ b/Modules/Numerics/Eigen/test/itkEigenAnalysis2DImageFilterTest.cxx
@@ -59,9 +59,7 @@ class EigenAnalysis2DImageFilterTester
     // Define their size, and start index
     auto size = mySizeType::Filled(2);
 
-    constexpr myIndexType start{};
-
-    const myRegionType region{ start, size };
+    const myRegionType region{ size };
 
     inputImage->SetRegions(region);
     inputImage->Allocate();

--- a/Modules/Numerics/Statistics/test/itkImageToHistogramFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToHistogramFilterTest.cxx
@@ -37,9 +37,8 @@ itkImageToHistogramFilterTest(int, char *[])
 
   auto image = RGBImageType::New();
 
-  constexpr RGBImageType::SizeType  size{ 127, 127, 127 };
-  constexpr RGBImageType::IndexType start{};
-  RGBImageType::RegionType          region = { start, size };
+  constexpr RGBImageType::SizeType size{ 127, 127, 127 };
+  RGBImageType::RegionType         region = { size };
 
   image->SetRegions(region);
   image->Allocate();

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
@@ -546,8 +546,7 @@ itkImageToImageMetricv4Test(int, char ** const)
 
   FieldType::SizeType defsize;
   defsize.Fill(imageSize);
-  constexpr FieldType::IndexType start{};
-  FieldType::RegionType          defregion = { start, defsize };
+  FieldType::RegionType defregion = { defsize };
   field->SetRegions(defregion);
   field->Allocate();
   // Fill it with 0's

--- a/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterTest.cxx
@@ -40,9 +40,6 @@ itkMultiLabelSTAPLEImageFilterTest(int, char *[])
   const unsigned int combinationAB[imageSize] = { 8, 1, 8, 8, 4, 8, 8, 8 };
   const unsigned int combinationABundecided255[imageSize] = { 255, 1, 255, 255, 4, 255, 255, 255 };
 
-  // Declare the type of the index to access images
-  using IndexType = itk::Index<Dimension>;
-
   // Declare the type of the size
   using SizeType = itk::Size<Dimension>;
 
@@ -65,9 +62,8 @@ itkMultiLabelSTAPLEImageFilterTest(int, char *[])
   const ImageTypePointer inputImageC = ImageType::New();
 
   // Define their size, and start index
-  constexpr SizeType  size{ imageSizePerDimension, imageSizePerDimension, imageSizePerDimension };
-  constexpr IndexType start{};
-  RegionType          region = { start, size };
+  constexpr SizeType size{ imageSizePerDimension, imageSizePerDimension, imageSizePerDimension };
+  RegionType         region = { size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoIOTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoIOTest.cxx
@@ -38,10 +38,9 @@ ImageType::Pointer
 itkImageFromBuffer(itk::OpenCVVideoIO::Pointer opencvIO, void * buffer, size_t bufferSize)
 {
   // Set up for incoming image
-  const ImageType::SizeType      size{ opencvIO->GetDimensions(0), opencvIO->GetDimensions(1) };
-  constexpr ImageType::IndexType start{};
-  ImageType::RegionType          region = { start, size };
-  ImageType::PointType           origin;
+  const ImageType::SizeType size{ opencvIO->GetDimensions(0), opencvIO->GetDimensions(1) };
+  ImageType::RegionType     region = { size };
+  ImageType::PointType      origin;
   origin.Fill(0.0);
   ImageType::SpacingType space;
   space.Fill(1.0); // May need fixing

--- a/Modules/Video/BridgeVXL/test/itkVXLVideoIOTest.cxx
+++ b/Modules/Video/BridgeVXL/test/itkVXLVideoIOTest.cxx
@@ -37,11 +37,10 @@ itkImageFromBuffer(itk::VXLVideoIO::Pointer vxlIO, void * buffer, size_t bufferS
 {
   // Set up for incoming image
 
-  ImageType::SizeType            size{ vxlIO->GetDimensions(0), vxlIO->GetDimensions(1) };
-  constexpr ImageType::IndexType start{};
-  ImageType::RegionType          region = { start, size };
-  ImageType::PointType           origin;
-  ImageType::SpacingType         space;
+  ImageType::SizeType    size{ vxlIO->GetDimensions(0), vxlIO->GetDimensions(1) };
+  ImageType::RegionType  region = { size };
+  ImageType::PointType   origin;
+  ImageType::SpacingType space;
   origin.Fill(0.0);
   space.Fill(1.0); // May need fixing
 

--- a/Modules/Video/Core/test/itkVideoStreamTest.cxx
+++ b/Modules/Video/Core/test/itkVideoStreamTest.cxx
@@ -257,11 +257,10 @@ itkVideoStreamTest(int, char *[])
   }
 
   // Set the cached meta-data for a non-buffered frame
-  constexpr FrameType::RegionType::SizeType  sz{ 10, 20 };
-  constexpr FrameType::RegionType::IndexType start{};
-  FrameType::RegionType                      spatReg = { start, sz };
-  FrameType::SpacingType                     space{ { 0.1, 0.5 } };
-  FrameType::PointType                       orgn{ { 5.432, -23.4 } };
+  constexpr FrameType::RegionType::SizeType sz{ 10, 20 };
+  FrameType::RegionType                     spatReg = { sz };
+  FrameType::SpacingType                    space{ { 0.1, 0.5 } };
+  FrameType::PointType                      orgn{ { 5.432, -23.4 } };
 
   FrameType::DirectionType direction;
   direction[0][0] = 1;


### PR DESCRIPTION
Using Notepad++, Replace in Files:

  Find what: `^([ ]+ )const.*Index.* start{};[\r\n]+\1(.+{ )start, `
  Find what: `^([ ]+ )const.*Index.* start{};[\r\n]+\1(.+\r\n\1.+{ )start, `
  Replace with: `$1$2`

Manually replaced an initialization by `= start` with `{}`, in BinaryMask3DQuadEdgeMeshSourceTest.

Found a few more cases by regular expression `const.*Index.* start{};`.

Removed the `IndexType` type aliases that became unused with this change.

- Follow-up to pull request #5574 commit 51976ee9d893f707c5da32e54f9895ccabb891d3