### PR TITLE
BUG: Let DataObjectError override `ExceptionObject::Print`

### DIFF
--- a/Modules/Core/Common/include/itkDataObject.h
+++ b/Modules/Core/Common/include/itkDataObject.h
@@ -90,8 +90,8 @@ protected:
    * specific exception subtypes.  The default is to print out the
    * location where the exception was first thrown and any description
    * provided by the "thrower".   */
-  virtual void
-  PrintSelf(std::ostream & os, Indent indent) const;
+  void
+  Print(std::ostream & os) const override;
 
 private:
   DataObject * m_DataObject{ nullptr };
@@ -126,14 +126,6 @@ public:
 
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(InvalidRequestedRegionError);
-
-protected:
-  /** Print exception information.  This method can be overridden by
-   * specific exception subtypes.  The default is to print out the
-   * location where the exception was first thrown and any description
-   * provided by the "thrower".   */
-  void
-  PrintSelf(std::ostream & os, Indent indent) const override;
 };
 
 /*----------------------------Data Object--------------------------------*/

--- a/Modules/Core/Common/src/itkDataObject.cxx
+++ b/Modules/Core/Common/src/itkDataObject.cxx
@@ -70,9 +70,11 @@ DataObjectError::GetDataObject() const noexcept
 
 
 void
-DataObjectError::PrintSelf(std::ostream & os, Indent indent) const
+DataObjectError::Print(std::ostream & os) const
 {
   ExceptionObject::Print(os);
+
+  const Indent indent{};
 
   os << indent << "Data object: ";
   if (m_DataObject)
@@ -98,12 +100,6 @@ InvalidRequestedRegionError::InvalidRequestedRegionError(const InvalidRequestedR
 
 InvalidRequestedRegionError &
 InvalidRequestedRegionError::operator=(const InvalidRequestedRegionError &) noexcept = default;
-
-void
-InvalidRequestedRegionError::PrintSelf(std::ostream & os, Indent indent) const
-{
-  DataObjectError::PrintSelf(os, indent);
-}
 
 //----------------------------------------------------------------------------
 DataObject::DataObject()


### PR DESCRIPTION
Instead of introducing a new virtual member function, `DataObjectError::PrintSelf`.

It is essential that DataObjectError overrides `ExceptionObject::Print`, because that is the member function that is called, when doing `std::cerr << error` for a DataObjectError.

- Fixes issue #5666