### PR TITLE
WIP: Let 3D SobelOperator have consistent, commonly used coefficients

### DIFF
--- a/Documentation/Doxygen/doxygen.bib
+++ b/Documentation/Doxygen/doxygen.bib
@@ -1127,12 +1127,6 @@
   doi          = {10.1109/42.668698},
   url          = {https://doi.org/10.1109/42.668698}
 }
-@techreport{sobel1995,
-  title        = {An Isotropic 3x3x3 Volume Gradient Operator},
-  author       = {Irwin Sobel},
-  year         = 1995,
-  institution  = {Hewlett-Packard Laboratories}
-}
 @inbook{soille2004,
   title        = {Geodesic Transformations},
   author       = {Soille, Pierre},

--- a/Modules/Core/Common/include/itkSobelOperator.h
+++ b/Modules/Core/Common/include/itkSobelOperator.h
@@ -61,14 +61,12 @@ namespace itk
  * The current implementation of the Sobel operator is for 2 and 3 dimensions only.
  * The ND version is planned for future releases.
  *
- * The extension to 3D was described in \cite sobel1995.
- *
  * The Sobel operator in 3D has the kernel
  *
  * \verbatim
- * -1 -3 -1   0 0 0  1 3 1
- * -3 -6 -3   0 0 0  3 6 3
- * -1 -3 -1   0 0 0  1 3 1
+ * -1 -2 -1   0 0 0  1 2 1
+ * -2 -4 -2   0 0 0  2 4 2
+ * -1 -2 -1   0 0 0  1 2 1
  *
  *    x-1       x     x+1
  * \endverbatim

--- a/Modules/Core/Common/include/itkSobelOperator.hxx
+++ b/Modules/Core/Common/include/itkSobelOperator.hxx
@@ -91,11 +91,11 @@ SobelOperator<TPixel, VDimension, TAllocator>::GenerateCoefficients() -> Coeffic
     switch (direction)
     {
       case 0:
-        return { -1, 0, 1, -3, 0, 3, -1, 0, 1, -3, 0, 3, -6, 0, 6, -3, 0, 3, -1, 0, 1, -3, 0, 3, -1, 0, 1 };
+        return { -1, 0, 1, -2, 0, 2, -1, 0, 1, -2, 0, 2, -4, 0, 4, -2, 0, 2, -1, 0, 1, -2, 0, 2, -1, 0, 1 };
       case 1:
-        return { -1, -3, -1, 0, 0, 0, 1, 3, 1, -3, -6, -3, 0, 0, 0, 3, 6, 3, -1, -3, -1, 0, 0, 0, 1, 3, 1 };
+        return { -1, -2, -1, 0, 0, 0, 1, 2, 1, -2, -4, -2, 0, 0, 0, 2, 4, 2, -1, -2, -1, 0, 0, 0, 1, 2, 1 };
       case 2:
-        return { -1, -3, -1, -3, -6, -3, -1, -3, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 1, 3, 6, 3, 1, 3, 1 };
+        return { -1, -2, -1, -2, -4, -2, -1, -2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 1, 2, 4, 2, 1, 2, 1 };
     }
   }
   itkExceptionMacro("The direction value (" << direction << ") should be less than the dimensionality (" << VDimension

--- a/Modules/Core/Common/test/itkSobelOperatorTest.cxx
+++ b/Modules/Core/Common/test/itkSobelOperatorTest.cxx
@@ -88,8 +88,8 @@ itkSobelOperatorTest(int, char *[])
     sobelOperator.CreateToRadius(radius);
 
     itk::FixedArray<SobelOperatorType::PixelType, Length> expectedValuesX{
-      { { -1.0, 0.0,  1.0, -3.0, 0.0,  3.0, -1.0, 0.0,  1.0, -3.0, 0.0,  3.0, -6.0, 0.0,
-          6.0,  -3.0, 0.0, 3.0,  -1.0, 0.0, 1.0,  -3.0, 0.0, 3.0,  -1.0, 0.0, 1.0 } }
+      { { -1.0, 0.0,  1.0, -2.0, 0.0,  2.0, -1.0, 0.0,  1.0, -2.0, 0.0,  2.0, -4.0, 0.0,
+          4.0,  -2.0, 0.0, 2.0,  -1.0, 0.0, 1.0,  -2.0, 0.0, 2.0,  -1.0, 0.0, 1.0 } }
     };
     const unsigned int size = sobelOperator.GetBufferReference().size();
     for (itk::SizeValueType i = 0; i < size; ++i)
@@ -105,8 +105,8 @@ itkSobelOperatorTest(int, char *[])
 
     ITK_TEST_SET_GET_VALUE(direction, sobelOperator.GetDirection());
     itk::FixedArray<SobelOperatorType::PixelType, Length> expectedValuesY{
-      { { -1.0, -3.0, -1.0, 0.0, 0.0,  0.0,  1.0,  3.0, 1.0, -3.0, -6.0, -3.0, 0.0, 0.0,
-          0.0,  3.0,  6.0,  3.0, -1.0, -3.0, -1.0, 0.0, 0.0, 0.0,  1.0,  3.0,  1.0 } }
+      { { -1.0, -2.0, -1.0, 0.0, 0.0,  0.0,  1.0,  2.0, 1.0, -2.0, -4.0, -2.0, 0.0, 0.0,
+          0.0,  2.0,  4.0,  2.0, -1.0, -2.0, -1.0, 0.0, 0.0, 0.0,  1.0,  2.0,  1.0 } }
     };
     for (itk::SizeValueType i = 0; i < size; ++i)
     {
@@ -121,8 +121,8 @@ itkSobelOperatorTest(int, char *[])
     sobelOperator.CreateDirectional();
 
     itk::FixedArray<SobelOperatorType::PixelType, Length> expectedValuesZ{
-      { { -1.0, -3.0, -1.0, -3.0, -6.0, -3.0, -1.0, -3.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-          0.0,  0.0,  0.0,  0.0,  1.0,  3.0,  1.0,  3.0,  6.0,  3.0, 1.0, 3.0, 1.0 } }
+      { { -1.0, -2.0, -1.0, -2.0, -4.0, -2.0, -1.0, -2.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+          0.0,  0.0,  0.0,  0.0,  1.0,  2.0,  1.0,  2.0,  4.0,  2.0, 1.0, 2.0, 1.0 } }
     };
     for (itk::SizeValueType i = 0; i < size; ++i)
     {


### PR DESCRIPTION
Aims to make the 3D coefficients more consistent with its 2D version, paving the way for an ND extension, as request by issue https://github.com/InsightSoftwareConsortium/ITK/issues/5702

The new coefficients are more commonly used by other toolkits, including scipy, and correspond with https://en.wikipedia.org/wiki/Sobel_operator

Removed the reference to "An Isotropic 3x3x3 Volume Gradient Operator", Sobel, 1995, as it cannot be found anymore.

----

👉  Work in progress: Still looking for an authoritative literature reference to support this change, and more evidence that these are indeed the more commonly used coefficients!