### PR TITLE
STYLE: Remove `T::IndexType index{0}` from region initialization in test

### DIFF
--- a/Modules/Core/Common/test/itkAbortProcessObjectTest.cxx
+++ b/Modules/Core/Common/test/itkAbortProcessObjectTest.cxx
@@ -64,9 +64,8 @@ itkAbortProcessObjectTest(int, char *[])
   auto img = ShortImage::New();
 
   // fill in an image
-  constexpr ShortImage::IndexType index{ 0, 0 };
-  constexpr ShortImage::SizeType  size{ 100, 100 };
-  const ShortImage::RegionType    region{ index, size };
+  constexpr ShortImage::SizeType size{ 100, 100 };
+  const ShortImage::RegionType   region{ size };
   img->SetRegions(region);
   img->Allocate();
 
@@ -85,9 +84,8 @@ itkAbortProcessObjectTest(int, char *[])
   extract->SetInput(img);
 
   // fill in an image
-  constexpr ShortImage::IndexType extractIndex{ 0, 0 };
-  constexpr ShortImage::SizeType  extractSize{ 99, 99 };
-  const ShortImage::RegionType    extractRegion{ extractIndex, extractSize };
+  constexpr ShortImage::SizeType extractSize{ 99, 99 };
+  const ShortImage::RegionType   extractRegion{ extractSize };
   extract->SetExtractionRegion(extractRegion);
 
   const itk::CStyleCommand::Pointer progressCmd = itk::CStyleCommand::New();

