### PR TITLE
BUG: Removed underscores from GTest test names (follow-up)

### DIFF
--- a/Modules/Core/Transform/test/itkBSplineTransformGTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformGTest.cxx
@@ -97,7 +97,7 @@ TEST(ITKBSplineTransform, Construction)
   bspline_eq(bspline2.GetPointer(), bspline1.GetPointer());
 }
 
-TEST(ITKBSplineTransform, Copying_Clone)
+TEST(ITKBSplineTransform, CopyingClone)
 {
   // This test sets up an non-trivial bspline transform then,
   // test various interface to set the parameters to the a new

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageFilterGTest.cxx
@@ -168,7 +168,7 @@ TEST(ResampleImageFilter, FilterPreservesMinAndMaxInt64PixelValuesByDefault)
 }
 
 
-TEST(ResampleImageFilter, Expect_ResampleImageFilter_thows_on_incomplete_configuration)
+TEST(ResampleImageFilter, ThrowsOnIncompleteConfiguration)
 {
   Expect_ResampleImageFilter_thows_on_incomplete_configuration(128.0);
 }

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterGTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterGTest.cxx
@@ -53,7 +53,7 @@ CreateTestImageA()
 } // namespace
 
 
-TEST(ConnectedComponentImageFilter, checkerboard_3D)
+TEST(ConnectedComponentImageFilter, Checkerboard3D)
 {
   auto image = CreateTestImageA();
   using ImageType = decltype(image)::ObjectType;

--- a/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterGTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterGTest.cxx
@@ -57,7 +57,7 @@ CreateTestImageA()
 }
 } // namespace
 
-TEST(RelabelComponentImageFilter, nosort_nosize)
+TEST(RelabelComponentImageFilter, NoSortNoSize)
 {
   auto image = CreateTestImageA();
   using ImageType = decltype(image)::ObjectType;
@@ -75,7 +75,7 @@ TEST(RelabelComponentImageFilter, nosort_nosize)
 }
 
 
-TEST(RelabelComponentImageFilter, nosort_size)
+TEST(RelabelComponentImageFilter, NoSortSize)
 {
   auto image = CreateTestImageA();
   using ImageType = decltype(image)::ObjectType;
@@ -92,7 +92,7 @@ TEST(RelabelComponentImageFilter, nosort_size)
   EXPECT_EQ(filter->GetOutput()->GetPixel({ { 2, 2 } }), 2u);
 }
 
-TEST(RelabelComponentImageFilter, sort_size)
+TEST(RelabelComponentImageFilter, SortSize)
 {
   auto image = CreateTestImageA();
   using ImageType = decltype(image)::ObjectType;
@@ -110,7 +110,7 @@ TEST(RelabelComponentImageFilter, sort_size)
 }
 
 
-TEST(RelabelComponentImageFilter, sort_nosize)
+TEST(RelabelComponentImageFilter, SortNoSize)
 {
   auto image = CreateTestImageA();
   using ImageType = decltype(image)::ObjectType;
@@ -128,7 +128,7 @@ TEST(RelabelComponentImageFilter, sort_nosize)
 }
 
 
-TEST(RelabelComponentImageFilter, big_zero)
+TEST(RelabelComponentImageFilter, BigZero)
 {
 
   using namespace itk::GTest::TypedefsAndConstructors::Dimension3;
@@ -151,7 +151,7 @@ TEST(RelabelComponentImageFilter, big_zero)
 }
 
 
-TEST(RelabelComponentImageFilter, big_random)
+TEST(RelabelComponentImageFilter, BigRandom)
 {
 
   using namespace itk::GTest::TypedefsAndConstructors::Dimension3;


### PR DESCRIPTION
Removed underscores from GTest test names and converted these names to Pascal case.

Shortened the unit test name
"ResampleImageFilter.Expect_ResampleImageFilter_thows_on_incomplete_configuration" to "ResampleImageFilter.ThrowsOnIncompleteConfiguration".

Follow-up to commit b275c76427d727a8bd03c4b018825dfe0116e4fb, Oct 8, 2018.

----

For the record, GoogleTest still doesn't like underscores in test names, more than seven years after commit b275c76427d727a8bd03c4b018825dfe0116e4fb ! Looking at https://github.com/google/googletest/blob/1b96fa13f549387b7549cc89e1a785cf143a1a50/docs/faq.md