### PR TITLE
ENH: Add `front()` and `back()` to `FixedArray`

### DIFF
--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -313,6 +313,31 @@ public:
     return m_InternalArray[index];
   }
   /** @ITKEndGrouping */
+
+  [[nodiscard]] constexpr reference
+  front()
+  {
+    return m_InternalArray[0];
+  }
+
+  [[nodiscard]] constexpr const_reference
+  front() const
+  {
+    return m_InternalArray[0];
+  }
+
+  [[nodiscard]] constexpr reference
+  back()
+  {
+    return m_InternalArray[VLength - 1];
+  }
+
+  [[nodiscard]] constexpr const_reference
+  back() const
+  {
+    return m_InternalArray[VLength - 1];
+  }
+
   /** Return a pointer to the data. */
   ValueType *
   GetDataPointer()

--- a/Modules/Core/Common/test/itkFixedArrayGTest.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayGTest.cxx
@@ -368,3 +368,12 @@ TEST(FixedArray, EmptyIsFalse)
 
   EXPECT_FALSE(itk::FixedArray<int>({ 0, 1, 2 }).empty());
 }
+
+
+// Tests front() and back().
+TEST(FixedArray, CheckFrontAndBack)
+{
+  itk::RangeGTestUtilities::CheckFrontAndBack(itk::FixedArray<int, 1>{});
+  itk::RangeGTestUtilities::CheckFrontAndBack(itk::FixedArray<int>({ 0, 1, 2 }));
+  itk::RangeGTestUtilities::CheckFrontAndBack(itk::FixedArray<double>::Filled(std::numeric_limits<double>::max()));
+}

--- a/Modules/Core/Common/test/itkRangeGTestUtilities.h
+++ b/Modules/Core/Common/test/itkRangeGTestUtilities.h
@@ -223,6 +223,22 @@ public:
   }
 
 
+  template <typename TRange>
+  static void
+  CheckFrontAndBack(TRange && range)
+  {
+    ASSERT_FALSE(std::empty(range));
+
+    // Check that front() is at the begin, and back() is just before the end.
+    EXPECT_EQ(&range.front(), &*std::cbegin(range));
+    EXPECT_EQ(&range.back(), &*std::prev(std::cend(range)));
+
+    // Check that const and non-const overloads return a reference to the same element.
+    EXPECT_EQ(&std::as_const(range).front(), &range.front());
+    EXPECT_EQ(&std::as_const(range).back(), &range.back());
+  }
+
+
   // Checks that each element of the specified range is zero.
   template <typename TRange>
   static void


### PR DESCRIPTION
Similar to the corresponding member functions of `std::array`.