### PR TITLE
ENH: Add `static_assert(VLength > 0)` to `FixedArray`

### DIFF
--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -52,6 +52,8 @@ namespace itk
 template <typename TValue, unsigned int VLength = 3>
 class ITK_TEMPLATE_EXPORT FixedArray
 {
+  static_assert(VLength > 0);
+
 public:
   /** Length constant */
   static constexpr unsigned int Length = VLength;


### PR DESCRIPTION
Zero-length arrays were never actively supported by `itk::FixedArray`. `FixedArray` uses a C array, so if it would compile at all, it would depend on a non-standard compiler extension.

It appears unnecessary to support zero-length, given one of the main purposes of `itk::FixedArray`: being a common base class of Point, Vector, CovariantVector, RGBAPixel, RGBAPixel and SymmetricSecondRankTensor.