### PR TITLE
STYLE: Default constructors that only initialized one member in hxx file

### DIFF
--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.h
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.h
@@ -114,7 +114,7 @@ public:
   itkGetConstMacro(PrecomputeFlag, bool);
 
 protected:
-  FiniteDifferenceSparseImageFilter();
+  FiniteDifferenceSparseImageFilter() = default;
   ~FiniteDifferenceSparseImageFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
@@ -206,7 +206,7 @@ private:
   bool m_PrecomputeFlag{};
 
   /** The Sparse function type. */
-  SparseFunctionType * m_SparseFunction{};
+  SparseFunctionType * m_SparseFunction{ nullptr };
 
   /** A list of subregions of the active set of pixels in the sparse image
       which are passed to each thread for parallel processing. */

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.hxx
@@ -22,11 +22,6 @@
 namespace itk
 {
 template <typename TInputImageType, typename TSparseOutputImageType>
-FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::FiniteDifferenceSparseImageFilter()
-  : m_SparseFunction(nullptr)
-{}
-
-template <typename TInputImageType, typename TSparseOutputImageType>
 void
 FiniteDifferenceSparseImageFilter<TInputImageType, TSparseOutputImageType>::PrintSelf(std::ostream & os,
                                                                                       Indent         indent) const

--- a/Modules/Core/ImageFunction/include/itkScatterMatrixImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkScatterMatrixImageFunction.h
@@ -117,13 +117,13 @@ public:
   itkGetConstReferenceMacro(NeighborhoodRadius, unsigned int);
   /** @ITKEndGrouping */
 protected:
-  ScatterMatrixImageFunction();
+  ScatterMatrixImageFunction() = default;
   ~ScatterMatrixImageFunction() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  unsigned int m_NeighborhoodRadius{};
+  unsigned int m_NeighborhoodRadius{ 1 };
 };
 } // end namespace itk
 

--- a/Modules/Core/ImageFunction/include/itkScatterMatrixImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkScatterMatrixImageFunction.hxx
@@ -24,11 +24,6 @@ namespace itk
 {
 
 template <typename TInputImage, typename TCoordinate>
-ScatterMatrixImageFunction<TInputImage, TCoordinate>::ScatterMatrixImageFunction()
-  : m_NeighborhoodRadius(1)
-{}
-
-template <typename TInputImage, typename TCoordinate>
 void
 ScatterMatrixImageFunction<TInputImage, TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Modules/Core/ImageFunction/include/itkVarianceImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVarianceImageFunction.h
@@ -111,13 +111,13 @@ public:
   itkGetConstReferenceMacro(NeighborhoodRadius, unsigned int);
   /** @ITKEndGrouping */
 protected:
-  VarianceImageFunction();
+  VarianceImageFunction() = default;
   ~VarianceImageFunction() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  unsigned int m_NeighborhoodRadius{};
+  unsigned int m_NeighborhoodRadius{ 1 };
 };
 } // end namespace itk
 

--- a/Modules/Core/ImageFunction/include/itkVarianceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVarianceImageFunction.hxx
@@ -25,11 +25,6 @@ namespace itk
 {
 
 template <typename TInputImage, typename TCoordinate>
-VarianceImageFunction<TInputImage, TCoordinate>::VarianceImageFunction()
-  : m_NeighborhoodRadius(1)
-{}
-
-template <typename TInputImage, typename TCoordinate>
 void
 VarianceImageFunction<TInputImage, TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Modules/Core/ImageFunction/include/itkVectorMeanImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorMeanImageFunction.h
@@ -113,13 +113,13 @@ public:
   itkGetConstReferenceMacro(NeighborhoodRadius, unsigned int);
   /** @ITKEndGrouping */
 protected:
-  VectorMeanImageFunction();
+  VectorMeanImageFunction() = default;
   ~VectorMeanImageFunction() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  unsigned int m_NeighborhoodRadius{};
+  unsigned int m_NeighborhoodRadius{ 1 };
 };
 } // end namespace itk
 

