### PR TITLE
DOC: BSplineTransform does not have ImageConstPointer type alias

### DIFF
--- a/Modules/Core/Transform/include/itkBSplineTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineTransform.h
@@ -82,7 +82,7 @@ namespace itk
  * are the same buffered region. The following illustrates the API:
  * \code
 
-   TransformType::ImageConstPointer images[2];
+   TransformType::ImagePointer images[2];
 
    // Fill the images up with values
 


### PR DESCRIPTION

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Updated API documentation (or API not changed)
