### PR TITLE
ENH: Add `FixedArray::empty()`, which always just returns false

### DIFF
--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -448,6 +448,12 @@ public:
     return VLength;
   }
 
+  [[nodiscard]] constexpr bool
+  empty() const noexcept
+  {
+    return false;
+  }
+
   /** Set all the elements of the container to the input value. */
   void
   Fill(const ValueType &);

--- a/Modules/Core/Common/test/itkFixedArrayGTest.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayGTest.cxx
@@ -356,3 +356,15 @@ TEST(FixedArray, ValueInitialized)
   expectEachElementValueInitialized(itk::FixedArray<float, 3>{});
   expectEachElementValueInitialized(itk::FixedArray<void *, 3>{});
 }
+
+
+// Tests that empty() always returns false for FixedArray.
+TEST(FixedArray, EmptyIsFalse)
+{
+  static_assert(!itk::FixedArray<int>{}.empty());
+  static_assert(!itk::FixedArray<float, 1>{}.empty());
+  static_assert(!itk::FixedArray<void *, 2>{}.empty());
+  static_assert(!itk::FixedArray<double>::Filled(1.0).empty());
+
+  EXPECT_FALSE(itk::FixedArray<int>({ 0, 1, 2 }).empty());
+}


### PR DESCRIPTION
In order to ease writing generic code.

`itk::Index`, `itk::Offset`, and `itk::Size` already have an `empty()` member function that just does `return false`.