### PR TITLE
ENH: Replace 'char' with int8_t when numeric is intended

### DIFF
--- a/Modules/Bridge/VtkGlue/src/QuickView.cxx
+++ b/Modules/Bridge/VtkGlue/src/QuickView.cxx
@@ -47,7 +47,7 @@ using UnsignedCharRGBImageType = itk::Image<itk::RGBPixel<unsigned char>, 2>;
 using FloatRGBImageType = itk::Image<itk::RGBPixel<float>, 2>;
 
 using UnsignedCharImageType = itk::Image<unsigned char, 2>;
-using CharImageType = itk::Image<char, 2>;
+using CharImageType = itk::Image<int8_t, 2>;
 using UnsignedShortImageType = itk::Image<unsigned short, 2>;
 using ShortImageType = itk::Image<short, 2>;
 using UnsignedIntImageType = itk::Image<unsigned int, 2>;

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.h
@@ -57,7 +57,7 @@ namespace itk
  *
  */
 template <typename TImage>
-class ITK_TEMPLATE_EXPORT ConstNeighborhoodIteratorWithOnlyIndex : public Neighborhood<char, TImage::ImageDimension>
+class ITK_TEMPLATE_EXPORT ConstNeighborhoodIteratorWithOnlyIndex : public Neighborhood<int8_t, TImage::ImageDimension>
 {
 public:
   ITK_DEFAULT_COPY_AND_MOVE(ConstNeighborhoodIteratorWithOnlyIndex);
@@ -68,7 +68,7 @@ public:
   /** Save the image dimension. */
   static constexpr DimensionValueType Dimension = TImage::ImageDimension;
 
-  using DummyNeighborhoodPixelType = char;
+  using DummyNeighborhoodPixelType = int8_t;
 
   /** Standard class type aliases. */
   using Self = ConstNeighborhoodIteratorWithOnlyIndex;

--- a/Modules/Core/Common/test/itkImageComputeOffsetAndIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageComputeOffsetAndIndexTest.cxx
@@ -112,7 +112,7 @@ itkImageComputeOffsetAndIndexTest(int, char *[])
 
 #define TRY_FAST_INDEX(dim)                                             \
   {                                                                     \
-    using PixelType = char;                                             \
+    using PixelType = int8_t;                                           \
     using ImageType = itk::Image<PixelType, dim>;                       \
     auto                        myImage = ImageType::New();             \
     const auto                  size = ImageType::SizeType::Filled(50); \
@@ -137,7 +137,7 @@ itkImageComputeOffsetAndIndexTest(int, char *[])
 
 #define TRY_INDEX(dim)                                                  \
   {                                                                     \
-    using PixelType = char;                                             \
+    using PixelType = int8_t;                                           \
     using ImageType = itk::Image<PixelType, dim>;                       \
     auto                        myImage = ImageType::New();             \
     const auto                  size = ImageType::SizeType::Filled(50); \
@@ -162,7 +162,7 @@ itkImageComputeOffsetAndIndexTest(int, char *[])
 
 #define TRY_FAST_OFFSET(dim)                                            \
   {                                                                     \
-    using PixelType = char;                                             \
+    using PixelType = int8_t;                                           \
     using ImageType = itk::Image<PixelType, dim>;                       \
     auto                        myImage = ImageType::New();             \
     const auto                  size = ImageType::SizeType::Filled(50); \
@@ -182,7 +182,7 @@ itkImageComputeOffsetAndIndexTest(int, char *[])
   ITK_MACROEND_NOOP_STATEMENT
 #define TRY_OFFSET(dim)                                                 \
   {                                                                     \
-    using PixelType = char;                                             \
+    using PixelType = int8_t;                                           \
     using ImageType = itk::Image<PixelType, dim>;                       \
     auto                        myImage = ImageType::New();             \
     const auto                  size = ImageType::SizeType::Filled(50); \

--- a/Modules/Core/Common/test/itkImageIteratorWithIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorWithIndexTest.cxx
@@ -140,7 +140,7 @@ itkImageIteratorWithIndexTest(int, char *[])
   // test the iterators on them
 
   std::cout << "Testing with Image< char, 3 > " << std::endl;
-  itkImageIteratorWithIndexTestIteratorTester<char> TesterC(10);
+  itkImageIteratorWithIndexTestIteratorTester<int8_t> TesterC(10);
   if (TesterC.TestIterator() == false)
   {
     testPassed = false;
@@ -259,8 +259,8 @@ itkImageIteratorWithIndexTest(int, char *[])
     testPassed = false;
   }
 
-  std::cout << "Testing with Image< itk::Vector<char,4>, 3 > " << std::endl;
-  using VC = itk::Vector<char, 4>;
+  std::cout << "Testing with Image< itk::Vector<int8_t,4>, 3 > " << std::endl;
+  using VC = itk::Vector<int8_t, 4>;
   auto                                            vc = itk::MakeFilled<VC>(127);
   itkImageIteratorWithIndexTestIteratorTester<VC> TesterVC(vc);
   if (TesterVC.TestIterator() == false)

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealWithNumberOfElementsTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealWithNumberOfElementsTest.cxx
@@ -120,7 +120,7 @@ itkFastMarchingImageFilterRealWithNumberOfElementsTest(int, char *[])
   ITK_TRY_EXPECT_NO_EXCEPTION(marcher->Update());
 
 
-  using OutputPixelType = char;
+  using OutputPixelType = int8_t;
 
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 

--- a/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
@@ -253,7 +253,7 @@ bool
 TestCastFrom()
 {
   bool success = true;
-  success &= TestCastFromTo<TInputPixelType, char>();
+  success &= TestCastFromTo<TInputPixelType, int8_t>();
   success &= TestCastFromTo<TInputPixelType, signed char>();
   success &= TestCastFromTo<TInputPixelType, unsigned char>();
   success &= TestCastFromTo<TInputPixelType, short>();
@@ -460,7 +460,7 @@ itkCastImageFilterTest(int, char *[])
   }
 
   bool success = true;
-  success &= TestCastFrom<char>();
+  success &= TestCastFrom<int8_t>();
   success &= TestCastFrom<signed char>();
   success &= TestCastFrom<unsigned char>();
   success &= TestCastFrom<short>();

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
@@ -254,7 +254,7 @@ itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest(int, char *[])
 
   constexpr unsigned int Dimension{ 3 };
 
-  using CharPixelType = char;
+  using CharPixelType = int8_t;
   using FloatPixelType = float;
 
   // Even input image size test

--- a/Modules/Filtering/ImageIntensity/test/itkClampImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkClampImageFilterTest.cxx
@@ -150,7 +150,7 @@ bool
 TestClampFrom()
 {
   const bool success =
-    TestClampFromTo<TInputPixelType, char>() && TestClampFromTo<TInputPixelType, unsigned char>() &&
+    TestClampFromTo<TInputPixelType, int8_t>() && TestClampFromTo<TInputPixelType, unsigned char>() &&
     TestClampFromTo<TInputPixelType, short>() && TestClampFromTo<TInputPixelType, unsigned short>() &&
     TestClampFromTo<TInputPixelType, int>() && TestClampFromTo<TInputPixelType, unsigned int>() &&
     TestClampFromTo<TInputPixelType, long>() && TestClampFromTo<TInputPixelType, unsigned long>() &&
@@ -263,7 +263,7 @@ template <typename TInputPixelType>
 bool
 TestClampFromWithCustomBounds()
 {
-  const bool success = TestClampFromToWithCustomBounds<TInputPixelType, char>() &&
+  const bool success = TestClampFromToWithCustomBounds<TInputPixelType, int8_t>() &&
                        TestClampFromToWithCustomBounds<TInputPixelType, unsigned char>() &&
                        TestClampFromToWithCustomBounds<TInputPixelType, short>() &&
                        TestClampFromToWithCustomBounds<TInputPixelType, unsigned short>() &&
@@ -290,12 +290,12 @@ itkClampImageFilterTest(int, char *[])
   auto filter = FilterType::New();
   ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, ClampImageFilter, UnaryFunctorImageFilter);
 
-  const bool success = TestClampFrom<char>() && TestClampFrom<unsigned char>() && TestClampFrom<short>() &&
+  const bool success = TestClampFrom<int8_t>() && TestClampFrom<unsigned char>() && TestClampFrom<short>() &&
                        TestClampFrom<unsigned short>() && TestClampFrom<int>() && TestClampFrom<unsigned int>() &&
                        TestClampFrom<long>() && TestClampFrom<unsigned long>() && TestClampFrom<long long>() &&
                        TestClampFrom<unsigned long long>() && TestClampFrom<float>() && TestClampFrom<double>() &&
 
-                       TestClampFromWithCustomBounds<char>() && TestClampFromWithCustomBounds<unsigned char>() &&
+                       TestClampFromWithCustomBounds<int8_t>() && TestClampFromWithCustomBounds<unsigned char>() &&
                        TestClampFromWithCustomBounds<short>() && TestClampFromWithCustomBounds<unsigned short>() &&
                        TestClampFromWithCustomBounds<int>() && TestClampFromWithCustomBounds<unsigned int>() &&
                        TestClampFromWithCustomBounds<long>() && TestClampFromWithCustomBounds<unsigned long>() &&

--- a/Modules/Filtering/ImageIntensity/test/itkHistogramMatchingImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkHistogramMatchingImageFilterTest.cxx
@@ -434,7 +434,7 @@ itkHistogramMatchingImageFilterTest(int, char *[])
   {
     return EXIT_FAILURE;
   }
-  if (itkHistogramMatchingImageFilterTest<char>() != EXIT_SUCCESS)
+  if (itkHistogramMatchingImageFilterTest<int8_t>() != EXIT_SUCCESS)
   {
     return EXIT_FAILURE;
   }

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -789,7 +789,7 @@ itkMINCImageIOTest(int argc, char * argv[])
   int result(0);
   // straightforward test
   result += MINCReadWriteTest<unsigned char, 3>("3DUCharImage.mnc", typeid(unsigned char).name());
-  result += MINCReadWriteTest<char, 3>("3DCharImage.mnc", typeid(unsigned char).name());
+  result += MINCReadWriteTest<int8_t, 3>("3DCharImage.mnc", typeid(unsigned char).name());
   result += MINCReadWriteTest<unsigned short, 3>("3DUShortImage.mnc", typeid(short).name());
   result += MINCReadWriteTest<short, 3>("3DShortImage.mnc", typeid(unsigned short).name());
   result += MINCReadWriteTest<unsigned int, 3>("3DUIntImage.mnc", typeid(int).name());

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.cxx
@@ -411,7 +411,7 @@ itkNiftiImageIOTest(int argc, char * argv[])
   }
   else // This is the mechanism for doing internal testing of all data types.
   {
-    int cur_return = MakeNiftiImage<char>(testFileName);
+    int cur_return = MakeNiftiImage<int8_t>(testFileName);
     if (cur_return != 0)
     {
       std::cerr << "Error writing Nifti file type char" << std::endl;

--- a/Modules/IO/NRRD/test/itkNrrdImageIOTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdImageIOTest.cxx
@@ -47,7 +47,7 @@ itkNrrdImageIOTest(int argc, char * argv[])
   int           ret = EXIT_SUCCESS;
 
   ret += itkNrrdImageIOTestReadWriteTest<unsigned char, 2>(std::string(argv[1]), sz, inputFile);
-  ret += itkNrrdImageIOTestReadWriteTest<char, 2>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<int8_t, 2>(std::string(argv[1]), sz, inputFile);
   ret += itkNrrdImageIOTestReadWriteTest<unsigned short, 2>(std::string(argv[1]), sz, inputFile);
   ret += itkNrrdImageIOTestReadWriteTest<short, 2>(std::string(argv[1]), sz, inputFile);
   ret += itkNrrdImageIOTestReadWriteTest<unsigned int, 2>(std::string(argv[1]), sz, inputFile);
@@ -59,7 +59,7 @@ itkNrrdImageIOTest(int argc, char * argv[])
   ret += itkNrrdImageIOTestReadWriteTest<float, 2>(std::string(argv[1]), sz, inputFile);
   ret += itkNrrdImageIOTestReadWriteTest<double, 2>(std::string(argv[1]), sz, inputFile);
 
-  ret += itkNrrdImageIOTestReadWriteTest<char, 3>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<int8_t, 3>(std::string(argv[1]), sz, inputFile);
   ret += itkNrrdImageIOTestReadWriteTest<unsigned char, 3>(std::string(argv[1]), sz, inputFile);
   ret += itkNrrdImageIOTestReadWriteTest<short, 3>(std::string(argv[1]), sz, inputFile);
   ret += itkNrrdImageIOTestReadWriteTest<unsigned short, 3>(std::string(argv[1]), sz, inputFile);
@@ -72,7 +72,7 @@ itkNrrdImageIOTest(int argc, char * argv[])
   ret += itkNrrdImageIOTestReadWriteTest<float, 3>(std::string(argv[1]), sz, inputFile);
   ret += itkNrrdImageIOTestReadWriteTest<double, 3>(std::string(argv[1]), sz, inputFile);
 
-  ret += itkNrrdImageIOTestReadWriteTest<char, 4>(std::string(argv[1]), sz, inputFile);
+  ret += itkNrrdImageIOTestReadWriteTest<int8_t, 4>(std::string(argv[1]), sz, inputFile);
   ret += itkNrrdImageIOTestReadWriteTest<unsigned char, 4>(std::string(argv[1]), sz, inputFile);
   ret += itkNrrdImageIOTestReadWriteTest<short, 4>(std::string(argv[1]), sz, inputFile);
   ret += itkNrrdImageIOTestReadWriteTest<unsigned short, 4>(std::string(argv[1]), sz, inputFile);
@@ -86,7 +86,7 @@ itkNrrdImageIOTest(int argc, char * argv[])
   ret += itkNrrdImageIOTestReadWriteTest<double, 4>(std::string(argv[1]), sz, inputFile);
 
   // Test with compression on
-  ret += itkNrrdImageIOTestReadWriteTest<char, 4>(std::string(argv[1]), sz, inputFile, true);
+  ret += itkNrrdImageIOTestReadWriteTest<int8_t, 4>(std::string(argv[1]), sz, inputFile, true);
   ret += itkNrrdImageIOTestReadWriteTest<unsigned char, 4>(std::string(argv[1]), sz, inputFile, true);
   ret += itkNrrdImageIOTestReadWriteTest<short, 4>(std::string(argv[1]), sz, inputFile, true);
   ret += itkNrrdImageIOTestReadWriteTest<unsigned short, 4>(std::string(argv[1]), sz, inputFile, true);

--- a/Modules/IO/VTK/test/itkVTKImageIO2Test.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIO2Test.cxx
@@ -130,7 +130,7 @@ public:
 
       writer->SetInput(image);
 
-      const std::string outputFileName = VTKImageIOTester<char, 3>::SetupFileName(filePrefix, "vtk", outputPath);
+      const std::string outputFileName = VTKImageIOTester<int8_t, 3>::SetupFileName(filePrefix, "vtk", outputPath);
 
       writer->SetFileName(outputFileName);
       writer->Update();
@@ -371,7 +371,7 @@ itkVTKImageIO2Test(int argc, char * argv[])
   int status = 0;
 
   status += Test1Type<unsigned char>(filePrefix, outputPath, "unsigned char");
-  status += Test1Type<char>(filePrefix, outputPath, "char");
+  status += Test1Type<int8_t>(filePrefix, outputPath, "char");
   status += Test1Type<unsigned short>(filePrefix, outputPath, "unsigned short");
   status += Test1Type<short>(filePrefix, outputPath, "short");
   status += Test1Type<unsigned int>(filePrefix, outputPath, "unsigned int");
@@ -399,7 +399,7 @@ itkVTKImageIO2Test(int argc, char * argv[])
   //
 
   // read bad file extension
-  if (VTKImageIOTester<char, 3>::CanReadFileTest(filePrefix, "bad", outputPath))
+  if (VTKImageIOTester<int8_t, 3>::CanReadFileTest(filePrefix, "bad", outputPath))
   {
     std::cout << "[FAILED] didn't properly reject bad file extension for reading" << std::endl;
     status++;
@@ -407,7 +407,7 @@ itkVTKImageIO2Test(int argc, char * argv[])
   std::cout << "[PASSED] rejected bad file extension for reading" << std::endl;
 
   // read bad file name
-  if (VTKImageIOTester<char, 3>::CanReadFileTest("BadFile", "vtk", outputPath))
+  if (VTKImageIOTester<int8_t, 3>::CanReadFileTest("BadFile", "vtk", outputPath))
   {
     std::cout << "[FAILED] didn't properly reject bad file name for reading" << std::endl;
     status++;
@@ -415,7 +415,7 @@ itkVTKImageIO2Test(int argc, char * argv[])
   std::cout << "[PASSED] rejected bad file name for reading" << std::endl;
 
   // write bad file extension
-  if (VTKImageIOTester<char, 3>::CanWriteFileTest(filePrefix, "bad", outputPath))
+  if (VTKImageIOTester<int8_t, 3>::CanWriteFileTest(filePrefix, "bad", outputPath))
   {
     std::cout << "[FAILED] didn't properly reject bad file extension for writing" << std::endl;
     status++;
@@ -423,7 +423,7 @@ itkVTKImageIO2Test(int argc, char * argv[])
   std::cout << "[PASSED] rejected bad file extension for writing" << std::endl;
 
   // write bad file extension when the string ".vtk" is part of the prefix
-  if (VTKImageIOTester<char, 3>::CanWriteFileTest(filePrefix + ".vtk", "bad", outputPath))
+  if (VTKImageIOTester<int8_t, 3>::CanWriteFileTest(filePrefix + ".vtk", "bad", outputPath))
   {
     std::cout << "[FAILED] didn't properly reject bad file extension for writing" << std::endl;
     status++;

--- a/Modules/IO/VTK/test/itkVTKImageIOStreamTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOStreamTest.cxx
@@ -308,7 +308,7 @@ itkVTKImageIOStreamTest(int argc, char * argv[])
   ReadWriteTestMACRO(float);
   ReadWriteTestMACRO(double);
   ReadWriteTestMACRO(unsigned char);
-  ReadWriteTestMACRO(char);
+  ReadWriteTestMACRO(int8_t);
   ReadWriteTestMACRO(unsigned short);
   ReadWriteTestMACRO(short);
   ReadWriteTestMACRO(unsigned int);

--- a/Modules/IO/VTK/test/itkVTKImageIOTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOTest.cxx
@@ -141,7 +141,7 @@ itkVTKImageIOTest(int argc, char * argv[])
   status += Test1Type<float>(file1, file2);
   status += Test1Type<double>(file1, file2);
   status += Test1Type<unsigned char>(file1, file2);
-  status += Test1Type<char>(file1, file2);
+  status += Test1Type<int8_t>(file1, file2);
   status += Test1Type<unsigned short>(file1, file2);
   status += Test1Type<short>(file1, file2);
   status += Test1Type<unsigned int>(file1, file2);

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_16.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_16.cxx
@@ -174,7 +174,7 @@ int
 itkImageRegistrationMethodTest_16(int itkNotUsed(argc), char *[] itkNotUsed(argv))
 {
   const bool result_uc = DoRegistration<unsigned char>();
-  const bool result_c = DoRegistration<char>();
+  const bool result_c = DoRegistration<int8_t>();
   const bool result_us = DoRegistration<unsigned short>();
   const bool result_s = DoRegistration<short>();
   const bool result_ui = DoRegistration<unsigned int>();


### PR DESCRIPTION
The 'char' type can be signed or unsigned on different platforms
and is generally used for ASCII character storage.  To conistently
represent 8-bit signed values on differnt platforms the int8_t
type is recommended.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
