### PR TITLE
STYLE: Use ImageBufferRange with std::iota in Filtering/ImageGrid tests

### DIFF
--- a/Modules/Filtering/ImageGrid/test/itkConstantPadImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkConstantPadImageTest.cxx
@@ -16,11 +16,14 @@
  *
  *=========================================================================*/
 
-#include <iostream>
 #include "itkConstantPadImageFilter.h"
+#include "itkImageBufferRange.h"
 #include "itkStreamingImageFilter.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkMath.h"
+
+#include <iostream>
+#include <numeric> // For iota.
 
 int
 itkConstantPadImageTest(int, char *[])
@@ -40,12 +43,8 @@ itkConstantPadImageTest(int, char *[])
   image->SetBufferedRegion(region);
   image->Allocate();
 
-  itk::ImageRegionIterator<ShortImage> iterator(image, region);
-
-  for (short i = 0; !iterator.IsAtEnd(); ++iterator, ++i)
-  {
-    iterator.Set(i);
-  }
+  const itk::ImageBufferRange<ShortImage> imageBufferRange(*image);
+  std::iota(imageBufferRange.begin(), imageBufferRange.end(), short{});
 
   // Create a filter
   using PadFilterType = itk::ConstantPadImageFilter<ShortImage, FloatImage>;

--- a/Modules/Filtering/ImageGrid/test/itkCropImageFilter3DTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkCropImageFilter3DTest.cxx
@@ -16,9 +16,12 @@
  *
  *=========================================================================*/
 
-#include <iostream>
 #include "itkCropImageFilter.h"
+#include "itkImageBufferRange.h"
 #include "itkTestingMacros.h"
+
+#include <iostream>
+#include <numeric> // For iota.
 
 int
 itkCropImageFilter3DTest(int, char *[])
@@ -44,11 +47,8 @@ itkCropImageFilter3DTest(int, char *[])
   image->SetRegions(region);
   image->Allocate();
 
-  itk::ImageRegionIterator<ImageType> it(image, region);
-  for (unsigned short i = 0; !it.IsAtEnd(); ++it, ++i)
-  {
-    it.Set(i);
-  }
+  const itk::ImageBufferRange<ImageType> imageBufferRange(*image);
+  std::iota(imageBufferRange.begin(), imageBufferRange.end(), PixelType{});
 
   const itk::CropImageFilter<ImageType, ImageType>::Pointer cropFilter =
     itk::CropImageFilter<ImageType, ImageType>::New();

--- a/Modules/Filtering/ImageGrid/test/itkCropImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkCropImageFilterTest.cxx
@@ -16,10 +16,13 @@
  *
  *=========================================================================*/
 
-#include <iostream>
 #include "itkCropImageFilter.h"
+#include "itkImageBufferRange.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkTestingMacros.h"
+
+#include <iostream>
+#include <numeric> // For iota.
 
 int
 itkCropImageFilterTest(int, char *[])
@@ -44,13 +47,8 @@ itkCropImageFilterTest(int, char *[])
   inputImage->SetBufferedRegion(region);
   inputImage->Allocate();
 
-  itk::ImageRegionIterator<ImageType> iterator(inputImage, region);
-
-  short i = 0;
-  for (; !iterator.IsAtEnd(); ++iterator, ++i)
-  {
-    iterator.Set(i);
-  }
+  const itk::ImageBufferRange<ImageType> imageBufferRange(*inputImage);
+  std::iota(imageBufferRange.begin(), imageBufferRange.end(), PixelType{});
 
   // Create the filter
   const itk::CropImageFilter<ImageType, ImageType>::Pointer cropFilter =

--- a/Modules/Filtering/ImageGrid/test/itkMirrorPadImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkMirrorPadImageTest.cxx
@@ -16,10 +16,13 @@
  *
  *=========================================================================*/
 
-#include <fstream>
 #include "itkMirrorPadImageFilter.h"
 #include "itkStreamingImageFilter.h"
 #include "itkSimpleFilterWatcher.h"
+#include "itkImageBufferRange.h"
+
+#include <fstream>
+#include <numeric> // For iota.
 
 //
 // Check that val represents the correct pixel value.  This routine
@@ -101,14 +104,9 @@ itkMirrorPadImageTest(int, char *[])
   if2->SetBufferedRegion(region);
   if2->Allocate();
 
