### PR TITLE
STYLE: Fix CMake style of Python wrapping tests

### DIFF
--- a/Wrapping/Generators/Python/Tests/CMakeLists.txt
+++ b/Wrapping/Generators/Python/Tests/CMakeLists.txt
@@ -207,10 +207,9 @@ if(ITK_WRAP_unsigned_char AND WRAP_2)
         DATA{${WrapITK_SOURCE_DIR}/images/cthead1.png}
     )
     itk_python_add_test(
-      NAME
-      PythonImreadSingleFileListTest
+      NAME PythonImreadSingleFileListTest
       COMMAND
-      ${CMAKE_CURRENT_SOURCE_DIR}/test_imread_single_file_list.py
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_imread_single_file_list.py
     )
   endif()
 endif()


### PR DESCRIPTION
PR #5630 was done in release branch,
which has a slightly different CMake code style.

