### PR TITLE
STYLE: Remove `const` from `Self` return type

### DIFF
--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -97,7 +97,7 @@ public:
 
 
   /** Add a size to an index.  */
-  const Self
+  Self
   operator+(const SizeType & sz) const
   {
     Self result;
@@ -122,7 +122,7 @@ public:
 
   /** Subtract a size from an index.
    */
-  const Self
+  Self
   operator-(const SizeType & sz) const
   {
     Self result;
@@ -146,7 +146,7 @@ public:
   }
 
   /** Add an offset to an index. */
-  const Self
+  Self
   operator+(const OffsetType & offset) const
   {
     Self result;
@@ -181,7 +181,7 @@ public:
   }
 
   /** Subtract an offset from an index. */
-  const Self
+  Self
   operator-(const OffsetType & off) const
   {
     Self result;
@@ -209,7 +209,7 @@ public:
   /**
    * Multiply an index by a size (elementwise product).
    */
-  const Self
+  Self
   operator*(const SizeType & vec) const
   {
     Self result;

--- a/Modules/Core/Common/include/itkNumericTraitsArrayPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsArrayPixel.h
@@ -68,31 +68,31 @@ public:
    * \note minimum value for floating pointer types is defined as
    * minimum positive normalize value.
    */
-  static const Self
+  static Self
   max(const Self & a)
   {
     return Self(a.Size(), NumericTraits<T>::max());
   }
 
-  static const Self
+  static Self
   min(const Self & a)
   {
     return Self(a.Size(), NumericTraits<T>::min());
   }
 
-  static const Self
+  static Self
   ZeroValue(const Self & a)
   {
     return Self(a.Size(), T{});
   }
 
-  static const Self
+  static Self
   OneValue(const Self & a)
   {
     return Self(a.Size(), NumericTraits<T>::OneValue());
   }
 
-  static const Self
+  static Self
   NonpositiveMin(const Self & a)
   {
     return Self(a.Size(), NumericTraits<T>::NonpositiveMin());

--- a/Modules/Core/Common/include/itkNumericTraitsCovariantVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsCovariantVectorPixel.h
@@ -83,61 +83,61 @@ public:
    * \note minimum value for floating pointer types is defined as
    * minimum positive normalize value.
    */
-  static const Self
+  static Self
   max(const Self &)
   {
     return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
-  static const Self
+  static Self
   min(const Self &)
   {
     return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
-  static const Self
+  static Self
   max()
   {
     return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
-  static const Self
+  static Self
   min()
   {
     return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
-  static const Self
+  static Self
   NonpositiveMin()
   {
     return MakeFilled<Self>(NumericTraits<T>::NonpositiveMin());
   }
 
-  static const Self
+  static Self
   ZeroValue()
   {
     return Self{};
   }
 
-  static const Self
+  static Self
   OneValue()
   {
     return MakeFilled<Self>(NumericTraits<T>::OneValue());
   }
 
-  static const Self
+  static Self
   NonpositiveMin(const Self &)
   {
     return NonpositiveMin();
   }
 
-  static const Self
+  static Self
   ZeroValue(const Self &)
   {
     return ZeroValue();
   }
 
-  static const Self
+  static Self
   OneValue(const Self &)
   {
     return OneValue();

--- a/Modules/Core/Common/include/itkNumericTraitsDiffusionTensor3DPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsDiffusionTensor3DPixel.h
@@ -84,61 +84,61 @@ public:
    * \note minimum value for floating pointer types is defined as
    * minimum positive normalize value.
    */
-  static const Self
+  static Self
   max(const Self &)
   {
     return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
-  static const Self
+  static Self
   min(const Self &)
   {
     return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
-  static const Self
+  static Self
   max()
   {
     return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
-  static const Self
+  static Self
   min()
   {
     return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
-  static const Self
+  static Self
   NonpositiveMin()
   {
     return MakeFilled<Self>(NumericTraits<T>::NonpositiveMin());
   }
 
-  static const Self
+  static Self
   ZeroValue()
   {
     return Self{};
   }
 
-  static const Self
+  static Self
   OneValue()
   {
     return MakeFilled<Self>(NumericTraits<T>::OneValue());
   }
 
-  static const Self
+  static Self
   NonpositiveMin(const Self &)
   {
     return NonpositiveMin();
   }
 
-  static const Self
+  static Self
   ZeroValue(const Self &)
   {
     return ZeroValue();
   }
 
-  static const Self
+  static Self
   OneValue(const Self &)
   {
     return OneValue();

--- a/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
@@ -83,61 +83,61 @@ public:
    * \note minimum value for floating pointer types is defined as
    * minimum positive normalize value.
    */
-  static const Self
+  static Self
   max(const Self &)
   {
     return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
-  static const Self
+  static Self
   min(const Self &)
   {
     return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
-  static const Self
+  static Self
   max()
   {
     return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
-  static const Self
+  static Self
   min()
   {
     return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
-  static const Self
+  static Self
   NonpositiveMin()
   {
     return MakeFilled<Self>(NumericTraits<T>::NonpositiveMin());
   }
 
-  static const Self
+  static Self
   ZeroValue()
   {
     return Self{};
   }
 
-  static const Self
+  static Self
   OneValue()
   {
     return MakeFilled<Self>(NumericTraits<T>::OneValue());
   }
 
-  static const Self
+  static Self
   NonpositiveMin(const Self &)
   {
     return NonpositiveMin();
   }
 
-  static const Self
+  static Self
   ZeroValue(const Self &)
   {
     return ZeroValue();
   }
 
-  static const Self
+  static Self
   OneValue(const Self &)
   {
     return OneValue();

--- a/Modules/Core/Common/include/itkNumericTraitsPointPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsPointPixel.h
@@ -70,61 +70,61 @@ public:
    * \note minimum value for floating pointer types is defined as
    * minimum positive normalize value.
    */
-  static const Self
+  static Self
   max(const Self &)
   {
     return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
-  static const Self
+  static Self
   min(const Self &)
   {
     return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
-  static const Self
+  static Self
   max()
   {
     return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
-  static const Self
+  static Self
   min()
   {
     return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
-  static const Self
+  static Self
   NonpositiveMin()
   {
     return MakeFilled<Self>(NumericTraits<T>::NonpositiveMin());
   }
 
-  static const Self
+  static Self
   ZeroValue()
   {
     return Self{};
   }
 
-  static const Self
+  static Self
   OneValue()
   {
     return MakeFilled<Self>(NumericTraits<T>::OneValue());
   }
 
-  static const Self
+  static Self
   NonpositiveMin(const Self &)
   {
     return NonpositiveMin();
   }
 
-  static const Self
+  static Self
   ZeroValue(const Self &)
   {
     return ZeroValue();
   }
 
-  static const Self
+  static Self
   OneValue(const Self &)
   {
     return OneValue();

--- a/Modules/Core/Common/include/itkNumericTraitsRGBAPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsRGBAPixel.h
@@ -82,61 +82,61 @@ public:
    * \note minimum value for floating pointer types is defined as
    * minimum positive normalize value.
    */
-  static const Self
+  static Self
   max(const Self &)
   {
     return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
-  static const Self
+  static Self
   min(const Self &)
   {
     return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
-  static const Self
+  static Self
   max()
   {
     return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
-  static const Self
+  static Self
   min()
   {
     return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
-  static const Self
+  static Self
   NonpositiveMin()
   {
     return MakeFilled<Self>(NumericTraits<T>::NonpositiveMin());
   }
 
-  static const Self
+  static Self
   ZeroValue()
   {
     return Self{};
   }
 
-  static const Self
+  static Self
   OneValue()
   {
     return MakeFilled<Self>(NumericTraits<T>::OneValue());
   }
 
-  static const Self
+  static Self
   NonpositiveMin(const Self &)
   {
     return NonpositiveMin();
   }
 
-  static const Self
+  static Self
   ZeroValue(const Self &)
   {
     return ZeroValue();
   }
 
-  static const Self
+  static Self
   OneValue(const Self &)
   {
     return OneValue();

--- a/Modules/Core/Common/include/itkNumericTraitsRGBPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsRGBPixel.h
@@ -82,61 +82,61 @@ public:
    * \note minimum value for floating pointer types is defined as
    * minimum positive normalize value.
    */
-  static const Self
+  static Self
   max(const Self &)
   {
     return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
-  static const Self
+  static Self
   min(const Self &)
   {
     return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
-  static const Self
+  static Self
   max()
   {
     return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
-  static const Self
+  static Self
   min()
   {
     return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
-  static const Self
+  static Self
   NonpositiveMin()
   {
     return MakeFilled<Self>(NumericTraits<T>::NonpositiveMin());
   }
 
-  static const Self
+  static Self
   ZeroValue()
   {
     return Self{};
   }
 
-  static const Self
+  static Self
   OneValue()
   {
     return MakeFilled<Self>(NumericTraits<T>::OneValue());
   }
 
-  static const Self
+  static Self
   NonpositiveMin(const Self &)
   {
     return NonpositiveMin();
   }
 
-  static const Self
+  static Self
   ZeroValue(const Self &)
   {
     return ZeroValue();
   }
 
-  static const Self
+  static Self
   OneValue(const Self &)
   {
     return OneValue();

--- a/Modules/Core/Common/include/itkNumericTraitsStdVector.h
+++ b/Modules/Core/Common/include/itkNumericTraitsStdVector.h
@@ -97,35 +97,35 @@ public:
    * minimum positive normalize value.
    */
   /** @ITKStartGrouping */
-  static const Self
+  static Self
   max(const Self & a)
   {
     Self b(a.Size(), NumericTraits<T>::max());
     return b;
   }
 
-  static const Self
+  static Self
   min(const Self & a)
   {
     Self b(a.Size(), NumericTraits<T>::min());
     return b;
   }
 
-  static const Self
+  static Self
   ZeroValue(const Self & a)
   {
     Self b(a.Size(), T{});
     return b;
   }
 
-  static const Self
+  static Self
   OneValue(const Self & a)
   {
     Self b(a.Size(), NumericTraits<T>::OneValue());
     return b;
   }
 
-  static const Self
+  static Self
   NonpositiveMin(const Self & a)
   {
     Self b(a.Size(), NumericTraits<T>::NonpositiveMin());

--- a/Modules/Core/Common/include/itkNumericTraitsTensorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsTensorPixel.h
@@ -83,61 +83,61 @@ public:
    * \note minimum value for floating pointer types is defined as
    * minimum positive normalize value.
    */
-  static const Self
+  static Self
   max(const Self &)
   {
     return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
-  static const Self
+  static Self
   min(const Self &)
   {
     return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
-  static const Self
+  static Self
   max()
   {
     return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
-  static const Self
+  static Self
   min()
   {
     return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
-  static const Self
+  static Self
   NonpositiveMin()
   {
     return MakeFilled<Self>(NumericTraits<T>::NonpositiveMin());
   }
 
-  static const Self
+  static Self
   ZeroValue()
   {
     return Self{};
   }
 
-  static const Self
+  static Self
   OneValue()
   {
     return MakeFilled<Self>(NumericTraits<T>::OneValue());
   }
 
-  static const Self
+  static Self
   NonpositiveMin(const Self &)
   {
     return NonpositiveMin();
   }
 
-  static const Self
+  static Self
   ZeroValue(const Self &)
   {
     return ZeroValue();
   }
 
-  static const Self
+  static Self
   OneValue(const Self &)
   {
     return OneValue();

--- a/Modules/Core/Common/include/itkNumericTraitsVariableLengthVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsVariableLengthVectorPixel.h
@@ -92,31 +92,31 @@ public:
    * \note minimum value for floating pointer types is defined as
    * minimum positive normalize value.
    */
-  static const Self
+  static Self
   max(const Self & a)
   {
     return Self(a.Size(), NumericTraits<T>::max());
   }
 
-  static const Self
+  static Self
   min(const Self & a)
   {
     return Self(a.Size(), NumericTraits<T>::min());
   }
 
-  static const Self
+  static Self
   ZeroValue(const Self & a)
   {
     return Self(a.Size(), T{});
   }
 
-  static const Self
+  static Self
   OneValue(const Self & a)
   {
     return Self(a.Size(), NumericTraits<T>::OneValue());
   }
 
-  static const Self
+  static Self
   NonpositiveMin(const Self & a)
   {
     return Self(a.Size(), NumericTraits<T>::NonpositiveMin());

--- a/Modules/Core/Common/include/itkNumericTraitsVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsVectorPixel.h
@@ -69,61 +69,61 @@ public:
    * \note minimum value for floating pointer types is defined as
    * minimum positive normalize value.
    */
-  static const Self
+  static Self
   max(const Self &)
   {
     return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
-  static const Self
+  static Self
   min(const Self &)
   {
     return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
-  static const Self
+  static Self
   max()
   {
     return MakeFilled<Self>(NumericTraits<T>::max());
   }
 
-  static const Self
+  static Self
   min()
   {
     return MakeFilled<Self>(NumericTraits<T>::min());
   }
 
-  static const Self
+  static Self
   NonpositiveMin()
   {
     return MakeFilled<Self>(NumericTraits<T>::NonpositiveMin());
   }
 
-  static const Self
+  static Self
   ZeroValue()
   {
     return Self{};
   }
 
-  static const Self
+  static Self
   OneValue()
   {
     return MakeFilled<Self>(NumericTraits<T>::OneValue());
   }
 
-  static const Self
+  static Self
   NonpositiveMin(const Self &)
   {
     return NonpositiveMin();
   }
 
-  static const Self
+  static Self
   ZeroValue(const Self &)
   {
     return ZeroValue();
   }
 
-  static const Self
+  static Self
   OneValue(const Self &)
   {
     return OneValue();

--- a/Modules/Core/Common/include/itkOffset.h
+++ b/Modules/Core/Common/include/itkOffset.h
@@ -88,7 +88,7 @@ public:
 
 
   /** Add two offsets. */
-  const Self
+  Self
   operator+(const Self & vec) const
   {
     Self result;
@@ -101,7 +101,7 @@ public:
   }
 
   /** Add a size to an offset.  */
-  const Self
+  Self
   operator+(const Size<VDimension> & sz) const
   {
     Self result;
@@ -136,7 +136,7 @@ public:
   }
 
   /** Subtract two offsets. */
-  const Self
+  Self
   operator-(const Self & vec) const
   {
     Self result;

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -90,7 +90,7 @@ public:
   }
 
   /** Add two sizes.  */
-  const Self
+  Self
   operator+(const Self & vec) const
   {
     Self result;
@@ -114,7 +114,7 @@ public:
   }
 
   /** Subtract two sizes.  */
-  const Self
+  Self
   operator-(const Self & vec) const
   {
     Self result;
@@ -138,7 +138,7 @@ public:
   }
 
   /** Multiply two sizes (elementwise product).  */
-  const Self
+  Self
   operator*(const Self & vec) const
   {
     Self result;


### PR DESCRIPTION
Using Notepad++, Replace in Files, doing:

    Find what: ^(  )const (Self)$
    Find what: ^(  static )const (Self)$
    Replace with: $1$2
    Filter: itk*.h
    [v] Match case
    (*) Regular expression

Following C++ Core Guidelines, [Don’t return `const T`](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rf-return-const)
