### PR TITLE
PERF: Let ImageRegionRange bypass OffsetTable[0] (which is always 1)

### DIFF
--- a/Modules/Core/Common/include/itkImageRegionRange.h
+++ b/Modules/Core/Common/include/itkImageRegionRange.h
@@ -148,7 +148,14 @@ private:
     void
     Increment() noexcept
     {
-      m_BufferIterator += m_OffsetTable[VIndex];
+      if constexpr (VIndex == 0)
+      {
+        ++m_BufferIterator;
+      }
+      else
+      {
+        m_BufferIterator += m_OffsetTable[VIndex];
+      }
 
       if constexpr (VIndex < (ImageDimension - 1))
       {
@@ -172,7 +179,14 @@ private:
     void
     Decrement() noexcept
     {
-      m_BufferIterator -= m_OffsetTable[VIndex];
+      if constexpr (VIndex == 0)
+      {
+        --m_BufferIterator;
+      }
+      else
+      {
+        m_BufferIterator -= m_OffsetTable[VIndex];
+      }
 
       if constexpr (VIndex < (ImageDimension - 1))
       {


### PR DESCRIPTION
It appears unnecessary to access `m_OffsetTable[VIndex]` when `VIndex` is zero.

A performance improvement of around 1% was observed, doing a range-based `for` loop on a region of 1'000'000 x 10'000 pixels.