### PR TITLE
STYLE: Do `auto size = SizeType::Filled(x)` in tests

### DIFF
--- a/Modules/Core/Common/test/itkImageIteratorsForwardBackwardTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorsForwardBackwardTest.cxx
@@ -29,11 +29,7 @@ itkImageIteratorsForwardBackwardTest(int, char *[])
 
   auto myImage = ImageType::New();
 
-  ImageType::SizeType size;
-
-  size[0] = 4;
-  size[1] = 4;
-  size[2] = 4;
+  auto size = ImageType::SizeType::Filled(4);
 
   const ImageType::RegionType region{ size };
 

--- a/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
+++ b/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
@@ -45,10 +45,7 @@ itkImageRandomIteratorTest2(int argc, char * argv[])
 
   auto image = ImageType::New();
 
-  ImageType::SizeType size;
-
-  size[0] = 1000;
-  size[1] = 1000;
+  auto size = ImageType::SizeType::Filled(1000);
 
   const unsigned long numberOfSamples = size[0] * size[1];
 

--- a/Modules/Core/Common/test/itkImageSliceIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageSliceIteratorTest.cxx
@@ -34,11 +34,7 @@ itkImageSliceIteratorTest(int, char *[])
 
   auto myImage = ImageType::New();
 
-  ImageType::SizeType size;
-
-  size[0] = 100;
-  size[1] = 100;
-  size[2] = 100;
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::IndexType start{};
 

