### PR TITLE
STYLE: Make `NumericTraits::GetLength` constexpr whenever possible

### DIFF
--- a/Modules/Core/Common/include/itkNumericTraits.h
+++ b/Modules/Core/Common/include/itkNumericTraits.h
@@ -198,14 +198,14 @@ public:
    * VariableLengthVector will provide a different implementation
    * where a vector of the correct size is built.
    */
-  static unsigned int
+  static constexpr unsigned int
   GetLength(const T &)
   {
     return GetLength();
   }
 
   /** Return the length of the scalar: 1. Array types can return a different value */
-  static unsigned int
+  static constexpr unsigned int
   GetLength()
   {
     return 1;

--- a/Modules/Core/Common/include/itkNumericTraitsCovariantVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsCovariantVectorPixel.h
@@ -161,14 +161,14 @@ public:
   }
 
   /** Return the length of the vector. */
-  static unsigned int
+  static constexpr unsigned int
   GetLength(const CovariantVector<T, D> &)
   {
     return D;
   }
 
   /** Return the length of the vector. */
-  static unsigned int
+  static constexpr unsigned int
   GetLength()
   {
     return D;

--- a/Modules/Core/Common/include/itkNumericTraitsDiffusionTensor3DPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsDiffusionTensor3DPixel.h
@@ -163,14 +163,14 @@ public:
   }
 
   /** Return the size of the tensor. Always returns 6. */
-  static unsigned int
+  static constexpr unsigned int
   GetLength(const DiffusionTensor3D<T> &)
   {
     return 6;
   }
 
   /** Return the size of the tensor. Always returns 6. */
-  static unsigned int
+  static constexpr unsigned int
   GetLength()
   {
     return 6;

--- a/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
@@ -157,14 +157,14 @@ public:
   }
 
   /** Return the length of the array. */
-  static unsigned int
+  static constexpr unsigned int
   GetLength(const FixedArray<T, D> &)
   {
     return D;
   }
 
   /** Return the length of the array. */
-  static unsigned int
+  static constexpr unsigned int
   GetLength()
   {
     return D;

--- a/Modules/Core/Common/include/itkNumericTraitsPointPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsPointPixel.h
@@ -148,14 +148,14 @@ public:
   }
 
   /** Return the dimensionality of the point. */
-  static unsigned int
+  static constexpr unsigned int
   GetLength(const Point<T, D> &)
   {
     return D;
   }
 
   /** Return the dimensionality of the point. */
-  static unsigned int
+  static constexpr unsigned int
   GetLength()
   {
     return D;

--- a/Modules/Core/Common/include/itkNumericTraitsRGBAPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsRGBAPixel.h
@@ -188,14 +188,14 @@ public:
   }
 
   /** Return the dimensionality of the pixel. Always returns 4. */
-  static unsigned int
+  static constexpr unsigned int
   GetLength(const RGBAPixel<T> &)
   {
     return 4;
   }
 
   /** Return the dimensionality of the pixel. Always returns 4. */
-  static unsigned int
+  static constexpr unsigned int
   GetLength()
   {
     return 4;

--- a/Modules/Core/Common/include/itkNumericTraitsRGBPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsRGBPixel.h
@@ -188,14 +188,14 @@ public:
   }
 
   /** Return the dimensionality of the pixel. Always returns 3. */
-  static unsigned int
+  static constexpr unsigned int
   GetLength(const RGBPixel<T> &)
   {
     return 3;
   }
 
   /** Return the dimensionality of the pixel. Always returns 3. */
-  static unsigned int
+  static constexpr unsigned int
   GetLength()
   {
     return 3;

--- a/Modules/Core/Common/include/itkNumericTraitsTensorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsTensorPixel.h
@@ -163,14 +163,14 @@ public:
   }
 
   /** Return the size of the underlying FixedArray. */
-  static unsigned int
+  static constexpr unsigned int
   GetLength(const SymmetricSecondRankTensor<T, D> &)
   {
     return GetLength();
   }
 
   /** Return the size of the underlying FixedArray. */
-  static unsigned int
+  static constexpr unsigned int
   GetLength()
   {
     return D * (D + 1) / 2;

--- a/Modules/Core/Common/include/itkNumericTraitsVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsVectorPixel.h
@@ -203,14 +203,14 @@ public:
   }
 
   /** Return the size of the vector. */
-  static unsigned int
+  static constexpr unsigned int
   GetLength(const Vector<T, D> &)
   {
     return D;
   }
 
   /** Return the size of the vector. */
-  static unsigned int
+  static constexpr unsigned int
   GetLength()
   {
     return D;


### PR DESCRIPTION
It appears that most `NumericTraits` specializations can have constexpr `GetLength` member functions. The only `NumericTraits` specializations whose `GetLength` member functions cannot be constexpr are for `std::vector` and `VariableLengthVector`

---

- Inspired by pull request #5670 (by @blowekamp), which uses the fact that `NumericTraits::GetLength` is very fast, and can often be evaluated at compile-time.