-  {
-    short i = 0;
-    for (itk::ImageRegionIterator<ShortImage> iterator(if2, region); !iterator.IsAtEnd(); ++iterator)
-    {
-      iterator.Set(i);
-      ++i;
-    }
-  }
+  const itk::ImageBufferRange<ShortImage> imageBufferRange(*if2);
+  std::iota(imageBufferRange.begin(), imageBufferRange.end(), short{});
+
   // Create a filter
   const itk::MirrorPadImageFilter<ShortImage, ShortImage>::Pointer mirrorPad =
     itk::MirrorPadImageFilter<ShortImage, ShortImage>::New();

--- a/Modules/Filtering/ImageGrid/test/itkShrinkImageStreamingTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkShrinkImageStreamingTest.cxx
@@ -16,12 +16,15 @@
  *
  *=========================================================================*/
 
-#include <iostream>
 #include "itkCastImageFilter.h"
 #include "itkShrinkImageFilter.h"
 #include "itkPipelineMonitorImageFilter.h"
 #include "itkStreamingImageFilter.h"
+#include "itkImageBufferRange.h"
 #include "itkTestingMacros.h"
+
+#include <iostream>
+#include <numeric> // For iota.
 
 int
 itkShrinkImageStreamingTest(int, char *[])
@@ -42,14 +45,8 @@ itkShrinkImageStreamingTest(int, char *[])
   sourceImage->SetRegions(region);
   sourceImage->Allocate();
 
-  itk::ImageRegionIterator<ShortImage> iterator(sourceImage, region);
-
-  short i = 0;
-  for (; !iterator.IsAtEnd(); ++iterator, ++i)
-  {
-    iterator.Set(i);
-  }
-
+  const itk::ImageBufferRange<ShortImage> imageBufferRange(*sourceImage);
+  std::iota(imageBufferRange.begin(), imageBufferRange.end(), short{});
 
   // use caster to copy source to intermediate image of only the
   // requested region

--- a/Modules/Filtering/ImageGrid/test/itkShrinkImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkShrinkImageTest.cxx
@@ -16,10 +16,13 @@
  *
  *=========================================================================*/
 
-#include <iostream>
 #include "itkImageRegionIterator.h"
+#include "itkImageBufferRange.h"
 #include "itkShrinkImageFilter.h"
 #include "itkFileOutputWindow.h"
+
+#include <iostream>
+#include <numeric> // For iota.
 
 
 int
@@ -51,13 +54,8 @@ itkShrinkImageTest(int, char *[])
   if2->SetBufferedRegion(region);
   if2->Allocate();
 
-  itk::ImageRegionIterator<ShortImage> iterator(if2, region);
-
-  short i = 0;
-  for (; !iterator.IsAtEnd(); ++iterator, ++i)
-  {
-    iterator.Set(i);
-  }
+  const itk::ImageBufferRange<ShortImage> imageBufferRange(*if2);
+  std::iota(imageBufferRange.begin(), imageBufferRange.end(), short{});
 
   // Create a filter, shrink by 2,3
   itk::ShrinkImageFilter<ShortImage, ShortImage>::Pointer shrink;

--- a/Modules/Filtering/ImageGrid/test/itkZeroFluxNeumannPadImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkZeroFluxNeumannPadImageFilterTest.cxx
@@ -16,12 +16,15 @@
  *
  *=========================================================================*/
 
-#include <fstream>
 #include "itkMath.h"
 #include "itkZeroFluxNeumannPadImageFilter.h"
+#include "itkImageBufferRange.h"
 #include "itkStreamingImageFilter.h"
 #include "itkTestingMacros.h"
+
+#include <fstream>
 #include <algorithm> // For clamp.
+#include <numeric>   // For iota.
 
 using ShortImage = itk::Image<short, 2>;
 using FloatImage = itk::Image<float, 2>;
@@ -177,13 +180,8 @@ itkZeroFluxNeumannPadImageFilterTest(int, char *[])
   inputImage->SetBufferedRegion(inputRegion);
   inputImage->Allocate();
 
-  itk::ImageRegionIterator<ShortImage> iterator(inputImage, inputRegion);
-
-  short i = 0;
-  for (; !iterator.IsAtEnd(); ++iterator, ++i)
-  {
-    iterator.Set(i);
-  }
+  const itk::ImageBufferRange<ShortImage> imageBufferRange(*inputImage);
+  std::iota(imageBufferRange.begin(), imageBufferRange.end(), short{});
 
   // Create a filter
   auto padFilter = FilterType::New();


### PR DESCRIPTION
Replaced manual `for` loops using `ImageRegionIterator` with `std::iota` calls, using the more modern and potentially faster `ImageBufferRange`.
