### PR TITLE
PERF: Avoid CI on RemoteModule hash changes

### DIFF
--- a/.github/workflows/macos-arm.yml
+++ b/.github/workflows/macos-arm.yml
@@ -13,6 +13,7 @@ on:
             - 'Utilities/Debugger/**'
             - 'Utilities/ITKv5Preparation/**'
             - 'Utilities/Maintenance/**'
+            - 'Modules/Remote/*.remote.cmake'
     pull_request:
         paths-ignore:
             - '*.md'
@@ -22,6 +23,7 @@ on:
             - 'Utilities/Debugger/**'
             - 'Utilities/ITKv5Preparation/**'
             - 'Utilities/Maintenance/**'
+            - 'Modules/Remote/*.remote.cmake'
 
 concurrency:
   group: '${{ github.workflow }}@${{ github.head_ref || github.ref }}'

--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -13,6 +13,7 @@ on:
             - 'Utilities/Debugger/**'
             - 'Utilities/ITKv5Preparation/**'
             - 'Utilities/Maintenance/**'
+            - 'Modules/Remote/*.remote.cmake'
     pull_request:
         paths-ignore:
             - '*.md'
@@ -22,6 +23,7 @@ on:
             - 'Utilities/Debugger/**'
             - 'Utilities/ITKv5Preparation/**'
             - 'Utilities/Maintenance/**'
+            - 'Modules/Remote/*.remote.cmake'
 
 concurrency:
   group: '${{ github.workflow }}@${{ github.head_ref || github.ref }}'
@@ -29,6 +31,7 @@ concurrency:
 
 env:
     ExternalDataVersion: 5.4.5
+
 
 jobs:
     Pixi-Cxx:

--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -14,6 +14,7 @@ trigger:
     - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
+    - Modules/Remote/*.remote.cmake
 pr:
   paths:
     exclude:
@@ -24,6 +25,7 @@ pr:
     - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
+    - Modules/Remote/*.remote.cmake
 variables:
   ExternalDataVersion: 5.4.5
 jobs:

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -14,6 +14,7 @@ trigger:
     - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
+    - Modules/Remote/*.remote.cmake
 pr:
   paths:
     exclude:
@@ -24,6 +25,7 @@ pr:
     - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
+    - Modules/Remote/*.remote.cmake
 variables:
   ExternalDataVersion: 5.4.5
 jobs:

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -14,6 +14,7 @@ trigger:
     - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
+    - Modules/Remote/*.remote.cmake
 pr:
   paths:
     exclude:
@@ -24,6 +25,7 @@ pr:
     - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
+    - Modules/Remote/*.remote.cmake
 variables:
   ExternalDataVersion: 5.4.5
 jobs:

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -14,6 +14,7 @@ trigger:
     - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
+    - Modules/Remote/*.remote.cmake
 pr:
   paths:
     exclude:
@@ -24,6 +25,7 @@ pr:
     - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
+    - Modules/Remote/*.remote.cmake
 variables:
   ExternalDataVersion: 5.4.5
 jobs:

--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -14,6 +14,7 @@ trigger:
     - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
+    - Modules/Remote/*.remote.cmake
 pr:
   paths:
     exclude:
@@ -24,6 +25,7 @@ pr:
     - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
+    - Modules/Remote/*.remote.cmake
 variables:
   ExternalDataVersion: 5.4.5
 jobs:

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -14,6 +14,7 @@ trigger:
     - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
+    - Modules/Remote/*.remote.cmake
 pr:
   paths:
     exclude:
@@ -24,6 +25,7 @@ pr:
     - Utilities/Debugger/*
     - Utilities/ITKv5Preparation/*
     - Utilities/Maintenance/*
+    - Modules/Remote/*.remote.cmake
 variables:
   ExternalDataVersion: 5.4.5
 jobs:


### PR DESCRIPTION
- **BUG: Update remotes  with bug fixes related to cmake modernization**
- **ENH: Require python3.10 or later for python wrapping.**
- **ENH: Update CI and scripts to require Python 3.10,**
- **PERF: Update CI paths to ignore remote module files**

Depends on:
- [ ] #5750


## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
