### PR TITLE
STYLE: Replace assignments to `size[i]` with `Filled` calls, in tests

### DIFF
--- a/Modules/Core/Common/test/itkImageAdaptorPipeLineTest.cxx
+++ b/Modules/Core/Common/test/itkImageAdaptorPipeLineTest.cxx
@@ -70,10 +70,7 @@ itkImageAdaptorPipeLineTest(int, char *[])
   //-------------------------------------------------------------
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 2;
-  size[1] = 2;
-  size[2] = 2; // Small size, because we are printing it
+  auto size = mySizeType::Filled(2); // Small size, because we are printing it
 
   const myRegionType region{ size };
 

--- a/Modules/Core/Common/test/itkObjectFactoryTest2.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryTest2.cxx
@@ -54,10 +54,7 @@ MakeImage(const int count, T pixel)
   index[1] = 0;
   index[2] = 0;
 
-  SizeType size;
-  size[0] = count;
-  size[1] = count;
-  size[2] = count;
+  auto             size = SizeType::Filled(count);
   const RegionType region{ index, size };
 
   testImage->SetRegions(region);

--- a/Modules/Core/Mesh/test/itkBinaryMask3DMeshSourceTest.cxx
+++ b/Modules/Core/Mesh/test/itkBinaryMask3DMeshSourceTest.cxx
@@ -75,10 +75,7 @@ itkBinaryMask3DMeshSourceTest(int argc, char * argv[])
   constexpr PixelType backgroundValue{ 0 };
   constexpr PixelType internalValue{ 1 };
 
-  SizeType size;
-  size[0] = 128;
-  size[1] = 128;
-  size[2] = 128;
+  auto size = SizeType::Filled(128);
 
   RegionType region{ size };
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryDilateImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryDilateImageFilterTest.cxx
@@ -45,9 +45,7 @@ itkBinaryDilateImageFilterTest(int, char *[])
   auto inputImage = myImageType::New();
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 20;
-  size[1] = 20;
+  auto size = mySizeType::Filled(20);
 
   const myRegionType region{ size };
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryErodeImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryErodeImageFilterTest.cxx
@@ -45,9 +45,7 @@ itkBinaryErodeImageFilterTest(int, char *[])
   auto inputImage = myImageType::New();
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 20;
-  size[1] = 20;
+  auto size = mySizeType::Filled(20);
 
   const myRegionType region{ size };
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkErodeObjectMorphologyImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkErodeObjectMorphologyImageFilterTest.cxx
@@ -46,9 +46,7 @@ itkErodeObjectMorphologyImageFilterTest(int, char *[])
   auto inputImage = myImageType::New();
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 20;
-  size[1] = 20;
+  auto size = mySizeType::Filled(20);
 
   const myRegionType region{ size };
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkFastIncrementalBinaryDilateImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkFastIncrementalBinaryDilateImageFilterTest.cxx
@@ -45,9 +45,7 @@ itkFastIncrementalBinaryDilateImageFilterTest(int, char *[])
   auto inputImage = myImageType::New();
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 20;
-  size[1] = 20;
+  auto size = mySizeType::Filled(20);
 
   const myRegionType region{ size };
 

--- a/Modules/Filtering/ImageCompare/test/itkAbsoluteValueDifferenceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkAbsoluteValueDifferenceImageFilterTest.cxx
@@ -54,10 +54,7 @@ itkAbsoluteValueDifferenceImageFilterTest(int, char *[])
   auto inputImageB = myImageType2::New();
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 2;
-  size[1] = 2;
-  size[2] = 2;
+  auto size = mySizeType::Filled(2);
 
   const myRegionType region{ size };
 

--- a/Modules/Filtering/ImageCompare/test/itkSquaredDifferenceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkSquaredDifferenceImageFilterTest.cxx
@@ -54,10 +54,7 @@ itkSquaredDifferenceImageFilterTest(int, char *[])
   auto inputImageB = myImageType2::New();
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 2;
-  size[1] = 2;
-  size[2] = 2;
+  auto size = mySizeType::Filled(2);
 
   const myRegionType region{ size };
 

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterSpeedTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterSpeedTest.cxx
@@ -54,10 +54,7 @@ itkGradientRecursiveGaussianFilterSpeedTest(int argc, char * argv[])
 
 
   // Define their size, and start index
-  mySizeType size;
-  size[0] = imageSize;
-  size[1] = imageSize;
-  size[2] = imageSize;
+  auto size = mySizeType::Filled(imageSize);
 
   myIndexType start{};
 

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest.cxx
@@ -51,10 +51,7 @@ itkGradientRecursiveGaussianFilterTest(int argc, char * argv[])
 
 
   // Define their size, and start index
