### PR TITLE
STYLE: Remove local zero-filled `myIndexType start` variables from tests

### DIFF
--- a/Modules/Core/Common/test/itkImageAdaptorPipeLineTest.cxx
+++ b/Modules/Core/Common/test/itkImageAdaptorPipeLineTest.cxx
@@ -69,18 +69,13 @@ itkImageAdaptorPipeLineTest(int, char *[])
   //                 Create and Allocate the image
   //-------------------------------------------------------------
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 2;
   size[1] = 2;
   size[2] = 2; // Small size, because we are printing it
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-  start[2] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   constexpr float spacing[3]{ 1.0, 1.0, 1.0 };
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryDilateImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryDilateImageFilterTest.cxx
@@ -35,9 +35,6 @@ itkBinaryDilateImageFilterTest(int, char *[])
   // Declare the types of the images
   using myImageType = itk::Image<unsigned short, myDimension>;
 
-  // Declare the type of the index to access images
-  using myIndexType = itk::Index<myDimension>;
-
   // Declare the type of the size
   using mySizeType = itk::Size<myDimension>;
 
@@ -47,16 +44,12 @@ itkBinaryDilateImageFilterTest(int, char *[])
   // Create an image
   auto inputImage = myImageType::New();
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 20;
   size[1] = 20;
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   // Initialize Image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryErodeImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryErodeImageFilterTest.cxx
@@ -35,9 +35,6 @@ itkBinaryErodeImageFilterTest(int, char *[])
   // Declare the types of the images
   using myImageType = itk::Image<unsigned short, myDimension>;
 
-  // Declare the type of the index to access images
-  using myIndexType = itk::Index<myDimension>;
-
   // Declare the type of the size
   using mySizeType = itk::Size<myDimension>;
 
@@ -47,16 +44,12 @@ itkBinaryErodeImageFilterTest(int, char *[])
   // Create an image
   auto inputImage = myImageType::New();
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 20;
   size[1] = 20;
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   // Initialize Image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkErodeObjectMorphologyImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkErodeObjectMorphologyImageFilterTest.cxx
@@ -36,9 +36,6 @@ itkErodeObjectMorphologyImageFilterTest(int, char *[])
   // Declare the types of the images
   using myImageType = itk::Image<unsigned short, myDimension>;
 
-  // Declare the type of the index to access images
-  using myIndexType = itk::Index<myDimension>;
-
   // Declare the type of the size
   using mySizeType = itk::Size<myDimension>;
 
@@ -48,16 +45,12 @@ itkErodeObjectMorphologyImageFilterTest(int, char *[])
   // Create an image
   auto inputImage = myImageType::New();
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 20;
   size[1] = 20;
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   // Initialize Image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkFastIncrementalBinaryDilateImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkFastIncrementalBinaryDilateImageFilterTest.cxx
@@ -35,9 +35,6 @@ itkFastIncrementalBinaryDilateImageFilterTest(int, char *[])
   // Declare the types of the images
   using myImageType = itk::Image<unsigned short, myDimension>;
 
-  // Declare the type of the index to access images
-  using myIndexType = itk::Index<myDimension>;
-
   // Declare the type of the size
   using mySizeType = itk::Size<myDimension>;
 
@@ -47,16 +44,12 @@ itkFastIncrementalBinaryDilateImageFilterTest(int, char *[])
   // Create an image
   auto inputImage = myImageType::New();
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 20;
   size[1] = 20;
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   // Initialize Image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageCompare/test/itkAbsoluteValueDifferenceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkAbsoluteValueDifferenceImageFilterTest.cxx
@@ -43,9 +43,6 @@ itkAbsoluteValueDifferenceImageFilterTest(int, char *[])
   using myImageType2 = itk::Image<float, myDimension>;
   using myImageType4 = itk::Image<float, myDimension>;
 
-  // Declare the type of the index to access images
-  using myIndexType = itk::Index<myDimension>;
-
   // Declare the type of the size
   using mySizeType = itk::Size<myDimension>;
 
