### PR TITLE
BUG: Remove MakePoint, MakeVector and other Make calls from GoogleTest

### DIFF
--- a/Modules/Core/TestKernel/test/itkGoogleTest.cxx
+++ b/Modules/Core/TestKernel/test/itkGoogleTest.cxx
@@ -36,30 +36,26 @@ TEST(GoogleTest, TypedefsAndConstructors_Dimension2)
   PointType pt1;
   pt1[0] = 1.1;
   pt1[1] = 2.2;
-  const PointType pt2 = itk::MakePoint(1.1, 2.2);
+  const auto pt2 = pt1;
   EXPECT_TRUE(pt1 == pt2);
   ITK_EXPECT_VECTOR_NEAR(pt1, pt2, 1e-10);
-  ITK_EXPECT_VECTOR_NEAR(pt1, itk::MakePoint(1.1, 2.2), 1e-10);
 
   VectorType vec1;
   vec1[0] = 1.1;
   vec1[1] = 2.2;
-  const VectorType vec2 = itk::MakeVector(1.1, 2.2);
+  const auto vec2 = vec1;
   EXPECT_TRUE(vec1 == vec2);
   ITK_EXPECT_VECTOR_NEAR(vec1, vec2, 1e-10);
-  ITK_EXPECT_VECTOR_NEAR(vec1, itk::MakeVector(1.1, 2.2), 1e-10);
 
   constexpr IndexType idx1{ 0, 1 };
-  const IndexType     idx2 = itk::MakeIndex(0, 1);
+  constexpr auto      idx2 = idx1;
   EXPECT_TRUE(idx1 == idx2);
   ITK_EXPECT_VECTOR_NEAR(idx1, idx2, 1e-10);
-  ITK_EXPECT_VECTOR_NEAR(idx1, itk::MakeIndex(0, 1), 1e-10);
 
   constexpr SizeType sz1{ 0u, 1u };
-  const SizeType     sz2 = itk::MakeSize(0u, 1u);
+  constexpr auto     sz2 = sz1;
   EXPECT_TRUE(sz1 == sz2);
   ITK_EXPECT_VECTOR_NEAR(sz1, sz2, 1e-10);
-  ITK_EXPECT_VECTOR_NEAR(sz1, itk::MakeSize(0u, 1u), 1e-10);
 }
 
 
@@ -73,27 +69,24 @@ TEST(GoogleTest, TypedefsAndConstructors_Dimension3)
   pt1[0] = 1.1;
   pt1[1] = 2.2;
   pt1[2] = 3.3;
-  const PointType pt2 = itk::MakePoint(1.1, 2.2, 3.3);
+  const auto pt2 = pt1;
   EXPECT_TRUE(pt1 == pt2);
   ITK_EXPECT_VECTOR_NEAR(pt1, pt2, 1e-10);
-  ITK_EXPECT_VECTOR_NEAR(pt1, itk::MakePoint(1.1, 2.2, 3.3), 1e-10);
 
   VectorType vec1;
   vec1[0] = 1.1;
   vec1[1] = 2.2;
   vec1[2] = 3.3;
-  const VectorType vec2 = itk::MakeVector(1.1, 2.2, 3.3);
+  const auto vec2 = vec1;
   EXPECT_TRUE(vec1 == vec2);
   ITK_EXPECT_VECTOR_NEAR(vec1, vec2, 1e-10);
-  ITK_EXPECT_VECTOR_NEAR(vec1, itk::MakeVector(1.1, 2.2, 3.3), 1e-10);
 
   constexpr IndexType idx1{ 0, 1, 2 };
-  const IndexType     idx2 = itk::MakeIndex(0, 1, 2);
+  constexpr auto      idx2 = idx1;
   EXPECT_TRUE(idx1 == idx2);
   ITK_EXPECT_VECTOR_NEAR(idx1, idx2, 1e-10);
 
   constexpr SizeType sz1{ 0u, 1u, 2u };
-  const SizeType     sz2 = itk::MakeSize(0u, 1u, 2u);
+  constexpr auto     sz2 = sz1;
   EXPECT_TRUE(sz1 == sz2);
-  ITK_EXPECT_VECTOR_NEAR(sz1, itk::MakeSize(0u, 1u, 2u), 1e-10);
 }


### PR DESCRIPTION
The MakePoint and MakeVector calls in itkGoogleTest always return a Point or Vector whose ValueType is 64-bit `double`. This causes test failures when SpacePrecisionType is a 32-bit `float` (when `ITK_USE_FLOAT_SPACE_PRECISION` is enabled). As was observed by Dženan Zukić (@dzenanz) at https://open.cdash.org/tests/2268459226

This commit removed these calls, as well as calls to MakeIndex and MakeSize, because all of these functions have been moved from `itk::GTest` to the ITK Core already in July 2021, so they do not need to be tested by itkGoogleTest anymore.

- Follow-up to pull request #2644

---

FYI, the "bug" was introduced by my PR #2644, which made ValueType depend on the (deduced) argument type, when calling MakePoint or MakeVector. Previously, MakePoint and MakeVector returned a Point or Vector whose ValueType was  always equal to `itk::SpacePrecisionType`.