### PR TITLE
BUG: `EXPECT_EQ` in `while` loop in BSplineTransformGTest unreachable

### DIFF
--- a/Modules/Core/Transform/test/itkBSplineTransformGTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformGTest.cxx
@@ -71,9 +71,9 @@ bspline_eq(const itk::BSplineTransform<TParametersValueType, VDimension, VSpline
     ImageConstIterator iter1(coeffImage1, coeffImage1->GetBufferedRegion());
     ImageConstIterator iter2(coeffImage2, coeffImage2->GetBufferedRegion());
 
-
-    while (!iter1.IsAtEnd() && iter2.IsAtEnd())
+    while (!iter1.IsAtEnd())
     {
+      ASSERT_FALSE(iter2.IsAtEnd());
       EXPECT_EQ(iter1.Get(), iter2.Get()) << description << " Expected value at: " << iter1.GetIndex();
       ++iter1;
       ++iter2;


### PR DESCRIPTION
The condition `!iter1.IsAtEnd() && iter2.IsAtEnd()` is usually false, because both iterators are expected to iterate over the same (buffered) region.

It should be sufficient to just check if the first iterator is not at the end. And then, it should be safe to _assert_ that the second iterator is not at the end either.