--- a/Modules/Core/Common/test/itkOctreeTest.cxx
+++ b/Modules/Core/Common/test/itkOctreeTest.cxx
@@ -40,10 +40,9 @@ int
 itkOctreeTest(int, char *[])
 {
   using ImageType = itk::Image<unsigned int, 3>;
-  constexpr ImageType::SizeType  imageSize{ 4, 4, 4 };
-  constexpr ImageType::IndexType imageIndex{ 0, 0, 0 };
-  const ImageType::RegionType    region{ imageIndex, imageSize };
-  auto                           img = ImageType::New();
+  constexpr ImageType::SizeType imageSize{ 4, 4, 4 };
+  const ImageType::RegionType   region{ imageSize };
+  auto                          img = ImageType::New();
   img->SetRegions(region);
   img->Allocate();
   srand(static_cast<unsigned int>(time(nullptr)));

--- a/Modules/Core/Common/test/itkSparseImageTest.cxx
+++ b/Modules/Core/Common/test/itkSparseImageTest.cxx
@@ -48,9 +48,8 @@ itkSparseImageTest(int, char *[])
 
   auto im = SparseImageType::New();
 
-  constexpr ImageType::SizeType  sz{ 24, 24 };
-  constexpr ImageType::IndexType idx{ 0, 0 };
-  ImageType::RegionType          r = { idx, sz };
+  constexpr ImageType::SizeType sz{ 24, 24 };
+  ImageType::RegionType         r{ sz };
 
   im->SetRegions(r);
   im->Allocate();

--- a/Modules/Core/Common/test/itkStreamingImageFilterTest.cxx
+++ b/Modules/Core/Common/test/itkStreamingImageFilterTest.cxx
@@ -34,9 +34,8 @@ itkStreamingImageFilterTest(int, char *[])
   auto if2 = ShortImage::New();
 
   // fill in an image
-  constexpr ShortImage::IndexType index{ 0, 0 };
-  constexpr ShortImage::SizeType  size{ 80, 122 };
-  const ShortImage::RegionType    region{ index, size };
+  constexpr ShortImage::SizeType size{ 80, 122 };
+  const ShortImage::RegionType   region{ size };
   if2->SetLargestPossibleRegion(region);
   if2->SetBufferedRegion(region);
   if2->Allocate();

--- a/Modules/Core/Common/test/itkStreamingImageFilterTest2.cxx
+++ b/Modules/Core/Common/test/itkStreamingImageFilterTest2.cxx
@@ -39,9 +39,8 @@ itkStreamingImageFilterTest2(int, char *[])
   auto if2 = ShortImage::New();
 
   // fill in an image
-  constexpr ShortImage::IndexType index{ 0, 0 };
-  constexpr ShortImage::SizeType  size{ 42, 64 };
-  const ShortImage::RegionType    region{ index, size };
+  constexpr ShortImage::SizeType size{ 42, 64 };
+  const ShortImage::RegionType   region{ size };
   if2->SetLargestPossibleRegion(region);
   if2->SetBufferedRegion(region);
   if2->Allocate();

--- a/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest4.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest4.cxx
@@ -86,8 +86,7 @@ itkTriangleMeshToBinaryImageFilterTest4(int argc, char * argv[])
   spacing[2] = std::stod(argv[11]);
 
 
-  constexpr ImageType::IndexType index3D{ 0, 0, 0 };
-  const ImageType::RegionType    region3D{ index3D, size };
+  const ImageType::RegionType region3D{ size };
 
   auto inputImage = ImageType::New();
   inputImage->SetRegions(region3D);

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest.cxx
@@ -41,10 +41,9 @@ itkImageMaskSpatialObjectTest(int, char *[])
   using ImageType = ImageMaskSpatialObject::ImageType;
   using Iterator = itk::ImageRegionIterator<ImageType>;
 
-  auto                           image = ImageType::New();
-  constexpr ImageType::SizeType  size{ 50, 50, 50 };
-  constexpr ImageType::IndexType index{ 0, 0, 0 };
-  ImageType::RegionType          region{ index, size };
+  auto                          image = ImageType::New();
+  constexpr ImageType::SizeType size{ 50, 50, 50 };
+  ImageType::RegionType         region{ size };
 
   image->SetRegions(region);
   image->AllocateInitialized();

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest5.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest5.cxx
@@ -41,10 +41,9 @@ itkImageMaskSpatialObjectTest5(int, char *[])
   using ImageType = ImageMaskSpatialObject::ImageType;
   using Iterator = itk::ImageRegionIterator<ImageType>;
 
-  auto                           image = ImageType::New();
-  constexpr ImageType::SizeType  size{ 50, 50, 50 };
-  constexpr ImageType::IndexType index{ 0, 0, 0 };
-  ImageType::RegionType          region{ index, size };
+  auto                          image = ImageType::New();
+  constexpr ImageType::SizeType size{ 50, 50, 50 };
+  ImageType::RegionType         region{ size };
 
   image->SetRegions(region);
   image->AllocateInitialized();

--- a/Modules/Filtering/DistanceMap/test/itkDanielssonDistanceMapImageFilterGTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkDanielssonDistanceMapImageFilterGTest.cxx
@@ -173,10 +173,9 @@ TEST(DanielssonDistanceMapImageFilter, Test)
 
   // Allocate the 3D image
   using ImageType3D = itk::Image<float, 3>;
-  constexpr ImageType3D::SizeType  size3D{ 200, 200, 200 };
-  constexpr ImageType3D::IndexType index3D{ 0, 0 };
-  const ImageType3D::RegionType    region3D{ index3D, size3D };
-  auto                             inputImage3D = ImageType3D::New();
+  constexpr ImageType3D::SizeType size3D{ 200, 200, 200 };
+  const ImageType3D::RegionType   region3D{ size3D };
+  auto                            inputImage3D = ImageType3D::New();
   inputImage3D->SetRegions(region3D);
   inputImage3D->Allocate();
   inputImage3D->FillBuffer(1);

--- a/Modules/Filtering/ImageGrid/test/itkCropImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkCropImageFilterTest.cxx
@@ -40,9 +40,8 @@ itkCropImageFilterTest(int, char *[])
   auto inputImage = ImageType::New();
 
   // Fill in the image
-  constexpr ImageType::IndexType index{ 0, 0 };
-  constexpr ImageType::SizeType  size{ 8, 12 };
-  ImageType::RegionType          region{ index, size };
+  constexpr ImageType::SizeType size{ 8, 12 };
+  ImageType::RegionType         region{ size };
   inputImage->SetLargestPossibleRegion(region);
   inputImage->SetBufferedRegion(region);
   inputImage->Allocate();

--- a/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest.cxx
@@ -26,10 +26,9 @@ using ImageType = itk::Image<unsigned int, 3>;
 ImageType::Pointer
 CreateRandomImage()
 {
-  constexpr ImageType::SizeType  imageSize{ 4, 4, 4 };
-  constexpr ImageType::IndexType imageIndex{ 0, 0, 0 };
-  const ImageType::RegionType    region{ imageIndex, imageSize };
-  auto                           img = ImageType::New();
+  constexpr ImageType::SizeType imageSize{ 4, 4, 4 };
+  const ImageType::RegionType   region{ imageSize };
+  auto                          img = ImageType::New();
   img->SetRegions(region);
   img->Allocate();
 

--- a/Modules/Filtering/ImageGrid/test/itkShrinkImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkShrinkImageTest.cxx
@@ -47,9 +47,8 @@ itkShrinkImageTest(int, char *[])
   auto if2 = ShortImage::New();
 
   // fill in an image
-  constexpr ShortImage::IndexType index{ 0, 0 };
-  constexpr ShortImage::SizeType  size{ 8, 12 };
-  const ShortImage::RegionType    region{ index, size };
+  constexpr ShortImage::SizeType size{ 8, 12 };
+  const ShortImage::RegionType   region{ size };
   if2->SetLargestPossibleRegion(region);
   if2->SetBufferedRegion(region);
   if2->Allocate();

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
@@ -47,9 +47,8 @@ MakeCheckerboard()
   constexpr ImageType::SizeType size{ 16, 16, 16 };
   ImageType::SpacingType        spacing;
   spacing[0] = spacing[1] = spacing[2] = 1.0;
-  constexpr ImageType::IndexType index{ 0, 0, 0 };
-  const ImageType::RegionType    region{ index, size };
-  ImageType::Pointer             image;
+  const ImageType::RegionType region{ size };
+  ImageType::Pointer          image;
   AllocateImageFromRegionAndSpacing(ImageType, image, region, spacing);
   image->FillBuffer(0.0);
   for (IteratorType it(image, image->GetLargestPossibleRegion()); !it.IsAtEnd(); ++it)
@@ -77,9 +76,8 @@ MakeDisplacementField()
   const DisplacementFieldType::SizeType size = { { TImageIndexSpaceSize, TImageIndexSpaceSize, TImageIndexSpaceSize } };
   DisplacementFieldType::SpacingType    spacing;
   spacing[0] = spacing[1] = spacing[2] = 16.0 / static_cast<double>(TImageIndexSpaceSize);
-  constexpr DisplacementFieldType::IndexType index{ 0, 0, 0 };
-  const DisplacementFieldType::RegionType    region{ index, size };
-  DisplacementFieldType::Pointer             image;
+  const DisplacementFieldType::RegionType region{ size };
+  DisplacementFieldType::Pointer          image;
   AllocateImageFromRegionAndSpacing(DisplacementFieldType, image, region, spacing);
   for (IteratorType it(image, image->GetLargestPossibleRegion()); !it.IsAtEnd(); ++it)
   {

--- a/Modules/Filtering/ImageGrid/test/itkZeroFluxNeumannPadImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkZeroFluxNeumannPadImageFilterTest.cxx
@@ -173,9 +173,8 @@ itkZeroFluxNeumannPadImageFilterTest(int, char *[])
   auto inputImage = ShortImage::New();
 
   // Fill in a test image
-  constexpr ShortImage::IndexType inputIndex{ 0, 0 };
-  constexpr ShortImage::SizeType  inputSize{ 8, 12 };
-  const ShortImage::RegionType    inputRegion{ inputIndex, inputSize };
+  constexpr ShortImage::SizeType inputSize{ 8, 12 };
+  const ShortImage::RegionType   inputRegion{ inputSize };
   inputImage->SetLargestPossibleRegion(inputRegion);
   inputImage->SetBufferedRegion(inputRegion);
   inputImage->Allocate();

--- a/Modules/IO/NIFTI/test/itkNiftiWriteCoerceOrthogonalDirectionTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiWriteCoerceOrthogonalDirectionTest.cxx
@@ -38,10 +38,9 @@ itkNiftiWriteCoerceOrthogonalDirectionTest(int argc, char * argv[])
   constexpr unsigned int dim{ 2 };
   using ImageType = itk::Image<unsigned char, dim>;
 
-  constexpr ImageType::IndexType startIndex{ 0, 0 };
-  constexpr ImageType::SizeType  imageSize{ 2, 2 };
-  const ImageType::RegionType    region{ startIndex, imageSize };
-  auto                           image1 = ImageType::New();
+  constexpr ImageType::SizeType imageSize{ 2, 2 };
+  const ImageType::RegionType   region{ imageSize };
+  auto                          image1 = ImageType::New();
   image1->SetRegions(region);
   image1->AllocateInitialized();
 

--- a/Modules/Numerics/NarrowBand/test/itkNarrowBandImageFilterBaseTest.cxx
+++ b/Modules/Numerics/NarrowBand/test/itkNarrowBandImageFilterBaseTest.cxx
@@ -123,9 +123,8 @@ itkNarrowBandImageFilterBaseTest(int argc, char * argv[])
   using WriterImageType = itk::Image<WriterPixelType, ImageDimension>;
   using PointType = itk::Point<double, ImageDimension>;
 
-  constexpr ImageType::SizeType  size{ 64, 64 };
-  constexpr ImageType::IndexType index{ 0, 0 };
-  const ImageType::RegionType    region{ index, size };
+  constexpr ImageType::SizeType size{ 64, 64 };
+  const ImageType::RegionType   region{ size };
 
   auto inputImage = ImageType::New();
   inputImage->SetRegions(region);

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_13.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_13.cxx
@@ -139,9 +139,8 @@ itkImageRegistrationMethodTest_13(int, char *[])
   constexpr double displacement[dimension]{ 7, 3, 2 };
   constexpr double scale[dimension]{ 0.80, 1.0, 1.0 };
 
-  FixedImageType::SizeType            size = { { 100, 100, 40 } };
-  constexpr FixedImageType::IndexType index{ 0, 0, 0 };
-  const FixedImageType::RegionType    region{ index, size };
+  FixedImageType::SizeType         size = { { 100, 100, 40 } };
+  const FixedImageType::RegionType region{ size };
 
   fixedImage->SetRegions(region);
   fixedImage->Allocate();

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_14.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_14.cxx
@@ -146,9 +146,8 @@ itkImageRegistrationMethodTest_14(int, char *[])
   constexpr double displacement[dimension]{ 7, 3, 2 };
   constexpr double angle{ 10.0 / 180.0 * itk::Math::pi };
 
-  FixedImageType::SizeType            size = { { 100, 100, 40 } };
-  constexpr FixedImageType::IndexType index{ 0, 0, 0 };
-  const FixedImageType::RegionType    region{ index, size };
+  FixedImageType::SizeType         size = { { 100, 100, 40 } };
+  const FixedImageType::RegionType region{ size };
 
   fixedImage->SetRegions(region);
   fixedImage->Allocate();

--- a/Modules/Registration/Common/test/itkKullbackLeiblerCompareHistogramImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkKullbackLeiblerCompareHistogramImageToImageMetricTest.cxx
@@ -52,9 +52,8 @@ itkKullbackLeiblerCompareHistogramImageToImageMetricTest(int, char *[])
     ImageDimension = MovingImageType::ImageDimension
   };
 
-  constexpr MovingImageType::SizeType  size{ 16, 16 };
-  constexpr MovingImageType::IndexType index{ 0, 0 };
-  const MovingImageType::RegionType    region{ index, size };
+  constexpr MovingImageType::SizeType size{ 16, 16 };
+  const MovingImageType::RegionType   region{ size };
 
   auto imgMoving = MovingImageType::New();
   imgMoving->SetRegions(region);

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_1.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_1.cxx
@@ -121,9 +121,8 @@ itkMultiResolutionImageRegistrationMethodTest_1(int, char *[])
   constexpr double displacement[dimension]{ 7, 3, 2 };
   constexpr double scale[dimension]{ 0.80, 1.0, 1.0 };
 
-  FixedImageType::SizeType            size = { { 100, 100, 40 } };
-  constexpr FixedImageType::IndexType index{ 0, 0, 0 };
-  const FixedImageType::RegionType    region{ index, size };
+  FixedImageType::SizeType         size = { { 100, 100, 40 } };
+  const FixedImageType::RegionType region{ size };
 
   fixedImage->SetRegions(region);
   fixedImage->Allocate();

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_2.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_2.cxx
@@ -118,9 +118,8 @@ itkMultiResolutionImageRegistrationMethodTest_2(int, char *[])
   constexpr double displacement[dimension]{ 7, 3, 2 };
   constexpr double angle{ 10.0 / 180.0 * itk::Math::pi };
 
-  FixedImageType::SizeType            size = { { 100, 100, 40 } };
-  constexpr FixedImageType::IndexType index{ 0, 0, 0 };
-  const FixedImageType::RegionType    region{ index, size };
+  FixedImageType::SizeType         size = { { 100, 100, 40 } };
+  const FixedImageType::RegionType region{ size };
 
   fixedImage->SetRegions(region);
   fixedImage->Allocate();

--- a/Modules/Registration/Common/test/itkMutualInformationMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMutualInformationMetricTest.cxx
@@ -48,9 +48,8 @@ itkMutualInformationMetricTest(int, char *[])
     ImageDimension = MovingImageType::ImageDimension
   };
 
-  constexpr MovingImageType::SizeType  size{ 100, 100 };
-  constexpr MovingImageType::IndexType index{ 0, 0 };
-  const MovingImageType::RegionType    region{ index, size };
+  constexpr MovingImageType::SizeType size{ 100, 100 };
+  const MovingImageType::RegionType   region{ size };
 
   auto imgMoving = MovingImageType::New();
   imgMoving->SetRegions(region);

--- a/Modules/Registration/Common/test/itkRecursiveMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkRecursiveMultiResolutionPyramidImageFilterTest.cxx
@@ -95,9 +95,8 @@ itkRecursiveMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
     std::cout << std::endl;
   }
 
