### PR TITLE
ENH: Add legacy Sobel option to GradientDifferenceImageToImageMetric

### DIFF
--- a/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.h
@@ -137,6 +137,22 @@ public:
   itkSetMacro(DerivativeDelta, double);
   itkGetConstReferenceMacro(DerivativeDelta, double);
   /** @ITKEndGrouping */
+
+  /** Allows specifying whether or not the Sobel operators should use the legacy coordinate values, compatible with ITK
+   * <= 5.4.
+   * \sa SobelOperator::SetUseLegacyCoefficients */
+  void
+  UseLegacySobelOperatorCoordinates(const bool useLegacyCoefficients);
+
+  /** Tells whether or not the Sobel operators are using the legacy coordinate values, compatible with ITK <= 5.4.
+   * \sa SobelOperator::SetUseLegacyCoefficients */
+  bool
+  IsUsingLegacySobelOperatorCoordinates() const
+  {
+    // It is sufficient to just check the first operator, because this property is the same for all operators.
+    return m_FixedSobelOperators[0].IsUsingLegacyCoefficients();
+  }
+
 protected:
   GradientDifferenceImageToImageMetric();
   ~GradientDifferenceImageToImageMetric() override = default;

--- a/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
@@ -126,6 +126,27 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
   }
 }
 
+
+template <typename TFixedImage, typename TMovingImage>
+void
+GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::UseLegacySobelOperatorCoordinates(
+  const bool useLegacyCoefficients)
+{
+  if (useLegacyCoefficients != IsUsingLegacySobelOperatorCoordinates())
+  {
+    for (auto & sobelOperator : m_FixedSobelOperators)
+    {
+      sobelOperator.UseLegacyCoefficients(useLegacyCoefficients);
+    }
+    for (auto & sobelOperator : m_MovedSobelOperators)
+    {
+      sobelOperator.UseLegacyCoefficients(useLegacyCoefficients);
+    }
+    this->Modified();
+  }
+}
+
+
 template <typename TFixedImage, typename TMovingImage>
 void
 GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const


### PR DESCRIPTION
Added `UseLegacySobelOperatorCoordinates(bool)` member function, allowing to switch off `UseLegacyCoefficients` from the Sobel operators used by the metric.

Added a complimentary member function, IsUsingLegacySobelOperatorCoordinates().

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/5735 commit e6d4997c5553cdef6815628bd33e4823aa617514
"ENH: Add UseLegacyOperatorCoefficients to SobelEdgeDetectionImageFilter"