### PR TITLE
STYLE: Call `Array(dimension, value)` instead of Fill, in NumericTraits

### DIFF
--- a/Modules/Core/Common/include/itkNumericTraitsArrayPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsArrayPixel.h
@@ -71,45 +71,31 @@ public:
   static const Self
   max(const Self & a)
   {
-    Self b(a.Size());
-
-    b.Fill(NumericTraits<T>::max());
-    return b;
+    return Self(a.Size(), NumericTraits<T>::max());
   }
 
   static const Self
   min(const Self & a)
   {
-    Self b(a.Size());
-
-    b.Fill(NumericTraits<T>::min());
-    return b;
+    return Self(a.Size(), NumericTraits<T>::min());
   }
 
   static const Self
   ZeroValue(const Self & a)
   {
-    Self b(a.Size());
-
-    b.Fill(T{});
-    return b;
+    return Self(a.Size(), T{});
   }
 
   static const Self
   OneValue(const Self & a)
   {
-    Self b(a.Size());
-
-    b.Fill(NumericTraits<T>::OneValue());
-    return b;
+    return Self(a.Size(), NumericTraits<T>::OneValue());
   }
 
   static const Self
   NonpositiveMin(const Self & a)
   {
-    Self b(a.Size());
-    b.Fill(NumericTraits<T>::NonpositiveMin());
-    return b;
+    return Self(a.Size(), NumericTraits<T>::NonpositiveMin());
   }
 
   static constexpr bool IsSigned = std::is_signed_v<ValueType>;


### PR DESCRIPTION
Following pull request https://github.com/InsightSoftwareConsortium/ITK/pull/5693 commit a912fac4b35281e14925510010c75bdcacb4aeff
"STYLE: Do return `VariableLengthVector(length, value)` in NumericTraits"