### PR TITLE
In the future, no longer use legacy Sobel operator coefficients by default

### DIFF
--- a/Modules/Core/Common/include/itkSobelOperator.h
+++ b/Modules/Core/Common/include/itkSobelOperator.h
@@ -158,7 +158,11 @@ protected:
   Fill(const CoefficientVector & coeff) override;
 
 private:
+#ifdef ITK_FUTURE_LEGACY_REMOVE
+  bool m_UseLegacyCoefficients{ false };
+#else
   bool m_UseLegacyCoefficients{ true };
+#endif
 };
 } // namespace itk
 

--- a/Modules/Core/Common/test/itkSobelOperatorGTest.cxx
+++ b/Modules/Core/Common/test/itkSobelOperatorGTest.cxx
@@ -73,11 +73,15 @@ TEST(SobelOperator, ExerciseBasicObjectMethods)
 }
 
 
-// Checks that the operator uses legacy coefficients by default.
-TEST(SobelOperator, IsUsingLegacyCoefficientsByDefault)
+// Checks that the operator uses legacy coefficients by default, unless ITK_FUTURE_LEGACY_REMOVE is enabled.
+TEST(SobelOperator, IsUsingLegacyCoefficientsByDefaultUnlessFutureLegacyRemove)
 {
   itk::SobelOperator<float, 2> sobelOperator;
+#ifdef ITK_FUTURE_LEGACY_REMOVE
+  EXPECT_FALSE(sobelOperator.IsUsingLegacyCoefficients());
+#else
   EXPECT_TRUE(sobelOperator.IsUsingLegacyCoefficients());
+#endif
 }
 
 

--- a/Modules/Filtering/ImageFeature/include/itkSobelEdgeDetectionImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkSobelEdgeDetectionImageFilter.h
@@ -135,7 +135,11 @@ protected:
   }
 
 private:
+#ifdef ITK_FUTURE_LEGACY_REMOVE
+  bool m_UseLegacyOperatorCoefficients{ false };
+#else
   bool m_UseLegacyOperatorCoefficients{ true };
+#endif
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ImageFeature/test/itkSobelEdgeDetectionImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkSobelEdgeDetectionImageFilterGTest.cxx
@@ -29,11 +29,16 @@
 #include <vector>
 
 
-// Checks that the filter uses legacy Sobel operator coefficients by default.
-TEST(SobelEdgeDetectionImageFilter, UseLegacyOperatorCoefficientsByDefault)
+// Checks that the filter uses legacy Sobel operator coefficients by default, unless ITK_FUTURE_LEGACY_REMOVE is
+// enabled.
+TEST(SobelEdgeDetectionImageFilter, UseLegacyOperatorCoefficientsByDefaultUnlessFutureLegacyRemove)
 {
   const auto filter = itk::SobelEdgeDetectionImageFilter<itk::Image<int>, itk::Image<double>>::New();
+#ifdef ITK_FUTURE_LEGACY_REMOVE
+  EXPECT_FALSE(filter->GetUseLegacyOperatorCoefficients());
+#else
   EXPECT_TRUE(filter->GetUseLegacyOperatorCoefficients());
+#endif
 }
 
 

--- a/Modules/Registration/Common/test/itkGradientDifferenceImageToImageMetricGTest.cxx
+++ b/Modules/Registration/Common/test/itkGradientDifferenceImageToImageMetricGTest.cxx
@@ -137,12 +137,17 @@ TEST(GradientDifferenceImageToImageMetric, Test)
 }
 
 
-// Checks that the metric uses legacy Sobel operator coefficients by default.
-TEST(GradientDifferenceImageToImageMetric, IsUsingLegacySobelOperatorCoordinatesByDefault)
+// Checks that the metric uses legacy Sobel operator coefficients by default, unless ITK_FUTURE_LEGACY_REMOVE is
+// enabled.
+TEST(GradientDifferenceImageToImageMetric, IsUsingLegacySobelOperatorCoordinatesByDefaultUnlessFutureLegacyRemove)
 {
   using ImageType = itk::Image<double>;
   const auto metric = itk::GradientDifferenceImageToImageMetric<ImageType, ImageType>::New();
+#ifdef ITK_FUTURE_LEGACY_REMOVE
+  EXPECT_FALSE(metric->IsUsingLegacySobelOperatorCoordinates());
+#else
   EXPECT_TRUE(metric->IsUsingLegacySobelOperatorCoordinates());
+#endif
 }
 
 


### PR DESCRIPTION
When `ITK_FUTURE_LEGACY_REMOVE` is enabled, ITK will use the new and more consistent Sobel operator coordinates by default (instead of the legacy coordinates), with this pull request. This may affect results for 3D applications that are using SobelOperator, SobelEdgeDetectionImageFilter, or GradientDifferenceImageToImageMetric.

- Follow-up to pull request #5718 commit 43801b28e751986614565e7266103624750cd44a "ENH: Make 3D SobelOperator consistent with 2D, add UseLegacyCoefficients"
