### PR TITLE
STYLE: Use `SizeType size{ x, y, z }` brace-initialization in tests

### DIFF
--- a/Modules/Bridge/VtkGlue/test/itkImageToVTKImageFilterTest.cxx
+++ b/Modules/Bridge/VtkGlue/test/itkImageToVTKImageFilterTest.cxx
@@ -33,11 +33,8 @@ itkImageToVTKImageFilterTest(int, char *[])
   using DirectionType = SourceType::DirectionType;
   using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
 
-  ImageType::SizeType size;
-  size[0] = 40;
-  size[1] = 10;
-  size[2] = 20;
-  auto source = SourceType::New();
+  ImageType::SizeType size{ 40, 10, 20 };
+  auto                source = SourceType::New();
   source->SetSize(size);
 
   SpacingType spacing;

--- a/Modules/Core/Common/test/itkImageLinearIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageLinearIteratorTest.cxx
@@ -146,10 +146,7 @@ itkImageLinearIteratorTest(int, char *[])
     start[1] = 20;
     start[2] = 30;
 
-    ImageType::SizeType size;
-    size[0] = 2;
-    size[1] = 3;
-    size[2] = 4;
+    ImageType::SizeType size{ 2, 3, 4 };
 
     const ImageType::RegionType region{ start, size };
 
@@ -225,10 +222,7 @@ itkImageLinearIteratorTest(int, char *[])
     start[1] = 12;
     start[2] = 14;
 
-    ImageType::SizeType size;
-    size[0] = 11;
-    size[1] = 12;
-    size[2] = 13;
+    ImageType::SizeType size{ 11, 12, 13 };
 
     const ImageType::RegionType region{ start, size };
 
@@ -271,10 +265,7 @@ itkImageLinearIteratorTest(int, char *[])
     start[1] = 12;
     start[2] = 14;
 
-    ImageType::SizeType size;
-    size[0] = 11;
-    size[1] = 12;
-    size[2] = 13;
+    ImageType::SizeType size{ 11, 12, 13 };
 
     const ImageType::RegionType region{ start, size };
 
@@ -317,10 +308,7 @@ itkImageLinearIteratorTest(int, char *[])
     start[1] = 12;
     start[2] = 14;
 
-    ImageType::SizeType size;
-    size[0] = 11;
-    size[1] = 12;
-    size[2] = 13;
+    ImageType::SizeType size{ 11, 12, 13 };
 
     const ImageType::RegionType region{ start, size };
 
@@ -361,10 +349,7 @@ itkImageLinearIteratorTest(int, char *[])
     start[1] = 12;
     start[2] = 14;
 
-    ImageType::SizeType size;
-    size[0] = 11;
-    size[1] = 12;
-    size[2] = 13;
+    ImageType::SizeType size{ 11, 12, 13 };
 
     const ImageType::RegionType region{ start, size };
 
@@ -405,10 +390,7 @@ itkImageLinearIteratorTest(int, char *[])
     start[1] = 12;
     start[2] = 14;
 
-    ImageType::SizeType size;
-    size[0] = 11;
-    size[1] = 12;
-    size[2] = 13;
+    ImageType::SizeType size{ 11, 12, 13 };
 
     const ImageType::RegionType region{ start, size };
 
@@ -456,10 +438,7 @@ itkImageLinearIteratorTest(int, char *[])
     start[1] = 12;
     start[2] = 14;
 
-    ImageType::SizeType size;
-    size[0] = 11;
-    size[1] = 12;
-    size[2] = 13;
+    ImageType::SizeType size{ 11, 12, 13 };
 
     const ImageType::RegionType region{ start, size };
 
@@ -513,10 +492,7 @@ itkImageLinearIteratorTest(int, char *[])
     start[1] = 12;
     start[2] = 14;
 
-    ImageType::SizeType size;
-    size[0] = 11;
-    size[1] = 12;
-    size[2] = 13;
+    ImageType::SizeType size{ 11, 12, 13 };
 
     const ImageType::RegionType region{ start, size };
 
@@ -554,10 +530,7 @@ itkImageLinearIteratorTest(int, char *[])
     start[1] = 12;
     start[2] = 14;
 
-    ImageType::SizeType size;
-    size[0] = 11;
-    size[1] = 12;
-    size[2] = 13;
+    ImageType::SizeType size{ 11, 12, 13 };
 
     const ImageType::RegionType region{ start, size };
 

