### PR TITLE
ENH: Support building with system Eigen3 >= 5

### DIFF
--- a/Modules/ThirdParty/Eigen3/CMakeLists.txt
+++ b/Modules/ThirdParty/Eigen3/CMakeLists.txt
@@ -52,15 +52,18 @@ set(_Eigen3_min_version 3.3)
 
 if(ITK_USE_SYSTEM_EIGEN)
   set(_Eigen3_SYSTEM_OR_INTERNAL "Eigen3")
-  find_package(${_Eigen3_SYSTEM_OR_INTERNAL} ${_Eigen3_min_version} REQUIRED CONFIG)
+  find_package(${_Eigen3_SYSTEM_OR_INTERNAL} REQUIRED CONFIG)
   set(Eigen3_DIR_INSTALL ${Eigen3_DIR})
   set(Eigen3_DIR_BUILD ${Eigen3_DIR})
 else()
   set(_Eigen3_SYSTEM_OR_INTERNAL "ITKInternalEigen3")
-  find_package(${_Eigen3_SYSTEM_OR_INTERNAL} ${_Eigen3_min_version} REQUIRED CONFIG)
+  find_package(${_Eigen3_SYSTEM_OR_INTERNAL} REQUIRED CONFIG)
   set(Eigen3_DIR_INSTALL "\${ITK_MODULES_DIR}")
   set(_eigen3_build_dir "${ITK_BINARY_DIR}/ITKInternalEigen3-build")
   set(Eigen3_DIR_BUILD "${_eigen3_build_dir}")
+endif()
+if(${_Eigen3_SYSTEM_OR_INTERNAL}_VERSION VERSION_LESS ${_Eigen3_min_version})
+  message(FATAL_ERROR "Eigen3 version ${_Eigen3_min_version} or later is required.")
 endif()
 
 # Eigen3 is header only, but there are compile definitions that we want to provide
@@ -77,12 +80,18 @@ set(ITKEigen3_INCLUDE_DIRS
 set(ITKEigen3_EXPORT_CODE_INSTALL "
 set(ITK_USE_SYSTEM_EIGEN \"${ITK_USE_SYSTEM_EIGEN}\")
 set(${_Eigen3_SYSTEM_OR_INTERNAL}_DIR \"${Eigen3_DIR_INSTALL}\")
-find_package(${_Eigen3_SYSTEM_OR_INTERNAL} ${_Eigen3_min_version} REQUIRED CONFIG)
+find_package(${_Eigen3_SYSTEM_OR_INTERNAL} REQUIRED CONFIG)
+if(${_Eigen3_SYSTEM_OR_INTERNAL}_VERSION VERSION_LESS ${_Eigen3_min_version})
+  message(FATAL_ERROR \"Eigen3 version ${_Eigen3_min_version} or later is required.\")
+endif()
 ")
 set(ITKEigen3_EXPORT_CODE_BUILD "
 set(ITK_USE_SYSTEM_EIGEN \"${ITK_USE_SYSTEM_EIGEN}\")
 set(${_Eigen3_SYSTEM_OR_INTERNAL}_DIR \"${Eigen3_DIR_BUILD}\")
-find_package(${_Eigen3_SYSTEM_OR_INTERNAL} ${_Eigen3_min_version} REQUIRED CONFIG)
+find_package(${_Eigen3_SYSTEM_OR_INTERNAL} REQUIRED CONFIG)
+if(${_Eigen3_SYSTEM_OR_INTERNAL}_VERSION VERSION_LESS ${_Eigen3_min_version})
+  message(FATAL_ERROR \"Eigen3 version ${_Eigen3_min_version} or later is required.\")
+endif()
 ")
 
 # Eigen3 targets are not installed if ITK_USE_SYSTEM_EIGEN==True


### PR DESCRIPTION
Eigen3 changed their version scheme in 5.0.0 to exclude the world version[^1] which makes CMake see it as an incompatible major version. To allow newer versions, perform an unversioned find_package and follow up with a version check.

[^1]: https://gitlab.com/libeigen/eigen/-/releases/5.0.0#versioning

---

Only handles system Eigen as was looking into this for Homebrew (https://github.com/Homebrew/homebrew-core/pull/246477). 

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.
