### PR TITLE
STYLE: Remove zero-index variables from region initialization in tests

### DIFF
--- a/Modules/Core/Common/test/itkImageComputeOffsetAndIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageComputeOffsetAndIndexTest.cxx
@@ -110,99 +110,95 @@ itkImageComputeOffsetAndIndexTest(int, char *[])
 
   itk::TimeProbesCollectorBase collector;
 
-#define TRY_FAST_INDEX(dim)                                                \
-  {                                                                        \
-    using PixelType = char;                                                \
-    using ImageType = itk::Image<PixelType, dim>;                          \
-    auto                           myImage = ImageType::New();             \
-    const auto                     size = ImageType::SizeType::Filled(50); \
-    constexpr ImageType::IndexType index{};                                \
-    const ImageType::RegionType    region{ index, size };                  \
-    myImage->SetRegions(region);                                           \
-    myImage->Allocate();                                                   \
-    collector.Start("ComputeIndexFast " #dim "D");                         \
-    unsigned int totalSize = 1;                                            \
-    for (unsigned int i = 0; i < dim; ++i)                                 \
-      totalSize *= size[i];                                                \
-    unsigned int repeat = 1000;                                            \
-    if (dim > 2)                                                           \
-      repeat = 100;                                                        \
-    if (dim > 3)                                                           \
-      repeat = 10;                                                         \
-    if (dim > 4)                                                           \
-      repeat = 1;                                                          \
-    ComputeFastIndex<ImageType>(myImage, totalSize, repeat);               \
-    collector.Stop("ComputeIndexFast " #dim "D");                          \
-  }                                                                        \
+#define TRY_FAST_INDEX(dim)                                             \
+  {                                                                     \
+    using PixelType = char;                                             \
+    using ImageType = itk::Image<PixelType, dim>;                       \
+    auto                        myImage = ImageType::New();             \
+    const auto                  size = ImageType::SizeType::Filled(50); \
+    const ImageType::RegionType region{ size };                         \
+    myImage->SetRegions(region);                                        \
+    myImage->Allocate();                                                \
+    collector.Start("ComputeIndexFast " #dim "D");                      \
+    unsigned int totalSize = 1;                                         \
+    for (unsigned int i = 0; i < dim; ++i)                              \
+      totalSize *= size[i];                                             \
+    unsigned int repeat = 1000;                                         \
+    if (dim > 2)                                                        \
+      repeat = 100;                                                     \
+    if (dim > 3)                                                        \
+      repeat = 10;                                                      \
+    if (dim > 4)                                                        \
+      repeat = 1;                                                       \
+    ComputeFastIndex<ImageType>(myImage, totalSize, repeat);            \
+    collector.Stop("ComputeIndexFast " #dim "D");                       \
+  }                                                                     \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define TRY_INDEX(dim)                                                     \
-  {                                                                        \
-    using PixelType = char;                                                \
-    using ImageType = itk::Image<PixelType, dim>;                          \
-    auto                           myImage = ImageType::New();             \
-    const auto                     size = ImageType::SizeType::Filled(50); \
-    constexpr ImageType::IndexType index{};                                \
-    const ImageType::RegionType    region{ index, size };                  \
-    myImage->SetRegions(region);                                           \
-    myImage->Allocate();                                                   \
-    collector.Start("ComputeIndex " #dim "D");                             \
-    unsigned int totalSize = 1;                                            \
-    for (unsigned int i = 0; i < dim; ++i)                                 \
-      totalSize *= size[i];                                                \
-    unsigned int repeat = 1000;                                            \
-    if (dim > 2)                                                           \
-      repeat = 100;                                                        \
-    if (dim > 3)                                                           \
-      repeat = 10;                                                         \
-    if (dim > 4)                                                           \
-      repeat = 1;                                                          \
-    ComputeIndex<ImageType>(myImage, totalSize, repeat);                   \
-    collector.Stop("ComputeIndex " #dim "D");                              \
-  }                                                                        \
+#define TRY_INDEX(dim)                                                  \
+  {                                                                     \
+    using PixelType = char;                                             \
+    using ImageType = itk::Image<PixelType, dim>;                       \
+    auto                        myImage = ImageType::New();             \
+    const auto                  size = ImageType::SizeType::Filled(50); \
+    const ImageType::RegionType region{ size };                         \
+    myImage->SetRegions(region);                                        \
+    myImage->Allocate();                                                \
+    collector.Start("ComputeIndex " #dim "D");                          \
+    unsigned int totalSize = 1;                                         \
+    for (unsigned int i = 0; i < dim; ++i)                              \
+      totalSize *= size[i];                                             \
+    unsigned int repeat = 1000;                                         \
+    if (dim > 2)                                                        \
+      repeat = 100;                                                     \
+    if (dim > 3)                                                        \
+      repeat = 10;                                                      \
+    if (dim > 4)                                                        \
+      repeat = 1;                                                       \
+    ComputeIndex<ImageType>(myImage, totalSize, repeat);                \
+    collector.Stop("ComputeIndex " #dim "D");                           \
+  }                                                                     \
   ITK_MACROEND_NOOP_STATEMENT
 
-#define TRY_FAST_OFFSET(dim)                                               \
-  {                                                                        \
-    using PixelType = char;                                                \
-    using ImageType = itk::Image<PixelType, dim>;                          \
-    auto                           myImage = ImageType::New();             \
-    const auto                     size = ImageType::SizeType::Filled(50); \
-    constexpr ImageType::IndexType index{};                                \
-    const ImageType::RegionType    region{ index, size };                  \
-    myImage->SetRegions(region);                                           \
-    myImage->Allocate();                                                   \
-    collector.Start("ComputeOffsetFast " #dim "D");                        \
-    unsigned int repeat = 1;                                               \
-    if (dim < 4)                                                           \
-      repeat = 100;                                                        \
-    unsigned int totalSize = 1;                                            \
-    for (unsigned int i = 0; i < dim; ++i)                                 \
-      totalSize *= size[i];                                                \
-    ComputeFastOffset<ImageType>(myImage, size[0], totalSize * repeat);    \
-    collector.Stop("ComputeOffsetFast " #dim "D");                         \
-  }                                                                        \
+#define TRY_FAST_OFFSET(dim)                                            \
+  {                                                                     \
+    using PixelType = char;                                             \
+    using ImageType = itk::Image<PixelType, dim>;                       \
+    auto                        myImage = ImageType::New();             \
+    const auto                  size = ImageType::SizeType::Filled(50); \
+    const ImageType::RegionType region{ size };                         \
+    myImage->SetRegions(region);                                        \
+    myImage->Allocate();                                                \
+    collector.Start("ComputeOffsetFast " #dim "D");                     \
+    unsigned int repeat = 1;                                            \
+    if (dim < 4)                                                        \
+      repeat = 100;                                                     \
+    unsigned int totalSize = 1;                                         \
+    for (unsigned int i = 0; i < dim; ++i)                              \
+      totalSize *= size[i];                                             \
+    ComputeFastOffset<ImageType>(myImage, size[0], totalSize * repeat); \
+    collector.Stop("ComputeOffsetFast " #dim "D");                      \
+  }                                                                     \
   ITK_MACROEND_NOOP_STATEMENT
-#define TRY_OFFSET(dim)                                                    \
-  {                                                                        \
-    using PixelType = char;                                                \
-    using ImageType = itk::Image<PixelType, dim>;                          \
-    auto                           myImage = ImageType::New();             \
-    const auto                     size = ImageType::SizeType::Filled(50); \
-    constexpr ImageType::IndexType index{};                                \
-    const ImageType::RegionType    region{ index, size };                  \
-    myImage->SetRegions(region);                                           \
-    myImage->Allocate();                                                   \
-    collector.Start("ComputeOffset " #dim "D");                            \
-    unsigned int repeat = 1;                                               \
-    if (dim < 4)                                                           \
-      repeat = 100;                                                        \
-    unsigned int totalSize = 1;                                            \
-    for (unsigned int i = 0; i < dim; ++i)                                 \
-      totalSize *= size[i];                                                \
-    ComputeOffset<ImageType>(myImage, size[0], totalSize * repeat);        \
-    collector.Stop("ComputeOffset " #dim "D");                             \
-  }                                                                        \
+#define TRY_OFFSET(dim)                                                 \
+  {                                                                     \
+    using PixelType = char;                                             \
+    using ImageType = itk::Image<PixelType, dim>;                       \
+    auto                        myImage = ImageType::New();             \
+    const auto                  size = ImageType::SizeType::Filled(50); \
+    const ImageType::RegionType region{ size };                         \
+    myImage->SetRegions(region);                                        \
+    myImage->Allocate();                                                \
+    collector.Start("ComputeOffset " #dim "D");                         \
+    unsigned int repeat = 1;                                            \
+    if (dim < 4)                                                        \
+      repeat = 100;                                                     \
+    unsigned int totalSize = 1;                                         \
+    for (unsigned int i = 0; i < dim; ++i)                              \
+      totalSize *= size[i];                                             \
+    ComputeOffset<ImageType>(myImage, size[0], totalSize * repeat);     \
+    collector.Stop("ComputeOffset " #dim "D");                          \
+  }                                                                     \
   ITK_MACROEND_NOOP_STATEMENT
 
   TRY_INDEX(1);

--- a/Modules/Core/Common/test/itkImageTest.cxx
+++ b/Modules/Core/Common/test/itkImageTest.cxx
@@ -157,12 +157,11 @@ itkImageTest(int, char *[])
   volume->SetDirection(directionVol);
 
 
-  constexpr Image3D::IndexType indexCuboid{};
-  Image3D::SizeType            sizeCuboid;
+  Image3D::SizeType sizeCuboid;
   sizeCuboid[0] = 1;
   sizeCuboid[1] = 2;
   sizeCuboid[2] = 3;
-  const Image3D::RegionType cuboid{ indexCuboid, sizeCuboid };
+  const Image3D::RegionType cuboid{ sizeCuboid };
   volume->SetRegions(cuboid);
 
   using ProjectionTransformType = TestTransform<Image3D::ImageDimension>;

--- a/Modules/Core/Common/test/itkImportImageTest.cxx
+++ b/Modules/Core/Common/test/itkImportImageTest.cxx
@@ -43,10 +43,9 @@ itkImportImageTest(int, char *[])
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(basicImport, ImportImageFilter, ImageSource);
 
-  ShortImage::Pointer                              image;
-  constexpr itk::ImageRegion<Dimension>::IndexType index = { { 0, 0 } };
-  constexpr itk::ImageRegion<Dimension>::SizeType  size = { { 8, 12 } };
-  itk::ImageRegion<Dimension>                      region = { index, size };
+  ShortImage::Pointer                             image;
+  constexpr itk::ImageRegion<Dimension>::SizeType size = { { 8, 12 } };
+  itk::ImageRegion<Dimension>                     region = { size };
   // local scope to make sure that imported data is not deleted with ImportImageFilter
   // but with the ImportImageContainer is creates.
   {

--- a/Modules/Core/Common/test/itkIteratorTests.cxx
+++ b/Modules/Core/Common/test/itkIteratorTests.cxx
@@ -38,14 +38,12 @@ itkIteratorTests(int, char *[])
   constexpr ScalarImage::SizeType bufferSize3D{ 200, 200, 200 };
   constexpr ScalarImage::SizeType regionSize3D{ 190, 190, 190 };
 
-  constexpr ScalarImage::IndexType startIndex3D{ 0, 0, 0 };
-  constexpr ScalarImage::IndexType bufferStartIndex3D{ 0, 0, 0 };
   constexpr ScalarImage::IndexType regionStartIndex3D{ 5, 5, 5 };
 
 
-  ScalarImage::RegionType region{ startIndex3D, imageSize3D };
+  ScalarImage::RegionType region{ imageSize3D };
   o3->SetLargestPossibleRegion(region);
-  region = { bufferStartIndex3D, bufferSize3D };
+  region = { bufferSize3D };
   o3->SetBufferedRegion(region);
   region = { regionStartIndex3D, regionSize3D };
   o3->SetRequestedRegion(region);

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
@@ -50,15 +50,13 @@ itkImageMaskSpatialObjectTest3(int, char *[])
   auto spacing = itk::MakeFilled<ImageType::SpacingType>(1);
   image->SetSpacing(spacing);
 
-  constexpr ImageType::IndexType index{};
-
   ImageType::DirectionType direction{};
   direction[0][1] = 1;
   direction[1][0] = 1;
   direction[2][2] = 1;
   image->SetDirection(direction);
 
-  ImageType::RegionType region{ index, size };
+  ImageType::RegionType region{ size };
   image->SetRegions(region);
   image->AllocateInitialized();
 

--- a/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
@@ -44,12 +44,11 @@ itkImageSpatialObjectTest(int, char *[])
   using Iterator = itk::ImageRegionIterator<ImageType>;
   using PointType = itk::Point<ScalarType, VDimension>;
 
-  auto                           image = ImageType::New();
-  constexpr ImageType::SizeType  size{ 10, 10, 10 };
-  constexpr ImageType::IndexType index{ 0, 0, 0 };
-  auto                           origin = itk::MakeFilled<ImageType::PointType>(5);
+  auto                          image = ImageType::New();
+  constexpr ImageType::SizeType size{ 10, 10, 10 };
+  auto                          origin = itk::MakeFilled<ImageType::PointType>(5);
 
-  ImageType::RegionType region = { index, size };
+  ImageType::RegionType region{ size };
   image->SetOrigin(origin);
   image->SetRegions(region);
   image->Allocate();

--- a/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DReconstructionImageFilterTest.cxx
@@ -65,9 +65,8 @@ itkDiffusionTensor3DReconstructionImageFilterTest(int argc, char * argv[])
     using ReferenceRegionType = ReferenceImageType::RegionType;
     using ReferenceIndexType = ReferenceRegionType::IndexType;
     using ReferenceSizeType = ReferenceRegionType::SizeType;
-    constexpr ReferenceSizeType  sizeReferenceImage{ 4, 4, 4 };
-    constexpr ReferenceIndexType indexReferenceImage{ 0, 0, 0 };
-    const ReferenceRegionType    regionReferenceImage{ indexReferenceImage, sizeReferenceImage };
+    constexpr ReferenceSizeType sizeReferenceImage{ 4, 4, 4 };
+    const ReferenceRegionType   regionReferenceImage{ sizeReferenceImage };
     referenceImage->SetRegions(regionReferenceImage);
     referenceImage->Allocate();
     referenceImage->FillBuffer(100);

--- a/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest1.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest1.cxx
@@ -72,9 +72,8 @@ itkTransformToDisplacementFieldFilterTest1(int argc, char * argv[])
 
 
   // Create input image.
-  auto                size = SizeType::Filled(24);
-  constexpr IndexType index{};
-  SpacingType         spacing;
+  auto        size = SizeType::Filled(24);
+  SpacingType spacing;
   spacing[0] = 1.1;
   spacing[1] = 2.2;
   spacing[2] = 3.3;
@@ -95,7 +94,7 @@ itkTransformToDisplacementFieldFilterTest1(int argc, char * argv[])
   inputDirection[2][1] = -1;
   inputDirection[2][2] = 0;
 
-  const RegionType region{ index, size };
+  const RegionType region{ size };
   auto             image = ImageType::New();
   image->SetRegions(region);
   image->AllocateInitialized();
@@ -131,10 +130,9 @@ itkTransformToDisplacementFieldFilterTest1(int argc, char * argv[])
   }
 
   // Set Output information.
-  constexpr IndexType outputIndex{};
-  SpacingType         outputSpacing;
-  auto                outputSize = SizeType::Filled(24);
-  const RegionType    outputRegion{ outputIndex, outputSize };
+  SpacingType      outputSpacing;
+  auto             outputSize = SizeType::Filled(24);
+  const RegionType outputRegion{ outputSize };
   outputSpacing[0] = 1.0;
   outputSpacing[1] = 2.0;
   outputSpacing[2] = 3.0;

--- a/Modules/Filtering/ImageGrid/test/itkCropImageFilter3DTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkCropImageFilter3DTest.cxx
@@ -36,11 +36,10 @@ itkCropImageFilter3DTest(int, char *[])
   // Declare the types of the images
   using ImageType = itk::Image<PixelType, ImageDimension>;
 
-  ImageType::RegionType                      region;
-  constexpr unsigned int                     dimSize(8);
-  constexpr ImageType::RegionType::SizeType  size{ dimSize, dimSize, dimSize };
-  constexpr ImageType::RegionType::IndexType index{ 0, 0, 0 };
-  region = { index, size };
+  ImageType::RegionType                     region;
+  constexpr unsigned int                    dimSize(8);
+  constexpr ImageType::RegionType::SizeType size{ dimSize, dimSize, dimSize };
+  region = { size };
 
   auto image = ImageType::New();
 

--- a/Modules/Filtering/ImageSources/test/itkGaussianImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGaussianImageSourceTest.cxx
@@ -78,11 +78,10 @@ itkGaussianImageSourceTest(int argc, char * argv[])
   ITK_TEST_SET_GET_VALUE(direction, gaussianImage->GetDirection());
 
   // Test SetReferenceImage from GenerateImageSource base class.
-  auto                           referenceImage = ImageType::New();
-  constexpr ImageType::IndexType startIndex{};
-  ImageType::SizeType            referenceSize;
+  auto                referenceImage = ImageType::New();
+  ImageType::SizeType referenceSize;
   referenceSize.SetSize(size);
-  const ImageType::RegionType region(startIndex, referenceSize);
+  const ImageType::RegionType region{ referenceSize };
   referenceImage->SetRegions(region);
   referenceImage->AllocateInitialized();
 

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftPointSetTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftPointSetTest.cxx
@@ -289,8 +289,6 @@ itkRegistrationParameterScalesFromPhysicalShiftPointSetTest(int, char *[])
   using RegionType = itk::ImageRegion<Dimension>;
   RegionType region;
   region.SetSize(virtualDomainSize);
-  constexpr RegionType::IndexType index{};
-  region.SetIndex(index);
 
   auto field = FieldType::New();
   field->SetRegions(region);

--- a/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthMatrixFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthMatrixFilterTest.cxx
@@ -50,10 +50,6 @@ itkScalarImageToRunLengthMatrixFilterTest(int, char *[])
   InputImageType::RegionType region;
 
   region.SetSize(inputImageSize);
-  {
-    constexpr InputImageType::IndexType index{};
-    region.SetIndex(index);
-  }
 
   //--------------------------------------------------------------------------
   // Set up the image first. It looks like:

--- a/Modules/Segmentation/ConnectedComponents/test/itkHardConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkHardConnectedComponentImageFilterTest.cxx
@@ -40,12 +40,11 @@ DoIt(int argc, char * argv[], const std::string & pixelType)
   using IndexType = typename InputImageType::IndexType;
 
   auto                               inputimg = InputImageType::New();
-  constexpr IndexType                index{};
   constexpr int                      height{ 20 };
   constexpr int                      width{ 20 };
   constexpr InputImageType::SizeType size{ width, height };
 
-  typename InputImageType::RegionType region{ index, size };
+  typename InputImageType::RegionType region{ size };
 
   inputimg->SetRegions(region);
   inputimg->Allocate();

--- a/Modules/Segmentation/Watersheds/test/itkMorphologicalWatershedFromMarkersImageFilterTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkMorphologicalWatershedFromMarkersImageFilterTest.cxx
@@ -81,9 +81,7 @@ itkMorphologicalWatershedFromMarkersImageFilterTest(int argc, char * argv[])
     size[i] = size[i] * 2;
   }
 
-  constexpr ImageType::RegionType::IndexType index{};
-
-  region = { index, size };
+  region = { size };
 
   const FilterType::LabelImageType::Pointer largerMarkerImage = FilterType::LabelImageType::New();
   largerMarkerImage->SetBufferedRegion(region);


### PR DESCRIPTION
- Another follow-up to pull request #5627

Found by `constexpr .*Index.*x.*\{[0, ]*}`. Adjusted the code manually.

----

Believe it or not, this might be the last zero-index removal PR for a while  😇 