--- a/Modules/Core/Common/test/itkImageRandomConstIteratorWithOnlyIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomConstIteratorWithOnlyIndexTest.cxx
@@ -160,10 +160,7 @@ itkImageRandomConstIteratorWithOnlyIndexTest(int, char *[])
     start[1] = 12;
     start[2] = 14;
 
-    ImageType::SizeType size;
-    size[0] = 11;
-    size[1] = 12;
-    size[2] = 13;
+    ImageType::SizeType size{ 11, 12, 13 };
 
     const ImageType::RegionType region{ start, size };
 

--- a/Modules/Core/Common/test/itkImageRandomIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomIteratorTest.cxx
@@ -210,10 +210,7 @@ itkImageRandomIteratorTest(int, char *[])
     start[1] = 12;
     start[2] = 14;
 
-    ImageType::SizeType size;
-    size[0] = 11;
-    size[1] = 12;
-    size[2] = 13;
+    ImageType::SizeType size{ 11, 12, 13 };
 
     const ImageType::RegionType region{ start, size };
 
@@ -256,10 +253,7 @@ itkImageRandomIteratorTest(int, char *[])
     start[1] = 12;
     start[2] = 14;
 
-    ImageType::SizeType size;
-    size[0] = 11;
-    size[1] = 12;
-    size[2] = 13;
+    ImageType::SizeType size{ 11, 12, 13 };
 
     const ImageType::RegionType region{ start, size };
 

--- a/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest.cxx
@@ -222,10 +222,7 @@ itkImageRandomNonRepeatingIteratorWithIndexTest(int, char *[])
     start[0] = 10;
     start[1] = 12;
     start[2] = 14;
-    ImageType::SizeType size;
-    size[0] = 11;
-    size[1] = 12;
-    size[2] = 13;
+    ImageType::SizeType         size{ 11, 12, 13 };
     const ImageType::RegionType region{ start, size };
     RandomIteratorType          cbot(myImage, region);
     cbot.SetNumberOfSamples(numberOfSamples); // 0=x, 1=y, 2=z
@@ -259,10 +256,7 @@ itkImageRandomNonRepeatingIteratorWithIndexTest(int, char *[])
     start[0] = 10;
     start[1] = 12;
     start[2] = 14;
-    ImageType::SizeType size;
-    size[0] = 11;
-    size[1] = 12;
-    size[2] = 13;
+    ImageType::SizeType         size{ 11, 12, 13 };
     const ImageType::RegionType region{ start, size };
     RandomConstIteratorType     cbot(myImage, region);
     cbot.SetNumberOfSamples(numberOfSamples);

--- a/Modules/Core/GPUCommon/test/itkGPUImageTest.cxx
+++ b/Modules/Core/GPUCommon/test/itkGPUImageTest.cxx
@@ -52,9 +52,7 @@ itkGPUImageTest(int argc, char * argv[])
   ItkImage1f::IndexType start;
   start[0] = 0;
   start[1] = 0;
-  ItkImage1f::SizeType size;
-  size[0] = width;
-  size[1] = height;
+  ItkImage1f::SizeType   size{ width, height };
   ItkImage1f::RegionType region{ start, size };
 
   // create

--- a/Modules/Core/ImageFunction/test/itkLabelImageGaussianInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLabelImageGaussianInterpolateImageFunctionTest.cxx
@@ -106,9 +106,7 @@ itkLabelImageGaussianInterpolateImageFunctionTest(int, char *[])
   {
     RegionType region;
     {
-      SizeType size;
-      size[0] = large_xSize;
-      size[1] = large_ySize;
+      SizeType size{ large_xSize, large_ySize };
       region = { size };
     }
 

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
@@ -461,9 +461,7 @@ itkBSplineDeformableTransformTest2()
     spacing[j] = 10.0;
     origin[j] = -10.0;
   }
-  ImageType::SizeType size;
-  size[0] = 5;
-  size[1] = 7;
+  ImageType::SizeType size{ 5, 7 };
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
@@ -496,9 +496,7 @@ itkBSplineTransformTest2()
     spacing[j] = 10.0;
     origin[j] = -10.0;
   }