-  mySizeType size;
-  size[0] = 8;
-  size[1] = 8;
-  size[2] = 8;
+  auto size = mySizeType::Filled(8);
 
   myIndexType start{};
 

--- a/Modules/Filtering/ImageIntensity/test/itkAddImageFilterFrameTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAddImageFilterFrameTest.cxx
@@ -52,10 +52,7 @@ itkAddImageFilterFrameTest(int, char *[])
   const myImageType2Pointer inputImageB = myImageType2::New();
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 2;
-  size[1] = 2;
-  size[2] = 2;
+  auto size = mySizeType::Filled(2);
 
   const myRegionType region{ size };
 

--- a/Modules/Filtering/ImageIntensity/test/itkEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkEqualTest.cxx
@@ -96,10 +96,7 @@ itkEqualTest(int, char *[])
   const myImageType2Pointer inputImageB = myImageType2::New();
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 2;
-  size[1] = 2;
-  size[2] = 2;
+  auto size = mySizeType::Filled(2);
 
   const myRegionType region{ size };
 

--- a/Modules/Filtering/ImageIntensity/test/itkGreaterEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkGreaterEqualTest.cxx
@@ -57,10 +57,7 @@ itkGreaterEqualTest(int, char *[])
   const myImageType2Pointer inputImageB = myImageType2::New();
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 2;
-  size[1] = 2;
-  size[2] = 2;
+  auto size = mySizeType::Filled(2);
 
   const myRegionType region{ size };
 

--- a/Modules/Filtering/ImageIntensity/test/itkGreaterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkGreaterTest.cxx
@@ -56,10 +56,7 @@ itkGreaterTest(int, char *[])
   const myImageType2Pointer inputImageB = myImageType2::New();
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 2;
-  size[1] = 2;
-  size[2] = 2;
+  auto size = mySizeType::Filled(2);
 
   const myRegionType region{ size };
 

--- a/Modules/Filtering/ImageIntensity/test/itkImageAdaptorNthElementTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkImageAdaptorNthElementTest.cxx
@@ -72,10 +72,7 @@ itkImageAdaptorNthElementTest(int, char *[])
   //-------------------------------------------------------------
 
   // Define their size, and start index
-  mySizeType size;
-  size[0] = 2;
-  size[1] = 2;
-  size[2] = 2; // Small size, because we are printing it
+  auto size = mySizeType::Filled(2); // Small size, because we are printing it
 
   const myRegionType region{ size };
 

--- a/Modules/Filtering/ImageIntensity/test/itkLessEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkLessEqualTest.cxx
@@ -57,10 +57,7 @@ itkLessEqualTest(int, char *[])
   const myImageType2Pointer inputImageB = myImageType2::New();
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 2;
-  size[1] = 2;
-  size[2] = 2;
+  auto size = mySizeType::Filled(2);
 
   const myRegionType region{ size };
 

--- a/Modules/Filtering/ImageIntensity/test/itkLessTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkLessTest.cxx
@@ -57,10 +57,7 @@ itkLessTest(int, char *[])
   const myImageType2Pointer inputImageB = myImageType2::New();
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 2;
-  size[1] = 2;
-  size[2] = 2;
+  auto size = mySizeType::Filled(2);
 
   const myRegionType region{ size };
 

--- a/Modules/Filtering/ImageIntensity/test/itkMaskImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMaskImageFilterTest.cxx
@@ -44,10 +44,7 @@ itkMaskImageFilterTest(int, char *[])
   auto inputImageB = myImageType2::New();
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 2;
-  size[1] = 2;
-  size[2] = 2;
+  auto size = mySizeType::Filled(2);
 
   const myRegionType region{ size };
 

--- a/Modules/Filtering/ImageIntensity/test/itkMaskNegatedImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMaskNegatedImageFilterTest.cxx
@@ -46,10 +46,7 @@ itkMaskNegatedImageFilterTest(int, char *[])
   auto inputMask = MaskImageType::New();
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 2;
-  size[1] = 2;
-  size[2] = 2;
+  auto size = mySizeType::Filled(2);
 
   const myRegionType region{ size };
 

--- a/Modules/Filtering/ImageIntensity/test/itkNotEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNotEqualTest.cxx
@@ -57,10 +57,7 @@ itkNotEqualTest(int, char *[])
   const myImageType2Pointer inputImageB = myImageType2::New();
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 2;
-  size[1] = 2;
-  size[2] = 2;
+  auto size = mySizeType::Filled(2);
 
   const myRegionType region{ size };
 

