### PR TITLE
STYLE: Replace `Allocate(); FillBuffer({})` with `AllocateInitialized()`

### DIFF
--- a/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest1.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest1.cxx
@@ -98,11 +98,10 @@ itkTransformToDisplacementFieldFilterTest1(int argc, char * argv[])
   const RegionType region{ index, size };
   auto             image = ImageType::New();
   image->SetRegions(region);
-  image->Allocate();
+  image->AllocateInitialized();
   image->SetSpacing(spacing);
   image->SetOrigin(origin);
   image->SetDirection(inputDirection);
-  image->FillBuffer(ScalarPixelType{});
 
   float     incrValue = 100.0;
   IndexType pixelIndex;

--- a/Modules/Filtering/DistanceMap/test/itkContourDirectedMeanDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkContourDirectedMeanDistanceImageFilterTest.cxx
@@ -40,11 +40,8 @@ itkContourDirectedMeanDistanceImageFilterTest(int, char *[])
   image1->SetRegions(size);
   image2->SetRegions(size);
 
-  image1->Allocate();
-  image2->Allocate();
-
-  image1->FillBuffer(Pixel1Type{});
-  image2->FillBuffer(Pixel2Type{});
+  image1->AllocateInitialized();
+  image2->AllocateInitialized();
 
   using RegionType = Image1Type::RegionType;
   using IndexType = Image1Type::IndexType;

--- a/Modules/Filtering/DistanceMap/test/itkContourMeanDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkContourMeanDistanceImageFilterTest.cxx
@@ -48,11 +48,8 @@ itkContourMeanDistanceImageFilterTest(int argc, char * argv[])
   image1->SetRegions(size);
   image2->SetRegions(size);
 
-  image1->Allocate();
-  image2->Allocate();
-
-  image1->FillBuffer(Pixel1Type{});
-  image2->FillBuffer(Pixel2Type{});
+  image1->AllocateInitialized();
+  image2->AllocateInitialized();
 
   using RegionType = Image1Type::RegionType;
 

--- a/Modules/Filtering/DistanceMap/test/itkDirectedHausdorffDistanceImageFilterTest1.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkDirectedHausdorffDistanceImageFilterTest1.cxx
@@ -39,11 +39,8 @@ itkDirectedHausdorffDistanceImageFilterTest1(int, char *[])
   image1->SetRegions(size);
   image2->SetRegions(size);
 
-  image1->Allocate();
-  image2->Allocate();
-
-  image1->FillBuffer(Pixel1Type{});
-  image2->FillBuffer(Pixel2Type{});
+  image1->AllocateInitialized();
+  image2->AllocateInitialized();
 
   using RegionType = Image1Type::RegionType;
 

--- a/Modules/Filtering/DistanceMap/test/itkHausdorffDistanceImageFilterGTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkHausdorffDistanceImageFilterGTest.cxx
@@ -41,11 +41,8 @@ TEST(HausdorffDistanceImageFilter, Test)
   image1->SetRegions(size);
   image2->SetRegions(size);
 
-  image1->Allocate();
-  image2->Allocate();
-
-  image1->FillBuffer(Pixel1Type{});
-  image2->FillBuffer(Pixel2Type{});
+  image1->AllocateInitialized();
+  image2->AllocateInitialized();
 
   using RegionType = Image1Type::RegionType;
 

--- a/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFunctionTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFunctionTest.cxx
@@ -45,8 +45,7 @@ itkBSplineControlPointImageFunctionTest(int, char *[])
   phiLattice->SetOrigin(origin);
   phiLattice->SetSpacing(spacing);
   phiLattice->SetRegions(size);
-  phiLattice->Allocate();
-  phiLattice->FillBuffer(VectorType{});
+  phiLattice->AllocateInitialized();
 
   // To create the specified function, the first and last control points have
   // a value of 1.0;

--- a/Modules/Filtering/ImageIntensity/test/itkDiscreteGaussianDerivativeImageFunctionTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkDiscreteGaussianDerivativeImageFunctionTest.cxx
@@ -121,8 +121,7 @@ itkDiscreteGaussianDerivativeImageFunctionTestND(int argc, char * argv[])
   output->SetLargestPossibleRegion(inputImage->GetLargestPossibleRegion());
   output->SetRequestedRegion(inputImage->GetRequestedRegion());
   output->SetBufferedRegion(inputImage->GetBufferedRegion());
-  output->Allocate();
-  output->FillBuffer(PixelType{});
+  output->AllocateInitialized();
 
 
   // Step over input and output images

--- a/Modules/Filtering/ImageIntensity/test/itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
@@ -123,8 +123,7 @@ itkDiscreteGradientMagnitudeGaussianImageFunctionTestND(int argc, char * argv[])
   output->SetLargestPossibleRegion(inputImage->GetLargestPossibleRegion());
   output->SetRequestedRegion(inputImage->GetRequestedRegion());
   output->SetBufferedRegion(inputImage->GetBufferedRegion());
