### PR TITLE
STYLE: Replace `push_back` calls with list-initialization, in tests

### DIFF
--- a/Modules/Core/Common/test/itkDerivativeOperatorTest.cxx
+++ b/Modules/Core/Common/test/itkDerivativeOperatorTest.cxx
@@ -90,10 +90,7 @@ itkDerivativeOperatorTest(int, char *[])
   ITK_TEST_SET_GET_VALUE(order, op1.GetOrder());
 
 
-  OperatorType::CoefficientVector expected1;
-  expected1.push_back(0.5);
-  expected1.push_back(0.0);
-  expected1.push_back(-0.5);
+  OperatorType::CoefficientVector expected1{ 0.5, 0.0, -0.5 };
 
   // Check actual coefficient values
   if (!op1.CheckCoefficients(expected1))
@@ -126,10 +123,7 @@ itkDerivativeOperatorTest(int, char *[])
   }
 
   // Test second order
-  OperatorType::CoefficientVector expected2;
-  expected2.push_back(1);
-  expected2.push_back(-2);
-  expected2.push_back(1);
+  OperatorType::CoefficientVector expected2{ 1, -2, 1 };
 
   OperatorType op2;
 

--- a/Modules/Core/Common/test/itkPeriodicBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkPeriodicBoundaryConditionTest.cxx
@@ -284,10 +284,7 @@ itkPeriodicBoundaryConditionTest(int, char *[])
   IterType              testIter(radius, testImage, testRegion);
   BoundaryConditionType boundaryCondition;
   testIter.OverrideBoundaryCondition(&boundaryCondition);
-  std::vector<IterType::OffsetType> back;
-  back.push_back({ { -1, 0 } });
-  back.push_back({ { 0, -1 } });
-  back.push_back({ { 0, 0 } });
+  std::vector<IterType::OffsetType> back{ { { -1, 0 } }, { { 0, -1 } }, { { 0, 0 } } };
   testIter.SetNeedToUseBoundaryCondition(true);
   testIter.GoToBegin();
   float sum = 0.0f;

--- a/Modules/Core/Common/test/itkPriorityQueueTest.cxx
+++ b/Modules/Core/Common/test/itkPriorityQueueTest.cxx
@@ -35,20 +35,7 @@ itkPriorityQueueTest(int, char *[])
   using MaxPQType = itk::PriorityQueueContainer<MaxPQElementType, MaxPQElementType, double, ElementIdentifier>;
   auto max_priority_queue = MaxPQType::New();
 
-  std::list<double> sequence;
-  sequence.push_back(-0.1);
-  sequence.push_back(0.1);
-  sequence.push_back(0.4);
-  sequence.push_back(-0.2);
-  sequence.push_back(-0.3);
-  sequence.push_back(0.3);
-  sequence.push_back(0.2);
-  sequence.push_back(0.5);
-  sequence.push_back(-0.6);
-  sequence.push_back(-0.5);
-  sequence.push_back(0.6);
-  sequence.push_back(1.);
-  sequence.push_back(-1.);
+  std::list<double> sequence{ -0.1, 0.1, 0.4, -0.2, -0.3, 0.3, 0.2, 0.5, -0.6, -0.5, 0.6, 1., -1. };
 
   auto   it = sequence.begin();
   size_t i = 0;

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorTest.cxx
@@ -408,10 +408,7 @@ itkSymmetricSecondRankTensorTest(int, char *[])
     tensor3D(2, 2) = 29.0;
 
     auto                matrix3D = itk::MakeFilled<Double3DMatrixType>(1.0);
-    std::vector<double> ans;
-    ans.push_back(26);
-    ans.push_back(23);
-    ans.push_back(36);
+    std::vector<double> ans{ 26, 23, 36 };
 
     Double3DMatrixType result1 = tensor3D.PreMultiply(matrix3D);
     std::cout << result1 << std::endl;

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshAddFaceTest1.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshAddFaceTest1.cxx
@@ -455,12 +455,7 @@ itkQuadEdgeMeshAddFaceTest1(int argc, char * argv[])
     //     pid[i] = mesh->AddPoint( points[i] );
     //     }
 
-    PointIdList quadPointIds;
-
-    quadPointIds.push_back(pid[0]);
-    quadPointIds.push_back(pid[2]);
-    quadPointIds.push_back(pid[3]);
-    quadPointIds.push_back(pid[4]);
+    PointIdList quadPointIds{ pid[0], pid[2], pid[3], pid[4] };
 
     MeshType::QEPrimal * quadFace = mesh->AddFace(quadPointIds);
 
