### PR TITLE
BUG: Fix CastImageFilter for VariableLengthVector

### DIFF
--- a/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.hxx
@@ -145,12 +145,12 @@ CastImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDataDispatche
   ImageScanlineConstIterator inputIt(inputPtr, inputRegionForThread);
   ImageScanlineIterator      outputIt(outputPtr, outputRegionForThread);
 
-  OutputPixelType value{ outputIt.Get() };
   while (!inputIt.IsAtEnd())
   {
     while (!inputIt.IsAtEndOfLine())
     {
       const InputPixelType & inputPixel = inputIt.Get();
+      OutputPixelType        value{ outputIt.Get() };
       for (unsigned int k = 0; k < componentsPerPixel; ++k)
       {
         value[k] = static_cast<typename OutputPixelType::ValueType>(inputPixel[k]);

--- a/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
@@ -400,6 +400,50 @@ TestVectorImageCast2()
 }
 
 
+bool
+TestVectorImageCast3()
+{
+  // This function casts an Image<Vector<float, 3>, 3>
+  // to a VectorImage<float, 3>
+  std::cout << "Casting from an Image<Vector<float,3>, 3> to VectorImage<float, 3> ... ";
+
+  using VectorFloatImageType = itk::Image<itk::Vector<float, 3>, 3>;
+  using FloatVectorImageType = itk::VectorImage<float, 3>;
+
+  // Create a 1x3 image of 2D vectors
+  auto image = VectorFloatImageType::New();
+
+  constexpr itk::Size<3>    size{ { 1, 1, 4 } };
+  const itk::ImageRegion<3> region{ size };
+  image->SetRegions(region);
+  image->AllocateInitialized();
+  VectorFloatImageType::PixelType vec{ { 1.3, 5.3, 6.4 } };
+  // Only the first pixel will be the vector (1.3, 5.3, 6.4)
+  image->SetPixel(itk::Index<3>(), vec);
+
+  using CastImageFilterType = itk::CastImageFilter<VectorFloatImageType, FloatVectorImageType>;
+  auto castImageFilter = CastImageFilterType::New();
+  castImageFilter->SetInput(image);
+  castImageFilter->SetNumberOfWorkUnits(1);
+  castImageFilter->Update();
+
+  bool success = true;
+  if (std::memcmp(castImageFilter->GetOutput()->GetBufferPointer(),
+                  image->GetBufferPointer(),
+                  sizeof(float) * size.CalculateProductOfElements()) == 0)
+  {
+    std::cout << "[PASSED]" << std::endl;
+  }
+  else
+  {
+    std::cout << "[FAILED]" << std::endl;
+    success = false;
+  }
+
+  return success;
+}
+
+
 int
 itkCastImageFilterTest(int, char *[])
 {
@@ -431,6 +475,7 @@ itkCastImageFilterTest(int, char *[])
   success &= TestCastFrom<double>();
   success &= TestVectorImageCast1();
   success &= TestVectorImageCast2();
+  success &= TestVectorImageCast3();
 
   std::cout << std::endl;
   if (!success)


### PR DESCRIPTION
The `Get` function of `VectorImage` iterators calls the `VariableLengthVector` constructor parameterized by a const pointer and a vector length (see `DefaultVectorPixelAccessor::Get`). The `m_Data` pointer of the constructed VariableLengthVector which was returned was then pointing to the returned pixel data. This led to an unexpected behavior in `CastImageFilter::DynamicThreadedGenerateDataDispatched` where modifications to the local variable
```
OutputPixelType value{ outputIt.Get() };
```
of `CastImageFilter::DynamicThreadedGenerateDataDispatched` were actually modifying the pixel of the image at the iterator position. The problem might occur elsewhere so it is safer to copy the data when a VariableLengthVector is constructed from a const pointer despite the potential loss in performances.

A `CastImageFilter` test has been added to illustrate the issue: when a `VectorImage` was casted to an `Image< Vector <`, the first pixel of the region was taking the value of the last pixel of the region. The test illustrated this by creating an image filled with 0 except the first pixel. The casted image was completely full of 0 before bug correction.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
