### PR TITLE
STYLE: Let DOMNode SetName, SetID, SetText pass `std::string` by value

### DIFF
--- a/Modules/IO/XML/include/itkDOMNode.h
+++ b/Modules/IO/XML/include/itkDOMNode.h
@@ -95,12 +95,12 @@ public:
   /** @ITKEndGrouping */
   /** Retrieve the tag name of this node. */
   /** @ITKStartGrouping */
-  itkSetMacro(Name, const std::string &);
+  itkSetMacro(Name, std::string);
   itkGetConstReferenceMacro(Name, std::string);
   /** @ITKEndGrouping */
   /** Retrieve the special attribute "id" of this node. */
   /** @ITKStartGrouping */
-  itkSetMacro(ID, const std::string &);
+  itkSetMacro(ID, std::string);
   itkGetConstReferenceMacro(ID, std::string);
   /** @ITKEndGrouping */
   /** Retrieve an attribute by key (return an empty string if not found). */

--- a/Modules/IO/XML/include/itkDOMTextNode.h
+++ b/Modules/IO/XML/include/itkDOMTextNode.h
@@ -56,7 +56,7 @@ public:
 
   /** Functions to set/get the enclosed text of this node. */
   /** @ITKStartGrouping */
-  itkSetMacro(Text, const std::string &);
+  itkSetMacro(Text, std::string);
   itkGetConstReferenceMacro(Text, std::string);
   /** @ITKEndGrouping */
 protected:


### PR DESCRIPTION
Pass those string arguments by value, instead of by const-reference, to allow those `Set` member functions to use fast move-semantics.

- Follow-up to pull request #4085