### PR TITLE
STYLE: Add `[[nodiscard]]` to non-const data(), begin(), end(), etc.

### DIFF
--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -324,7 +324,7 @@ public:
     return m_InternalArray;
   }
 
-  ValueType *
+  [[nodiscard]] ValueType *
   data()
   {
     return m_InternalArray;
@@ -370,7 +370,7 @@ public:
     return m_InternalArray;
   }
 
-  constexpr iterator
+  [[nodiscard]] constexpr iterator
   begin() noexcept
   {
     return m_InternalArray;
@@ -388,7 +388,7 @@ public:
     return m_InternalArray + VLength;
   }
 
-  constexpr iterator
+  [[nodiscard]] constexpr iterator
   end() noexcept
   {
     return m_InternalArray + VLength;
@@ -400,7 +400,7 @@ public:
     return this->cend();
   }
 
-  reverse_iterator
+  [[nodiscard]] reverse_iterator
   rbegin()
   {
     return reverse_iterator{ this->end() };
@@ -418,7 +418,7 @@ public:
     return this->crbegin();
   }
 
-  reverse_iterator
+  [[nodiscard]] reverse_iterator
   rend()
   {
     return reverse_iterator{ this->begin() };

--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -355,7 +355,7 @@ public:
     return &m_InternalArray[0];
   }
 
-  constexpr iterator
+  [[nodiscard]] constexpr iterator
   begin()
   {
     return &m_InternalArray[0];
@@ -373,7 +373,7 @@ public:
     return &m_InternalArray[VDimension];
   }
 
-  constexpr iterator
+  [[nodiscard]] constexpr iterator
   end()
   {
     return &m_InternalArray[VDimension];
@@ -385,7 +385,7 @@ public:
     return &m_InternalArray[VDimension];
   }
 
-  reverse_iterator
+  [[nodiscard]] reverse_iterator
   rbegin()
   {
     return reverse_iterator(end());
@@ -397,7 +397,7 @@ public:
     return const_reverse_iterator(end());
   }
 
-  reverse_iterator
+  [[nodiscard]] reverse_iterator
   rend()
   {
     return reverse_iterator(begin());
@@ -453,7 +453,7 @@ public:
     return m_InternalArray[pos];
   }
 
-  constexpr reference
+  [[nodiscard]] constexpr reference
   front()
   {
     return *begin();
@@ -465,7 +465,7 @@ public:
     return *begin();
   }
 
-  constexpr reference
+  [[nodiscard]] constexpr reference
   back()
   {
     return VDimension ? *(end() - 1) : *end();
@@ -477,7 +477,7 @@ public:
     return VDimension ? *(end() - 1) : *end();
   }
 
-  IndexValueType *
+  [[nodiscard]] IndexValueType *
   data()
   {
     return &m_InternalArray[0];

--- a/Modules/Core/Common/include/itkMatrix.h
+++ b/Modules/Core/Common/include/itkMatrix.h
@@ -341,14 +341,14 @@ public:
   }
 
   /** Returns an iterator to the first element. */
-  iterator
+  [[nodiscard]] iterator
   begin()
   {
     return m_Matrix.begin();
   }
 
   /** Returns an iterator just beyond the last element. */