--- a/Modules/Core/ImageFunction/include/itkVectorMeanImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVectorMeanImageFunction.hxx
@@ -25,11 +25,6 @@ namespace itk
 {
 
 template <typename TInputImage, typename TCoordinate>
-VectorMeanImageFunction<TInputImage, TCoordinate>::VectorMeanImageFunction()
-  : m_NeighborhoodRadius(1)
-{}
-
-template <typename TInputImage, typename TCoordinate>
 void
 VectorMeanImageFunction<TInputImage, TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Modules/Core/SpatialObjects/include/itkCastSpatialObjectFilter.h
+++ b/Modules/Core/SpatialObjects/include/itkCastSpatialObjectFilter.h
@@ -221,7 +221,7 @@ public:
   }
 
 protected:
-  CastSpatialObjectFilter();
+  CastSpatialObjectFilter() = default;
   ~CastSpatialObjectFilter() override = default;
 
   void
@@ -229,7 +229,7 @@ protected:
 
 
 private:
-  typename InputSpatialObjectType::Pointer m_Input{};
+  typename InputSpatialObjectType::Pointer m_Input{ nullptr };
 
 }; // End class CastSpatialObjectFilter
 

--- a/Modules/Core/SpatialObjects/include/itkCastSpatialObjectFilter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkCastSpatialObjectFilter.hxx
@@ -26,14 +26,6 @@ namespace itk
 {
 
 /**
- *    Constructor
- */
-template <unsigned int ObjectDimension>
-CastSpatialObjectFilter<ObjectDimension>::CastSpatialObjectFilter()
-  : m_Input(nullptr)
-{}
-
-/**
  *  Print Self
  */
 template <unsigned int ObjectDimension>

--- a/Modules/Filtering/Deconvolution/include/itkProjectedIterativeDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkProjectedIterativeDeconvolutionImageFilter.h
@@ -73,7 +73,7 @@ public:
   itkOverrideGetNameOfClassMacro(ProjectedIterativeDeconvolutionImageFilter);
 
 protected:
-  ProjectedIterativeDeconvolutionImageFilter();
+  ProjectedIterativeDeconvolutionImageFilter() = default;
   ~ProjectedIterativeDeconvolutionImageFilter() override;
 
   void
@@ -85,7 +85,7 @@ protected:
 private:
   using ProjectionFilterType = ThresholdImageFilter<InternalImageType>;
 
-  typename ProjectionFilterType::Pointer m_ProjectionFilter{};
+  typename ProjectionFilterType::Pointer m_ProjectionFilter{ nullptr };
 };
 } // namespace itk
 

--- a/Modules/Filtering/Deconvolution/include/itkProjectedIterativeDeconvolutionImageFilter.hxx
+++ b/Modules/Filtering/Deconvolution/include/itkProjectedIterativeDeconvolutionImageFilter.hxx
@@ -23,11 +23,6 @@ namespace itk
 {
 
 template <typename TSuperclass>
-ProjectedIterativeDeconvolutionImageFilter<TSuperclass>::ProjectedIterativeDeconvolutionImageFilter()
-  : m_ProjectionFilter(nullptr)
-{}
-
-template <typename TSuperclass>
 ProjectedIterativeDeconvolutionImageFilter<TSuperclass>::~ProjectedIterativeDeconvolutionImageFilter()
 {
   m_ProjectionFilter = nullptr;

--- a/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.h
@@ -109,7 +109,7 @@ public:
                   (Concept::SameDimension<TInputImage::ImageDimension, TOutputImage::ImageDimension>));
 
 protected:
-  IterativeInverseDisplacementFieldImageFilter();
+  IterativeInverseDisplacementFieldImageFilter() = default;
   ~IterativeInverseDisplacementFieldImageFilter() override = default;
 
   void
@@ -118,7 +118,7 @@ protected:
   void
   GenerateData() override;
 
-  unsigned int m_NumberOfIterations{};
+  unsigned int m_NumberOfIterations{ 5 };
 
   double m_StopValue{};
   double m_Time{};

--- a/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.hxx
@@ -24,13 +24,6 @@
 namespace itk
 {
 //----------------------------------------------------------------------------
-// Constructor
-template <typename TInputImage, typename TOutputImage>
-IterativeInverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::IterativeInverseDisplacementFieldImageFilter()
-  : m_NumberOfIterations(5)
-{}
-
-//----------------------------------------------------------------------------
 template <typename TInputImage, typename TOutputImage>
 void
 IterativeInverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::GenerateData()

--- a/Modules/Filtering/ImageStatistics/include/itkHistogramAlgorithmBase.h
+++ b/Modules/Filtering/ImageStatistics/include/itkHistogramAlgorithmBase.h
@@ -81,7 +81,7 @@ public:
 #endif
 
 protected:
-  HistogramAlgorithmBase();
+  HistogramAlgorithmBase() = default;
   ~HistogramAlgorithmBase() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
@@ -91,7 +91,7 @@ protected:
 
 private:
   /** Target histogram data pointer */
-  typename TInputHistogram::ConstPointer m_InputHistogram{};
+  typename TInputHistogram::ConstPointer m_InputHistogram{ nullptr };
 }; // end of class
 } // end of namespace itk
 