@@ -481,12 +476,7 @@ itkQuadEdgeMeshAddFaceTest1(int argc, char * argv[])
       pid[i] = mesh->AddPoint(points[i]);
     }
 
-    PointIdList quadPointIds2;
-
-    quadPointIds2.push_back(pid[0]);
-    quadPointIds2.push_back(pid[2]);
-    quadPointIds2.push_back(pid[4]);
-    quadPointIds2.push_back(pid[3]);
+    PointIdList quadPointIds2{ pid[0], pid[2], pid[4], pid[3] };
 
     MeshType::QEPrimal * quadFace2 = mesh->AddFace(quadPointIds2);
 
@@ -535,12 +525,7 @@ itkQuadEdgeMeshAddFaceTest1(int argc, char * argv[])
     //                                                        //
     std::cout << "Adding a face with five edges" << std::endl;
 
-    PointIdList fivePointIds;
-    fivePointIds.push_back(pid[0]);
-    fivePointIds.push_back(pid[1]);
-    fivePointIds.push_back(pid[2]);
-    fivePointIds.push_back(pid[3]);
-    fivePointIds.push_back(pid[4]);
+    PointIdList fivePointIds{ pid[0], pid[1], pid[2], pid[3], pid[4] };
 
     MeshType::QEPrimal * fiveFace = mesh->AddFace(fivePointIds);
 

--- a/Modules/Core/SpatialObjects/test/itkContourSpatialObjectPointTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkContourSpatialObjectPointTest.cxx
@@ -150,9 +150,7 @@ itkContourSpatialObjectPointTest(int, char *[])
     // Assign
     const ContourSpatialObjectPoint3DType pAssign = pOriginal;
 
