### PR TITLE
ENH: Update CI images from Windows-2019 to Windows-2022

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -31,7 +31,7 @@ jobs:
   timeoutInMinutes: 0
   cancelTimeoutInMinutes: 300
   pool:
-    vmImage: 'windows-2019'
+    vmImage: 'windows-2022'
   steps:
     - checkout: self
       clean: true

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -31,7 +31,7 @@ jobs:
   timeoutInMinutes: 0
   cancelTimeoutInMinutes: 300
   pool:
-    vmImage: 'windows-2019'
+    vmImage: 'windows-2022'
   steps:
     - checkout: self
       clean: true


### PR DESCRIPTION
Windows Server 2019 will be retired on January 1, 2026. For more details, see [devblogs.microsoft.com/devops/upcoming-updates-for-azure-pipelines-agents-images](https://devblogs.microsoft.com/devops/upcoming-updates-for-azure-pipelines-agents-images). Brownout encountered in #5676.