### PR TITLE
STYLE: Default constructors in class definition instead of hxx file (part 2)

### DIFF
--- a/Modules/Filtering/Deconvolution/include/itkProjectedLandweberDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkProjectedLandweberDeconvolutionImageFilter.h
@@ -79,7 +79,7 @@ public:
   itkOverrideGetNameOfClassMacro(ProjectedLandweberDeconvolutionImageFilter);
 
 protected:
-  ProjectedLandweberDeconvolutionImageFilter();
+  ProjectedLandweberDeconvolutionImageFilter() = default;
   ~ProjectedLandweberDeconvolutionImageFilter() override;
 };
 } // end namespace itk

--- a/Modules/Filtering/Deconvolution/include/itkProjectedLandweberDeconvolutionImageFilter.hxx
+++ b/Modules/Filtering/Deconvolution/include/itkProjectedLandweberDeconvolutionImageFilter.hxx
@@ -24,10 +24,6 @@ namespace itk
 
 template <typename TInputImage, typename TKernelImage, typename TOutputImage, typename TInternalPrecision>
 ProjectedLandweberDeconvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrecision>::
-  ProjectedLandweberDeconvolutionImageFilter() = default;
-
-template <typename TInputImage, typename TKernelImage, typename TOutputImage, typename TInternalPrecision>
-ProjectedLandweberDeconvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrecision>::
   ~ProjectedLandweberDeconvolutionImageFilter() = default;
 
 } // end namespace itk

--- a/Modules/Filtering/Deconvolution/include/itkTikhonovDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkTikhonovDeconvolutionImageFilter.h
@@ -104,7 +104,7 @@ public:
   itkGetConstMacro(RegularizationConstant, double);
   /** @ITKEndGrouping */
 protected:
-  TikhonovDeconvolutionImageFilter();
+  TikhonovDeconvolutionImageFilter() = default;
   ~TikhonovDeconvolutionImageFilter() override = default;
 
   /** This filter uses a minipipeline to compute the output. */

--- a/Modules/Filtering/Deconvolution/include/itkTikhonovDeconvolutionImageFilter.hxx
+++ b/Modules/Filtering/Deconvolution/include/itkTikhonovDeconvolutionImageFilter.hxx
@@ -25,10 +25,6 @@ namespace itk
 {
 
 template <typename TInputImage, typename TKernelImage, typename TOutputImage, typename TInternalPrecision>
-TikhonovDeconvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrecision>::
-  TikhonovDeconvolutionImageFilter() = default;
-
-template <typename TInputImage, typename TKernelImage, typename TOutputImage, typename TInternalPrecision>
 void
 TikhonovDeconvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrecision>::GenerateData()
 {

--- a/Modules/Filtering/Deconvolution/include/itkWienerDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkWienerDeconvolutionImageFilter.h
@@ -128,7 +128,7 @@ public:
   itkGetConstMacro(NoiseVariance, double);
   /** @ITKEndGrouping */
 protected:
-  WienerDeconvolutionImageFilter();
+  WienerDeconvolutionImageFilter() = default;
   ~WienerDeconvolutionImageFilter() override = default;
 
   /** This filter uses a minipipeline to compute the output. */

--- a/Modules/Filtering/Deconvolution/include/itkWienerDeconvolutionImageFilter.hxx
+++ b/Modules/Filtering/Deconvolution/include/itkWienerDeconvolutionImageFilter.hxx
@@ -25,10 +25,6 @@ namespace itk
 {
 
 template <typename TInputImage, typename TKernelImage, typename TOutputImage, typename TInternalPrecision>
-WienerDeconvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrecision>::
-  WienerDeconvolutionImageFilter() = default;
-
-template <typename TInputImage, typename TKernelImage, typename TOutputImage, typename TInternalPrecision>
 void
 WienerDeconvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrecision>::GenerateData()
 {

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.h
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.h
@@ -103,7 +103,7 @@ public:
   itkBooleanMacro(SubtractMean);
   /** @ITKEndGrouping */
 protected:
-  NormalizedCorrelationPointSetToImageMetric();
+  NormalizedCorrelationPointSetToImageMetric() = default;
   ~NormalizedCorrelationPointSetToImageMetric() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.hxx
@@ -24,10 +24,6 @@ namespace itk
 {
 
 template <typename TFixedPointSet, typename TMovingImage>
-NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::NormalizedCorrelationPointSetToImageMetric() =
-  default;
-
-template <typename TFixedPointSet, typename TMovingImage>
 auto
 NormalizedCorrelationPointSetToImageMetric<TFixedPointSet, TMovingImage>::GetValue(
   const TransformParametersType & parameters) const -> MeasureType

--- a/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.h
@@ -252,7 +252,7 @@ public:
 
 protected:
   /** Constructor */
-  BinaryImageToLevelSetImageAdaptor();
+  BinaryImageToLevelSetImageAdaptor() = default;
 
   /** Destructor */
   ~BinaryImageToLevelSetImageAdaptor() override;
@@ -338,7 +338,7 @@ public:
 
 protected:
   /** Constructor */
-  BinaryImageToLevelSetImageAdaptor();
+  BinaryImageToLevelSetImageAdaptor() = default;
 
   /** Destructor */
   ~BinaryImageToLevelSetImageAdaptor() override;

--- a/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.hxx
@@ -59,10 +59,6 @@ BinaryImageToLevelSetImageAdaptor<TInputImage, LevelSetDenseImage<TLevelSetImage
 
 template <typename TInput, typename TOutput>
 BinaryImageToLevelSetImageAdaptor<TInput, WhitakerSparseLevelSetImage<TOutput, TInput::ImageDimension>>::
-  BinaryImageToLevelSetImageAdaptor() = default;
-
-template <typename TInput, typename TOutput>
-BinaryImageToLevelSetImageAdaptor<TInput, WhitakerSparseLevelSetImage<TOutput, TInput::ImageDimension>>::
   ~BinaryImageToLevelSetImageAdaptor() = default;
 
 template <typename TInput, typename TOutput>
@@ -329,11 +325,6 @@ BinaryImageToLevelSetImageAdaptor<TInput, WhitakerSparseLevelSetImage<TOutput, T
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-
-template <typename TInput>
-BinaryImageToLevelSetImageAdaptor<TInput,
-                                  ShiSparseLevelSetImage<TInput::ImageDimension>>::BinaryImageToLevelSetImageAdaptor() =
-  default;
 
 template <typename TInput>
 BinaryImageToLevelSetImageAdaptor<TInput, ShiSparseLevelSetImage<TInput::ImageDimension>>::


### PR DESCRIPTION
Defaulted default-constructors within their class definition, instead of in their hxx file. Cases found by the following regular expressions:

    ::\r\n  \w+\(\) = default;
    ::\w+\(\) =\r\n  default;

- Follow-up to pull request #5559 commit e7f265f9032ea87ae352b6b2b379ff49e546700b "STYLE: Default constructors within class definition instead of hxx file"