-    std::vector<ContourSpatialObjectPoint3DType> pointVector;
-    pointVector.push_back(pCopy);
-    pointVector.push_back(pAssign);
+    std::vector<ContourSpatialObjectPoint3DType> pointVector{ pCopy, pAssign };
 
     for (const auto & pv : pointVector)
     {

--- a/Modules/Core/SpatialObjects/test/itkContourSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkContourSpatialObjectTest.cxx
@@ -74,11 +74,7 @@ itkContourSpatialObjectTest(int, char *[])
   // Test Control Points (SetControlPoints, GetControlPoints,
   // GetNumberOfControlPoints, GetControlPoint)
   //
-  SpatialObjectType::ContourPointListType controlPointList;
-  controlPointList.push_back(pt1);
-  controlPointList.push_back(pt2);
-  controlPointList.push_back(pt3);
-  controlPointList.push_back(pt4);
+  SpatialObjectType::ContourPointListType controlPointList{ pt1, pt2, pt3, pt4 };
 
   contour->SetControlPoints(controlPointList);
 
@@ -191,9 +187,7 @@ itkContourSpatialObjectTest(int, char *[])
   pnt[1] = 0;
   intPt2.SetPositionInObjectSpace(pnt);
 
-  SpatialObjectType::ContourPointListType interpPointList;
-  interpPointList.push_back(intPt1);
-  interpPointList.push_back(intPt2);
+  SpatialObjectType::ContourPointListType interpPointList{ intPt1, intPt2 };
 
   contour->SetControlPoints(interpPointList);
   contour->SetInterpolationMethod(SpatialObjectType::InterpolationMethodEnum::NO_INTERPOLATION);

--- a/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
@@ -469,8 +469,7 @@ itkDTITubeSpatialObjectTest(int, char *[])
   using PointBasedType = itk::PointBasedSpatialObject<3>;
   auto                                       pBSO = PointBasedType::New();
   PointBasedType::SpatialObjectPointType     pnt;
-  PointBasedType::SpatialObjectPointListType ll;
-  ll.push_back(pnt);
+  PointBasedType::SpatialObjectPointListType ll{ pnt };
   pBSO->SetPoints(ll);
   pBSO->GetPoint(0);
   pBSO->Update();
@@ -532,9 +531,7 @@ itkDTITubeSpatialObjectTest(int, char *[])
     // Assign
     const TubePointType pAssign = pOriginal;
 
-    std::vector<TubePointType> pointVector;
-    pointVector.push_back(pCopy);
-    pointVector.push_back(pAssign);
+    std::vector<TubePointType> pointVector{ pCopy, pAssign };
 
     for (const auto & pv : pointVector)
     {

--- a/Modules/Core/SpatialObjects/test/itkLineSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkLineSpatialObjectTest.cxx
@@ -181,9 +181,7 @@ itkLineSpatialObjectTest(int, char *[])
     // Assign
     const LinePointType pAssign = pOriginal;
 
-    std::vector<LinePointType> pointVector;
-    pointVector.push_back(pCopy);
-    pointVector.push_back(pAssign);
+    std::vector<LinePointType> pointVector{ pCopy, pAssign };
 
     for (const auto & pv : pointVector)
     {

--- a/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
@@ -196,9 +196,7 @@ itkSurfaceSpatialObjectTest(int, char *[])
     // Assign
     const SurfacePointType pAssign = pOriginal;
 
-    std::vector<SurfacePointType> pointVector;
-    pointVector.push_back(pCopy);
-    pointVector.push_back(pAssign);
+    std::vector<SurfacePointType> pointVector{ pCopy, pAssign };
 
     for (const auto & pv : pointVector)
     {

--- a/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
@@ -484,8 +484,7 @@ itkTubeSpatialObjectTest(int, char *[])
   using PointBasedType = itk::PointBasedSpatialObject<3>;
   auto                                       pBSO = PointBasedType::New();
   PointBasedType::SpatialObjectPointType     pnt;
-  PointBasedType::SpatialObjectPointListType ll;
-  ll.push_back(pnt);
+  PointBasedType::SpatialObjectPointListType ll{ pnt };
   pBSO->SetPoints(ll);
   pBSO->GetPoint(0);
   pBSO->Update();
@@ -543,9 +542,7 @@ itkTubeSpatialObjectTest(int, char *[])
     // Assign
     const TubePointType pAssign = pOriginal;
 
-    std::vector<TubePointType> pointVector;
-    pointVector.push_back(pCopy);
-    pointVector.push_back(pAssign);
+    std::vector<TubePointType> pointVector{ pCopy, pAssign };
 
     for (const auto & pv : pointVector)
     {

--- a/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
+++ b/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
@@ -208,8 +208,7 @@ ProcessArguments(int * argc, ArgumentStringType * argv, ProcessedOutputType * pr
         std::cerr << "Warning: argument does not appear to be a valid md5 hash \"" << md5hash0 << "\"." << std::endl;
       }
 
-      std::vector<std::string> hashVector;
-      hashVector.push_back(md5hash0);
+      std::vector<std::string> hashVector{ md5hash0 };
 
       *argv += 3;
       *argc -= 3;

--- a/Modules/Filtering/GPUAnisotropicSmoothing/test/itkGPUGradientAnisotropicDiffusionImageFilterTest.cxx
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/test/itkGPUGradientAnisotropicDiffusionImageFilterTest.cxx
@@ -67,12 +67,7 @@ runGPUGradientAnisotropicDiffusionImageFilterTest(const std::string & inFile, co
   // -------
 
   // test 1~8 threads for CPU
-  std::vector<int> nThreadVec;
-  nThreadVec.push_back(1);
-  nThreadVec.push_back(2);
-  nThreadVec.push_back(4);
-  nThreadVec.push_back(8);
-  nThreadVec.push_back(128);
+  std::vector<int> nThreadVec{ 1, 2, 4, 8, 128 };
 
   for (unsigned int idx = 0; idx < nThreadVec.size(); ++idx)
   {

--- a/Modules/Filtering/ImageStatistics/test/itkBinaryProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkBinaryProjectionImageFilterTest.cxx
@@ -49,9 +49,7 @@ itkBinaryProjectionImageFilterTest(int argc, char * argv[])
   using LabelerType = itk::ThresholdLabelerImageFilter<ImageType, ImageType>;
   auto labeler = LabelerType::New();
   labeler->SetInput(reader->GetOutput());
-  LabelerType::RealThresholdVector thresholds;
-  thresholds.push_back(100);
-  thresholds.push_back(200);
+  LabelerType::RealThresholdVector thresholds{ 100, 200 };
   labeler->SetRealThresholds(thresholds);
 
   using ChangeType = itk::ChangeLabelImageFilter<ImageType, ImageType>;

--- a/Modules/Filtering/ImageStatistics/test/itkImagePCADecompositionCalculatorTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImagePCADecompositionCalculatorTest.cxx
@@ -273,9 +273,7 @@ itkImagePCADecompositionCalculatorTest(int, char *[])
   // Set the parameters of the clusterer
   //----------------------------------------------------------------------
   // add the first two vectors to the projection basis
-  ImagePCAShapeModelEstimatorType::BasisImagePointerVector basis;
-  basis.push_back(image1);
-  basis.push_back(image2);
+  ImagePCAShapeModelEstimatorType::BasisImagePointerVector basis{ image1, image2 };
   decomposer->SetBasisImages(basis);
 
   ImagePCAShapeModelEstimatorType::BasisImagePointerVector basisObtained = decomposer->GetBasisImages();

--- a/Modules/Filtering/ImageStatistics/test/itkProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkProjectionImageFilterTest.cxx
@@ -91,9 +91,7 @@ itkProjectionImageFilterTest(int argc, char * argv[])
   using LabelerType = itk::ThresholdLabelerImageFilter<ImageType, ImageType>;
   auto labeler = LabelerType::New();
   labeler->SetInput(reader->GetOutput());
-  LabelerType::RealThresholdVector thresholds;
-  thresholds.push_back(100);
-  thresholds.push_back(200);
+  LabelerType::RealThresholdVector thresholds{ 100, 200 };
   labeler->SetRealThresholds(thresholds);
 
   using ChangeType = itk::ChangeLabelImageFilter<ImageType, ImageType>;

--- a/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsCalculatorTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsCalculatorTest.cxx
@@ -52,11 +52,7 @@ itkOtsuMultipleThresholdsCalculatorTest(int argc, char * argv[])
 
   // Create vector of values
   using ValuesVectorType = std::vector<MeasurementType>;
-  ValuesVectorType values;
-  values.push_back(8.0);
-  values.push_back(16.0);
-  values.push_back(32.0);
-  values.push_back(48.0);
+  ValuesVectorType values{ 8.0, 16.0, 32.0, 48.0 };
 
   constexpr MeasurementType range{ 2.0 };
 

--- a/Modules/Filtering/Thresholding/test/itkThresholdLabelerImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkThresholdLabelerImageFilterTest.cxx
@@ -53,28 +53,16 @@ ThresholdLabelerImageFilterTestHelper(bool useRealTypeThresholds)
 
   // Stripe y indexes
   using IndexValueVectorType = std::vector<InputImageType::IndexType::IndexValueType>;
-  IndexValueVectorType yindexes;
-  yindexes.push_back(0);
-  yindexes.push_back(8);
-  yindexes.push_back(16);
-  yindexes.push_back(24);
+  IndexValueVectorType yindexes{ 0, 8, 16, 24 };
 
   // Set the values for each stripe
-  std::vector<InputPixelType> values;
-  values.push_back(0.5);
-  values.push_back(1.5);
-  values.push_back(2.5);
-  values.push_back(3.5);
+  std::vector<InputPixelType> values{ 0.5, 1.5, 2.5, 3.5 };
 
   // Set the value for the offset
   constexpr unsigned long offset{ 4 };
 
   //  Set the labels vector
-  std::vector<LabeledPixelType> labels;
-  labels.push_back(0 + offset);
-  labels.push_back(1 + offset);
-  labels.push_back(2 + offset);
-  labels.push_back(3 + offset);
+  std::vector<LabeledPixelType> labels{ 0 + offset, 1 + offset, 2 + offset, 3 + offset };
 
   // Fill in the image
   {
@@ -102,10 +90,7 @@ ThresholdLabelerImageFilterTestHelper(bool useRealTypeThresholds)
   labelerFilter->SetInput(inputImage);
 
   // Test exception when providing unsorted thresholds
-  std::vector<LabelerFilterType::RealThresholdType> unsrtThresholds;
-  unsrtThresholds.push_back(2.0);
-  unsrtThresholds.push_back(1.0);
-  unsrtThresholds.push_back(3.0);
+  std::vector<LabelerFilterType::RealThresholdType> unsrtThresholds{ 2.0, 1.0, 3.0 };
 
   labelerFilter->SetRealThresholds(unsrtThresholds);
 
@@ -114,10 +99,7 @@ ThresholdLabelerImageFilterTestHelper(bool useRealTypeThresholds)
   if (!useRealTypeThresholds)
   {
     // Set the thresholds between values
-    std::vector<InputPixelType> thresholds;
-    thresholds.push_back(1.0);
-    thresholds.push_back(2.0);
-    thresholds.push_back(3.0);
+    std::vector<InputPixelType> thresholds{ 1.0, 2.0, 3.0 };
 
     labelerFilter->SetThresholds(thresholds);
     // ITK_TEST_SET_GET_VALUE( thresholds, labelerFilter->GetThresholds() );
@@ -125,10 +107,7 @@ ThresholdLabelerImageFilterTestHelper(bool useRealTypeThresholds)
   else
   {
     // Set the thresholds between values
-    std::vector<LabelerFilterType::RealThresholdType> thresholds;
-    thresholds.push_back(1.0);
-    thresholds.push_back(2.0);
-    thresholds.push_back(3.0);
+    std::vector<LabelerFilterType::RealThresholdType> thresholds{ 1.0, 2.0, 3.0 };
 
     labelerFilter->SetRealThresholds(thresholds);
     // ITK_TEST_SET_GET_VALUE( thresholds, labelerFilter->GetRealThresholds() );

--- a/Modules/IO/CSV/test/itkCSVArray2DFileReaderTest.cxx
+++ b/Modules/IO/CSV/test/itkCSVArray2DFileReaderTest.cxx
@@ -243,11 +243,7 @@ itkCSVArray2DFileReaderTest(int argc, char * argv[])
   // Test a row (using index access)
   const std::vector<double> test_row_1 = dfo->GetRow(1);
 
-  std::vector<double> row_1;
-  row_1.push_back(99);
-  row_1.push_back(0);
-  row_1.push_back(3.75);
-  row_1.push_back(0.008);
+  std::vector<double> row_1{ 99, 0, 3.75, 0.008 };
 
   if (!testVector(row_1, test_row_1))
   {
@@ -260,12 +256,7 @@ itkCSVArray2DFileReaderTest(int argc, char * argv[])
   // Test a row (using string access)
   const std::vector<double> test_row_Jan = dfo->GetRow("Jan");
 
-  std::vector<double> row_Jan;
-  row_Jan.push_back(nan);
-  row_Jan.push_back(1e+9);
-  row_Jan.push_back(5);
-  row_Jan.push_back(9);
-  row_Jan.push_back(6.1);
+  std::vector<double> row_Jan{ nan, 1e+9, 5, 9, 6.1 };
 
   if (!testVector(row_Jan, test_row_Jan))
   {
@@ -278,10 +269,7 @@ itkCSVArray2DFileReaderTest(int argc, char * argv[])
   // Test a column (using index)
   const std::vector<double> test_col_2 = dfo->GetColumn(2);
 
-  std::vector<double> col_2;
-  col_2.push_back(5);
-  col_2.push_back(3.75);
-  col_2.push_back(9);
+  std::vector<double> col_2{ 5, 3.75, 9 };
 
   if (!testVector(col_2, test_col_2))
   {
@@ -295,10 +283,7 @@ itkCSVArray2DFileReaderTest(int argc, char * argv[])
   // Test a column (using string access)
   const std::vector<double> test_col_Africa = dfo->GetColumn("Africa");
 
-  std::vector<double> col_Africa;
-  col_Africa.push_back(nan);
-  col_Africa.push_back(99);
-  col_Africa.push_back(1);
+  std::vector<double> col_Africa{ nan, 99, 1 };
 
   if (!testVector(col_Africa, test_col_Africa))
   {

--- a/Modules/IO/ImageBase/test/itkImageFileWriterPastingTest2.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterPastingTest2.cxx
@@ -110,16 +110,9 @@ itkImageFileWriterPastingTest2(int argc, char * argv[])
 
   // create a valid region from the largest
   itk::ImageIORegion            ioregion(3);
-  itk::ImageIORegion::IndexType index;
-
-  index.push_back(pasteIndex[0]);
-  index.push_back(pasteIndex[1]);
-  index.push_back(pasteIndex[2]);
+  itk::ImageIORegion::IndexType index{ pasteIndex[0], pasteIndex[1], pasteIndex[2] };
   ioregion.SetIndex(index);
-  itk::ImageIORegion::SizeType size;
-  size.push_back(pasteSize[0]);
-  size.push_back(pasteSize[1]);
-  size.push_back(pasteSize[2]);
+  itk::ImageIORegion::SizeType size{ pasteSize[0], pasteSize[1], pasteSize[2] };
   ioregion.SetSize(size);
   writer->SetIORegion(ioregion);
 

--- a/Modules/IO/ImageBase/test/itkUnicodeIOTest.cxx
+++ b/Modules/IO/ImageBase/test/itkUnicodeIOTest.cxx
@@ -34,8 +34,7 @@ checkAlphaExists()
 {
 #if LOCAL_USE_WIN32_WOPEN
   // mingw has _wfopen
-  std::wstring wstr;
-  wstr.push_back((wchar_t)(0x03B1));
+  std::wstring wstr{ (wchar_t)(0x03B1) };
   wstr += L".txt";
   FILE * tmp = _wfopen(wstr.c_str(), L"r");
 #else
@@ -61,8 +60,7 @@ removeAlpha()
 {
 #if LOCAL_USE_WIN32_WOPEN
   // mingw has _wunlink
-  std::wstring wstr;
-  wstr.push_back((wchar_t)(0x03B1));
+  std::wstring wstr{ (wchar_t)(0x03B1) };
   wstr += L".txt";
   return (_wunlink(wstr.c_str()) != -1);
 #else
@@ -100,8 +98,7 @@ main(int, char *[])
 
 #if LOCAL_USE_WIN32_WOPEN
   // Check that the string to wide string conversion works
-  std::wstring utf16_str;
-  utf16_str.push_back((wchar_t)(0x03B1));
+  std::wstring utf16_str{ (wchar_t)(0x03B1) };
   utf16_str += L".txt";
   const std::wstring fromutf8_utf16_str = itk::i18n::Utf8StringToWString(utf8_str);
 
@@ -112,9 +109,7 @@ main(int, char *[])
   }
 
   // Create a non utf8 std::string
-  std::string bad_utf8_str;
-  bad_utf8_str.push_back('\xCE');
-  bad_utf8_str.push_back('\xCE');
+  std::string bad_utf8_str{ '\xCE', '\xCE' };
   bad_utf8_str += ".txt";
 
   // Check if we actually find it is a non-valid utf-8 string

--- a/Modules/IO/Meta/test/itkMetaImageStreamingWriterIOTest.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageStreamingWriterIOTest.cxx
@@ -107,15 +107,9 @@ itkMetaImageStreamingWriterIOTest(int argc, char * argv[])
     // Write the image
     itk::ImageIORegion ioregion(3);
 
-    itk::ImageIORegion::IndexType index2;
-    index2.push_back(index[0]);
-    index2.push_back(index[1]);
-    index2.push_back(index[2]);
+    itk::ImageIORegion::IndexType index2{ index[0], index[1], index[2] };
 
-    itk::ImageIORegion::SizeType size2;
-    size2.push_back(size[0]);
-    size2.push_back(size[1]);
-    size2.push_back(size[2]);
+    itk::ImageIORegion::SizeType size2{ size[0], size[1], size[2] };
 
     ioregion.SetIndex(index2);
     ioregion.SetSize(size2);

--- a/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest1.cxx
+++ b/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest1.cxx
@@ -58,8 +58,7 @@ itkShapedFloodFilledImageFunctionConditionalConstIteratorTest1(int argc, char * 
   index[0] = 29;
   index[1] = 47;
 
-  std::vector<IndexType> seedList;
-  seedList.push_back(index);
+  std::vector<IndexType> seedList{ index };
 
   RegionType region = reader->GetOutput()->GetBufferedRegion();
 

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainMapImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainMapImageFilterTest.cxx
@@ -49,9 +49,7 @@ itkLevelSetDomainMapImageFilterTest(int, char *[])
 
   for (unsigned int i = 0; i < 10; ++i)
   {
-    ListPixelType ll;
-    ll.push_back(i);
-    ll.push_back(i + 1);
+    ListPixelType ll{ static_cast<int>(i), static_cast<int>(i + 1) };
 
     index[0] = index[1] = i;
     input->SetPixel(index, ll);

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationBinaryMaskTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationBinaryMaskTermTest.cxx
@@ -96,8 +96,7 @@ itkLevelSetEquationBinaryMaskTermTest(int, char *[])
 
   const SparseLevelSetType::Pointer level_set1 = adaptor1->GetModifiableLevelSet();
 
-  IdListType list_ids;
-  list_ids.push_back(1);
+  IdListType list_ids{ 1 };
 
   auto id_image = IdListImageType::New();
   id_image->SetRegions(binary->GetLargestPossibleRegion());

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseExternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseExternalTermTest.cxx
@@ -105,8 +105,7 @@ itkLevelSetEquationChanAndVeseExternalTermTest(int argc, char * argv[])
 
   const SparseLevelSetType::Pointer level_set = adaptor->GetModifiableLevelSet();
 
-  IdListType list_ids;
-  list_ids.push_back(1);
+  IdListType list_ids{ 1 };
 
   auto id_image = IdListImageType::New();
   id_image->SetRegions(binary->GetLargestPossibleRegion());

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseInternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseInternalTermTest.cxx
@@ -108,8 +108,7 @@ itkLevelSetEquationChanAndVeseInternalTermTest(int argc, char * argv[])
 
   const SparseLevelSetType::Pointer level_set = adaptor->GetModifiableLevelSet();
 
-  IdListType list_ids;
-  list_ids.push_back(1);
+  IdListType list_ids{ 1 };
 
   auto id_image = IdListImageType::New();
   id_image->SetRegions(binary->GetLargestPossibleRegion());

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationCurvatureTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationCurvatureTermTest.cxx
@@ -103,8 +103,7 @@ itkLevelSetEquationCurvatureTermTest(int argc, char * argv[])
 
   const SparseLevelSetType::Pointer level_set = adaptor->GetModifiableLevelSet();
 
-  IdListType list_ids;
-  list_ids.push_back(1);
+  IdListType list_ids{ 1 };
 
   auto id_image = IdListImageType::New();
   id_image->SetRegions(binary->GetLargestPossibleRegion());

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationLaplacianTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationLaplacianTermTest.cxx
@@ -102,8 +102,7 @@ itkLevelSetEquationLaplacianTermTest(int argc, char * argv[])
 
   const SparseLevelSetType::Pointer level_set = adaptor->GetModifiableLevelSet();
 
-  IdListType list_ids;
-  list_ids.push_back(1);
+  IdListType list_ids{ 1 };
 
   auto id_image = IdListImageType::New();
   id_image->SetRegions(binary->GetLargestPossibleRegion());

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationOverlapPenaltyTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationOverlapPenaltyTermTest.cxx
@@ -103,9 +103,7 @@ itkLevelSetEquationOverlapPenaltyTermTest(int, char *[])
   const SparseLevelSetType::Pointer level_set1 = adaptor1->GetModifiableLevelSet();
   const SparseLevelSetType::Pointer level_set2 = adaptor2->GetModifiableLevelSet();
 
-  IdListType list_ids;
-  list_ids.push_back(1);
-  list_ids.push_back(2);
+  IdListType list_ids{ 1, 2 };
 
   auto id_image = IdListImageType::New();
   id_image->SetRegions(binary->GetLargestPossibleRegion());

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationPropagationTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationPropagationTermTest.cxx
@@ -102,8 +102,7 @@ itkLevelSetEquationPropagationTermTest(int argc, char * argv[])
 
   const SparseLevelSetType::Pointer level_set = adaptor->GetModifiableLevelSet();
 
-  IdListType list_ids;
-  list_ids.push_back(1);
+  IdListType list_ids{ 1 };
 
   auto id_image = IdListImageType::New();
   id_image->SetRegions(binary->GetLargestPossibleRegion());

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermContainerTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermContainerTest.cxx
@@ -110,8 +110,7 @@ itkLevelSetEquationTermContainerTest(int argc, char * argv[])
 
   const SparseLevelSetType::Pointer level_set = adaptor->GetModifiableLevelSet();
 
-  IdListType list_ids;
-  list_ids.push_back(1);
+  IdListType list_ids{ 1 };
 
   auto id_image = IdListImageType::New();
   id_image->SetRegions(binary->GetLargestPossibleRegion());

--- a/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetDenseImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetDenseImage2DTest.cxx
@@ -127,9 +127,7 @@ itkTwoLevelSetDenseImage2DTest(int argc, char * argv[])
   fastMarching->SetOutputSize(inputBufferedRegionSize);
   fastMarching->Update();
 
-  IdListType list_ids;
-  list_ids.push_back(1);
-  list_ids.push_back(2);
+  IdListType list_ids{ 1, 2 };
 
   auto id_image = IdListImageType::New();
   id_image->SetRegions(input->GetLargestPossibleRegion());

--- a/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetMalcolmImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetMalcolmImage2DTest.cxx
@@ -113,9 +113,7 @@ itkTwoLevelSetMalcolmImage2DTest(int argc, char * argv[])
   const SparseLevelSetType::Pointer level_set1 = adaptor1->GetModifiableLevelSet();
 
   // Create a list image specifying both level set ids
-  IdListType list_ids;
-  list_ids.push_back(1);
-  list_ids.push_back(2);
+  IdListType list_ids{ 1, 2 };
 
   auto id_image = IdListImageType::New();
   id_image->SetRegions(input->GetLargestPossibleRegion());

--- a/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetShiImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetShiImage2DTest.cxx
@@ -113,9 +113,7 @@ itkTwoLevelSetShiImage2DTest(int argc, char * argv[])
   const SparseLevelSetType::Pointer level_set1 = adaptor1->GetModifiableLevelSet();
 
   // Create a list image specifying both level set ids
-  IdListType list_ids;
-  list_ids.push_back(1);
-  list_ids.push_back(2);
+  IdListType list_ids{ 1, 2 };
 
   auto id_image = IdListImageType::New();
   id_image->SetRegions(input->GetLargestPossibleRegion());

--- a/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetWhitakerImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetWhitakerImage2DTest.cxx
@@ -115,9 +115,7 @@ itkTwoLevelSetWhitakerImage2DTest(int argc, char * argv[])
   const SparseLevelSetType::Pointer level_set1 = adaptor1->GetModifiableLevelSet();
 
   // Create a list image specifying both level set ids
-  IdListType list_ids;
-  list_ids.push_back(1);
-  list_ids.push_back(2);
+  IdListType list_ids{ 1, 2 };
 
   auto id_image = IdListImageType::New();
   id_image->SetRegions(input->GetLargestPossibleRegion());

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoIOTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoIOTest.cxx
@@ -434,9 +434,7 @@ test_OpenCVVideoIO(char *          input,
   std::cout << "OpenCVVIdeoIO::SetWriterParameters..." << std::endl;
 
   // Reset the saved parameters
-  std::vector<itk::SizeValueType> size;
-  size.push_back(width);
-  size.push_back(height);
+  std::vector<itk::SizeValueType> size{ width, height };
   opencvIO->SetWriterParameters(fps, size, fourCC, nChannels, itk::IOComponentEnum::UCHAR);
 
   // Make sure they set correctly

--- a/Modules/Video/BridgeVXL/test/itkVXLVideoIOTest.cxx
+++ b/Modules/Video/BridgeVXL/test/itkVXLVideoIOTest.cxx
@@ -441,9 +441,7 @@ test_VXLVideoIO(char *        input,
   std::cout << "VXLVIdeoIO::SetWriterParameters..." << std::endl;
 
   // Reset the saved parameters
-  std::vector<itk::SizeValueType> size;
-  size.push_back(width);
-  size.push_back(height);
+  std::vector<itk::SizeValueType> size{ width, height };
   vxlIO_write->SetWriterParameters(fps, size, fourCC, nChannels, itk::IOComponentEnum::UCHAR);
 
   // Make sure they set correctly

--- a/Modules/Video/IO/test/itkFileListVideoIOTest.cxx
+++ b/Modules/Video/IO/test/itkFileListVideoIOTest.cxx
@@ -198,9 +198,7 @@ test_FileListVideoIO(const char *  input,
   std::cout << "FileListVideoIO::SetWriterParameters..." << std::endl;
 
   // Reset the saved parameters
-  std::vector<itk::SizeValueType> size;
-  size.push_back(width);
-  size.push_back(height);
+  std::vector<itk::SizeValueType> size{ width, height };
   fileListIO->SetWriterParameters(fps, size, fourCC, nChannels, itk::IOComponentEnum::UCHAR);
 
   // Make sure they set correctly


### PR DESCRIPTION
Replaced code like

    ContainerType var;
    var.push_back(x);
    var.push_back(y);
    var.push_back(z);

With the equivalent list-initialization:

    ContainerType var{ x, y, z };

Using Notepad++, Replace in Files (Filters: `itk*Test*.cxx`; Search Mode: Regular expression), doing:

    Find what: ^( [ ]+)([^ ].* )(\w+);[\r\n]+\1\3\.+push_back\(([^ ].*)(\);)$
    Replace with: $1$2$3{ $4 };

And then repeatedly doing:

    Find what: ^( [ ]+)([^ ].* )(\w+)({ [^ ].*) };[\r\n]+\1\3\.+push_back\(([^ ].*)(\);)$
    Replace with: $1$2$3$4, $5 };