@@ -56,18 +53,13 @@ itkAbsoluteValueDifferenceImageFilterTest(int, char *[])
   auto inputImageA = myImageType1::New();
   auto inputImageB = myImageType2::New();
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 2;
   size[1] = 2;
   size[2] = 2;
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-  start[2] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageCompare/test/itkSquaredDifferenceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkSquaredDifferenceImageFilterTest.cxx
@@ -43,9 +43,6 @@ itkSquaredDifferenceImageFilterTest(int, char *[])
   using myImageType2 = itk::Image<float, myDimension>;
   using myImageType4 = itk::Image<float, myDimension>;
 
-  // Declare the type of the index to access images
-  using myIndexType = itk::Index<myDimension>;
-
   // Declare the type of the size
   using mySizeType = itk::Size<myDimension>;
 
@@ -56,18 +53,13 @@ itkSquaredDifferenceImageFilterTest(int, char *[])
   auto inputImageA = myImageType1::New();
   auto inputImageB = myImageType2::New();
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 2;
   size[1] = 2;
   size[2] = 2;
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-  start[2] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageCompose/test/itkJoinImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkJoinImageFilterTest.cxx
@@ -33,9 +33,6 @@ itkJoinImageFilterTest(int, char *[])
   using myImageType2 = itk::Image<itk::Vector<unsigned short, 2>, myDimension>;
   using myImageType3 = itk::Image<itk::RGBAPixel<short>, myDimension>;
 
-  // Declare the type of the index to access images
-  using myIndexType = itk::Index<myDimension>;
-
   // Declare the type of the size
   using mySizeType = itk::Size<myDimension>;
 
@@ -47,16 +44,12 @@ itkJoinImageFilterTest(int, char *[])
   auto inputImageB = myImageType2::New();
   auto inputImageC = myImageType3::New();
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 5;
   size[1] = 8;
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkAddImageFilterFrameTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAddImageFilterFrameTest.cxx
@@ -32,9 +32,6 @@ itkAddImageFilterFrameTest(int, char *[])
   using myImageType2 = itk::Image<float, myDimension>;
   using myImageType3 = itk::Image<float, myDimension>;
 
-  // Declare the type of the index to access images
-  using myIndexType = itk::Index<myDimension>;
-
   // Declare the type of the size
   using mySizeType = itk::Size<myDimension>;
 
@@ -54,18 +51,13 @@ itkAddImageFilterFrameTest(int, char *[])
   const myImageType1Pointer inputImageA = myImageType1::New();
   const myImageType2Pointer inputImageB = myImageType2::New();
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 2;
   size[1] = 2;
   size[2] = 2;
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-  start[2] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkEqualTest.cxx
@@ -73,9 +73,6 @@ itkEqualTest(int, char *[])
   using myImageType3 = itk::Image<float, myDimension>;
   using PixelType = myImageType1::PixelType;
 
-  // Declare the type of the index to access images
-  using myIndexType = itk::Index<myDimension>;
-
   // Declare the type of the size
   using mySizeType = itk::Size<myDimension>;
 
@@ -98,18 +95,13 @@ itkEqualTest(int, char *[])
   const myImageType1Pointer inputImageA = myImageType1::New();
   const myImageType2Pointer inputImageB = myImageType2::New();
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 2;
   size[1] = 2;
   size[2] = 2;
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-  start[2] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkGreaterEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkGreaterEqualTest.cxx
@@ -33,9 +33,6 @@ itkGreaterEqualTest(int, char *[])
   using myImageType3 = itk::Image<float, myDimension>;
   using PixelType = myImageType1::PixelType;
 
-  // Declare the type of the index to access images
-  using myIndexType = itk::Index<myDimension>;
-
   // Declare the type of the size
   using mySizeType = itk::Size<myDimension>;
 
@@ -59,18 +56,13 @@ itkGreaterEqualTest(int, char *[])
   const myImageType1Pointer inputImageA = myImageType1::New();
   const myImageType2Pointer inputImageB = myImageType2::New();
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 2;
   size[1] = 2;
   size[2] = 2;
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-  start[2] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkGreaterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkGreaterTest.cxx
@@ -32,9 +32,6 @@ itkGreaterTest(int, char *[])
   using myImageType2 = itk::Image<float, myDimension>;
   using myImageType3 = itk::Image<float, myDimension>;
   using PixelType = myImageType1::PixelType;
