### PR TITLE
STYLE: Use `ImageRegionRange` in DistanceMap tests

### DIFF
--- a/Modules/Filtering/DistanceMap/test/itkContourDirectedMeanDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkContourDirectedMeanDistanceImageFilterTest.cxx
@@ -17,8 +17,12 @@
  *=========================================================================*/
 
 #include "itkContourDirectedMeanDistanceImageFilter.h"
+#include "itkImageRegionRange.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkTestingMacros.h"
+
+#include <algorithm> // For fill.
+#include <numeric>   // For iota.
 
 int
 itkContourDirectedMeanDistanceImageFilterTest(int, char *[])
@@ -54,20 +58,11 @@ itkContourDirectedMeanDistanceImageFilterTest(int, char *[])
   index.Fill(20);
   RegionType region2 = { index, size };
 
-  itk::ImageRegionIterator<Image1Type> it1(image1, region1);
-  Pixel1Type                           count{};
-  while (!it1.IsAtEnd())
-  {
-    it1.Set(++count);
-    ++it1;
-  }
+  const itk::ImageRegionRange<Image1Type> imageRegionRange1(*image1, region1);
+  std::iota(imageRegionRange1.begin(), imageRegionRange1.end(), Pixel1Type{ 1 });
 
-  itk::ImageRegionIterator<Image2Type> it2(image2, region2);
-  while (!it2.IsAtEnd())
-  {
-    it2.Set(7.2);
-    ++it2;
-  }
+  const itk::ImageRegionRange<Image2Type> imageRegionRange2(*image2, region2);
+  std::fill(imageRegionRange2.begin(), imageRegionRange2.end(), Pixel2Type{ 7.2 });
 
   auto useImageSpacing = true;
 

--- a/Modules/Filtering/DistanceMap/test/itkContourMeanDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkContourMeanDistanceImageFilterTest.cxx
@@ -17,8 +17,12 @@
  *=========================================================================*/
 
 #include "itkContourMeanDistanceImageFilter.h"
+#include "itkImageRegionRange.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkTestingMacros.h"
+
+#include <algorithm> // For fill.
+#include <numeric>   // For iota.
 
 int
 itkContourMeanDistanceImageFilterTest(int argc, char * argv[])
@@ -64,20 +68,11 @@ itkContourMeanDistanceImageFilterTest(int argc, char * argv[])
   index.Fill(20);
   RegionType region2 = { index, size };
 
-  itk::ImageRegionIterator<Image1Type> it1(image1, region1);
-  Pixel1Type                           count{};
-  while (!it1.IsAtEnd())
-  {
-    it1.Set(++count);
-    ++it1;
-  }
+  const itk::ImageRegionRange<Image1Type> imageRegionRange1(*image1, region1);
+  std::iota(imageRegionRange1.begin(), imageRegionRange1.end(), Pixel1Type{ 1 });
 
-  itk::ImageRegionIterator<Image2Type> it2(image2, region2);
-  while (!it2.IsAtEnd())
-  {
-    it2.Set(7.2);
-    ++it2;
-  }
+  const itk::ImageRegionRange<Image2Type> imageRegionRange2(*image2, region2);
+  std::fill(imageRegionRange2.begin(), imageRegionRange2.end(), Pixel2Type{ 7.2 });
 
 
   // compute the directed Mean distance h(image1,image2)

--- a/Modules/Filtering/DistanceMap/test/itkDirectedHausdorffDistanceImageFilterTest1.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkDirectedHausdorffDistanceImageFilterTest1.cxx
@@ -17,8 +17,12 @@
  *=========================================================================*/
 
 #include "itkDirectedHausdorffDistanceImageFilter.h"
+#include "itkImageRegionRange.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkTestingMacros.h"
+
+#include <algorithm> // For fill.
+#include <numeric>   // For iota.
 
 int
 itkDirectedHausdorffDistanceImageFilterTest1(int, char *[])
@@ -54,20 +58,11 @@ itkDirectedHausdorffDistanceImageFilterTest1(int, char *[])
   index.Fill(20);
   RegionType region2 = { index, size };
 
-  itk::ImageRegionIterator<Image1Type> it1(image1, region1);
-  Pixel1Type                           count{};
-  while (!it1.IsAtEnd())
-  {
-    it1.Set(++count);
-    ++it1;
-  }
+  const itk::ImageRegionRange<Image1Type> imageRegionRange1(*image1, region1);
+  std::iota(imageRegionRange1.begin(), imageRegionRange1.end(), Pixel1Type{ 1 });
 
-  itk::ImageRegionIterator<Image2Type> it2(image2, region2);
-  while (!it2.IsAtEnd())
-  {
-    it2.Set(7.2);
-    ++it2;
-  }
+  const itk::ImageRegionRange<Image2Type> imageRegionRange2(*image2, region2);
+  std::fill(imageRegionRange2.begin(), imageRegionRange2.end(), Pixel2Type{ 7.2 });
 
   // If no failures detected, then EXIT_SUCCESS
   int exit_status = EXIT_SUCCESS;

--- a/Modules/Filtering/DistanceMap/test/itkHausdorffDistanceImageFilterGTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkHausdorffDistanceImageFilterGTest.cxx
@@ -18,8 +18,12 @@
 
 // First include the header file to be tested:
 #include "itkHausdorffDistanceImageFilter.h"
+#include "itkImageRegionRange.h"
 
 #include "itkGTest.h"
+
+#include <algorithm> // For fill.
+#include <numeric>   // For iota.
 
 TEST(HausdorffDistanceImageFilter, Test)
 {
@@ -53,20 +57,11 @@ TEST(HausdorffDistanceImageFilter, Test)
   index.Fill(20);
   RegionType region2 = { index, size };
 
-  itk::ImageRegionIterator<Image1Type> it1(image1, region1);
-  Pixel1Type                           count{};
-  while (!it1.IsAtEnd())
-  {
-    it1.Set(++count);
-    ++it1;
-  }
+  const itk::ImageRegionRange<Image1Type> imageRegionRange1(*image1, region1);
+  std::iota(imageRegionRange1.begin(), imageRegionRange1.end(), Pixel1Type{ 1 });
 
-  itk::ImageRegionIterator<Image2Type> it2(image2, region2);
-  while (!it2.IsAtEnd())
-  {
-    it2.Set(7.2);
-    ++it2;
-  }
+  const itk::ImageRegionRange<Image2Type> imageRegionRange2(*image2, region2);
+  std::fill(imageRegionRange2.begin(), imageRegionRange2.end(), Pixel2Type{ 7.2 });
 
   // Compute the Hausdorff distance H(image1,image2)
   {


### PR DESCRIPTION
Replaced hand-written `while` loops (which were using the old `ImageRegionIterator`) with modern range-based `std` algorithm calls.