### PR TITLE
ENH: Add `std::vector`-like interface to VariableLengthVector

### DIFF
--- a/Modules/Core/Common/include/itkVariableLengthVector.h
+++ b/Modules/Core/Common/include/itkVariableLengthVector.h
@@ -20,6 +20,7 @@
 
 #include <cassert>
 #include <algorithm>
+#include <iterator>
 #include <type_traits>
 #include "itkNumericTraits.h"
 #include "itkMetaProgrammingLibrary.h"
@@ -313,6 +314,17 @@ public:
 
   /** Typedef used to indicate the number of elements in the vector */
   using ElementIdentifier = unsigned int;
+
+  // Nested types from C++ Standard section "Container requirements" [container.reqmts], and from `std::vector`:
+  using value_type = TValue;
+  using reference = TValue &;
+  using const_reference = const TValue &;
+  using iterator = TValue *;
+  using const_iterator = const TValue *;
+  using difference_type = ptrdiff_t;
+  using size_type = size_t;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
   /** Default constructor. It is created with an empty array
    *  it has to be allocated later by assignment, \c SetSize() or \c Reserve().
@@ -983,11 +995,156 @@ public:
     return !m_LetArrayManageMemory;
   }
 
+  [[nodiscard]] bool
+  empty() const noexcept
+  {
+    return m_NumElements == 0;
+  }
+
+  [[nodiscard]] size_type
+  size() const noexcept
+  {
+    return m_NumElements;
+  }
+
+  [[nodiscard]] reference
+  at(size_type pos)
+  {
+    ExceptionThrowingBoundsCheck(pos);
+    return m_Data[pos];
+  }
+
+  [[nodiscard]] const_reference
+  at(size_type pos) const
+  {
+    ExceptionThrowingBoundsCheck(pos);
+    return m_Data[pos];
+  }
+
+  [[nodiscard]] reference
+  front()
+  {
+    return m_Data[0];
+  }
+
+  [[nodiscard]] const_reference
+  front() const
+  {
+    return m_Data[0];
+  }
+
+  [[nodiscard]] reference
+  back()
+  {
+    return m_Data[m_NumElements - 1];
+  }
+
+  [[nodiscard]] const_reference
+  back() const
+  {
+    return m_Data[m_NumElements - 1];
+  }
+
+  [[nodiscard]] TValue *
+  data() noexcept
+  {
+    return m_Data;
+  }
+
+  [[nodiscard]] const TValue *
+  data() const noexcept
+  {
+    return m_Data;
+  }
+
+  [[nodiscard]] const_iterator
+  cbegin() const noexcept
+  {
+    return m_Data;
+  }
+
+  [[nodiscard]] iterator
+  begin() noexcept
+  {
+    return m_Data;
+  }
+
+  [[nodiscard]] const_iterator
+  begin() const noexcept
+  {
+    return cbegin();
+  }
+
+  [[nodiscard]] const_iterator
+  cend() const noexcept
+  {
+    return m_Data + m_NumElements;
+  }
+
+  [[nodiscard]] iterator
+  end() noexcept
+  {
+    return m_Data + m_NumElements;
+  }
+
+  [[nodiscard]] const_iterator
+  end() const noexcept
+  {
+    return cend();
+  }
+
+  [[nodiscard]] reverse_iterator
+  rbegin()
+  {
+    return reverse_iterator{ end() };
+  }
+
+  [[nodiscard]] const_reverse_iterator
+  crbegin() const
+  {
+    return const_reverse_iterator{ cend() };
+  }
+
+  [[nodiscard]] const_reverse_iterator
+  rbegin() const
+  {
+    return crbegin();
+  }
+
+  [[nodiscard]] reverse_iterator
+  rend()
+  {
+    return reverse_iterator{ begin() };
+  }
+
+  [[nodiscard]] const_reverse_iterator
+  crend() const
+  {
+    return const_reverse_iterator{ cbegin() };
+  }
+
+  [[nodiscard]] const_reverse_iterator
+  rend() const
+  {
+    return crend();
+  }
+
 private:
   bool m_LetArrayManageMemory{ true }; // if true, the array is responsible
                                        // for memory of data
   TValue *          m_Data{};          // Array to hold data
   ElementIdentifier m_NumElements{ 0 };
+
+  void
+  ExceptionThrowingBoundsCheck(size_type pos) const
+  {
+    if (pos >= m_NumElements)
+    {
+      throw std::out_of_range("Out of range: `itk::VariableLengthVector::at` argument `pos` (which is " +
+                              std::to_string(pos) + ") should be less than `m_NumElements` (which is " +
+                              std::to_string(m_NumElements) + ")!");
+    }
+  }
 };
 
 /// \cond HIDE_META_PROGRAMMING

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -1902,6 +1902,7 @@ set(
   itkSizeGTest.cxx
   itkSmartPointerGTest.cxx
   itkSymmetricSecondRankTensorGTest.cxx
+  itkVariableLengthVectorGTest.cxx
   itkVectorContainerGTest.cxx
   itkVectorGTest.cxx
   itkWeakPointerGTest.cxx

--- a/Modules/Core/Common/test/itkVariableLengthVectorGTest.cxx
+++ b/Modules/Core/Common/test/itkVariableLengthVectorGTest.cxx
@@ -1,0 +1,142 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkVariableLengthVector.h"
+#include "itkRangeGTestUtilities.h"
+#include <gtest/gtest.h>
+#include <numeric> // For iota.
+#include <random>  // For mt19937.
+
+using itk::RangeGTestUtilities;
+
+
+static_assert(RangeGTestUtilities::CheckContainerRequirementsOnNestedTypes<itk::VariableLengthVector<int>>() &&
+              RangeGTestUtilities::CheckContainerRequirementsOnNestedTypes<itk::VariableLengthVector<double>>());
+
+
+// Tests that begin() == end() for a default-constructed object.
+TEST(VariableLengthVector, BeginIsEndWhenDefaultConstructed)
+{
+  RangeGTestUtilities::ExpectBeginIsEndWhenRangeIsDefaultConstructed<itk::VariableLengthVector<int>>();
+  RangeGTestUtilities::ExpectBeginIsEndWhenRangeIsDefaultConstructed<itk::VariableLengthVector<double>>();
+
+  RangeGTestUtilities::ExpectReverseBeginIsReverseEndWhenRangeIsDefaultConstructed<itk::VariableLengthVector<int>>();
+  RangeGTestUtilities::ExpectReverseBeginIsReverseEndWhenRangeIsDefaultConstructed<itk::VariableLengthVector<double>>();
+}
+
+
+// Tests that size() returns 0 for a default-constructed object.
+TEST(VariableLengthVector, SizeIsZeroWhenDefaultConstructed)
+{
+  RangeGTestUtilities::ExpectZeroSizeWhenRangeIsDefaultConstructed<itk::VariableLengthVector<int>>();
+  RangeGTestUtilities::ExpectZeroSizeWhenRangeIsDefaultConstructed<itk::VariableLengthVector<double>>();
+}
+
+
+// Tests empty() for a default-constructed object.
+TEST(VariableLengthVector, IsEmptyWhenDefaultConstructed)
+{
+  RangeGTestUtilities::ExpectRangeIsEmptyWhenDefaultConstructed<itk::VariableLengthVector<int>>();
+  RangeGTestUtilities::ExpectRangeIsEmptyWhenDefaultConstructed<itk::VariableLengthVector<double>>();
+}
+
+
+// Tests that the distance from begin() to end() equals its size().
+TEST(VariableLengthVector, DistanceFromBeginToEndEqualsSize)
+{
+  for (const unsigned int size : { 0, 1, 2 })
+  {
+    RangeGTestUtilities::ExpectDistanceFromBeginToEndEqualsSize(itk::VariableLengthVector<int>(size));
+    RangeGTestUtilities::ExpectDistanceFromBeginToEndEqualsSize(itk::VariableLengthVector<double>(size));
+  }
+}
+
+
+// Tests that `distance(&front, &back) + 1` is equal to `size`, for a non-empty VariableLengthVector.
+TEST(VariableLengthVector, DistanceFromFrontToBackPlusOneEqualsSize)
+{
+  for (const unsigned int size : { 1, 2 })
+  {
+    RangeGTestUtilities::ExpectDistanceFromFrontToBackPlusOneEqualsSize(itk::VariableLengthVector<int>(size));
+    RangeGTestUtilities::ExpectDistanceFromFrontToBackPlusOneEqualsSize(itk::VariableLengthVector<double>(size));
+  }
+}
+
+
+// Tests that `at(i)` is equal to `[i]`, for a non-empty VariableLengthVector.
+TEST(VariableLengthVector, AtReturnsSameElementAsSubscriptOperator)
+{
+  std::mt19937                    randomNumberEngine{};
+  std::uniform_int_distribution<> randomNumberDistribution{};
+
+  for (const unsigned int size : { 1, 2, 3 })
+  {
+    itk::VariableLengthVector<int> variableLengthVector(size);
+
+    std::generate(
+      variableLengthVector.begin(), variableLengthVector.end(), [&randomNumberEngine, &randomNumberDistribution] {
+        return randomNumberDistribution(randomNumberEngine);
+      });
+
+    for (unsigned int i = 0; i < size; ++i)
+    {
+      EXPECT_EQ(variableLengthVector.at(i), variableLengthVector[i]);
+      EXPECT_EQ(&(variableLengthVector.at(i)), &(variableLengthVector[i]));
+    }
+  }
+}
+
+
+// Tests that `at(i)` throws an `std::out_of_range` exception when `i >= size`.
+TEST(VariableLengthVector, AtThrowsOutOfRange)
+{
+  for (const unsigned int size : { 0, 1, 2 })
+  {
+    itk::VariableLengthVector<int> variableLengthVector(size);
+    std::fill(variableLengthVector.begin(), variableLengthVector.end(), 0);
+
+    for (const unsigned int i : { size, UINT_MAX })
+    {
+      EXPECT_THROW(static_cast<void>(variableLengthVector.at(i)), std::out_of_range);
+    }
+  }
+}
+
+// Tests reverse iteration.
+TEST(VariableLengthVector, ReverseIteration)
+{
+  for (const unsigned int size : { 0, 1, 2, 3 })
+  {
+    itk::VariableLengthVector<int> variableLengthVector(size);
+
+    // Fill with { 1, 2, 3, ..., size }.
+    std::iota(variableLengthVector.begin(), variableLengthVector.end(), 1);
+
+    // Check that reverse iteration yields { size, size-1, ..., 2, 1 }.
+    auto expectedValue = static_cast<int>(size);
+
+    const auto reverseEnd = variableLengthVector.crend();
+
+    for (auto reverseIterator = variableLengthVector.crbegin(); reverseIterator != reverseEnd; ++reverseIterator)
+    {
+      EXPECT_EQ(*reverseIterator, expectedValue);
+      --expectedValue;
+    }
+  }
+}


### PR DESCRIPTION
Added the following member functions:

     empty()
     size()
     at(size_type)
     front()
     back()
     data()
     begin()
     end()
     cbegin()
     cend()
     rbegin()
     rend()
     crbegin()
     crend()

As well as STL-style nested type aliases.

Aims to ease using `VariableLengthVector` in generic code.