-  InputImageType::SizeType            size = { { 100, 100, 40 } };
-  constexpr InputImageType::IndexType index{ 0, 0, 0 };
-  const InputImageType::RegionType    region{ index, size };
+  InputImageType::SizeType         size = { { 100, 100, 40 } };
+  const InputImageType::RegionType region{ size };
 
   auto imgTarget = InputImageType::New();
   imgTarget->SetRegions(region);

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
@@ -385,9 +385,8 @@ itkImageToImageMetricv4Test(int, char ** const)
   using DimensionSizeType = unsigned int;
   constexpr DimensionSizeType imageSize{ 4 };
 
-  constexpr ImageToImageMetricv4TestImageType::SizeType  size{ imageSize, imageSize };
-  constexpr ImageToImageMetricv4TestImageType::IndexType index{ 0, 0 };
-  const ImageToImageMetricv4TestImageType::RegionType    region{ index, size };
+  constexpr ImageToImageMetricv4TestImageType::SizeType size{ imageSize, imageSize };
+  const ImageToImageMetricv4TestImageType::RegionType   region{ size };
 
 
   // Create simple test images.

--- a/Modules/Segmentation/LevelSets/test/itkAnisotropicFourthOrderLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkAnisotropicFourthOrderLevelSetImageFilterTest.cxx
@@ -27,9 +27,8 @@ itkAnisotropicFourthOrderLevelSetImageFilterTest(int, char *[])
 
   auto im_init = ImageType::New();
 
