### PR TITLE
STYLE: Let `SobelOperator::Fill` use IndexRange, allowing ND support

### DIFF
--- a/Modules/Core/Common/include/itkSobelOperator.h
+++ b/Modules/Core/Common/include/itkSobelOperator.h
@@ -99,6 +99,9 @@ public:
   using Self = SobelOperator;
   using Superclass = NeighborhoodOperator<TPixel, VDimension, TAllocator>;
 
+  /** Additional type alias. */
+  using typename Superclass::SizeType;
+
   itkOverrideGetNameOfClassMacro(SobelOperator);
 
   static_assert(

--- a/Modules/Core/Common/include/itkSobelOperator.hxx
+++ b/Modules/Core/Common/include/itkSobelOperator.hxx
@@ -18,6 +18,7 @@
 #ifndef itkSobelOperator_hxx
 #define itkSobelOperator_hxx
 
+#include "itkIndexRange.h"
 #include "itkObject.h"
 
 namespace itk
@@ -32,41 +33,26 @@ SobelOperator<TPixel, VDimension, TAllocator>::Fill(const CoefficientVector & co
   // coefficients in the exact center of the neighborhood
   const unsigned int center = this->GetCenterNeighborhoodIndex();
 
-  if constexpr (VDimension == 2)
+  using IndexType = Index<VDimension>;
+
+  unsigned int coeff_index = 0;
+  for (const IndexType & index :
+       ImageRegionIndexRange<VDimension>(ImageRegion{ IndexType::Filled(-1), SizeType::Filled(3) }))
   {
-    unsigned int coeff_index = 0;
-    for (int y = -1; y <= 1; ++y)
+    auto pos = static_cast<int>(center);
+
+    for (unsigned int i{}; i < VDimension; ++i)
     {
-      for (int x = -1; x <= 1; ++x)
-      {
-        const int pos = center + y * this->GetStride(1) + x * this->GetStride(0);
-        // Note, The following line copies the double precision
-        // coefficients of SobelOperator to the pixel type
-        // of the neighborhood operator which may not support
-        // negative numbers, or floating point numbers.
-        this->operator[](pos) = static_cast<TPixel>(coeff[coeff_index]);
-
-        ++coeff_index;
-      }
+      pos += static_cast<int>(index[i] * this->GetStride(i));
     }
-  }
-  if constexpr (VDimension == 3)
-  {
-    unsigned int coeff_index = 0;
-    for (int z = -1; z <= 1; ++z)
-    {
-      for (int y = -1; y <= 1; ++y)
-      {
-        for (int x = -1; x <= 1; ++x)
-        {
-          const int pos = center + z * this->GetStride(2) + y * this->GetStride(1) + x * this->GetStride(0);
 
-          this->operator[](pos) = static_cast<TPixel>(coeff[coeff_index]);
+    // Note, The following line copies the double precision
+    // coefficients of SobelOperator to the pixel type
+    // of the neighborhood operator which may not support
+    // negative numbers, or floating point numbers.
+    this->operator[](pos) = static_cast<TPixel>(coeff[coeff_index]);
 
-          ++coeff_index;
-        }
-      }
-    }
+    ++coeff_index;
   }
 }
 


### PR DESCRIPTION
Using the same code for 2D and 3D to pave the way to support ND, as requested by issue https://github.com/InsightSoftwareConsortium/ITK/issues/5702 "A ND Sobel implementation is needed"

----

- 👉  Note: This pull request is complementary to #5718, but I think it can be processed independently. (It can serve as a style PR, even when ND is not yet fully supported.) It supersedes pull request #5722
- ☝️  When reviewing, it may be helpful to ignore white-space changes: https://github.com/InsightSoftwareConsortium/ITK/pull/5723/files?w=1
