### PR TITLE
ENH: Replace "vnl/vnl_sample.h" with `<random>`, in Core tests

### DIFF
--- a/Modules/Core/Common/test/itkPointSetTest.cxx
+++ b/Modules/Core/Common/test/itkPointSetTest.cxx
@@ -17,12 +17,12 @@
  *=========================================================================*/
 
 #include "itkPointSet.h"
-#include "vnl/vnl_sample.h"
 #include "itkTestingMacros.h"
 
 #include <algorithm> // For generate.
 #include <iterator>  // For begin and end.
 #include <iostream>
+#include <random> // For mt19937.
 
 /**
  * Define a PointSet type that stores a PixelType of "int".  Use the defaults
@@ -68,11 +68,15 @@ itkPointSetTest(int, char *[])
    */
   try
   {
+    std::mt19937                                             randomNumberEngine{};
+    std::uniform_real_distribution<PointSet::CoordinateType> randomNumberDistribution(-1.0, 1.0);
+
     for (int i = 0; i < numOfPoints; ++i)
     {
-      std::generate(std::begin(testPointCoords), std::end(testPointCoords), [] {
-        return static_cast<PointSet::CoordinateType>(vnl_sample_uniform(-1.0, 1.0));
-      });
+      std::generate(
+        std::begin(testPointCoords), std::end(testPointCoords), [&randomNumberEngine, &randomNumberDistribution] {
+          return randomNumberDistribution(randomNumberEngine);
+        });
       pset->SetPoint(i, PointType(testPointCoords));
     }
   }

--- a/Modules/Core/ImageFunction/test/itkBSplineDecompositionImageFilterTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineDecompositionImageFilterTest.cxx
@@ -26,10 +26,10 @@
  *
  *=========================================================================*/
 #include "itkSimpleFilterWatcher.h"
-#include "vnl/vnl_sample.h"
 #include "makeRandomImageBsplineInterpolator.h"
 #include "itkMath.h"
 #include "itkTestingMacros.h"
+#include <random> // For mt19937.
 
 
 template <typename TFilter>
@@ -150,12 +150,16 @@ itkBSplineDecompositionImageFilterTest(int argc, char * argv[])
   const double maxValue = lastPhysicalLocation[0];
 
   constexpr double tolerance2{ 1e-5 };
