### PR TITLE
STYLE: Let Index, Offset, Size front and back return m_InternalArray[i]

### DIFF
--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -456,25 +456,25 @@ public:
   [[nodiscard]] constexpr reference
   front()
   {
-    return *begin();
+    return m_InternalArray[0];
   }
 
   [[nodiscard]] constexpr const_reference
   front() const
   {
-    return *begin();
+    return m_InternalArray[0];
   }
 
   [[nodiscard]] constexpr reference
   back()
   {
-    return VDimension ? *(end() - 1) : *end();
+    return m_InternalArray[VDimension - 1];
   }
 
   [[nodiscard]] constexpr const_reference
   back() const
   {
-    return VDimension ? *(end() - 1) : *end();
+    return m_InternalArray[VDimension - 1];
   }
 
   [[nodiscard]] IndexValueType *

--- a/Modules/Core/Common/include/itkOffset.h
+++ b/Modules/Core/Common/include/itkOffset.h
@@ -405,25 +405,25 @@ public:
   [[nodiscard]] constexpr reference
   front()
   {
-    return *begin();
+    return m_InternalArray[0];
   }
 
   [[nodiscard]] constexpr const_reference
   front() const
   {
-    return *begin();
+    return m_InternalArray[0];
   }
 
   [[nodiscard]] constexpr reference
   back()
   {
-    return VDimension ? *(end() - 1) : *end();
+    return m_InternalArray[VDimension - 1];
   }
 
   [[nodiscard]] constexpr const_reference
   back() const
   {
-    return VDimension ? *(end() - 1) : *end();
+    return m_InternalArray[VDimension - 1];
   }
 
   [[nodiscard]] OffsetValueType *

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -380,25 +380,25 @@ public:
   [[nodiscard]] constexpr reference
   front()
   {
-    return *begin();
+    return m_InternalArray[0];
   }
 
   [[nodiscard]] constexpr const_reference
   front() const
   {
-    return *begin();
+    return m_InternalArray[0];
   }
 
   [[nodiscard]] constexpr reference
   back()
   {
-    return VDimension ? *(end() - 1) : *end();
+    return m_InternalArray[VDimension - 1];
   }
 
   [[nodiscard]] constexpr const_reference
   back() const
   {
-    return VDimension ? *(end() - 1) : *end();
+    return m_InternalArray[VDimension - 1];
   }
 
   [[nodiscard]] SizeValueType *


### PR DESCRIPTION
Let `front()` and `back()` directly return a reference to the appropriate element of their internal array, instead of internally calling `begin()` or `end()`. This will especially simplify the `back()` member functions.

Note that it is OK to assume that `VDimension` is greater than zero, because this is already ensured by a `static_assert`, in the class definitions of Index, Offset, and Size.