### PR TITLE
BUG: Fix GPUPDEDeformable module dependencies

### DIFF
--- a/Modules/Registration/GPUPDEDeformable/itk-module.cmake
+++ b/Modules/Registration/GPUPDEDeformable/itk-module.cmake
@@ -12,7 +12,6 @@ itk_module(
     ITKCommon
     ITKGPUCommon
     ITKGPUFiniteDifference
-  COMPILE_DEPENDS
     ITKPDEDeformableRegistration
     ITKGPURegistrationCommon
   TEST_DEPENDS


### PR DESCRIPTION
## Description

This PR fixes a compilation error in the `ITKGPUPDEDeformableRegistration` module where test builds were failing because required headers could not be found.

## Issue

The module's public header `itkGPUDemonsRegistrationFilter.h` includes `itkDemonsRegistrationFilter.h` from the `ITKPDEDeformableRegistration` module, but this dependency was listed as `COMPILE_DEPENDS` instead of `DEPENDS`.

Build error from CDash:
```
error C1083: Cannot open include file: 'itkDemonsRegistrationFilter.h': No such file or directory
```
https://open.cdash.org/viewBuildError.php?buildid=11026050

## Changes

Moved `ITKPDEDeformableRegistration` and `ITKGPURegistrationCommon` from `COMPILE_DEPENDS` to `DEPENDS` in `itk-module.cmake`.

## Rationale

- `COMPILE_DEPENDS` only makes headers available during compilation of the module's source files
- `DEPENDS` makes headers available for tests and dependent modules
- Since public API headers directly include headers from these modules, they must be regular dependencies

## Testing

This fix resolves the compilation error reported on the Windows build on CDash.