### PR TITLE
STYLE: Remove `T::IndexType index{}` from region initialization in tests

### DIFF
--- a/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
@@ -304,11 +304,8 @@ itkConstNeighborhoodIteratorTest(int, char *[])
   {
     // Create an image
     using ChangeRegionTestImageType = itk::Image<int, 2>;
-    constexpr ChangeRegionTestImageType::IndexType imageCorner{};
-
-    auto imageSize = ChangeRegionTestImageType::SizeType::Filled(4);
-
-    const ChangeRegionTestImageType::RegionType imageRegion(imageCorner, imageSize);
+    auto                                        imageSize = ChangeRegionTestImageType::SizeType::Filled(4);
+    const ChangeRegionTestImageType::RegionType imageRegion{ imageSize };
 
     auto image = ChangeRegionTestImageType::New();
     image->SetRegions(imageRegion);

--- a/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
@@ -409,11 +409,8 @@ itkConstShapedNeighborhoodIteratorTest(int, char *[])
   {
     // Create an image
     using ChangeRegionTestImageType = itk::Image<int, 2>;
-    constexpr ChangeRegionTestImageType::IndexType imageCorner{};
-
-    auto imageSize = ChangeRegionTestImageType::SizeType::Filled(4);
-
-    const ChangeRegionTestImageType::RegionType imageRegion(imageCorner, imageSize);
+    auto                                        imageSize = ChangeRegionTestImageType::SizeType::Filled(4);
+    const ChangeRegionTestImageType::RegionType imageRegion{ imageSize };
 
     auto image = ChangeRegionTestImageType::New();
     image->SetRegions(imageRegion);

--- a/Modules/Core/Common/test/itkImageAlgorithmCopyTest.cxx
+++ b/Modules/Core/Common/test/itkImageAlgorithmCopyTest.cxx
@@ -30,8 +30,7 @@ AverageTestCopy(typename TImage::SizeType & size)
   using PixelType = typename TImage::PixelType;
   using ImageType = TImage;
 
-  constexpr typename ImageType::IndexType index{};
-  typename ImageType::RegionType          region = { index, size };
+  typename ImageType::RegionType region{ size };
 
   auto inImage = ImageType::New();
   inImage->SetRegions(region);

--- a/Modules/Core/Common/test/itkImageAlgorithmCopyTest2.cxx
+++ b/Modules/Core/Common/test/itkImageAlgorithmCopyTest2.cxx
@@ -64,10 +64,8 @@ itkImageAlgorithmCopyTest2(int, char *[])
   using RegionType = itk::ImageRegion<3>;
 
 
-  constexpr RegionType::IndexType index{};
-  auto                            size = RegionType::SizeType::Filled(64);
-
-  const RegionType region{ index, size };
+  auto             size = RegionType::SizeType::Filled(64);
+  const RegionType region{ size };
 
 
   auto image1 = Short3DImageType::New();

--- a/Modules/Core/Common/test/itkImageDuplicatorTest.cxx
+++ b/Modules/Core/Common/test/itkImageDuplicatorTest.cxx
@@ -28,9 +28,8 @@ int
 itkImageDuplicatorTest(int, char *[])
 {
   using ImageType = itk::Image<float, 3>;
-  constexpr ImageType::SizeType  size{ 10, 20, 30 };
-  constexpr ImageType::IndexType index{};
-  ImageType::RegionType          region = { index, size };
+  constexpr ImageType::SizeType size{ 10, 20, 30 };
+  ImageType::RegionType         region{ size };
 
   {
     /** Create an image */

--- a/Modules/Core/Common/test/itkImageLinearIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageLinearIteratorTest.cxx
@@ -41,9 +41,7 @@ itkImageLinearIteratorTest(int, char *[])
   size0[1] = 100;
   size0[2] = 100;
 
-  constexpr ImageType::IndexType start0{};
-
-  const ImageType::RegionType region0{ start0, size0 };
+  const ImageType::RegionType region0{ size0 };
 
   myImage->SetRegions(region0);
   myImage->Allocate();

--- a/Modules/Core/Common/test/itkImageRandomConstIteratorWithOnlyIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomConstIteratorWithOnlyIndexTest.cxx
@@ -43,9 +43,7 @@ itkImageRandomConstIteratorWithOnlyIndexTest(int, char *[])
 
   constexpr unsigned long numberOfSamples{ 10 };
 
-  constexpr ImageType::IndexType start0{};
-
-  const ImageType::RegionType region0{ start0, size0 };
+  const ImageType::RegionType region0{ size0 };
 
   myImage->SetRegions(region0);
   myImage->Allocate();

--- a/Modules/Core/Common/test/itkImageRandomIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomIteratorTest.cxx
@@ -43,9 +43,7 @@ itkImageRandomIteratorTest(int, char *[])
 
   constexpr unsigned long numberOfSamples{ 10 };
 
-  constexpr ImageType::IndexType start0{};
-
-  const ImageType::RegionType region0{ start0, size0 };
+  const ImageType::RegionType region0{ size0 };
 
   myImage->SetRegions(region0);
   myImage->Allocate();

--- a/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest.cxx
@@ -46,9 +46,8 @@ itkImageRandomNonRepeatingIteratorWithIndexTest(int, char *[])
   size0[0] = 50;
   size0[1] = 50;
   size0[2] = 50;
-  constexpr unsigned long        numberOfSamples{ 10 };
-  constexpr ImageType::IndexType start0{};
-  const ImageType::RegionType    region0{ start0, size0 };
+  constexpr unsigned long     numberOfSamples{ 10 };
+  const ImageType::RegionType region0{ size0 };
   myImage->SetRegions(region0);
   myImage->Allocate();
   // Make the priority image
@@ -57,8 +56,7 @@ itkImageRandomNonRepeatingIteratorWithIndexTest(int, char *[])
   prioritySize[0] = 50;
   prioritySize[1] = 50;
   prioritySize[2] = 50;
-  constexpr PriorityImageType::IndexType priorityStart{};
-  const PriorityImageType::RegionType    priorityRegion{ priorityStart, prioritySize };
+  const PriorityImageType::RegionType priorityRegion{ prioritySize };
   priorityImage->SetRegions(priorityRegion);
   priorityImage->Allocate();
   // we will make most of this image ones, with a small region of

--- a/Modules/Core/Common/test/itkImageRegionIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionIteratorTest.cxx
@@ -135,11 +135,8 @@ itkImageRegionIteratorTest(int, char *[])
   {
     // Create an image
     using TestImageType = itk::Image<int, 2>;
-    constexpr TestImageType::IndexType imageCorner{};
-
-    auto imageSize = TestImageType::SizeType::Filled(3);
-
-    const TestImageType::RegionType imageRegion(imageCorner, imageSize);
+    auto                            imageSize = TestImageType::SizeType::Filled(3);
+    const TestImageType::RegionType imageRegion{ imageSize };
 
     auto image = TestImageType::New();
     image->SetRegions(imageRegion);
@@ -163,11 +160,8 @@ itkImageRegionIteratorTest(int, char *[])
     }
 
     // Setup and iterate over the first region
-    constexpr TestImageType::IndexType region1Start{};
-
-    auto regionSize = TestImageType::SizeType::Filled(2);
-
-    const TestImageType::RegionType region1(region1Start, regionSize);
+    auto                            regionSize = TestImageType::SizeType::Filled(2);
+    const TestImageType::RegionType region1{ regionSize };
 
     itk::ImageRegionConstIterator<TestImageType> imageIterator(image, region1);
 

--- a/Modules/Core/Common/test/itkImageScanlineIteratorTest1.cxx
+++ b/Modules/Core/Common/test/itkImageScanlineIteratorTest1.cxx
@@ -148,11 +148,8 @@ itkImageScanlineIteratorTest1(int, char *[])
   {
     // Create an image
     using TestImageType = itk::Image<int, 2>;
-    constexpr TestImageType::IndexType imageCorner{};
-
-    auto imageSize = TestImageType::SizeType::Filled(3);
-
-    const TestImageType::RegionType imageRegion(imageCorner, imageSize);
+    auto                            imageSize = TestImageType::SizeType::Filled(3);
+    const TestImageType::RegionType imageRegion{ imageSize };
 
     auto image = TestImageType::New();
     image->SetRegions(imageRegion);
@@ -179,11 +176,8 @@ itkImageScanlineIteratorTest1(int, char *[])
     }
 
     // Setup and iterate over the first region
-    constexpr TestImageType::IndexType region1Start{};
-
-    auto regionSize = TestImageType::SizeType::Filled(2);
-
-    const TestImageType::RegionType region1(region1Start, regionSize);
+    auto                            regionSize = TestImageType::SizeType::Filled(2);
+    const TestImageType::RegionType region1{ regionSize };
 
     itk::ImageScanlineConstIterator<TestImageType> imageIterator(image, region1);
 

--- a/Modules/Core/Common/test/itkImageTest.cxx
+++ b/Modules/Core/Common/test/itkImageTest.cxx
@@ -118,9 +118,8 @@ itkImageTest(int, char *[])
   direction.SetIdentity();
   image->SetDirection(direction);
 
-  constexpr Image::IndexType index{};
-  constexpr auto             size = Image::SizeType::Filled(4);
-  const Image::RegionType    region{ index, size };
+  constexpr auto          size = Image::SizeType::Filled(4);
+  const Image::RegionType region{ size };
   image->SetRegions(region);
 
   auto                       imageRef = Image::New();
@@ -131,9 +130,8 @@ itkImageTest(int, char *[])
   imageRef->SetSpacing(spacingRef);
   imageRef->SetOrigin(originRef);
   imageRef->SetDirection(directionRef);
-  constexpr Image::IndexType indexRef{};
-  constexpr auto             sizeRef = itk::MakeFilled<Image::SizeType>(5);
-  const Image::RegionType    regionRef{ indexRef, sizeRef };
+  constexpr auto          sizeRef = itk::MakeFilled<Image::SizeType>(5);
+  const Image::RegionType regionRef{ sizeRef };
   imageRef->SetRegions(regionRef);
 
   using TransformType = itk::Transform<double, Image::ImageDimension, Image::ImageDimension>;

--- a/Modules/Core/Common/test/itkLineIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkLineIteratorTest.cxx
@@ -42,11 +42,8 @@ itkLineIteratorTest(int argc, char * argv[])
 
 
   // Set up a test image
-  constexpr ImageType::RegionType::IndexType index{};
-
-  auto size = ImageType::RegionType::SizeType::Filled(200);
-
-  const ImageType::RegionType region{ index, size };
+  auto                        size = ImageType::RegionType::SizeType::Filled(200);
+  const ImageType::RegionType region{ size };
 
   auto output = ImageType::New();
   output->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkIntensityWindowingImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkIntensityWindowingImageFilterTest.cxx
@@ -33,9 +33,8 @@ itkIntensityWindowingImageFilterTest(int, char *[])
   using TestInputImage = itk::Image<PixelType, Dimension>;
   using TestOutputImage = itk::Image<PixelType, Dimension>;
 
-  auto                                size = TestInputImage::SizeType::Filled(64);
-  constexpr TestInputImage::IndexType index{};
-  TestInputImage::RegionType          region = { index, size };
+  auto                       size = TestInputImage::SizeType::Filled(64);
+  TestInputImage::RegionType region{ size };
 
 
   using FilterType = itk::IntensityWindowingImageFilter<TestInputImage, TestOutputImage>;

--- a/Modules/Filtering/ImageIntensity/test/itkRescaleIntensityImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkRescaleIntensityImageFilterTest.cxx
@@ -38,9 +38,8 @@ itkRescaleIntensityImageFilterTest(int, char *[])
   using TestInputImage = itk::Image<PixelType, ImageDimension>;
   using TestOutputImage = itk::Image<PixelType, ImageDimension>;
 
-  auto                                size = TestInputImage::SizeType::Filled(64);
-  constexpr TestInputImage::IndexType index{};
-  TestInputImage::RegionType          region = { index, size };
+  auto                       size = TestInputImage::SizeType::Filled(64);
+  TestInputImage::RegionType region{ size };
 
 
   using FilterType = itk::RescaleIntensityImageFilter<TestInputImage, TestOutputImage>;

--- a/Modules/Filtering/ImageIntensity/test/itkShiftScaleImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkShiftScaleImageFilterTest.cxx
@@ -33,10 +33,9 @@ itkShiftScaleImageFilterTest(int, char *[])
   using TestOutputImage = itk::Image<unsigned char, 3>;
   using RealType = itk::NumericTraits<char>::RealType;
 
-  auto                                inputImage = TestInputImage::New();
-  auto                                size = TestInputImage::SizeType::Filled(64);
-  constexpr TestInputImage::IndexType index{};
-  TestInputImage::RegionType          region = { index, size };
+  auto                       inputImage = TestInputImage::New();
+  auto                       size = TestInputImage::SizeType::Filled(64);
+  TestInputImage::RegionType region{ size };
 
   // first try a constant image
   constexpr double fillValue{ -100.0 };

--- a/Modules/Filtering/ImageIntensity/test/itkTernaryOperatorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkTernaryOperatorImageFilterTest.cxx
@@ -67,9 +67,8 @@ itkTernaryOperatorImageFilterTest(int, char *[])
   using MaskImageType = itk::Image<MaskPixelType, ImageDimension>;
   using GrayImageType = itk::Image<GrayPixelType, ImageDimension>;
 
-  constexpr MaskImageType::IndexType origin{};
-  auto                               size = MaskImageType::SizeType::Filled(20);
-  const MaskImageType::RegionType    region(origin, size);
+  auto                            size = MaskImageType::SizeType::Filled(20);
+  const MaskImageType::RegionType region{ size };
 
   auto mask = MaskImageType::New();
   mask->SetRegions(region);

--- a/Modules/Filtering/ImageIntensity/test/itkVectorRescaleIntensityImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkVectorRescaleIntensityImageFilterTest.cxx
@@ -36,10 +36,9 @@ itkVectorRescaleIntensityImageFilterTest(int, char *[])
   using InputImageType = itk::Image<InputPixelType, ImageDimension>;
   using OutputImageType = itk::Image<OutputPixelType, ImageDimension>;
 
-  auto                                inputImage = InputImageType::New();
-  constexpr InputImageType::SizeType  size{ 20, 20, 20 };
-  constexpr InputImageType::IndexType index{};
-  InputImageType::RegionType          region = { index, size };
+  auto                               inputImage = InputImageType::New();
+  constexpr InputImageType::SizeType size{ 20, 20, 20 };
+  InputImageType::RegionType         region{ size };
 
   InputPixelType pixelValue{ { 10, 20, 30 } };
 

--- a/Modules/Filtering/ImageStatistics/test/itkImagePCADecompositionCalculatorTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImagePCADecompositionCalculatorTest.cxx
@@ -77,8 +77,7 @@ itkImagePCADecompositionCalculatorTest(int, char *[])
 
   constexpr InputImageType::SizeType inputImageSize{ IMGWIDTH, IMGHEIGHT };
 
-  constexpr InputImageType::IndexType index{};
-  InputImageType::RegionType          region{ index, inputImageSize };
+  InputImageType::RegionType region{ inputImageSize };
 
   //--------------------------------------------------------------------------
   // Set up Image 1 first

--- a/Modules/Filtering/ImageStatistics/test/itkImagePCAShapeModelEstimatorTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImagePCAShapeModelEstimatorTest.cxx
@@ -69,8 +69,7 @@ itkImagePCAShapeModelEstimatorTest(int, char *[])
 
   constexpr InputImageType::SizeType inputImageSize{ IMGWIDTH, IMGHEIGHT };
 
-  constexpr InputImageType::IndexType index{};
-  InputImageType::RegionType          region{ index, inputImageSize };
+  InputImageType::RegionType region{ inputImageSize };
 
   // Set up Image 1 first
 

--- a/Modules/Filtering/ImageStatistics/test/itkStatisticsImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkStatisticsImageFilterTest.cxx
@@ -46,10 +46,9 @@ itkStatisticsImageFilterTest(int argc, char * argv[])
 
   itk::Statistics::MersenneTwisterRandomVariateGenerator::GetInstance()->SetSeed(987);
 
-  auto                            image = FloatImage::New();
-  auto                            size = FloatImage::SizeType::Filled(64);
-  constexpr FloatImage::IndexType index{};
-  FloatImage::RegionType          region = { index, size };
+  auto                   image = FloatImage::New();
+  auto                   size = FloatImage::SizeType::Filled(64);
+  FloatImage::RegionType region{ size };
 
   // first try a constant image
   constexpr float fillValue{ -100.0 };

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
@@ -37,10 +37,9 @@ HDF5ReadWriteTest(const char * fileName)
     spacing[i] = 1.0 + static_cast<double>(i);
     origin[i] = static_cast<double>(i) * 5.0;
   }
-  constexpr typename ImageType::SizeType  size{ 5, 5, 5 };
-  constexpr typename ImageType::IndexType index{};
-  typename ImageType::RegionType          imageRegion = { index, size };
-  const typename ImageType::Pointer       im =
+  constexpr typename ImageType::SizeType size{ 5, 5, 5 };
+  typename ImageType::RegionType         imageRegion{ size };
+  const typename ImageType::Pointer      im =
     itk::IOTestHelper::AllocateImageFromRegionAndSpacing<ImageType>(imageRegion, spacing);
 
   itk::Matrix<itk::SpacePrecisionType> mat;

--- a/Modules/IO/ImageBase/test/itkImageFileWriterTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterTest.cxx
@@ -33,11 +33,9 @@ itkImageFileWriterTest(int argc, char * argv[])
   using ImageNDType = itk::Image<short, 2>;
   using WriterType = itk::ImageFileWriter<ImageNDType>;
 
-  auto                             image = ImageNDType::New();
-  constexpr ImageNDType::IndexType index{};
-  auto                             size = itk::MakeFilled<ImageNDType::SizeType>(5);
-
-  const ImageNDType::RegionType region{ index, size };
+  auto                          image = ImageNDType::New();
+  auto                          size = itk::MakeFilled<ImageNDType::SizeType>(5);
+  const ImageNDType::RegionType region{ size };
 
   image->SetRegions(region);
   image->Allocate();

--- a/Modules/IO/ImageBase/test/itkLargeImageWriteConvertReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkLargeImageWriteConvertReadTest.cxx
@@ -45,10 +45,8 @@ itkLargeImageWriteConvertReadTest(int argc, char * argv[])
 
     const size_t numberOfPixelsInOneDimension = atol(argv[2]);
 
-    auto size = itk::MakeFilled<OutputImageType::SizeType>(numberOfPixelsInOneDimension);
-    constexpr OutputImageType::IndexType index{};
-
-    const OutputImageType::RegionType region{ index, size };
+    auto                              size = itk::MakeFilled<OutputImageType::SizeType>(numberOfPixelsInOneDimension);
+    const OutputImageType::RegionType region{ size };
     image->SetRegions(region);
 
     chronometer.Start("Allocate");

--- a/Modules/IO/ImageBase/test/itkReadWriteImageWithDictionaryTest.cxx
+++ b/Modules/IO/ImageBase/test/itkReadWriteImageWithDictionaryTest.cxx
@@ -38,9 +38,8 @@ itkReadWriteImageWithDictionaryTest(int argc, char * argv[])
   // Create the 16x16 input image
   auto inputImage = ImageType::New();
 
-  auto                           size = ImageType::SizeType::Filled(16);
-  constexpr ImageType::IndexType index{};
-  const ImageType::RegionType    region{ index, size };
+  auto                        size = ImageType::SizeType::Filled(16);
+  const ImageType::RegionType region{ size };
   inputImage->SetRegions(region);
   inputImage->AllocateInitialized();
 

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest11.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest11.cxx
@@ -49,8 +49,7 @@ itkNiftiImageIOTest11(int argc, char * argv[])
   size[1] = 1;
   size[2] = 1;
 
-  constexpr ImageType::IndexType index{};
-  const ImageType::RegionType    imageRegion{ index, size };
+  const ImageType::RegionType imageRegion{ size };
 
   auto                     spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
   const ImageType::Pointer im = itk::IOTestHelper::AllocateImageFromRegionAndSpacing<ImageType>(imageRegion, spacing);

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest4.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest4.cxx
@@ -52,11 +52,10 @@ itkNiftiImageIOTest4(int argc, char * argv[])
   //
   constexpr unsigned int dimsize{ 2 };
 
-  constexpr Test4ImageType::SizeType  size{ dimsize, dimsize, dimsize };
-  constexpr Test4ImageType::IndexType index{};
-  Test4ImageType::RegionType          imageRegion = { index, size };
-  Test4ImageType::SpacingType         spacing{ { 1.0, 1.0, 1.0 } };
-  const Test4ImageType::Pointer       test4Image =
+  constexpr Test4ImageType::SizeType size{ dimsize, dimsize, dimsize };
+  Test4ImageType::RegionType         imageRegion{ size };
+  Test4ImageType::SpacingType        spacing{ { 1.0, 1.0, 1.0 } };
+  const Test4ImageType::Pointer      test4Image =
     itk::IOTestHelper::AllocateImageFromRegionAndSpacing<Test4ImageType>(imageRegion, spacing);
   test4Image->FillBuffer(0);
 

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest6.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest6.cxx
@@ -34,10 +34,8 @@ itkNiftiImageIOTest6(int argc, char * argv[])
 
   using VectorImageType = itk::VectorImage<double, 3>;
 
-  constexpr VectorImageType::SizeType  size{ 3, 3, 3 };
-  constexpr VectorImageType::IndexType index{};
-
-  VectorImageType::RegionType                 imageRegion = { index, size };
+  constexpr VectorImageType::SizeType         size{ 3, 3, 3 };
+  VectorImageType::RegionType                 imageRegion{ size };
   VectorImageType::SpacingType                spacing{ { 1.0, 1.0, 1.0 } };
   constexpr VectorImageType::VectorLengthType vecLength(4);
 

--- a/Modules/IO/PNG/test/itkPNGImageIOTest.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTest.cxx
@@ -171,9 +171,8 @@ itkPNGImageIOTest(int argc, char * argv[])
 
   auto volume = ImageType3D::New();
 
-  auto                             size3D = ImageType3D::SizeType::Filled(10);
-  constexpr ImageType3D::IndexType start3D{};
-  ImageType3D::RegionType          region3D{ start3D, size3D };
+  auto                    size3D = ImageType3D::SizeType::Filled(10);
+  ImageType3D::RegionType region3D{ size3D };
 
   volume->SetRegions(region3D);
   volume->AllocateInitialized();
@@ -211,9 +210,8 @@ itkPNGImageIOTest(int argc, char * argv[])
   //
   auto image = ImageType2D::New();
 
-  auto                             size2D = ImageType2D::SizeType::Filled(10);
-  constexpr ImageType2D::IndexType start2D{};
-  ImageType2D::RegionType          region2D{ start2D, size2D };
+  auto                    size2D = ImageType2D::SizeType::Filled(10);
+  ImageType2D::RegionType region2D{ size2D };
 
   image->SetRegions(region2D);
   image->AllocateInitialized();
@@ -250,9 +248,8 @@ itkPNGImageIOTest(int argc, char * argv[])
   //
   auto line = ImageType1D::New();
 
-  auto                             size1D = ImageType1D::SizeType::Filled(10);
-  constexpr ImageType1D::IndexType start1D{};
-  const ImageType1D::RegionType    region1D{ start1D, size1D };
+  auto                          size1D = ImageType1D::SizeType::Filled(10);
+  const ImageType1D::RegionType region1D{ size1D };
   line->SetRegions(region1D);
 
   line->AllocateInitialized();

--- a/Modules/IO/RAW/test/itkRawImageIOTest3.cxx
+++ b/Modules/IO/RAW/test/itkRawImageIOTest3.cxx
@@ -48,9 +48,8 @@ itkRawImageIOTest3(int argc, char * argv[])
   // Create a source object (in this case a random image generator).
   // The source object is templated on the output type.
   //
-  constexpr ImageType::SizeType  size{ 517, 293 }; // prime numbers are good bug testers...
-  constexpr ImageType::IndexType index{};
-  ImageType::RegionType          region{ index, size };
+  constexpr ImageType::SizeType size{ 517, 293 }; // prime numbers are good bug testers...
+  ImageType::RegionType         region{ size };
 
   auto image = ImageType::New();
   image->SetRegions(region);

--- a/Modules/Numerics/Statistics/test/itkCovarianceSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkCovarianceSampleFilterTest.cxx
@@ -36,10 +36,9 @@ itkCovarianceSampleFilterTest(int, char *[])
   using ImageType = itk::Image<MeasurementVectorType, 3>;
   using MaskImageType = itk::Image<unsigned char, 3>;
 
-  auto                           image = ImageType::New();
-  constexpr ImageType::SizeType  size{ 5, 5, 5 };
-  constexpr ImageType::IndexType index{};
-  ImageType::RegionType          region = { index, size };
+  auto                          image = ImageType::New();
+  constexpr ImageType::SizeType size{ 5, 5, 5 };
+  ImageType::RegionType         region{ size };
 
 
   image->SetBufferedRegion(region);

--- a/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceListSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceListSampleFilterTest.cxx
@@ -40,8 +40,7 @@ itkScalarImageToCooccurrenceListSampleFilterTest(int, char *[])
 
   constexpr InputImageType::SizeType inputImageSize{ IMGWIDTH, IMGHEIGHT };
 
-  constexpr InputImageType::IndexType index{};
-  InputImageType::RegionType          region{ index, inputImageSize };
+  InputImageType::RegionType region{ inputImageSize };
 
   //--------------------------------------------------------------------------
   // Set up the image first. It looks like:

--- a/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest.cxx
@@ -44,8 +44,7 @@ itkScalarImageToCooccurrenceMatrixFilterTest(int, char *[])
 
   constexpr InputImageType::SizeType inputImageSize{ IMGWIDTH, IMGHEIGHT };
 
-  constexpr InputImageType::IndexType index{};
-  InputImageType::RegionType          region{ index, inputImageSize };
+  InputImageType::RegionType region{ inputImageSize };
 
   //--------------------------------------------------------------------------
   // Set up the image first. It looks like:

--- a/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest2.cxx
@@ -46,8 +46,7 @@ itkScalarImageToCooccurrenceMatrixFilterTest2(int, char *[])
 
   constexpr InputImageType::SizeType inputImageSize{ IMGWIDTH, IMGHEIGHT };
 
-  constexpr InputImageType::IndexType index{};
-  InputImageType::RegionType          region{ index, inputImageSize };
+  InputImageType::RegionType region{ inputImageSize };
 
   //--------------------------------------------------------------------------
   // Set up the image first. It looks like:

--- a/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthFeaturesFilterTest.cxx
@@ -43,8 +43,7 @@ itkScalarImageToRunLengthFeaturesFilterTest(int, char *[])
 
   constexpr InputImageType::SizeType inputImageSize{ IMGWIDTH, IMGHEIGHT };
 
-  constexpr InputImageType::IndexType index{};
-  InputImageType::RegionType          region{ index, inputImageSize };
+  InputImageType::RegionType region{ inputImageSize };
 
   //--------------------------------------------------------------------------
   // Set up the image first. It looks like:

--- a/Modules/Numerics/Statistics/test/itkScalarImageToTextureFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToTextureFeaturesFilterTest.cxx
@@ -46,8 +46,7 @@ itkScalarImageToTextureFeaturesFilterTest(int, char *[])
 
   constexpr InputImageType::SizeType inputImageSize{ IMGWIDTH, IMGHEIGHT };
 
-  constexpr InputImageType::IndexType index{};
-  InputImageType::RegionType          region{ index, inputImageSize };
+  InputImageType::RegionType region{ inputImageSize };
 
   //--------------------------------------------------------------------------
   // Set up the image first. It looks like:

--- a/Modules/Numerics/Statistics/test/itkStandardDeviationPerComponentSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkStandardDeviationPerComponentSampleFilterTest.cxx
@@ -39,9 +39,8 @@ itkStandardDeviationPerComponentSampleFilterTest(int, char *[])
 
   auto image = ImageType::New();
 
-  ImageType::SizeType            size{ 5, 5, 5 };
-  constexpr ImageType::IndexType index{};
-  ImageType::RegionType          region = { index, size };
+  ImageType::SizeType   size{ 5, 5, 5 };
+  ImageType::RegionType region{ size };
 
 
   image->SetBufferedRegion(region);

--- a/Modules/Numerics/Statistics/test/itkStatisticsAlgorithmTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkStatisticsAlgorithmTest2.cxx
@@ -106,9 +106,7 @@ itkStatisticsAlgorithmTest2(int, char *[])
 
   auto size = ImageType::SizeType::Filled(5);
 
-  constexpr ImageType::IndexType index{};
-
-  const ImageType::RegionType region{ index, size };
+  const ImageType::RegionType region{ size };
 
   image->SetLargestPossibleRegion(region);
   image->SetBufferedRegion(region);

--- a/Modules/Registration/Common/test/itkLandmarkBasedTransformInitializerTest.cxx
+++ b/Modules/Registration/Common/test/itkLandmarkBasedTransformInitializerTest.cxx
@@ -32,8 +32,7 @@ CreateTestImage()
 
   typename FixedImageType::SizeType fSize;
   fSize.Fill(30);
-  constexpr typename FixedImageType::IndexType fIndex{};
-  typename FixedImageType::RegionType          fRegion = { fIndex, fSize };
+  typename FixedImageType::RegionType fRegion{ fSize };
   image->SetRegions(fRegion);
   image->Allocate();
   return image;

--- a/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
@@ -133,9 +133,8 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
   // When shrink factors are not divisible, this still does
   // a best does the best possible job.
   // InputImageType::SizeType size = {{101,101,41}};
-  InputImageType::SizeType            size = { { 128, 132, 48 } };
-  constexpr InputImageType::IndexType index{};
-  const InputImageType::RegionType    region{ index, size };
+  InputImageType::SizeType         size = { { 128, 132, 48 } };
+  const InputImageType::RegionType region{ size };
 
   InputImageType::SpacingType spacing;
   spacing[0] = 0.5;

--- a/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
@@ -151,9 +151,8 @@ itkANTSNeighborhoodCorrelationImageToImageMetricv4Test(int, char ** const)
 
   constexpr itk::SizeValueType imageSize{ 6 };
 
-  auto                           size = ImageType::SizeType::Filled(imageSize);
-  constexpr ImageType::IndexType index{};
-  const ImageType::RegionType    region{ index, size };
+  auto                        size = ImageType::SizeType::Filled(imageSize);
+  const ImageType::RegionType region{ size };
 
   /* Create simple test images. */
   auto fixedImage = ImageType::New();

--- a/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
@@ -128,9 +128,8 @@ itkCorrelationImageToImageMetricv4Test(int, char ** const)
   constexpr unsigned int imageDimensionality{ 3 };
   using ImageType = itk::Image<double, imageDimensionality>;
 
-  auto                           size = ImageType::SizeType::Filled(imageSize);
-  constexpr ImageType::IndexType index{};
-  const ImageType::RegionType    region{ index, size };
+  auto                        size = ImageType::SizeType::Filled(imageSize);
+  const ImageType::RegionType region{ size };
 
   /* Create simple test images. */
   auto fixedImage = ImageType::New();

--- a/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
@@ -36,9 +36,8 @@ itkDemonsImageToImageMetricv4Test(int, char ** const)
   constexpr unsigned int imageDimensionality{ 3 };
   using ImageType = itk::Image<double, imageDimensionality>;
 
-  auto                           size = ImageType::SizeType::Filled(imageSize);
-  constexpr ImageType::IndexType index{};
-  const ImageType::RegionType    region{ index, size };
+  auto                        size = ImageType::SizeType::Filled(imageSize);
+  const ImageType::RegionType region{ size };
 
 
   /* Create simple test images. */

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
@@ -266,9 +266,7 @@ itkEuclideanDistancePointSetMetricRegistrationTest(int argc, char * argv[])
 
   auto regionSize = RegionType::SizeType::Filled(static_cast<itk::SizeValueType>(pointMax) + 1);
 
-  constexpr RegionType::IndexType regionIndex{};
-
-  const RegionType region{ regionIndex, regionSize };
+  const RegionType region{ regionSize };
 
   auto displacementField = FieldType::New();
   displacementField->SetOrigin(origin);

--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
@@ -35,9 +35,8 @@ itkJointHistogramMutualInformationImageToImageMetricv4Test(int, char *[])
   constexpr unsigned int imageDimensionality{ 3 };
   using ImageType = itk::Image<double, imageDimensionality>;
 
-  auto                           size = ImageType::SizeType::Filled(imageSize);
-  constexpr ImageType::IndexType index{};
-  const ImageType::RegionType    region{ index, size };
+  auto                        size = ImageType::SizeType::Filled(imageSize);
+  const ImageType::RegionType region{ size };
 
   /* Create simple test images. */
   auto fixedImage = ImageType::New();

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
@@ -38,9 +38,8 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest(int, char ** const)
   using VectorType = itk::Vector<double, vectorLength>;
   using ImageType = itk::Image<VectorType, imageDimensionality>;
 
-  auto                           size = ImageType::SizeType::Filled(imageSize);
-  constexpr ImageType::IndexType index{};
-  const ImageType::RegionType    region{ index, size };
+  auto                        size = ImageType::SizeType::Filled(imageSize);
+  const ImageType::RegionType region{ size };
 
   /* Create simple test images. */
   auto fixedImage = ImageType::New();

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
@@ -39,9 +39,8 @@ itkMeanSquaresImageToImageMetricv4SpeedTest(int argc, char * argv[])
   constexpr unsigned int imageDimensionality{ 3 };
   using ImageType = itk::Image<double, imageDimensionality>;
 
-  auto                           size = ImageType::SizeType::Filled(imageSize);
-  constexpr ImageType::IndexType index{};
-  const ImageType::RegionType    region{ index, size };
+  auto                        size = ImageType::SizeType::Filled(imageSize);
+  const ImageType::RegionType region{ size };
 
   /* Create simple test images. */
   auto fixedImage = ImageType::New();

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4Test.cxx
@@ -34,9 +34,8 @@ itkMeanSquaresImageToImageMetricv4Test(int, char ** const)
   constexpr unsigned int imageDimensionality{ 3 };
   using ImageType = itk::Image<double, imageDimensionality>;
 
-  auto                           size = ImageType::SizeType::Filled(imageSize);
-  constexpr ImageType::IndexType index{};
-  const ImageType::RegionType    region{ index, size };
+  auto                        size = ImageType::SizeType::Filled(imageSize);
+  const ImageType::RegionType region{ size };
 
   /* Create simple test images. */
   auto fixedImage = ImageType::New();

--- a/Modules/Segmentation/Classifiers/test/itkKmeansModelEstimatorTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkKmeansModelEstimatorTest.cxx
@@ -64,8 +64,7 @@ itkKmeansModelEstimatorTest(int, char *[])
 
   constexpr VecImageType::SizeType vecImgSize{ IMGWIDTH, IMGHEIGHT, NFRAMES };
 
-  constexpr VecImageType::IndexType index{};
-  VecImageType::RegionType          region{ index, vecImgSize };
+  VecImageType::RegionType region{ vecImgSize };
 
   vecImage->SetLargestPossibleRegion(region);
   vecImage->SetBufferedRegion(region);

--- a/Modules/Segmentation/Classifiers/test/itkSupervisedImageClassifierTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSupervisedImageClassifierTest.cxx
@@ -69,9 +69,8 @@ itkSupervisedImageClassifierTest(int, char *[])
 
   auto vecImage = VecImageType::New();
 
-  constexpr VecImageType::SizeType  vecImgSize{ IMGWIDTH, IMGHEIGHT, NFRAMES };
-  constexpr VecImageType::IndexType index{};
-  VecImageType::RegionType          region{ index, vecImgSize };
+  constexpr VecImageType::SizeType vecImgSize{ IMGWIDTH, IMGHEIGHT, NFRAMES };
+  VecImageType::RegionType         region{ vecImgSize };
 
   vecImage->SetLargestPossibleRegion(region);
   vecImage->SetBufferedRegion(region);
@@ -171,9 +170,7 @@ itkSupervisedImageClassifierTest(int, char *[])
 
   constexpr ClassImageType::SizeType classImgSize{ IMGWIDTH, IMGHEIGHT, NFRAMES };
 
-  constexpr ClassImageType::IndexType classindex{};
-
-  ClassImageType::RegionType classregion{ classindex, classImgSize };
+  ClassImageType::RegionType classregion{ classImgSize };
 
   classImage->SetLargestPossibleRegion(classregion);
   classImage->SetBufferedRegion(classregion);

--- a/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
@@ -126,9 +126,7 @@ test_RegionGrowKLMExceptionHandling()
 
   auto imageSize5D = ImageType5D::SizeType::Filled(sizeLen);
 
-  constexpr ImageType5D::IndexType index5D{};
-
-  ImageType5D::RegionType region5D{ index5D, imageSize5D };
+  ImageType5D::RegionType region5D{ imageSize5D };
 
   image5D->SetLargestPossibleRegion(region5D);
   image5D->SetBufferedRegion(region5D);
@@ -239,9 +237,7 @@ test_regiongrowKLM1D()
   constexpr unsigned int numPixelsHalf{ 50 };
   auto                   imageSize = ImageType::SizeType::Filled(numPixels);
 
-  constexpr ImageType::IndexType index{};
-
-  const ImageType::RegionType region{ index, imageSize };
+  const ImageType::RegionType region{ imageSize };
 
   image->SetLargestPossibleRegion(region);
   image->SetBufferedRegion(region);
@@ -818,9 +814,7 @@ test_regiongrowKLM2D()
   imageSize[1] = 20;
   constexpr unsigned int numPixels{ 200 };
 
-  constexpr ImageType::IndexType index{};
-
-  const ImageType::RegionType region{ index, imageSize };
+  const ImageType::RegionType region{ imageSize };
 
   image->SetLargestPossibleRegion(region);
   image->SetBufferedRegion(region);
@@ -1267,9 +1261,7 @@ test_regiongrowKLM3D()
   imageSize[2] = 3;
   constexpr unsigned int numPixels = 10 * 20 * 3;
 
-  constexpr ImageType::IndexType index{};
-
-  const ImageType::RegionType region{ index, imageSize };
+  const ImageType::RegionType region{ imageSize };
 
   image->SetLargestPossibleRegion(region);
   image->SetBufferedRegion(region);
@@ -1768,9 +1760,7 @@ test_regiongrowKLM4D()
   imageSize[3] = 7 * multVal;
   const unsigned int numPixels = imageSize[0] * imageSize[1] * imageSize[2] * imageSize[3];
 
-  constexpr ImageType::IndexType index{};
-
-  const ImageType::RegionType region{ index, imageSize };
+  const ImageType::RegionType region{ imageSize };
 
   image->SetLargestPossibleRegion(region);
   image->SetBufferedRegion(region);

--- a/Modules/Segmentation/LevelSets/test/itkCannySegmentationLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkCannySegmentationLevelSetImageFilterTest.cxx
@@ -153,9 +153,8 @@ itkCannySegmentationLevelSetImageFilterTest(int, char *[])
 {
   std::cout << "Last modified 11/08/02" << std::endl;
 
-  constexpr CSIFTN::ImageType::RegionType::SizeType  sz{ 64, 64, 64 };
-  constexpr CSIFTN::ImageType::RegionType::IndexType idx{};
-  CSIFTN::ImageType::RegionType                      reg = { idx, sz };
+  constexpr CSIFTN::ImageType::RegionType::SizeType sz{ 64, 64, 64 };
+  CSIFTN::ImageType::RegionType                     reg{ sz };
 
   const CSIFTN::ImageType::Pointer     inputImage = CSIFTN::ImageType::New();
   const CSIFTN::SeedImageType::Pointer seedImage = CSIFTN::SeedImageType::New();

--- a/Modules/Segmentation/LevelSets/test/itkLaplacianSegmentationLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLaplacianSegmentationLevelSetImageFilterTest.cxx
@@ -152,9 +152,8 @@ protected:
 int
 itkLaplacianSegmentationLevelSetImageFilterTest(int, char *[])
 {
-  constexpr LSIFTN::ImageType::RegionType::SizeType  sz{ 64, 64, 64 };
-  constexpr LSIFTN::ImageType::RegionType::IndexType idx{};
-  LSIFTN::ImageType::RegionType                      reg = { idx, sz };
+  constexpr LSIFTN::ImageType::RegionType::SizeType sz{ 64, 64, 64 };
+  LSIFTN::ImageType::RegionType                     reg{ sz };
 
   const LSIFTN::ImageType::Pointer     inputImage = LSIFTN::ImageType::New();
   const LSIFTN::SeedImageType::Pointer seedImage = LSIFTN::SeedImageType::New();

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageTest.cxx
@@ -47,9 +47,7 @@ itkLevelSetDomainPartitionImageTest(int, char *[])
   spacing[0] = 1.0;
   spacing[1] = 1.0;
 
-  constexpr InputImageType::IndexType index{};
-
-  const InputImageType::RegionType region{ index, size };
+  const InputImageType::RegionType region{ size };
 
   // Binary initialization
   auto binary = InputImageType::New();

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkMRFImageFilterTest.cxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkMRFImageFilterTest.cxx
@@ -52,9 +52,7 @@ itkMRFImageFilterTest(int, char *[])
 
   VecImageType::SizeType vecImgSize = { { IMGWIDTH, IMGHEIGHT, NFRAMES } };
 
-  constexpr VecImageType::IndexType index{};
-
-  VecImageType::RegionType region{ index, vecImgSize };
+  VecImageType::RegionType region{ vecImgSize };
 
   vecImage->SetLargestPossibleRegion(region);
   vecImage->SetBufferedRegion(region);
@@ -214,9 +212,7 @@ itkMRFImageFilterTest(int, char *[])
 
   constexpr ClassImageType::SizeType classImgSize{ IMGWIDTH, IMGHEIGHT, NFRAMES };
 
-  constexpr ClassImageType::IndexType classindex{};
-
-  ClassImageType::RegionType classregion{ classindex, classImgSize };
+  ClassImageType::RegionType classregion{ classImgSize };
 
   classImage->SetLargestPossibleRegion(classregion);
   classImage->SetBufferedRegion(classregion);

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkRGBGibbsPriorFilterTest.cxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkRGBGibbsPriorFilterTest.cxx
@@ -89,9 +89,7 @@ itkRGBGibbsPriorFilterTest(int, char *[])
 
   constexpr VecImageType::SizeType vecImgSize{ ImageWidth, ImageHeight, NumFrames };
 
-  constexpr VecImageType::IndexType index{};
-
-  VecImageType::RegionType region{ index, vecImgSize };
+  VecImageType::RegionType region{ vecImgSize };
 
   vecImage->SetLargestPossibleRegion(region);
   vecImage->SetBufferedRegion(region);
@@ -134,9 +132,7 @@ itkRGBGibbsPriorFilterTest(int, char *[])
 
   constexpr ClassImageType::SizeType classImgSize{ ImageWidth, ImageHeight, NumFrames };
 
-  constexpr ClassImageType::IndexType classindex{};
-
-  ClassImageType::RegionType classregion{ classindex, classImgSize };
+  ClassImageType::RegionType classregion{ classImgSize };
 
   classImage->SetLargestPossibleRegion(classregion);
   classImage->SetBufferedRegion(classregion);

--- a/Modules/Segmentation/SignedDistanceFunction/test/itkPCAShapeSignedDistanceFunctionGTest.cxx
+++ b/Modules/Segmentation/SignedDistanceFunction/test/itkPCAShapeSignedDistanceFunctionGTest.cxx
@@ -61,9 +61,7 @@ TEST(PCAShapeSignedDistanceFunction, Test)
 
   constexpr ImageType::SizeType imageSize{ ImageWidth, ImageHeight };
 
-  constexpr ImageType::IndexType startIndex{};
-
-  const ImageType::RegionType region{ startIndex, imageSize };
+  const ImageType::RegionType region{ imageSize };
 
 
   // set up the random number generator

--- a/Modules/Video/Core/test/itkVideoSourceTest.cxx
+++ b/Modules/Video/Core/test/itkVideoSourceTest.cxx
@@ -109,10 +109,9 @@ protected:
 FrameType::Pointer
 CreateEmptyFrame()
 {
-  auto                           out = FrameType::New();
-  constexpr FrameType::SizeType  sizeLR{ 50, 40 };
-  constexpr FrameType::IndexType startLR{};
-  FrameType::RegionType          largestRegion = { startLR, sizeLR };
+  auto                          out = FrameType::New();
+  constexpr FrameType::SizeType sizeLR{ 50, 40 };
+  FrameType::RegionType         largestRegion{ sizeLR };
   out->SetLargestPossibleRegion(largestRegion);
 
   constexpr FrameType::SizeType sizeReq{ 20, 10 };

--- a/Modules/Video/Core/test/itkVideoToVideoFilterTest.cxx
+++ b/Modules/Video/Core/test/itkVideoToVideoFilterTest.cxx
@@ -41,9 +41,8 @@ CreateInputFrame(InputPixelType val)
 {
   auto out = InputFrameType::New();
 
-  constexpr InputFrameType::SizeType  sizeLR{ 50, 40 };
-  constexpr InputFrameType::IndexType startLR{};
-  InputFrameType::RegionType          largestRegion = { startLR, sizeLR };
+  constexpr InputFrameType::SizeType sizeLR{ 50, 40 };
+  InputFrameType::RegionType         largestRegion{ sizeLR };
   out->SetRegions(largestRegion);
 
   out->Allocate();

--- a/Modules/Video/Filtering/test/itkFrameAverageVideoFilterTest.cxx
+++ b/Modules/Video/Filtering/test/itkFrameAverageVideoFilterTest.cxx
@@ -48,10 +48,9 @@ namespace itk::FrameAverageVideoFilterTest
 InputFrameType::Pointer
 CreateInputFrame(InputPixelType val)
 {
-  auto                                out = InputFrameType::New();
-  constexpr InputFrameType::SizeType  sizeLR{ 50, 40 };
-  constexpr InputFrameType::IndexType startLR{};
-  InputFrameType::RegionType          largestRegion = { startLR, sizeLR };
+  auto                               out = InputFrameType::New();
+  constexpr InputFrameType::SizeType sizeLR{ 50, 40 };
+  InputFrameType::RegionType         largestRegion{ sizeLR };
   out->SetRegions(largestRegion);
 
   out->Allocate();

--- a/Modules/Video/Filtering/test/itkFrameDifferenceVideoFilterTest.cxx
+++ b/Modules/Video/Filtering/test/itkFrameDifferenceVideoFilterTest.cxx
@@ -50,9 +50,8 @@ CreateInputFrame(InputPixelType val)
 {
   auto out = InputFrameType::New();
 
-  InputFrameType::SizeType            sizeLR{ 50, 40 };
-  constexpr InputFrameType::IndexType startLR{};
-  InputFrameType::RegionType          largestRegion = { startLR, sizeLR };
+  InputFrameType::SizeType   sizeLR{ 50, 40 };
+  InputFrameType::RegionType largestRegion{ sizeLR };
   out->SetRegions(largestRegion);
 
   out->Allocate();


### PR DESCRIPTION
Removed `{}`-initialized `IndexType` variables that were only there as the index argument of a region initialization.

Using Notepad++, Replace in Files (Search Mode: Regular expression), doing:

  Find what: `^( [ ]+)constexpr .+::IndexType[ ]+(\w+){};[\r\n]+\1(.*[rR]egion.* .*) = { \2, (.*) };$`
  Find what: `^( [ ]+)constexpr .+::IndexType[ ]+(\w+){};[\r\n]+\1(.*[rR]egion.* .*[rR]egion.*){ \2, (.*) };$`
  Replace with: `$1$3{ $4 };`

  Find what: `^( [ ]+)constexpr .+::IndexType[ ]+(\w+){};[\r\n]+(\1.+)[\r\n]+\1(.*[rR]egion.* \w+){ \2, (.*) };$`
  Find what: `^( [ ]+)constexpr .+::IndexType[ ]+(\w+){};[\r\n]+(\1.+)[\r\n]+\1(.*[rR]egion.* \w+)\(\2, (.*)\);$`
  Replace with: `$3\r\n$1$4{ $5 };`

  Filters: `itk*Test*.cxx`