+
+  std::mt19937                                                         randomNumberEngine{};
+  std::uniform_real_distribution<ResampleFunctionType::CoordinateType> randomNumberDistribution(minValue, maxValue);
+
   for (unsigned int k = 0; k < 10; ++k)
   {
     ResampleFunctionType::PointType point;
     for (unsigned int j = 0; j < ImageDimension; ++j)
     {
-      point[j] = vnl_sample_uniform(minValue, maxValue);
+      point[j] = randomNumberDistribution(randomNumberEngine);
     }
 
     const double f = resample->Evaluate(point);

--- a/Modules/Core/ImageFunction/test/itkBSplineResampleImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineResampleImageFunctionTest.cxx
@@ -26,8 +26,8 @@
  *
  *=========================================================================*/
 #include "itkSimpleFilterWatcher.h"
-#include "vnl/vnl_sample.h"
 #include "makeRandomImageBsplineInterpolator.h"
+#include <random> // For mt19937.
 
 /** Note:  This is the same test used for the itkBSplineDecompositionFilter
  *        It is duplicated here because it exercises the itkBSplineResampleImageFunctionTest
@@ -74,12 +74,15 @@ itkBSplineResampleImageFunctionTest(int, char *[])
   const double minValue = randImage->GetOrigin()[0];
   const double maxValue = LastPhysicalLocation[0];
 
+  std::mt19937                                                         randomNumberEngine{};
+  std::uniform_real_distribution<ResampleFunctionType::CoordinateType> randomNumberDistribution(minValue, maxValue);
+
   for (unsigned int k = 0; k < 10; ++k)
   {
     ResampleFunctionType::PointType point;
     for (unsigned int j = 0; j < ImageDimension; ++j)
     {
-      point[j] = vnl_sample_uniform(minValue, maxValue);
+      point[j] = randomNumberDistribution(randomNumberEngine);
     }
 
     const double f = resample->Evaluate(point);

--- a/Modules/Core/Transform/test/itkComposeScaleSkewVersor3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkComposeScaleSkewVersor3DTransformTest.cxx
@@ -26,8 +26,7 @@
 
 #include "itkComposeScaleSkewVersor3DTransform.h"
 #include <iostream>
-
-#include <vnl/vnl_sample.h>
+#include <random> // For mt19937.
 
 // -------------------------
 //
@@ -476,12 +475,16 @@ itkComposeScaleSkewVersor3DTransformTest(int, char *[])
     std::cout << "SetMatrix parameters do match!" << std::endl;
 
     int diff = 0;
+
+    std::mt19937                              randomNumberEngine{};
+    std::uniform_real_distribution<ValueType> randomNumberDistribution(-100, 100);
+
     for (unsigned int p = 0; p < 100; ++p)
     {
       TransformType::InputPointType pnt;
       for (unsigned int i = 0; i < 3; ++i)
       {
-        pnt[i] = vnl_sample_uniform(-100, 100);
+        pnt[i] = randomNumberDistribution(randomNumberEngine);
       }
 
       TransformType::OutputPointType tPnt;

--- a/Modules/Core/Transform/test/itkTransformsSetParametersTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformsSetParametersTest.cxx
@@ -35,10 +35,10 @@
 #include "itkThinPlateSplineKernelTransform.h"
 #include "itkVolumeSplineKernelTransform.h"
 #include "itkIntTypes.h"
-#include <vnl/vnl_sample.h>
 
 #include <algorithm> // For generate.
 #include <iterator>  // For begin and end.
+#include <random>    // For mt19937.
 
 
 // Generic Kernel Transform Tester
@@ -58,16 +58,19 @@ TestKernelTransform(const char * name, KernelType *)
   sourceLandmarks->GetPoints()->Reserve(4);
 
   // Generate some random coordinates
-  typename KernelPointSetType::CoordinateType randomCoords[3];
+  typename KernelPointSetType::CoordinateType                                 randomCoords[3];
+  std::mt19937                                                                randomNumberEngine{};
+  std::uniform_real_distribution<typename KernelPointSetType::CoordinateType> randomNumberDistribution(-1.0, 1.0);
+
   for (int i = 0; i < 4; ++i)
   {
-    std::generate(std::begin(randomCoords), std::end(randomCoords), [] {
-      return static_cast<typename KernelPointSetType::CoordinateType>(vnl_sample_uniform(-1.0, 1.0));
+    std::generate(std::begin(randomCoords), std::end(randomCoords), [&randomNumberEngine, &randomNumberDistribution] {
+      return randomNumberDistribution(randomNumberEngine);
     });
     targetLandmarks->GetPoints()->SetElement(i, randomCoords);
 
-    std::generate(std::begin(randomCoords), std::end(randomCoords), [] {
-      return static_cast<typename KernelPointSetType::CoordinateType>(vnl_sample_uniform(-1.0, 1.0));
+    std::generate(std::begin(randomCoords), std::end(randomCoords), [&randomNumberEngine, &randomNumberDistribution] {
+      return randomNumberDistribution(randomNumberEngine);
     });
     sourceLandmarks->GetPoints()->SetElement(i, randomCoords);
   }


### PR DESCRIPTION
Replaced code like `randomNumber = vnl_sample_uniform(min, max)` with something like:

    std::mt19937                 randomNumberEngine{};
    std::uniform_distribution<T> randomNumberDistribution(min, max);

    randomNumber = randomNumberDistribution(randomNumberEngine);

`vnl_sample_uniform` is discouraged, especially because it has a global state (static data). This problem is addressed by declaring random number engines as local (non-static) variables, local to the tests that use them.

----

Obviously, this modernization yields more lines of code than before. While in general, I like it better when modernization yields _less_ code! But I can't help it 🤷 It appears fundamental to modern random number generation to declare separate "engine" and "distribution" variables, instead of just doing a single library function call.