### PR TITLE
ENH: Add UseLegacyOperatorCoefficients to SobelEdgeDetectionImageFilter

### DIFF
--- a/Modules/Filtering/ImageFeature/include/itkSobelEdgeDetectionImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkSobelEdgeDetectionImageFilter.h
@@ -108,6 +108,12 @@ public:
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputPixelType>));
   itkConceptMacro(OutputPixelIsFloatingPointCheck, (Concept::IsFloatingPoint<OutputPixelType>));
 
+  /** Set/Get whether to use the legacy Sobel operator coefficients (compatible with ITK <= 5.4). True by default.
+   * \sa SobelOperator::SetUseLegacyCoefficients */
+  itkSetMacro(UseLegacyOperatorCoefficients, bool);
+  itkGetConstReferenceMacro(UseLegacyOperatorCoefficients, bool);
+  itkBooleanMacro(UseLegacyOperatorCoefficients);
+
 protected:
   SobelEdgeDetectionImageFilter() = default;
   ~SobelEdgeDetectionImageFilter() override = default;
@@ -127,6 +133,9 @@ protected:
   {
     Superclass::PrintSelf(os, indent);
   }
+
+private:
+  bool m_UseLegacyOperatorCoefficients{ true };
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageFeature/include/itkSobelEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkSobelEdgeDetectionImageFilter.hxx
@@ -111,6 +111,7 @@ SobelEdgeDetectionImageFilter<TInputImage, TOutputImage>::GenerateData()
     multFilter[i] = MultFilter::New();
 
     // Set boundary condition and operator for this axis.
+    opers[i].UseLegacyCoefficients(m_UseLegacyOperatorCoefficients);
     opers[i].SetDirection(i);
     opers[i].CreateDirectional();
     opFilter[i]->OverrideBoundaryCondition(&nbc);

--- a/Modules/Filtering/ImageFeature/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageFeature/test/CMakeLists.txt
@@ -553,3 +553,7 @@ itk_add_test(
     0
     ${ITK_TEST_OUTPUT_DIR}/itkMultiScaleHessianBasedMeasureImageFilterTestEnhancedOutput2.mha
 )
+
+set(ITKImageFeatureGTests itkSobelEdgeDetectionImageFilterGTest.cxx)
+
+creategoogletestdriver(ITKImageFeature "${ITKImageFeature-Test_LIBRARIES}" "${ITKImageFeatureGTests}")

--- a/Modules/Filtering/ImageFeature/test/itkSobelEdgeDetectionImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkSobelEdgeDetectionImageFilterGTest.cxx
@@ -1,0 +1,86 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkSobelEdgeDetectionImageFilter.h"
+
+#include "itkDeref.h"
+#include "itkImage.h"
+#include "itkImageBufferRange.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath> // For sqrt.
+#include <vector>
+
+
+// Checks that the filter uses legacy Sobel operator coefficients by default.
+TEST(SobelEdgeDetectionImageFilter, UseLegacyOperatorCoefficientsByDefault)
+{
+  const auto filter = itk::SobelEdgeDetectionImageFilter<itk::Image<int>, itk::Image<double>>::New();
+  EXPECT_TRUE(filter->GetUseLegacyOperatorCoefficients());
+}
+
+
+// Checks the output for a minimal 3D example, both when using legacy and when using non-legacy Sobel operator
+// coefficients.
+TEST(SobelEdgeDetectionImageFilter, UseLegacyOperatorCoefficientsFor3D)
+{
+  constexpr unsigned int dimension{ 3 };
+
+  using InputImageType = itk::Image<int, dimension>;
+  using OutputImageType = itk::Image<double, dimension>;
+
+  const auto     inputImage = InputImageType::New();
+  constexpr auto imageSize = itk::Size<dimension>::Filled(3);
+  inputImage->SetRegions(imageSize);
+  inputImage->AllocateInitialized();
+  inputImage->SetPixel(itk::Index<dimension>::Filled(1), 1);
+
+  constexpr auto sqrtOfValues = [](auto values) {
+    for (auto & value : values)
+    {
+      value = std::sqrt(value);
+    }
+    return values;
+  };
+
+  for (const bool useLegacyCoefficients : { true, false })
+  {
+    const auto filter = itk::SobelEdgeDetectionImageFilter<InputImageType, OutputImageType>::New();
+    filter->SetInput(inputImage);
+    filter->SetUseLegacyOperatorCoefficients(useLegacyCoefficients);
+    filter->Update();
+    const OutputImageType & outputImage = itk::Deref(filter->GetOutput());
+
+    const itk::ImageBufferRange outputImageBufferRange(outputImage);
+
+    // Note that the expected pixel values are square roots, because the filter also computes the square root, after
+    // convolving the coefficients with the pixels.
+    const auto expectedPixelValues =
+      sqrtOfValues(useLegacyCoefficients ? std::vector<double>{ 3,  18, 3,  18, 36, 18, 3, 18, 3,  18, 36, 18, 36, 0,
+                                                                36, 18, 36, 18, 3,  18, 3, 18, 36, 18, 3,  18, 3 }
+                                         : std::vector<double>{ 3,  8, 3,  8, 16, 8, 3, 8, 3,  8, 16, 8, 16, 0,
+                                                                16, 8, 16, 8, 3,  8, 3, 8, 16, 8, 3,  8, 3 });
+
+    const std::vector<double> actualPixelValues(outputImageBufferRange.cbegin(), outputImageBufferRange.cend());
+
+    EXPECT_EQ(actualPixelValues.size(), expectedPixelValues.size());
+    EXPECT_EQ(actualPixelValues, expectedPixelValues);
+  }
+}


### PR DESCRIPTION
Allowed switching off `UseLegacyCoefficients` from the Sobel operators used by SobelEdgeDetectionImageFilter.

Included GoogleTest unit tests.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/5718 commit 43801b28e751986614565e7266103624750cd44a
"ENH: Make 3D SobelOperator consistent with 2D, add UseLegacyCoefficients"