### PR TITLE
ENH: Add front() and back() GoogleTest unit tests to Index, Offset, Size

### DIFF
--- a/Modules/Core/Common/test/itkIndexGTest.cxx
+++ b/Modules/Core/Common/test/itkIndexGTest.cxx
@@ -102,3 +102,11 @@ TEST(Index, Make)
   const auto values = { 1, 2, 3, 4 };
   EXPECT_TRUE(std::equal(itkIndex.begin(), itkIndex.end(), values.begin(), values.end()));
 }
+
+
+// Tests front() and back().
+TEST(Index, CheckFrontAndBack)
+{
+  itk::RangeGTestUtilities::CheckFrontAndBack(itk::Index<1>{});
+  itk::RangeGTestUtilities::CheckFrontAndBack(itk::Index<>{ 1, 2 });
+}

--- a/Modules/Core/Common/test/itkOffsetGTest.cxx
+++ b/Modules/Core/Common/test/itkOffsetGTest.cxx
@@ -19,6 +19,7 @@
 // First include the header file to be tested:
 #include "itkOffset.h"
 #include "itkRangeGTestUtilities.h"
+#include <gtest/gtest.h>
 
 
 static_assert(itk::RangeGTestUtilities::CheckConstexprBeginAndEndOfContainer<itk::Offset<>>() &&
@@ -28,3 +29,11 @@ static_assert(itk::RangeGTestUtilities::CheckConstexprBeginAndEndOfContainer<itk
 static_assert(itk::RangeGTestUtilities::IsDistanceFromFrontToBackPlusOneEqualToSize(itk::Offset<>()) &&
                 itk::RangeGTestUtilities::IsDistanceFromFrontToBackPlusOneEqualToSize(itk::Offset<1>()),
               "Check that `distance(&front, &back) + 1` is equal to `size`");
+
+
+// Tests front() and back().
+TEST(Offset, CheckFrontAndBack)
+{
+  itk::RangeGTestUtilities::CheckFrontAndBack(itk::Offset<1>{});
+  itk::RangeGTestUtilities::CheckFrontAndBack(itk::Offset<>{ 1, 2 });
+}

--- a/Modules/Core/Common/test/itkSizeGTest.cxx
+++ b/Modules/Core/Common/test/itkSizeGTest.cxx
@@ -174,3 +174,11 @@ TEST(Size, CalculateProductOfElements)
   checkArbitrarySize(itk::MakeSize(2, 4));
   checkArbitrarySize(itk::MakeSize(1, 2, 3));
 }
+
+
+// Tests front() and back().
+TEST(Size, CheckFrontAndBack)
+{
+  itk::RangeGTestUtilities::CheckFrontAndBack(itk::Size<1>{});
+  itk::RangeGTestUtilities::CheckFrontAndBack(itk::Size<>{ 1, 2 });
+}


### PR DESCRIPTION
For the sake of completeness. It appeared that some of the `const` overloads of these member functions did not yet have code coverage.

----
For the record, missing code coverage of the `const` overloads of `front()` and `back()` can be observed for `Offset` at https://open.cdash.org/builds/10915460/coverage/14136929