### PR TITLE
COMP: Upgrade from macos-14 to macos-15 in CI

### DIFF
--- a/.github/workflows/macos-arm.yml
+++ b/.github/workflows/macos-arm.yml
@@ -53,7 +53,7 @@ jobs:
               CMAKE_OSX_ARCHITECTURES:STRING=x86_64
             ctest-options: ""
 
-          - os: macos-14
+          - os: macos-15
             name: "Python"
             cmake-build-type: "Release"
             cmake-generator: "Ninja"

--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -36,7 +36,7 @@ jobs:
       timeout-minutes: 0
       strategy:
         matrix:
-          os: [ubuntu-22.04, windows-2022, macos-14]
+          os: [ubuntu-22.04, windows-2022, macos-15]
       steps:
         - name: Checkout
           uses: actions/checkout@v4


### PR DESCRIPTION
Per #5369 macos 10.15 is the minimum with ITK 6.
