### PR TITLE
COMP: Set minimum CMAKE_CXX_STANDARD for Remote/Modules

### DIFF
--- a/CMake/ITKConfig.cmake.in
+++ b/CMake/ITKConfig.cmake.in
@@ -116,8 +116,11 @@ set(ITK_WRAPPING "@ITK_WRAPPING@")
 # ITK_WRAP_DOC is disabled by default.
 
 # expose C++ standard used to build ITK for supporting external packages
-set(ITK_CXX_STANDARD CMAKE_CXX_STANDARD)
-
+set(ITK_CXX_STANDARD "@CMAKE_CXX_STANDARD@")
+if( NOT DEFINED CMAKE_CXX_STANDARD )
+  # If not explicitly set, initialize external modules to the same standard as ITK.
+  set(CMAKE_CXX_STANDARD ${ITK_CXX_STANDARD})
+endif()
 if( NOT DEFINED ITK_WRAP_PYTHON)
   set(ITK_WRAP_PYTHON "@ITK_WRAP_PYTHON@")
 endif()


### PR DESCRIPTION
When building remote modules outside of ITK, the
CMAKE_CXX_STANDARD must be defaulted to at least the
same standard as ITK was built against.

If not explicitly set, initialize external modules to the same standard
as ITK.

```bash
git clone https://github.com/InsightSoftwareConsortium/ITKTotalVariation.git
cd ITKTotalVariation
cmake -S . -B cmake-build-release \
  -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON \
  -DBUILD_TESTING=ON -DITK_DIR=../ITK/build-python
ninja -C cmake-build-release
```

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