-  constexpr ImageType::SizeType  sz{ 128, 128 };
-  constexpr ImageType::IndexType idx{ 0, 0 };
-  ImageType::RegionType          r = { idx, sz };
+  constexpr ImageType::SizeType sz{ 128, 128 };
+  ImageType::RegionType         r{ sz };
 
   im_init->SetRegions(r);
   im_init->Allocate();

--- a/Modules/Segmentation/LevelSets/test/itkImplicitManifoldNormalVectorFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkImplicitManifoldNormalVectorFilterTest.cxx
@@ -30,10 +30,9 @@ itkImplicitManifoldNormalVectorFilterTest(int, char *[])
   using FilterType = itk::ImplicitManifoldNormalVectorFilter<InputImageType, OutputImageType>;
   using FunctionType = itk::NormalVectorDiffusionFunction<OutputImageType>;
 
-  auto                                im_init = InputImageType::New();
-  constexpr InputImageType::SizeType  sz{ 50, 50 };
-  constexpr InputImageType::IndexType idx{ 0, 0 };
-  InputImageType::RegionType          r = { idx, sz };
+  auto                               im_init = InputImageType::New();
+  constexpr InputImageType::SizeType sz{ 50, 50 };
+  InputImageType::RegionType         r{ sz };
   im_init->SetRegions(r);
   im_init->Allocate();
 

