### PR TITLE
DOC: BSplineDeformableTransform does not have ImageConstPointer typedef

### DIFF
--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.h
@@ -86,7 +86,7 @@ outputPoint = transform->TransformPoint( inputPoint );
  *
 \code
 
-TransformType::ImageConstPointer images[2];
+TransformType::ImagePointer images[2];
 
 // Fill the images up with values
 


### PR DESCRIPTION
Follow up to #5672.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Updated API documentation (or API not changed)