-  // Declare the type of the index to access images
-  using myIndexType = itk::Index<myDimension>;
-
   // Declare the type of the size
   using mySizeType = itk::Size<myDimension>;
 
@@ -58,18 +55,13 @@ itkGreaterTest(int, char *[])
   const myImageType1Pointer inputImageA = myImageType1::New();
   const myImageType2Pointer inputImageB = myImageType2::New();
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 2;
   size[1] = 2;
   size[2] = 2;
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-  start[2] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkLessEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkLessEqualTest.cxx
@@ -33,9 +33,6 @@ itkLessEqualTest(int, char *[])
   using myImageType3 = itk::Image<float, myDimension>;
   using PixelType = myImageType1::PixelType;
 
-  // Declare the type of the index to access images
-  using myIndexType = itk::Index<myDimension>;
-
   // Declare the type of the size
   using mySizeType = itk::Size<myDimension>;
 
@@ -59,18 +56,13 @@ itkLessEqualTest(int, char *[])
   const myImageType1Pointer inputImageA = myImageType1::New();
   const myImageType2Pointer inputImageB = myImageType2::New();
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 2;
   size[1] = 2;
   size[2] = 2;
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-  start[2] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkLessTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkLessTest.cxx
@@ -33,9 +33,6 @@ itkLessTest(int, char *[])
   using myImageType3 = itk::Image<float, myDimension>;
   using PixelType = myImageType1::PixelType;
 
-  // Declare the type of the index to access images
-  using myIndexType = itk::Index<myDimension>;
-
   // Declare the type of the size
   using mySizeType = itk::Size<myDimension>;
 
@@ -59,18 +56,13 @@ itkLessTest(int, char *[])
   const myImageType1Pointer inputImageA = myImageType1::New();
   const myImageType2Pointer inputImageB = myImageType2::New();
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 2;
   size[1] = 2;
   size[2] = 2;
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-  start[2] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkMaskImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMaskImageFilterTest.cxx
@@ -33,9 +33,6 @@ itkMaskImageFilterTest(int, char *[])
   using myImageType2 = itk::Image<unsigned short, myDimension>;
   using myImageType3 = itk::Image<float, myDimension>;
 
-  // Declare the type of the index to access images
-  using myIndexType = itk::Index<myDimension>;
-
   // Declare the type of the size
   using mySizeType = itk::Size<myDimension>;
 
@@ -46,18 +43,13 @@ itkMaskImageFilterTest(int, char *[])
   auto inputImageA = myImageType1::New();
   auto inputImageB = myImageType2::New();
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 2;
   size[1] = 2;
   size[2] = 2;
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-  start[2] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkMaskNegatedImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMaskNegatedImageFilterTest.cxx
@@ -35,9 +35,6 @@ itkMaskNegatedImageFilterTest(int, char *[])
   using MaskImageType = itk::Image<unsigned short, myDimension>;
   using OutputImageType = itk::Image<float, myDimension>;
 
-  // Declare the type of the index to access images
-  using myIndexType = itk::Index<myDimension>;
-
   // Declare the type of the size
   using mySizeType = itk::Size<myDimension>;
 
@@ -48,18 +45,13 @@ itkMaskNegatedImageFilterTest(int, char *[])
   auto inputImage = InputImageType::New();
   auto inputMask = MaskImageType::New();
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 2;
   size[1] = 2;
   size[2] = 2;
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-  start[2] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   // Initialize the image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkNotEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNotEqualTest.cxx
@@ -33,9 +33,6 @@ itkNotEqualTest(int, char *[])
   using myImageType3 = itk::Image<float, myDimension>;
   using PixelType = myImageType1::PixelType;
 
-  // Declare the type of the index to access images
-  using myIndexType = itk::Index<myDimension>;
-
   // Declare the type of the size
   using mySizeType = itk::Size<myDimension>;
 