--- a/Modules/Segmentation/LevelSets/test/itkIsotropicFourthOrderLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkIsotropicFourthOrderLevelSetImageFilterTest.cxx
@@ -27,9 +27,8 @@ itkIsotropicFourthOrderLevelSetImageFilterTest(int, char *[])
 
   auto im_init = ImageType::New();
 
-  constexpr ImageType::SizeType  sz{ 128, 128 };
-  constexpr ImageType::IndexType idx{ 0, 0 };
-  ImageType::RegionType          r = { idx, sz };
+  constexpr ImageType::SizeType sz{ 128, 128 };
+  ImageType::RegionType         r{ sz };
 
   im_init->SetRegions(r);
   im_init->Allocate();

--- a/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
@@ -218,9 +218,8 @@ itkLevelSetFunctionTest(int, char *[])
   auto im_init = ImageType::New();
   auto im_target = ImageType::New();
 
-  constexpr ImageType::SizeType  sz{ LSFT::HEIGHT, LSFT::WIDTH };
-  constexpr ImageType::IndexType idx{ 0, 0 };
-  ImageType::RegionType          r = { idx, sz };
+  constexpr ImageType::SizeType sz{ LSFT::HEIGHT, LSFT::WIDTH };
+  ImageType::RegionType         r{ sz };
 
   im_init->SetRegions(r);
 

