### PR TITLE
STYLE: Remove `/*one-line-declaration*/` comments

### DIFF
--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -856,9 +856,9 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::Compute3x3EigenAnalys
   // n = (I1/3)^2 - I2/3
   // s = (I1/3)^3 - I1*I2/6 + I3/2
 
-  RealTensorValueT n;     /*one-line-declaration*/
-  RealTensorValueT sqrtn; /*one-line-declaration*/
-  RealTensorValueT s;     /*one-line-declaration*/
+  RealTensorValueT n;
+  RealTensorValueT sqrtn;
+  RealTensorValueT s;
   n = I1div3 * I1div3 - I2 / 3;
   s = I1div3 * I1div3 * I1div3 - I1 * I2 / 6 + I3 / 2;
   sqrtn = std::sqrt(n);

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
@@ -844,7 +844,7 @@ FlatStructuringElement<VDimension>::GeneratePolygon(itk::FlatStructuringElement<
         // Find a line perpendicular to each face
         LType3 A = FacetArray[j].P2 - FacetArray[j].P1;
         LType3 B = FacetArray[j].P3 - FacetArray[j].P1;
-        LType3 L; /*one-line-declaration*/
+        LType3 L;
         L[0] = A[1] * B[2] - B[1] * A[2];
         L[1] = B[0] * A[2] - A[0] * B[2];
         L[2] = A[0] * B[1] - B[0] * A[1];

--- a/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanUtilities.hxx
@@ -150,8 +150,8 @@ DoFace(typename TImage::ConstPointer             input,
   for (unsigned int it = 0; it < face.GetNumberOfPixels(); ++it)
   {
     const typename TImage::IndexType Ind = dumbImg->ComputeIndex(it);
-    unsigned int                     start = 0; /*one-line-declaration*/
-    unsigned int                     end = 0;   /*one-line-declaration*/
+    unsigned int                     start = 0;
+    unsigned int                     end = 0;
     if (FillLineBuffer<TImage, TBres, TLine>(input, Ind, NormLine, tol, LineOffsets, AllImage, pixbuffer, start, end))
     {
       const unsigned int len = end - start + 1;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
@@ -181,7 +181,7 @@ public:
   void
   AddPoint(const PointType & iP, const VectorType & iN, const CoordType & iWeight = static_cast<CoordType>(1.))
   {
-    unsigned int    k(0); /*one-line-declaration*/
+    unsigned int    k(0);
     const CoordType d = -iN * iP.GetVectorFromOrigin();
     for (unsigned int dim1 = 0; dim1 < PointDimension; ++dim1)
     {

--- a/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
@@ -89,13 +89,13 @@ RecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetUp(ScalarRealType sp
   constexpr ScalarRealType W2{ 2.0787 };
   constexpr ScalarRealType L2{ -1.3732 };
 
-  ScalarRealType SD; /*one-line-declaration*/
-  ScalarRealType DD; /*one-line-declaration*/
-  ScalarRealType ED; /*one-line-declaration*/
+  ScalarRealType SD;
+  ScalarRealType DD;
+  ScalarRealType ED;
   this->ComputeDCoefficients(sigmad, W1, L1, W2, L2, SD, DD, ED);
-  ScalarRealType SN; /*one-line-declaration*/
-  ScalarRealType DN; /*one-line-declaration*/
-  ScalarRealType EN; /*one-line-declaration*/
+  ScalarRealType SN;
+  ScalarRealType DN;
+  ScalarRealType EN;
 
   switch (m_Order)
   {
@@ -145,20 +145,20 @@ RecursiveGaussianImageFilter<TInputImage, TOutputImage>::SetUp(ScalarRealType sp
       }
       // Approximation of convolution with the second derivative of a
       // Gaussian.
-      ScalarRealType N0_0; /*one-line-declaration*/
-      ScalarRealType N1_0; /*one-line-declaration*/
-      ScalarRealType N2_0; /*one-line-declaration*/
-      ScalarRealType N3_0; /*one-line-declaration*/
-      ScalarRealType N0_2; /*one-line-declaration*/
-      ScalarRealType N1_2; /*one-line-declaration*/
-      ScalarRealType N2_2; /*one-line-declaration*/
-      ScalarRealType N3_2; /*one-line-declaration*/
-      ScalarRealType SN0;  /*one-line-declaration*/
-      ScalarRealType DN0;  /*one-line-declaration*/
-      ScalarRealType EN0;  /*one-line-declaration*/
-      ScalarRealType SN2;  /*one-line-declaration*/
-      ScalarRealType DN2;  /*one-line-declaration*/
-      ScalarRealType EN2;  /*one-line-declaration*/
+      ScalarRealType N0_0;
+      ScalarRealType N1_0;
+      ScalarRealType N2_0;
+      ScalarRealType N3_0;
+      ScalarRealType N0_2;
+      ScalarRealType N1_2;
+      ScalarRealType N2_2;
+      ScalarRealType N3_2;
+      ScalarRealType SN0;
+      ScalarRealType DN0;
+      ScalarRealType EN0;
+      ScalarRealType SN2;
+      ScalarRealType DN2;
+      ScalarRealType EN2;
       ComputeNCoefficients(sigmad, A1[0], B1[0], W1, L1, A2[0], B2[0], W2, L2, N0_0, N1_0, N2_0, N3_0, SN0, DN0, EN0);
       ComputeNCoefficients(sigmad, A1[2], B1[2], W1, L1, A2[2], B2[2], W2, L2, N0_2, N1_2, N2_2, N3_2, SN2, DN2, EN2);
 


### PR DESCRIPTION
Nowadays, it is common practice to have each local variable declaration on a separate line, so these comments are no longer necessary.