### PR TITLE
ENH: Update connected component testing baselines

### DIFF
--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
@@ -22,9 +22,9 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkSimpleFilterWatcher.h"
-#include "vnl/vnl_sample.h"
 #include "itkTestingMacros.h"
 #include <algorithm> // For generate.
+#include <random>    // For mt19937.
 
 int
 itkConnectedComponentImageFilterTest(int argc, char * argv[])
@@ -124,12 +124,20 @@ itkConnectedComponentImageFilterTest(int argc, char * argv[])
 
   std::vector<RGBPixelType> colormap;
   colormap.resize(numObjects + 1);
-  vnl_sample_reseed(1031571);
+
+  using RGBComponentType = RGBPixelType::ComponentType;
+  constexpr auto maxRGBComponentValue = std::numeric_limits<RGBComponentType>::max();
+
+  constexpr std::mt19937::result_type randomSeed{ 1031571 };
+  std::mt19937                        randomNumberEngine(randomSeed);
+  std::uniform_int_distribution<>     randomNumberDistribution(maxRGBComponentValue / 3, maxRGBComponentValue);
+
   for (auto & i : colormap)
   {
     RGBPixelType px;
-    std::generate(
-      px.begin(), px.end(), [] { return static_cast<unsigned char>(255 * vnl_sample_uniform(0.3333, 1.0)); });
+    std::generate(px.begin(), px.end(), [&randomNumberEngine, &randomNumberDistribution] {
+      return static_cast<RGBComponentType>(randomNumberDistribution(randomNumberEngine));
+    });
 
     i = px;
   }

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTestRGB.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTestRGB.cxx
@@ -23,8 +23,8 @@
 #include "itkImageFileWriter.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkTestingMacros.h"
-#include "vnl/vnl_sample.h"
 #include <algorithm> // For generate.
+#include <random>    // For mt19937.
 
 int
 itkConnectedComponentImageFilterTestRGB(int argc, char * argv[])
@@ -104,11 +104,19 @@ itkConnectedComponentImageFilterTestRGB(int argc, char * argv[])
   std::vector<RGBPixelType> colormap;
   RGBPixelType              px;
   colormap.resize(numObjects + 1);
-  vnl_sample_reseed(1031571);
+
+  using RGBComponentType = RGBPixelType::ComponentType;
+  constexpr auto maxRGBComponentValue = std::numeric_limits<RGBComponentType>::max();
+
+  constexpr std::mt19937::result_type randomSeed{ 1031571 };
+  std::mt19937                        randomNumberEngine(randomSeed);
+  std::uniform_int_distribution<>     randomNumberDistribution(maxRGBComponentValue / 3, maxRGBComponentValue);
+
   for (auto & i : colormap)
   {
-    std::generate(
-      px.begin(), px.end(), [] { return static_cast<unsigned char>(255 * vnl_sample_uniform(0.3333, 1.0)); });
+    std::generate(px.begin(), px.end(), [&randomNumberEngine, &randomNumberDistribution] {
+      return static_cast<RGBComponentType>(randomNumberDistribution(randomNumberEngine));
+    });
 
     i = px;
   }

--- a/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest.1.png.cid
+++ b/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest.1.png.cid
@@ -1,1 +1,1 @@
-bafkreidtm3ujuq2se3t4evejuuibd2cuk2xbv72yeqemnwo3syno72vjqq
+bafkreicqlhg6xztvfqmgynbf3xb6qhbghwfzvkugt6nwxn2kloiwnfalp4

--- a/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest.png.cid
+++ b/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest.png.cid
@@ -1,1 +1,1 @@
-bafkreig3gdn4rui4nxur5kkxrfv2nwh22vutbjmh5xl24ipxc2th7rz5qe
+bafkreidv7hznlkcvddhdi7udpvsvqd7q677dhiamqenhskxyq53vogf62q

--- a/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest2.1.png.cid
+++ b/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest2.1.png.cid
@@ -1,1 +1,1 @@
-bafkreiamfgwxqutd2spazedlyworg33yphhvjqcq7mkiq3eto2i5x4hy3y
+bafkreidngvamh6ejxx5j6lzf57p3kqtjjvgm4dtil7ofekz4blhmns3pf4

--- a/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest2.png.cid
+++ b/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest2.png.cid
@@ -1,1 +1,1 @@
-bafkreig5qyo7d7klilcdl5was6yoahhljq42p4cujwbcv3ar3twguajod4
+bafkreihut6bgxwhnrmts5ov5hr357n4u7m53f2sjquuobazjizetlqb4ky

--- a/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest3.1.png.cid
+++ b/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest3.1.png.cid
@@ -1,1 +1,1 @@
-bafkreiecgg7dkdhieady5toarh75h5qrocfxecsonscbt27xzwkxxu2uwq
+bafkreiejqekgsjh7frp43eya5fssenr56bfxazjo2ocp7qyevse5xfjjrq

--- a/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest3.png.cid
+++ b/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest3.png.cid
@@ -1,1 +1,1 @@
-bafkreigngeop4cdefb3bd7rjgqwgsbu5kwzkr2dirwhpx27l2twlq7vkuq
+bafkreifvvwy6zmh7td3cutymiervm7ipqgkfwx6rxuyxej2acw4i5ebcmu


### PR DESCRIPTION
## Description

This PR updates the baseline images for ConnectedComponent tests following the changes in PR #5622, which replaced `vnl_sample.h` with `<random>`. The switch to the standard library random number generator produced different random sequences, causing the existing baseline images to fail validation.

## Related Issues/PRs

Follow-up to #5622 

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

## Testing

Baseline images were regenerated by running the ConnectedComponent tests with the updated random number generator. All tests now pass with the new baselines.