--- a/Modules/Core/ImageAdaptors/test/itkImageAdaptorTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkImageAdaptorTest.cxx
@@ -57,9 +57,7 @@ itkImageAdaptorTest(int, char *[])
 {
 
 
-  myImageType::SizeType size;
-  size[0] = 2;
-  size[1] = 2;
+  auto size = myImageType::SizeType::Filled(2);
 
   myImageType::IndexType index;
   index[0] = 0;

--- a/Modules/Core/ImageAdaptors/test/itkNthElementPixelAccessorTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkNthElementPixelAccessorTest.cxx
@@ -55,9 +55,7 @@ itkNthElementPixelAccessorTest(int, char *[])
   using myIteratorType = itk::ImageRegionIteratorWithIndex<myImageType>;
   using myNthIteratorType = itk::ImageRegionIteratorWithIndex<myNthAdaptorType>;
 
-  myImageType::SizeType size;
-  size[0] = 2;
-  size[1] = 2;
+  auto size = myImageType::SizeType::Filled(2);
 
   myImageType::IndexType index;
   index[0] = 0;

--- a/Modules/Core/ImageAdaptors/test/itkRGBToVectorImageAdaptorTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkRGBToVectorImageAdaptorTest.cxx
@@ -56,9 +56,7 @@ itkRGBToVectorImageAdaptorTest(int, char *[])
 
   using RedIteratorType = itk::ImageRegionIteratorWithIndex<ImageAdaptorType>;
 
-  ImageType::SizeType size;
-  size[0] = 2;
-  size[1] = 2;
+  auto size = ImageType::SizeType::Filled(2);
 
   ImageType::IndexType index;
   index[0] = 0;

--- a/Modules/Core/Mesh/test/itkImageToParametricSpaceFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkImageToParametricSpaceFilterTest.cxx
@@ -63,9 +63,7 @@ itkImageToParametricSpaceFilterTest(int, char *[])
   const ImagePointer imageY = ImageType::New();
   const ImagePointer imageZ = ImageType::New();
 
-  ImageType::SizeType size;
-  size[0] = 10;
-  size[1] = 10;
+  auto size = ImageType::SizeType::Filled(10);
 
   const ImageType::RegionType region{ size };
 

--- a/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest.cxx
@@ -72,11 +72,7 @@ itkTriangleMeshToBinaryImageFilterTest(int argc, char * argv[])
 
 
   imageFilter->SetInput(mySphereMeshSource->GetOutput());
-  ImageType::SizeType size;
-
-  size[0] = 100;
-  size[1] = 100;
-  size[2] = 100;
+  auto size = ImageType::SizeType::Filled(100);
   imageFilter->SetSize(size);
 
   constexpr double dspacing[3]{ 2.0, 2.0, 2.0 };

--- a/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest2.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest2.cxx
@@ -87,11 +87,7 @@ itkTriangleMeshToBinaryImageFilterTest2(int argc, char * argv[])
 
   imageFilter->SetInput(triangleMesh);
 
-  ImageType::SizeType size;
-
-  size[0] = 100;
-  size[1] = 100;
-  size[2] = 100;
+  auto size = ImageType::SizeType::Filled(100);
   imageFilter->SetSize(size);
 
   auto index = ImageType::IndexType::Filled(-50);

--- a/Modules/Core/Mesh/test/itkWarpMeshFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkWarpMeshFilterTest.cxx
@@ -64,10 +64,7 @@ itkWarpMeshFilterTest(int, char *[])
   start[1] = 0;
   start[2] = 0;
 
-  DisplacementFieldType::SizeType size;
-  size[0] = 25;
-  size[1] = 25;
-  size[2] = 25;
+  auto size = DisplacementFieldType::SizeType::Filled(25);
 
   const DisplacementFieldType::RegionType region{ start, size };
 

--- a/Modules/Core/SpatialObjects/test/itkBoxSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkBoxSpatialObjectTest.cxx
@@ -140,9 +140,7 @@ itkBoxSpatialObjectTest(int argc, char * argv[])
   auto imageFilter = SpatialObjectToImageFilterType::New();
   imageFilter->SetInput(scene);
 
-  OutputImageType::SizeType size;
-  size[0] = 100;
-  size[1] = 100;
+  auto size = OutputImageType::SizeType::Filled(100);
   imageFilter->SetSize(size);
 
   SpatialObjectToImageFilterType::PointType origin;

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageFilterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageFilterTest.cxx
@@ -74,9 +74,7 @@ itkSpatialObjectToImageFilterTest(int, char *[])
   imageFilter->SetIndex(indx);
   ITK_TEST_SET_GET_VALUE(indx, imageFilter->GetIndex());
 
-  ImageType::SizeType size;
-  size[0] = 50;
-  size[1] = 50;
+  auto size = ImageType::SizeType::Filled(50);
   imageFilter->SetSize(size);
   ITK_TEST_SET_GET_VALUE(size, imageFilter->GetSize());
 

--- a/Modules/Core/TestKernel/test/itkTestingExtractSliceImageFilterTest.cxx
+++ b/Modules/Core/TestKernel/test/itkTestingExtractSliceImageFilterTest.cxx
@@ -39,10 +39,7 @@ itkTestingExtractSliceImageFilterTest(int, char *[])
 
   auto inputImage = InputImageType::New();
 
-  InputImageType::SizeType size;
-  size[0] = 20;
-  size[1] = 20;
-  size[2] = 20;
+  auto size = InputImageType::SizeType::Filled(20);
 
   InputImageType::RegionType region;
   region.SetSize(size);

--- a/Modules/Filtering/DisplacementField/test/itkIterativeInverseDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkIterativeInverseDisplacementFieldImageFilterTest.cxx
@@ -62,9 +62,7 @@ itkIterativeInverseDisplacementFieldImageFilterTest(int argc, char * argv[])
   // Creating an input displacement field
   auto field = DisplacementFieldType::New();
 
-  DisplacementFieldType::SizeType size;
-  size[0] = 128;
-  size[1] = 128;
+  auto size = DisplacementFieldType::SizeType::Filled(128);
 
   DisplacementFieldType::IndexType start;
   start[0] = 0;

--- a/Modules/Filtering/DisplacementField/test/itkLandmarkDisplacementFieldSourceTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkLandmarkDisplacementFieldSourceTest.cxx
@@ -54,9 +54,7 @@ itkLandmarkDisplacementFieldSourceTest(int argc, char * argv[])
   const itk::SimpleFilterWatcher watcher(filter);
 
 
-  DisplacementFieldType::SizeType size;
-  size[0] = 128;
-  size[1] = 128;
+  auto                             size = DisplacementFieldType::SizeType::Filled(128);
   DisplacementFieldType::IndexType start;
   start[0] = 0;
   start[1] = 0;

--- a/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest.cxx
@@ -65,9 +65,7 @@ itkAdaptImageFilterTest(int, char *[])
 {
 
 
-  myRGBImageType::SizeType size;
-  size[0] = 2;
-  size[1] = 2;
+  auto size = myRGBImageType::SizeType::Filled(2);
 
   myRGBImageType::IndexType index;
   index[0] = 0;

--- a/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest2.cxx
@@ -60,9 +60,7 @@ itkAdaptImageFilterTest2(int, char *[])
 {
 
 
-  myVectorImageType::SizeType size;
-  size[0] = 2;
-  size[1] = 2;
+  auto size = myVectorImageType::SizeType::Filled(2);
 
   myVectorImageType::IndexType index;
   index[0] = 0;

--- a/Modules/Filtering/ImageIntensity/test/itkNthElementPixelAccessorTest2.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNthElementPixelAccessorTest2.cxx
@@ -60,9 +60,7 @@ itkNthElementPixelAccessorTest2(int, char *[])
   using AdaptorType = itk::AdaptImageFilter<VectorImageType, ScalarImageType, AccessorType>;
 
   // Test on variable length vector image
-  VectorImageType::SizeType size;
-  size[0] = 1;
-  size[1] = 1;
+  auto size = VectorImageType::SizeType::Filled(1);
 
   VectorImageType::IndexType index;
   index[0] = 0;

--- a/Modules/Filtering/ImageIntensity/test/itkPolylineMaskImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkPolylineMaskImageFilterTest.cxx
@@ -71,9 +71,7 @@ itkPolylineMaskImageFilterTest(int argc, char * argv[])
   origin[1] = 0.0;
   origin[2] = 20.0;
 
-  inputImageType::SizeType size;
-  size[0] = 40;
-  size[1] = 40;
+  auto size = inputImageType::SizeType::Filled(40);
   size[2] = 35;
 
   imageGenerationFilter->SetOrigin(origin);

--- a/Modules/Filtering/ImageIntensity/test/itkRGBToVectorAdaptImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkRGBToVectorAdaptImageFilterTest.cxx
@@ -63,9 +63,7 @@ itkRGBToVectorAdaptImageFilterTest(int, char *[])
 
   using myVectorIteratorType = itk::ImageRegionIteratorWithIndex<myImageType>;
 
-  RGBImageType::SizeType size;
-  size[0] = 100;
-  size[1] = 100;
+  auto size = RGBImageType::SizeType::Filled(100);
 
   RGBImageType::IndexType index;
   index[0] = 0;

--- a/Modules/Filtering/ImageIntensity/test/itkVectorToRGBImageAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkVectorToRGBImageAdaptorTest.cxx
@@ -56,9 +56,7 @@ itkVectorToRGBImageAdaptorTest(int, char *[])
   using IteratorType = itk::ImageRegionIteratorWithIndex<ImageType>;
   using RGBIteratorType = itk::ImageRegionIteratorWithIndex<ImageAdaptorType>;
 
-  ImageType::SizeType size;
-  size[0] = 2;
-  size[1] = 2;
+  auto size = ImageType::SizeType::Filled(2);
 
   ImageType::IndexType index;
   index[0] = 0;

--- a/Modules/Filtering/Path/test/itkExtractOrthogonalSwath2DImageFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkExtractOrthogonalSwath2DImageFilterTest.cxx
@@ -58,9 +58,7 @@ itkExtractOrthogonalSwath2DImageFilterTest(int argc, char * argv[])
   IndexType start;
   start[0] = 0;
   start[1] = 0;
-  ImageType::SizeType size;
-  size[0] = 128;
-  size[1] = 128;
+  auto                        size = ImageType::SizeType::Filled(128);
   const ImageType::RegionType region{ start, size };
   inputImage->SetRegions(region);
   double spacing[ImageType::ImageDimension];

--- a/Modules/Filtering/Path/test/itkOrthogonalSwath2DPathFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkOrthogonalSwath2DPathFilterTest.cxx
@@ -102,9 +102,7 @@ itkOrthogonalSwath2DPathFilterTest(int, char *[])
   IndexType start;
   start[0] = 0;
   start[1] = 0;
-  UCharImageType::SizeType size;
-  size[0] = 128;
-  size[1] = 128;
+  auto                             size = UCharImageType::SizeType::Filled(128);
   const UCharImageType::RegionType region{ start, size };
   inputImage->SetRegions(region);
   double spacing[UCharImageType::ImageDimension];

--- a/Modules/Filtering/Path/test/itkPathFunctionsTest.cxx
+++ b/Modules/Filtering/Path/test/itkPathFunctionsTest.cxx
@@ -49,9 +49,7 @@ itkPathFunctionsTest(int, char *[])
   IndexType start;
   start[0] = 0;
   start[1] = 0;
-  ImageType::SizeType size;
-  size[0] = 128;
-  size[1] = 128;
+  auto                        size = ImageType::SizeType::Filled(128);
   const ImageType::RegionType region{ start, size };
   image->SetRegions(region);
   double spacing[ImageType::ImageDimension];

--- a/Modules/Filtering/Path/test/itkPathIteratorTest.cxx
+++ b/Modules/Filtering/Path/test/itkPathIteratorTest.cxx
@@ -45,9 +45,7 @@ itkPathIteratorTest(int, char *[])
   IndexType start;
   start[0] = 0;
   start[1] = 0;
-  ImageType::SizeType size;
-  size[0] = 128;
-  size[1] = 128;
+  auto                        size = ImageType::SizeType::Filled(128);
   const ImageType::RegionType region{ start, size };
   image->SetRegions(region);
   double spacing[ImageType::ImageDimension];

--- a/Modules/Filtering/Path/test/itkPathToImageFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkPathToImageFilterTest.cxx
@@ -68,9 +68,7 @@ itkPathToImageFilterTest(int, char *[])
   pathToImageFilter->SetBackgroundValue(backgroundValue);
   ITK_TEST_SET_GET_VALUE(backgroundValue, pathToImageFilter->GetBackgroundValue());
 
-  ImageType::SizeType size;
-  size[0] = 256;
-  size[1] = 256;
+  auto size = ImageType::SizeType::Filled(256);
   pathToImageFilter->SetSize(size);
   ITK_TEST_SET_GET_VALUE(size, pathToImageFilter->GetSize());
 

--- a/Modules/Numerics/FEM/test/itkFEMRobustSolverTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMRobustSolverTest.cxx
@@ -263,9 +263,7 @@ itkFEMRobustSolverTest(int, char *[])
   spacing[1] = 1.0;
   solver->SetSpacing(spacing);
 
-  InterpolationGridType::SizeType size;
-  size[0] = 5;
-  size[1] = 5;
+  auto                             size = InterpolationGridType::SizeType::Filled(5);
   InterpolationGridType::IndexType start;
   start[0] = 0;
   start[1] = 0;

--- a/Modules/Numerics/FEM/test/itkFEMScatteredDataPointSetToImageFilterTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMScatteredDataPointSetToImageFilterTest.cxx
@@ -127,9 +127,7 @@ itkFEMScatteredDataPointSetToImageFilterTest(int, char *[])
   ITK_TEST_SET_GET_VALUE(elementSpacing, filter->GetSpacingPerElement());
 
   // Set the output
-  DeformationFieldType::SizeType size;
-  size[0] = 5;
-  size[1] = 5;
+  auto size = DeformationFieldType::SizeType::Filled(5);
   filter->SetSize(size);
 
   DeformationFieldType::SpacingType spacing;

--- a/Modules/Registration/Common/test/itkCenteredTransformInitializerTest.cxx
+++ b/Modules/Registration/Common/test/itkCenteredTransformInitializerTest.cxx
@@ -227,9 +227,7 @@ itkCenteredTransformInitializerTest(int, char *[])
     using IndexType = FixedImageType::IndexType;
     using RegionType = FixedImageType::RegionType;
 
-    SizeType size;
-    size[0] = 100;
-    size[1] = 100;
+    auto size = SizeType::Filled(100);
     size[2] = 60;
 
     PointType fixedOrigin;
@@ -287,9 +285,7 @@ itkCenteredTransformInitializerTest(int, char *[])
     using RegionType = FixedImageType::RegionType;
     using DirectionType = FixedImageType::DirectionType;
 
-    SizeType size;
-    size[0] = 100;
-    size[1] = 100;
+    auto size = SizeType::Filled(100);
     size[2] = 60;
 
     PointType fixedOrigin;

--- a/Modules/Registration/Common/test/itkImageToSpatialObjectRegistrationTest.cxx
+++ b/Modules/Registration/Common/test/itkImageToSpatialObjectRegistrationTest.cxx
@@ -250,9 +250,7 @@ itkImageToSpatialObjectRegistrationTest(int, char *[])
   using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<GroupType, ImageType>;
   auto imageFilter = SpatialObjectToImageFilterType::New();
   imageFilter->SetInput(group);
-  ImageType::SizeType size;
-  size[0] = 200;
-  size[1] = 200;
+  auto size = ImageType::SizeType::Filled(200);
   imageFilter->SetSize(size);
   imageFilter->Update();
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainMapImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainMapImageFilterTest.cxx
@@ -36,9 +36,7 @@ itkLevelSetDomainMapImageFilterTest(int, char *[])
   index[0] = 0;
   index[1] = 0;
 
-  InputImageType::SizeType size;
-  size[0] = 10;
-  size[1] = 10;
+  auto size = InputImageType::SizeType::Filled(10);
 
   const InputImageType::RegionType region{ index, size };
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetChanAndVeseInternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetChanAndVeseInternalTermTest.cxx
@@ -52,9 +52,7 @@ itkMultiLevelSetChanAndVeseInternalTermTest(int, char *[])
   index[0] = 0;
   index[1] = 0;
 
-  ImageType::SizeType size;
-  size[0] = 10;
-  size[1] = 10;
+  auto size = ImageType::SizeType::Filled(10);
 
   const ImageType::RegionType region{ index, size };
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageTest.cxx
@@ -36,9 +36,7 @@ itkMultiLevelSetDenseImageTest(int, char *[])
   index[0] = 0;
   index[1] = 0;
 
-  ImageType::SizeType size;
-  size[0] = 10;
-  size[1] = 10;
+  auto size = ImageType::SizeType::Filled(10);
 
   const ImageType::RegionType region{ index, size };
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetEvolutionTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetEvolutionTest.cxx
@@ -62,9 +62,7 @@ itkMultiLevelSetEvolutionTest(int, char *[])
   index[0] = 0;
   index[1] = 0;
 
-  ImageType::SizeType size;
-  size[0] = 10;
-  size[1] = 10;
+  auto size = ImageType::SizeType::Filled(10);
 
   const ImageType::RegionType region{ index, size };
 


### PR DESCRIPTION
Searched for code like:

    SizeType size;

    size[0] = x;
    size[1] = x;
    size[2] = x;

And replaced it with the equivalent `auto size = SizeType::Filled(x);`.

Using Notepad++, Replace in Files, doing:

  Find what: `^([ ]+)(.*SizeType)[ ]+size;[\r\n]+\1size\[0\] = (\w+);\r\n\1size\[1\] = \3;\r\n\1size\[2\] = \3;$`
  Find what: `^([ ]+)(.*SizeType)[ ]+size;[\r\n]+\1size\[0\] = (\w+);\r\n\1size\[1\] = \3;$`
  Replace with: `$1size = $2::Filled\($3\);`
  Filters: `itk*Test*.cxx`
  (*) Regular expression