### PR TITLE
prevent apple clang 17 wrapping

### DIFF
--- a/Wrapping/Generators/CastXML/CMakeLists.txt
+++ b/Wrapping/Generators/CastXML/CMakeLists.txt
@@ -30,6 +30,16 @@ else()
   set(_castxml_hash)
   set(_castxml_version 2025.09.03)
   set(_castxml_git_tag v0.6.13)
+  # castxml 2025.09.03 currently not compatible with AppleClang 17 (XCode 26)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "17")
+      message(
+        FATAL_ERROR
+        "Apple Clang ${CMAKE_CXX_COMPILER_VERSION} is not supported. Need AppleClang < 17."
+      )
+    endif()
+  endif()
+
   # If 64 bit Linux build host, use the CastXML binary
   if(
     CMAKE_HOST_SYSTEM_NAME


### PR DESCRIPTION
`castxml` fails to configure ITK properly

```log
FAILED: [code=1] Wrapping/Modules/ITKCommon/itkVersorPython.cpp Wrapping/Generators/Python/itk/itkVersorPython.py <ITK_BLD>/Wrapping/Modules/ITKCommon/itkVersorPython.cpp <ITK_BLD>/Wrapping/Generators/Python/itk/itkVersorPython.py

cd <ITK_BLD>/Wrapping/Typedefs/python && \
  /opt/homebrew/bin/ccache <ITK_BLD>/Wrapping/Generators/SwigInterface/swigmacos-arm64-2024-03-26-master/bin/swig \
  -c++ -python -fastdispatch -fvirtual -features autodoc=2 -doxygen -Werror -w302 -w303 -w312 -w314 -w361 -w362 -w350 -w383 -w384 -w389 -w394 -w395 -w467 -w508 -w509 \
  -o <ITK_BLD>/Wrapping/Modules/ITKCommon/itkVersorPython.cpp \
  -I<ITK_BLD>/Wrapping/Generators/SwigInterface/swigmacos-arm64-2024-03-26-master/share/swig/4.3.0/python -I<ITK_BLD>/Wrapping/Generators/SwigInterface/swigmacos-arm64-2024-03-26-master/share/swig/4.3.0 -I<ITK_SRC>/Wrapping/Generators -I<ITK_BLD>/Wrapping/Typedefs/python -I<ITK_BLD>/Wrapping/Typedefs \
  -outdir <ITK_BLD>/Wrapping/Generators/Python/itk <ITK_BLD>/Wrapping/Typedefs/itkVersor.i
```
The problem originates with the xml used to generate `<ITK_BLD>/Wrapping/Modules/ITKCommon/itkVersorPython.cpp`.