### PR TITLE
COMP: Fix doc-string of TreeIteratorBase::RemoveChild from Deprecated

### DIFF
--- a/Modules/Compatibility/Deprecated/include/itkTreeIteratorBase.h
+++ b/Modules/Compatibility/Deprecated/include/itkTreeIteratorBase.h
@@ -147,7 +147,7 @@ public:
   /** Remove a child.
    *
    * Removes its child nodes as well.
-   * /
+   */
   virtual bool
   RemoveChild(int number);
 


### PR DESCRIPTION
Problem inadvertently introduced by d58bf56fe2320fe3c7a451c96e3d8cd5e7c68358.

The error message was:
```log
C:\Misc\ITK-patches-rel\Modules\Compatibility\Deprecated\include\itkTreeIteratorBase.hxx(238,30): error C2039: 'RemoveChild': is not a member of 'itk::TreeIteratorBase<TTreeType>' C:\Misc\ITK-patches-rel\Modules\Compatibility\Deprecated\include\itkTreeIteratorBase.hxx(238,30): error C2039: 'RemoveChild': is not a member of 'itk::TreeIteratorBase<TTreeType>'
  (compiling source file '../../../../../ITK-patches-rel/Modules/Compatibility/Deprecated/test/itkTreeContainerTest.cxx')
      C:\Misc\ITK-patches-rel\Modules\Compatibility\Deprecated\include\itkTreeIteratorBase.h(68,27):
      see declaration of 'itk::TreeIteratorBase<TTreeType>'
C:\Misc\ITK-patches-rel\Modules\Compatibility\Deprecated\include\itkTreeIteratorBase.hxx(239,1): error C2447: '{': missing function header (old-style formal list?)
  (compiling source file '../../../../../ITK-patches-rel/Modules/Compatibility/Deprecated/test/itkTreeContainerTest.cxx')
  (compiling source file '../../../../../ITK-patches-rel/Modules/Compatibility/Deprecated/test/itkTreeContainerTest2.cxx')
      C:\Misc\ITK-patches-rel\Modules\Compatibility\Deprecated\include\itkTreeIteratorBase.h(68,27):
      see declaration of 'itk::TreeIteratorBase<TTreeType>'
C:\Misc\ITK-patches-rel\Modules\Compatibility\Deprecated\include\itkTreeIteratorBase.hxx(239,1): error C2447: '{': missing function header (old-style formal list?)
  (compiling source file '../../../../../ITK-patches-rel/Modules/Compatibility/Deprecated/test/itkTreeContainerTest2.cxx')
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