--- a/Modules/Filtering/ImageStatistics/include/itkHistogramAlgorithmBase.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkHistogramAlgorithmBase.hxx
@@ -22,11 +22,6 @@
 namespace itk
 {
 template <typename TInputHistogram>
-HistogramAlgorithmBase<TInputHistogram>::HistogramAlgorithmBase()
-  : m_InputHistogram(nullptr)
-{}
-
-template <typename TInputHistogram>
 void
 HistogramAlgorithmBase<TInputHistogram>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.h
@@ -131,7 +131,7 @@ public:
   }
 
 protected:
-  ShapeLabelMapFilter();
+  ShapeLabelMapFilter() = default;
   ~ShapeLabelMapFilter() override = default;
 
   void
@@ -148,7 +148,7 @@ protected:
 
 private:
   bool                   m_ComputeFeretDiameter{};
-  bool                   m_ComputePerimeter{};
+  bool                   m_ComputePerimeter{ true };
   bool                   m_ComputeOrientedBoundingBox{};
   LabelImageConstPointer m_LabelImage{};
 

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -35,11 +35,6 @@
 namespace itk
 {
 template <typename TImage, typename TLabelImage>
-ShapeLabelMapFilter<TImage, TLabelImage>::ShapeLabelMapFilter()
-  : m_ComputePerimeter(true)
-{}
-
-template <typename TImage, typename TLabelImage>
 void
 ShapeLabelMapFilter<TImage, TLabelImage>::BeforeThreadedGenerateData()
 {

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.h
@@ -98,7 +98,7 @@ public:
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
 
 protected:
-  HConcaveImageFilter();
+  HConcaveImageFilter() = default;
   ~HConcaveImageFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
@@ -119,7 +119,7 @@ protected:
   GenerateData() override;
 
 private:
-  InputImagePixelType m_Height{};
+  InputImagePixelType m_Height{ 2 };
   unsigned long       m_NumberOfIterationsUsed{ 1 };
   bool                m_FullyConnected{ false };
 }; // end of class

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.hxx
@@ -25,11 +25,6 @@
 namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
-HConcaveImageFilter<TInputImage, TOutputImage>::HConcaveImageFilter()
-  : m_Height(2)
-{}
-
-template <typename TInputImage, typename TOutputImage>
 void
 HConcaveImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
 {

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.h
@@ -98,7 +98,7 @@ public:
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
 
 protected:
-  HConvexImageFilter();
+  HConvexImageFilter() = default;
   ~HConvexImageFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
@@ -119,7 +119,7 @@ protected:
   GenerateData() override;
 
 private:
-  InputImagePixelType m_Height{};
+  InputImagePixelType m_Height{ 2 };
   unsigned long       m_NumberOfIterationsUsed{ 1 };
   bool                m_FullyConnected{ false };
 }; // end of class

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.hxx
@@ -25,11 +25,6 @@
 namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
-HConvexImageFilter<TInputImage, TOutputImage>::HConvexImageFilter()
-  : m_Height(2)
-{}
-
-template <typename TInputImage, typename TOutputImage>
 void
 HConvexImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
 {

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.h
@@ -110,7 +110,7 @@ public:
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
 
 protected:
-  HMaximaImageFilter();
+  HMaximaImageFilter() = default;
   ~HMaximaImageFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
@@ -130,7 +130,7 @@ protected:
   GenerateData() override;
 
 private:
-  InputImagePixelType m_Height{};
+  InputImagePixelType m_Height{ 2 };
   unsigned long       m_NumberOfIterationsUsed{ 1 };
   bool                m_FullyConnected{ false };
 }; // end of class

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.hxx
@@ -27,11 +27,6 @@
 namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
-HMaximaImageFilter<TInputImage, TOutputImage>::HMaximaImageFilter()
-  : m_Height(2)
-{}
-
-template <typename TInputImage, typename TOutputImage>
 void
 HMaximaImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
 {

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.h
@@ -108,7 +108,7 @@ public:
   itkConceptMacro(InputOStreamWritableCheck, (Concept::OStreamWritable<InputImagePixelType>));
 
 protected:
-  HMinimaImageFilter();
+  HMinimaImageFilter() = default;
   ~HMinimaImageFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
@@ -129,7 +129,7 @@ protected:
   GenerateData() override;
 
 private:
-  InputImagePixelType m_Height{};
+  InputImagePixelType m_Height{ 2 };
   unsigned long       m_NumberOfIterationsUsed{ 1 };
   bool                m_FullyConnected{ false };
 }; // end of class

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.hxx
@@ -27,11 +27,6 @@
 namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
-HMinimaImageFilter<TInputImage, TOutputImage>::HMinimaImageFilter()
-  : m_Height(2)
-{}
-
-template <typename TInputImage, typename TOutputImage>
 void
 HMinimaImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
 {

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.h
@@ -135,7 +135,7 @@ public:
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputImagePixelType>));
 
 protected:
-  ValuedRegionalExtremaImageFilter();
+  ValuedRegionalExtremaImageFilter() = default;
   ~ValuedRegionalExtremaImageFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
@@ -154,7 +154,7 @@ protected:
   GenerateData() override;
 
 private:
-  typename TInputImage::PixelType m_MarkerValue{};
+  typename TInputImage::PixelType m_MarkerValue{ 0 };
 
   bool m_FullyConnected{ false };
   bool m_Flat{ false };

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.hxx
@@ -27,11 +27,6 @@
 namespace itk
 {
 
-template <typename TInputImage, typename TOutputImage, typename TFunction1, typename TFunction2>
-ValuedRegionalExtremaImageFilter<TInputImage, TOutputImage, TFunction1, TFunction2>::ValuedRegionalExtremaImageFilter()
-  : m_MarkerValue(0)
-{}
-
 
 template <typename TInputImage, typename TOutputImage, typename TFunction1, typename TFunction2>
 void

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.h
@@ -204,7 +204,7 @@ public:
 protected:
   /** Default constructor*/
   /** @ITKStartGrouping */
-  LaplacianDeformationQuadEdgeMeshFilter();
+  LaplacianDeformationQuadEdgeMeshFilter() = default;
   ~LaplacianDeformationQuadEdgeMeshFilter() override = default;
   /** @ITKEndGrouping */
 
@@ -239,7 +239,7 @@ protected:
   CoefficientMapType       m_CoefficientMap{};
   AreaMapType              m_MixedAreaMap{};
 
-  CoefficientsComputationType * m_CoefficientsMethod{};
+  CoefficientsComputationType * m_CoefficientsMethod{ nullptr };
 
   unsigned int m_Order{ 1 };
   AreaEnum     m_AreaComputationType{ AreaEnum::NONE };

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
@@ -22,11 +22,6 @@
 namespace itk
 {
 template <typename TInputMesh, typename TOutputMesh, typename TSolverTraits>
-LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::LaplacianDeformationQuadEdgeMeshFilter()
-  : m_CoefficientsMethod(nullptr)
-{}
-
-template <typename TInputMesh, typename TOutputMesh, typename TSolverTraits>
 void
 LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::SolveLinearSystems(
   const MatrixType & iM,

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionData.h
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionData.h
@@ -118,12 +118,12 @@ public:
   double m_WeightedNumberOfPixelsInsideLevelSet{};
   double m_WeightedNumberOfPixelsOutsideLevelSet{};
 
-  InputImagePointer m_HeavisideFunctionOfLevelSetImage{};
+  InputImagePointer m_HeavisideFunctionOfLevelSetImage{ nullptr };
   InputIndexType    m_Start{};
   InputIndexType    m_End{};
 
 protected:
-  RegionBasedLevelSetFunctionData();
+  RegionBasedLevelSetFunctionData() = default;
   ~RegionBasedLevelSetFunctionData() override = default;
 };
 } // end namespace itk

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionData.hxx
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionData.hxx
@@ -22,11 +22,6 @@
 namespace itk
 {
 template <typename TInputImage, typename TFeatureImage>
-RegionBasedLevelSetFunctionData<TInputImage, TFeatureImage>::RegionBasedLevelSetFunctionData()
-  : m_HeavisideFunctionOfLevelSetImage(nullptr)
-{}
-
-template <typename TInputImage, typename TFeatureImage>
 void
 RegionBasedLevelSetFunctionData<TInputImage, TFeatureImage>::CreateHeavisideFunctionOfLevelSetImage(
   const InputImageType * image)

--- a/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.h
@@ -103,7 +103,7 @@ protected:
   [[nodiscard]] typename LightObject::Pointer
   InternalClone() const override;
 
-  GaussianRandomSpatialNeighborSubsampler();
+  GaussianRandomSpatialNeighborSubsampler() = default;
   ~GaussianRandomSpatialNeighborSubsampler() override = default;
 
   void
@@ -115,7 +115,7 @@ protected:
   RandomIntType
   GetIntegerVariate(RandomIntType lowerBound, RandomIntType upperBound, RandomIntType mean) override;
 
-  RealType m_Variance{};
+  RealType m_Variance{ DefaultVariance };
 }; // end of class GaussianRandomSpatialNeighborSubsampler
 
 } // namespace itk::Statistics