-  ImageType::SizeType size;
-  size[0] = 5;
-  size[1] = 7;
+  ImageType::SizeType size{ 5, 7 };
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/Modules/Filtering/ImageCompose/test/itkJoinImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkJoinImageFilterTest.cxx
@@ -46,9 +46,7 @@ itkJoinImageFilterTest(int, char *[])
   auto inputImageC = myImageType3::New();
 
   // Define their size and region
-  mySizeType size;
-  size[0] = 5;
-  size[1] = 8;
+  mySizeType size{ 5, 8 };
 
   const myRegionType region{ size };
 

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest5.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest5.cxx
@@ -140,9 +140,7 @@ itkBSplineScatteredDataPointSetToImageFilterTest5(int argc, char * argv[])
   spacing[1] = 0.01;
   filter->SetSpacing(spacing);
 
-  ImageType::SizeType size;
-  size[0] = 1000;
-  size[1] = 100;
+  ImageType::SizeType size{ 1000, 100 };
 
   constexpr ImageType::PointType origin{};
 

--- a/Modules/Filtering/ImageIntensity/test/itkHistogramMatchingImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkHistogramMatchingImageFilterTest.cxx
@@ -161,10 +161,7 @@ itkHistogramMatchingImageFilterTest()
   using ImageType = itk::Image<PixelType, ImageDimension>;
   using Iterator = itk::ImageRegionIterator<ImageType>;
 
-  typename ImageType::SizeType size;
-  size[0] = 30;
-  size[1] = 20;
-  size[2] = 2;
+  typename ImageType::SizeType size{ 30, 20, 2 };
 
   typename ImageType::RegionType region;
   region.SetSize(size);

--- a/Modules/IO/NRRD/test/itkNrrd5dVectorImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrd5dVectorImageReadWriteTest.cxx
@@ -34,9 +34,7 @@ void
 GenerateImageSequence(int numberOfTimePoints, std::vector<typename ImageType::Pointer> & imageList)
 {
   // Region
-  typename ImageType::SizeType size;
-  size[0] = 8;
-  size[1] = 12;
+  typename ImageType::SizeType size{ 8, 12 };
   if (ImageType::SizeType::Dimension > 2)
   {
     size[2] = 10;

--- a/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
@@ -124,11 +124,8 @@ itkImageFunctionTest(int, char *[])
 
   auto image = ImageType::New();
 
-  auto     start = IndexType::Filled(1);
-  SizeType size;
-  size[0] = 3;
-  size[1] = 4;
-  size[2] = 5;
+  auto       start = IndexType::Filled(1);
+  SizeType   size{ 3, 4, 5 };
   RegionType region{ start, size };
 
   image->SetRegions(region);

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDenseImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDenseImageTest.cxx
@@ -83,9 +83,7 @@ itkLevelSetDenseImageTest(int, char *[])
   index[0] = 0;
   index[1] = 0;
 
-  ImageType::SizeType size;
-  size[0] = 10;
-  size[1] = 20;
+  ImageType::SizeType size{ 10, 20 };
 
   const ImageType::RegionType region{ index, size };
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageWithKdTreeTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageWithKdTreeTest.cxx
@@ -41,9 +41,7 @@ itkLevelSetDomainPartitionImageWithKdTreeTest(int, char *[])
   using ListImageIteratorType = itk::ImageRegionConstIteratorWithIndex<ListImageType>;
 
   // load binary mask
-  InputImageType::SizeType size;
-  size[0] = 100;
-  size[1] = 10;
+  InputImageType::SizeType size{ 100, 10 };
 
   InputImageType::PointType origin;
   origin[0] = 0.0;


### PR DESCRIPTION
Searched for code like:

    SizeType size;

    size[0] = x;
    size[1] = y;
    size[2] = z;

And replaced it with the equivalent `SizeType size{ x, y, z };`.

Using Notepad++, Replace in Files, doing:

  Find what: `^([ ]+)(.*SizeType)[ ]+size;[\r\n]+\1size\[0\] = (\w+);\r\n\1size\[1\] = (\w+);\r\n\1size\[2\] = (\w+);$`
  Replace with: `$1$2 size{ $3, $4, $5 };`
  Find what: `^([ ]+)(.*SizeType)[ ]+size;[\r\n]+\1size\[0\] = (\w+);\r\n\1size\[1\] = (\w+);$`
  Replace with: `$1$2 size{ $3, $4 };`
  Filters: `itk*Test*.cxx`
  (*) Regular expression

- Follow-up to pull request #5662