### PR TITLE
STYLE: Do `speedImage->FillBuffer(1.0)` instead of iteration, in tests

### DIFF
--- a/Modules/Filtering/FastMarching/test/itkFastMarchingExtensionImageFilterTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingExtensionImageFilterTest.cxx
@@ -123,13 +123,7 @@ itkFastMarchingExtensionImageFilterTest(int, char *[])
   speedImage->SetLargestPossibleRegion(region);
   speedImage->SetBufferedRegion(region);
   speedImage->Allocate();
-
-  itk::ImageRegionIterator<FloatImageType> speedIter(speedImage, speedImage->GetBufferedRegion());
-  while (!speedIter.IsAtEnd())
-  {
-    speedIter.Set(1.0);
-    ++speedIter;
-  }
+  speedImage->FillBuffer(1.0);
 
   marcher->SetInput(speedImage);
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest1.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest1.cxx
@@ -147,13 +147,7 @@ itkFastMarchingImageFilterRealTest1(int itkNotUsed(argc), char * itkNotUsed(argv
   speedImage->SetLargestPossibleRegion(region);
   speedImage->SetBufferedRegion(region);
   speedImage->Allocate();
-
-  itk::ImageRegionIterator<FloatImageType> speedIter(speedImage, speedImage->GetBufferedRegion());
-  while (!speedIter.IsAtEnd())
-  {
-    speedIter.Set(1.0);
-    ++speedIter;
-  }
+  speedImage->FillBuffer(1.0);
 
   marcher->SetInput(speedImage);
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest2.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest2.cxx
@@ -85,6 +85,7 @@ itkFastMarchingImageFilterRealTest2(int itkNotUsed(argc), char * itkNotUsed(argv
   speedImage->SetLargestPossibleRegion(region);
   speedImage->SetBufferedRegion(region);
   speedImage->Allocate();
+  speedImage->FillBuffer(1.0);
 
   // Set up an 'alive image'
   auto aliveImage = FloatImageType::New();
@@ -126,11 +127,9 @@ itkFastMarchingImageFilterRealTest2(int itkNotUsed(argc), char * itkNotUsed(argv
   maskImage->SetBufferedRegion(region);
   maskImage->Allocate();
 
-  itk::ImageRegionIterator<FloatImageType>          speedIter(speedImage, speedImage->GetBufferedRegion());
   itk::ImageRegionIteratorWithIndex<FloatImageType> maskIter(maskImage, maskImage->GetBufferedRegion());
-  while (!speedIter.IsAtEnd())
+  while (!maskIter.IsAtEnd())
   {
-    speedIter.Set(1.0);
     FloatImageType::IndexType idx = maskIter.GetIndex();
     if (((idx[0] > 22) && (idx[0] < 42) && (idx[1] > 27) && (idx[1] < 37)) ||
         ((idx[1] > 22) && (idx[1] < 42) && (idx[0] > 27) && (idx[0] < 37)))
@@ -143,7 +142,6 @@ itkFastMarchingImageFilterRealTest2(int itkNotUsed(argc), char * itkNotUsed(argv
     }
 
     ++maskIter;
-    ++speedIter;
   }
 
   marcher->SetInput(speedImage);

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealWithNumberOfElementsTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealWithNumberOfElementsTest.cxx
@@ -113,13 +113,7 @@ itkFastMarchingImageFilterRealWithNumberOfElementsTest(int, char *[])
   speedImage->SetLargestPossibleRegion(region);
   speedImage->SetBufferedRegion(region);
   speedImage->Allocate();
-
-  itk::ImageRegionIterator<FloatImageType> speedIter(speedImage, speedImage->GetBufferedRegion());
-  while (!speedIter.IsAtEnd())
-  {
-    speedIter.Set(1.0);
-    ++speedIter;
-  }
+  speedImage->FillBuffer(1.0);
 
   marcher->SetInput(speedImage);
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
@@ -181,12 +181,7 @@ itkFastMarchingTest(int argc, char * argv[])
   speedImage->SetLargestPossibleRegion(region);
   speedImage->SetBufferedRegion(region);
   speedImage->Allocate();
-
-  itk::ImageRegionIterator<FloatImage> speedIter(speedImage, speedImage->GetBufferedRegion());
-  for (; !speedIter.IsAtEnd(); ++speedIter)
-  {
-    speedIter.Set(1.0);
-  }
+  speedImage->FillBuffer(1.0);
 
   marcher->SetInput(speedImage);
   ITK_TEST_SET_GET_VALUE(speedImage, marcher->GetInput());

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingTest2.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingTest2.cxx
@@ -127,6 +127,7 @@ itkFastMarchingTest2(int, char *[])
   speedImage->SetLargestPossibleRegion(region);
   speedImage->SetBufferedRegion(region);
   speedImage->Allocate();
+  speedImage->FillBuffer(1.0);
 
   // setup a binary mask image in float (to make sure it works with float)
   auto MaskImage = FloatImage::New();
@@ -134,11 +135,9 @@ itkFastMarchingTest2(int, char *[])
   MaskImage->SetBufferedRegion(region);
   MaskImage->Allocate();
 
-  itk::ImageRegionIterator<FloatImage>          speedIter(speedImage, speedImage->GetBufferedRegion());
   itk::ImageRegionIteratorWithIndex<FloatImage> maskIter(MaskImage, MaskImage->GetBufferedRegion());
-  while (!speedIter.IsAtEnd())
+  while (!maskIter.IsAtEnd())
   {
-    speedIter.Set(1.0);
     FloatImage::IndexType idx = maskIter.GetIndex();
     if (((idx[0] > 22) && (idx[0] < 42) && (idx[1] > 27) && (idx[1] < 37)) ||
         ((idx[1] > 22) && (idx[1] < 42) && (idx[0] > 27) && (idx[0] < 37)))
@@ -151,7 +150,6 @@ itkFastMarchingTest2(int, char *[])
     }
 
     ++maskIter;
-    ++speedIter;
   }
 
   speedImage->Print(std::cout);

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientBaseTest.cxx
@@ -125,14 +125,7 @@ itkFastMarchingUpwindGradientBaseTest(int, char *[])
   speedImage->SetLargestPossibleRegion(region);
   speedImage->SetBufferedRegion(region);
   speedImage->Allocate();
-
-  itk::ImageRegionIterator<FloatImageType> speedIter(speedImage, speedImage->GetBufferedRegion());
-
-  while (!speedIter.IsAtEnd())
-  {
-    speedIter.Set(1.0);
-    ++speedIter;
-  }
+  speedImage->FillBuffer(1.0);
 
   //  speedImage->Print( std::cout );
   marcher->SetInput(speedImage);

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientTest.cxx
@@ -131,12 +131,7 @@ itkFastMarchingUpwindGradientTest(int, char *[])
   speedImage->SetLargestPossibleRegion(region);
   speedImage->SetBufferedRegion(region);
   speedImage->Allocate();
-
-  itk::ImageRegionIterator<FloatImage> speedIter(speedImage, speedImage->GetBufferedRegion());
-  for (; !speedIter.IsAtEnd(); ++speedIter)
-  {
-    speedIter.Set(1.0);
-  }
+  speedImage->FillBuffer(1.0);
 
   //  speedImage->Print( std::cout );
   marcher->SetInput(speedImage);


### PR DESCRIPTION
Replaced manual `for` and `while` loops with FillBuffer function calls, in FastMarching tests.