--- a/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.hxx
@@ -22,11 +22,6 @@ namespace itk::Statistics
 {
 
 template <typename TSample, typename TRegion>
-GaussianRandomSpatialNeighborSubsampler<TSample, TRegion>::GaussianRandomSpatialNeighborSubsampler()
-  : m_Variance(DefaultVariance)
-{}
-
-template <typename TSample, typename TRegion>
 typename LightObject::Pointer
 GaussianRandomSpatialNeighborSubsampler<TSample, TRegion>::InternalClone() const
 {

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.h
@@ -296,13 +296,13 @@ public:
   }
 
 protected:
-  ImageToListSampleAdaptor();
+  ImageToListSampleAdaptor() = default;
   ~ImageToListSampleAdaptor() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  ImageConstPointer             m_Image{};
+  ImageConstPointer             m_Image{ nullptr };
   mutable MeasurementVectorType m_MeasurementVectorInternal{};
 
 }; // end of class ImageToListSampleAdaptor

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.hxx
@@ -21,11 +21,6 @@
 namespace itk::Statistics
 {
 template <typename TImage>
-ImageToListSampleAdaptor<TImage>::ImageToListSampleAdaptor()
-  : m_Image(nullptr)
-{}
-
-template <typename TImage>
 auto
 ImageToListSampleAdaptor<TImage>::GetMeasurementVector(InstanceIdentifier id) const -> const MeasurementVectorType &
 {

--- a/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.h
@@ -243,14 +243,14 @@ public:
   }
 
 protected:
-  VectorContainerToListSampleAdaptor();
+  VectorContainerToListSampleAdaptor() = default;
 
   ~VectorContainerToListSampleAdaptor() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  VectorContainerConstPointer m_VectorContainer{};
+  VectorContainerConstPointer m_VectorContainer{ nullptr };
 }; // end of class VectorContainerToListSampleAdaptor
 } // namespace itk::Statistics
 

--- a/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.hxx
@@ -21,11 +21,6 @@
 namespace itk::Statistics
 {
 template <typename TVectorContainer>
-VectorContainerToListSampleAdaptor<TVectorContainer>::VectorContainerToListSampleAdaptor()
-  : m_VectorContainer(nullptr)
-{}
-
-template <typename TVectorContainer>
 void
 VectorContainerToListSampleAdaptor<TVectorContainer>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
@@ -110,13 +110,13 @@ public:
   Evaluate(const InputPointType & point) const override = 0;
 
 protected:
-  PointSetFunction();
+  PointSetFunction() = default;
   ~PointSetFunction() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Const pointer to the input image. */
-  InputPointSetConstPointer m_PointSet{};
+  InputPointSetConstPointer m_PointSet{ nullptr };
 };
 
 } // end namespace itk

