### PR TITLE
COMP: Fix ExternalData when ITK is built with FetchContent

### DIFF
--- a/CMake/ITKExternalData.cmake
+++ b/CMake/ITKExternalData.cmake
@@ -1,3 +1,4 @@
+set(ExternalData_SOURCE_ROOT "${PROJECT_SOURCE_DIR}")
 get_filename_component(_ITKExternalData_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 include(${_ITKExternalData_DIR}/ExternalData.cmake)
 
@@ -28,10 +29,10 @@ list(
   APPEND
   ExternalData_OBJECT_STORES
   # Local data store populated by the ITK pre-commit hook
-  "${CMAKE_SOURCE_DIR}/.ExternalData"
+  "${PROJECT_SOURCE_DIR}/.ExternalData"
 )
 
-set(ExternalData_BINARY_ROOT ${CMAKE_BINARY_DIR}/ExternalData)
+set(ExternalData_BINARY_ROOT ${PROJECT_BINARY_DIR}/ExternalData)
 
 # Expands %(algo:lower)
 set(ExternalData_URL_ALGO_CID_lower cid)


### PR DESCRIPTION
Addresses two issue:
- When ITK is built from FetchContent, the fetched source is outside of the main source. This is an error with external data paths, so use the ITK PROJECT source path as the default for ITK's External data.
- Use PROJECT_BINARY_DIR for output of download data, to prevent target conflics with the main project.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