-  output->Allocate();
-  output->FillBuffer(PixelType{});
+  output->AllocateInitialized();
 
 
   // Step over input and output images

--- a/Modules/Filtering/ImageIntensity/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
@@ -116,8 +116,7 @@ itkDiscreteHessianGaussianImageFunctionTestND(int argc, char * argv[])
   output->SetLargestPossibleRegion(reader->GetOutput()->GetLargestPossibleRegion());
   output->SetRequestedRegion(reader->GetOutput()->GetRequestedRegion());
   output->SetBufferedRegion(reader->GetOutput()->GetBufferedRegion());
-  output->Allocate();
-  output->FillBuffer(PixelType{});
+  output->AllocateInitialized();
 
 
   // Step over input and output images

--- a/Modules/Filtering/ImageStatistics/test/itkImageMomentsTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImageMomentsTest.cxx
@@ -96,9 +96,7 @@ itkImageMomentsTest(int argc, char * argv[])
   /* Set origin and spacing of physical coordinates */
   image->SetOrigin(origin);
   image->SetSpacing(spacing);
-  image->Allocate();
-
-  image->FillBuffer(PixelType{});
+  image->AllocateInitialized();
 
   /* Set a few mass points within the image */
   /* FIXME: The method used here to set the points is klutzy,

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterTest.cxx
@@ -193,9 +193,8 @@ itkRecursiveGaussianImageFilterTest(int, char *[])
 
     auto inputImage = ImageType::New();
     inputImage->SetRegions(region);
-    inputImage->Allocate();
+    inputImage->AllocateInitialized();
     inputImage->SetSpacing(spacing);
-    inputImage->FillBuffer(PixelType{});
 
     IndexType index;
     index[0] = (size[0] - 1) / 2; // the middle pixel
@@ -466,9 +465,8 @@ itkRecursiveGaussianImageFilterTest(int, char *[])
 
     auto inputImage = ImageType::New();
     inputImage->SetRegions(region);
-    inputImage->Allocate();
+    inputImage->AllocateInitialized();
     inputImage->SetSpacing(spacing);
-    inputImage->FillBuffer(PixelType{});
 
     IndexType index;
     index[0] = (size[0] - 1) / 2; // the middle pixel

--- a/Modules/Segmentation/ConnectedComponents/test/itkMaskConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkMaskConnectedComponentImageFilterTest.cxx
@@ -83,8 +83,7 @@ itkMaskConnectedComponentImageFilterTest(int argc, char * argv[])
   auto mask = MaskImageType::New();
   mask->SetRegions(threshold->GetOutput()->GetLargestPossibleRegion());
   mask->CopyInformation(threshold->GetOutput());
-  mask->Allocate();
-  mask->FillBuffer(MaskPixelType{});
+  mask->AllocateInitialized();
 
   const MaskImageType::RegionType maskRegion = mask->GetLargestPossibleRegion();
   MaskImageType::SizeType         maskSize = maskRegion.GetSize();

--- a/Modules/Segmentation/ConnectedComponents/test/itkScalarConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkScalarConnectedComponentImageFilterTest.cxx
@@ -70,8 +70,7 @@ itkScalarConnectedComponentImageFilterTest(int argc, char * argv[])
   auto mask = MaskImageType::New();
   mask->SetRegions(reader->GetOutput()->GetLargestPossibleRegion());
   mask->CopyInformation(reader->GetOutput());
-  mask->Allocate();
-  mask->FillBuffer(MaskPixelType{});
+  mask->AllocateInitialized();
 
   const MaskImageType::RegionType maskRegion = mask->GetLargestPossibleRegion();
   MaskImageType::SizeType         maskSize = maskRegion.GetSize();

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageTest.cxx
@@ -56,8 +56,7 @@ itkLevelSetDomainPartitionImageTest(int, char *[])
   binary->SetRegions(region);
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   constexpr IdentifierType numberOfLevelSetFunctions{ 2 };
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageWithKdTreeTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageWithKdTreeTest.cxx
@@ -62,8 +62,7 @@ itkLevelSetDomainPartitionImageWithKdTreeTest(int, char *[])
   binary->SetRegions(region);
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   constexpr IdentifierType numberOfLevelSetFunctions{ 10 };
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationBinaryMaskTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationBinaryMaskTermTest.cxx
@@ -73,8 +73,7 @@ itkLevelSetEquationBinaryMaskTermTest(int, char *[])
   binary->SetRegions(region);
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   index.Fill(10);
   size.Fill(30);

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseExternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseExternalTermTest.cxx
@@ -82,8 +82,7 @@ itkLevelSetEquationChanAndVeseExternalTermTest(int argc, char * argv[])
   binary->SetRegions(region);
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   index.Fill(10);
   size.Fill(30);

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseInternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseInternalTermTest.cxx
@@ -85,8 +85,7 @@ itkLevelSetEquationChanAndVeseInternalTermTest(int argc, char * argv[])
   binary->SetRegions(region);
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   index.Fill(10);
   size.Fill(30);

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationCurvatureTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationCurvatureTermTest.cxx
@@ -80,8 +80,7 @@ itkLevelSetEquationCurvatureTermTest(int argc, char * argv[])
   binary->SetRegions(region);
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   index.Fill(10);
   size.Fill(30);

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationLaplacianTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationLaplacianTermTest.cxx
@@ -79,8 +79,7 @@ itkLevelSetEquationLaplacianTermTest(int argc, char * argv[])
   binary->SetRegions(region);
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   index.Fill(10);
   size.Fill(30);

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationOverlapPenaltyTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationOverlapPenaltyTermTest.cxx
@@ -73,8 +73,7 @@ itkLevelSetEquationOverlapPenaltyTermTest(int, char *[])
   binary->SetRegions(region);
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   index.Fill(10);
   size.Fill(30);

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationPropagationTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationPropagationTermTest.cxx
@@ -79,8 +79,7 @@ itkLevelSetEquationPropagationTermTest(int argc, char * argv[])
   binary->SetRegions(region);
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   index.Fill(10);
   size.Fill(30);

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermContainerTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermContainerTest.cxx
@@ -87,8 +87,7 @@ itkLevelSetEquationTermContainerTest(int argc, char * argv[])
   binary->SetRegions(region);
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   index.Fill(10);
   size.Fill(30);

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageSubset2DTest.cxx
@@ -86,8 +86,7 @@ itkMultiLevelSetDenseImageSubset2DTest(int, char *[])
   input->SetRegions(region);
   input->SetSpacing(spacing);
   input->SetOrigin(origin);
-  input->Allocate();
-  input->FillBuffer(InputPixelType{});
+  input->AllocateInitialized();
 
   index.Fill(910);
   size.Fill(80);
@@ -112,8 +111,7 @@ itkMultiLevelSetDenseImageSubset2DTest(int, char *[])
   binary->SetRegions(region);
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   index.Fill(30);
   size.Fill(40);

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetMalcolmImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetMalcolmImageSubset2DTest.cxx
@@ -87,8 +87,7 @@ itkMultiLevelSetMalcolmImageSubset2DTest(int, char *[])
   input->SetRegions(region);
   input->SetSpacing(spacing);
   input->SetOrigin(origin);
-  input->Allocate();
-  input->FillBuffer(InputPixelType{});
+  input->AllocateInitialized();
 
   index.Fill(910);
   size.Fill(80);
@@ -113,8 +112,7 @@ itkMultiLevelSetMalcolmImageSubset2DTest(int, char *[])
   binary->SetRegions(region);
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   index.Fill(30);
   size.Fill(40);

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetShiImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetShiImageSubset2DTest.cxx
@@ -87,8 +87,7 @@ itkMultiLevelSetShiImageSubset2DTest(int, char *[])
   input->SetRegions(region);
   input->SetSpacing(spacing);
   input->SetOrigin(origin);
-  input->Allocate();
-  input->FillBuffer(InputPixelType{});
+  input->AllocateInitialized();
 
   index.Fill(910);
   size.Fill(80);
@@ -113,8 +112,7 @@ itkMultiLevelSetShiImageSubset2DTest(int, char *[])
   binary->SetRegions(region);
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   index.Fill(30);
   size.Fill(40);

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetWhitakerImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetWhitakerImageSubset2DTest.cxx
@@ -87,8 +87,7 @@ itkMultiLevelSetWhitakerImageSubset2DTest(int, char *[])
   input->SetRegions(region);
   input->SetSpacing(spacing);
   input->SetOrigin(origin);
-  input->Allocate();
-  input->FillBuffer(InputPixelType{});
+  input->AllocateInitialized();
 
   index.Fill(910);
   size.Fill(80);
@@ -113,8 +112,7 @@ itkMultiLevelSetWhitakerImageSubset2DTest(int, char *[])
   binary->SetRegions(region);
   binary->SetSpacing(spacing);
   binary->SetOrigin(origin);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   index.Fill(30);
   size.Fill(40);

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetMalcolmImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetMalcolmImage2DTest.cxx
@@ -78,8 +78,7 @@ itkSingleLevelSetMalcolmImage2DTest(int argc, char * argv[])
   auto binary = InputImageType::New();
   binary->SetRegions(input->GetLargestPossibleRegion());
   binary->CopyInformation(input);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   constexpr InputImageType::IndexType index{ 10, 10 };
   constexpr InputImageType::SizeType  size{ 30, 30 };

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetShiImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetShiImage2DTest.cxx
@@ -78,8 +78,7 @@ itkSingleLevelSetShiImage2DTest(int argc, char * argv[])
   auto binary = InputImageType::New();
   binary->SetRegions(input->GetLargestPossibleRegion());
   binary->CopyInformation(input);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   constexpr InputImageType::IndexType index{ 10, 10 };
   constexpr InputImageType::SizeType  size{ 30, 30 };

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DTest.cxx
@@ -80,8 +80,7 @@ itkSingleLevelSetWhitakerImage2DTest(int argc, char * argv[])
   auto binary = InputImageType::New();
   binary->SetRegions(input->GetLargestPossibleRegion());
   binary->CopyInformation(input);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   constexpr InputImageType::IndexType index{ 10, 10 };
   constexpr InputImageType::SizeType  size{ 30, 30 };

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DWithCurvatureTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DWithCurvatureTest.cxx
@@ -80,8 +80,7 @@ itkSingleLevelSetWhitakerImage2DWithCurvatureTest(int argc, char * argv[])
   auto binary = InputImageType::New();
   binary->SetRegions(input->GetLargestPossibleRegion());
   binary->CopyInformation(input);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   InputImageType::IndexType          index{ 10, 10 };
   constexpr InputImageType::SizeType size{ 30, 30 };

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DWithLaplacianTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DWithLaplacianTest.cxx
@@ -82,8 +82,7 @@ itkSingleLevelSetWhitakerImage2DWithLaplacianTest(int argc, char * argv[])
   auto binary = InputImageType::New();
   binary->SetRegions(input->GetLargestPossibleRegion());
   binary->CopyInformation(input);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   constexpr InputImageType::IndexType index{ 10, 10 };
   constexpr InputImageType::SizeType  size{ 30, 30 };

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DWithPropagationTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DWithPropagationTest.cxx
@@ -80,8 +80,7 @@ itkSingleLevelSetWhitakerImage2DWithPropagationTest(int argc, char * argv[])
   auto binary = InputImageType::New();
   binary->SetRegions(input->GetLargestPossibleRegion());
   binary->CopyInformation(input);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   constexpr InputImageType::IndexType index{ 10, 10 };
   constexpr InputImageType::SizeType  size{ 30, 30 };

--- a/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetMalcolmImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetMalcolmImage2DTest.cxx
@@ -83,8 +83,7 @@ itkTwoLevelSetMalcolmImage2DTest(int argc, char * argv[])
   auto binary = InputImageType::New();
   binary->SetRegions(input->GetLargestPossibleRegion());
   binary->CopyInformation(input);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   constexpr InputImageType::IndexType index{ 10, 10 };
   constexpr InputImageType::SizeType  size{ 30, 30 };

--- a/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetShiImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetShiImage2DTest.cxx
@@ -83,8 +83,7 @@ itkTwoLevelSetShiImage2DTest(int argc, char * argv[])
   auto binary = InputImageType::New();
   binary->SetRegions(input->GetLargestPossibleRegion());
   binary->CopyInformation(input);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   constexpr InputImageType::IndexType index{ 10, 10 };
   constexpr InputImageType::SizeType  size{ 30, 30 };

--- a/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetWhitakerImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetWhitakerImage2DTest.cxx
@@ -85,8 +85,7 @@ itkTwoLevelSetWhitakerImage2DTest(int argc, char * argv[])
   auto binary = InputImageType::New();
   binary->SetRegions(input->GetLargestPossibleRegion());
   binary->CopyInformation(input);
-  binary->Allocate();
-  binary->FillBuffer(InputPixelType{});
+  binary->AllocateInitialized();
 
   constexpr InputImageType::IndexType index{ 10, 10 };
   constexpr InputImageType::SizeType  size{ 30, 30 };

--- a/Modules/Segmentation/RegionGrowing/include/itkNeighborhoodConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkNeighborhoodConnectedImageFilter.hxx
@@ -110,8 +110,7 @@ NeighborhoodConnectedImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   // Zero the output
   outputImage->SetBufferedRegion(outputImage->GetRequestedRegion());
-  outputImage->Allocate();
-  outputImage->FillBuffer(OutputImagePixelType{});
+  outputImage->AllocateInitialized();
 
   using FunctionType = NeighborhoodBinaryThresholdImageFunction<InputImageType>;
   using IteratorType = FloodFilledImageFunctionConditionalIterator<OutputImageType, FunctionType>;


### PR DESCRIPTION
Replaced lines of code of the form

    image->Allocate();
    image->FillBuffer(PixelType{});

With `image->AllocateInitialized();`.

Using Notepad++, Replace in Files, doing:

  Find what: `(.+->)Allocate\(\);[\r\n]+\1FillBuffer\(.*{}\);`
  Replace with: `$1AllocateInitialized\(\);`

- Follow-up to pull request #4494