--- a/Modules/Filtering/ImageIntensity/test/itkSymmetricEigenAnalysisImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSymmetricEigenAnalysisImageFilterTest.cxx
@@ -207,10 +207,7 @@ public:
     auto inputImage = InputImageType::New();
 
     // Define its size, and start index
-    SizeType size;
-    size[0] = 8;
-    size[1] = 8;
-    size[2] = 8;
+    auto size = SizeType::Filled(8);
 
     RegionType region{ size };
 

--- a/Modules/Filtering/ImageIntensity/test/itkWeightedAddImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkWeightedAddImageFilterTest.cxx
@@ -61,10 +61,7 @@ itkWeightedAddImageFilterTest(int argc, char * argv[])
   const myImageType2Pointer inputImageB = myImageType2::New();
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 2;
-  size[1] = 2;
-  size[2] = 2;
+  auto size = mySizeType::Filled(2);
 
   const myRegionType region{ size };
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionDilateImageFilterTest.cxx
@@ -46,9 +46,7 @@ itkGrayscaleFunctionDilateImageFilterTest(int argc, char * argv[])
   auto inputImage = myImageType::New();
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 20;
-  size[1] = 20;
+  auto size = mySizeType::Filled(20);
 
   const myRegionType region{ size };
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionErodeImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionErodeImageFilterTest.cxx
@@ -46,9 +46,7 @@ itkGrayscaleFunctionErodeImageFilterTest(int argc, char * argv[])
   auto inputImage = myImageType::New();
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 20;
-  size[1] = 20;
+  auto size = mySizeType::Filled(20);
 
   const myRegionType region{ size };
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkObjectMorphologyImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkObjectMorphologyImageFilterTest.cxx
@@ -55,10 +55,7 @@ itkObjectMorphologyImageFilterTest(int, char *[])
   auto inputImage = myImageType::New();
 
   // Define their size, and start index
-  mySizeType size;
-  size[0] = 20;
-  size[1] = 20;
-  size[2] = 20;
+  auto size = mySizeType::Filled(20);
 
   myIndexType index;
   index[0] = 0;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkBinaryMask3DQuadEdgeMeshSourceTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkBinaryMask3DQuadEdgeMeshSourceTest.cxx
@@ -50,10 +50,7 @@ itkBinaryMask3DQuadEdgeMeshSourceTest(int, char *[])
   constexpr PixelType backgroundValue{ 0 };
   constexpr PixelType internalValue{ 1 };
 
-  SizeType size;
-  size[0] = 128;
-  size[1] = 128;
-  size[2] = 128;
+  auto size = SizeType::Filled(128);
 
   const RegionType region{ size };
 

--- a/Modules/Nonunit/IntegratedTest/test/itkFilterImageAddTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkFilterImageAddTest.cxx
@@ -41,10 +41,7 @@ itkFilterImageAddTest(int, char *[])
   auto inputImageB = myImageType2::New();
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 2;
-  size[1] = 2;
-  size[2] = 2;
+  auto size = mySizeType::Filled(2);
 
   const myRegionType region{ size };
 

