### PR TITLE
STYLE: Use `generate` in tests, assigning values from vnl_sample_uniform

### DIFF
--- a/Modules/Core/Common/test/itkPointSetTest.cxx
+++ b/Modules/Core/Common/test/itkPointSetTest.cxx
@@ -19,6 +19,9 @@
 #include "itkPointSet.h"
 #include "vnl/vnl_sample.h"
 #include "itkTestingMacros.h"
+
+#include <algorithm> // For generate.
+#include <iterator>  // For begin and end.
 #include <iostream>
 
 /**
@@ -67,9 +70,9 @@ itkPointSetTest(int, char *[])
   {
     for (int i = 0; i < numOfPoints; ++i)
     {
-      testPointCoords[0] = static_cast<PointSet::CoordinateType>(vnl_sample_uniform(-1.0, 1.0));
-      testPointCoords[1] = static_cast<PointSet::CoordinateType>(vnl_sample_uniform(-1.0, 1.0));
-      testPointCoords[2] = static_cast<PointSet::CoordinateType>(vnl_sample_uniform(-1.0, 1.0));
+      std::generate(std::begin(testPointCoords), std::end(testPointCoords), [] {
+        return static_cast<PointSet::CoordinateType>(vnl_sample_uniform(-1.0, 1.0));
+      });
       pset->SetPoint(i, PointType(testPointCoords));
     }
   }

--- a/Modules/Core/Transform/test/itkTransformsSetParametersTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformsSetParametersTest.cxx
@@ -37,6 +37,9 @@
 #include "itkIntTypes.h"
 #include <vnl/vnl_sample.h>
 
+#include <algorithm> // For generate.
+#include <iterator>  // For begin and end.
+
 
 // Generic Kernel Transform Tester
 template <typename KernelType>
@@ -58,14 +61,14 @@ TestKernelTransform(const char * name, KernelType *)
   typename KernelPointSetType::CoordinateType randomCoords[3];
   for (int i = 0; i < 4; ++i)
   {
-    randomCoords[0] = (typename KernelPointSetType::CoordinateType)vnl_sample_uniform(-1.0, 1.0);
-    randomCoords[1] = (typename KernelPointSetType::CoordinateType)vnl_sample_uniform(-1.0, 1.0);
-    randomCoords[2] = (typename KernelPointSetType::CoordinateType)vnl_sample_uniform(-1.0, 1.0);
+    std::generate(std::begin(randomCoords), std::end(randomCoords), [] {
+      return static_cast<typename KernelPointSetType::CoordinateType>(vnl_sample_uniform(-1.0, 1.0));
+    });
     targetLandmarks->GetPoints()->SetElement(i, randomCoords);
 
-    randomCoords[0] = (typename KernelPointSetType::CoordinateType)vnl_sample_uniform(-1.0, 1.0);
-    randomCoords[1] = (typename KernelPointSetType::CoordinateType)vnl_sample_uniform(-1.0, 1.0);
-    randomCoords[2] = (typename KernelPointSetType::CoordinateType)vnl_sample_uniform(-1.0, 1.0);
+    std::generate(std::begin(randomCoords), std::end(randomCoords), [] {
+      return static_cast<typename KernelPointSetType::CoordinateType>(vnl_sample_uniform(-1.0, 1.0));
+    });
     sourceLandmarks->GetPoints()->SetElement(i, randomCoords);
   }
 

--- a/Modules/Filtering/ImageCompose/test/itkJoinImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkJoinImageFilterTest.cxx
@@ -21,6 +21,7 @@
 #include "vnl/vnl_sample.h"
 #include "itkImageRegionIterator.h"
 #include "itkTestingMacros.h"
+#include <algorithm> // For generate.
 
 int
 itkJoinImageFilterTest(int, char *[])
@@ -89,8 +90,7 @@ itkJoinImageFilterTest(int, char *[])
   itk::Vector<unsigned short, 2> vec;
   while (!it2.IsAtEnd())
   {
-    vec[0] = static_cast<unsigned short>(vnl_sample_uniform(0, 32765));
-    vec[1] = static_cast<unsigned short>(vnl_sample_uniform(0, 32765));
+    std::generate(vec.begin(), vec.end(), [] { return static_cast<unsigned short>(vnl_sample_uniform(0, 32765)); });
     it2.Set(vec);
     std::cout << it2.Get() << std::endl;
     ++it2;
@@ -105,10 +105,7 @@ itkJoinImageFilterTest(int, char *[])
   itk::RGBAPixel<short> rgbaVec;
   while (!itRGBA.IsAtEnd())
   {
-    rgbaVec[0] = static_cast<short>(vnl_sample_uniform(0, 255));
-    rgbaVec[1] = static_cast<short>(vnl_sample_uniform(0, 255));
-    rgbaVec[2] = static_cast<short>(vnl_sample_uniform(0, 255));
-    rgbaVec[3] = static_cast<short>(vnl_sample_uniform(0, 255));
+    std::generate(rgbaVec.begin(), rgbaVec.end(), [] { return static_cast<short>(vnl_sample_uniform(0, 255)); });
     itRGBA.Set(rgbaVec);
     //  std::cout << itRGBA.Get() << std::endl;
     ++itRGBA;

--- a/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest.cxx
@@ -40,6 +40,8 @@
 #include "vnl/vnl_sample.h"
 #include "itkMath.h"
 
+#include <algorithm> // For generate.
+
 
 //-------------------------------------
 //     Typedefs for convenience
@@ -89,9 +91,7 @@ itkAdaptImageFilterTest(int, char *[])
   it1.GoToBegin();
   while (!it1.IsAtEnd())
   {
-    color.Set(static_cast<float>(vnl_sample_uniform(0.0, 1.0)),
-              static_cast<float>(vnl_sample_uniform(0.0, 1.0)),
-              static_cast<float>(vnl_sample_uniform(0.0, 1.0)));
+    std::generate(color.begin(), color.end(), [] { return static_cast<float>(vnl_sample_uniform(0.0, 1.0)); });
     it1.Set(color);
     ++it1;
   }

--- a/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest2.cxx
@@ -37,6 +37,8 @@
 #include "vnl/vnl_sample.h"
 #include "itkMath.h"
 
+#include <algorithm> // For generate.
+
 
 //-------------------------------------
 //     Typedefs for convenience
@@ -84,9 +86,7 @@ itkAdaptImageFilterTest2(int, char *[])
   it1.GoToBegin();
   while (!it1.IsAtEnd())
   {
-    color[0] = static_cast<float>(vnl_sample_uniform(0.0, 1.0));
-    color[1] = static_cast<float>(vnl_sample_uniform(0.0, 1.0));
-    color[2] = static_cast<float>(vnl_sample_uniform(0.0, 1.0));
+    std::generate(color.begin(), color.end(), [] { return static_cast<float>(vnl_sample_uniform(0.0, 1.0)); });
     it1.Set(color);
     ++it1;
   }

--- a/Modules/Filtering/ImageIntensity/test/itkRGBToVectorAdaptImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkRGBToVectorAdaptImageFilterTest.cxx
@@ -35,6 +35,8 @@
 #include "vnl/vnl_sample.h"
 #include "itkMath.h"
 
+#include <algorithm> // For generate.
+
 
 //-------------------------
 //
@@ -87,9 +89,7 @@ itkRGBToVectorAdaptImageFilterTest(int, char *[])
   it1.GoToBegin();
   while (!it1.IsAtEnd())
   {
-    color.Set(static_cast<float>(vnl_sample_uniform(0.0, 1.0)),
-              static_cast<float>(vnl_sample_uniform(0.0, 1.0)),
-              static_cast<float>(vnl_sample_uniform(0.0, 1.0)));
+    std::generate(color.begin(), color.end(), [] { return static_cast<float>(vnl_sample_uniform(0.0, 1.0)); });
     it1.Set(color);
     ++it1;
   }

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
@@ -24,6 +24,7 @@
 #include "itkSimpleFilterWatcher.h"
 #include "vnl/vnl_sample.h"
 #include "itkTestingMacros.h"
+#include <algorithm> // For generate.
 
 int
 itkConnectedComponentImageFilterTest(int argc, char * argv[])
@@ -127,9 +128,8 @@ itkConnectedComponentImageFilterTest(int argc, char * argv[])
   for (auto & i : colormap)
   {
     RGBPixelType px;
-    px.SetRed(static_cast<unsigned char>(255 * vnl_sample_uniform(0.3333, 1.0)));
-    px.SetGreen(static_cast<unsigned char>(255 * vnl_sample_uniform(0.3333, 1.0)));
-    px.SetBlue(static_cast<unsigned char>(255 * vnl_sample_uniform(0.3333, 1.0)));
+    std::generate(
+      px.begin(), px.end(), [] { return static_cast<unsigned char>(255 * vnl_sample_uniform(0.3333, 1.0)); });
 
     i = px;
   }

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTestRGB.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTestRGB.cxx
@@ -24,6 +24,7 @@
 #include "itkSimpleFilterWatcher.h"
 #include "itkTestingMacros.h"
 #include "vnl/vnl_sample.h"
+#include <algorithm> // For generate.
 
 int
 itkConnectedComponentImageFilterTestRGB(int argc, char * argv[])
@@ -106,9 +107,8 @@ itkConnectedComponentImageFilterTestRGB(int argc, char * argv[])
   vnl_sample_reseed(1031571);
   for (auto & i : colormap)
   {
-    px.SetRed(static_cast<unsigned char>(255 * vnl_sample_uniform(0.3333, 1.0)));
-    px.SetGreen(static_cast<unsigned char>(255 * vnl_sample_uniform(0.3333, 1.0)));
-    px.SetBlue(static_cast<unsigned char>(255 * vnl_sample_uniform(0.3333, 1.0)));
+    std::generate(
+      px.begin(), px.end(), [] { return static_cast<unsigned char>(255 * vnl_sample_uniform(0.3333, 1.0)); });
 
     i = px;
   }

--- a/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationRGBImageFilterTest.cxx
+++ b/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationRGBImageFilterTest.cxx
@@ -19,8 +19,10 @@
 #include "itkImageFileReader.h"
 #include "itkVoronoiSegmentationRGBImageFilter.h"
 #include "itkImageRegionIterator.h"
-#include <iostream>
 #include "itkMath.h"
+
+#include <algorithm> // For generate.
+#include <iostream>
 
 // type alias for all functions
 using PixelType = itk::RGBPixel<unsigned char>;
@@ -72,9 +74,9 @@ SetUpInputImage()
   while (!iter.IsAtEnd())
   {
     PixelType px;
-    px[0] = static_cast<unsigned char>(vnl_sample_uniform(bgMean - bgStd, bgMean + bgStd));
-    px[1] = static_cast<unsigned char>(vnl_sample_uniform(bgMean - bgStd, bgMean + bgStd));
-    px[2] = static_cast<unsigned char>(vnl_sample_uniform(bgMean - bgStd, bgMean + bgStd));
+    std::generate(px.begin(), px.end(), [] {
+      return static_cast<unsigned char>(vnl_sample_uniform(bgMean - bgStd, bgMean + bgStd));
+    });
     iter.Set(px);
     ++iter;
   }
@@ -89,9 +91,9 @@ SetUpInputImage()
       idx[1] = y;
 
       PixelType px;
-      px[0] = static_cast<unsigned char>(vnl_sample_uniform(fgMean - fgStd, fgMean + fgStd));
-      px[1] = static_cast<unsigned char>(vnl_sample_uniform(fgMean - fgStd, fgMean + fgStd));
-      px[2] = static_cast<unsigned char>(vnl_sample_uniform(fgMean - fgStd, fgMean + fgStd));
+      std::generate(px.begin(), px.end(), [] {
+        return static_cast<unsigned char>(vnl_sample_uniform(fgMean - fgStd, fgMean + fgStd));
+      });
       inputImage->SetPixel(idx, px);
     }
   }
@@ -104,9 +106,9 @@ SetUpInputImage()
       idx[1] = y;
 
       PixelType px;
-      px[0] = static_cast<unsigned char>(vnl_sample_uniform(fgMean - fgStd, fgMean + fgStd));
-      px[1] = static_cast<unsigned char>(vnl_sample_uniform(fgMean - fgStd, fgMean + fgStd));
-      px[2] = static_cast<unsigned char>(vnl_sample_uniform(fgMean - fgStd, fgMean + fgStd));
+      std::generate(px.begin(), px.end(), [] {
+        return static_cast<unsigned char>(vnl_sample_uniform(fgMean - fgStd, fgMean + fgStd));
+      });
       inputImage->SetPixel(idx, px);
     }
   }


### PR DESCRIPTION
Did find code like:

    v[0] = static_cast<T>(vnl_sample_uniform(a, b));
    v[1] = static_cast<T>(vnl_sample_uniform(a, b));
    v[2] = static_cast<T>(vnl_sample_uniform(a, b));

And replaced it with the equivalent `std::generate` call:

    std::generate(v.begin(), v.end(), [] {
      return static_cast<T>(vnl_sample_uniform(a, b));
    });

Aims to reduce code redundancy.

----

Motivation: in a follow-up I would like those `vnl_sample_uniform` calls to be replaced with modern C++ random number generation. This pull request should pave the way.