--- a/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
@@ -233,9 +233,8 @@ itkParallelSparseFieldLevelSetImageFilterTest(int argc, char * argv[])
   auto im_init = ImageType::New();
   auto im_target = ImageType::New();
 
-  constexpr ImageType::SizeType  sz{ PSFLSIFT::HEIGHT, PSFLSIFT::WIDTH, PSFLSIFT::DEPTH };
-  constexpr ImageType::IndexType idx{ 0, 0, 0 };
-  ImageType::RegionType          r = { idx, sz };
+  constexpr ImageType::SizeType sz{ PSFLSIFT::HEIGHT, PSFLSIFT::WIDTH, PSFLSIFT::DEPTH };
+  ImageType::RegionType         r{ sz };
 
   ImageType::PointType     origin;
   ImageType::SpacingType   spacing;

--- a/Modules/Segmentation/LevelSets/test/itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
@@ -140,9 +140,8 @@ itkSparseFieldFourthOrderLevelSetImageFilterTest(int, char *[])
 
   auto image = ImageType::New();
 
-  constexpr ImageType::SizeType  sz{ SFFOLSIFT::HEIGHT, SFFOLSIFT::WIDTH };
-  constexpr ImageType::IndexType idx{ 0, 0 };
-  ImageType::RegionType          r = { idx, sz };
+  constexpr ImageType::SizeType sz{ SFFOLSIFT::HEIGHT, SFFOLSIFT::WIDTH };
+  ImageType::RegionType         r{ sz };
 
   image->SetRegions(r);
   image->Allocate();

--- a/Modules/Segmentation/LevelSets/test/itkUnsharpMaskLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkUnsharpMaskLevelSetImageFilterTest.cxx
@@ -62,9 +62,8 @@ itkUnsharpMaskLevelSetImageFilterTest(int, char *[])
 
   auto im_init = ImageType::New();
 
-  constexpr ImageType::SizeType  sz{ HEIGHT, WIDTH };
-  constexpr ImageType::IndexType idx{ 0, 0 };
-  ImageType::RegionType          r = { idx, sz };
+  constexpr ImageType::SizeType sz{ HEIGHT, WIDTH };
+  ImageType::RegionType         r{ sz };
 
   im_init->SetRegions(r);
   im_init->Allocate();


### PR DESCRIPTION
Removed `IndexType` variables initialized by zero's (`{ 0, ..., 0 }`), that were only there as the index argument of a region initialization.

Using Notepad++, Replace in Files (Search Mode: Regular expression), doing:

  Find what: `^( [ ]+)constexpr .+::IndexType[ ]+(\w+){[0, ]*};[\r\n]+\1(.*[rR]egion.* .*) = { \2, (.*) };$`
  Find what: `^( [ ]+)constexpr .+::IndexType[ ]+(\w+){[0, ]*};[\r\n]+\1(.*[rR]egion.* .*\w.*){ \2, (.*) };$`
  Replace with: `$1$3{ $4 };`

  Find what: `^( [ ]+)constexpr .+::IndexType[ ]+(\w+){[0, ]*};[\r\n]+(\1.+)[\r\n]+\1(.*[rR]egion.* \w+){ \2, (.*) };$`
  Replace with: `$3\r\n$1$4{ $5 };`

- Follow-up to pull request #5627