### PR TITLE
Use initializer lists, constexpr-if and switch in SobelOperator::GenerateCoefficients()

### DIFF
--- a/Modules/Core/Common/include/itkSobelOperator.h
+++ b/Modules/Core/Common/include/itkSobelOperator.h
@@ -101,6 +101,10 @@ public:
 
   itkOverrideGetNameOfClassMacro(SobelOperator);
 
+  static_assert(
+    VDimension == 2 || VDimension == 3,
+    "The ND version of the Sobel operator has not been implemented. Currently only 2D and 3D versions are available.");
+
   /** Creates the operator with length only in the specified direction.
    * The radius of the operator will be 0 except along the axis on which
    * the operator will work.

--- a/Modules/Core/Common/include/itkSobelOperator.hxx
+++ b/Modules/Core/Common/include/itkSobelOperator.hxx
@@ -28,42 +28,39 @@ SobelOperator<TPixel, VDimension, TAllocator>::Fill(const CoefficientVector & co
 {
   this->InitializeToZero();
 
-  if constexpr (VDimension == 2 || VDimension == 3)
+  // Note that this code is only good for 2d and 3d operators.  Places the
+  // coefficients in the exact center of the neighborhood
+  const unsigned int center = this->GetCenterNeighborhoodIndex();
+
+  if constexpr (VDimension == 2)
   {
-    // Note that this code is only good for 2d and 3d operators.  Places the
-    // coefficients in the exact center of the neighborhood
-    const unsigned int center = this->GetCenterNeighborhoodIndex();
-
-    if constexpr (VDimension == 3)
+    unsigned int coeff_index = 0;
+    for (int y = -1; y <= 1; ++y)
     {
-      unsigned int coeff_index = 0;
-      for (int z = -1; z <= 1; ++z)
+      for (int x = -1; x <= 1; ++x)
       {
-        for (int y = -1; y <= 1; ++y)
-        {
-          for (int x = -1; x <= 1; ++x)
-          {
-            const int pos = center + z * this->GetStride(2) + y * this->GetStride(1) + x * this->GetStride(0);
+        const int pos = center + y * this->GetStride(1) + x * this->GetStride(0);
+        // Note, The following line copies the double precision
+        // coefficients of SobelOperator to the pixel type
+        // of the neighborhood operator which may not support
+        // negative numbers, or floating point numbers.
+        this->operator[](pos) = static_cast<TPixel>(coeff[coeff_index]);
 
-            this->operator[](pos) = static_cast<TPixel>(coeff[coeff_index]);
-
-            ++coeff_index;
-          }
-        }
+        ++coeff_index;
       }
     }
-    else // So now VDimension == 2
+  }
+  if constexpr (VDimension == 3)
+  {
+    unsigned int coeff_index = 0;
+    for (int z = -1; z <= 1; ++z)
     {
-      unsigned int coeff_index = 0;
       for (int y = -1; y <= 1; ++y)
       {
         for (int x = -1; x <= 1; ++x)
         {
-          const int pos = center + y * this->GetStride(1) + x * this->GetStride(0);
-          // Note, The following line copies the double precision
-          // coefficients of SobelOperator to the pixel type
-          // of the neighborhood operator which may not support
-          // negative numbers, or floating point numbers.
+          const int pos = center + z * this->GetStride(2) + y * this->GetStride(1) + x * this->GetStride(0);
+
           this->operator[](pos) = static_cast<TPixel>(coeff[coeff_index]);
 
           ++coeff_index;
@@ -71,20 +68,17 @@ SobelOperator<TPixel, VDimension, TAllocator>::Fill(const CoefficientVector & co
       }
     }
   }
-  else
-  {
-    itkExceptionStringMacro("The ND version of the Sobel operator is not yet implemented.  Currently only the 2D and "
-                            "3D versions are available.");
-  }
 }
 
 template <typename TPixel, unsigned int VDimension, typename TAllocator>
 auto
 SobelOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> CoefficientVector
 {
+  const unsigned int direction = this->GetDirection();
+
   if constexpr (VDimension == 2)
   {
-    switch (this->GetDirection())
+    switch (direction)
     {
       case 0:
         return { -1, 0, 1, -2, 0, 2, -1, 0, 1 };
@@ -94,7 +88,7 @@ SobelOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> Coeffic
   }
   if constexpr (VDimension == 3)
   {
-    switch (this->GetDirection())
+    switch (direction)
     {
       case 0:
         return { -1, 0, 1, -3, 0, 3, -1, 0, 1, -3, 0, 3, -6, 0, 6, -3, 0, 3, -1, 0, 1, -3, 0, 3, -1, 0, 1 };
@@ -104,8 +98,8 @@ SobelOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> Coeffic
         return { -1, -3, -1, -3, -6, -3, -1, -3, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 1, 3, 6, 3, 1, 3, 1 };
     }
   }
-  itkExceptionStringMacro(
-    "The ND version of the Sobel operator has not been implemented. Currently only 2D and 3D versions are available.");
+  itkExceptionMacro("The direction value (" << direction << ") should be less than the dimensionality (" << VDimension
+                                            << ").");
 }
 } // namespace itk
 

--- a/Modules/Core/Common/test/itkSobelOperatorTest.cxx
+++ b/Modules/Core/Common/test/itkSobelOperatorTest.cxx
@@ -26,7 +26,6 @@ itkSobelOperatorTest(int, char *[])
 
   constexpr unsigned int Dimension2D{ 2 };
   constexpr unsigned int Dimension3D{ 3 };
-  constexpr unsigned int Dimension4D{ 4 };
 
   using PixelType = float;
 
@@ -130,16 +129,6 @@ itkSobelOperatorTest(int, char *[])
       ITK_TEST_EXPECT_EQUAL(expectedValuesZ[i], sobelOperator[i]);
       ITK_TEST_EXPECT_EQUAL(expectedValuesZ[i], sobelOperator.GetElement(i));
     }
-  }
-
-  {
-    using SobelOperatorType = itk::SobelOperator<PixelType, Dimension4D>;
-    SobelOperatorType sobelOperator;
-
-    constexpr unsigned long direction{ 0 };
-    sobelOperator.SetDirection(direction);
-    auto radius = itk::Size<Dimension4D>::Filled(1);
-    ITK_TRY_EXPECT_EXCEPTION(sobelOperator.CreateToRadius(radius));
   }
 
   std::cout << "Test finished." << std::endl;


### PR DESCRIPTION
Replaced groups of consecutive `CoefficientVector::push_back` calls with `return` statements that simply initialize the CoefficientVector by an initializer list of those coefficients.

Used constexpr-`if` and `switch` blocks to avoid calling `this->GetDirection()` repeatedly during one and the same
execution of the function.