--- a/Modules/Registration/Metricsv4/include/itkPointSetFunction.hxx
+++ b/Modules/Registration/Metricsv4/include/itkPointSetFunction.hxx
@@ -23,11 +23,6 @@ namespace itk
 {
 
 template <typename TInputPointSet, typename TOutput, typename TCoordinate>
-PointSetFunction<TInputPointSet, TOutput, TCoordinate>::PointSetFunction()
-  : m_PointSet(nullptr)
-{}
-
-template <typename TInputPointSet, typename TOutput, typename TCoordinate>
 void
 PointSetFunction<TInputPointSet, TOutput, TCoordinate>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Modules/Segmentation/Classifiers/include/itkClassifierBase.h
+++ b/Modules/Segmentation/Classifiers/include/itkClassifierBase.h
@@ -156,7 +156,7 @@ public:
   Update();
 
 protected:
-  ClassifierBase();
+  ClassifierBase() = default;
   ~ClassifierBase() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
@@ -171,7 +171,7 @@ private:
   unsigned int m_NumberOfClasses{};
 
   /** Pointer to the decision rule to be used for classification. */
-  typename DecisionRuleType::Pointer m_DecisionRule{};
+  typename DecisionRuleType::Pointer m_DecisionRule{ nullptr };
 
   /** Container to hold the membership functions */
   MembershipFunctionPointerVector m_MembershipFunctions{};

--- a/Modules/Segmentation/Classifiers/include/itkClassifierBase.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkClassifierBase.hxx
@@ -23,11 +23,6 @@
 namespace itk
 {
 template <typename TDataContainer>
-ClassifierBase<TDataContainer>::ClassifierBase()
-  : m_DecisionRule(nullptr)
-{}
-
-template <typename TDataContainer>
 void
 ClassifierBase<TDataContainer>::PrintSelf(std::ostream & os, Indent indent) const
 {

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImageWithKdTree.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImageWithKdTree.h
@@ -80,7 +80,7 @@ public:
   PopulateListDomain() override;
 
 protected:
-  LevelSetDomainPartitionImageWithKdTree();
+  LevelSetDomainPartitionImageWithKdTree() = default;
   ~LevelSetDomainPartitionImageWithKdTree() override = default;
 
   /** Populate a list image with each pixel being a list of overlapping
@@ -89,7 +89,7 @@ protected:
   PopulateDomainWithKdTree();
 
 private:
-  KdTreePointer   m_KdTree{};
+  KdTreePointer   m_KdTree{ nullptr };
   NeighborsIdType m_NumberOfNeighbors{ 10 };
 };
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImageWithKdTree.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImageWithKdTree.hxx
@@ -22,11 +22,6 @@
 namespace itk
 {
 template <typename TImage>
-LevelSetDomainPartitionImageWithKdTree<TImage>::LevelSetDomainPartitionImageWithKdTree()
-  : m_KdTree(nullptr)
-{}
-
-template <typename TImage>
 void
 LevelSetDomainPartitionImageWithKdTree<TImage>::PopulateListDomain()
 {


### PR DESCRIPTION
Removed user-defined constructors of the form:

    template <typename TParameter>
    ClassTemplate<TParameter>::ClassTemplate()
      : m_DataMember(initialValue)
    {}

Defaulted each of those constructors in its header file. Added the specified initial value of the data member to its default member initializer.

Cases found by Notepad++, Find in Files, doing:

  Find what: `^template <.+>\r\n(\w+)<.+>::\1\(\)$[\r\n]+  : m_\w+\(\w+\)[\r\n]+{}\r\n\r\n`
  Filters: itk*.hxx
  [v] Match case
  Search Mode: Regular expression

Following C++ Core Guidelines, [Don’t define a default constructor that only initializes data members; use default member initializers instead](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c45-dont-define-a-default-constructor-that-only-initializes-data-members-use-default-member-initializers-instead)