--- a/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
@@ -64,9 +64,7 @@ itkAutoScaledGradientDescentRegistrationOnVectorTestTemplated(int               
 
   imageSource = ImageSourceType::New();
 
-  SizeType size;
-  size[0] = 100;
-  size[1] = 100;
+  auto size = SizeType::Filled(100);
 
   imageSource->GenerateImages(size);
 

--- a/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationTest.cxx
@@ -67,9 +67,7 @@ itkAutoScaledGradientDescentRegistrationTestTemplated(int                 number
 
   imageSource = ImageSourceType::New();
 
-  SizeType size;
-  size[0] = 100;
-  size[1] = 100;
+  auto size = SizeType::Filled(100);
 
   imageSource->GenerateImages(size);
 

--- a/Modules/Numerics/Optimizersv4/test/itkQuasiNewtonOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkQuasiNewtonOptimizerv4Test.cxx
@@ -66,9 +66,7 @@ itkQuasiNewtonOptimizerv4TestTemplated(int                 numberOfIterations,
 
   imageSource = ImageSourceType::New();
 
-  SizeType size;
-  size[0] = 100;
-  size[1] = 100;
+  auto size = SizeType::Filled(100);
 
   imageSource->GenerateImages(size);
 

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_1.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_1.cxx
@@ -82,9 +82,7 @@ itkImageRegistrationMethodTest_1(int argc, char * argv[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(imageSource, ImageRegistrationMethodImageSource, Object);
 
 
-  SizeType size;
-  size[0] = 100;
-  size[1] = 100;
+  auto size = SizeType::Filled(100);
 
   imageSource->GenerateImages(size);
 

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_10.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_10.cxx
@@ -77,9 +77,7 @@ itkImageRegistrationMethodTest_10(int argc, char * argv[])
 
   auto imageSource = ImageSourceType::New();
 
-  SizeType size;
-  size[0] = 100;
-  size[1] = 100;
+  auto size = SizeType::Filled(100);
 
   imageSource->GenerateImages(size);
 

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_12.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_12.cxx
@@ -78,9 +78,7 @@ itkImageRegistrationMethodTest_12(int argc, char * argv[])
 
   auto imageSource = ImageSourceType::New();
 
-  SizeType size;
-  size[0] = 100;
-  size[1] = 100;
+  auto size = SizeType::Filled(100);
 
   imageSource->GenerateImages(size);
 

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_16.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_16.cxx
@@ -85,9 +85,7 @@ DoRegistration()
 
   auto imageSource = ImageSourceType::New();
 
-  SizeType size;
-  size[0] = 100;
-  size[1] = 100;
+  auto size = SizeType::Filled(100);
 
   imageSource->GenerateImages(size);
 

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_2.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_2.cxx
@@ -77,9 +77,7 @@ itkImageRegistrationMethodTest_2(int argc, char * argv[])
 
   auto imageSource = ImageSourceType::New();
 
-  SizeType size;
-  size[0] = 100;
-  size[1] = 100;
+  auto size = SizeType::Filled(100);
 
   imageSource->GenerateImages(size);
 

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_3.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_3.cxx
@@ -78,9 +78,7 @@ itkImageRegistrationMethodTest_3(int argc, char * argv[])
 
   auto imageSource = ImageSourceType::New();
 
-  SizeType size;
-  size[0] = 100;
-  size[1] = 100;
+  auto size = SizeType::Filled(100);
 
   imageSource->GenerateImages(size);
 

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_4.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_4.cxx
@@ -78,9 +78,7 @@ itkImageRegistrationMethodTest_4(int argc, char * argv[])
 
   auto imageSource = ImageSourceType::New();
 
-  SizeType size;
-  size[0] = 100;
-  size[1] = 100;
+  auto size = SizeType::Filled(100);
 
   imageSource->GenerateImages(size);
 

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_5.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_5.cxx
@@ -77,9 +77,7 @@ itkImageRegistrationMethodTest_5_Func(int argc, char * argv[], bool subtractMean
 
   auto imageSource = ImageSourceType::New();
 
-  SizeType size;
-  size[0] = 100;
-  size[1] = 100;
+  auto size = SizeType::Filled(100);
 
   imageSource->GenerateImages(size);
 

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_6.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_6.cxx
@@ -77,9 +77,7 @@ itkImageRegistrationMethodTest_6(int argc, char * argv[])
 
   auto imageSource = ImageSourceType::New();
 
-  SizeType size;
-  size[0] = 100;
-  size[1] = 100;
+  auto size = SizeType::Filled(100);
 
   imageSource->GenerateImages(size);
 

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_7.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_7.cxx
@@ -78,9 +78,7 @@ itkImageRegistrationMethodTest_7(int argc, char * argv[])
 
   auto imageSource = ImageSourceType::New();
 
-  SizeType size;
-  size[0] = 100;
-  size[1] = 100;
+  auto size = SizeType::Filled(100);
 
   imageSource->GenerateImages(size);
 

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_8.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_8.cxx
@@ -78,9 +78,7 @@ itkImageRegistrationMethodTest_8(int argc, char * argv[])
 
   auto imageSource = ImageSourceType::New();
 
-  SizeType size;
-  size[0] = 100;
-  size[1] = 100;
+  auto size = SizeType::Filled(100);
 
   imageSource->GenerateImages(size);
 

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_9.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_9.cxx
@@ -79,9 +79,7 @@ itkImageRegistrationMethodTest_9(int argc, char * argv[])
 
   auto imageSource = ImageSourceType::New();
 
-  SizeType size;
-  size[0] = 100;
-  size[1] = 100;
+  auto size = SizeType::Filled(100);
 
   imageSource->GenerateImages(size);
 


### PR DESCRIPTION
Using Notepad++, Replace in Files (Search Mode: Regular expression), doing:

  Find what: `^( [ ]+)(\w+)[ ]+size;\r\n\1size\[0\] = (\w+);\r\n\1size\[1\] = \3;\r\n\1size\[2\] = \3;`
  Replace with: `$1auto size = $2::Filled\($3\);`

  Find what: `^( [ ]+)(\w+)[ ]+size;\r\n\1size\[0\] = (\w+);\r\n\1size\[1\] = \3;\r\n\r\n`
  Replace with: `$1auto size = $2::Filled\($3\);\r\n\r\n`