@@ -59,18 +56,13 @@ itkNotEqualTest(int, char *[])
   const myImageType1Pointer inputImageA = myImageType1::New();
   const myImageType2Pointer inputImageB = myImageType2::New();
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 2;
   size[1] = 2;
   size[2] = 2;
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-  start[2] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkWeightedAddImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkWeightedAddImageFilterTest.cxx
@@ -41,9 +41,6 @@ itkWeightedAddImageFilterTest(int argc, char * argv[])
   using myImageType2 = itk::Image<float, myDimension>;
   using myImageType3 = itk::Image<float, myDimension>;
 
-  // Declare the type of the index to access images
-  using myIndexType = itk::Index<myDimension>;
-
   // Declare the type of the size
   using mySizeType = itk::Size<myDimension>;
 
@@ -63,18 +60,13 @@ itkWeightedAddImageFilterTest(int argc, char * argv[])
   const myImageType1Pointer inputImageA = myImageType1::New();
   const myImageType2Pointer inputImageB = myImageType2::New();
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 2;
   size[1] = 2;
   size[2] = 2;
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-  start[2] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionDilateImageFilterTest.cxx
@@ -36,9 +36,6 @@ itkGrayscaleFunctionDilateImageFilterTest(int argc, char * argv[])
   // Declare the types of the images
   using myImageType = itk::Image<unsigned short, myDimension>;
 
-  // Declare the type of the index to access images
-  using myIndexType = itk::Index<myDimension>;
-
   // Declare the type of the size
   using mySizeType = itk::Size<myDimension>;
 
@@ -48,16 +45,12 @@ itkGrayscaleFunctionDilateImageFilterTest(int argc, char * argv[])
   // Create an image
   auto inputImage = myImageType::New();
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 20;
   size[1] = 20;
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   // Initialize Image
   inputImage->SetRegions(region);

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionErodeImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionErodeImageFilterTest.cxx
@@ -36,9 +36,6 @@ itkGrayscaleFunctionErodeImageFilterTest(int argc, char * argv[])
   // Declare the types of the images
   using myImageType = itk::Image<unsigned short, myDimension>;
 
-  // Declare the type of the index to access images
-  using myIndexType = itk::Index<myDimension>;
-
   // Declare the type of the size
   using mySizeType = itk::Size<myDimension>;
 
@@ -48,16 +45,12 @@ itkGrayscaleFunctionErodeImageFilterTest(int argc, char * argv[])
   // Create an image
   auto inputImage = myImageType::New();
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 20;
   size[1] = 20;
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   // Initialize Image
   inputImage->SetRegions(region);

--- a/Modules/Nonunit/IntegratedTest/test/itkFilterImageAddTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkFilterImageAddTest.cxx
@@ -30,9 +30,6 @@ itkFilterImageAddTest(int, char *[])
   using myImageType2 = itk::Image<float, myDimension>;
   using myImageType3 = itk::Image<float, myDimension>;
 
-  // Declare the type of the index to access images
-  using myIndexType = itk::Index<myDimension>;
-
   // Declare the type of the size
   using mySizeType = itk::Size<myDimension>;
 
@@ -43,18 +40,13 @@ itkFilterImageAddTest(int, char *[])
   auto inputImageA = myImageType1::New();
   auto inputImageB = myImageType2::New();
 
-  // Define their size, and start index
+  // Define their size and region
   mySizeType size;
   size[0] = 2;
   size[1] = 2;
   size[2] = 2;
 
-  myIndexType start;
-  start[0] = 0;
-  start[1] = 0;
-  start[2] = 0;
-
-  const myRegionType region{ start, size };
+  const myRegionType region{ size };
 
   // Initialize Image A
   inputImageA->SetRegions(region);


### PR DESCRIPTION
Using Notepad++, doing Replace in Files (Search Mode Extended):

  Find what: `  myIndexType start;\r\n  start[0] = 0;\r\n  start[1] = 0;\r\n\r\n  const myRegionType region{ start, size };`
  Find what: `  myIndexType start;\r\n  start[0] = 0;\r\n  start[1] = 0;\r\n  start[2] = 0;\r\n\r\n  const myRegionType region{ start, size };`
  Replace with: `  const myRegionType region{ size };`

Adjusted the comments accordingly. Removed `myIndexType = itk::Index<myDimension>` type aliases.