### PR TITLE
COMP: Refactor ccache configuration into standalone CMake module

### DIFF
--- a/CMake/itkCCacheSupport.cmake
+++ b/CMake/itkCCacheSupport.cmake
@@ -1,0 +1,62 @@
+###############################################################################
+# ccache management for building ITK
+if(CMAKE_CXX_COMPILER_LAUNCHER OR CMAKE_C_COMPILER_LAUNCHER)
+  set(_default_ITK_USE_CCACHE ON)
+else()
+  set(_default_ITK_USE_CCACHE OFF)
+endif()
+
+option(
+  ITK_USE_CCACHE
+  "Use ccache to cache swig/castxml/... output and speedup the rebuild."
+  ${_default_ITK_USE_CCACHE}
+)
+unset(_default_ITK_USE_CCACHE)
+mark_as_advanced(ITK_USE_CCACHE)
+if(ITK_USE_CCACHE)
+  find_program(
+    CCACHE_EXECUTABLE
+    NAMES
+      ${CMAKE_C_COMPILER_LAUNCHER}
+      ${CMAKE_CXX_COMPILER_LAUNCHER}
+      ccache
+    DOC "ccache executable is needed for ITK_USE_CCACHE=ON"
+    REQUIRED
+  )
+
+  if(CCACHE_EXECUTABLE)
+    execute_process(
+      COMMAND
+        ${CCACHE_EXECUTABLE} --version
+      OUTPUT_VARIABLE CCACHE_OUTPUT
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    string(
+      REGEX
+      MATCH
+      "ccache *version *([0-9]+\\.[0-9]+\\.[0-9]+)"
+      _match
+      "${CCACHE_OUTPUT}"
+    )
+    set(CCACHE_VERSION "${CMAKE_MATCH_1}")
+    message(STATUS "ccache version: ${CCACHE_VERSION} at ${CCACHE_EXECUTABLE}")
+    set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}")
+    # ccache hashes absolute source and include paths into the cache key.
+    # ITK developers utilizing ccache often will be using git worktrees
+    # where the absolute paths differ, producing cache misses.
+    # By setting CCACHE_BASEDIR, increased cache hits occur based on
+    # hits relative to the ITK_SOURCE_DIR.
+    # Export CCACHE_BASEDIR for all build commands to the base of the
+    set(ENV{CCACHE_BASEDIR} "${ITK_SOURCE_DIR}")
+    message(STATUS "Set CCACHE_BASEDIR = $ENV{CCACHE_BASEDIR}")
+  else()
+    message(FATAL_ERROR "ccache not found, turn off ITK_USE_CCACHE")
+  endif()
+  if(CCACHE_VERSION VERSION_LESS 4.0)
+    message(
+      FATAL_ERROR
+      "Only ccache greater than 4.0 is supported, ${CCACHE_VERSION} found."
+    )
+  endif()
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ include(itkSupportMacros)
 # that can be configured as an independent project.
 set(ITK_CONFIG_CMAKE_DIR "${ITK_SOURCE_DIR}/CMake")
 set(ITK_USE_FILE "${ITK_CONFIG_CMAKE_DIR}/UseITK.cmake")
+include(itkCCacheSupport)
 # ITKInternalConfig.cmake is used to handle find_package(ITK) calls. This is useful
 # to remote module examples which are set up as independent projects that can be copied
 # outside of their original project and used without any modification.

--- a/Wrapping/Generators/CMakeLists.txt
+++ b/Wrapping/Generators/CMakeLists.txt
@@ -1,26 +1,6 @@
 ###############################################################################
 # the macros in charge of dispatching to the language specific macros
 
-###############################################################################
-# ccache management. This option is shared by most of generators, so put it here.
-cmake_dependent_option(
-  ITK_USE_CCACHE
-  "Use ccache to cache swig/castxml/... output and speedup the rebuild."
-  OFF
-  ITK_WRAP_PYTHON
-  OFF
-)
-mark_as_advanced(ITK_USE_CCACHE)
-if(ITK_USE_CCACHE)
-  find_program(
-    CCACHE_EXECUTABLE
-    NAMES
-      ccache-swig
-      ccache
-    DOC "ccache executable."
-  )
-endif()
-
 if(DEFINED ITK_WRAP_GCCXML)
   message(
     FATAL_ERROR


### PR DESCRIPTION
ccache has more utility than only wrapped versions.  since ccache
version 4.0 (december of 2020), support for SWIG is built in.  There is
no need for ccache-swig support after ccache version 4.0, so the logic
could be simplified.

Moved ccache setup from `Wrapping/Generators/CMakeLists.txt` to a
dedicated `itkCCacheSupport.cmake` module for better modularity and
reusability. Updated root CMakeLists.txt to include the new module.

This significantly speeds up clean builds

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