-  iterator
+  [[nodiscard]] iterator
   end()
   {
     return m_Matrix.end();

--- a/Modules/Core/Common/include/itkNeighborhoodAllocator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodAllocator.h
@@ -120,7 +120,7 @@ public:
 
   /** STL-style iterator support for the memory buffer. */
   /** @ITKStartGrouping */
-  iterator
+  [[nodiscard]] iterator
   begin()
   {
     return m_Data.get();
@@ -130,7 +130,7 @@ public:
   {
     return m_Data.get();
   }
-  iterator
+  [[nodiscard]] iterator
   end()
   {
     return m_Data.get() + m_ElementCount;
@@ -173,7 +173,7 @@ public:
     }
   }
 
-  TPixel *
+  [[nodiscard]] TPixel *
   data() noexcept
   {
     return m_Data.get();

--- a/Modules/Core/Common/include/itkOffset.h
+++ b/Modules/Core/Common/include/itkOffset.h
@@ -304,7 +304,7 @@ public:
     return &m_InternalArray[0];
   }
 
-  constexpr iterator
+  [[nodiscard]] constexpr iterator
   begin()
   {
     return &m_InternalArray[0];
@@ -322,7 +322,7 @@ public:
     return &m_InternalArray[VDimension];
   }
 
-  constexpr iterator
+  [[nodiscard]] constexpr iterator
   end()
   {
     return &m_InternalArray[VDimension];
@@ -334,7 +334,7 @@ public:
     return &m_InternalArray[VDimension];
   }
 
-  reverse_iterator
+  [[nodiscard]] reverse_iterator
   rbegin()
   {
     return reverse_iterator(end());
@@ -346,7 +346,7 @@ public:
     return const_reverse_iterator(end());
   }
 
-  reverse_iterator
+  [[nodiscard]] reverse_iterator
   rend()
   {
     return reverse_iterator(begin());
@@ -402,7 +402,7 @@ public:
     return m_InternalArray[pos];
   }
 
-  constexpr reference
+  [[nodiscard]] constexpr reference
   front()
   {
     return *begin();
@@ -414,7 +414,7 @@ public:
     return *begin();
   }
 
-  constexpr reference
+  [[nodiscard]] constexpr reference
   back()
   {
     return VDimension ? *(end() - 1) : *end();
@@ -426,7 +426,7 @@ public:
     return VDimension ? *(end() - 1) : *end();
   }
 
-  OffsetValueType *
+  [[nodiscard]] OffsetValueType *
   data()
   {
     return &m_InternalArray[0];

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -279,7 +279,7 @@ public:
     return &m_InternalArray[0];
   }
 
-  constexpr iterator
+  [[nodiscard]] constexpr iterator
   begin()
   {
     return &m_InternalArray[0];
@@ -297,7 +297,7 @@ public:
     return &m_InternalArray[VDimension];
   }
 
-  constexpr iterator
+  [[nodiscard]] constexpr iterator
   end()
   {
     return &m_InternalArray[VDimension];
@@ -309,7 +309,7 @@ public:
     return &m_InternalArray[VDimension];
   }
 
-  reverse_iterator
+  [[nodiscard]] reverse_iterator
   rbegin()
   {
     return reverse_iterator(end());
@@ -321,7 +321,7 @@ public:
     return const_reverse_iterator(end());
   }
 
-  reverse_iterator
+  [[nodiscard]] reverse_iterator
   rend()
   {
     return reverse_iterator(begin());
@@ -377,7 +377,7 @@ public:
     return m_InternalArray[pos];
   }
 
-  constexpr reference
+  [[nodiscard]] constexpr reference
   front()
   {
     return *begin();
@@ -389,7 +389,7 @@ public:
     return *begin();
   }
 
-  constexpr reference
+  [[nodiscard]] constexpr reference
   back()
   {
     return VDimension ? *(end() - 1) : *end();
@@ -401,7 +401,7 @@ public:
     return VDimension ? *(end() - 1) : *end();
   }
 
-  SizeValueType *
+  [[nodiscard]] SizeValueType *
   data()
   {
     return &m_InternalArray[0];

--- a/Modules/IO/IPL/include/itkIPLFileNameList.h
+++ b/Modules/IO/IPL/include/itkIPLFileNameList.h
@@ -139,13 +139,13 @@ public:
 
   virtual ~IPLFileNameList();
 
-  IteratorType
+  [[nodiscard]] IteratorType
   begin()
   {
     return m_List.begin();
   }
 
-  IteratorType
+  [[nodiscard]] IteratorType
   end()
   {
     return m_List.end();


### PR DESCRIPTION
The clang-tidy [`modernize-use-nodiscard`](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-nodiscard.html) check only considers _const_ member functions, whereas this commit specifically addresses non-const member functions.

- Follow-up to pull request #5404 by @hjmjohnson 