### PR TITLE
ENH: Python version exact match requested for range

### DIFF
--- a/CMake/ITKSetPython3Vars.cmake
+++ b/CMake/ITKSetPython3Vars.cmake
@@ -12,11 +12,11 @@ set(PYTHON_VERSION_MAX 3.999)
 if(DEFINED Python3_EXECUTABLE) # if already specified
   set(_specified_Python3_EXECUTABLE ${Python3_EXECUTABLE})
   # If a specific Python executable is provided, lock the Python version range
-  # to the exact version of that executable so FindPython3 searches that version.
+  # to the exact version down to the minor release of that executable so FindPython3 searches that version.
   execute_process(
     COMMAND
       "${_specified_Python3_EXECUTABLE}" -c
-      "import sys; print('{}.{}'.format(sys.version_info[0], sys.version_info[1]))"
+      "import sys; print('{}.{}.{}'.format(sys.version_info[0], sys.version_info[1], sys.version_info[2]))"
     OUTPUT_VARIABLE _specified_Python3_VERSION_MM
     ERROR_VARIABLE _specified_Python3_VERSION_MM_ERR
     OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
When Python3_EXECUTABLE is specified, then the allowed
range of versions that are searched for needs to
exactly match that reported by Python3_EXECUTABLE.

Could NOT find Python3: Found unsuitable version "3.11.13",
required range is "3.11...3.11"

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
