### PR TITLE
BUG: Make `VariableLengthVector::m_Data` null when its length is zero

### DIFF
--- a/Modules/Core/Common/include/itkVariableLengthVector.h
+++ b/Modules/Core/Common/include/itkVariableLengthVector.h
@@ -270,10 +270,13 @@ public:
     void
     operator()(unsigned int newSize, unsigned int oldSize, TValue2 * oldBuffer, TValue2 * newBuffer) const
     {
-      itkAssertInDebugAndIgnoreInReleaseMacro(newBuffer);
       const size_t nb = std::min(newSize, oldSize);
-      itkAssertInDebugAndIgnoreInReleaseMacro(nb == 0 || (nb > 0 && oldBuffer != nullptr));
-      std::copy_n(oldBuffer, nb, newBuffer);
+      if (nb > 0)
+      {
+        itkAssertInDebugAndIgnoreInReleaseMacro(newBuffer);
+        itkAssertInDebugAndIgnoreInReleaseMacro(oldBuffer);
+        std::copy_n(oldBuffer, nb, newBuffer);
+      }
     }
   };
 


### PR DESCRIPTION
Originally, a zero-length VariableLengthVector might still have its `m_Data` pointing to the heap, as it might have its memory allocated by `new TValue[length]`, with `length == 0`.

A memory leak in `VariableLengthVector(unsigned int length)` was then introduced by pull request https://github.com/InsightSoftwareConsortium/ITK/pull/5710 commit bb79801dcf43e99ca11b7d47cbbc88c1a549889a
"STYLE: Replace AllocateElements calls within VariableLengthVector" forgetting to `delete` memory that was allocated by `new TValue[0]`. As was reported by Mihail Isakov (@issakomi) at https://github.com/InsightSoftwareConsortium/ITK/pull/5710#issuecomment-3690435714, referring to the Valgrind results at https://open.cdash.org/builds/10917349/dynamic_analysis

With this commit, m_Data should always be null when the VariableLengthVector is empty and manages its own memory (m_LetArrayManageMemory is `true`).