### PR TITLE
DOC: Use --as-is for pixi run in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,15 +79,13 @@ cmake -B build-python -S . \
 
 ### Building
 ```bash
-# Standard build
-cmake --build build -j
+# Build via Pixi (recommended for development)
+pixi run --as-is build         # Build C++ tests
+pixi run --as-is build-python  # Build Python tests
 
-# Python build
-cmake --build build-python -j
-
-# Pixi (recommended for development)
-pixi run test         # C++ tests
-pixi run test-python  # Python tests
+# Run tests via Pixi (recommended for development)
+pixi run --as-is test         # C++ tests
+pixi run --as-is test-python  # Python tests
 ```
 
 For an interactive shell with ITK environment:


### PR DESCRIPTION
This allows agents to run much faster. And, they can falsely assume a
command hang when pixi is resolving dependencies.

Also use pixi run for agent build commands, which works more reliabily
out-of-the-box because of the configured build environment.
