### PR TITLE
Remove const from return type of `ImageConstIterator::GetIndex()`, remove static_cast 

### DIFF
--- a/Modules/Core/Common/include/itkImageConstIterator.h
+++ b/Modules/Core/Common/include/itkImageConstIterator.h
@@ -299,7 +299,7 @@ public:
    * This causes the index to be calculated from pointer arithmetic and is
    * therefore an expensive operation.
    * \sa SetIndex */
-  [[nodiscard]] const IndexType
+  [[nodiscard]] IndexType
   GetIndex() const
   {
     return m_Image->ComputeIndex(m_Offset);


### PR DESCRIPTION
Two small style commits, as suggested by @dzenanz at https://github.com/InsightSoftwareConsortium/ITK/pull/5787#issuecomment-3886246294