### PR TITLE
STYLE: Remove redundant `typename` in type aliases

### DIFF
--- a/Examples/Filtering/SpatialObjectToImage1.cxx
+++ b/Examples/Filtering/SpatialObjectToImage1.cxx
@@ -186,9 +186,9 @@ main(int argc, char * argv[])
   // Software Guide : BeginCodeSnippet
   ellipse->SetRadiusInObjectSpace(size[0] * 0.2 * spacing[0]);
 
-  typename TubeType::PointType         point;
-  typename TubeType::TubePointType     tubePoint;
-  typename TubeType::TubePointListType tubePointList;
+  TubeType::PointType         point;
+  TubeType::TubePointType     tubePoint;
+  TubeType::TubePointListType tubePointList;
   point[0] = size[0] * 0.2 * spacing[0];
   point[1] = size[1] * 0.2 * spacing[1];
   point[2] = size[2] * 0.2 * spacing[2];

--- a/Examples/Filtering/SpatialObjectToImage3.cxx
+++ b/Examples/Filtering/SpatialObjectToImage3.cxx
@@ -142,21 +142,21 @@ main(int argc, char * argv[])
   //  Software Guide : EndLatex
 
   // Software Guide : BeginCodeSnippet
-  constexpr unsigned int                      numberOfPoints = 6;
-  typename PolygonType::PointType             point;
-  typename PolygonType::PointType::VectorType radial;
+  constexpr unsigned int             numberOfPoints = 6;
+  PolygonType::PointType             point;
+  PolygonType::PointType::VectorType radial;
   radial[0] = 0.0;
   radial[1] = 0.0;
   radial[2] = 0.0;
 
-  typename PolygonType::PointType center;
+  PolygonType::PointType center;
   center[0] = 50.0;
   center[1] = 50.0;
   center[2] = 0.0;
 
   constexpr double radius = 40.0;
 
-  typename PolygonType::PolygonPointType polygonPoint;
+  PolygonType::PolygonPointType polygonPoint;
 
   for (unsigned int i = 0; i < numberOfPoints; ++i)
   {

--- a/Modules/Core/Common/include/itkAnatomicalOrientation.h
+++ b/Modules/Core/Common/include/itkAnatomicalOrientation.h
@@ -54,7 +54,7 @@ class ITKCommon_EXPORT AnatomicalOrientation
 {
 public:
   static constexpr unsigned int Dimension = 3;
-  using DirectionType = typename ImageBase<Dimension>::DirectionType;
+  using DirectionType = ImageBase<Dimension>::DirectionType;
   static constexpr unsigned int ImageDimension = Dimension;
 
 #ifndef ITK_FUTURE_LEGACY_REMOVE
@@ -563,16 +563,16 @@ protected:
 
 /** Outputs unambiguous anatomical orientation names such as "right-to-left". */
 ITKCommon_EXPORT std::ostream &
-                 operator<<(std::ostream & out, typename AnatomicalOrientation::CoordinateEnum value);
+                 operator<<(std::ostream & out, AnatomicalOrientation::CoordinateEnum value);
 
 /** Outputs the PositiveEnum encoding as a string such as "LPS". */
 ITKCommon_EXPORT std::ostream &
-                 operator<<(std::ostream & out, typename AnatomicalOrientation::PositiveEnum value);
+                 operator<<(std::ostream & out, AnatomicalOrientation::PositiveEnum value);
 
 
 /** Outputs the NegativeEnum encoding as a string such as "RAI" */
 ITKCommon_EXPORT std::ostream &
-                 operator<<(std::ostream & out, typename AnatomicalOrientation::NegativeEnum value);
+                 operator<<(std::ostream & out, AnatomicalOrientation::NegativeEnum value);
 
 ITKCommon_EXPORT std::ostream &
                  operator<<(std::ostream & out, const AnatomicalOrientation & orientation);

--- a/Modules/Core/Common/include/itkCompensatedSummation.hxx
+++ b/Modules/Core/Common/include/itkCompensatedSummation.hxx
@@ -142,7 +142,7 @@ CompensatedSummation<TFloat>::GetSum() const -> const AccumulateType &
 
 
 template <typename TFloat>
-CompensatedSummation<TFloat>::operator typename CompensatedSummation<TFloat>::FloatType() const
+CompensatedSummation<TFloat>::operator FloatType() const
 {
   return this->m_Sum;
 }

--- a/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.h
@@ -52,7 +52,7 @@ public:
   using IndexType = typename TImage::IndexType;
 
   /** Index ContainerType */
-  using SeedsContainerType = typename std::vector<IndexType>;
+  using SeedsContainerType = std::vector<IndexType>;
 
   /** Size type alias support. */
   using SizeType = typename TImage::SizeType;

--- a/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.hxx
@@ -105,7 +105,7 @@ void
 FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPixel()
 {
   // Create an iterator that will walk the input image
-  using IRIType = typename itk::ImageRegionConstIterator<TImage>;
+  using IRIType = itk::ImageRegionConstIterator<TImage>;
 
   // Now we search the input image for the first pixel which is inside
   // the function of interest

--- a/Modules/Core/Common/include/itkImageDuplicator.hxx
+++ b/Modules/Core/Common/include/itkImageDuplicator.hxx
@@ -64,8 +64,7 @@ ImageDuplicator<TInputImage>::PrintSelf(std::ostream & os, Indent indent) const
   itkPrintSelfObjectMacro(InputImage);
   itkPrintSelfObjectMacro(DuplicateImage);
 
-  os << indent
-     << "InternalImageTime: " << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(m_InternalImageTime)
+  os << indent << "InternalImageTime: " << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_InternalImageTime)
      << std::endl;
 }
 } // end namespace itk

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.h
@@ -230,7 +230,7 @@ private:
   void
   RandomJump();
 
-  using GeneratorPointer = typename Statistics::MersenneTwisterRandomVariateGenerator::Pointer;
+  using GeneratorPointer = Statistics::MersenneTwisterRandomVariateGenerator::Pointer;
   GeneratorPointer m_Generator{ Statistics::MersenneTwisterRandomVariateGenerator::New() };
   SizeValueType    m_NumberOfSamplesRequested{};
   SizeValueType    m_NumberOfSamplesDone{};

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.h
@@ -232,7 +232,7 @@ private:
   void
   RandomJump();
 
-  using GeneratorPointer = typename Statistics::MersenneTwisterRandomVariateGenerator::Pointer;
+  using GeneratorPointer = Statistics::MersenneTwisterRandomVariateGenerator::Pointer;
   GeneratorPointer m_Generator{ Statistics::MersenneTwisterRandomVariateGenerator::New() };
   SizeValueType    m_NumberOfSamplesRequested{};
   SizeValueType    m_NumberOfSamplesDone{};

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.h
@@ -65,7 +65,7 @@ public:
 class RandomPermutation
 {
 public:
-  using GeneratorPointer = typename Statistics::MersenneTwisterRandomVariateGenerator::Pointer;
+  using GeneratorPointer = Statistics::MersenneTwisterRandomVariateGenerator::Pointer;
   NodeOfPermutation * m_Permutation;
   GeneratorPointer    m_Generator;
   SizeValueType       m_Size;

--- a/Modules/Core/Common/include/itkImageSink.h
+++ b/Modules/Core/Common/include/itkImageSink.h
@@ -77,7 +77,7 @@ public:
 
   /** SmartPointer to a region splitting object */
   using SplitterType = ImageRegionSplitterBase;
-  using RegionSplitterPointer = typename SplitterType::Pointer;
+  using RegionSplitterPointer = SplitterType::Pointer;
 
   using typename Superclass::DataObjectIdentifierType;
 

--- a/Modules/Core/Common/include/itkObjectStore.hxx
+++ b/Modules/Core/Common/include/itkObjectStore.hxx
@@ -134,9 +134,8 @@ ObjectStore<TObjectType>::PrintSelf(std::ostream & os, Indent indent) const
   Superclass::PrintSelf(os, indent);
 
   os << indent << "GrowthStrategy: " << m_GrowthStrategy << std::endl;
-  os << indent << "Size: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_Size) << std::endl;
-  os << indent
-     << "LinearGrowthSize: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_LinearGrowthSize)
+  os << indent << "Size: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_Size) << std::endl;
+  os << indent << "LinearGrowthSize: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_LinearGrowthSize)
      << std::endl;
   os << indent << "FreeList: " << m_FreeList << std::endl;
 }

--- a/Modules/Core/Common/include/itkResourceProbe.hxx
+++ b/Modules/Core/Common/include/itkResourceProbe.hxx
@@ -72,12 +72,9 @@ ResourceProbe<ValueType, MeanType>::Print(std::ostream & os, Indent indent) cons
   os << indent << "StandardError: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_StandardError)
      << std::endl;
 
-  os << indent << "NumberOfStarts: " << static_cast<typename NumericTraits<CountType>::PrintType>(m_NumberOfStarts)
-     << std::endl;
-  os << indent << "NumberOfStops: " << static_cast<typename NumericTraits<CountType>::PrintType>(m_NumberOfStops)
-     << std::endl;
-  os << indent
-     << "NumberOfIteration: " << static_cast<typename NumericTraits<CountType>::PrintType>(m_NumberOfIteration)
+  os << indent << "NumberOfStarts: " << static_cast<NumericTraits<CountType>::PrintType>(m_NumberOfStarts) << std::endl;
+  os << indent << "NumberOfStops: " << static_cast<NumericTraits<CountType>::PrintType>(m_NumberOfStops) << std::endl;
+  os << indent << "NumberOfIteration: " << static_cast<NumericTraits<CountType>::PrintType>(m_NumberOfIteration)
      << std::endl;
 
   os << indent << "ProbeValueList: " << m_ProbeValueList << std::endl;

--- a/Modules/Core/Common/include/itkSpatialOrientationAdapter.h
+++ b/Modules/Core/Common/include/itkSpatialOrientationAdapter.h
@@ -88,7 +88,7 @@ public:
   using ImageType = ImageBase<3>;
 
   /** Direction Cosines type alias. */
-  using DirectionType = typename ImageType::DirectionType;
+  using DirectionType = ImageType::DirectionType;
 
   /** Constructor */
   SpatialOrientationAdapter() = default;

--- a/Modules/Core/Common/include/itkStreamingImageFilter.h
+++ b/Modules/Core/Common/include/itkStreamingImageFilter.h
@@ -76,7 +76,7 @@ public:
 
   /** SmartPointer to a region splitting object */
   using SplitterType = ImageRegionSplitterBase;
-  using RegionSplitterPointer = typename SplitterType::Pointer;
+  using RegionSplitterPointer = SplitterType::Pointer;
 
   /** Set the number of pieces to divide the input.  The upstream pipeline
    * will be executed this many times. */

--- a/Modules/Core/Common/src/itkAnatomicalOrientation.cxx
+++ b/Modules/Core/Common/src/itkAnatomicalOrientation.cxx
@@ -79,8 +79,8 @@ AnatomicalOrientation::CreateFromPositiveStringEncoding(std::string str)
 {
   std::transform(str.begin(), str.end(), str.begin(), ::toupper);
 
-  const std::map<std::string, typename AnatomicalOrientation::PositiveEnum> & stringToCode = GetStringToCode();
-  auto                                                                        iter = stringToCode.find(str);
+  const std::map<std::string, AnatomicalOrientation::PositiveEnum> & stringToCode = GetStringToCode();
+  auto                                                               iter = stringToCode.find(str);
   if (iter == stringToCode.end())
   {
     return { PositiveEnum::INVALID };
@@ -136,7 +136,7 @@ AnatomicalOrientation::GetCoordinateTerm(CoordinateMajornessTermsEnum cmt) const
 }
 
 
-const std::map<typename AnatomicalOrientation::PositiveEnum, std::string> &
+const std::map<AnatomicalOrientation::PositiveEnum, std::string> &
 AnatomicalOrientation::GetCodeToString()
 {
   auto createCodeToString = []() -> std::map<PositiveEnum, std::string> {
@@ -247,7 +247,7 @@ AnatomicalOrientation::ConvertDirectionToPositiveEnum(const DirectionType & dir)
 }
 
 
-typename AnatomicalOrientation::DirectionType
+AnatomicalOrientation::DirectionType
 AnatomicalOrientation::ConvertPositiveEnumToDirection(PositiveEnum orientationEnum)
 {
   const AnatomicalOrientation o(orientationEnum);
@@ -281,7 +281,7 @@ AnatomicalOrientation::ConvertPositiveEnumToDirection(PositiveEnum orientationEn
 }
 
 std::ostream &
-operator<<(std::ostream & out, typename AnatomicalOrientation::CoordinateEnum value)
+operator<<(std::ostream & out, AnatomicalOrientation::CoordinateEnum value)
 {
   switch (value)
   {
@@ -305,13 +305,13 @@ operator<<(std::ostream & out, typename AnatomicalOrientation::CoordinateEnum va
 }
 
 std::ostream &
-operator<<(std::ostream & out, typename AnatomicalOrientation::PositiveEnum value)
+operator<<(std::ostream & out, AnatomicalOrientation::PositiveEnum value)
 {
   return out << AnatomicalOrientation(value).GetAsPositiveStringEncoding();
 }
 
 std::ostream &
-operator<<(std::ostream & out, typename AnatomicalOrientation::NegativeEnum value)
+operator<<(std::ostream & out, AnatomicalOrientation::NegativeEnum value)
 {
   return out << AnatomicalOrientation(value).GetAsNegativeStringEncoding();
 }

--- a/Modules/Core/Common/test/itkAnnulusOperatorTest.cxx
+++ b/Modules/Core/Common/test/itkAnnulusOperatorTest.cxx
@@ -118,15 +118,15 @@ itkAnnulusOperatorTest(int, char *[])
   annulus.SetThickness(thickness);
   ITK_TEST_SET_GET_VALUE(thickness, annulus.GetThickness());
 
-  constexpr typename OperatorType::PixelType exteriorValue{ 1 };
+  constexpr OperatorType::PixelType exteriorValue{ 1 };
   annulus.SetExteriorValue(exteriorValue);
   ITK_TEST_SET_GET_VALUE(exteriorValue, annulus.GetExteriorValue());
 
-  constexpr typename OperatorType::PixelType annulusValue{ 8 };
+  constexpr OperatorType::PixelType annulusValue{ 8 };
   annulus.SetAnnulusValue(annulusValue);
   ITK_TEST_SET_GET_VALUE(annulusValue, annulus.GetAnnulusValue());
 
-  constexpr typename OperatorType::PixelType interiorValue{ 4 };
+  constexpr OperatorType::PixelType interiorValue{ 4 };
   annulus.SetInteriorValue(interiorValue);
   ITK_TEST_SET_GET_VALUE(interiorValue, annulus.GetInteriorValue());
 

--- a/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
@@ -519,7 +519,7 @@ template <typename ImageType>
 class MyDerivedCSNI : public itk::ConstShapedNeighborhoodIterator<ImageType>
 {
 public:
-  using Superclass = typename itk::ConstShapedNeighborhoodIterator<ImageType>;
+  using Superclass = itk::ConstShapedNeighborhoodIterator<ImageType>;
   using typename Superclass::SizeType;
   using typename Superclass::IndexType;
   using typename Superclass::RadiusType;

--- a/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest2.cxx
+++ b/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest2.cxx
@@ -27,7 +27,7 @@ template <typename ImageType>
 class MyDerivedCSNI : public itk::ConstShapedNeighborhoodIterator<ImageType>
 {
 public:
-  using Superclass = typename itk::ConstShapedNeighborhoodIterator<ImageType>;
+  using Superclass = itk::ConstShapedNeighborhoodIterator<ImageType>;
   using typename Superclass::SizeType;
   using typename Superclass::IndexType;
   using typename Superclass::RadiusType;

--- a/Modules/Core/Common/test/itkMetaDataDictionaryGTest.cxx
+++ b/Modules/Core/Common/test/itkMetaDataDictionaryGTest.cxx
@@ -39,7 +39,7 @@ createMetaDataDictionary()
   itk::EncapsulateMetaData<float>(metaDataDictionary, "two", static_cast<float>(2));
 
   using ObjectType = itk::LightObject;
-  using PointerType = typename ObjectType::Pointer;
+  using PointerType = ObjectType::Pointer;
   const PointerType obj = ObjectType::New();
   itk::EncapsulateMetaData<PointerType>(metaDataDictionary, "object", obj);
 

--- a/Modules/Core/Common/test/itkPointSetTest.cxx
+++ b/Modules/Core/Common/test/itkPointSetTest.cxx
@@ -31,7 +31,7 @@
 using PointSet = itk::PointSet<int>;
 using PointType = PointSet::PointType;
 using PointsVectorContainer = PointSet::PointsVectorContainer;
-using PointsVectorContainerPointer = typename PointsVectorContainer::Pointer;
+using PointsVectorContainerPointer = PointsVectorContainer::Pointer;
 
 /**
  * The point set that is created consists of a 100 random points.

--- a/Modules/Core/Common/test/itkPointSetToImageFilterTest1.cxx
+++ b/Modules/Core/Common/test/itkPointSetToImageFilterTest1.cxx
@@ -76,14 +76,13 @@ itkPointSetToImageFilterTest1(int argc, char * argv[])
   filter->SetOrigin(origin);
   ITK_TEST_SET_GET_VALUE(origin, filter->GetOrigin());
 
-  typename BinaryImageType::DirectionType direction;
+  BinaryImageType::DirectionType direction;
   direction.SetIdentity();
   filter->SetDirection(direction);
   ITK_TEST_SET_GET_VALUE(direction, filter->GetDirection());
 
-  constexpr typename BinaryImageType::ValueType insideValue{
-    itk::NumericTraits<typename BinaryImageType::ValueType>::OneValue()
-  };
+  constexpr
+    typename BinaryImageType::ValueType insideValue{ itk::NumericTraits<BinaryImageType::ValueType>::OneValue() };
   filter->SetInsideValue(insideValue);
   ITK_TEST_SET_GET_VALUE(insideValue, filter->GetInsideValue());
 

--- a/Modules/Core/Common/test/itkSpatialOrientationAdaptorGTest.cxx
+++ b/Modules/Core/Common/test/itkSpatialOrientationAdaptorGTest.cxx
@@ -24,7 +24,7 @@
 TEST(SpatialOrientationAdaptor, test1)
 {
   using ImageType = itk::Image<float, 3>;
-  using DirectionType = typename ImageType::DirectionType;
+  using DirectionType = ImageType::DirectionType;
 
   itk::SpatialOrientationAdapter adapter;
 

--- a/Modules/Core/GPUCommon/include/itkGPUImageDataManager.h
+++ b/Modules/Core/GPUCommon/include/itkGPUImageDataManager.h
@@ -88,10 +88,10 @@ protected:
 private:
   WeakPointer<ImageType> m_Image{}; // WeakPointer has to be used here
                                     // to avoid SmartPointer loop
-  int                              m_BufferedRegionIndex[ImageType::ImageDimension]{};
-  int                              m_BufferedRegionSize[ImageType::ImageDimension]{};
-  typename GPUDataManager::Pointer m_GPUBufferedRegionIndex{};
-  typename GPUDataManager::Pointer m_GPUBufferedRegionSize{};
+  int                     m_BufferedRegionIndex[ImageType::ImageDimension]{};
+  int                     m_BufferedRegionSize[ImageType::ImageDimension]{};
+  GPUDataManager::Pointer m_GPUBufferedRegionIndex{};
+  GPUDataManager::Pointer m_GPUBufferedRegionSize{};
 };
 
 } // namespace itk

--- a/Modules/Core/GPUCommon/include/itkGPUImageToImageFilter.h
+++ b/Modules/Core/GPUCommon/include/itkGPUImageToImageFilter.h
@@ -98,7 +98,7 @@ protected:
   {}
 
   // GPU kernel manager
-  typename GPUKernelManager::Pointer m_GPUKernelManager{};
+  GPUKernelManager::Pointer m_GPUKernelManager{};
 
   // GPU kernel handle - kernel should be defined in specific filter (not in the
   // base class)

--- a/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
@@ -522,7 +522,7 @@ private:
   // to have the correct vector length of the image.
   template <typename TPixelType>
   void
-  UpdateAccessor(typename itk::VectorImage<TPixelType, ImageDimension> * itkNotUsed(dummy))
+  UpdateAccessor(itk::VectorImage<TPixelType, ImageDimension> * itkNotUsed(dummy))
   {
     this->m_PixelAccessor.SetVectorLength(this->m_Image->GetNumberOfComponentsPerPixel());
   }

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
@@ -75,8 +75,7 @@ BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::Prin
 
   itkPrintSelfBooleanMacro(UseImageDirection);
 
-  os << indent
-     << "NumberOfWorkUnits: " << static_cast<typename NumericTraits<ThreadIdType>::PrintType>(m_NumberOfWorkUnits)
+  os << indent << "NumberOfWorkUnits: " << static_cast<NumericTraits<ThreadIdType>::PrintType>(m_NumberOfWorkUnits)
      << std::endl;
 
   os << indent << "ThreadedEvaluateIndex: ";

--- a/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
@@ -41,16 +41,15 @@ RunLinearInterpolateTest()
   using IndexType = typename ImageType::IndexType;
 
   using CoordinateType = float;
-  using ContinuousIndexType = typename itk::ContinuousIndex<CoordinateType, Dimensions>;
+  using ContinuousIndexType = itk::ContinuousIndex<CoordinateType, Dimensions>;
 
   using AccumulatorType = typename ContinuousIndexType::ValueType;
 
-  using PointType = typename itk::Point<CoordinateType, Dimensions>;
+  using PointType = itk::Point<CoordinateType, Dimensions>;
 
-  using InterpolatorType = typename itk::LinearInterpolateImageFunction<ImageType, CoordinateType>;
-  using VectorInterpolatorType = typename itk::LinearInterpolateImageFunction<VectorImageType, CoordinateType>;
-  using VariableVectorInterpolatorType =
-    typename itk::LinearInterpolateImageFunction<VariableVectorImageType, CoordinateType>;
+  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, CoordinateType>;
+  using VectorInterpolatorType = itk::LinearInterpolateImageFunction<VectorImageType, CoordinateType>;
+  using VariableVectorInterpolatorType = itk::LinearInterpolateImageFunction<VariableVectorImageType, CoordinateType>;
 
   using InterpolatedVectorType = typename VectorInterpolatorType::OutputType;
   using InterpolatedVariableVectorType = typename VariableVectorInterpolatorType::OutputType;

--- a/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
@@ -126,7 +126,7 @@ itkNearestNeighborInterpolateImageFunctionTest(int, char *[])
 
   interpolator->SetInputImage(image);
 
-  typename ImageType::SizeType radius{};
+  ImageType::SizeType radius{};
   for (unsigned int d = 0; d < Dimension; ++d)
   {
     ITK_TEST_SET_GET_VALUE(radius[d], interpolator->GetRadius()[d]);

--- a/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
@@ -2650,9 +2650,8 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::PrintSelf(std::ostream & os, I
 
   os << indent << "LUT: " << m_LUT << std::endl;
 
-  os << indent << "LastVoxel: " << static_cast<typename NumericTraits<IdentifierType>::PrintType>(*m_LastVoxel)
-     << std::endl;
-  os << indent << "CurrentVoxel: " << static_cast<typename NumericTraits<IdentifierType>::PrintType>(*m_CurrentVoxel)
+  os << indent << "LastVoxel: " << static_cast<NumericTraits<IdentifierType>::PrintType>(*m_LastVoxel) << std::endl;
+  os << indent << "CurrentVoxel: " << static_cast<NumericTraits<IdentifierType>::PrintType>(*m_CurrentVoxel)
      << std::endl;
 
   os << indent << "LastRow: ";
@@ -2660,7 +2659,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::PrintSelf(std::ostream & os, I
   {
     if (*m_LastRow != nullptr)
     {
-      os << static_cast<typename NumericTraits<IdentifierType>::PrintType>(**m_LastRow) << std::endl;
+      os << static_cast<NumericTraits<IdentifierType>::PrintType>(**m_LastRow) << std::endl;
     }
   }
   else
@@ -2673,7 +2672,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::PrintSelf(std::ostream & os, I
   {
     if (*m_LastFrame != nullptr)
     {
-      os << static_cast<typename NumericTraits<IdentifierType>::PrintType>(**m_LastFrame) << std::endl;
+      os << static_cast<NumericTraits<IdentifierType>::PrintType>(**m_LastFrame) << std::endl;
     }
   }
   else
@@ -2686,7 +2685,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::PrintSelf(std::ostream & os, I
   {
     if (*m_CurrentRow != nullptr)
     {
-      os << static_cast<typename NumericTraits<IdentifierType>::PrintType>(**m_CurrentRow) << std::endl;
+      os << static_cast<NumericTraits<IdentifierType>::PrintType>(**m_CurrentRow) << std::endl;
     }
   }
   else
@@ -2699,7 +2698,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::PrintSelf(std::ostream & os, I
   {
     if (*m_CurrentFrame != nullptr)
     {
-      os << static_cast<typename NumericTraits<IdentifierType>::PrintType>(**m_CurrentFrame) << std::endl;
+      os << static_cast<NumericTraits<IdentifierType>::PrintType>(**m_CurrentFrame) << std::endl;
     }
   }
   else
@@ -2717,9 +2716,9 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::PrintSelf(std::ostream & os, I
 
   os << indent << "LocationOffset: " << m_LocationOffset << std::endl;
 
-  os << indent << "NumberOfNodes: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfNodes)
+  os << indent << "NumberOfNodes: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfNodes)
      << std::endl;
-  os << indent << "NumberOfCells: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfCells)
+  os << indent << "NumberOfCells: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfCells)
      << std::endl;
 
   os << indent << "NodeLimit: " << m_NodeLimit << std::endl;

--- a/Modules/Core/Mesh/include/itkMesh.h
+++ b/Modules/Core/Mesh/include/itkMesh.h
@@ -188,8 +188,8 @@ public:
   using CellDataContainer = typename MeshTraits::CellDataContainer;
 
   /** For improving Python support for Triangle Meshes **/
-  using CellsVectorContainer = typename itk::VectorContainer<IdentifierType>;
-  using CellsVectorContainerPointer = typename CellsVectorContainer::Pointer;
+  using CellsVectorContainer = itk::VectorContainer<IdentifierType>;
+  using CellsVectorContainerPointer = CellsVectorContainer::Pointer;
 
   /** Used to support geometric operations on the toolkit. */
   using BoundingBoxType = BoundingBox<PointIdentifier, Self::PointDimension, CoordinateType, PointsContainer>;

--- a/Modules/Core/Mesh/include/itkSimplexMesh.h
+++ b/Modules/Core/Mesh/include/itkSimplexMesh.h
@@ -62,13 +62,13 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** definition for array of indices. */
-  using IndexArray = typename SimplexMeshGeometry::IndexArray;
+  using IndexArray = SimplexMeshGeometry::IndexArray;
 
   /** definition for a set of neighbor indices */
   using NeighborSetType = std::set<SizeValueType>;
 
   /** */
-  using NeighborSetIterator = typename NeighborSetType::iterator;
+  using NeighborSetIterator = NeighborSetType::iterator;
 
   /** */
   using NeighborListType = std::vector<SizeValueType>;
@@ -99,11 +99,11 @@ public:
   using GeometryMapType = itk::MapContainer<SizeValueType, SimplexMeshGeometry *>;
 
   /** smartpointer def for the geometry map */
-  using GeometryMapPointer = typename GeometryMapType::Pointer;
+  using GeometryMapPointer = GeometryMapType::Pointer;
 
   /** iterator definition for iterating over a geometry map */
-  using GeometryMapIterator = typename GeometryMapType::Iterator;
-  using GeometryMapConstIterator = typename GeometryMapType::ConstIterator;
+  using GeometryMapIterator = GeometryMapType::Iterator;
+  using GeometryMapConstIterator = GeometryMapType::ConstIterator;
 
   // Backward compatibility to expose enum from class.
   using MeshClassCellsAllocationMethodEnum = itk::MeshEnums::MeshClassCellsAllocationMethod;

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
@@ -273,11 +273,10 @@ SimplexMeshVolumeCalculator<TInputMesh>::PrintSelf(std::ostream & os, Indent ind
   os << indent << "Wxy: " << m_Wxy << std::endl;
   os << indent << "Wxz: " << m_Wxz << std::endl;
   os << indent << "Wyz: " << m_Wyz << std::endl;
-  os << indent << "Muncx: " << static_cast<typename NumericTraits<IndexValueType>::PrintType>(m_Muncx) << std::endl;
-  os << indent << "Muncy: " << static_cast<typename NumericTraits<IndexValueType>::PrintType>(m_Muncy) << std::endl;
-  os << indent << "Muncz: " << static_cast<typename NumericTraits<IndexValueType>::PrintType>(m_Muncz) << std::endl;
-  os << indent
-     << "NumberOfTriangles: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfTriangles)
+  os << indent << "Muncx: " << static_cast<NumericTraits<IndexValueType>::PrintType>(m_Muncx) << std::endl;
+  os << indent << "Muncy: " << static_cast<NumericTraits<IndexValueType>::PrintType>(m_Muncy) << std::endl;
+  os << indent << "Muncz: " << static_cast<NumericTraits<IndexValueType>::PrintType>(m_Muncz) << std::endl;
+  os << indent << "NumberOfTriangles: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfTriangles)
      << std::endl;
 }
 } // namespace itk

--- a/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.h
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.h
@@ -108,7 +108,7 @@ public:
   using InputPointsContainerIterator = typename InputPointsContainer::Iterator;
 
   using PointSetType = itk::PointSet<double, 3>;
-  using PointsContainer = typename PointSetType::PointsContainer;
+  using PointsContainer = PointSetType::PointsContainer;
 
   using PointType = itk::Point<double, 3>;
   using Point2DType = itk::Point<double, 2>;

--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.h
@@ -103,7 +103,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 
 private:

--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
@@ -134,12 +134,12 @@ ArrowSpatialObject<TDimension>::GetLengthInWorldSpace() const
 }
 
 template <unsigned int TDimension>
-typename LightObject::Pointer
+LightObject::Pointer
 ArrowSpatialObject<TDimension>::InternalClone() const
 {
   // Default implementation just copies the parameters from
   // this to new transform.
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
   const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())
@@ -159,8 +159,6 @@ ArrowSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) cons
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "DirectionInObjectSpace: "
-     << static_cast<typename NumericTraits<VectorType>::PrintType>(m_DirectionInObjectSpace) << std::endl;
   os << indent
      << "PositionInObjectSpace: " << static_cast<typename NumericTraits<PointType>::PrintType>(m_PositionInObjectSpace)
      << std::endl;

--- a/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.h
@@ -77,7 +77,7 @@ protected:
   BlobSpatialObject();
   ~BlobSpatialObject() override = default;
 
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 };
 } // end namespace itk

--- a/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.hxx
@@ -36,14 +36,14 @@ BlobSpatialObject<TDimension>::BlobSpatialObject()
 }
 
 template <unsigned int TDimension>
-typename LightObject::Pointer
+LightObject::Pointer
 BlobSpatialObject<TDimension>::InternalClone() const
 {
   // Default implementation just copies the parameters from
   // this to new transform.
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
-  const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
+  const Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())
   {
     itkExceptionMacro("downcast to type " << this->GetNameOfClass() << " failed.");

--- a/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.h
@@ -91,7 +91,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 
 private:

--- a/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
@@ -75,14 +75,14 @@ BoxSpatialObject<TDimension>::ComputeMyBoundingBox()
 }
 
 template <unsigned int TDimension>
-typename LightObject::Pointer
+LightObject::Pointer
 BoxSpatialObject<TDimension>::InternalClone() const
 {
   // Default implementation just copies the parameters from
   // this to new transform.
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
-  const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
+  const Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())
   {
     itkExceptionMacro("downcast to type " << this->GetNameOfClass() << " failed.");

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.h
@@ -200,7 +200,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  typename LightObject::Pointer
+  LightObject::Pointer
   InternalClone() const override;
 
 private:

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
@@ -125,14 +125,14 @@ ContourSpatialObject<TDimension>::AddControlPoint(const ContourPointType & point
 }
 
 template <unsigned int TDimension>
-typename LightObject::Pointer
+LightObject::Pointer
 ContourSpatialObject<TDimension>::InternalClone() const
 {
   // Default implementation just copies the parameters from
   // this to new transform.
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
-  const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
+  const Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())
   {
     itkExceptionMacro("downcast to type " << this->GetNameOfClass() << " failed.");
@@ -160,7 +160,7 @@ ContourSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) co
   itkPrintSelfBooleanMacro(IsClosed);
   os << indent << "OrientationInObjectSpace: " << m_OrientationInObjectSpace << std::endl;
   os << indent << "OrientationInObjectSpaceMTime: "
-     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(m_OrientationInObjectSpaceMTime) << std::endl;
+     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_OrientationInObjectSpaceMTime) << std::endl;
   os << indent << "AttachedToSlice: " << m_AttachedToSlice << std::endl;
 }
 

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObject.h
@@ -72,7 +72,7 @@ protected:
   DTITubeSpatialObject();
   ~DTITubeSpatialObject() override = default;
 
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 };
 } // end namespace itk

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObject.hxx
@@ -29,14 +29,14 @@ DTITubeSpatialObject<TDimension>::DTITubeSpatialObject()
 }
 
 template <unsigned int TDimension>
-typename LightObject::Pointer
+LightObject::Pointer
 DTITubeSpatialObject<TDimension>::InternalClone() const
 {
   // Default implementation just copies the parameters from
   // this to new transform.
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
-  const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
+  const Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())
   {
     itkExceptionMacro("downcast to type " << this->GetNameOfClass() << " failed.");

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
@@ -133,7 +133,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 
 private:

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
@@ -112,12 +112,12 @@ EllipseSpatialObject<TDimension>::ComputeMyBoundingBox()
 }
 
 template <unsigned int TDimension>
-typename LightObject::Pointer
+LightObject::Pointer
 EllipseSpatialObject<TDimension>::InternalClone() const
 {
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
-  const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
+  const Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())
   {
     itkExceptionMacro("Downcast to type " << this->GetNameOfClass() << " failed.");

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
@@ -148,7 +148,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 
 private:

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.hxx
@@ -164,14 +164,14 @@ GaussianSpatialObject<TDimension>::GetEllipsoid() const
 }
 
 template <unsigned int TDimension>
-typename LightObject::Pointer
+LightObject::Pointer
 GaussianSpatialObject<TDimension>::InternalClone() const
 {
   // Default implementation just copies the parameters from
   // this to new transform.
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
-  const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
+  const Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())
   {
     itkExceptionMacro("downcast to type " << this->GetNameOfClass() << " failed.");

--- a/Modules/Core/SpatialObjects/include/itkGroupSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkGroupSpatialObject.h
@@ -57,7 +57,7 @@ protected:
   GroupSpatialObject();
   ~GroupSpatialObject() override = default;
 
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 };
 } // end namespace itk

--- a/Modules/Core/SpatialObjects/include/itkGroupSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkGroupSpatialObject.hxx
@@ -29,12 +29,12 @@ GroupSpatialObject<TDimension>::GroupSpatialObject()
 }
 
 template <unsigned int TDimension>
-typename LightObject::Pointer
+LightObject::Pointer
 GroupSpatialObject<TDimension>::InternalClone() const
 {
   // Default implementation just copies the parameters from
   // this to new transform.
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
   const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
@@ -131,7 +131,7 @@ protected:
   ImageMaskSpatialObject();
   ~ImageMaskSpatialObject() override = default;
 
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 
 private:

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -115,12 +115,12 @@ ImageMaskSpatialObject<TDimension, TPixel>::ComputeMyBoundingBox()
 }
 
 template <unsigned int TDimension, typename TPixel>
-typename LightObject::Pointer
+LightObject::Pointer
 ImageMaskSpatialObject<TDimension, TPixel>::InternalClone() const
 {
   // Default implementation just copies the parameters from
   // this to new transform.
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
   const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
@@ -145,7 +145,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 
 private:

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
@@ -168,12 +168,12 @@ ImageSpatialObject<TDimension, PixelType>::GetImage() const -> const ImageType *
 }
 
 template <unsigned int TDimension, typename PixelType>
-typename LightObject::Pointer
+LightObject::Pointer
 ImageSpatialObject<TDimension, PixelType>::InternalClone() const
 {
   // Default implementation just copies the parameters from
   // this to new transform.
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
   const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())

--- a/Modules/Core/SpatialObjects/include/itkLandmarkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkLandmarkSpatialObject.h
@@ -67,7 +67,7 @@ protected:
   LandmarkSpatialObject();
   ~LandmarkSpatialObject() override = default;
 
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 };
 } // end namespace itk

--- a/Modules/Core/SpatialObjects/include/itkLandmarkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLandmarkSpatialObject.hxx
@@ -36,12 +36,12 @@ LandmarkSpatialObject<TDimension>::LandmarkSpatialObject()
 }
 
 template <unsigned int TDimension>
-typename LightObject::Pointer
+LightObject::Pointer
 LandmarkSpatialObject<TDimension>::InternalClone() const
 {
   // Default implementation just copies the parameters from
   // this to new transform.
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
   const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObject.h
@@ -81,7 +81,7 @@ protected:
   LineSpatialObject();
   ~LineSpatialObject() override = default;
 
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 };
 } // end namespace itk

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObject.hxx
@@ -33,12 +33,12 @@ LineSpatialObject<TDimension>::LineSpatialObject()
 }
 
 template <unsigned int TDimension>
-typename LightObject::Pointer
+LightObject::Pointer
 LineSpatialObject<TDimension>::InternalClone() const
 {
   // Default implementation just copies the parameters from
   // this to new transform.
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
   const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
@@ -124,7 +124,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 
 private:

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
@@ -134,12 +134,12 @@ MeshSpatialObject<TMesh>::GetMesh() const -> const MeshType *
 }
 
 template <typename TMesh>
-typename LightObject::Pointer
+LightObject::Pointer
 MeshSpatialObject<TMesh>::InternalClone() const
 {
   // Default implementation just copies the parameters from
   // this to new transform.
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
   const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())

--- a/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.hxx
@@ -60,7 +60,7 @@ MetaMeshConverter<VDimension, PixelType, TMeshTraits>::MetaObjectToSpatialObject
   auto mesh = MeshType::New();
 
   // Add Points
-  using PointListType = typename MeshMetaObjectType::PointListType;
+  using PointListType = MeshMetaObjectType::PointListType;
   const PointListType points = _mesh->GetPoints();
   auto                it_points = points.begin();
 
@@ -82,7 +82,7 @@ MetaMeshConverter<VDimension, PixelType, TMeshTraits>::MetaObjectToSpatialObject
 
   for (unsigned int celltype = 0; celltype < MET_NUM_CELL_TYPES; ++celltype)
   {
-    using CellListType = typename MetaMesh::CellListType;
+    using CellListType = MetaMesh::CellListType;
     const CellListType cells = _mesh->GetCells(static_cast<MET_CellGeometry>(celltype));
     auto               it_cells = cells.begin();
 
@@ -145,7 +145,7 @@ MetaMeshConverter<VDimension, PixelType, TMeshTraits>::MetaObjectToSpatialObject
   }
 
   // Add cell links
-  using CellLinkListType = typename MetaMesh::CellLinkListType;
+  using CellLinkListType = MetaMesh::CellLinkListType;
   const CellLinkListType links = _mesh->GetCellLinks();
   auto                   it_links = links.begin();
 

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
@@ -145,7 +145,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 };
 } // end namespace itk

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
@@ -205,12 +205,12 @@ PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::IsInsideInObjectSp
 }
 
 template <unsigned int TDimension, class TSpatialObjectPointType>
-typename LightObject::Pointer
+LightObject::Pointer
 PointBasedSpatialObject<TDimension, TSpatialObjectPointType>::InternalClone() const
 {
   // Default implementation just copies the parameters from
   // this to new transform.
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
   const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())

--- a/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.h
@@ -105,7 +105,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  typename LightObject::Pointer
+  LightObject::Pointer
   InternalClone() const override;
 
 private:

--- a/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
@@ -283,12 +283,12 @@ PolygonSpatialObject<TDimension>::IsInsideInObjectSpace(const PointType & point)
 
 /** InternalClone */
 template <unsigned int TDimension>
-typename LightObject::Pointer
+LightObject::Pointer
 PolygonSpatialObject<TDimension>::InternalClone() const
 {
   // Default implementation just copies the parameters from
   // this to new transform.
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
   const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -733,7 +733,7 @@ protected:
     return m_MyBoundingBoxInObjectSpace.GetPointer();
   }
 
-  typename LightObject::Pointer
+  LightObject::Pointer
   InternalClone() const override;
 
 private:

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -322,10 +322,10 @@ SpatialObject<TDimension>::ValueAtChildrenInObjectSpace(const PointType &   poin
 }
 
 template <unsigned int TDimension>
-typename LightObject::Pointer
+LightObject::Pointer
 SpatialObject<TDimension>::InternalClone() const
 {
-  typename LightObject::Pointer loPtr = CreateAnother();
+  LightObject::Pointer loPtr = CreateAnother();
 
   const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
@@ -131,7 +131,7 @@ SpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent indent)
   os << indent
      << "PositionInObjectSpace: " << static_cast<typename NumericTraits<PointType>::PrintType>(m_PositionInObjectSpace)
      << std::endl;
-  os << indent << "Color: " << static_cast<typename NumericTraits<ColorType>::PrintType>(m_Color) << std::endl;
+  os << indent << "Color: " << static_cast<NumericTraits<ColorType>::PrintType>(m_Color) << std::endl;
 
   os << indent << "ScalarDictionary: " << std::endl;
   for (const auto & keyval : m_ScalarDictionary)

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
@@ -222,17 +222,15 @@ SpatialObjectToImageStatisticsCalculator<TInputImage, TInputSpatialObject, TSamp
 
   os << indent << "Mean: " << m_Mean << std::endl;
   os << indent << "Sum: " << static_cast<typename NumericTraits<AccumulateType>::PrintType>(m_Sum) << std::endl;
-  os << indent << "NumberOfPixels: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixels)
+  os << indent << "NumberOfPixels: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixels)
      << std::endl;
   os << indent << "CovarianceMatrix: " << m_CovarianceMatrix << std::endl;
   os << indent << "SampleDirection: " << m_SampleDirection << std::endl;
-  os << indent
-     << "InternalImageTime: " << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(m_InternalImageTime)
+  os << indent << "InternalImageTime: " << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_InternalImageTime)
      << std::endl;
   os << indent << "InternalSpatialObjectTime: "
-     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(m_InternalSpatialObjectTime) << std::endl;
-  os << indent << "ModifiedTime: " << static_cast<typename NumericTraits<TimeStamp>::PrintType>(m_ModifiedTime)
-     << std::endl;
+     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_InternalSpatialObjectTime) << std::endl;
+  os << indent << "ModifiedTime: " << static_cast<NumericTraits<TimeStamp>::PrintType>(m_ModifiedTime) << std::endl;
 
   itkPrintSelfObjectMacro(Sample);
 }

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.h
@@ -85,7 +85,7 @@ protected:
   SurfaceSpatialObject();
   ~SurfaceSpatialObject() override = default;
 
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 };
 

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.hxx
@@ -49,12 +49,12 @@ SurfaceSpatialObject<TDimension, TSurfacePointType>::Clear()
 }
 
 template <unsigned int TDimension, typename TSurfacePointType>
-typename LightObject::Pointer
+LightObject::Pointer
 SurfaceSpatialObject<TDimension, TSurfacePointType>::InternalClone() const
 {
   // Default implementation just copies the parameters from
   // this to new transform.
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
   const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
@@ -141,7 +141,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 
 private:

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
@@ -86,10 +86,10 @@ TubeSpatialObject<TDimension, TTubePointType>::CopyInformation(const DataObject 
 }
 
 template <unsigned int TDimension, typename TTubePointType>
-typename LightObject::Pointer
+LightObject::Pointer
 TubeSpatialObject<TDimension, TTubePointType>::InternalClone() const
 {
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
   const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())

--- a/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
@@ -67,7 +67,7 @@ itkImageSpatialObjectTest(int, char *[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(imageSO, ImageSpatialObject, SpatialObject);
 
 
-  constexpr typename ImageSpatialObject::IndexType sliceNumber{};
+  constexpr ImageSpatialObject::IndexType sliceNumber{};
   imageSO->SetSliceNumber(sliceNumber);
   ITK_TEST_SET_GET_VALUE(sliceNumber, imageSO->GetSliceNumber());
 

--- a/Modules/Core/TestKernel/include/itkTestingHashImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkTestingHashImageFilter.h
@@ -80,7 +80,7 @@ public:
   itkOverrideGetNameOfClassMacro(HashImageFilter);
 
   /** Smart Pointer type to a DataObject. */
-  using DataObjectPointer = typename DataObject::Pointer;
+  using DataObjectPointer = DataObject::Pointer;
 
   /** Type of DataObjects used for scalar outputs */
   using HashObjectType = SimpleDataObjectDecorator<std::string>;

--- a/Modules/Core/Transform/include/itkCompositeTransform.h
+++ b/Modules/Core/Transform/include/itkCompositeTransform.h
@@ -426,7 +426,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Clone the current transform */
-  typename LightObject::Pointer
+  LightObject::Pointer
   InternalClone() const override;
 
   void

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -962,21 +962,20 @@ CompositeTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & o
   }
 
   os << indent << "PreviousTransformsToOptimizeUpdateTime: "
-     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(m_PreviousTransformsToOptimizeUpdateTime)
-     << std::endl;
+     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_PreviousTransformsToOptimizeUpdateTime) << std::endl;
 }
 
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename LightObject::Pointer
+LightObject::Pointer
 CompositeTransform<TParametersValueType, VDimension>::InternalClone() const
 {
   // This class doesn't use its superclass implementation
   // TODO: is it really the right behavior?
   // LightObject::Pointer loPtr = Superclass::InternalClone();
 
-  LightObject::Pointer         loPtr = CreateAnother();
-  const typename Self::Pointer clone = dynamic_cast<Self *>(loPtr.GetPointer());
+  LightObject::Pointer loPtr = CreateAnother();
+  const Self::Pointer  clone = dynamic_cast<Self *>(loPtr.GetPointer());
   if (clone.IsNull())
   {
     itkExceptionMacro("downcast to type " << this->GetNameOfClass() << " failed.");

--- a/Modules/Core/Transform/include/itkTransform.h
+++ b/Modules/Core/Transform/include/itkTransform.h
@@ -564,7 +564,7 @@ protected:
    * This does a complete copy of the transform
    * state to the new transform
    */
-  typename LightObject::Pointer
+  LightObject::Pointer
   InternalClone() const override;
 
   /** Default-constructor. Creates a transform, having empty `Parameters` and `FixedParameters`. */

--- a/Modules/Core/Transform/include/itkTransform.hxx
+++ b/Modules/Core/Transform/include/itkTransform.hxx
@@ -45,12 +45,12 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::GetTransform
 
 
 template <typename TParametersValueType, unsigned int VInputDimension, unsigned int VOutputDimension>
-typename LightObject::Pointer
+LightObject::Pointer
 Transform<TParametersValueType, VInputDimension, VOutputDimension>::InternalClone() const
 {
   // Default implementation just copies the parameters from
   // this to new transform.
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
   const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest2.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest2.cxx
@@ -86,7 +86,7 @@ public:
 
     movingReader->SetFileName(argv[3]);
 
-    const typename FixedImageType::ConstPointer fixedImage = fixedReader->GetOutput();
+    const FixedImageType::ConstPointer fixedImage = fixedReader->GetOutput();
 
 
     using FilterType = itk::ResampleImageFilter<MovingImageType, FixedImageType>;
@@ -99,17 +99,16 @@ public:
 
     resampler->SetInterpolator(interpolator);
 
-    typename FixedImageType::SpacingType         fixedSpacing = fixedImage->GetSpacing();
-    typename FixedImageType::PointType           fixedOrigin = fixedImage->GetOrigin();
-    const typename FixedImageType::DirectionType fixedDirection = fixedImage->GetDirection();
+    FixedImageType::SpacingType         fixedSpacing = fixedImage->GetSpacing();
+    FixedImageType::PointType           fixedOrigin = fixedImage->GetOrigin();
+    const FixedImageType::DirectionType fixedDirection = fixedImage->GetDirection();
 
     resampler->SetOutputSpacing(fixedSpacing);
     resampler->SetOutputOrigin(fixedOrigin);
     resampler->SetOutputDirection(fixedDirection);
 
-
-    const typename FixedImageType::RegionType fixedRegion = fixedImage->GetBufferedRegion();
-    typename FixedImageType::SizeType         fixedSize = fixedRegion.GetSize();
+    const FixedImageType::RegionType fixedRegion = fixedImage->GetBufferedRegion();
+    FixedImageType::SizeType         fixedSize = fixedRegion.GetSize();
     resampler->SetSize(fixedSize);
     resampler->SetOutputStartIndex(fixedRegion.GetIndex());
 

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest3.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest3.cxx
@@ -87,7 +87,7 @@ public:
 
     movingReader->SetFileName(argv[3]);
 
-    const typename FixedImageType::ConstPointer fixedImage = fixedReader->GetOutput();
+    const FixedImageType::ConstPointer fixedImage = fixedReader->GetOutput();
 
 
     using FilterType = itk::ResampleImageFilter<MovingImageType, FixedImageType>;
@@ -100,17 +100,16 @@ public:
 
     resampler->SetInterpolator(interpolator);
 
-    typename FixedImageType::SpacingType         fixedSpacing = fixedImage->GetSpacing();
-    typename FixedImageType::PointType           fixedOrigin = fixedImage->GetOrigin();
-    const typename FixedImageType::DirectionType fixedDirection = fixedImage->GetDirection();
+    FixedImageType::SpacingType         fixedSpacing = fixedImage->GetSpacing();
+    FixedImageType::PointType           fixedOrigin = fixedImage->GetOrigin();
+    const FixedImageType::DirectionType fixedDirection = fixedImage->GetDirection();
 
     resampler->SetOutputSpacing(fixedSpacing);
     resampler->SetOutputOrigin(fixedOrigin);
     resampler->SetOutputDirection(fixedDirection);
 
-
-    const typename FixedImageType::RegionType fixedRegion = fixedImage->GetBufferedRegion();
-    typename FixedImageType::SizeType         fixedSize = fixedRegion.GetSize();
+    const FixedImageType::RegionType fixedRegion = fixedImage->GetBufferedRegion();
+    FixedImageType::SizeType         fixedSize = fixedRegion.GetSize();
     resampler->SetSize(fixedSize);
     resampler->SetOutputStartIndex(fixedRegion.GetIndex());
 

--- a/Modules/Core/Transform/test/itkBSplineTransformGTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformGTest.cxx
@@ -109,9 +109,9 @@ TEST(ITKBSplineTransform, CopyingClone)
   using namespace itk::GTest::TypedefsAndConstructors::Dimension2;
 
   using BSplineType = itk::BSplineTransform<double, 2, 3>;
-  using ImageType = typename BSplineType::ImageType;
+  using ImageType = BSplineType::ImageType;
 
-  typename BSplineType::CoefficientImageArray coeffImageArray;
+  BSplineType::CoefficientImageArray coeffImageArray;
 
   ASSERT_EQ(coeffImageArray.Size(), 2);
 

--- a/Modules/Core/Transform/test/itkBSplineTransformTest2.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest2.cxx
@@ -86,7 +86,7 @@ public:
 
     movingReader->SetFileName(argv[3]);
 
-    const typename FixedImageType::ConstPointer fixedImage = fixedReader->GetOutput();
+    const FixedImageType::ConstPointer fixedImage = fixedReader->GetOutput();
 
 
     using FilterType = itk::ResampleImageFilter<MovingImageType, FixedImageType>;
@@ -99,17 +99,17 @@ public:
 
     resampler->SetInterpolator(interpolator);
 
-    typename FixedImageType::SpacingType         fixedSpacing = fixedImage->GetSpacing();
-    const typename FixedImageType::PointType     fixedOrigin = fixedImage->GetOrigin();
-    const typename FixedImageType::DirectionType fixedDirection = fixedImage->GetDirection();
+    FixedImageType::SpacingType         fixedSpacing = fixedImage->GetSpacing();
+    const FixedImageType::PointType     fixedOrigin = fixedImage->GetOrigin();
+    const FixedImageType::DirectionType fixedDirection = fixedImage->GetDirection();
 
     resampler->SetOutputSpacing(fixedSpacing);
     resampler->SetOutputOrigin(fixedOrigin);
     resampler->SetOutputDirection(fixedDirection);
 
 
-    const typename FixedImageType::RegionType fixedRegion = fixedImage->GetBufferedRegion();
-    typename FixedImageType::SizeType         fixedSize = fixedRegion.GetSize();
+    const FixedImageType::RegionType fixedRegion = fixedImage->GetBufferedRegion();
+    FixedImageType::SizeType         fixedSize = fixedRegion.GetSize();
     resampler->SetSize(fixedSize);
     resampler->SetOutputStartIndex(fixedRegion.GetIndex());
 

--- a/Modules/Core/Transform/test/itkBSplineTransformTest3.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest3.cxx
@@ -86,7 +86,7 @@ public:
 
     movingReader->SetFileName(argv[3]);
 
-    const typename FixedImageType::ConstPointer fixedImage = fixedReader->GetOutput();
+    const FixedImageType::ConstPointer fixedImage = fixedReader->GetOutput();
 
 
     using FilterType = itk::ResampleImageFilter<MovingImageType, FixedImageType>;
@@ -99,17 +99,17 @@ public:
 
     resampler->SetInterpolator(interpolator);
 
-    typename FixedImageType::SpacingType         fixedSpacing = fixedImage->GetSpacing();
-    const typename FixedImageType::PointType     fixedOrigin = fixedImage->GetOrigin();
-    const typename FixedImageType::DirectionType fixedDirection = fixedImage->GetDirection();
+    FixedImageType::SpacingType         fixedSpacing = fixedImage->GetSpacing();
+    const FixedImageType::PointType     fixedOrigin = fixedImage->GetOrigin();
+    const FixedImageType::DirectionType fixedDirection = fixedImage->GetDirection();
 
     resampler->SetOutputSpacing(fixedSpacing);
     resampler->SetOutputOrigin(fixedOrigin);
     resampler->SetOutputDirection(fixedDirection);
 
 
-    const typename FixedImageType::RegionType fixedRegion = fixedImage->GetBufferedRegion();
-    typename FixedImageType::SizeType         fixedSize = fixedRegion.GetSize();
+    const FixedImageType::RegionType fixedRegion = fixedImage->GetBufferedRegion();
+    FixedImageType::SizeType         fixedSize = fixedRegion.GetSize();
     resampler->SetSize(fixedSize);
     resampler->SetOutputStartIndex(fixedRegion.GetIndex());
 

--- a/Modules/Core/Transform/test/itkFixedCenterOfRotationAffineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkFixedCenterOfRotationAffineTransformTest.cxx
@@ -108,7 +108,7 @@ itkFixedCenterOfRotationAffineTransformTest(int, char *[])
     ITK_TEST_EXPECT_EQUAL(scale1[i], scale3[i]);
   }
 
-  const typename FCoRAffine2DType::InputVectorType vScale = itk::MakeVector(2.0, 4.0);
+  const FCoRAffine2DType::InputVectorType vScale = itk::MakeVector(2.0, 4.0);
   aff2->SetScaleComponent(vScale);
   ITK_TEST_SET_GET_VALUE(vScale, aff2->GetScaleComponent());
 

--- a/Modules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx
@@ -42,15 +42,15 @@ itkRigid3DPerspectiveTransformTest(int, char *[])
     const typename TransformType::InputVectorType vector = itk::MakeVector(1.0, 4.0, 9.0);
     ITK_TRY_EXPECT_EXCEPTION(transform->TransformVector(vector));
 
-    typename TransformType::InputVnlVectorType vnlVector;
+    TransformType::InputVnlVectorType vnlVector;
     vnlVector.fill(1.0);
     ITK_TRY_EXPECT_EXCEPTION(transform->TransformVector(vnlVector));
 
-    auto covVector = itk::MakeFilled<typename TransformType::InputCovariantVectorType>(1.0);
+    auto covVector = itk::MakeFilled<TransformType::InputCovariantVectorType>(1.0);
     ITK_TRY_EXPECT_EXCEPTION(transform->TransformCovariantVector(covVector));
 
-    auto                                         point = itk::MakeFilled<typename TransformType::InputPointType>(1.0);
-    typename TransformType::JacobianPositionType jacobianPosition;
+    auto                                point = itk::MakeFilled<TransformType::InputPointType>(1.0);
+    TransformType::JacobianPositionType jacobianPosition;
     ITK_TRY_EXPECT_EXCEPTION(transform->ComputeJacobianWithRespectToPosition(point, jacobianPosition));
   }
 

--- a/Modules/Core/Transform/test/itkScaleTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkScaleTransformTest.cxx
@@ -63,7 +63,7 @@ itkScaleTransformTest(int, char *[])
 
     identityTransform->SetIdentity();
 
-    typename TransformType::ScaleType identityScale{ 1.0 };
+    TransformType::ScaleType identityScale{ 1.0 };
     ITK_TEST_SET_GET_VALUE(identityScale, identityTransform->GetScale());
 
     if (!Ok)

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -942,7 +942,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::PrintSelf(s
 
   os << indent << "BiasFieldDegree: " << m_BiasFieldDegree << std::endl;
   os << indent << "NumberOfLevels: " << m_NumberOfLevels << std::endl;
-  os << indent << "Schedule: " << static_cast<typename NumericTraits<ScheduleType>::PrintType>(m_Schedule) << std::endl;
+  os << indent << "Schedule: " << static_cast<NumericTraits<ScheduleType>::PrintType>(m_Schedule) << std::endl;
 
   os << indent << "VolumeCorrectionMaximumIteration: " << m_VolumeCorrectionMaximumIteration << std::endl;
   os << indent << "InterSliceCorrectionMaximumIteration: " << m_InterSliceCorrectionMaximumIteration << std::endl;

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryClosingByReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryClosingByReconstructionImageFilterTest.cxx
@@ -66,7 +66,7 @@ itkBinaryClosingByReconstructionImageFilterTest(int argc, char * argv[])
   auto fullyConnected = static_cast<bool>(std::stoi(argv[3]));
   ITK_TEST_SET_GET_BOOLEAN(reconstructionFilter, FullyConnected, fullyConnected);
 
-  const typename FilterType::InputImagePixelType foregroundValue = std::stoi(argv[4]);
+  const FilterType::InputImagePixelType foregroundValue = std::stoi(argv[4]);
   reconstructionFilter->SetForegroundValue(foregroundValue);
   ITK_TEST_SET_GET_VALUE(foregroundValue, reconstructionFilter->GetForegroundValue());
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryOpeningByReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryOpeningByReconstructionImageFilterTest.cxx
@@ -64,11 +64,11 @@ itkBinaryOpeningByReconstructionImageFilterTest(int argc, char * argv[])
   auto fullyConnected = static_cast<bool>(std::stoi(argv[4]));
   ITK_TEST_SET_GET_BOOLEAN(reconstruction, FullyConnected, fullyConnected);
 
-  auto foregroundValue = static_cast<typename I2LType::PixelType>(std::stoi(argv[5]));
+  auto foregroundValue = static_cast<I2LType::PixelType>(std::stoi(argv[5]));
   reconstruction->SetForegroundValue(foregroundValue);
   ITK_TEST_SET_GET_VALUE(foregroundValue, reconstruction->GetForegroundValue());
 
-  auto backgroundValue = static_cast<typename I2LType::PixelType>(std::stoi(argv[6]));
+  auto backgroundValue = static_cast<I2LType::PixelType>(std::stoi(argv[6]));
   reconstruction->SetBackgroundValue(backgroundValue);
   ITK_TEST_SET_GET_VALUE(backgroundValue, reconstruction->GetBackgroundValue());
 

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterStreamingTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterStreamingTest.cxx
@@ -28,11 +28,11 @@
 
 using KernelImageType = itk::Image<float, 2>;
 
-typename KernelImageType::Pointer
+KernelImageType::Pointer
 GenerateKernelForStreamingTest()
 {
   using SourceType = itk::GaussianImageSource<KernelImageType>;
-  using KernelSizeType = typename SourceType::SizeType;
+  using KernelSizeType = SourceType::SizeType;
   auto                     source = SourceType::New();
   constexpr KernelSizeType kernelSize{ 3, 5 };
   source->SetSize(kernelSize);
@@ -52,9 +52,9 @@ doConvolutionImageFilterStreamingTest(int argc, char * argv[])
 
   using PixelType = float;
   using ImageType = itk::Image<PixelType, ImageDimension>;
-  using RegionType = typename ImageType::RegionType;
-  using SizeType = typename RegionType::SizeType;
-  using IndexType = typename RegionType::IndexType;
+  using RegionType = ImageType::RegionType;
+  using SizeType = RegionType::SizeType;
+  using IndexType = RegionType::IndexType;
 
   // Request a subregion of the largest possible output
   IndexType requestedIndex;

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterSubregionTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterSubregionTest.cxx
@@ -26,11 +26,11 @@
 
 using KernelImageType = itk::Image<float, 2>;
 
-typename KernelImageType::Pointer
+KernelImageType::Pointer
 GenerateGaussianKernelForSubregionTest()
 {
   using SourceType = itk::GaussianImageSource<KernelImageType>;
-  using KernelSizeType = typename SourceType::SizeType;
+  using KernelSizeType = SourceType::SizeType;
   auto                     source = SourceType::New();
   constexpr KernelSizeType kernelSize{ 3, 5 };
   source->SetSize(kernelSize);
@@ -51,9 +51,9 @@ doConvolutionImageFilterSubregionTest(int argc, char * argv[])
 
   using PixelType = float;
   using ImageType = itk::Image<PixelType, ImageDimension>;
-  using RegionType = typename ImageType::RegionType;
-  using SizeType = typename RegionType::SizeType;
-  using IndexType = typename RegionType::IndexType;
+  using RegionType = ImageType::RegionType;
+  using SizeType = RegionType::SizeType;
+  using IndexType = RegionType::IndexType;
 
   // Request a subregion of the largest possible output
   IndexType requestedIndex;

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
@@ -90,7 +90,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
   {
     return;
   }
-  const typename ImageMaskSpatialObject<3>::Pointer maskSpatialObject =
+  const ImageMaskSpatialObject<3>::Pointer maskSpatialObject =
     dynamic_cast<ImageMaskSpatialObject<3> *>(this->ProcessObject::GetInput(1));
   if (maskSpatialObject.IsNull())
   {
@@ -176,7 +176,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
   vnl_vector<double> D(6);
 
   // if a mask is present, iterate through mask image and skip zero voxels
-  typename MaskSpatialObjectType::Pointer maskSpatialObject;
+  MaskSpatialObjectType::Pointer maskSpatialObject;
   if (this->m_MaskImagePresent)
   {
     maskSpatialObject = static_cast<MaskSpatialObjectType *>(this->ProcessObject::GetInput(1));

--- a/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.hxx
@@ -195,8 +195,7 @@ BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::Prin
      << "NumberOfControlPointsForTheConstantVelocityField: " << m_NumberOfControlPointsForTheConstantVelocityField
      << std::endl;
   os << indent << "NumberOfControlPointsForTheUpdateField: " << m_NumberOfControlPointsForTheUpdateField << std::endl;
-  os << indent << "SplineOrder: " << static_cast<typename NumericTraits<SplineOrderType>::PrintType>(m_SplineOrder)
-     << std::endl;
+  os << indent << "SplineOrder: " << static_cast<NumericTraits<SplineOrderType>::PrintType>(m_SplineOrder) << std::endl;
 }
 
 } // namespace itk

--- a/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.h
@@ -181,7 +181,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Clone the current transform */
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 
   /** Smooth the displacement field using B-splines.

--- a/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.hxx
@@ -182,12 +182,12 @@ BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimens
 }
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename LightObject::Pointer
+LightObject::Pointer
 BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::InternalClone() const
 {
   LightObject::Pointer loPtr = Superclass::InternalClone();
 
-  const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
+  const Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())
   {
     itkExceptionMacro("downcast to type " << this->GetNameOfClass() << " failed.");
@@ -214,8 +214,7 @@ BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimens
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "SplineOrder: " << static_cast<typename NumericTraits<SplineOrderType>::PrintType>(m_SplineOrder)
-     << std::endl;
+  os << indent << "SplineOrder: " << static_cast<NumericTraits<SplineOrderType>::PrintType>(m_SplineOrder) << std::endl;
   itkPrintSelfBooleanMacro(EnforceStationaryBoundary);
   os << indent << "NumberOfControlPointsForTheUpdateField: " << m_NumberOfControlPointsForTheUpdateField << std::endl;
   os << indent << "NumberOfControlPointsForTheTotalField: " << m_NumberOfControlPointsForTheTotalField << std::endl;

--- a/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.h
@@ -199,7 +199,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Clone the current transform */
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 
   typename DisplacementFieldType::Pointer

--- a/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
@@ -313,7 +313,7 @@ ConstantVelocityFieldTransform<TParametersValueType, VDimension>::CopyDisplaceme
 }
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename LightObject::Pointer
+LightObject::Pointer
 ConstantVelocityFieldTransform<TParametersValueType, VDimension>::InternalClone() const
 {
   // create a new instance

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
@@ -235,7 +235,7 @@ DisplacementFieldJacobianDeterminantFilter<TInputImage, TRealType, TOutputImage>
   os << indent << "HalfDerivativeWeights: " << m_HalfDerivativeWeights << std::endl;
   itkPrintSelfBooleanMacro(UseImageSpacing);
   os << indent << "RequestedNumberOfThreads: "
-     << static_cast<typename NumericTraits<ThreadIdType>::PrintType>(m_RequestedNumberOfWorkUnits) << std::endl;
+     << static_cast<NumericTraits<ThreadIdType>::PrintType>(m_RequestedNumberOfWorkUnits) << std::endl;
   os << indent << "RealValuedInputImage: " << m_RealValuedInputImage.GetPointer() << std::endl;
   os << indent
      << "NeighborhoodRadius: " << static_cast<typename NumericTraits<RadiusType>::PrintType>(m_NeighborhoodRadius)

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -588,7 +588,7 @@ DisplacementFieldTransform<TParametersValueType, VDimension>::PrintSelf(std::ost
   itkPrintSelfObjectMacro(InverseInterpolator);
 
   os << indent << "DisplacementFieldSetTime: "
-     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(m_DisplacementFieldSetTime) << std::endl;
+     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_DisplacementFieldSetTime) << std::endl;
 
   os << indent
      << "IdentityJacobian: " << static_cast<typename NumericTraits<JacobianType>::PrintType>(m_IdentityJacobian)

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.h
@@ -112,7 +112,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Clone the current transform */
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 
   /** Used in GaussianSmoothDisplacementField as variance for the

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.hxx
@@ -216,7 +216,7 @@ GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimen
 }
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename LightObject::Pointer
+LightObject::Pointer
 GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimension>::InternalClone() const
 {
   LightObject::Pointer loPtr = Superclass::InternalClone();

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.h
@@ -214,7 +214,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Clone the current transform */
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 
   typename DisplacementFieldType::Pointer

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
@@ -240,7 +240,7 @@ VelocityFieldTransform<TParametersValueType, VDimension>::CopyDisplacementField(
 }
 
 template <typename TParametersValueType, unsigned int VDimension>
-typename LightObject::Pointer
+LightObject::Pointer
 VelocityFieldTransform<TParametersValueType, VDimension>::InternalClone() const
 {
   // create a new instance

--- a/Modules/Filtering/DisplacementField/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest.cxx
@@ -42,14 +42,12 @@ itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest(int, char *[])
     displacementTransform, BSplineSmoothingOnUpdateDisplacementFieldTransform, DisplacementFieldTransform);
 
 
-  constexpr typename DisplacementTransformType::ArrayType::ValueType controlPointsUpdateFieldVal = 4;
-  auto                                                               controlPointsUpdateField =
-    itk::MakeFilled<typename DisplacementTransformType::ArrayType>(controlPointsUpdateFieldVal);
+  constexpr DisplacementTransformType::ArrayType::ValueType controlPointsUpdateFieldVal = 4;
+  auto controlPointsUpdateField = itk::MakeFilled<DisplacementTransformType::ArrayType>(controlPointsUpdateFieldVal);
   ITK_TEST_SET_GET_VALUE(controlPointsUpdateField, displacementTransform->GetNumberOfControlPointsForTheUpdateField());
 
-  constexpr typename DisplacementTransformType::ArrayType::ValueType controlPointsTotalFieldVal = 0;
-  auto                                                               controlPointsTotalField =
-    itk::MakeFilled<typename DisplacementTransformType::ArrayType>(controlPointsTotalFieldVal);
+  constexpr DisplacementTransformType::ArrayType::ValueType controlPointsTotalFieldVal = 0;
+  auto controlPointsTotalField = itk::MakeFilled<DisplacementTransformType::ArrayType>(controlPointsTotalFieldVal);
   ITK_TEST_SET_GET_VALUE(controlPointsTotalField, displacementTransform->GetNumberOfControlPointsForTheTotalField());
 
   using FieldType = DisplacementTransformType::DisplacementFieldType;
@@ -83,7 +81,7 @@ itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest(int, char *[])
   auto meshSizeForTotalField = itk::MakeFilled<DisplacementTransformType::ArrayType>(30);
   displacementTransform->SetMeshSizeForTheTotalField(meshSizeForTotalField);
 
-  constexpr typename DisplacementTransformType::SplineOrderType splineOrder = 3;
+  constexpr DisplacementTransformType::SplineOrderType splineOrder = 3;
   displacementTransform->SetSplineOrder(splineOrder);
   ITK_TEST_SET_GET_VALUE(splineOrder, displacementTransform->GetSplineOrder());
 

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldToBSplineImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldToBSplineImageFilterTest.cxx
@@ -106,8 +106,8 @@ itkDisplacementFieldToBSplineImageFilterTest(int, char *[])
   bspliner->SetSplineOrder(splineOrder);
   ITK_TEST_SET_GET_VALUE(splineOrder, bspliner->GetSplineOrder());
 
-  typename BSplineFilterType::ArrayType::ValueType numberOfFittingLevelsVal = 8;
-  auto numberOfFittingLevels = itk::MakeFilled<typename BSplineFilterType::ArrayType>(numberOfFittingLevelsVal);
+  BSplineFilterType::ArrayType::ValueType numberOfFittingLevelsVal = 8;
+  auto numberOfFittingLevels = itk::MakeFilled<BSplineFilterType::ArrayType>(numberOfFittingLevelsVal);
   bspliner->SetNumberOfFittingLevels(numberOfFittingLevelsVal);
   ITK_TEST_SET_GET_VALUE(numberOfFittingLevels, bspliner->GetNumberOfFittingLevels());
 
@@ -118,19 +118,19 @@ itkDisplacementFieldToBSplineImageFilterTest(int, char *[])
 
   ITK_TEST_SET_GET_BOOLEAN(bspliner, EstimateInverse, false);
 
-  constexpr typename BSplineFilterType::OriginType::ValueType bSplineDomainOriginVal = 0.0;
-  auto bSplineDomainOrigin = itk::MakeFilled<typename BSplineFilterType::OriginType>(bSplineDomainOriginVal);
+  constexpr BSplineFilterType::OriginType::ValueType bSplineDomainOriginVal = 0.0;
+  auto bSplineDomainOrigin = itk::MakeFilled<BSplineFilterType::OriginType>(bSplineDomainOriginVal);
   ITK_TEST_EXPECT_EQUAL(bSplineDomainOrigin, bspliner->GetBSplineDomainOrigin());
 
-  constexpr typename BSplineFilterType::SpacingType::ValueType bSplineDomainSpacingVal = 1.0;
-  auto bSplineDomainSpacing = itk::MakeFilled<typename BSplineFilterType::SpacingType>(bSplineDomainSpacingVal);
+  constexpr BSplineFilterType::SpacingType::ValueType bSplineDomainSpacingVal = 1.0;
+  auto bSplineDomainSpacing = itk::MakeFilled<BSplineFilterType::SpacingType>(bSplineDomainSpacingVal);
   ITK_TEST_EXPECT_EQUAL(bSplineDomainSpacing, bspliner->GetBSplineDomainSpacing());
 
-  constexpr typename BSplineFilterType::SizeType::value_type bSplineDomainSizeVal = 0;
+  constexpr BSplineFilterType::SizeType::value_type bSplineDomainSizeVal = 0;
   auto bSplineDomainSize = BSplineFilterType::SizeType::Filled(bSplineDomainSizeVal);
   ITK_TEST_EXPECT_EQUAL(bSplineDomainSize, bspliner->GetBSplineDomainSize());
 
-  typename BSplineFilterType::DirectionType bSplineDomainDirection;
+  BSplineFilterType::DirectionType bSplineDomainDirection;
   bSplineDomainDirection.SetIdentity();
   ITK_TEST_EXPECT_EQUAL(bSplineDomainDirection, bspliner->GetBSplineDomainDirection());
 

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
@@ -568,16 +568,14 @@ itkDisplacementFieldTransformTest(int argc, char * argv[])
     {
       std::cerr << "Test failed!" << std::endl;
       std::cerr << "Error in UpdateTransformParameters at index [" << i << "]" << std::endl;
-      std::cerr
-        << "Expected value "
-        << static_cast<typename itk::NumericTraits<DisplacementTransformType::DerivativeType::ValueType>::PrintType>(
-             updateTruth[i])
-        << std::endl;
-      std::cerr
-        << " differs from "
-        << static_cast<typename itk::NumericTraits<DisplacementTransformType::DerivativeType::ValueType>::PrintType>(
-             params[i])
-        << std::endl;
+      std::cerr << "Expected value "
+                << static_cast<itk::NumericTraits<DisplacementTransformType::DerivativeType::ValueType>::PrintType>(
+                     updateTruth[i])
+                << std::endl;
+      std::cerr << " differs from "
+                << static_cast<itk::NumericTraits<DisplacementTransformType::DerivativeType::ValueType>::PrintType>(
+                     params[i])
+                << std::endl;
       return EXIT_FAILURE;
     }
   }

--- a/Modules/Filtering/DisplacementField/test/itkInvertDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkInvertDisplacementFieldImageFilterTest.cxx
@@ -101,11 +101,11 @@ itkInvertDisplacementFieldImageFilterTest(int argc, char * argv[])
   inverter->SetMaximumNumberOfIterations(numberOfIterations);
   ITK_TEST_SET_GET_VALUE(numberOfIterations, inverter->GetMaximumNumberOfIterations());
 
-  auto meanTolerance = static_cast<typename InverterType::RealType>(std::stod(argv[2]));
+  auto meanTolerance = static_cast<InverterType::RealType>(std::stod(argv[2]));
   inverter->SetMeanErrorToleranceThreshold(meanTolerance);
   ITK_TEST_SET_GET_VALUE(meanTolerance, inverter->GetMeanErrorToleranceThreshold());
 
-  auto maxTolerance = static_cast<typename InverterType::RealType>(std::stod(argv[3]));
+  auto maxTolerance = static_cast<InverterType::RealType>(std::stod(argv[3]));
   inverter->SetMaxErrorToleranceThreshold(maxTolerance);
   ITK_TEST_SET_GET_VALUE(maxTolerance, inverter->GetMaxErrorToleranceThreshold());
 

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
@@ -84,11 +84,11 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int argc, char * argv[])
   integrator->SetInitialDiffeomorphism(initialDiffeomorphism);
   ITK_TEST_SET_GET_VALUE(initialDiffeomorphism, integrator->GetInitialDiffeomorphism());
 
-  auto lowerTimeBound = static_cast<typename IntegratorType::RealType>(std::stod(argv[1]));
+  auto lowerTimeBound = static_cast<IntegratorType::RealType>(std::stod(argv[1]));
   integrator->SetLowerTimeBound(lowerTimeBound);
   ITK_TEST_SET_GET_VALUE(lowerTimeBound, integrator->GetLowerTimeBound());
 
-  auto upperTimeBound = static_cast<typename IntegratorType::RealType>(std::stod(argv[2]));
+  auto upperTimeBound = static_cast<IntegratorType::RealType>(std::stod(argv[2]));
   integrator->SetUpperTimeBound(upperTimeBound);
   ITK_TEST_SET_GET_VALUE(upperTimeBound, integrator->GetUpperTimeBound());
 
@@ -107,11 +107,11 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int argc, char * argv[])
 
   auto inverseIntegrator = IntegratorType::New();
 
-  auto invLowerTimeBound = static_cast<typename IntegratorType::RealType>(std::stod(argv[7]));
+  auto invLowerTimeBound = static_cast<IntegratorType::RealType>(std::stod(argv[7]));
   inverseIntegrator->SetLowerTimeBound(invLowerTimeBound);
   ITK_TEST_SET_GET_VALUE(invLowerTimeBound, inverseIntegrator->GetLowerTimeBound());
 
-  auto invUpperTimeBound = static_cast<typename IntegratorType::RealType>(std::stod(argv[8]));
+  auto invUpperTimeBound = static_cast<IntegratorType::RealType>(std::stod(argv[8]));
   inverseIntegrator->SetUpperTimeBound(invUpperTimeBound);
   ITK_TEST_SET_GET_VALUE(invUpperTimeBound, inverseIntegrator->GetUpperTimeBound());
 
@@ -213,10 +213,10 @@ itkTimeVaryingVelocityFieldIntegrationImageFilterTest(int argc, char * argv[])
 
   const TimeVaryingVelocityFieldType::Pointer timeVaryingVelocityField = importFilter->GetOutput();
 
-  lowerTimeBound = static_cast<typename IntegratorType::RealType>(std::stod(argv[4]));
+  lowerTimeBound = static_cast<IntegratorType::RealType>(std::stod(argv[4]));
   integrator->SetLowerTimeBound(lowerTimeBound);
 
-  upperTimeBound = static_cast<typename IntegratorType::RealType>(std::stod(argv[5]));
+  upperTimeBound = static_cast<IntegratorType::RealType>(std::stod(argv[5]));
   integrator->SetUpperTimeBound(upperTimeBound);
 
   integrator->SetInput(timeVaryingVelocityField);

--- a/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
@@ -201,8 +201,7 @@ DirectedHausdorffDistanceImageFilter<TInputImage1, TInputImage2>::PrintSelf(std:
 
   os << indent << "MaxDistance: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_MaxDistance)
      << std::endl;
-  os << indent << "PixelCount: " << static_cast<typename NumericTraits<IdentifierType>::PrintType>(m_PixelCount)
-     << std::endl;
+  os << indent << "PixelCount: " << static_cast<NumericTraits<IdentifierType>::PrintType>(m_PixelCount) << std::endl;
   os << indent << "Sum: " << m_Sum.GetSum();
 
   os << std::endl;

--- a/Modules/Filtering/DistanceMap/test/itkDirectedHausdorffDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkDirectedHausdorffDistanceImageFilterTest.cxx
@@ -59,11 +59,11 @@ itkDirectedHausdorffDistanceImageFilterTest(int argc, char * argv[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, DirectedHausdorffDistanceImageFilter, ImageToImageFilter);
 
 
-  const typename ImageType::Pointer image1 = reader1->GetOutput();
+  const ImageType::Pointer image1 = reader1->GetOutput();
   filter->SetInput1(image1);
   ITK_TEST_SET_GET_VALUE(image1, filter->GetInput1());
 
-  const typename ImageType::Pointer image2 = reader2->GetOutput();
+  const ImageType::Pointer image2 = reader2->GetOutput();
   filter->SetInput2(image2);
   ITK_TEST_SET_GET_VALUE(image2, filter->GetInput2());
 

--- a/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.h
@@ -59,8 +59,8 @@ public:
    * configured in, or float if only double is configured.
    */
   using FFTW1DProxyType = typename fftw::ComplexToComplexProxy<typename TInputImage::PixelType::value_type>;
-  using PlanArrayType = typename std::vector<typename FFTW1DProxyType::PlanType>;
-  using PlanBufferPointerType = typename std::vector<typename FFTW1DProxyType::ComplexType *>;
+  using PlanArrayType = std::vector<typename FFTW1DProxyType::PlanType>;
+  using PlanBufferPointerType = std::vector<typename FFTW1DProxyType::ComplexType *>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.h
@@ -61,8 +61,8 @@ public:
    * configured in, or float if only double is configured.
    */
   using FFTW1DProxyType = typename fftw::ComplexToComplexProxy<typename TInputImage::PixelType>;
-  using PlanArrayType = typename std::vector<typename FFTW1DProxyType::PlanType>;
-  using PlanBufferPointerType = typename std::vector<typename FFTW1DProxyType::ComplexType *>;
+  using PlanArrayType = std::vector<typename FFTW1DProxyType::PlanType>;
+  using PlanBufferPointerType = std::vector<typename FFTW1DProxyType::ComplexType *>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.h
@@ -61,8 +61,8 @@ public:
    * configured in, or float if only double is configured.
    */
   using FFTW1DProxyType = typename fftw::ComplexToComplexProxy<typename TOutputImage::PixelType>;
-  using PlanArrayType = typename std::vector<typename FFTW1DProxyType::PlanType>;
-  using PlanBufferPointerType = typename std::vector<typename FFTW1DProxyType::ComplexType *>;
+  using PlanArrayType = std::vector<typename FFTW1DProxyType::PlanType>;
+  using PlanBufferPointerType = std::vector<typename FFTW1DProxyType::ComplexType *>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
@@ -49,8 +49,7 @@ FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::PrintSelf(std::os
   os << indent << "TargetOffset: " << m_TargetOffset << std::endl;
   os << indent << "TargetReachedMode: " << m_TargetReachedMode << std::endl;
   os << indent << "TargetValue: " << m_TargetValue << std::endl;
-  os << indent
-     << "NumberOfTargets: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfTargets)
+  os << indent << "NumberOfTargets: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfTargets)
      << std::endl;
 }
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingBaseTest.cxx
@@ -144,7 +144,7 @@ itkFastMarchingBaseTest(int argc, char * argv[])
     double normalizationFactor = 1.0;
     ITK_TEST_SET_GET_VALUE(normalizationFactor, fmm->GetNormalizationFactor());
 
-    constexpr typename ImageFastMarching::OutputPixelType targetReachedValue{};
+    constexpr ImageFastMarching::OutputPixelType targetReachedValue{};
     ITK_TEST_EXPECT_EQUAL(targetReachedValue, fmm->GetTargetReachedValue());
 
     bool collectPoints = false;
@@ -155,9 +155,9 @@ itkFastMarchingBaseTest(int argc, char * argv[])
     fmm->SetTopologyCheck(topologyCheck);
     ITK_TEST_SET_GET_VALUE(topologyCheck, fmm->GetTopologyCheck());
 
-    auto                                     processedPoints = ImageFastMarching::NodePairContainerType::New();
-    typename ImageFastMarching::NodePairType node_pair;
-    constexpr ImageType::OffsetType          offset{ 28, 35 };
+    auto                            processedPoints = ImageFastMarching::NodePairContainerType::New();
+    ImageFastMarching::NodePairType node_pair;
+    constexpr ImageType::OffsetType offset{ 28, 35 };
 
     constexpr itk::Index<Dimension> index{};
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest1.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest1.cxx
@@ -59,7 +59,7 @@ itkFastMarchingImageFilterRealTest1(int itkNotUsed(argc), char * itkNotUsed(argv
 
   auto criterion = CriterionType::New();
 
-  constexpr typename FloatImageType::PixelType threshold = 100.0;
+  constexpr FloatImageType::PixelType threshold = 100.0;
   criterion->SetThreshold(threshold);
   ITK_TEST_SET_GET_VALUE(threshold, criterion->GetThreshold());
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest2.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest2.cxx
@@ -159,14 +159,14 @@ itkFastMarchingImageFilterRealTest2(int itkNotUsed(argc), char * itkNotUsed(argv
   adaptor->SetAliveImage(aliveImage.GetPointer());
   ITK_TEST_SET_GET_VALUE(aliveImage.GetPointer(), adaptor->GetAliveImage());
 
-  constexpr typename AdaptorType::OutputPixelType aliveValue = 0.0;
+  constexpr AdaptorType::OutputPixelType aliveValue = 0.0;
   adaptor->SetAliveValue(aliveValue);
   ITK_TEST_SET_GET_VALUE(aliveValue, adaptor->GetAliveValue());
 
   adaptor->SetTrialImage(trialImage.GetPointer());
   ITK_TEST_SET_GET_VALUE(trialImage.GetPointer(), adaptor->GetTrialImage());
 
-  constexpr typename AdaptorType::OutputPixelType trialValue = 1.0;
+  constexpr AdaptorType::OutputPixelType trialValue = 1.0;
   adaptor->SetTrialValue(trialValue);
   ITK_TEST_SET_GET_VALUE(trialValue, adaptor->GetTrialValue());
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
@@ -145,29 +145,29 @@ itkFastMarchingTest(int argc, char * argv[])
   auto collectPoints = static_cast<bool>(std::stoi(argv[4]));
   ITK_TEST_SET_GET_BOOLEAN(marcher, CollectPoints, collectPoints);
 
-  constexpr typename FloatImage::SizeType size = { { 64, 64 } };
+  constexpr FloatImage::SizeType size = { { 64, 64 } };
   marcher->SetOutputSize(size);
   ITK_TEST_SET_GET_VALUE(size, marcher->GetOutputSize());
 
   auto outputRegionIndexValue =
-    static_cast<typename FloatFMType::LevelSetImageType::IndexType::IndexValueType>(std::stoi(argv[5]));
+    static_cast<FloatFMType::LevelSetImageType::IndexType::IndexValueType>(std::stoi(argv[5]));
   auto outputRegionIndex = FloatFMType::LevelSetImageType::IndexType::Filled(outputRegionIndexValue);
-  const typename FloatFMType::OutputRegionType outputRegion{ outputRegionIndex, size };
+  const FloatFMType::OutputRegionType outputRegion{ outputRegionIndex, size };
   marcher->SetOutputRegion(outputRegion);
   ITK_TEST_SET_GET_VALUE(outputRegion, marcher->GetOutputRegion());
 
-  auto outputSpacingValue = static_cast<typename FloatFMType::OutputSpacingType::ValueType>(std::stod(argv[6]));
-  auto outputSpacing = itk::MakeFilled<typename FloatFMType::OutputSpacingType>(outputSpacingValue);
+  auto outputSpacingValue = static_cast<FloatFMType::OutputSpacingType::ValueType>(std::stod(argv[6]));
+  auto outputSpacing = itk::MakeFilled<FloatFMType::OutputSpacingType>(outputSpacingValue);
   marcher->SetOutputSpacing(outputSpacing);
   ITK_TEST_SET_GET_VALUE(outputSpacing, marcher->GetOutputSpacing());
 
-  typename FloatFMType::OutputDirectionType outputDirection;
+  FloatFMType::OutputDirectionType outputDirection;
   outputDirection.SetIdentity();
   marcher->SetOutputDirection(outputDirection);
   ITK_TEST_SET_GET_VALUE(outputDirection, marcher->GetOutputDirection());
 
-  auto outputOriginValue = static_cast<typename FloatFMType::OutputPointType::ValueType>(std::stod(argv[7]));
-  auto outputOrigin = itk::MakeFilled<typename FloatFMType::OutputPointType>(outputOriginValue);
+  auto outputOriginValue = static_cast<FloatFMType::OutputPointType::ValueType>(std::stod(argv[7]));
+  auto outputOrigin = itk::MakeFilled<FloatFMType::OutputPointType>(outputOriginValue);
   marcher->SetOutputOrigin(outputOrigin);
   ITK_TEST_SET_GET_VALUE(outputOrigin, marcher->GetOutputOrigin());
 

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientBaseTest.cxx
@@ -195,7 +195,7 @@ itkFastMarchingUpwindGradientBaseTest(int, char *[])
   }
   criterion->SetTargetNodes(TargetNodes);
 
-  constexpr typename CriterionType::OutputPixelType targetOffset{};
+  constexpr CriterionType::OutputPixelType targetOffset{};
   criterion->SetTargetOffset(targetOffset);
   ITK_TEST_SET_GET_VALUE(targetOffset, criterion->GetTargetOffset());
 

--- a/Modules/Filtering/ImageCompare/test/itkTestingComparisonImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkTestingComparisonImageFilterTest.cxx
@@ -69,7 +69,7 @@ itkTestingComparisonImageFilterTest(int argc, char * argv[])
   auto ignoreBoundaryPixels = static_cast<bool>(std::stoi(argv[4]));
   ITK_TEST_SET_GET_BOOLEAN(filter, IgnoreBoundaryPixels, ignoreBoundaryPixels);
 
-  auto differenceThreshold = static_cast<typename FilterType::OutputPixelType>(std::stoi(argv[5]));
+  auto differenceThreshold = static_cast<FilterType::OutputPixelType>(std::stoi(argv[5]));
   filter->SetDifferenceThreshold(differenceThreshold);
   ITK_TEST_SET_GET_VALUE(differenceThreshold, filter->GetDifferenceThreshold());
 
@@ -99,13 +99,13 @@ itkTestingComparisonImageFilterTest(int argc, char * argv[])
   char * end = nullptr;
   ITK_TEST_EXPECT_EQUAL(numberOfPixelsWithDifferences, std::strtoul(argv[7], &end, 10));
 
-  auto minimumDifference = static_cast<typename FilterType::OutputPixelType>(std::stod(argv[8]));
+  auto minimumDifference = static_cast<FilterType::OutputPixelType>(std::stod(argv[8]));
   ITK_TEST_EXPECT_EQUAL(minimumDifference, filter->GetMinimumDifference());
 
-  auto maximumDifference = static_cast<typename FilterType::OutputPixelType>(std::stod(argv[9]));
+  auto maximumDifference = static_cast<FilterType::OutputPixelType>(std::stod(argv[9]));
   ITK_TEST_EXPECT_EQUAL(maximumDifference, filter->GetMaximumDifference());
 
-  auto meanDifference = static_cast<typename FilterType::RealType>(std::stod(argv[10]));
+  auto meanDifference = static_cast<FilterType::RealType>(std::stod(argv[10]));
 
   constexpr double epsilon{ 1e-4 };
   std::cout.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
@@ -120,7 +120,7 @@ itkTestingComparisonImageFilterTest(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  auto totalDifference = static_cast<typename FilterType::AccumulateType>(std::stod(argv[11]));
+  auto totalDifference = static_cast<FilterType::AccumulateType>(std::stod(argv[11]));
   ITK_TEST_EXPECT_EQUAL(totalDifference, filter->GetTotalDifference());
 
   // Change test input spacing to test that comparison filter fails if spacings are different

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.h
@@ -94,10 +94,10 @@ public:
 
   /** Circle type alias. */
   using CircleType = EllipseSpatialObject<2>;
-  using CirclePointer = typename CircleType::Pointer;
+  using CirclePointer = CircleType::Pointer;
   using CirclesListType = std::list<CirclePointer>;
 
-  using CirclesListSizeType = typename CirclesListType::size_type;
+  using CirclesListSizeType = CirclesListType::size_type;
 
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(HoughTransform2DCirclesImageFilter);

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.h
@@ -83,11 +83,11 @@ public:
 
   /** Line type alias */
   using LineType = LineSpatialObject<2>;
-  using LinePointer = typename LineType::Pointer;
+  using LinePointer = LineType::Pointer;
   using LinesListType = std::list<LinePointer>;
   using LinePointType = LineType::LinePointType;
 
-  using LinesListSizeType = typename LinesListType::size_type;
+  using LinesListSizeType = LinesListType::size_type;
 
   /** Standard "Superclass" type alias. */
   using Superclass = ImageToImageFilter<InputImageType, OutputImageType>;

--- a/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
@@ -50,8 +50,7 @@ MaskFeaturePointSelectionFilter<TImage, TMask, TFeatures>::PrintSelf(std::ostrea
 
   os << indent << "NonConnectivity: " << m_NonConnectivity << std::endl;
   os << indent << "NonConnectivityOffsets: " << m_NonConnectivityOffsets << std::endl;
-  os << indent << "BlockRadius: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_BlockRadius)
-     << std::endl;
+  os << indent << "BlockRadius: " << static_cast<NumericTraits<SizeType>::PrintType>(m_BlockRadius) << std::endl;
   os << indent << "SelectFraction: " << m_SelectFraction << std::endl;
   itkPrintSelfBooleanMacro(ComputeStructureTensors);
 }
@@ -196,7 +195,7 @@ MaskFeaturePointSelectionFilter<TImage, TMask, TFeatures>::GenerateData()
       const double meanOfSquares = sumOfSquares.GetSum() / numPixelsInNeighborhood;
 
       const double variance = meanOfSquares - squaredMean;
-      using PairType = typename MultiMapType::value_type;
+      using PairType = MultiMapType::value_type;
 
       // we only insert blocks with variance > 0
       if (itk::NumericTraits<double>::IsPositive(variance))

--- a/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest.cxx
@@ -37,8 +37,8 @@ itkBilateralImageFilterTest(int, char *[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, BilateralImageFilter, ImageToImageFilter);
 
 
-  double                         domainSigmaVal = 2.0;
-  typename FilterType::ArrayType domainSigma = FilterType::ArrayType::Filled(domainSigmaVal);
+  double                domainSigmaVal = 2.0;
+  FilterType::ArrayType domainSigma = FilterType::ArrayType::Filled(domainSigmaVal);
   filter->SetDomainSigma(domainSigmaVal);
   ITK_TEST_SET_GET_VALUE(domainSigma, filter->GetDomainSigma());
 
@@ -61,8 +61,8 @@ itkBilateralImageFilterTest(int, char *[])
   constexpr bool automaticKernelSize{ true };
   ITK_TEST_SET_GET_BOOLEAN(filter, AutomaticKernelSize, automaticKernelSize);
 
-  constexpr typename FilterType::SizeType::SizeValueType radiusVal = 2;
-  constexpr typename FilterType::SizeType                radius = FilterType::SizeType::Filled(radiusVal);
+  constexpr FilterType::SizeType::SizeValueType radiusVal = 2;
+  constexpr FilterType::SizeType                radius = FilterType::SizeType::Filled(radiusVal);
   filter->SetRadius(radius);
   ITK_TEST_SET_GET_VALUE(radius, filter->GetRadius());
 

--- a/Modules/Filtering/ImageFeature/test/itkHessian3DToVesselnessMeasureImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessian3DToVesselnessMeasureImageFilterTest.cxx
@@ -106,7 +106,7 @@ itkHessian3DToVesselnessMeasureImageFilterTest(int argc, char * argv[])
   filterVesselness->SetInput(filterHessian->GetOutput());
 
   // Select the value of Sigma
-  auto sigma = static_cast<typename myHessianFilterType::RealType>(std::stod(argv[1]));
+  auto sigma = static_cast<myHessianFilterType::RealType>(std::stod(argv[1]));
   filterHessian->SetSigma(sigma);
 
   auto alpha1 = std::stod(argv[2]);

--- a/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterTest.cxx
@@ -91,7 +91,7 @@ itkHessianRecursiveGaussianFilterTest(int argc, char * argv[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, HessianRecursiveGaussianImageFilter, ImageToImageFilter);
 
 
-  auto sigma = static_cast<typename myFilterType::RealType>(std::stod(argv[1]));
+  auto sigma = static_cast<myFilterType::RealType>(std::stod(argv[1]));
   filter->SetSigma(sigma);
   ITK_TEST_SET_GET_VALUE(sigma, filter->GetSigma());
 

--- a/Modules/Filtering/ImageFeature/test/itkMaskFeaturePointSelectionFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkMaskFeaturePointSelectionFilterTest.cxx
@@ -78,7 +78,7 @@ itkMaskFeaturePointSelectionFilterTest(int argc, char * argv[])
   filter->SetNonConnectivity(nonConnectivity);
   ITK_TEST_SET_GET_VALUE(nonConnectivity, filter->GetNonConnectivity());
 
-  auto blockRadiusValue = static_cast<typename FilterType::SizeType::SizeValueType>(std::stod(argv[4]));
+  auto blockRadiusValue = static_cast<FilterType::SizeType::SizeValueType>(std::stod(argv[4]));
   auto blockRadius = FilterType::SizeType::Filled(blockRadiusValue);
   filter->SetBlockRadius(blockRadius);
   ITK_TEST_SET_GET_VALUE(blockRadius, filter->GetBlockRadius());

--- a/Modules/Filtering/ImageFeature/test/itkZeroCrossingBasedEdgeDetectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkZeroCrossingBasedEdgeDetectionImageFilterTest.cxx
@@ -79,11 +79,11 @@ itkZeroCrossingBasedEdgeDetectionImageFilterTest(int argc, char * argv[])
   filter->SetMaximumError(maximumError);
   ITK_TEST_SET_GET_VALUE(maximumError, filter->GetMaximumError());
 
-  auto backgroundValue = static_cast<typename FilterType::OutputImagePixelType>(std::stod(argv[3]));
+  auto backgroundValue = static_cast<FilterType::OutputImagePixelType>(std::stod(argv[3]));
   filter->SetBackgroundValue(backgroundValue);
   ITK_TEST_SET_GET_VALUE(backgroundValue, filter->GetBackgroundValue());
 
-  auto foregroundValue = static_cast<typename FilterType::OutputImagePixelType>(std::stod(argv[4]));
+  auto foregroundValue = static_cast<FilterType::OutputImagePixelType>(std::stod(argv[4]));
   filter->SetForegroundValue(foregroundValue);
   ITK_TEST_SET_GET_VALUE(foregroundValue, filter->GetForegroundValue());
 

--- a/Modules/Filtering/ImageFeature/test/itkZeroCrossingImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkZeroCrossingImageFilterTest.cxx
@@ -44,12 +44,12 @@ itkZeroCrossingImageFilterTest(int, char *[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, ZeroCrossingImageFilter, ImageToImageFilter);
 
 
-  constexpr typename FilterType::OutputImagePixelType foregroundValue =
-    itk::NumericTraits<typename FilterType::OutputImagePixelType>::OneValue();
+  constexpr FilterType::OutputImagePixelType foregroundValue =
+    itk::NumericTraits<FilterType::OutputImagePixelType>::OneValue();
   filter->SetForegroundValue(foregroundValue);
   ITK_TEST_SET_GET_VALUE(foregroundValue, filter->GetForegroundValue());
 
-  constexpr typename FilterType::OutputImagePixelType backgroundValue{};
+  constexpr FilterType::OutputImagePixelType backgroundValue{};
   filter->SetBackgroundValue(backgroundValue);
   ITK_TEST_SET_GET_VALUE(backgroundValue, filter->GetBackgroundValue());
 

--- a/Modules/Filtering/ImageFusion/include/itkLabelOverlayImageFilter.hxx
+++ b/Modules/Filtering/ImageFusion/include/itkLabelOverlayImageFilter.hxx
@@ -100,7 +100,7 @@ LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>::PrintSelf(std::
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Opacity: " << static_cast<typename NumericTraits<double>::PrintType>(m_Opacity) << std::endl
+  os << indent << "Opacity: " << static_cast<NumericTraits<double>::PrintType>(m_Opacity) << std::endl
      << indent
      << "BackgroundValue: " << static_cast<typename NumericTraits<LabelPixelType>::PrintType>(m_BackgroundValue)
      << std::endl;

--- a/Modules/Filtering/ImageFusion/test/itkLabelToRGBImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelToRGBImageFilterTest.cxx
@@ -56,7 +56,7 @@ itkLabelToRGBImageFilterTest(int argc, char * argv[])
 
 
   // Exercising Background Value methods
-  typename FilterType::LabelPixelType backgroundValue = 10;
+  FilterType::LabelPixelType backgroundValue = 10;
   filter->SetBackgroundValue(backgroundValue);
   ITK_TEST_SET_GET_VALUE(backgroundValue, filter->GetBackgroundValue());
 

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
@@ -54,7 +54,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::PrintS
   itkPrintSelfBooleanMacro(UseImageSpacing);
   os << indent << "UsePrincipleComponents: " << m_UsePrincipleComponents << std::endl;
   os << indent << "RequestedNumberOfThreads: "
-     << static_cast<typename NumericTraits<ThreadIdType>::PrintType>(m_RequestedNumberOfWorkUnits) << std::endl;
+     << static_cast<NumericTraits<ThreadIdType>::PrintType>(m_RequestedNumberOfWorkUnits) << std::endl;
 
   itkPrintSelfObjectMacro(RealValuedInputImage);
 }

--- a/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeRecursiveGaussianFilterTest.cxx
@@ -109,7 +109,7 @@ itkGradientMagnitudeRecursiveGaussianFilterTest(int argc, char * argv[])
 
   const itk::SimpleFilterWatcher watcher(filter);
 
-  auto sigma = static_cast<typename myFilterType::RealType>(std::stod(argv[1]));
+  auto sigma = static_cast<myFilterType::RealType>(std::stod(argv[1]));
   filter->SetSigma(sigma);
   ITK_TEST_SET_GET_VALUE(sigma, filter->GetSigma());
 

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest.cxx
@@ -105,7 +105,7 @@ itkGradientRecursiveGaussianFilterTest(int argc, char * argv[])
   ITK_TEST_SET_GET_BOOLEAN(filter, UseImageDirection, useImageDirection);
 
   // Select the value of Sigma
-  constexpr typename myFilterType::ScalarRealType sigma = 2.5;
+  constexpr myFilterType::ScalarRealType sigma = 2.5;
   filter->SetSigma(sigma);
   ITK_TEST_SET_GET_VALUE(sigma, filter->GetSigma());
 

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.h
@@ -252,11 +252,11 @@ private:
 
   vnl_matrix<RealType> m_RefinedLatticeCoefficients[ImageDimension]{};
 
-  typename KernelType::Pointer       m_Kernel[ImageDimension]{};
-  typename KernelOrder0Type::Pointer m_KernelOrder0{};
-  typename KernelOrder1Type::Pointer m_KernelOrder1{};
-  typename KernelOrder2Type::Pointer m_KernelOrder2{};
-  typename KernelOrder3Type::Pointer m_KernelOrder3{};
+  KernelType::Pointer       m_Kernel[ImageDimension]{};
+  KernelOrder0Type::Pointer m_KernelOrder0{};
+  KernelOrder1Type::Pointer m_KernelOrder1{};
+  KernelOrder2Type::Pointer m_KernelOrder2{};
+  KernelOrder3Type::Pointer m_KernelOrder3{};
 
   RealType m_BSplineEpsilon{ static_cast<RealType>(1e-3) };
 

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
@@ -114,7 +114,7 @@ BSplineControlPointImageFilter<TInputImage, TOutputImage>::SetSplineOrder(ArrayT
 
     if (this->m_DoMultilevel)
     {
-      typename KernelType::MatrixType C = this->m_Kernel[i]->GetShapeFunctionsInZeroToOneInterval();
+      KernelType::MatrixType C = this->m_Kernel[i]->GetShapeFunctionsInZeroToOneInterval();
 
       vnl_matrix<RealType> R;
       vnl_matrix<RealType> S;

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.h
@@ -302,11 +302,11 @@ private:
 
   RealImagePointer m_NeighborhoodWeightImage{};
 
-  typename KernelType::Pointer       m_Kernel[ImageDimension]{};
-  typename KernelOrder0Type::Pointer m_KernelOrder0{};
-  typename KernelOrder1Type::Pointer m_KernelOrder1{};
-  typename KernelOrder2Type::Pointer m_KernelOrder2{};
-  typename KernelOrder3Type::Pointer m_KernelOrder3{};
+  KernelType::Pointer       m_Kernel[ImageDimension]{};
+  KernelOrder0Type::Pointer m_KernelOrder0{};
+  KernelOrder1Type::Pointer m_KernelOrder1{};
+  KernelOrder2Type::Pointer m_KernelOrder2{};
+  KernelOrder3Type::Pointer m_KernelOrder3{};
 
   CoordinateType m_BSplineEpsilon{};
 };

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.h
@@ -356,7 +356,7 @@ private:
   ArrayType    m_SplineOrder{};
   ArrayType    m_NumberOfLevels{};
 
-  typename WeightsContainerType::Pointer m_PointWeights{};
+  WeightsContainerType::Pointer m_PointWeights{};
 
   typename PointDataImageType::Pointer m_PhiLattice{};
   typename PointDataImageType::Pointer m_PsiLattice{};
@@ -365,12 +365,12 @@ private:
 
   PointDataContainerPointer m_ResidualPointSetValues{};
 
-  typename KernelType::Pointer m_Kernel[ImageDimension]{};
+  KernelType::Pointer m_Kernel[ImageDimension]{};
 
-  typename KernelOrder0Type::Pointer m_KernelOrder0{};
-  typename KernelOrder1Type::Pointer m_KernelOrder1{};
-  typename KernelOrder2Type::Pointer m_KernelOrder2{};
-  typename KernelOrder3Type::Pointer m_KernelOrder3{};
+  KernelOrder0Type::Pointer m_KernelOrder0{};
+  KernelOrder1Type::Pointer m_KernelOrder1{};
+  KernelOrder2Type::Pointer m_KernelOrder2{};
+  KernelOrder3Type::Pointer m_KernelOrder3{};
 
   std::vector<RealImagePointer>      m_OmegaLatticePerThread{};
   std::vector<PointDataImagePointer> m_DeltaLatticePerThread{};

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -93,7 +93,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::SetSpli
 
     if (this->m_DoMultilevel)
     {
-      typename KernelType::MatrixType C = this->m_Kernel[i]->GetShapeFunctionsInZeroToOneInterval();
+      KernelType::MatrixType C = this->m_Kernel[i]->GetShapeFunctionsInZeroToOneInterval();
 
       vnl_matrix<RealType> R;
       vnl_matrix<RealType> S;

--- a/Modules/Filtering/ImageGrid/test/itkPasteImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkPasteImageFilterGTest.cxx
@@ -161,7 +161,7 @@ TEST_F(PasteFixture, ConstantPaste)
 TEST_F(PasteFixture, ConstantPaste3_2)
 {
   using Utils = FixtureUtilities<itk::Image<int, 3>, itk::Image<int, 2>>;
-  using SkipType = typename Utils::FilterType::InputSkipAxesArrayType;
+  using SkipType = Utils::FilterType::InputSkipAxesArrayType;
   auto filter = Utils::FilterType::New();
 
 
@@ -297,7 +297,7 @@ TEST_F(PasteFixture, Paste3_2)
 {
   using Utils = FixtureUtilities<itk::Image<int, 3>, itk::Image<int, 2>>;
 
-  using SkipType = typename Utils::FilterType::InputSkipAxesArrayType;
+  using SkipType = Utils::FilterType::InputSkipAxesArrayType;
   constexpr int constantValue{ -53 };
 
   auto filter = Utils::FilterType::New();

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest2.cxx
@@ -153,13 +153,13 @@ itkResampleImageTest2(int argc, char * argv[])
   else
   {
     // Set a fixed, isotropic output spacing
-    typename ImageType::SpacingType::ValueType outputSpacingValue = 1.5;
+    ImageType::SpacingType::ValueType outputSpacingValue = 1.5;
     if (argc > 7)
     {
       outputSpacingValue = std::stod(argv[8]);
     }
 
-    typename ImageType::SpacingType outputSpacing;
+    ImageType::SpacingType outputSpacing;
     for (unsigned int i = 0; i < VDimension; ++i)
     {
       outputSpacing[i] = outputSpacingValue;
@@ -168,9 +168,9 @@ itkResampleImageTest2(int argc, char * argv[])
     const typename ImageType::SizeType &    inputSize = resample->GetInput()->GetLargestPossibleRegion().GetSize();
     const typename ImageType::SpacingType & inputSpacing = resample->GetInput()->GetSpacing();
 
-    typename ImageType::SizeType outputSize;
+    ImageType::SizeType outputSize;
 
-    using SizeValueType = typename ImageType::SizeType::SizeValueType;
+    using SizeValueType = ImageType::SizeType::SizeValueType;
     for (unsigned int i = 0; i < VDimension; ++i)
     {
       outputSize[i] =

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
@@ -98,8 +98,7 @@ public:
   OutputPointType
   TransformPoint(const InputPointType & inputPoint) const override
   {
-    auto outputPoint =
-      itk::MakeFilled<OutputPointType>(std::numeric_limits<typename OutputPointType::ValueType>::max());
+    auto outputPoint = itk::MakeFilled<OutputPointType>(std::numeric_limits<OutputPointType::ValueType>::max());
     for (unsigned int d = 0; d < 2; ++d)
     {
       outputPoint[d] = inputPoint[d] * 0.5;

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
@@ -200,18 +200,18 @@ itkWarpImageFilterTest(int, char *[])
   warper->SetOutputOrigin(ptarray.GetDataPointer());
   ITK_TEST_SET_GET_VALUE(ptarray, warper->GetOutputOrigin());
 
-  typename WarperType::DirectionType outputDirection;
+  WarperType::DirectionType outputDirection;
   outputDirection.SetIdentity();
   warper->SetOutputDirection(outputDirection);
   ITK_TEST_SET_GET_VALUE(outputDirection, warper->GetOutputDirection());
 
-  constexpr typename WarperType::IndexType::value_type outputStartIndexVal = 0;
-  auto outputStartIndex = WarperType::IndexType::Filled(outputStartIndexVal);
+  constexpr WarperType::IndexType::value_type outputStartIndexVal = 0;
+  auto                                        outputStartIndex = WarperType::IndexType::Filled(outputStartIndexVal);
   warper->SetOutputStartIndex(outputStartIndex);
   ITK_TEST_SET_GET_VALUE(outputStartIndex, warper->GetOutputStartIndex());
 
-  constexpr typename WarperType::SizeType::value_type outputSizeVal = 0;
-  auto                                                outputSize = WarperType::SizeType::Filled(outputSizeVal);
+  constexpr WarperType::SizeType::value_type outputSizeVal = 0;
+  auto                                       outputSize = WarperType::SizeType::Filled(outputSizeVal);
   warper->SetOutputSize(outputSize);
   ITK_TEST_SET_GET_VALUE(outputSize, warper->GetOutputSize());
 

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
@@ -69,7 +69,7 @@ MakeCheckerboard()
 }
 
 template <long unsigned int TImageIndexSpaceSize>
-typename DisplacementFieldType::Pointer
+DisplacementFieldType::Pointer
 MakeDisplacementField()
 {
   using IteratorType = itk::ImageRegionIterator<DisplacementFieldType>;

--- a/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
@@ -197,7 +197,7 @@ itkWarpVectorImageFilterTest(int, char *[])
   warper->SetOutputOrigin(ptarray.GetDataPointer());
   ITK_TEST_SET_GET_VALUE(ptarray, warper->GetOutputOrigin());
 
-  typename WarperType::DirectionType outputDirection;
+  WarperType::DirectionType outputDirection;
   outputDirection.SetIdentity();
   warper->SetOutputDirection(outputDirection);
   ITK_TEST_SET_GET_VALUE(outputDirection, warper->GetOutputDirection());

--- a/Modules/Filtering/ImageIntensity/test/itkWeightedAddImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkWeightedAddImageFilterTest.cxx
@@ -114,7 +114,7 @@ itkWeightedAddImageFilterTest(int argc, char * argv[])
   filter->SetInput1(inputImageA);
   filter->SetInput2(inputImageB);
 
-  auto alpha = static_cast<typename myFilterType::RealType>(std::stod(argv[1]));
+  auto alpha = static_cast<myFilterType::RealType>(std::stod(argv[1]));
   filter->SetAlpha(alpha);
   ITK_TEST_SET_GET_VALUE(alpha, filter->GetAlpha());
 

--- a/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
+++ b/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
@@ -126,7 +126,7 @@ protected:
   using LineEncodingConstIterator = typename LineEncodingType::const_iterator;
 
   using OffsetVectorType = std::vector<OffsetValueType>;
-  using OffsetVectorConstIterator = typename OffsetVectorType::const_iterator;
+  using OffsetVectorConstIterator = OffsetVectorType::const_iterator;
 
   using LineMapType = std::vector<LineEncodingType>;
 

--- a/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
@@ -87,8 +87,8 @@ AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostr
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Mean: " << static_cast<typename NumericTraits<double>::PrintType>(m_Mean) << std::endl;
-  os << indent << "StandardDeviation: " << static_cast<typename NumericTraits<double>::PrintType>(m_StandardDeviation)
+  os << indent << "Mean: " << static_cast<NumericTraits<double>::PrintType>(m_Mean) << std::endl;
+  os << indent << "StandardDeviation: " << static_cast<NumericTraits<double>::PrintType>(m_StandardDeviation)
      << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.hxx
@@ -70,7 +70,7 @@ NoiseBaseImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, In
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Seed: " << static_cast<typename NumericTraits<uint32_t>::PrintType>(m_Seed) << std::endl;
+  os << indent << "Seed: " << static_cast<NumericTraits<uint32_t>::PrintType>(m_Seed) << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.hxx
@@ -102,7 +102,7 @@ SaltAndPepperNoiseImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Probability: " << static_cast<typename NumericTraits<double>::PrintType>(m_Probability) << std::endl;
+  os << indent << "Probability: " << static_cast<NumericTraits<double>::PrintType>(m_Probability) << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
@@ -113,7 +113,7 @@ ShotNoiseImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, In
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Scale: " << static_cast<typename NumericTraits<double>::PrintType>(m_Scale) << std::endl;
+  os << indent << "Scale: " << static_cast<NumericTraits<double>::PrintType>(m_Scale) << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
@@ -122,7 +122,7 @@ SpeckleNoiseImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os,
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "StandardDeviation: " << static_cast<typename NumericTraits<double>::PrintType>(m_StandardDeviation)
+  os << indent << "StandardDeviation: " << static_cast<NumericTraits<double>::PrintType>(m_StandardDeviation)
      << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/ImageSources/include/itkGridImageSource.h
+++ b/Modules/Filtering/ImageSources/include/itkGridImageSource.h
@@ -139,9 +139,9 @@ protected:
 
 private:
   /** Internal variable to speed up the calculation of pixel values. */
-  typename PixelArrayContainerType::Pointer m_PixelArrays{};
+  PixelArrayContainerType::Pointer m_PixelArrays{};
 
-  typename KernelFunctionType::Pointer m_KernelFunction{};
+  KernelFunctionType::Pointer m_KernelFunction{};
 
   ArrayType m_Sigma{};
 

--- a/Modules/Filtering/ImageStatistics/include/itkAdaptiveEqualizationHistogram.h
+++ b/Modules/Filtering/ImageStatistics/include/itkAdaptiveEqualizationHistogram.h
@@ -148,7 +148,7 @@ private:
   }
 
 private:
-  using MapType = typename std::unordered_map<TInputPixel, size_t, StructHashFunction<TInputPixel>>;
+  using MapType = std::unordered_map<TInputPixel, size_t, StructHashFunction<TInputPixel>>;
 
 
   MapType m_Map;

--- a/Modules/Filtering/ImageStatistics/include/itkAdaptiveHistogramEqualizationImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkAdaptiveHistogramEqualizationImageFilter.h
@@ -72,7 +72,7 @@ class ITK_TEMPLATE_EXPORT AdaptiveHistogramEqualizationImageFilter
       TImageType,
       TImageType,
       TKernel,
-      typename Function::AdaptiveEqualizationHistogram<typename TImageType::PixelType, typename TImageType::PixelType>>
+      Function::AdaptiveEqualizationHistogram<typename TImageType::PixelType, typename TImageType::PixelType>>
 
 {
 public:
@@ -86,7 +86,7 @@ public:
     TImageType,
     TImageType,
     TKernel,
-    typename Function::AdaptiveEqualizationHistogram<typename TImageType::PixelType, typename TImageType::PixelType>>;
+    Function::AdaptiveEqualizationHistogram<typename TImageType::PixelType, typename TImageType::PixelType>>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.hxx
@@ -149,8 +149,7 @@ ImagePCADecompositionCalculator<TInputImage, TBasisImage>::PrintSelf(std::ostrea
 
   os << indent << "BasisMatrix: " << m_BasisMatrix << std::endl;
   itkPrintSelfBooleanMacro(BasisMatrixCalculated);
-  os << indent << "NumPixels: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumPixels)
-     << std::endl;
+  os << indent << "NumPixels: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumPixels) << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.h
@@ -99,7 +99,7 @@ public:
   using RealType = typename NumericTraits<PixelType>::RealType;
 
   /** Smart Pointer type to a DataObject. */
-  using DataObjectPointer = typename DataObject::Pointer;
+  using DataObjectPointer = DataObject::Pointer;
 
   /** Type of DataObjects used for scalar outputs */
   using RealObjectType = SimpleDataObjectDecorator<RealType>;
@@ -218,8 +218,7 @@ public:
     {
       using namespace print_helper;
 
-      os << "Count: " << static_cast<typename NumericTraits<IdentifierType>::PrintType>(labelStatistics.m_Count)
-         << std::endl;
+      os << "Count: " << static_cast<NumericTraits<IdentifierType>::PrintType>(labelStatistics.m_Count) << std::endl;
       os << "Minimum: " << static_cast<typename NumericTraits<RealType>::PrintType>(labelStatistics.m_Minimum)
          << std::endl;
       os << "Maximum: " << static_cast<typename NumericTraits<RealType>::PrintType>(labelStatistics.m_Maximum)

--- a/Modules/Filtering/ImageStatistics/include/itkMinimumMaximumImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkMinimumMaximumImageFilter.h
@@ -68,7 +68,7 @@ public:
   using PixelType = typename TInputImage::PixelType;
 
   /** Smart Pointer type to a DataObject. */
-  using DataObjectPointer = typename DataObject::Pointer;
+  using DataObjectPointer = DataObject::Pointer;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.h
@@ -84,7 +84,7 @@ public:
   using RealType = typename NumericTraits<PixelType>::RealType;
 
   /** Smart Pointer type to a DataObject. */
-  using DataObjectPointer = typename DataObject::Pointer;
+  using DataObjectPointer = DataObject::Pointer;
 
   /** Type of DataObjects used for scalar outputs */
   using RealObjectType = SimpleDataObjectDecorator<RealType>;

--- a/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.hxx
@@ -139,8 +139,7 @@ StatisticsImageFilter<TImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Count: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(this->m_Count)
-     << std::endl;
+  os << indent << "Count: " << static_cast<NumericTraits<SizeValueType>::PrintType>(this->m_Count) << std::endl;
   os << indent << "Minimum: " << static_cast<typename NumericTraits<PixelType>::PrintType>(this->GetMinimum())
      << std::endl;
   os << indent << "Maximum: " << static_cast<typename NumericTraits<PixelType>::PrintType>(this->GetMaximum())

--- a/Modules/Filtering/ImageStatistics/test/itkImageMomentsTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImageMomentsTest.cxx
@@ -124,7 +124,7 @@ itkImageMomentsTest(int argc, char * argv[])
     maskimg->FillBuffer(itk::NumericTraits<PixelType>::OneValue());
 
     // convert mask image to mask
-    using LFFImageMaskSpatialObjectType = typename itk::ImageMaskSpatialObject<MaskImageType::ImageDimension>;
+    using LFFImageMaskSpatialObjectType = itk::ImageMaskSpatialObject<MaskImageType::ImageDimension>;
     auto mask = LFFImageMaskSpatialObjectType::New();
     mask->SetImage(maskimg.GetPointer());
     mask->Update();

--- a/Modules/Filtering/LabelMap/include/itkAttributeKeepNObjectsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeKeepNObjectsLabelMapFilter.h
@@ -40,8 +40,7 @@ namespace itk
  * \ingroup ITKLabelMap
  */
 template <typename TImage,
-          typename TAttributeAccessor =
-            typename Functor::AttributeLabelObjectAccessor<typename TImage::LabelObjectType>>
+          typename TAttributeAccessor = Functor::AttributeLabelObjectAccessor<typename TImage::LabelObjectType>>
 class ITK_TEMPLATE_EXPORT AttributeKeepNObjectsLabelMapFilter : public InPlaceLabelMapFilter<TImage>
 {
 public:

--- a/Modules/Filtering/LabelMap/include/itkAttributeKeepNObjectsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAttributeKeepNObjectsLabelMapFilter.hxx
@@ -50,7 +50,7 @@ AttributeKeepNObjectsLabelMapFilter<TImage, TAttributeAccessor>::GenerateData()
   ProgressReporter progress(this, 0, 2 * output->GetNumberOfLabelObjects());
 
   // get the label objects in a vector, so they can be sorted
-  using VectorType = typename std::vector<typename LabelObjectType::Pointer>;
+  using VectorType = std::vector<typename LabelObjectType::Pointer>;
   VectorType labelObjects;
   labelObjects.reserve(output->GetNumberOfLabelObjects());
   for (typename ImageType::Iterator it(output); !it.IsAtEnd(); ++it)

--- a/Modules/Filtering/LabelMap/include/itkAttributeOpeningLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeOpeningLabelMapFilter.h
@@ -41,8 +41,7 @@ namespace itk
  * \ingroup ITKLabelMap
  */
 template <typename TImage,
-          typename TAttributeAccessor =
-            typename Functor::AttributeLabelObjectAccessor<typename TImage::LabelObjectType>>
+          typename TAttributeAccessor = Functor::AttributeLabelObjectAccessor<typename TImage::LabelObjectType>>
 class ITK_TEMPLATE_EXPORT AttributeOpeningLabelMapFilter : public InPlaceLabelMapFilter<TImage>
 {
 public:

--- a/Modules/Filtering/LabelMap/include/itkAttributePositionLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributePositionLabelMapFilter.h
@@ -41,8 +41,7 @@ namespace itk
  * \ingroup ITKLabelMap
  */
 template <typename TImage,
-          typename TAttributeAccessor =
-            typename Functor::AttributeLabelObjectAccessor<typename TImage::LabelObjectType>,
+          typename TAttributeAccessor = Functor::AttributeLabelObjectAccessor<typename TImage::LabelObjectType>,
           bool VPhysicalPosition = true>
 class ITK_TEMPLATE_EXPORT AttributePositionLabelMapFilter : public InPlaceLabelMapFilter<TImage>
 {

--- a/Modules/Filtering/LabelMap/include/itkAttributeRelabelLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeRelabelLabelMapFilter.h
@@ -41,8 +41,7 @@ namespace itk
  * \ingroup ITKLabelMap
  */
 template <typename TImage,
-          typename TAttributeAccessor =
-            typename Functor::AttributeLabelObjectAccessor<typename TImage::LabelObjectType>>
+          typename TAttributeAccessor = Functor::AttributeLabelObjectAccessor<typename TImage::LabelObjectType>>
 class ITK_TEMPLATE_EXPORT AttributeRelabelLabelMapFilter : public InPlaceLabelMapFilter<TImage>
 {
 public:

--- a/Modules/Filtering/LabelMap/include/itkAttributeRelabelLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAttributeRelabelLabelMapFilter.hxx
@@ -34,7 +34,7 @@ AttributeRelabelLabelMapFilter<TImage, TAttributeAccessor>::GenerateData()
 
   ImageType * output = this->GetOutput();
 
-  using VectorType = typename std::vector<typename LabelObjectType::Pointer>;
+  using VectorType = std::vector<typename LabelObjectType::Pointer>;
 
   ProgressReporter progress(this, 0, 2 * output->GetNumberOfLabelObjects());
 

--- a/Modules/Filtering/LabelMap/include/itkAttributeSelectionLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeSelectionLabelMapFilter.h
@@ -48,8 +48,7 @@ namespace itk
  * \ingroup ITKLabelMap
  */
 template <typename TImage,
-          typename TAttributeAccessor =
-            typename Functor::AttributeLabelObjectAccessor<typename TImage::LabelObjectType>>
+          typename TAttributeAccessor = Functor::AttributeLabelObjectAccessor<typename TImage::LabelObjectType>>
 class ITK_TEMPLATE_EXPORT AttributeSelectionLabelMapFilter : public InPlaceLabelMapFilter<TImage>
 {
 public:
@@ -72,7 +71,7 @@ public:
   using AttributeAccessorType = TAttributeAccessor;
   using AttributeValueType = typename AttributeAccessorType::AttributeValueType;
 
-  using AttributeSetType = typename std::set<AttributeValueType>;
+  using AttributeSetType = std::set<AttributeValueType>;
 
   /** ImageDimension constants */
   static constexpr unsigned int ImageDimension = TImage::ImageDimension;

--- a/Modules/Filtering/LabelMap/include/itkAttributeUniqueLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeUniqueLabelMapFilter.h
@@ -44,8 +44,7 @@ namespace itk
  * \ingroup ITKLabelMap
  */
 template <typename TImage,
-          typename TAttributeAccessor =
-            typename Functor::AttributeLabelObjectAccessor<typename TImage::LabelObjectType>>
+          typename TAttributeAccessor = Functor::AttributeLabelObjectAccessor<typename TImage::LabelObjectType>>
 class ITK_TEMPLATE_EXPORT AttributeUniqueLabelMapFilter : public InPlaceLabelMapFilter<TImage>
 {
 public:

--- a/Modules/Filtering/LabelMap/include/itkAttributeUniqueLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAttributeUniqueLabelMapFilter.hxx
@@ -34,7 +34,7 @@ AttributeUniqueLabelMapFilter<TImage, TAttributeAccessor>::GenerateData()
 
   // the priority queue to store all the lines of all the objects sorted
   using PriorityQueueType =
-    typename std::priority_queue<LineOfLabelObject, std::vector<LineOfLabelObject>, LineOfLabelObjectComparator>;
+    std::priority_queue<LineOfLabelObject, std::vector<LineOfLabelObject>, LineOfLabelObjectComparator>;
   PriorityQueueType pq;
 
   auto           labelMap = this->GetLabelMap();
@@ -72,7 +72,7 @@ AttributeUniqueLabelMapFilter<TImage, TAttributeAccessor>::GenerateData()
 
   ProgressReporter progress2(this, 0, numberOfLines, 100, 0.3f, 0.60f);
 
-  using LinesType = typename std::deque<LineOfLabelObject>;
+  using LinesType = std::deque<LineOfLabelObject>;
   LinesType lines;
 
   lines.push_back(pq.top());

--- a/Modules/Filtering/LabelMap/include/itkBinaryFillholeImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryFillholeImageFilter.hxx
@@ -88,7 +88,7 @@ BinaryFillholeImageFilter<TInputImage>::GenerateData()
   notInput->SetReleaseDataFlag(true);
   progress->RegisterInternalFilter(notInput, .2f);
 
-  using LabelizerType = typename itk::BinaryImageToShapeLabelMapFilter<InputImageType>;
+  using LabelizerType = itk::BinaryImageToShapeLabelMapFilter<InputImageType>;
   auto labelizer = LabelizerType::New();
   labelizer->SetInput(notInput->GetOutput());
   labelizer->SetInputForegroundValue(m_ForegroundValue);
@@ -98,7 +98,7 @@ BinaryFillholeImageFilter<TInputImage>::GenerateData()
   progress->RegisterInternalFilter(labelizer, .5f);
 
   using LabelMapType = typename LabelizerType::OutputImageType;
-  using OpeningType = typename itk::ShapeOpeningLabelMapFilter<LabelMapType>;
+  using OpeningType = itk::ShapeOpeningLabelMapFilter<LabelMapType>;
   auto opening = OpeningType::New();
   opening->SetInput(labelizer->GetOutput());
   opening->SetAttribute(LabelMapType::LabelObjectType::NUMBER_OF_PIXELS_ON_BORDER);
@@ -107,7 +107,7 @@ BinaryFillholeImageFilter<TInputImage>::GenerateData()
   progress->RegisterInternalFilter(opening, .1f);
 
   // invert the image during the binarization
-  using BinarizerType = typename itk::LabelMapMaskImageFilter<LabelMapType, OutputImageType>;
+  using BinarizerType = itk::LabelMapMaskImageFilter<LabelMapType, OutputImageType>;
   auto binarizer = BinarizerType::New();
   binarizer->SetInput(opening->GetOutput());
   binarizer->SetLabel(backgroundValue);

--- a/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.hxx
@@ -65,7 +65,7 @@ BinaryGrindPeakImageFilter<TInputImage>::GenerateData()
   // Allocate the output
   this->AllocateOutputs();
 
-  using LabelizerType = typename itk::BinaryImageToShapeLabelMapFilter<InputImageType>;
+  using LabelizerType = itk::BinaryImageToShapeLabelMapFilter<InputImageType>;
   auto labelizer = LabelizerType::New();
   labelizer->SetInput(this->GetInput());
   labelizer->SetInputForegroundValue(m_ForegroundValue);
@@ -75,7 +75,7 @@ BinaryGrindPeakImageFilter<TInputImage>::GenerateData()
   progress->RegisterInternalFilter(labelizer, .65f);
 
   using LabelMapType = typename LabelizerType::OutputImageType;
-  using OpeningType = typename itk::ShapeOpeningLabelMapFilter<LabelMapType>;
+  using OpeningType = itk::ShapeOpeningLabelMapFilter<LabelMapType>;
   auto opening = OpeningType::New();
   opening->SetInput(labelizer->GetOutput());
   opening->SetAttribute(LabelMapType::LabelObjectType::NUMBER_OF_PIXELS_ON_BORDER);
@@ -83,7 +83,7 @@ BinaryGrindPeakImageFilter<TInputImage>::GenerateData()
   opening->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
   progress->RegisterInternalFilter(opening, .1f);
 
-  using BinarizerType = typename itk::LabelMapToBinaryImageFilter<LabelMapType, OutputImageType>;
+  using BinarizerType = itk::LabelMapToBinaryImageFilter<LabelMapType, OutputImageType>;
   auto binarizer = BinarizerType::New();
   binarizer->SetInput(opening->GetOutput());
   binarizer->SetForegroundValue(m_ForegroundValue);

--- a/Modules/Filtering/LabelMap/include/itkBinaryReconstructionLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryReconstructionLabelMapFilter.h
@@ -43,8 +43,7 @@ namespace itk
  */
 template <typename TImage,
           typename TMarkerImage,
-          typename TAttributeAccessor =
-            typename Functor::AttributeLabelObjectAccessor<typename TImage::LabelObjectType>>
+          typename TAttributeAccessor = Functor::AttributeLabelObjectAccessor<typename TImage::LabelObjectType>>
 class ITK_TEMPLATE_EXPORT BinaryReconstructionLabelMapFilter : public InPlaceLabelMapFilter<TImage>
 {
 public:

--- a/Modules/Filtering/LabelMap/include/itkChangeLabelLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkChangeLabelLabelMapFilter.h
@@ -74,7 +74,7 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ChangeLabelLabelMapFilter);
 
-  using ChangeMapType = typename std::map<PixelType, PixelType>;
+  using ChangeMapType = std::map<PixelType, PixelType>;
   using ChangeMapIterator = typename ChangeMapType::const_iterator;
 
   /*itkConceptMacro(InputEqualityComparableCheck,

--- a/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.hxx
@@ -387,8 +387,7 @@ LabelMapMaskImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os,
   os << indent << "Negated: " << m_Negated << std::endl;
   os << indent << "Crop: " << m_Crop << std::endl;
   os << indent << "CropBorder: " << m_CropBorder << std::endl;
-  os << indent << "CropTimeStamp: " << static_cast<typename NumericTraits<TimeStamp>::PrintType>(m_CropTimeStamp)
-     << std::endl;
+  os << indent << "CropTimeStamp: " << static_cast<NumericTraits<TimeStamp>::PrintType>(m_CropTimeStamp) << std::endl;
 }
 
 

--- a/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
@@ -192,7 +192,7 @@ template <typename TLabel, unsigned int VImageDimension>
 auto
 LabelObject<TLabel, VImageDimension>::GetNumberOfLines() const -> SizeValueType
 {
-  return static_cast<typename LabelObject<TLabel, VImageDimension>::SizeValueType>(m_LineContainer.size());
+  return static_cast<LabelObject<TLabel, VImageDimension>::SizeValueType>(m_LineContainer.size());
 }
 
 template <typename TLabel, unsigned int VImageDimension>

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -71,7 +71,7 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ThreadedProcessLabelObject(LabelObject
     sizePerPixel *= output->GetSpacing()[i];
   }
 
-  typename std::vector<double> sizePerPixelPerDimension;
+  std::vector<double> sizePerPixelPerDimension;
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     sizePerPixelPerDimension.push_back(sizePerPixel / output->GetSpacing()[i]);

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
@@ -733,14 +733,14 @@ protected:
     Superclass::PrintSelf(os, indent);
 
     os << indent << "BoundingBox: " << m_BoundingBox << std::endl;
-    os << indent
-       << "NumberOfPixels: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixels)
+    os << indent << "NumberOfPixels: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixels)
        << std::endl;
     os << indent << "PhysicalSize: " << m_PhysicalSize << std::endl;
     os << indent << "Centroid: " << static_cast<typename NumericTraits<CentroidType>::PrintType>(m_Centroid)
        << std::endl;
-    os << indent << "NumberOfPixelsOnBorder: "
-       << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsOnBorder) << std::endl;
+    os << indent
+       << "NumberOfPixelsOnBorder: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsOnBorder)
+       << std::endl;
     os << indent << "PerimeterOnBorder: " << m_PerimeterOnBorder << std::endl;
     os << indent << "FeretDiameter: " << m_FeretDiameter << std::endl;
     os << indent << "PrincipalMoments: " << m_PrincipalMoments << std::endl;

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelObject.h
@@ -592,7 +592,7 @@ private:
   double     m_Kurtosis{};
   double     m_WeightedElongation{};
 
-  typename HistogramType::ConstPointer m_Histogram{};
+  HistogramType::ConstPointer m_Histogram{};
 
   double m_WeightedFlatness{};
 };

--- a/Modules/Filtering/LabelMap/test/itkBinaryImageToLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryImageToLabelMapFilterTest.cxx
@@ -65,11 +65,11 @@ itkBinaryImageToLabelMapFilterTest(int argc, char * argv[])
   auto fullyConnected = static_cast<bool>(std::stoi(argv[3]));
   ITK_TEST_SET_GET_BOOLEAN(imageToLabel, FullyConnected, fullyConnected);
 
-  const typename ImageToLabelType::InputPixelType inputForegroundValue = std::stoi(argv[4]);
+  const ImageToLabelType::InputPixelType inputForegroundValue = std::stoi(argv[4]);
   imageToLabel->SetInputForegroundValue(inputForegroundValue);
   ITK_TEST_SET_GET_VALUE(inputForegroundValue, imageToLabel->GetInputForegroundValue());
 
-  const typename ImageToLabelType::OutputPixelType outputBackgroundValue = std::stoi(argv[5]);
+  const ImageToLabelType::OutputPixelType outputBackgroundValue = std::stoi(argv[5]);
   imageToLabel->SetOutputBackgroundValue(outputBackgroundValue);
   ITK_TEST_SET_GET_VALUE(outputBackgroundValue, imageToLabel->GetOutputBackgroundValue());
 

--- a/Modules/Filtering/LabelMap/test/itkLabelMapToAttributeImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelMapToAttributeImageFilterTest1.cxx
@@ -66,7 +66,7 @@ itkLabelMapToAttributeImageFilterTest1(int argc, char * argv[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(l2i, LabelMapToAttributeImageFilter, ImageToImageFilter);
 
 
-  auto backgroundValue = itk::NumericTraits<typename L2ImageFilterType::OutputImagePixelType>::NonpositiveMin();
+  auto backgroundValue = itk::NumericTraits<L2ImageFilterType::OutputImagePixelType>::NonpositiveMin();
   l2i->SetBackgroundValue(backgroundValue);
   ITK_TEST_SET_GET_VALUE(backgroundValue, l2i->GetBackgroundValue());
 

--- a/Modules/Filtering/LabelMap/test/itkUniqueLabelMapFiltersGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkUniqueLabelMapFiltersGTest.cxx
@@ -203,11 +203,11 @@ TEST_F(UniqueLabelMapFixture, EmptyImage)
 
 TEST_F(UniqueLabelMapFixture, OneLabel)
 {
-  const std::vector<typename FixtureUtilities<2>::IndexType> indices = { { 10, 10 } };
-  auto                                                       image = FixtureUtilities<2>::CreateLabelImage(indices);
+  const std::vector<FixtureUtilities<2>::IndexType> indices = { { 10, 10 } };
+  auto                                              image = FixtureUtilities<2>::CreateLabelImage(indices);
   auto labelMap = FixtureUtilities<2>::LabelMapFromLabelImage(image.GetPointer(), 0);
 
-  auto filter = itk::LabelUniqueLabelMapFilter<typename decltype(labelMap)::ObjectType>::New();
+  auto filter = itk::LabelUniqueLabelMapFilter<decltype(labelMap)::ObjectType>::New();
   filter->SetInput(labelMap);
   filter->Update();
 
@@ -222,12 +222,12 @@ TEST_F(UniqueLabelMapFixture, OneLabel)
 
 TEST_F(UniqueLabelMapFixture, OnesLabel)
 {
-  const std::vector<typename FixtureUtilities<2>::IndexType> indices = { { 0, 0 }, { 1, 0 }, { 2, 0 }, { 3, 0 },
-                                                                         { 0, 4 }, { 2, 4 }, { 0, 5 } };
-  auto                                                       image = FixtureUtilities<2>::CreateLabelImage(indices);
+  const std::vector<FixtureUtilities<2>::IndexType> indices = { { 0, 0 }, { 1, 0 }, { 2, 0 }, { 3, 0 },
+                                                                { 0, 4 }, { 2, 4 }, { 0, 5 } };
+  auto                                              image = FixtureUtilities<2>::CreateLabelImage(indices);
   auto labelMap = FixtureUtilities<2>::LabelMapFromLabelImage(image.GetPointer(), 0);
 
-  auto filter = itk::LabelUniqueLabelMapFilter<typename decltype(labelMap)::ObjectType>::New();
+  auto filter = itk::LabelUniqueLabelMapFilter<decltype(labelMap)::ObjectType>::New();
   filter->SetInput(labelMap);
   filter->Update();
 
@@ -242,12 +242,12 @@ TEST_F(UniqueLabelMapFixture, OnesLabel)
 
 TEST_F(UniqueLabelMapFixture, Dilate1)
 {
-  const std::vector<typename FixtureUtilities<2>::IndexType> indices = { { 0, 0 }, { 1, 0 }, { 2, 0 }, { 3, 0 },
-                                                                         { 0, 4 }, { 2, 4 }, { 0, 10 } };
-  auto                                                       image = FixtureUtilities<2>::CreateLabelImage(indices);
+  const std::vector<FixtureUtilities<2>::IndexType> indices = { { 0, 0 }, { 1, 0 }, { 2, 0 }, { 3, 0 },
+                                                                { 0, 4 }, { 2, 4 }, { 0, 10 } };
+  auto                                              image = FixtureUtilities<2>::CreateLabelImage(indices);
   auto labelMap = FixtureUtilities<2>::LabelMapFromLabelImage(image.GetPointer(), 1);
 
-  auto filter = itk::LabelUniqueLabelMapFilter<typename decltype(labelMap)::ObjectType>::New();
+  auto filter = itk::LabelUniqueLabelMapFilter<decltype(labelMap)::ObjectType>::New();
   filter->SetInput(labelMap);
   filter->InPlaceOff();
   filter->ReverseOrderingOff();
@@ -274,12 +274,12 @@ TEST_F(UniqueLabelMapFixture, Dilate1)
 
 TEST_F(UniqueLabelMapFixture, Dilate2)
 {
-  const std::vector<typename FixtureUtilities<2>::IndexType> indices = { { 0, 0 }, { 1, 0 }, { 2, 0 }, { 3, 0 },
-                                                                         { 0, 4 }, { 2, 4 }, { 0, 5 } };
-  auto                                                       image = FixtureUtilities<2>::CreateLabelImage(indices);
+  const std::vector<FixtureUtilities<2>::IndexType> indices = { { 0, 0 }, { 1, 0 }, { 2, 0 }, { 3, 0 },
+                                                                { 0, 4 }, { 2, 4 }, { 0, 5 } };
+  auto                                              image = FixtureUtilities<2>::CreateLabelImage(indices);
   auto labelMap = FixtureUtilities<2>::LabelMapFromLabelImage(image.GetPointer(), 2);
 
-  auto filter = itk::LabelUniqueLabelMapFilter<typename decltype(labelMap)::ObjectType>::New();
+  auto filter = itk::LabelUniqueLabelMapFilter<decltype(labelMap)::ObjectType>::New();
   filter->SetInput(labelMap);
   filter->InPlaceOff();
   filter->ReverseOrderingOff();

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.h
@@ -118,7 +118,7 @@ public:
   using DecompType = std::vector<LType>;
 
   /** ImageType used in constructors */
-  using ImageType = typename itk::Image<PixelType, VDimension>;
+  using ImageType = itk::Image<PixelType, VDimension>;
 
   /** Default destructor. */
   ~FlatStructuringElement() override = default;

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
@@ -1262,8 +1262,7 @@ FlatStructuringElement<VDimension>::ComputeBufferFromLines()
 /** Check if size of input Image is odd in all dimensions, throwing exception if even */
 template <unsigned int VDimension>
 auto
-FlatStructuringElement<VDimension>::CheckImageSize(const typename FlatStructuringElement<VDimension>::ImageType * image)
-  -> RadiusType
+FlatStructuringElement<VDimension>::CheckImageSize(const ImageType * image) -> RadiusType
 {
   const RadiusType & size = image->GetLargestPossibleRegion().GetSize();
 
@@ -1280,7 +1279,7 @@ FlatStructuringElement<VDimension>::CheckImageSize(const typename FlatStructurin
 
 template <unsigned int VDimension>
 FlatStructuringElement<VDimension>
-FlatStructuringElement<VDimension>::FromImage(const typename FlatStructuringElement<VDimension>::ImageType * image)
+FlatStructuringElement<VDimension>::FromImage(const ImageType * image)
 {
   Self              res{};
   RadiusType        size = res.CheckImageSize(image);

--- a/Modules/Filtering/MathematicalMorphology/include/itkMaskedRankImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMaskedRankImageFilter.hxx
@@ -59,7 +59,7 @@ MaskedRankImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel>::PrintSelf
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Rank: " << static_cast<typename NumericTraits<float>::PrintType>(m_Rank) << std::endl;
+  os << indent << "Rank: " << static_cast<NumericTraits<float>::PrintType>(m_Rank) << std::endl;
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkRankImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRankImageFilter.hxx
@@ -58,7 +58,7 @@ RankImageFilter<TInputImage, TOutputImage, TKernel>::PrintSelf(std::ostream & os
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Rank: " << static_cast<typename NumericTraits<float>::PrintType>(m_Rank) << std::endl;
+  os << indent << "Rank: " << static_cast<NumericTraits<float>::PrintType>(m_Rank) << std::endl;
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/test/itkAnchorErodeDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkAnchorErodeDilateImageFilterTest.cxx
@@ -30,7 +30,7 @@ itkAnchorErodeDilateImageFilterTest(int, char ** const)
 
   using ImageType = itk::Image<PixelType, Dimension>;
   using KernelType = itk::FlatStructuringElement<Dimension>;
-  using FunctionType = std::less<typename ImageType::PixelType>;
+  using FunctionType = std::less<ImageType::PixelType>;
 
   using FilterType = itk::AnchorErodeDilateImageFilter<ImageType, KernelType, FunctionType>;
   auto filter = FilterType::New();
@@ -38,7 +38,7 @@ itkAnchorErodeDilateImageFilterTest(int, char ** const)
   ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, AnchorErodeDilateImageFilter, KernelImageFilter);
 
 
-  constexpr typename FilterType::InputImagePixelType boundary = 255;
+  constexpr FilterType::InputImagePixelType boundary = 255;
   filter->SetBoundary(boundary);
   ITK_TEST_SET_GET_VALUE(boundary, filter->GetBoundary());
 

--- a/Modules/Filtering/MathematicalMorphology/test/itkAnchorOpenCloseImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkAnchorOpenCloseImageFilterTest.cxx
@@ -30,8 +30,8 @@ itkAnchorOpenCloseImageFilterTest(int, char ** const)
 
   using ImageType = itk::Image<PixelType, Dimension>;
   using KernelType = itk::FlatStructuringElement<Dimension>;
-  using CompateType1 = std::less<typename ImageType::PixelType>;
-  using CompateType2 = std::greater<typename ImageType::PixelType>;
+  using CompateType1 = std::less<ImageType::PixelType>;
+  using CompateType2 = std::greater<ImageType::PixelType>;
 
   using FilterType = itk::AnchorOpenCloseImageFilter<ImageType, KernelType, CompateType1, CompateType2>;
   auto filter = FilterType::New();

--- a/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest2.cxx
@@ -33,9 +33,9 @@ template <unsigned int VDimension>
 typename itk::Image<unsigned char, VDimension>::Pointer
 GetImage(const itk::FlatStructuringElement<VDimension> & flatElement)
 {
-  using ImageType = typename itk::Image<unsigned char, VDimension>;
-  using RadiusType = typename FlatStructuringElement<2U>::RadiusType;
-  using ConstIterator = typename FlatStructuringElement<2U>::ConstIterator;
+  using ImageType = itk::Image<unsigned char, VDimension>;
+  using RadiusType = FlatStructuringElement<2U>::RadiusType;
+  using ConstIterator = FlatStructuringElement<2U>::ConstIterator;
   using PixelType = unsigned char;
 
   auto                           image = ImageType::New();

--- a/Modules/Filtering/MathematicalMorphology/test/itkVanHerkGilWermanErodeDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkVanHerkGilWermanErodeDilateImageFilterTest.cxx
@@ -29,7 +29,7 @@ itkVanHerkGilWermanErodeDilateImageFilterTest(int, char ** const)
   using PixelType = float;
   using ImageType = itk::Image<PixelType, Dimension>;
   using KernelType = itk::FlatStructuringElement<Dimension>;
-  using FunctionType = std::less<typename ImageType::PixelType>;
+  using FunctionType = std::less<ImageType::PixelType>;
 
   using FilterType = itk::VanHerkGilWermanErodeDilateImageFilter<ImageType, KernelType, FunctionType>;
   auto filter = FilterType::New();

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.h
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.h
@@ -135,11 +135,11 @@ public:
   using InputOffsetType = typename InputImageType::OffsetType;
   using InputPixelType = typename InputImageType::PixelType;
   using InputRegionType = typename InputImageType::RegionType;
-  using OutputPathPointer = typename OutputPathType::Pointer;
-  using VertexListType = typename OutputPathType::VertexListType;
-  using VertexListConstPointer = typename VertexListType::ConstPointer;
-  using VertexType = typename OutputPathType::VertexType;
-  using VertexValueType = typename VertexType::ValueType;
+  using OutputPathPointer = OutputPathType::Pointer;
+  using VertexListType = OutputPathType::VertexListType;
+  using VertexListConstPointer = VertexListType::ConstPointer;
+  using VertexType = OutputPathType::VertexType;
+  using VertexValueType = VertexType::ValueType;
 
   /** Real type associated to the input pixel type. */
   using InputRealType = typename NumericTraits<InputPixelType>::RealType;
@@ -262,7 +262,7 @@ private:
 
   struct VertexHash
   {
-    using CoordinateType = typename VertexType::CoordinateType;
+    using CoordinateType = VertexType::CoordinateType;
     inline size_t
     operator()(const VertexType & v) const noexcept
     {

--- a/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.h
+++ b/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.h
@@ -66,13 +66,13 @@ public:
   using ImageIndexType = typename ImageType::IndexType;
   using ImagePixelType = typename ImageType::PixelType;
   using PathType = ParametricPath<2>;
-  using PathConstPointer = typename PathType::ConstPointer;
-  using PathInputType = typename PathType::InputType;
-  using PathOutputType = typename PathType::OutputType;
-  using PathIndexType = typename PathType::IndexType;
-  using PathContinuousIndexType = typename PathType::ContinuousIndexType;
-  using PathOffsetType = typename PathType::OffsetType;
-  using PathVectorType = typename PathType::VectorType;
+  using PathConstPointer = PathType::ConstPointer;
+  using PathInputType = PathType::InputType;
+  using PathOutputType = PathType::OutputType;
+  using PathIndexType = PathType::IndexType;
+  using PathContinuousIndexType = PathType::ContinuousIndexType;
+  using PathOffsetType = PathType::OffsetType;
+  using PathVectorType = PathType::VectorType;
   using SizeType = typename ImageType::SizeType;
 
   /** ImageDimension constants */

--- a/Modules/Filtering/Path/include/itkHilbertPath.hxx
+++ b/Modules/Filtering/Path/include/itkHilbertPath.hxx
@@ -238,8 +238,7 @@ HilbertPath<TIndexValue, VDimension>::PrintSelf(std::ostream & os, Indent indent
 
   Superclass::PrintSelf(os, indent);
 
-  os << "HilbertOrder: " << static_cast<typename NumericTraits<HilbertOrderType>::PrintType>(m_HilbertOrder)
-     << std::endl;
+  os << "HilbertOrder: " << static_cast<NumericTraits<HilbertOrderType>::PrintType>(m_HilbertOrder) << std::endl;
   os << "HilbertPath: " << m_HilbertPath << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.h
+++ b/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.h
@@ -79,10 +79,10 @@ public:
   using ImageConstPointer = typename ImageType::ConstPointer;
 
   using OutputPathType = OrthogonallyCorrected2DParametricPath;
-  using OutputPathPointer = typename OutputPathType::Pointer;
-  using OutputPathInputType = typename OutputPathType::InputType;
-  using OrthogonalCorrectionTableType = typename OutputPathType::OrthogonalCorrectionTableType;
-  using OrthogonalCorrectionTablePointer = typename OutputPathType::OrthogonalCorrectionTablePointer;
+  using OutputPathPointer = OutputPathType::Pointer;
+  using OutputPathInputType = OutputPathType::InputType;
+  using OrthogonalCorrectionTableType = OutputPathType::OrthogonalCorrectionTableType;
+  using OrthogonalCorrectionTablePointer = OutputPathType::OrthogonalCorrectionTablePointer;
 
   using IndexType = typename InputPathType::IndexType;
   using OffsetType = typename InputPathType::OffsetType;

--- a/Modules/Filtering/Path/test/itkExtractOrthogonalSwath2DImageFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkExtractOrthogonalSwath2DImageFilterTest.cxx
@@ -122,7 +122,7 @@ itkExtractOrthogonalSwath2DImageFilterTest(int argc, char * argv[])
     extractOrthogonalSwath2DImageFilter, ExtractOrthogonalSwath2DImageFilter, ImageAndPathToImageFilter);
 
 
-  constexpr typename ImageType::PixelType defaultPixelValue{};
+  constexpr ImageType::PixelType defaultPixelValue{};
   extractOrthogonalSwath2DImageFilter->SetDefaultPixelValue(defaultPixelValue);
 
   extractOrthogonalSwath2DImageFilter->SetImageInput(inputImage);

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkCleanQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkCleanQuadEdgeMeshFilterTest.cxx
@@ -66,7 +66,7 @@ itkCleanQuadEdgeMeshFilterTest(int argc, char * argv[])
 
   filter->SetInput(mesh);
 
-  constexpr typename CleanFilterType::InputCoordinateType absTol{};
+  constexpr CleanFilterType::InputCoordinateType absTol{};
   filter->SetAbsoluteTolerance(absTol);
   ITK_TEST_SET_GET_VALUE(absTol, filter->GetAbsoluteTolerance());
 

--- a/Modules/Filtering/Smoothing/include/itkBoxSigmaImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkBoxSigmaImageFilter.hxx
@@ -47,8 +47,8 @@ BoxSigmaImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 {
   // Accumulate type is too small
   using AccValueType = typename itk::NumericTraits<PixelType>::RealType;
-  using AccPixType = typename itk::Vector<AccValueType, 2>;
-  using AccumImageType = typename itk::Image<AccPixType, TInputImage::ImageDimension>;
+  using AccPixType = itk::Vector<AccValueType, 2>;
+  using AccumImageType = itk::Image<AccPixType, TInputImage::ImageDimension>;
 
   typename TInputImage::SizeType internalRadius;
   for (unsigned int i = 0; i < TInputImage::ImageDimension; ++i)

--- a/Modules/Filtering/Smoothing/test/itkFFTDiscreteGaussianImageFilterFactoryTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkFFTDiscreteGaussianImageFilterFactoryTest.cxx
@@ -31,7 +31,7 @@ itkFFTDiscreteGaussianImageFilterFactoryTest(int, char *[])
   using PixelType = float;
   using ImageType = itk::Image<PixelType, ImageDimension>;
   using BaseFilterType = itk::DiscreteGaussianImageFilter<ImageType>;
-  using OverrideFilterType = typename itk::FFTDiscreteGaussianImageFilter<ImageType>;
+  using OverrideFilterType = itk::FFTDiscreteGaussianImageFilter<ImageType>;
 
   BaseFilterType::Pointer baseFilter;
 

--- a/Modules/Filtering/Thresholding/include/itkHistogramThresholdCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkHistogramThresholdCalculator.h
@@ -95,7 +95,7 @@ public:
   }
 
   using Superclass::MakeOutput;
-  typename DataObject::Pointer
+  DataObject::Pointer
   MakeOutput(DataObjectPointerArraySizeType) override
   {
     return DecoratedOutputType::New().GetPointer();

--- a/Modules/Filtering/Thresholding/include/itkIntermodesThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkIntermodesThresholdCalculator.hxx
@@ -148,7 +148,7 @@ IntermodesThresholdCalculator<THistogram, TOutput>::PrintSelf(std::ostream & os,
   Superclass::PrintSelf(os, indent);
 
   os << indent << "MaximumSmoothingIterations: "
-     << static_cast<typename itk::NumericTraits<SizeValueType>::PrintType>(m_MaximumSmoothingIterations) << std::endl;
+     << static_cast<itk::NumericTraits<SizeValueType>::PrintType>(m_MaximumSmoothingIterations) << std::endl;
   os << indent << "UseInterMode: " << m_UseInterMode << std::endl;
 }
 

--- a/Modules/Filtering/Thresholding/test/itkBinaryThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkBinaryThresholdImageFilterTest.cxx
@@ -130,10 +130,10 @@ itkBinaryThresholdImageFilterTest(int, char *[])
   // Exercise the const variants
   const FilterType::ConstPointer constFilter = (const FilterType *)(filter.GetPointer());
 
-  const typename FilterType::InputPixelObjectType * lowerThresholdInput = constFilter->GetLowerThresholdInput();
+  const FilterType::InputPixelObjectType * lowerThresholdInput = constFilter->GetLowerThresholdInput();
   ITK_TEST_SET_GET_VALUE(lowerThresholdInput->Get(), lowerThreshold2->Get());
 
-  const typename FilterType::InputPixelObjectType * upperThresholdInput = constFilter->GetUpperThresholdInput();
+  const FilterType::InputPixelObjectType * upperThresholdInput = constFilter->GetUpperThresholdInput();
   ITK_TEST_SET_GET_VALUE(upperThresholdInput->Get(), upperThreshold2->Get());
 
 

--- a/Modules/IO/CSV/include/itkCSVArray2DDataObject.h
+++ b/Modules/IO/CSV/include/itkCSVArray2DDataObject.h
@@ -62,11 +62,11 @@ public:
   itkOverrideGetNameOfClassMacro(CSVArray2DDataObject);
 
   /* Vector type alias. */
-  using NumericVectorType = typename std::vector<TData>;
-  using StringVectorType = typename std::vector<std::string>;
+  using NumericVectorType = std::vector<TData>;
+  using StringVectorType = std::vector<std::string>;
 
   /** Typedef for the Array2D object. */
-  using MatrixType = typename itk::Array2D<TData>;
+  using MatrixType = itk::Array2D<TData>;
 
   /** Set macros */
   /** @ITKStartGrouping */

--- a/Modules/IO/CSV/include/itkCSVArray2DFileReader.h
+++ b/Modules/IO/CSV/include/itkCSVArray2DFileReader.h
@@ -94,7 +94,7 @@ public:
   itkOverrideGetNameOfClassMacro(CSVArray2DFileReader);
 
   /** DataFrame Object types */
-  using Array2DDataObjectType = typename itk::CSVArray2DDataObject<TData>;
+  using Array2DDataObjectType = itk::CSVArray2DDataObject<TData>;
   using Array2DDataObjectPointer = typename Array2DDataObjectType::Pointer;
 
   /** The value type of the dataset. */

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOStreamingReadWriteTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOStreamingReadWriteTest.cxx
@@ -96,7 +96,7 @@ HDF5ReadWriteTest2(const char * fileName)
     // pipeline and the itk::StreamingImageFilter will maintain handles to open HDF5 files
     // until their destructors run.
 
-    using ImageType = typename itk::Image<TPixel, 3>;
+    using ImageType = itk::Image<TPixel, 3>;
 
     // Create a source object (in this case a constant image).
     typename ImageType::SizeType size;
@@ -108,9 +108,9 @@ HDF5ReadWriteTest2(const char * fileName)
     imageSource->SetSize(size);
 
     // Write image with streaming.
-    using WriterType = typename itk::ImageFileWriter<ImageType>;
+    using WriterType = itk::ImageFileWriter<ImageType>;
     auto writer = WriterType::New();
-    using MonitorFilterType = typename itk::PipelineMonitorImageFilter<ImageType>;
+    using MonitorFilterType = itk::PipelineMonitorImageFilter<ImageType>;
     auto writerMonitor = MonitorFilterType::New();
     writerMonitor->SetInput(imageSource->GetOutput());
     writer->SetFileName(fileName);
@@ -153,13 +153,13 @@ HDF5ReadWriteTest2(const char * fileName)
     writer = typename WriterType::Pointer();
 
     // Read image with streaming.
-    using ReaderType = typename itk::ImageFileReader<ImageType>;
+    using ReaderType = itk::ImageFileReader<ImageType>;
     auto reader = ReaderType::New();
     reader->SetFileName(fileName);
     reader->SetUseStreaming(true);
     auto readerMonitor = MonitorFilterType::New();
     readerMonitor->SetInput(reader->GetOutput());
-    using StreamingFilter = typename itk::StreamingImageFilter<ImageType, ImageType>;
+    using StreamingFilter = itk::StreamingImageFilter<ImageType, ImageType>;
     auto streamer = StreamingFilter::New();
     streamer->SetInput(readerMonitor->GetOutput());
     streamer->SetNumberOfStreamDivisions(5);

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
@@ -30,7 +30,7 @@ HDF5ReadWriteTest(const char * fileName)
 {
   std::cout << fileName << std::endl;
   int success(EXIT_SUCCESS);
-  using ImageType = typename itk::Image<TPixel, 3>;
+  using ImageType = itk::Image<TPixel, 3>;
   typename ImageType::SpacingType spacing;
   typename ImageType::PointType   origin;
   for (unsigned int i = 0; i < 3; ++i)

--- a/Modules/IO/ImageBase/include/itkIOTestHelper.h
+++ b/Modules/IO/ImageBase/include/itkIOTestHelper.h
@@ -31,9 +31,7 @@ class IOTestHelper
 public:
   template <typename TImage>
   static typename TImage::Pointer
-  ReadImage(const std::string &           fileName,
-            const bool                    zeroOrigin = false,
-            typename ImageIOBase::Pointer imageio = nullptr)
+  ReadImage(const std::string & fileName, const bool zeroOrigin = false, ImageIOBase::Pointer imageio = nullptr)
   {
     using ReaderType = itk::ImageFileReader<TImage>;
 

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -305,7 +305,7 @@ MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double 
 {
   int success(EXIT_SUCCESS);
 
-  using ImageType = typename itk::Image<TPixel, VDimension>;
+  using ImageType = itk::Image<TPixel, VDimension>;
 
   typename ImageType::SizeType    size;
   typename ImageType::IndexType   index;
@@ -567,7 +567,7 @@ MINCReadWriteTestVector(const char * fileName,
 {
   int success(EXIT_SUCCESS);
 
-  using ImageType = typename itk::VectorImage<TPixel, VDimension>;
+  using ImageType = itk::VectorImage<TPixel, VDimension>;
   using InternalPixelType = typename itk::VectorImage<TPixel, VDimension>::PixelType;
 
   typename ImageType::SizeType    size;

--- a/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
+++ b/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
@@ -528,7 +528,7 @@ BYUMeshIO::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FilePosition: " << static_cast<typename NumericTraits<StreamOffsetType>::PrintType>(m_FilePosition)
+  os << indent << "FilePosition: " << static_cast<NumericTraits<StreamOffsetType>::PrintType>(m_FilePosition)
      << std::endl;
   os << indent << "PartId: " << m_PartId << std::endl;
   os << indent << "First Cell Id: " << m_FirstCellId << std::endl;

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.h
@@ -109,7 +109,7 @@ public:
   using OutputCellIdentifier = typename OutputMeshType::CellIdentifier;
   using OutputCellAutoPointer = typename OutputMeshType::CellAutoPointer;
   using OutputCellType = typename OutputMeshType::CellType;
-  using SizeValueType = typename MeshIOBase::SizeValueType;
+  using SizeValueType = MeshIOBase::SizeValueType;
 
   using OutputVertexCellType = VertexCell<OutputCellType>;
   using OutputLineCellType = LineCell<OutputCellType>;

--- a/Modules/IO/MeshBase/include/itkMeshFileWriter.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriter.h
@@ -72,7 +72,7 @@ public:
   using InputMeshRegionType = typename InputMeshType::RegionType;
   using InputMeshPixelType = typename InputMeshType::PixelType;
   using InputMeshCellType = typename InputMeshType::CellType;
-  using SizeValueType = typename MeshIOBase::SizeValueType;
+  using SizeValueType = MeshIOBase::SizeValueType;
 
   /** Set/Get the mesh input of this writer.  */
   using Superclass::SetInput;

--- a/Modules/IO/MeshVTK/test/itkVTKPolyDataMeshIOGTest.cxx
+++ b/Modules/IO/MeshVTK/test/itkVTKPolyDataMeshIOGTest.cxx
@@ -116,8 +116,8 @@ TEST(VTKPolyDataMeshIO, LosslessWriteAndReadOfPoints)
 
   // Generate various input points that have finite coordinate values.
   const auto inputPoints = [] {
-    using PointType = typename MeshType::PointType;
-    using CoordinateType = typename MeshType::CoordinateType;
+    using PointType = MeshType::PointType;
+    using CoordinateType = MeshType::CoordinateType;
     using NumericLimits = std::numeric_limits<MeshType::CoordinateType>;
 
     std::vector<PointType> points;
@@ -160,8 +160,8 @@ TEST(VTKPolyDataMeshIO, SupportWriteAndReadOfNaNCoordValues)
   for (const bool writeAsBinary : { false, true })
   {
     using MeshType = itk::Mesh<int>;
-    using PointType = typename MeshType::PointType;
-    using CoordinateType = typename MeshType::CoordinateType;
+    using PointType = MeshType::PointType;
+    using CoordinateType = MeshType::CoordinateType;
 
     Expect_lossless_writing_and_reading_of_points<MeshType>(
       "VTKPolyDataMeshIOGTest_SupportWriteAndReadOfNaNCoordValues.vtk",

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.cxx
@@ -395,7 +395,7 @@ itkNiftiImageIOTest(int argc, char * argv[])
 
       // The way the test is structured, we cannot know the expected file
       // type, so just print it
-      const typename itk::NiftiImageIOEnums::NiftiFileEnum fileType = imageIO->DetermineFileType(fileName.c_str());
+      const itk::NiftiImageIOEnums::NiftiFileEnum fileType = imageIO->DetermineFileType(fileName.c_str());
       std::cout << "File type: " << fileType << std::endl;
 
       try

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
@@ -252,10 +252,10 @@ TestImageOfSymMats(const std::string & fname)
 
   constexpr int dimsize{ 2 };
   /** Deformation field pixel type. */
-  //  using PixelType = typename itk::DiffusionTenor3D<ScalarType>;
+  //  using PixelType =  itk::DiffusionTenor3D<ScalarType>;
 
   /** Deformation field type. */
-  using DtiImageType = typename itk::Image<PixelType, VDimension>;
+  using DtiImageType = itk::Image<PixelType, VDimension>;
 
   // original test case was destined for failure.  NIfTI always writes out 3D
   // orientation.  The only sensible matrices you could pass in would be of the form
@@ -467,7 +467,7 @@ RGBTest(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  using RGBImageType = typename itk::Image<RGBPixelType, 3>;
+  using RGBImageType = itk::Image<RGBPixelType, 3>;
   constexpr typename RGBImageType::SizeType  size{ 5, 5, 5 };
   constexpr typename RGBImageType::IndexType index{};
   typename RGBImageType::RegionType          imageRegion{ index, size };

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
@@ -46,10 +46,10 @@ TestImageOfVectors(const std::string & fname, const std::string & intentCode = "
 {
   constexpr int dimsize{ 2 };
   /** Deformation field pixel type. */
-  using FieldPixelType = typename itk::Vector<ScalarType, TVecLength>;
+  using FieldPixelType = itk::Vector<ScalarType, TVecLength>;
 
   /** Deformation field type. */
-  using VectorImageType = typename itk::Image<FieldPixelType, TDimension>;
+  using VectorImageType = itk::Image<FieldPixelType, TDimension>;
 
   //
   // swizzle up a random vector image.

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest5.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest5.cxx
@@ -97,8 +97,8 @@ SlopeInterceptTest()
 
   //
   // read the image back in
-  using ImageType = typename itk::Image<float, 3>;
-  typename ImageType::Pointer image;
+  using ImageType = itk::Image<float, 3>;
+  ImageType::Pointer image;
   try
   {
     image = itk::IOTestHelper::ReadImage<ImageType>(std::string(filename));
@@ -108,7 +108,7 @@ SlopeInterceptTest()
     itk::IOTestHelper::Remove(filename);
     return EXIT_FAILURE;
   }
-  using IteratorType = typename itk::ImageRegionIterator<ImageType>;
+  using IteratorType = itk::ImageRegionIterator<ImageType>;
   IteratorType it(image, image->GetLargestPossibleRegion());
   it.GoToBegin();
   double maxerror = 0.0;
@@ -178,7 +178,7 @@ SlopeInterceptWriteTest()
   //
   // read the image back in
   using ImageType = itk::Image<float, 3>;
-  typename ImageType::Pointer image;
+  ImageType::Pointer image;
   try
   {
     image = itk::IOTestHelper::ReadImage<ImageType>(std::string(filename));

--- a/Modules/IO/NIFTI/test/itkNiftiReadAnalyzeTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiReadAnalyzeTest.cxx
@@ -146,8 +146,8 @@ ReadImage(const std::string &                     fileName,
 {
   using ReaderType = itk::ImageFileReader<TImage>;
 
-  auto                                      reader = ReaderType::New();
-  const typename itk::NiftiImageIO::Pointer imageIO = itk::NiftiImageIO::New();
+  auto                             reader = ReaderType::New();
+  const itk::NiftiImageIO::Pointer imageIO = itk::NiftiImageIO::New();
   {
     imageIO->SetLegacyAnalyze75Mode(analyze_mode);
     reader->SetImageIO(imageIO);

--- a/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
+++ b/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
@@ -1320,7 +1320,7 @@ NrrdImageIO::Write(const void * buffer)
   }
   else
   {
-    const typename Superclass::IOFileEnum fileType = this->GetFileType();
+    const Superclass::IOFileEnum fileType = this->GetFileType();
     switch (fileType)
     {
       default:
@@ -1335,7 +1335,7 @@ NrrdImageIO::Write(const void * buffer)
   }
 
   // set desired endianness of output
-  const typename Superclass::IOByteOrderEnum byteOrder = this->GetByteOrder();
+  const Superclass::IOByteOrderEnum byteOrder = this->GetByteOrder();
   switch (byteOrder)
   {
     default:

--- a/Modules/IO/NRRD/test/itkNrrd5dVectorImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrd5dVectorImageReadWriteTest.cxx
@@ -381,7 +381,7 @@ itkNrrd5dVectorImageReadWriteTest(int argc, char * argv[])
     WriteImageSequenceFile<PixelType, SpaceDimension>(filename, imageListToWrite);
     CheckImageSequenceFileHeader(
       filename, SpaceDimension, SpaceDimension + 1, expectedPixelType, 1, useNonListExtensionAsPixel);
-    std::vector<typename itk::Image<PixelType, SpaceDimension>::Pointer> imageListRead;
+    std::vector<itk::Image<PixelType, SpaceDimension>::Pointer> imageListRead;
     ReadImageSequenceFile<PixelType, SpaceDimension>(filename, imageListRead);
   }
 
@@ -398,7 +398,7 @@ itkNrrd5dVectorImageReadWriteTest(int argc, char * argv[])
     WriteImageSequenceFile<PixelType, SpaceDimension>(filename, imageListToWrite);
     CheckImageSequenceFileHeader(
       filename, SpaceDimension, SpaceDimension + 1, expectedPixelType, 1, useNonListExtensionAsPixel);
-    std::vector<typename itk::Image<PixelType, SpaceDimension>::Pointer> imageListRead;
+    std::vector<itk::Image<PixelType, SpaceDimension>::Pointer> imageListRead;
     ReadImageSequenceFile<PixelType, SpaceDimension>(filename, imageListRead);
   }
 
@@ -526,7 +526,7 @@ itkNrrd5dVectorImageReadWriteTest(int argc, char * argv[])
     WriteImageSequenceFile<PixelType, SpaceDimension>(filename, imageListToWrite);
     CheckImageSequenceFileHeader(
       filename, SpaceDimension, SpaceDimension + 1, expectedPixelType, SpaceDimension, useNonListExtensionAsPixel);
-    std::vector<typename itk::Image<PixelType, SpaceDimension>::Pointer> imageListRead;
+    std::vector<itk::Image<PixelType, SpaceDimension>::Pointer> imageListRead;
     ReadImageSequenceFile<PixelType, SpaceDimension>(filename, imageListRead);
   }
 
@@ -543,7 +543,7 @@ itkNrrd5dVectorImageReadWriteTest(int argc, char * argv[])
     WriteImageSequenceFile<PixelType, SpaceDimension>(filename, imageListToWrite);
     CheckImageSequenceFileHeader(
       filename, SpaceDimension, SpaceDimension + 1, expectedPixelType, SpaceDimension, useNonListExtensionAsPixel);
-    std::vector<typename itk::Image<PixelType, SpaceDimension>::Pointer> imageListRead;
+    std::vector<itk::Image<PixelType, SpaceDimension>::Pointer> imageListRead;
     ReadImageSequenceFile<PixelType, SpaceDimension>(filename, imageListRead);
   }
 
@@ -561,7 +561,7 @@ itkNrrd5dVectorImageReadWriteTest(int argc, char * argv[])
     WriteImageSequenceFile<PixelType, SpaceDimension>(filename, imageListToWrite);
     CheckImageSequenceFileHeader(
       filename, SpaceDimension, SpaceDimension + 1, expectedPixelType, expectedComponents, useNonListExtensionAsPixel);
-    std::vector<typename itk::Image<PixelType, SpaceDimension>::Pointer> imageListRead;
+    std::vector<itk::Image<PixelType, SpaceDimension>::Pointer> imageListRead;
     ReadImageSequenceFile<PixelType, SpaceDimension>(filename, imageListRead);
   }
 
@@ -579,7 +579,7 @@ itkNrrd5dVectorImageReadWriteTest(int argc, char * argv[])
     WriteImageSequenceFile<PixelType, SpaceDimension>(filename, imageListToWrite);
     CheckImageSequenceFileHeader(
       filename, SpaceDimension, SpaceDimension + 1, expectedPixelType, expectedComponents, useNonListExtensionAsPixel);
-    std::vector<typename itk::Image<PixelType, SpaceDimension>::Pointer> imageListRead;
+    std::vector<itk::Image<PixelType, SpaceDimension>::Pointer> imageListRead;
     ReadImageSequenceFile<PixelType, SpaceDimension>(filename, imageListRead);
   }
 

--- a/Modules/IO/RAW/include/itkRawImageIO.hxx
+++ b/Modules/IO/RAW/include/itkRawImageIO.hxx
@@ -100,9 +100,8 @@ RawImageIO<TPixel, VImageDimension>::GetHeaderSize()
     // Get the size of the header from the size of the image
     file.seekg(0, std::ios::end);
 
-    m_HeaderSize =
-      static_cast<SizeValueType>(static_cast<typename itk::intmax_t>(file.tellg()) -
-                                 static_cast<typename itk::intmax_t>(this->m_Strides[m_FileDimensionality + 1]));
+    m_HeaderSize = static_cast<SizeValueType>(static_cast<itk::intmax_t>(file.tellg()) -
+                                              static_cast<itk::intmax_t>(this->m_Strides[m_FileDimensionality + 1]));
   }
 
   return m_HeaderSize;

--- a/Modules/IO/RAW/test/itkRawImageIOTest5.cxx
+++ b/Modules/IO/RAW/test/itkRawImageIOTest5.cxx
@@ -40,8 +40,8 @@ public:
   {
     m_Image = ImageType::New();
 
-    constexpr typename ImageType::SizeType size{ 16, 16 };
-    typename ImageType::RegionType         region = { size };
+    constexpr ImageType::SizeType size{ 16, 16 };
+    ImageType::RegionType         region = { size };
 
     m_Image->SetRegions(region);
     m_Image->Allocate();
@@ -149,7 +149,7 @@ public:
 private:
   std::string m_FileName;
 
-  typename ImageType::Pointer m_Image;
+  ImageType::Pointer m_Image;
 
   bool m_Error;
 };

--- a/Modules/IO/TIFF/test/itkImageSeriesReaderReverse.cxx
+++ b/Modules/IO/TIFF/test/itkImageSeriesReaderReverse.cxx
@@ -104,9 +104,9 @@ TEST_F(ITKIOTIFF, ReverseOrder_with_ImageIO)
   }
   {
     // Create an ImageSeriesWriter to write the series of images
-    auto writer = itk::ImageSeriesWriter<
-      ImageType,
-      typename ImageType::RebindImageType<ImageType::PixelType, ImageType::ImageDimension - 1>>::New();
+    auto writer =
+      itk::ImageSeriesWriter<ImageType,
+                             ImageType::RebindImageType<ImageType::PixelType, ImageType::ImageDimension - 1>>::New();
     writer->SetFileNames(filePaths);
     writer->SetInput(img);
     writer->Update();

--- a/Modules/IO/TransformBase/src/itkTransformFileReader.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformFileReader.cxx
@@ -44,7 +44,7 @@ struct KernelTransformHelper
   {
     if (transform->GetInputSpaceDimension() == Dimension)
     {
-      using KernelTransformType = typename itk::KernelTransform<TParameterType, Dimension>;
+      using KernelTransformType = itk::KernelTransform<TParameterType, Dimension>;
       auto * kernelTransform = static_cast<KernelTransformType *>(transform.GetPointer());
       kernelTransform->ComputeWMatrix();
       return 0;

--- a/Modules/IO/TransformHDF5/test/itkIOTransformHDF5Test.cxx
+++ b/Modules/IO/TransformHDF5/test/itkIOTransformHDF5Test.cxx
@@ -403,7 +403,7 @@ itkIOTransformHDF5Test(int argc, char * argv[])
     else if (itksys::SystemTools::FileExists(testType)) // Assume the final parameter is a filename to be read
     {
       // This test only verifies that the test can read the transform.
-      using TFM_READER_TYPE = typename itk::TransformFileReaderTemplate<double>;
+      using TFM_READER_TYPE = itk::TransformFileReaderTemplate<double>;
       auto reader = TFM_READER_TYPE::New();
       reader->SetFileName(testType);
       reader->Update();

--- a/Modules/IO/XML/include/itkDOMReader.h
+++ b/Modules/IO/XML/include/itkDOMReader.h
@@ -75,10 +75,10 @@ public:
   using OutputType = TOutput;
 
   using DOMNodeType = DOMNode;
-  using DOMNodePointer = typename DOMNodeType::Pointer;
+  using DOMNodePointer = DOMNodeType::Pointer;
 
   using LoggerType = Logger;
-  using LoggerPointer = typename LoggerType::Pointer;
+  using LoggerPointer = LoggerType::Pointer;
 
   /** Set the input XML filename. */
   itkSetStringMacro(FileName);
@@ -147,7 +147,7 @@ private:
   OutputType * m_Output{};
 
   /** Variable to hold the output object if it is a smart object. */
-  typename LightObject::Pointer m_OutputHolder{};
+  LightObject::Pointer m_OutputHolder{};
 
   /** Variable to hold the intermediate DOM object. */
   DOMNodePointer m_IntermediateDOM{};

--- a/Modules/IO/XML/include/itkDOMWriter.h
+++ b/Modules/IO/XML/include/itkDOMWriter.h
@@ -77,10 +77,10 @@ public:
   using InputType = TInput;
 
   using DOMNodeType = DOMNode;
-  using DOMNodePointer = typename DOMNodeType::Pointer;
+  using DOMNodePointer = DOMNodeType::Pointer;
 
   using LoggerType = Logger;
-  using LoggerPointer = typename LoggerType::Pointer;
+  using LoggerPointer = LoggerType::Pointer;
 
   /** Set the output XML filename. */
   itkSetStringMacro(FileName);
@@ -142,7 +142,7 @@ private:
   const InputType * m_Input{};
 
   /** Variable to hold the input object if it is a smart object. */
-  typename LightObject::ConstPointer m_InputHolder{};
+  LightObject::ConstPointer m_InputHolder{};
 
   /** Variable to hold the intermediate DOM object. */
   DOMNodePointer m_IntermediateDOM{};

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
@@ -123,7 +123,7 @@ public:
   using RealType = typename NumericTraits<PixelType>::RealType;
 
   /** Smart Pointer type to a DataObject. */
-  using DataObjectPointer = typename DataObject::Pointer;
+  using DataObjectPointer = DataObject::Pointer;
 
   /** Type of DataObjects used for scalar outputs */
   using RealObjectType = SimpleDataObjectDecorator<RealType>;

--- a/Modules/Nonunit/Review/include/itkScalarRegionBasedLevelSetFunction.h
+++ b/Modules/Nonunit/Review/include/itkScalarRegionBasedLevelSetFunction.h
@@ -97,8 +97,8 @@ public:
   using ConstFeatureIteratorType = ImageRegionConstIterator<FeatureImageType>;
 
   using ListPixelType = std::list<unsigned int>;
-  using ListPixelConstIterator = typename ListPixelType::const_iterator;
-  using ListPixelIterator = typename ListPixelType::iterator;
+  using ListPixelConstIterator = ListPixelType::const_iterator;
+  using ListPixelIterator = ListPixelType::iterator;
   using ListImageType = Image<ListPixelType, Self::ImageDimension>;
 
   /** Performs the narrow-band update of the Heaviside function for each

--- a/Modules/Numerics/FEM/include/itkFEMRobustSolver.h
+++ b/Modules/Numerics/FEM/include/itkFEMRobustSolver.h
@@ -100,7 +100,7 @@ public:
   using typename Superclass::FEMObjectType;
 
   /** Some convenient types */
-  using MatrixType = typename Element::MatrixType;
+  using MatrixType = Element::MatrixType;
   using LoadContainerType = typename FEMObjectType::LoadContainerType;
   using NodeContainerType = typename FEMObjectType::NodeContainerType;
   using LoadContainerIterator = typename FEMObjectType::LoadContainerIterator;

--- a/Modules/Numerics/FEM/include/itkFEMSolver.h
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.h
@@ -88,10 +88,10 @@ public:
   static constexpr unsigned int MaxDimensions = 3;
 
   /** Smart Pointer type to a DataObject. */
-  using FEMObjectType = typename itk::fem::FEMObject<VDimension>;
+  using FEMObjectType = itk::fem::FEMObject<VDimension>;
   using FEMObjectPointer = typename FEMObjectType::Pointer;
   using FEMObjectConstPointer = typename FEMObjectType::ConstPointer;
-  using DataObjectPointer = typename DataObject::Pointer;
+  using DataObjectPointer = DataObject::Pointer;
 
   /** Some convenient type alias. */
   using Float = Element::Float;
@@ -104,7 +104,7 @@ public:
   /**
    * Type used to store interpolation grid
    */
-  using InterpolationGridType = typename itk::Image<Element::ConstPointer, VDimension>;
+  using InterpolationGridType = itk::Image<Element::ConstPointer, VDimension>;
   using InterpolationGridPointerType = typename InterpolationGridType::Pointer;
   using InterpolationGridSizeType = typename InterpolationGridType::SizeType;
   using InterpolationGridRegionType = typename InterpolationGridType::RegionType;

--- a/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.h
+++ b/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.h
@@ -67,10 +67,10 @@ public:
   using ImageIndexType = typename InputImageType::IndexType;
 
   /** Typedefs for Output FEMObject */
-  using FEMObjectType = typename itk::fem::FEMObject<NDimensions>;
+  using FEMObjectType = itk::fem::FEMObject<NDimensions>;
   using FEMObjectPointer = typename FEMObjectType::Pointer;
   using FEMObjectConstPointer = typename FEMObjectType::ConstPointer;
-  using DataObjectPointer = typename DataObject::Pointer;
+  using DataObjectPointer = DataObject::Pointer;
 
   /** Some convenient type alias. */
   using MaterialType = itk::fem::MaterialLinearElasticity;

--- a/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
@@ -195,24 +195,19 @@ ExhaustiveOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "CurrentValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_CurrentValue)
-     << std::endl;
-  os << indent << "NumberOfSteps: " << static_cast<typename NumericTraits<StepsType>::PrintType>(m_NumberOfSteps)
-     << std::endl;
-  os << indent
-     << "CurrentIteration: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_CurrentIteration)
+  os << indent << "CurrentValue: " << static_cast<NumericTraits<MeasureType>::PrintType>(m_CurrentValue) << std::endl;
+  os << indent << "NumberOfSteps: " << static_cast<NumericTraits<StepsType>::PrintType>(m_NumberOfSteps) << std::endl;
+  os << indent << "CurrentIteration: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_CurrentIteration)
      << std::endl;
   itkPrintSelfBooleanMacro(Stop);
   os << indent << "CurrentParameter: " << m_CurrentParameter << std::endl;
   os << indent << "StepLength: " << m_StepLength << std::endl;
   os << indent << "CurrentIndex: " << m_CurrentIndex << std::endl;
   os << indent << "MaximumNumberOfIterations: "
-     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_MaximumNumberOfIterations) << std::endl;
-  os << indent
-     << "MaximumMetricValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_MaximumMetricValue)
+     << static_cast<NumericTraits<SizeValueType>::PrintType>(m_MaximumNumberOfIterations) << std::endl;
+  os << indent << "MaximumMetricValue: " << static_cast<NumericTraits<MeasureType>::PrintType>(m_MaximumMetricValue)
      << std::endl;
-  os << indent
-     << "MinimumMetricValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_MinimumMetricValue)
+  os << indent << "MinimumMetricValue: " << static_cast<NumericTraits<MeasureType>::PrintType>(m_MinimumMetricValue)
      << std::endl;
   os << indent << "MinimumMetricValuePosition: " << m_MinimumMetricValuePosition << std::endl;
   os << indent << "MaximumMetricValuePosition: " << m_MaximumMetricValuePosition << std::endl;

--- a/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
@@ -43,29 +43,28 @@ SPSAOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Gradient: " << static_cast<typename NumericTraits<DerivativeType>::PrintType>(m_Gradient)
-     << std::endl;
+  os << indent << "Gradient: " << static_cast<NumericTraits<DerivativeType>::PrintType>(m_Gradient) << std::endl;
   os << indent << "LearningRate: " << m_LearningRate << std::endl;
-  os << indent << "Delta: " << static_cast<typename NumericTraits<DerivativeType>::PrintType>(m_Delta) << std::endl;
+  os << indent << "Delta: " << static_cast<NumericTraits<DerivativeType>::PrintType>(m_Delta) << std::endl;
   itkPrintSelfBooleanMacro(Stop);
   os << indent << "StopCondition: " << m_StopCondition << std::endl;
   os << indent << "StateOfConvergence: " << m_StateOfConvergence << std::endl;
-  os << indent
-     << "CurrentIteration: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_CurrentIteration)
+  os << indent << "CurrentIteration: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_CurrentIteration)
      << std::endl;
 
   itkPrintSelfObjectMacro(Generator);
 
   os << indent << "MinimumNumberOfIterations: "
-     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_MinimumNumberOfIterations) << std::endl;
+     << static_cast<NumericTraits<SizeValueType>::PrintType>(m_MinimumNumberOfIterations) << std::endl;
   os << indent << "MaximumNumberOfIterations: "
-     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_MaximumNumberOfIterations) << std::endl;
+     << static_cast<NumericTraits<SizeValueType>::PrintType>(m_MaximumNumberOfIterations) << std::endl;
   os << indent << "StateOfConvergenceDecayRate: " << m_StateOfConvergenceDecayRate << std::endl;
   os << indent << "Tolerance: " << m_Tolerance << std::endl;
   itkPrintSelfBooleanMacro(Maximize);
   os << indent << "GradientMagnitude: " << m_GradientMagnitude << std::endl;
-  os << indent << "NumberOfPerturbations: "
-     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPerturbations) << std::endl;
+  os << indent
+     << "NumberOfPerturbations: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfPerturbations)
+     << std::endl;
 
   os << indent << "Sa: " << m_Sa << std::endl;
   os << indent << "Sc: " << m_Sc << std::endl;

--- a/Modules/Numerics/Optimizers/test/itkAmoebaOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkAmoebaOptimizerTest.cxx
@@ -274,7 +274,7 @@ AmoebaTest1()
   ITK_TEST_EXPECT_TRUE(itkOptimizer->CanUseScales());
 
   // set optimizer parameters
-  constexpr typename OptimizerType::NumberOfIterationsType numberOfIterations = 10;
+  constexpr OptimizerType::NumberOfIterationsType numberOfIterations = 10;
   itkOptimizer->SetMaximumNumberOfIterations(numberOfIterations);
   ITK_TEST_SET_GET_VALUE(numberOfIterations, itkOptimizer->GetMaximumNumberOfIterations());
 

--- a/Modules/Numerics/Optimizers/test/itkInitializationBiasedParticleSwarmOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkInitializationBiasedParticleSwarmOptimizerTest.cxx
@@ -31,29 +31,29 @@ static OptimizerType::RandomVariateGeneratorType::IntegerType seedOffset = 0;
  * domain of either parabolas (runs the optimizer once with initial guess in
  * each of the domains).
  */
-int IBPSOTest1(typename OptimizerType::CoefficientType,
-               typename OptimizerType::CoefficientType,
-               typename OptimizerType::CoefficientType,
-               typename OptimizerType::CoefficientType);
+int IBPSOTest1(OptimizerType::CoefficientType,
+               OptimizerType::CoefficientType,
+               OptimizerType::CoefficientType,
+               OptimizerType::CoefficientType);
 
 
 /**
  * Test using a 2D quadratic function (single minimum), check that converges
  * correctly.
  */
-int IBPSOTest2(typename OptimizerType::CoefficientType,
-               typename OptimizerType::CoefficientType,
-               typename OptimizerType::CoefficientType,
-               typename OptimizerType::CoefficientType);
+int IBPSOTest2(OptimizerType::CoefficientType,
+               OptimizerType::CoefficientType,
+               OptimizerType::CoefficientType,
+               OptimizerType::CoefficientType);
 
 
 /**
  * Test using the 2D Rosenbrock function.
  */
-int IBPSOTest3(typename OptimizerType::CoefficientType,
-               typename OptimizerType::CoefficientType,
-               typename OptimizerType::CoefficientType,
-               typename OptimizerType::CoefficientType);
+int IBPSOTest3(OptimizerType::CoefficientType,
+               OptimizerType::CoefficientType,
+               OptimizerType::CoefficientType,
+               OptimizerType::CoefficientType);
 
 bool initalizationBasedTestVerboseFlag = false;
 
@@ -84,10 +84,10 @@ itkInitializationBiasedParticleSwarmOptimizerTest(int argc, char * argv[])
 
   std::cout << "Initialization Biased Particle Swarm Optimizer Test \n \n";
 
-  auto inertiaCoefficient = static_cast<typename OptimizerType::CoefficientType>(std::stod(argv[1]));
-  auto personalCoefficient = static_cast<typename OptimizerType::CoefficientType>(std::stod(argv[2]));
-  auto globalCoefficient = static_cast<typename OptimizerType::CoefficientType>(std::stod(argv[3]));
-  auto initializationCoefficient = static_cast<typename OptimizerType::CoefficientType>(std::stod(argv[4]));
+  auto inertiaCoefficient = static_cast<OptimizerType::CoefficientType>(std::stod(argv[1]));
+  auto personalCoefficient = static_cast<OptimizerType::CoefficientType>(std::stod(argv[2]));
+  auto globalCoefficient = static_cast<OptimizerType::CoefficientType>(std::stod(argv[3]));
+  auto initializationCoefficient = static_cast<OptimizerType::CoefficientType>(std::stod(argv[4]));
 
   unsigned int           success1{ 0 };
   unsigned int           success2{ 0 };
@@ -127,10 +127,10 @@ itkInitializationBiasedParticleSwarmOptimizerTest(int argc, char * argv[])
 
 
 int
-IBPSOTest1(typename OptimizerType::CoefficientType inertiaCoefficient,
-           typename OptimizerType::CoefficientType personalCoefficient,
-           typename OptimizerType::CoefficientType globalCoefficient,
-           typename OptimizerType::CoefficientType initializationCoefficient)
+IBPSOTest1(OptimizerType::CoefficientType inertiaCoefficient,
+           OptimizerType::CoefficientType personalCoefficient,
+           OptimizerType::CoefficientType globalCoefficient,
+           OptimizerType::CoefficientType initializationCoefficient)
 {
   std::cout << "Particle Swarm Optimizer Test 1 [f(x) = if(x<0) x^2+4x; else 2x^2-8x]\n";
   std::cout << "-------------------------------\n";
@@ -251,10 +251,10 @@ IBPSOTest1(typename OptimizerType::CoefficientType inertiaCoefficient,
 
 
 int
-IBPSOTest2(typename OptimizerType::CoefficientType inertiaCoefficient,
-           typename OptimizerType::CoefficientType personalCoefficient,
-           typename OptimizerType::CoefficientType globalCoefficient,
-           typename OptimizerType::CoefficientType initializationCoefficient)
+IBPSOTest2(OptimizerType::CoefficientType inertiaCoefficient,
+           OptimizerType::CoefficientType personalCoefficient,
+           OptimizerType::CoefficientType globalCoefficient,
+           OptimizerType::CoefficientType initializationCoefficient)
 {
   std::cout << "Particle Swarm Optimizer Test 2 [f(x) = 1/2 x^T A x - b^T x]\n";
   std::cout << "----------------------------------\n";
@@ -350,10 +350,10 @@ IBPSOTest2(typename OptimizerType::CoefficientType inertiaCoefficient,
 }
 
 int
-IBPSOTest3(typename OptimizerType::CoefficientType inertiaCoefficient,
-           typename OptimizerType::CoefficientType personalCoefficient,
-           typename OptimizerType::CoefficientType globalCoefficient,
-           typename OptimizerType::CoefficientType initializationCoefficient)
+IBPSOTest3(OptimizerType::CoefficientType inertiaCoefficient,
+           OptimizerType::CoefficientType personalCoefficient,
+           OptimizerType::CoefficientType globalCoefficient,
+           OptimizerType::CoefficientType initializationCoefficient)
 {
   std::cout << "Particle Swarm Optimizer Test 3 [f(x,y) = (1-x)^2 + 100(y-x^2)^2]\n";
   std::cout << "----------------------------------\n";

--- a/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
@@ -226,8 +226,7 @@ ExhaustiveOptimizerv4<TInternalComputationValueType>::PrintSelf(std::ostream & o
   os << indent << "InitialPosition: " << m_InitialPosition << std::endl;
   os << indent << "CurrentValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_CurrentValue)
      << std::endl;
-  os << indent << "NumberOfSteps: " << static_cast<typename NumericTraits<StepsType>::PrintType>(m_NumberOfSteps)
-     << std::endl;
+  os << indent << "NumberOfSteps: " << static_cast<NumericTraits<StepsType>::PrintType>(m_NumberOfSteps) << std::endl;
   itkPrintSelfBooleanMacro(Stop);
   os << indent << "StepLength: " << m_StepLength << std::endl;
   os << indent << "CurrentIndex: " << m_CurrentIndex << std::endl;

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
@@ -59,8 +59,9 @@ GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::PrintSelf
      << static_cast<typename NumericTraits<TInternalComputationValueType>::PrintType>(m_MaximumStepSizeInPhysicalUnits)
      << std::endl;
   itkPrintSelfBooleanMacro(UseConvergenceMonitoring);
-  os << indent << "ConvergenceWindowSize: "
-     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_ConvergenceWindowSize) << std::endl;
+  os << indent
+     << "ConvergenceWindowSize: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_ConvergenceWindowSize)
+     << std::endl;
 
   itkPrintSelfObjectMacro(ConvergenceMonitoring);
   itkPrintSelfObjectMacro(ModifyGradientByScalesThreader);

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
@@ -541,8 +541,7 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
   itkPrintSelfObjectMacro(VirtualImage);
 
   itkPrintSelfBooleanMacro(UserHasSetVirtualDomain);
-  os << indent
-     << "NumberOfValidPoints: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfValidPoints)
+  os << indent << "NumberOfValidPoints: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfValidPoints)
      << std::endl;
 }
 

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetricBase.h
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetricBase.h
@@ -118,7 +118,7 @@ public:
 
   /**  Type of object. */
   using ObjectType = Object;
-  using ObjectConstPointer = typename ObjectType::ConstPointer;
+  using ObjectConstPointer = ObjectType::ConstPointer;
 
   /** Get/Set the Fixed Object.  */
   /** @ITKStartGrouping */

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
@@ -622,12 +622,12 @@ RegistrationParameterScalesEstimator<TMetric>::PrintSelf(std::ostream & os, Inde
   itkPrintSelfObjectMacro(Metric);
 
   os << indent << "SamplePoints: " << m_SamplePoints << std::endl;
-  os << indent << "SamplingTime: " << static_cast<typename NumericTraits<TimeStamp>::PrintType>(m_SamplingTime)
-     << std::endl;
-  os << indent << "NumberOfRandomSamples: "
-     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfRandomSamples) << std::endl;
+  os << indent << "SamplingTime: " << static_cast<NumericTraits<TimeStamp>::PrintType>(m_SamplingTime) << std::endl;
   os << indent
-     << "CentralRegionRadius: " << static_cast<typename NumericTraits<IndexValueType>::PrintType>(m_CentralRegionRadius)
+     << "NumberOfRandomSamples: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfRandomSamples)
+     << std::endl;
+  os << indent
+     << "CentralRegionRadius: " << static_cast<NumericTraits<IndexValueType>::PrintType>(m_CentralRegionRadius)
      << std::endl;
 
   itkPrintSelfObjectMacro(VirtualDomainPointSet);

--- a/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
@@ -114,7 +114,7 @@ itkAutoScaledGradientDescentRegistrationOnVectorTestTemplated(int               
   iterationCommand->SetOptimizer(optimizer);
 
   // Optimizer parameter scales estimator
-  typename itk::OptimizerParameterScalesEstimator::Pointer scalesEstimator;
+  itk::OptimizerParameterScalesEstimator::Pointer scalesEstimator;
 
   using ShiftScalesEstimatorType = itk::RegistrationParameterScalesFromPhysicalShift<MetricType>;
   using JacobianScalesEstimatorType = itk::RegistrationParameterScalesFromJacobian<MetricType>;

--- a/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationTest.cxx
@@ -115,7 +115,7 @@ itkAutoScaledGradientDescentRegistrationTestTemplated(int                 number
   iterationCommand->SetOptimizer(optimizer);
 
   // Optimizer parameter scales estimator
-  typename itk::OptimizerParameterScalesEstimator::Pointer scalesEstimator;
+  itk::OptimizerParameterScalesEstimator::Pointer scalesEstimator;
 
   using PhysicalShiftScalesEstimatorType = itk::RegistrationParameterScalesFromPhysicalShift<MetricType>;
   using IndexShiftScalesEstimatorType = itk::RegistrationParameterScalesFromIndexShift<MetricType>;

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentLineSearchOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentLineSearchOptimizerv4Test.cxx
@@ -252,15 +252,15 @@ itkGradientDescentLineSearchOptimizerv4Test(int, char *[])
   ScalesType scales(metric->GetNumberOfLocalParameters(), 0.5);
   itkOptimizer->SetScales(scales);
 
-  constexpr typename OptimizerType::InternalComputationValueType epsilon = 1.e-4;
+  constexpr OptimizerType::InternalComputationValueType epsilon = 1.e-4;
   itkOptimizer->SetEpsilon(epsilon);
   ITK_TEST_SET_GET_VALUE(epsilon, itkOptimizer->GetEpsilon());
 
-  constexpr typename OptimizerType::InternalComputationValueType lowerLimit = -10;
+  constexpr OptimizerType::InternalComputationValueType lowerLimit = -10;
   itkOptimizer->SetLowerLimit(lowerLimit);
   ITK_TEST_SET_GET_VALUE(lowerLimit, itkOptimizer->GetLowerLimit());
 
-  constexpr typename OptimizerType::InternalComputationValueType upperLimit = 10;
+  constexpr OptimizerType::InternalComputationValueType upperLimit = 10;
   itkOptimizer->SetUpperLimit(upperLimit);
   ITK_TEST_SET_GET_VALUE(upperLimit, itkOptimizer->GetUpperLimit());
 

--- a/Modules/Numerics/Statistics/include/itkDistanceToCentroidMembershipFunction.h
+++ b/Modules/Numerics/Statistics/include/itkDistanceToCentroidMembershipFunction.h
@@ -104,7 +104,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Return a copy of the current membership function */
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 
 private:

--- a/Modules/Numerics/Statistics/include/itkDistanceToCentroidMembershipFunction.hxx
+++ b/Modules/Numerics/Statistics/include/itkDistanceToCentroidMembershipFunction.hxx
@@ -64,7 +64,7 @@ DistanceToCentroidMembershipFunction<TVector>::Evaluate(const MeasurementVectorT
 }
 
 template <typename TVector>
-typename LightObject::Pointer
+LightObject::Pointer
 DistanceToCentroidMembershipFunction<TVector>::InternalClone() const
 {
   LightObject::Pointer         loPtr = Superclass::InternalClone();

--- a/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.h
+++ b/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.h
@@ -144,7 +144,7 @@ public:
 
   /** type alias for decorated array of proportion */
   using MembershipFunctionsWeightsArrayObjectType = SimpleDataObjectDecorator<ProportionVectorType>;
-  using MembershipFunctionsWeightsArrayPointer = typename MembershipFunctionsWeightsArrayObjectType::Pointer;
+  using MembershipFunctionsWeightsArrayPointer = MembershipFunctionsWeightsArrayObjectType::Pointer;
 
   /** Get method for data decorated Membership functions weights array */
   const MembershipFunctionsWeightsArrayObjectType *

--- a/Modules/Numerics/Statistics/include/itkGaussianMembershipFunction.h
+++ b/Modules/Numerics/Statistics/include/itkGaussianMembershipFunction.h
@@ -115,7 +115,7 @@ public:
   /** Method to clone a membership function, i.e. create a new instance of
    * the same type of membership function and configure its ivars to
    * match. */
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 
 protected:

--- a/Modules/Numerics/Statistics/include/itkGaussianMembershipFunction.hxx
+++ b/Modules/Numerics/Statistics/include/itkGaussianMembershipFunction.hxx
@@ -166,7 +166,7 @@ GaussianMembershipFunction<TMeasurementVector>::Evaluate(const MeasurementVector
 }
 
 template <typename TVector>
-typename LightObject::Pointer
+LightObject::Pointer
 GaussianMembershipFunction<TVector>::InternalClone() const
 {
   LightObject::Pointer         loPtr = Superclass::InternalClone();

--- a/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.h
@@ -100,7 +100,7 @@ protected:
    * This does a complete copy of the subsampler state
    * to the new subsampler
    */
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 
   GaussianRandomSpatialNeighborSubsampler() = default;

--- a/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.hxx
@@ -22,10 +22,10 @@ namespace itk::Statistics
 {
 
 template <typename TSample, typename TRegion>
-typename LightObject::Pointer
+LightObject::Pointer
 GaussianRandomSpatialNeighborSubsampler<TSample, TRegion>::InternalClone() const
 {
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
   const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())

--- a/Modules/Numerics/Statistics/include/itkHistogram.h
+++ b/Modules/Numerics/Statistics/include/itkHistogram.h
@@ -114,11 +114,11 @@ public:
 
   /** Index type alias support An index is used to access pixel values. */
   using IndexType = Array<itk::IndexValueType>;
-  using IndexValueType = typename IndexType::ValueType;
+  using IndexValueType = IndexType::ValueType;
 
   /** size array type */
   using SizeType = Array<itk::SizeValueType>;
-  using SizeValueType = typename SizeType::ValueType;
+  using SizeValueType = SizeType::ValueType;
 
   /** bin min max value storage types */
   using BinMinVectorType = std::vector<MeasurementType>;

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -659,7 +659,7 @@ Histogram<TMeasurement, TFrequencyContainer>::PrintSelf(std::ostream & os, Inden
 
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Size: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_Size) << std::endl;
+  os << indent << "Size: " << static_cast<NumericTraits<SizeType>::PrintType>(m_Size) << std::endl;
   os << indent << "OffsetTable: " << std::endl;
   for (const auto & elem : m_OffsetTable)
   {
@@ -691,7 +691,7 @@ Histogram<TMeasurement, TFrequencyContainer>::PrintSelf(std::ostream & os, Inden
   }
 
   os << indent << "TempMeasurementVector: " << m_TempMeasurementVector << std::endl;
-  os << indent << "TempIndex: " << static_cast<typename NumericTraits<IndexType>::PrintType>(m_TempIndex) << std::endl;
+  os << indent << "TempIndex: " << static_cast<NumericTraits<IndexType>::PrintType>(m_TempIndex) << std::endl;
   itkPrintSelfBooleanMacro(ClipBinsAtEnds);
 }
 

--- a/Modules/Numerics/Statistics/include/itkImageClassifierFilter.h
+++ b/Modules/Numerics/Statistics/include/itkImageClassifierFilter.h
@@ -99,7 +99,7 @@ public:
   using MembershipFunctionsWeightsArrayType = Array<double>;
 
   using MembershipFunctionsWeightsArrayObjectType = SimpleDataObjectDecorator<MembershipFunctionsWeightsArrayType>;
-  using MembershipFunctionsWeightsArrayPointer = typename MembershipFunctionsWeightsArrayObjectType::Pointer;
+  using MembershipFunctionsWeightsArrayPointer = MembershipFunctionsWeightsArrayObjectType::Pointer;
 
   /** type alias for class label type */
   using ClassLabelType = IdentifierType;

--- a/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.h
+++ b/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.h
@@ -324,7 +324,7 @@ private:
   typename TKdTree::Pointer m_KdTree{};
 
   /** pointer to the euclidean distance function */
-  typename EuclideanDistanceMetric<ParameterType>::Pointer m_DistanceMetric{};
+  EuclideanDistanceMetric<ParameterType>::Pointer m_DistanceMetric{};
 
   /** k-means */
   ParametersType m_Parameters{};

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.h
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.h
@@ -119,7 +119,7 @@ public:
   /** Method to clone a membership function, i.e. create a new instance of
    * the same type of membership function and configure its ivars to
    * match. */
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 
 protected:

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.hxx
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.hxx
@@ -169,7 +169,7 @@ MahalanobisDistanceMembershipFunction<TVector>::PrintSelf(std::ostream & os, Ind
 }
 
 template <typename TVector>
-typename LightObject::Pointer
+LightObject::Pointer
 MahalanobisDistanceMembershipFunction<TVector>::InternalClone() const
 {
   LightObject::Pointer         loPtr = Superclass::InternalClone();

--- a/Modules/Numerics/Statistics/include/itkRegionConstrainedSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkRegionConstrainedSubsampler.h
@@ -117,7 +117,7 @@ protected:
    * This does a complete copy of the subsampler state
    * to the new subsampler
    */
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 
   RegionConstrainedSubsampler();

--- a/Modules/Numerics/Statistics/include/itkRegionConstrainedSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkRegionConstrainedSubsampler.hxx
@@ -29,10 +29,10 @@ RegionConstrainedSubsampler<TSample, TRegion>::RegionConstrainedSubsampler()
 }
 
 template <typename TSample, typename TRegion>
-typename LightObject::Pointer
+LightObject::Pointer
 RegionConstrainedSubsampler<TSample, TRegion>::InternalClone() const
 {
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
   const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())

--- a/Modules/Numerics/Statistics/include/itkSample.h
+++ b/Modules/Numerics/Statistics/include/itkSample.h
@@ -86,7 +86,7 @@ public:
 
   /** InstanceIdentifier type alias. This identifier is a unique
    * sequential id for each measurement vector in a Sample subclass. */
-  using InstanceIdentifier = typename MeasurementVectorTraits::InstanceIdentifier;
+  using InstanceIdentifier = MeasurementVectorTraits::InstanceIdentifier;
 
   /** Type of the length of each measurement vector */
   using MeasurementVectorSizeType = unsigned int;

--- a/Modules/Numerics/Statistics/include/itkSampleClassifierFilter.h
+++ b/Modules/Numerics/Statistics/include/itkSampleClassifierFilter.h
@@ -78,7 +78,7 @@ public:
   using MembershipFunctionsWeightsArrayType = Array<double>;
 
   using MembershipFunctionsWeightsArrayObjectType = SimpleDataObjectDecorator<MembershipFunctionsWeightsArrayType>;
-  using MembershipFunctionsWeightsArrayPointer = typename MembershipFunctionsWeightsArrayObjectType::Pointer;
+  using MembershipFunctionsWeightsArrayPointer = MembershipFunctionsWeightsArrayObjectType::Pointer;
 
   using ClassLabelType = IdentifierType;
   using ClassLabelVectorType = std::vector<ClassLabelType>;

--- a/Modules/Numerics/Statistics/include/itkScalarImageToHistogramGenerator.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToHistogramGenerator.h
@@ -60,8 +60,8 @@ public:
 
   using GeneratorPointer = typename GeneratorType::Pointer;
 
-  using HistogramPointer = typename HistogramType::Pointer;
-  using HistogramConstPointer = typename HistogramType::ConstPointer;
+  using HistogramPointer = HistogramType::Pointer;
+  using HistogramConstPointer = HistogramType::ConstPointer;
 
 public:
   /** Triggers the Computation of the histogram */

--- a/Modules/Numerics/Statistics/include/itkScalarImageToHistogramGenerator.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToHistogramGenerator.hxx
@@ -53,7 +53,7 @@ template <typename TImage>
 void
 ScalarImageToHistogramGenerator<TImage>::SetNumberOfBins(unsigned int numberOfBins)
 {
-  typename HistogramType::SizeType size;
+  HistogramType::SizeType size;
   size.SetSize(1);
   size.Fill(numberOfBins);
   m_HistogramGenerator->SetHistogramSize(size);

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.h
@@ -116,10 +116,10 @@ public:
   // using RunLengthFeatureName = itk::Statistics::RunLengthFeatureEnum;
   using RunLengthFeatureName = uint8_t;
   using FeatureNameVector = VectorContainer<unsigned char, RunLengthFeatureName>;
-  using FeatureNameVectorPointer = typename FeatureNameVector::Pointer;
-  using FeatureNameVectorConstPointer = typename FeatureNameVector::ConstPointer;
+  using FeatureNameVectorPointer = FeatureNameVector::Pointer;
+  using FeatureNameVectorConstPointer = FeatureNameVector::ConstPointer;
   using FeatureValueVector = VectorContainer<unsigned char, double>;
-  using FeatureValueVectorPointer = typename FeatureValueVector::Pointer;
+  using FeatureValueVectorPointer = FeatureValueVector::Pointer;
 
   /** Smart Pointer type to a DataObject. */
   using DataObjectPointer = DataObject::Pointer;

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
@@ -131,7 +131,7 @@ ScalarImageToRunLengthFeaturesFilter<TImage, THistogramFrequencyContainer>::Full
       runLengthMatrixCalculator->SetInput(this->m_RunLengthMatrixGenerator->GetOutput());
       runLengthMatrixCalculator->Update();
 
-      typename FeatureNameVector::ConstIterator fnameIt;
+      FeatureNameVector::ConstIterator fnameIt;
       {
         size_t featureNum = 0;
         for (fnameIt = this->m_RequestedFeatures->Begin(); fnameIt != this->m_RequestedFeatures->End();
@@ -221,7 +221,7 @@ ScalarImageToRunLengthFeaturesFilter<TImage, THistogramFrequencyContainer>::Fast
   using InternalRunLengthFeatureName = itk::Statistics::RunLengthFeatureEnum;
   this->m_FeatureMeans->clear();
   this->m_FeatureStandardDeviations->clear();
-  for (typename FeatureNameVector::ConstIterator fnameIt = this->m_RequestedFeatures->Begin();
+  for (FeatureNameVector::ConstIterator fnameIt = this->m_RequestedFeatures->Begin();
        fnameIt != this->m_RequestedFeatures->End();
        ++fnameIt)
   {

--- a/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.h
@@ -133,10 +133,10 @@ public:
   using TextureFeatureName = uint8_t;
   using FeatureNameVector = VectorContainer<unsigned char, TextureFeatureName>;
 
-  using FeatureNameVectorPointer = typename FeatureNameVector::Pointer;
-  using FeatureNameVectorConstPointer = typename FeatureNameVector::ConstPointer;
+  using FeatureNameVectorPointer = FeatureNameVector::Pointer;
+  using FeatureNameVectorConstPointer = FeatureNameVector::ConstPointer;
   using FeatureValueVector = VectorContainer<unsigned char, double>;
-  using FeatureValueVectorPointer = typename FeatureValueVector::Pointer;
+  using FeatureValueVectorPointer = FeatureValueVector::Pointer;
 
   /** Smart Pointer type to a DataObject. */
   using DataObjectPointer = DataObject::Pointer;

--- a/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
@@ -128,8 +128,7 @@ ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMa
 
 
     size_t featureNum = 0;
-    for (typename FeatureNameVector::ConstIterator fnameIt = m_RequestedFeatures->Begin();
-         fnameIt != m_RequestedFeatures->End();
+    for (FeatureNameVector::ConstIterator fnameIt = m_RequestedFeatures->Begin(); fnameIt != m_RequestedFeatures->End();
          ++fnameIt, featureNum++)
     {
       features[offsetNum][featureNum] =
@@ -213,7 +212,7 @@ ScalarImageToTextureFeaturesFilter<TImageType, THistogramFrequencyContainer, TMa
   using InternalTextureFeatureName = itk::Statistics::HistogramToTextureFeaturesFilterEnums::TextureFeature;
   m_FeatureMeans->clear();
   m_FeatureStandardDeviations->clear();
-  typename FeatureNameVector::ConstIterator fnameIt;
+  FeatureNameVector::ConstIterator fnameIt;
   for (fnameIt = m_RequestedFeatures->Begin(); fnameIt != m_RequestedFeatures->End(); ++fnameIt)
   {
     m_FeatureMeans->push_back(

--- a/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.h
@@ -113,7 +113,7 @@ protected:
    * This does a complete copy of the subsampler state
    * to the new subsampler
    */
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 
   SpatialNeighborSubsampler();

--- a/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.hxx
@@ -30,10 +30,10 @@ SpatialNeighborSubsampler<TSample, TRegion>::SpatialNeighborSubsampler()
 }
 
 template <typename TSample, typename TRegion>
-typename LightObject::Pointer
+LightObject::Pointer
 SpatialNeighborSubsampler<TSample, TRegion>::InternalClone() const
 {
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
   const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())

--- a/Modules/Numerics/Statistics/include/itkSubsamplerBase.h
+++ b/Modules/Numerics/Statistics/include/itkSubsamplerBase.h
@@ -123,7 +123,7 @@ protected:
    * This does a complete copy of the subsampler state
    * to the new subsampler
    */
-  typename LightObject::Pointer
+  LightObject::Pointer
   InternalClone() const override;
 
   SubsamplerBase();

--- a/Modules/Numerics/Statistics/include/itkSubsamplerBase.hxx
+++ b/Modules/Numerics/Statistics/include/itkSubsamplerBase.hxx
@@ -29,10 +29,10 @@ SubsamplerBase<TSample>::SubsamplerBase()
 {}
 
 template <typename TSample>
-typename LightObject::Pointer
+LightObject::Pointer
 SubsamplerBase<TSample>::InternalClone() const
 {
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
   const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())

--- a/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.h
@@ -140,7 +140,7 @@ protected:
    * This does a complete copy of the subsampler state
    * to the new subsampler
    */
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 
   UniformRandomSpatialNeighborSubsampler();

--- a/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
@@ -31,10 +31,10 @@ UniformRandomSpatialNeighborSubsampler<TSample, TRegion>::UniformRandomSpatialNe
 }
 
 template <typename TSample, typename TRegion>
-typename LightObject::Pointer
+LightObject::Pointer
 UniformRandomSpatialNeighborSubsampler<TSample, TRegion>::InternalClone() const
 {
-  typename LightObject::Pointer loPtr = Superclass::InternalClone();
+  LightObject::Pointer loPtr = Superclass::InternalClone();
 
   const typename Self::Pointer rval = dynamic_cast<Self *>(loPtr.GetPointer());
   if (rval.IsNull())

--- a/Modules/Numerics/Statistics/test/itkUniformRandomSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkUniformRandomSpatialNeighborSubsamplerTest.cxx
@@ -83,7 +83,7 @@ itkUniformRandomSpatialNeighborSubsamplerTest(int argc, char * argv[])
   query = std::pow(regionSizeVal, Dimension);
   samplerOrig->Search(query, subsample);
 
-  typename SamplerType::SubsampleType::TotalAbsoluteFrequencyType expectedTotalFrequency = 0;
+  SamplerType::SubsampleType::TotalAbsoluteFrequencyType expectedTotalFrequency = 0;
   ITK_TEST_EXPECT_EQUAL(expectedTotalFrequency, subsample->GetTotalFrequency());
   size_t expectedIdHolderSize = 0;
   ITK_TEST_EXPECT_EQUAL(expectedIdHolderSize, subsample->GetIdHolder().size());

--- a/Modules/Registration/Common/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
@@ -127,11 +127,10 @@ BSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor<TTransform>:
   os << indent << "NumberOfControlPointsForTheUpdateField: " << m_NumberOfControlPointsForTheUpdateField << std::endl;
   os << indent << "NumberOfControlPointsForTheTotalField: " << m_NumberOfControlPointsForTheTotalField << std::endl;
   os << indent << "NumberOfControlPointsForTheUpdateFieldSetTime: "
-     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(
-          m_NumberOfControlPointsForTheUpdateFieldSetTime)
+     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_NumberOfControlPointsForTheUpdateFieldSetTime)
      << std::endl;
   os << indent << "NumberOfControlPointsForTheTotalFieldSetTime: "
-     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(m_NumberOfControlPointsForTheTotalFieldSetTime)
+     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_NumberOfControlPointsForTheTotalFieldSetTime)
      << std::endl;
 }
 

--- a/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
@@ -64,8 +64,7 @@ BlockMatchingImageFilter<TFixedImage, TMovingImage, TFeatures, TDisplacements, T
      << std::endl;
   os << indent << "SearchRadius: " << static_cast<typename NumericTraits<ImageSizeType>::PrintType>(m_SearchRadius)
      << std::endl;
-  os << indent << "PointsCount: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_PointsCount)
-     << std::endl;
+  os << indent << "PointsCount: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_PointsCount) << std::endl;
 
   os << indent << "DisplacementsVectorsArray: ";
   if (m_DisplacementsVectorsArray != nullptr)

--- a/Modules/Registration/Common/include/itkGaussianExponentialDiffeomorphicTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkGaussianExponentialDiffeomorphicTransformParametersAdaptor.hxx
@@ -91,12 +91,11 @@ GaussianExponentialDiffeomorphicTransformParametersAdaptor<TTransform>::PrintSel
      << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_GaussianSmoothingVarianceForTheUpdateField)
      << std::endl;
   os << indent << "GaussianSmoothingVarianceForTheConstantVelocityFieldSetTime: "
-     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(
+     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(
           m_GaussianSmoothingVarianceForTheConstantVelocityFieldSetTime)
      << std::endl;
   os << indent << "GaussianSmoothingVarianceForTheUpdateFieldSetTime: "
-     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(
-          m_GaussianSmoothingVarianceForTheUpdateFieldSetTime)
+     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_GaussianSmoothingVarianceForTheUpdateFieldSetTime)
      << std::endl;
 }
 

--- a/Modules/Registration/Common/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
@@ -89,12 +89,10 @@ GaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor<TTransform>
      << std::endl;
 
   os << indent << "GaussianSmoothingVarianceForTheUpdateFieldSetTime: "
-     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(
-          m_GaussianSmoothingVarianceForTheUpdateFieldSetTime)
+     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_GaussianSmoothingVarianceForTheUpdateFieldSetTime)
      << std::endl;
   os << indent << "GaussianSmoothingVarianceForTheTotalFieldSetTime: "
-     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(
-          m_GaussianSmoothingVarianceForTheTotalFieldSetTime)
+     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_GaussianSmoothingVarianceForTheTotalFieldSetTime)
      << std::endl;
 }
 

--- a/Modules/Registration/Common/include/itkHistogramImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkHistogramImageToImageMetric.h
@@ -73,9 +73,9 @@ public:
       error with such declaration. */
   using HistogramType = Statistics::Histogram<double>;
 
-  using MeasurementVectorType = typename HistogramType::MeasurementVectorType;
-  using HistogramSizeType = typename HistogramType::SizeType;
-  using HistogramPointer = typename HistogramType::Pointer;
+  using MeasurementVectorType = HistogramType::MeasurementVectorType;
+  using HistogramSizeType = HistogramType::SizeType;
+  using HistogramPointer = HistogramType::Pointer;
 
   /** Initializes the metric. */
   void

--- a/Modules/Registration/Common/include/itkHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkHistogramImageToImageMetric.hxx
@@ -250,7 +250,7 @@ HistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputeHistogram(const T
 
   typename FixedImageType::IndexType  index;
   typename FixedImageType::RegionType fixedRegion;
-  typename HistogramType::IndexType   hIndex;
+  HistogramType::IndexType            hIndex;
 
   fixedRegion = this->GetFixedImageRegion();
   FixedIteratorType ti(fixedImage, fixedRegion);
@@ -290,7 +290,7 @@ HistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputeHistogram(const T
         const RealType fixedValue = ti.Get();
         this->m_NumberOfPixelsCounted++;
 
-        typename HistogramType::MeasurementVectorType sample;
+        HistogramType::MeasurementVectorType sample;
         sample.SetSize(2);
         sample[0] = fixedValue;
         sample[1] = movingValue;
@@ -316,13 +316,13 @@ HistogramImageToImageMetric<TFixedImage, TMovingImage>::CopyHistogram(HistogramT
                                                                       HistogramType & source) const
 {
   // Initialize the target.
-  typename HistogramType::MeasurementVectorType min;
-  typename HistogramType::MeasurementVectorType max;
+  HistogramType::MeasurementVectorType min;
+  HistogramType::MeasurementVectorType max;
 
   min.SetSize(2);
   max.SetSize(2);
 
-  typename HistogramType::SizeType size = source.GetSize();
+  HistogramType::SizeType size = source.GetSize();
 
   for (unsigned int i = 0; i < min.Size(); ++i)
   {
@@ -337,9 +337,9 @@ HistogramImageToImageMetric<TFixedImage, TMovingImage>::CopyHistogram(HistogramT
   target.Initialize(size, min, max);
 
   // Copy the values.
-  typename HistogramType::Iterator       sourceIt = source.Begin();
+  HistogramType::Iterator                sourceIt = source.Begin();
   const typename HistogramType::Iterator sourceEnd = source.End();
-  typename HistogramType::Iterator       targetIt = target.Begin();
+  HistogramType::Iterator                targetIt = target.Begin();
   const typename HistogramType::Iterator targetEnd = target.End();
 
   while (sourceIt != sourceEnd && targetIt != targetEnd)

--- a/Modules/Registration/Common/include/itkImageRegistrationMethod.h
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethod.h
@@ -119,7 +119,7 @@ public:
   using ParametersType = typename MetricType::TransformParametersType;
 
   /** Smart Pointer type to a DataObject. */
-  using DataObjectPointer = typename DataObject::Pointer;
+  using DataObjectPointer = DataObject::Pointer;
 
   /** Set/Get the Fixed image. */
   /** @ITKStartGrouping */

--- a/Modules/Registration/Common/include/itkImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.h
@@ -63,7 +63,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Type used for representing point components  */
-  using CoordinateRepresentationType = typename Superclass::ParametersValueType;
+  using CoordinateRepresentationType = Superclass::ParametersValueType;
 
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ImageToImageMetric);

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -1219,13 +1219,13 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Inde
      << static_cast<typename NumericTraits<FixedImagePixelType>::PrintType>(m_FixedImageSamplesIntensityThreshold)
      << std::endl;
   os << indent << "FixedImageSamples: " << m_FixedImageSamples << std::endl;
-  os << indent
-     << "NumberOfParameters: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfParameters)
+  os << indent << "NumberOfParameters: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfParameters)
      << std::endl;
   os << indent << "NumberOfFixedImageSamples: "
-     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfFixedImageSamples) << std::endl;
-  os << indent << "NumberOfPixelsCounted: "
-     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsCounted) << std::endl;
+     << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfFixedImageSamples) << std::endl;
+  os << indent
+     << "NumberOfPixelsCounted: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsCounted)
+     << std::endl;
 
   itkPrintSelfObjectMacro(MovingImage);
   itkPrintSelfObjectMacro(FixedImage);
@@ -1249,8 +1249,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Inde
   itkPrintSelfObjectMacro(MovingImageMask);
   itkPrintSelfObjectMacro(FixedImageMask);
 
-  os << indent
-     << "NumberOfWorkUnits: " << static_cast<typename NumericTraits<ThreadIdType>::PrintType>(m_NumberOfWorkUnits)
+  os << indent << "NumberOfWorkUnits: " << static_cast<NumericTraits<ThreadIdType>::PrintType>(m_NumberOfWorkUnits)
      << std::endl;
   itkPrintSelfBooleanMacro(UseAllPixels);
   itkPrintSelfBooleanMacro(UseSequentialSampling);
@@ -1261,8 +1260,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Inde
   itkPrintSelfBooleanMacro(TransformIsBSpline);
 #endif
 
-  os << indent
-     << "NumBSplineWeights: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumBSplineWeights)
+  os << indent << "NumBSplineWeights: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumBSplineWeights)
      << std::endl;
 
   itkPrintSelfObjectMacro(BSplineTransform);

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.hxx
@@ -82,8 +82,7 @@ ImageToSpatialObjectMetric<TFixedImage, TMovingSpatialObject>::PrintSelf(std::os
   Superclass::PrintSelf(os, indent);
 
 
-  os << indent << "MatchMeasure: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_MatchMeasure)
-     << std::endl;
+  os << indent << "MatchMeasure: " << static_cast<NumericTraits<MeasureType>::PrintType>(m_MatchMeasure) << std::endl;
   os << indent << "MatchMeasureDerivatives: " << m_MatchMeasureDerivatives << std::endl;
 
   itkPrintSelfObjectMacro(Transform);

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectRegistrationMethod.h
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectRegistrationMethod.h
@@ -132,7 +132,7 @@ public:
   using ParametersType = typename MetricType::TransformParametersType;
 
   /** Smart Pointer type to a DataObject. */
-  using DataObjectPointer = typename DataObject::Pointer;
+  using DataObjectPointer = DataObject::Pointer;
 
   /** Set/Get the Fixed image. */
   /** @ITKStartGrouping */

--- a/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
@@ -185,10 +185,10 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const
   using ArrayType = Array<double>;
 
   ArrayType sum1(ParametersDimension);
-  sum1.Fill(typename ArrayType::ValueType{});
+  sum1.Fill(ArrayType::ValueType{});
 
   ArrayType sum2(ParametersDimension);
-  sum2.Fill(typename ArrayType::ValueType{});
+  sum2.Fill(ArrayType::ValueType{});
 
   int fixedArea = 0;
   int movingArea = 0;

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
@@ -340,8 +340,8 @@ private:
     DerivativeType MetricDerivative;
 
     /** The joint PDF and PDF derivatives. */
-    typename JointPDFType::Pointer            JointPDF;
-    typename JointPDFDerivativesType::Pointer JointPDFDerivatives;
+    JointPDFType::Pointer            JointPDF;
+    JointPDFDerivativesType::Pointer JointPDFDerivatives;
 
     typename TransformType::JacobianType Jacobian;
 

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -235,10 +235,10 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Initialize
 
     // By setting these values, the joint histogram physical locations will
     // correspond to intensity values.
-    typename JointPDFType::PointType origin;
+    JointPDFType::PointType origin;
     origin[0] = this->m_FixedImageTrueMin;
     origin[1] = this->m_MovingImageTrueMin;
-    typename JointPDFType::SpacingType spacing;
+    JointPDFType::SpacingType spacing;
     spacing[0] = this->m_FixedImageBinSize;
     spacing[1] = this->m_MovingImageBinSize;
     /**

--- a/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
@@ -281,10 +281,9 @@ MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::PrintSelf(std
   os << indent << "FixedImageRegion: " << m_FixedImageRegion << std::endl;
   os << indent << "FixedImageRegionPyramid: " << m_FixedImageRegionPyramid << std::endl;
 
-  os << indent << "NumberOfLevels: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfLevels)
+  os << indent << "NumberOfLevels: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfLevels)
      << std::endl;
-  os << indent << "CurrentLevel: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_CurrentLevel)
-     << std::endl;
+  os << indent << "CurrentLevel: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_CurrentLevel) << std::endl;
 
   itkPrintSelfBooleanMacro(Stop);
 

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
@@ -293,7 +293,7 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ost
 
   os << indent << "MaximumError: " << m_MaximumError << std::endl;
   os << indent << "NumberOfLevels: " << m_NumberOfLevels << std::endl;
-  os << indent << "Schedule: " << static_cast<typename NumericTraits<ScheduleType>::PrintType>(m_Schedule) << std::endl;
+  os << indent << "Schedule: " << static_cast<NumericTraits<ScheduleType>::PrintType>(m_Schedule) << std::endl;
   itkPrintSelfBooleanMacro(UseShrinkImageFilter);
 }
 

--- a/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.h
@@ -224,7 +224,7 @@ private:
   double       m_FixedImageStandardDeviation{};
   double       m_MinProbability{};
 
-  typename KernelFunctionType::Pointer m_KernelFunction{};
+  KernelFunctionType::Pointer m_KernelFunction{};
 
   /** Uniformly select samples from the fixed image buffer.
    *

--- a/Modules/Registration/Common/include/itkPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToImageMetric.hxx
@@ -108,8 +108,9 @@ PointSetToImageMetric<TFixedPointSet, TMovingImage>::PrintSelf(std::ostream & os
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "NumberOfPixelsCounted: "
-     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsCounted) << std::endl;
+  os << indent
+     << "NumberOfPixelsCounted: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsCounted)
+     << std::endl;
 
   itkPrintSelfObjectMacro(FixedPointSet);
   itkPrintSelfObjectMacro(MovingImage);

--- a/Modules/Registration/Common/include/itkPointSetToImageRegistrationMethod.h
+++ b/Modules/Registration/Common/include/itkPointSetToImageRegistrationMethod.h
@@ -115,7 +115,7 @@ public:
   using ParametersType = typename MetricType::TransformParametersType;
 
   /** Smart Pointer type to a DataObject. */
-  using DataObjectPointer = typename DataObject::Pointer;
+  using DataObjectPointer = DataObject::Pointer;
 
   /** Set/Get the Fixed image. */
   /** @ITKStartGrouping */

--- a/Modules/Registration/Common/include/itkPointSetToPointSetRegistrationMethod.h
+++ b/Modules/Registration/Common/include/itkPointSetToPointSetRegistrationMethod.h
@@ -110,7 +110,7 @@ public:
   using ParametersType = typename MetricType::TransformParametersType;
 
   /** Smart Pointer type to a DataObject. */
-  using DataObjectPointer = typename DataObject::Pointer;
+  using DataObjectPointer = DataObject::Pointer;
 
   /** Set/Get the Fixed PointSet. */
   /** @ITKStartGrouping */

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
@@ -97,7 +97,7 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Pr
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "ZeroUpdateReturn: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_ZeroUpdateReturn)
+  os << indent << "ZeroUpdateReturn: " << static_cast<NumericTraits<PixelType>::PrintType>(m_ZeroUpdateReturn)
      << std::endl;
   os << indent << "Normalizer: " << m_Normalizer << std::endl;
 
@@ -108,15 +108,16 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Pr
 
   itkPrintSelfObjectMacro(MovingImageInterpolator);
 
-  os << indent << "TimeStep: " << static_cast<typename NumericTraits<TimeStepType>::PrintType>(m_TimeStep) << std::endl;
+  os << indent << "TimeStep: " << static_cast<NumericTraits<TimeStepType>::PrintType>(m_TimeStep) << std::endl;
 
   os << indent << "DenominatorThreshold: " << m_DenominatorThreshold << std::endl;
   os << indent << "IntensityDifferenceThreshold: " << m_IntensityDifferenceThreshold << std::endl;
 
   os << indent << "Metric: " << m_Metric << std::endl;
   os << indent << "SumOfSquaredDifference: " << m_SumOfSquaredDifference << std::endl;
-  os << indent << "NumberOfPixelsProcessed: "
-     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsProcessed) << std::endl;
+  os << indent
+     << "NumberOfPixelsProcessed: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsProcessed)
+     << std::endl;
   os << indent << "RMSChange: " << m_RMSChange << std::endl;
   os << indent << "SumOfSquaredChange: " << m_SumOfSquaredChange << std::endl;
 

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
@@ -311,9 +311,9 @@ GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TParentImageFilter>
 void
 GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField, TParentImageFilter>::
-  GPUSmoothVectorField(DisplacementFieldPointer         field,
-                       typename GPUDataManager::Pointer GPUSmoothingKernels[],
-                       int                              GPUSmoothingKernelSizes[])
+  GPUSmoothVectorField(DisplacementFieldPointer field,
+                       GPUDataManager::Pointer  GPUSmoothingKernels[],
+                       int                      GPUSmoothingKernelSizes[])
 {
   using GPUBufferImage = typename itk::GPUTraits<TDisplacementField>::Type;
   using GPUOutputImage = typename itk::GPUTraits<TDisplacementField>::Type;

--- a/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.h
@@ -109,7 +109,7 @@ public:
 
   /** Clone method will clone the existing instance of this type,
    *  including its internal member variables. */
-  [[nodiscard]] typename LightObject::Pointer
+  [[nodiscard]] LightObject::Pointer
   InternalClone() const override;
 
 protected:

--- a/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.hxx
@@ -123,7 +123,7 @@ ExpectationBasedPointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInt
 }
 
 template <typename TFixedPointSet, typename TMovingPointSet, class TInternalComputationValueType>
-typename LightObject::Pointer
+LightObject::Pointer
 ExpectationBasedPointSetToPointSetMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputationValueType>::
   InternalClone() const
 {

--- a/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.h
@@ -210,7 +210,7 @@ public:
 
   /** Clone method will clone the existing instance of this type,
    *  including its internal member variables. */
-  typename LightObject::Pointer
+  LightObject::Pointer
   InternalClone() const override;
 
 protected:

--- a/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.hxx
@@ -175,7 +175,7 @@ JensenHavrdaCharvatTsallisPointSetToPointSetMetricv4<TPointSet, TInternalComputa
 }
 
 template <typename TPointSet, class TInternalComputationValueType>
-typename LightObject::Pointer
+LightObject::Pointer
 JensenHavrdaCharvatTsallisPointSetToPointSetMetricv4<TPointSet, TInternalComputationValueType>::InternalClone() const
 {
   auto rval = Self::New();

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.h
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.h
@@ -87,8 +87,8 @@ protected:
   // TODO: This needs updating
   struct JointHistogramMIPerThreadStruct
   {
-    typename JointHistogramType::Pointer JointHistogram;
-    SizeValueType                        JointHistogramCount;
+    JointHistogramType::Pointer JointHistogram;
+    SizeValueType               JointHistogramCount;
   };
   itkPadStruct(ITK_CACHE_LINE_ALIGNMENT, JointHistogramMIPerThreadStruct, PaddedJointHistogramMIPerThreadStruct);
   itkAlignedTypedef(ITK_CACHE_LINE_ALIGNMENT,

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
@@ -84,7 +84,7 @@ JointHistogramMutualInformationComputeJointPDFThreaderBase<TDomainPartitioner, T
         if (this->m_JointHistogramMIPerThreadVariables[threadId].JointHistogram->GetBufferedRegion().IsInside(
               jointPDFIndex))
         {
-          typename JointHistogramType::PixelType jointHistogramPixel =
+          JointHistogramType::PixelType jointHistogramPixel =
             this->m_JointHistogramMIPerThreadVariables[threadId].JointHistogram->GetPixel(jointPDFIndex);
           ++jointHistogramPixel;
           this->m_JointHistogramMIPerThreadVariables[threadId].JointHistogram->SetPixel(jointPDFIndex,
@@ -111,7 +111,7 @@ JointHistogramMutualInformationComputeJointPDFThreaderBase<TDomainPartitioner,
 {
   const ThreadIdType numberOfWorkUnitsUsed = this->GetNumberOfWorkUnitsUsed();
 
-  using JointHistogramPixelType = typename JointHistogramType::PixelType;
+  using JointHistogramPixelType = JointHistogramType::PixelType;
   this->m_Associate->m_JointHistogramTotalCount = SizeValueType{};
   for (ThreadIdType i = 0; i < numberOfWorkUnitsUsed; ++i)
   {

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
@@ -659,9 +659,9 @@ PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointSet, TInternalCo
   itkPrintSelfBooleanMacro(StoreDerivativeAsSparseFieldForLocalSupportTransforms);
 
   os << indent << "MovingTransformedPointSetTime: "
-     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(m_MovingTransformedPointSetTime) << std::endl;
+     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_MovingTransformedPointSetTime) << std::endl;
   os << indent << "FixedTransformedPointSetTime: "
-     << static_cast<typename NumericTraits<ModifiedTimeType>::PrintType>(m_FixedTransformedPointSetTime) << std::endl;
+     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_FixedTransformedPointSetTime) << std::endl;
 }
 } // end namespace itk
 

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
@@ -669,7 +669,7 @@ itkImageToImageMetricv4Test(int, char ** const)
             << std::endl;
   std::cout << "MetricCategory: " << metric->GetMetricCategory() << std::endl;
 
-  typename ImageToImageMetricv4TestMetricType::DerivativeType derivative{};
+  ImageToImageMetricv4TestMetricType::DerivativeType derivative{};
   metric->GetDerivative(derivative);
   std::cout << "Derivative: " << derivative << std::endl;
 

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.hxx
@@ -81,8 +81,9 @@ FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDispla
 
   os << indent << "Metric: " << m_Metric << std::endl;
   os << indent << "SumOfSquaredDifference: " << m_SumOfSquaredDifference << std::endl;
-  os << indent << "NumberOfPixelsProcessed: "
-     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsProcessed) << std::endl;
+  os << indent
+     << "NumberOfPixelsProcessed: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsProcessed)
+     << std::endl;
   os << indent << "RMSChange: " << m_RMSChange << std::endl;
   os << indent << "SumOfSquaredChange: " << m_SumOfSquaredChange << std::endl;
 }

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.hxx
@@ -84,8 +84,9 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
 
   os << indent << "Metric: " << m_Metric << std::endl;
   os << indent << "SumOfSquaredDifference: " << m_SumOfSquaredDifference << std::endl;
-  os << indent << "NumberOfPixelsProcessed: "
-     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsProcessed) << std::endl;
+  os << indent
+     << "NumberOfPixelsProcessed: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsProcessed)
+     << std::endl;
   os << indent << "RMSChange: " << m_RMSChange << std::endl;
   os << indent << "SumOfSquaredChange: " << m_SumOfSquaredChange << std::endl;
 

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
@@ -170,7 +170,7 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
                                          TRegistrationType,
                                          TDefaultRegistrationType>::GetNumberOfValidRequiredInputs() const
 {
-  typename std::vector<SmartPointer<DataObject>>::size_type num = 0;
+  std::vector<SmartPointer<DataObject>>::size_type num = 0;
 
   if (this->GetFixedImage())
   {
@@ -576,7 +576,7 @@ MultiResolutionPDEDeformableRegistration<TFixedImage,
                                          TRegistrationType,
                                          TDefaultRegistrationType>::GenerateOutputInformation()
 {
-  typename DataObject::Pointer output;
+  DataObject::Pointer output;
 
   if (this->GetInput(0))
   {

--- a/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.hxx
@@ -65,7 +65,7 @@ template <typename TFixedImage, typename TMovingImage, typename TDisplacementFie
 std::vector<SmartPointer<DataObject>>::size_type
 PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GetNumberOfValidRequiredInputs() const
 {
-  typename std::vector<SmartPointer<DataObject>>::size_type num = 0;
+  std::vector<SmartPointer<DataObject>>::size_type num = 0;
 
   if (this->GetFixedImage())
   {
@@ -184,7 +184,7 @@ template <typename TFixedImage, typename TMovingImage, typename TDisplacementFie
 void
 PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::GenerateOutputInformation()
 {
-  typename DataObject::Pointer output;
+  DataObject::Pointer output;
 
   if (this->GetInput(0))
   {

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
@@ -70,8 +70,9 @@ SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplaceme
 
   os << indent << "Metric: " << m_Metric << std::endl;
   os << indent << "SumOfSquaredDifference: " << m_SumOfSquaredDifference << std::endl;
-  os << indent << "NumberOfPixelsProcessed: "
-     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsProcessed) << std::endl;
+  os << indent
+     << "NumberOfPixelsProcessed: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsProcessed)
+     << std::endl;
   os << indent << "RMSChange: " << m_RMSChange << std::endl;
   os << indent << "SumOfSquaredChange: " << m_SumOfSquaredChange << std::endl;
 }

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
@@ -1117,12 +1117,10 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
 
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "CurrentLevel: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_CurrentLevel)
+  os << indent << "CurrentLevel: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_CurrentLevel) << std::endl;
+  os << indent << "NumberOfLevels: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfLevels)
      << std::endl;
-  os << indent << "NumberOfLevels: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfLevels)
-     << std::endl;
-  os << indent
-     << "CurrentIteration: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_CurrentIteration)
+  os << indent << "CurrentIteration: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_CurrentIteration)
      << std::endl;
   os << indent
      << "CurrentMetricValue: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_CurrentMetricValue)
@@ -1141,10 +1139,12 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
   os << indent << "FixedPointSets: " << m_FixedPointSets << std::endl;
   os << indent << "MovingPointSets: " << m_MovingPointSets << std::endl;
 
-  os << indent << "NumberOfFixedObjects: "
-     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfFixedObjects) << std::endl;
-  os << indent << "NumberOfMovingObjects: "
-     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfMovingObjects) << std::endl;
+  os << indent
+     << "NumberOfFixedObjects: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfFixedObjects)
+     << std::endl;
+  os << indent
+     << "NumberOfMovingObjects: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfMovingObjects)
+     << std::endl;
 
   itkPrintSelfObjectMacro(Optimizer);
 
@@ -1157,8 +1157,7 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
 
   os << indent << "MetricSamplingStrategy: " << m_MetricSamplingStrategy << std::endl;
   os << indent << "MetricSamplingPercentagePerLevel: " << m_MetricSamplingPercentagePerLevel << std::endl;
-  os << indent
-     << "NumberOfMetrics: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfMetrics)
+  os << indent << "NumberOfMetrics: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfMetrics)
      << std::endl;
   os << indent << "FirstImageMetricIndex: " << m_FirstImageMetricIndex << std::endl;
   os << indent << "ShrinkFactorsPerLevel: " << m_ShrinkFactorsPerLevel << std::endl;

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
@@ -871,8 +871,9 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<TFixedImage,
      << std::endl;
   os << indent << "ConvergenceWindowSize: " << m_ConvergenceWindowSize << std::endl;
   os << indent << "NumberOfIterationsPerLevel: " << m_NumberOfIterationsPerLevel << std::endl;
-  os << indent << "NumberOfTimePointSamples: "
-     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfTimePointSamples) << std::endl;
+  os << indent
+     << "NumberOfTimePointSamples: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfTimePointSamples)
+     << std::endl;
   os << indent << "BoundaryWeight: " << m_BoundaryWeight << std::endl;
 }
 

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
@@ -342,8 +342,8 @@ BayesianClassifierImageFilter<TInputVectorImage, TLabelsType, TPosteriorsPrecisi
   itrLabelsImage.GoToBegin();
   itrPosteriorsImage.GoToBegin();
 
-  typename PosteriorsImageType::PixelType         posteriorsPixel;
-  typename DecisionRuleType::MembershipVectorType posteriorsVector;
+  typename PosteriorsImageType::PixelType posteriorsPixel;
+  DecisionRuleType::MembershipVectorType  posteriorsVector;
   posteriorsPixel = itrPosteriorsImage.Get();
   posteriorsVector.reserve(posteriorsPixel.Size());
   posteriorsVector.insert(posteriorsVector.begin(), posteriorsPixel.Size(), 0.0);

--- a/Modules/Segmentation/Classifiers/include/itkClassifierBase.h
+++ b/Modules/Segmentation/Classifiers/include/itkClassifierBase.h
@@ -171,7 +171,7 @@ private:
   unsigned int m_NumberOfClasses{};
 
   /** Pointer to the decision rule to be used for classification. */
-  typename DecisionRuleType::Pointer m_DecisionRule{ nullptr };
+  DecisionRuleType::Pointer m_DecisionRule{ nullptr };
 
   /** Container to hold the membership functions */
   MembershipFunctionPointerVector m_MembershipFunctions{};

--- a/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
@@ -53,14 +53,13 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::PrintSelf(std::ostr
   os << indent << "OutputDistortion: " << m_OutputDistortion << std::endl;
   os << indent << "OutputNumberOfEmptyCells: " << m_OutputNumberOfEmptyCells << std::endl;
 
-  os << indent
-     << "VectorDimension: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_VectorDimension)
+  os << indent << "VectorDimension: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_VectorDimension)
+     << std::endl;
+  os << indent << "NumberOfCodewords: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfCodewords)
      << std::endl;
   os << indent
-     << "NumberOfCodewords: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfCodewords)
+     << "CurrentNumberOfCodewords: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_CurrentNumberOfCodewords)
      << std::endl;
-  os << indent << "CurrentNumberOfCodewords: "
-     << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_CurrentNumberOfCodewords) << std::endl;
 
   os << indent << "CodewordHistogram: " << m_CodewordHistogram << std::endl;
   os << indent << "CodewordDistortion: " << m_CodewordDistortion << std::endl;

--- a/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilterTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilterTest.cxx
@@ -62,7 +62,7 @@ itkScalarImageKmeansImageFilterTest(int argc, char * argv[])
 
   constexpr typename KMeansFilterType::ImageRegionType::IndexType index = { { 50, 50 } };
   constexpr typename KMeansFilterType::ImageRegionType::SizeType  size = { { 80, 100 } };
-  typename KMeansFilterType::ImageRegionType                      region = { index, size };
+  KMeansFilterType::ImageRegionType                               region = { index, size };
   kmeansFilter->SetImageRegion(region);
   ITK_TEST_SET_GET_VALUE(region, kmeansFilter->GetImageRegion());
 

--- a/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.hxx
@@ -191,8 +191,7 @@ ThresholdMaximumConnectedComponentsImageFilter<TInputImage, TOutputImage>::Print
      << std::endl;
   os << indent << "Threshold Value: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_ThresholdValue)
      << std::endl;
-  os << indent
-     << "NumberOfObjects: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfObjects)
+  os << indent << "NumberOfObjects: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfObjects)
      << std::endl;
 }
 } // end namespace itk

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterGTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterGTest.cxx
@@ -28,7 +28,7 @@ using itk::print_helper::operator<<;
 
 namespace
 {
-typename itk::Image<unsigned char, 3>::Pointer
+itk::Image<unsigned char, 3>::Pointer
 CreateTestImageA()
 {
   std::bitset<8> bits(105); // 3D Checkerboard: 01101001

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
@@ -89,7 +89,7 @@ itkConnectedComponentImageFilterTest(int argc, char * argv[])
   }
   ITK_TEST_SET_GET_BOOLEAN(filter, FullyConnected, fullyConnected);
 
-  constexpr typename FilterType::OutputPixelType backgroundValue{};
+  constexpr FilterType::OutputPixelType backgroundValue{};
   filter->SetBackgroundValue(backgroundValue);
   ITK_TEST_SET_GET_VALUE(backgroundValue, filter->GetBackgroundValue());
 

--- a/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterGTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterGTest.cxx
@@ -31,7 +31,7 @@ namespace
 {
 
 
-typename itk::Image<unsigned int, 2>::Pointer
+itk::Image<unsigned int, 2>::Pointer
 CreateTestImageA()
 {
 
@@ -136,8 +136,8 @@ TEST(RelabelComponentImageFilter, BigZero)
   using PixelType = unsigned short;
   using ImageType = itk::Image<PixelType, Dimension>;
 
-  auto                           image = ImageType::New();
-  typename ImageType::RegionType region;
+  auto                  image = ImageType::New();
+  ImageType::RegionType region;
   region.SetSize({ { 512, 512, 512 } });
   image->SetRegions(region);
   image->AllocateInitialized();

--- a/Modules/Segmentation/ConnectedComponents/test/itkScalarConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkScalarConnectedComponentImageFilterTest.cxx
@@ -108,7 +108,7 @@ itkScalarConnectedComponentImageFilterTest(int argc, char * argv[])
   filter->SetInput(reader->GetOutput());
   filter->SetMaskImage(mask);
 
-  auto distanceThreshold = static_cast<typename FilterType::InputImageType::ValueType>(std::stod(argv[3]));
+  auto distanceThreshold = static_cast<FilterType::InputImageType::ValueType>(std::stod(argv[3]));
   filter->SetDistanceThreshold(distanceThreshold);
   ITK_TEST_SET_GET_VALUE(distanceThreshold, filter->GetDistanceThreshold());
 

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.h
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.h
@@ -104,9 +104,9 @@ public:
   using InputPointsContainerConstIterator = typename InputMeshType::PointsContainer::ConstIterator;
 
   /** Other definitions. */
-  using PointType = typename SimplexMeshGeometry::PointType;
-  using VectorType = typename PointType::VectorType;
-  using CovariantVectorType = CovariantVector<typename VectorType::ValueType, 3>;
+  using PointType = SimplexMeshGeometry::PointType;
+  using VectorType = PointType::VectorType;
+  using CovariantVectorType = CovariantVector<VectorType::ValueType, 3>;
   using PixelType = typename InputMeshType::PixelType;
 
   /** Image and Image iterator definition. */
@@ -134,8 +134,8 @@ public:
   using NeighborSetType = std::set<IdentifierType>;
   using IndexSetType = std::set<IdentifierType>;
   using VertexNeighborListType = itk::MapContainer<IdentifierType, NeighborSetType>;
-  using NeighborSetIterator = typename NeighborSetType::iterator;
-  using IndexSetIterator = typename IndexSetType::iterator;
+  using NeighborSetIterator = NeighborSetType::iterator;
+  using IndexSetIterator = IndexSetType::iterator;
 
   using GeometryMapType = typename InputMeshType::GeometryMapType;
   using GeometryMapPointer = typename GeometryMapType::Pointer;

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.h
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.h
@@ -186,9 +186,9 @@ public:
   using GradientIntensityImagePointer = typename GradientIntensityImageType::Pointer;
 
   using OriginalImageType = Image<float, 3>;
-  using OriginalImageIndexType = typename OriginalImageType::IndexType;
-  using ImageIndexValueType = typename OriginalImageIndexType::IndexValueType;
-  using OriginalImagePointer = typename OriginalImageType::ConstPointer;
+  using OriginalImageIndexType = OriginalImageType::IndexType;
+  using ImageIndexValueType = OriginalImageIndexType::IndexValueType;
+  using OriginalImagePointer = OriginalImageType::ConstPointer;
 
   /** control the range of search for Bresenham at normal line */
   /** @ITKStartGrouping */

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.h
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.h
@@ -230,7 +230,7 @@ public:
   using OutputImageIterator = ImageRegionIterator<TOutputImage>;
 
   /** type definition for the region label type. */
-  using RegionLabelType = typename KLMSegmentationRegion::RegionLabelType;
+  using RegionLabelType = KLMSegmentationRegion::RegionLabelType;
 
   /** The dimension of the labelled image. */
   static constexpr RegionLabelType LabelImageDimension = InputImageDimension;
@@ -359,8 +359,8 @@ protected:
 
 private:
   using InputImageSizeType = typename TInputImage::SizeType;
-  using KLMSegmentationRegionPtr = typename KLMSegmentationRegion::Pointer;
-  using KLMSegmentationBorderPtr = typename KLMSegmentationBorder::Pointer;
+  using KLMSegmentationRegionPtr = KLMSegmentationRegion::Pointer;
+  using KLMSegmentationBorderPtr = KLMSegmentationBorder::Pointer;
 
   double       m_MaximumLambda{ 1000 };
   unsigned int m_NumberOfRegions{ 0 };

--- a/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterTest.cxx
@@ -136,7 +136,7 @@ itkMultiLabelSTAPLEImageFilterTest(int, char *[])
   ITK_TEST_EXPECT_TRUE(!filter->GetHasPriorProbabilities());
 
   constexpr typename FilterType::PriorProbabilitiesType::ValueType priorProbabilitiesVal(0.0);
-  typename FilterType::PriorProbabilitiesType                      priorProbabilities(1, priorProbabilitiesVal);
+  FilterType::PriorProbabilitiesType                               priorProbabilities(1, priorProbabilitiesVal);
   filter->SetPriorProbabilities(priorProbabilities);
   ITK_TEST_SET_GET_VALUE(priorProbabilities, filter->GetPriorProbabilities());
 

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -100,8 +100,8 @@ typename ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::Valu
 
 template <typename TInputImage, typename TOutputImage>
 typename ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::StatusType
-  ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::m_StatusNull = NumericTraits<
-    typename ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::StatusType>::NonpositiveMin();
+  ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::m_StatusNull =
+    NumericTraits<ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::StatusType>::NonpositiveMin();
 
 template <typename TInputImage, typename TOutputImage>
 typename ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::StatusType
@@ -2426,7 +2426,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::PrintSelf(std
 
   os << indent << "Layers: " << m_Layers << std::endl;
 
-  os << indent << "NumberOfLayers: " << static_cast<typename NumericTraits<StatusType>::PrintType>(m_NumberOfLayers)
+  os << indent << "NumberOfLayers: " << static_cast<NumericTraits<StatusType>::PrintType>(m_NumberOfLayers)
      << std::endl;
 
   itkPrintSelfObjectMacro(StatusImage);
@@ -2445,7 +2445,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::PrintSelf(std
 
   os << indent << "TimeStep: " << static_cast<typename NumericTraits<TimeStepType>::PrintType>(m_TimeStep) << std::endl;
 
-  os << indent << "NumOfWorkUnits: " << static_cast<typename NumericTraits<ThreadIdType>::PrintType>(m_NumOfWorkUnits)
+  os << indent << "NumOfWorkUnits: " << static_cast<NumericTraits<ThreadIdType>::PrintType>(m_NumOfWorkUnits)
      << std::endl;
 
   os << indent << "SplitAxis: " << m_SplitAxis << std::endl;

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunction.h
@@ -157,7 +157,7 @@ private:
   ArrayType   m_ShapeParameterStandardDeviations{};
   WeightsType m_Weights{};
 
-  typename GaussianKernelFunction<double>::Pointer m_GaussianFunction{};
+  GaussianKernelFunction<double>::Pointer m_GaussianFunction{};
 };
 } // end namespace itk
 

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetImageFilter.h
@@ -112,7 +112,7 @@ public:
   /** The type of optimizer used to compute the MAP estimate of the shape and
     pose parameters. */
   using OptimizerType = SingleValuedNonLinearOptimizer;
-  using OptimizerPointer = typename OptimizerType::Pointer;
+  using OptimizerPointer = OptimizerType::Pointer;
 
   /** Set/Get the shape signed distance function. */
   /** @ITKStartGrouping */

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -96,7 +96,7 @@ typename SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ValueType
 template <typename TInputImage, typename TOutputImage>
 typename SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::StatusType
   SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::m_StatusNull =
-    NumericTraits<typename SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::StatusType>::NonpositiveMin();
+    NumericTraits<SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::StatusType>::NonpositiveMin();
 
 template <typename TInputImage, typename TOutputImage>
 typename SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::StatusType

--- a/Modules/Segmentation/LevelSets/test/itkCollidingFrontsImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkCollidingFrontsImageFilterTest.cxx
@@ -67,7 +67,7 @@ itkCollidingFrontsImageFilterTest(int argc, char * argv[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(collidingFronts, CollidingFrontsImageFilter, ImageToImageFilter);
 
   using NodeContainer = CollidingFrontsFilterType::NodeContainer;
-  using NodeType = typename CollidingFrontsFilterType::NodeType;
+  using NodeType = CollidingFrontsFilterType::NodeType;
 
   // select seeds 20 pixels apart
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionBase.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionBase.h
@@ -63,8 +63,8 @@ protected:
   AllocateListDomain() = 0;
 
   using IdentifierListType = std::list<IdentifierType>;
-  using IdentifierListIterator = typename IdentifierListType::iterator;
-  using IdentifierListConstIterator = typename IdentifierListType::const_iterator;
+  using IdentifierListIterator = IdentifierListType::iterator;
+  using IdentifierListConstIterator = IdentifierListType::const_iterator;
 
   IdentifierType m_NumberOfLevelSetFunctions{};
 };

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetDenseAdvectionImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetDenseAdvectionImage2DTest.cxx
@@ -153,7 +153,7 @@ itkSingleLevelSetDenseAdvectionImage2DTest(int argc, char * argv[])
   advectionTerm->SetInput(input);
   advectionTerm->SetCoefficient(1.0);
 
-  auto derivativeSigma = static_cast<typename AdvectionTermType::LevelSetOutputRealType>(std::stod(argv[6]));
+  auto derivativeSigma = static_cast<AdvectionTermType::LevelSetOutputRealType>(std::stod(argv[6]));
   advectionTerm->SetDerivativeSigma(derivativeSigma);
   ITK_TEST_SET_GET_VALUE(derivativeSigma, advectionTerm->GetDerivativeSigma());
 

--- a/Modules/Segmentation/RegionGrowing/include/itkConnectedThresholdImageFilter.h
+++ b/Modules/Segmentation/RegionGrowing/include/itkConnectedThresholdImageFilter.h
@@ -88,7 +88,7 @@ public:
   using InputImageRegionType = typename InputImageType::RegionType;
   using InputImagePixelType = typename InputImageType::PixelType;
   using IndexType = typename InputImageType::IndexType;
-  using SeedContainerType = typename std::vector<IndexType>;
+  using SeedContainerType = std::vector<IndexType>;
   using SizeType = typename InputImageType::SizeType;
 
   using OutputImageType = TOutputImage;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.h
@@ -122,7 +122,7 @@ public:
   using EdgeAutoPointer = typename Edge::SelfAutoPointer;
   using PointList = std::list<PointType>;
   using INTvector = std::vector<int>;
-  using NeighborIdIterator = typename INTvector::iterator;
+  using NeighborIdIterator = INTvector::iterator;
   using VertexIterator = PointsContainerIterator;
   /** Get the number of Voronoi seeds. */
   itkGetConstMacro(NumberOfSeeds, unsigned int);

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.h
@@ -87,16 +87,16 @@ public:
 
   using VoronoiDiagram = VoronoiDiagram2D<double>;
   using VoronoiDiagramGenerator = VoronoiDiagram2DGenerator<double>;
-  using PointType = typename VoronoiDiagram::PointType;
-  using CellType = typename VoronoiDiagram::CellType;
-  using CellAutoPointer = typename VoronoiDiagram::CellAutoPointer;
-  using VoronoiPointer = typename VoronoiDiagram::Pointer;
-  using PointIdIterator = typename CellType::PointIdIterator;
-  using SeedsType = typename VoronoiDiagram::SeedsType;
-  using SeedsIterator = typename VoronoiDiagram::SeedsIterator;
-  using NeighborIdIterator = typename VoronoiDiagram::NeighborIdIterator;
-  using EdgeIterator = typename VoronoiDiagram::VoronoiEdgeIterator;
-  using EdgeInfo = typename VoronoiDiagram::VoronoiEdge;
+  using PointType = VoronoiDiagram::PointType;
+  using CellType = VoronoiDiagram::CellType;
+  using CellAutoPointer = VoronoiDiagram::CellAutoPointer;
+  using VoronoiPointer = VoronoiDiagram::Pointer;
+  using PointIdIterator = CellType::PointIdIterator;
+  using SeedsType = VoronoiDiagram::SeedsType;
+  using SeedsIterator = VoronoiDiagram::SeedsIterator;
+  using NeighborIdIterator = VoronoiDiagram::NeighborIdIterator;
+  using EdgeIterator = VoronoiDiagram::VoronoiEdgeIterator;
+  using EdgeInfo = VoronoiDiagram::VoronoiEdge;
   using PointTypeVector = std::vector<PointType>;
   using PointTypeDeque = std::deque<PointType>;
   using BinaryObjectImage = TBinaryPriorImage;
@@ -105,7 +105,7 @@ public:
 
   /** To output the drawing of Voronoi Diagram (VD) . */
   using VDImage = Image<unsigned char, 2>;
-  using VDImagePointer = typename VDImage::Pointer;
+  using VDImagePointer = VDImage::Pointer;
 
   /** Set/Get the initial number of seeds for VD. */
   /** @ITKStartGrouping */
@@ -266,9 +266,9 @@ protected:
                                     // output the object.
   bool m_InteractiveSegmentation{ false };
 
-  typename VoronoiDiagram::Pointer m_WorkingVD{};
+  VoronoiDiagram::Pointer m_WorkingVD{};
 
-  typename VoronoiDiagramGenerator::Pointer m_VDGenerator{};
+  VoronoiDiagramGenerator::Pointer m_VDGenerator{};
 
   std::vector<PointType> m_SeedsToAdded{};
 

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
@@ -46,8 +46,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
 
   os << indent << "Size: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_Size) << std::endl;
   os << indent << "NumberOfSeeds: " << m_NumberOfSeeds << std::endl;
-  os << indent << "MinRegion: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_MinRegion)
-     << std::endl;
+  os << indent << "MinRegion: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_MinRegion) << std::endl;
   os << indent << "Steps: " << m_Steps << std::endl;
   os << indent << "LastStepSeeds: " << m_LastStepSeeds << std::endl;
   os << indent << "NumberOfSeedsToAdded: " << m_NumberOfSeedsToAdded << std::endl;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.h
@@ -213,16 +213,16 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  double                        m_Mean[6]{};
-  double                        m_STD[6]{};
-  double                        m_MeanTolerance[6]{};
-  double                        m_STDTolerance[6]{};
-  double                        m_MeanPercentError[6]{};
-  double                        m_STDPercentError[6]{};
-  double                        m_MaxValueOfRGB{};
-  unsigned int                  m_TestMean[3]{};
-  unsigned int                  m_TestSTD[3]{};
-  typename RGBHCVImage::Pointer m_WorkingImage{};
+  double               m_Mean[6]{};
+  double               m_STD[6]{};
+  double               m_MeanTolerance[6]{};
+  double               m_STDTolerance[6]{};
+  double               m_MeanPercentError[6]{};
+  double               m_STDPercentError[6]{};
+  double               m_MaxValueOfRGB{};
+  unsigned int         m_TestMean[3]{};
+  unsigned int         m_TestSTD[3]{};
+  RGBHCVImage::Pointer m_WorkingImage{};
 
   bool
   TestHomogeneity(IndexList & Plist) override;

--- a/Modules/Segmentation/Watersheds/include/itkWatershedEquivalenceRelabeler.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedEquivalenceRelabeler.hxx
@@ -28,7 +28,7 @@ EquivalenceRelabeler<TScalar, TImageDimension>::GenerateData()
   const typename ImageType::ConstPointer input = this->GetInputImage();
   const typename ImageType::Pointer      output = this->GetOutputImage();
 
-  const typename EquivalencyTableType::Pointer eqT = this->GetEquivalencyTable();
+  const EquivalencyTableType::Pointer eqT = this->GetEquivalencyTable();
 
   output->SetBufferedRegion(output->GetRequestedRegion());
   output->Allocate();

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.h
@@ -99,7 +99,7 @@ public:
 
   /** Typedefs to avoid internal compiler error bug on Microsoft VC++ */
   using SegmentTableTypePointer = typename SegmentTableType::Pointer;
-  using OneWayEquivalencyTableTypePointer = typename OneWayEquivalencyTableType::Pointer;
+  using OneWayEquivalencyTableTypePointer = OneWayEquivalencyTableType::Pointer;
   using SegmentTreeTypePointer = typename SegmentTreeType::Pointer;
 
   /** Get/Set the input table of segments to process */

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
@@ -115,8 +115,8 @@ void
 SegmentTreeGenerator<TScalar>::MergeEquivalencies()
 {
   const typename SegmentTableType::Pointer segTable = this->GetInputSegmentTable();
-  auto threshold = static_cast<ScalarType>(m_FloodLevel * segTable->GetMaximumDepth());
-  const typename EquivalencyTableType::Pointer eqTable = this->GetInputEquivalencyTable();
+  auto                                threshold = static_cast<ScalarType>(m_FloodLevel * segTable->GetMaximumDepth());
+  const EquivalencyTableType::Pointer eqTable = this->GetInputEquivalencyTable();
   eqTable->Flatten();
   IdentifierType counter = 0;
 

--- a/Modules/Video/Core/include/itkImageToVideoFilter.hxx
+++ b/Modules/Video/Core/include/itkImageToVideoFilter.hxx
@@ -273,7 +273,7 @@ ImageToVideoFilter<TInputImage, TOutputVideoStream>::GenerateData()
     inputSliceRegion.SetSize(m_FrameAxis, 0);
     inputSliceRegion.SetIndex(m_FrameAxis, idx);
 
-    using ExtractFilterType = typename itk::ExtractImageFilter<InputImageType, OutputFrameType>;
+    using ExtractFilterType = itk::ExtractImageFilter<InputImageType, OutputFrameType>;
     auto extractFilter = ExtractFilterType::New();
     extractFilter->SetDirectionCollapseToSubmatrix();
 

--- a/Modules/Video/Core/include/itkRingBuffer.hxx
+++ b/Modules/Video/Core/include/itkRingBuffer.hxx
@@ -106,7 +106,7 @@ template <typename TElement>
 auto
 RingBuffer<TElement>::GetNumberOfBuffers() -> SizeValueType
 {
-  return static_cast<typename RingBuffer<TElement>::SizeValueType>(this->m_PointerVector.size());
+  return static_cast<RingBuffer<TElement>::SizeValueType>(this->m_PointerVector.size());
 }
 
 template <typename TElement>

--- a/Modules/Video/Core/include/itkVideoStream.h
+++ b/Modules/Video/Core/include/itkVideoStream.h
@@ -54,7 +54,7 @@ public:
   using FrameType = TFrameType;
   using FramePointer = typename FrameType::Pointer;
   using FrameConstPointer = typename FrameType::ConstPointer;
-  using typename Superclass::BufferType;
+  using Superclass::BufferType;
 
   using SpatialRegionType = typename FrameType::RegionType;
   using IndexType = typename FrameType::IndexType;
@@ -66,11 +66,11 @@ public:
   using NumberOfComponentsPerPixelType = unsigned int;
 
   /** Types used to store map between frame numbers and frame meta data */
-  using SpatialRegionMapType = typename std::map<SizeValueType, SpatialRegionType>;
-  using PointMapType = typename std::map<SizeValueType, PointType>;
-  using DirectionMapType = typename std::map<SizeValueType, DirectionType>;
-  using SpacingMapType = typename std::map<SizeValueType, SpacingType>;
-  using NumberOfComponentsPerPixelMapType = typename std::map<SizeValueType, NumberOfComponentsPerPixelType>;
+  using SpatialRegionMapType = std::map<SizeValueType, SpatialRegionType>;
+  using PointMapType = std::map<SizeValueType, PointType>;
+  using DirectionMapType = std::map<SizeValueType, DirectionType>;
+  using SpacingMapType = std::map<SizeValueType, SpacingType>;
+  using NumberOfComponentsPerPixelMapType = std::map<SizeValueType, NumberOfComponentsPerPixelType>;
 
   /** Access the spatial dimensionality of the frames */
   static constexpr unsigned int FrameDimension = FrameType::ImageDimension;

--- a/Modules/Video/Core/include/itkVideoStream.hxx
+++ b/Modules/Video/Core/include/itkVideoStream.hxx
@@ -227,7 +227,7 @@ VideoStream<TFrameType>::GetFrameNumberOfComponentsPerPixel(SizeValueType frameN
 
 template <typename TFrameType>
 void
-VideoStream<TFrameType>::SetFrameBuffer(typename VideoStream<TFrameType>::BufferType * buffer)
+VideoStream<TFrameType>::SetFrameBuffer(VideoStream<TFrameType>::BufferType * buffer)
 {
   // We reinterpret the buffer to match TemporalDataObject's buffer type. We
   // assume that any tampering with the internal buffer will use our BufferType
@@ -299,10 +299,9 @@ VideoStream<TFrameType>::InitializeEmptyFrames()
   {
     if (!m_DataObjectBuffer->BufferIsFull(i))
     {
-      const FramePointer                        newFrame = FrameType::New();
-      FrameType *                               newFrameRawPointer = newFrame.GetPointer();
-      const typename BufferType::ElementPointer element =
-        dynamic_cast<typename BufferType::ElementType *>(newFrameRawPointer);
+      const FramePointer               newFrame = FrameType::New();
+      FrameType *                      newFrameRawPointer = newFrame.GetPointer();
+      const BufferType::ElementPointer element = dynamic_cast<BufferType::ElementType *>(newFrameRawPointer);
       m_DataObjectBuffer->SetBufferContents(i, element);
     }
 
@@ -343,8 +342,8 @@ template <typename TFrameType>
 void
 VideoStream<TFrameType>::SetFrame(SizeValueType frameNumber, FramePointer frame)
 {
-  auto * dataObjectRawPointer = dynamic_cast<typename BufferType::ElementType *>(frame.GetPointer());
-  const typename BufferType::ElementPointer dataObject = dataObjectRawPointer;
+  auto *                           dataObjectRawPointer = dynamic_cast<BufferType::ElementType *>(frame.GetPointer());
+  const BufferType::ElementPointer dataObject = dataObjectRawPointer;
   m_DataObjectBuffer->SetBufferContents(frameNumber, dataObject);
 
   // Cache the meta data
@@ -363,8 +362,8 @@ VideoStream<TFrameType>::GetFrame(SizeValueType frameNumber) -> FrameType *
 {
 
   // Fetch the frame
-  const typename BufferType::ElementPointer element = m_DataObjectBuffer->GetBufferContents(frameNumber);
-  const FramePointer                        frame = dynamic_cast<FrameType *>(element.GetPointer());
+  const BufferType::ElementPointer element = m_DataObjectBuffer->GetBufferContents(frameNumber);
+  const FramePointer               frame = dynamic_cast<FrameType *>(element.GetPointer());
   return frame;
 }
 
@@ -373,8 +372,8 @@ template <typename TFrameType>
 auto
 VideoStream<TFrameType>::GetFrame(SizeValueType frameNumber) const -> const FrameType *
 {
-  const typename BufferType::ElementPointer element = m_DataObjectBuffer->GetBufferContents(frameNumber);
-  const FrameConstPointer                   frame = dynamic_cast<FrameType *>(element.GetPointer());
+  const BufferType::ElementPointer element = m_DataObjectBuffer->GetBufferContents(frameNumber);
+  const FrameConstPointer          frame = dynamic_cast<FrameType *>(element.GetPointer());
   return frame;
 }
 

--- a/Modules/Video/Core/test/itkImageToVideoFilterTest.cxx
+++ b/Modules/Video/Core/test/itkImageToVideoFilterTest.cxx
@@ -47,8 +47,8 @@ itkImageToVideoFilterTest(int argc, char * argv[])
   using ImageType = itk::Image<PixelType, Dimension>;
 
   // Get 3D image to represent a temporal dataset of 2D frames
-  const auto                        inputImage = itk::ReadImage<ImageType>(argv[1]);
-  typename ImageType::DirectionType inputDirection;
+  const auto               inputImage = itk::ReadImage<ImageType>(argv[1]);
+  ImageType::DirectionType inputDirection;
   /* Set input image direction matrix to
    * 1  0 0
    * 0  0 1
@@ -99,7 +99,7 @@ itkImageToVideoFilterTest(int argc, char * argv[])
   }
 
   // Verify spatial direction in output frames match input direction
-  typename VideoFilterType::OutputFrameType::DirectionType outputDirection;
+  VideoFilterType::OutputFrameType::DirectionType outputDirection;
   outputDirection(0, 1) = 1;
   outputDirection(1, 0) = -1;
   for (auto frameIdx = videoOutput->GetLargestPossibleTemporalRegion().GetFrameStart();
@@ -110,7 +110,7 @@ itkImageToVideoFilterTest(int argc, char * argv[])
   }
 
   // Iterate over 3D input + video output to verify pixel data matches across each slice/frame
-  using ImageIteratorType = typename itk::ImageSliceConstIteratorWithIndex<ImageType>;
+  using ImageIteratorType = itk::ImageSliceConstIteratorWithIndex<ImageType>;
   ImageIteratorType it(inputImage, inputImage->GetLargestPossibleRegion());
   it.SetFirstDirection(1);  // fastest moving remaining spatial axis
   it.SetSecondDirection(2); // second-fastest moving remaining spatial axis

--- a/Modules/Video/Core/test/itkVectorImageToVideoTest.cxx
+++ b/Modules/Video/Core/test/itkVectorImageToVideoTest.cxx
@@ -87,7 +87,7 @@ itkVectorImageToVideoTest(int argc, char * argv[])
   }
 
   // Verify spatial direction in output frames match input direction
-  typename VideoFilterType::OutputFrameType::DirectionType outputDirection;
+  VideoFilterType::OutputFrameType::DirectionType outputDirection;
   outputDirection.SetIdentity();
   for (auto frameIdx = videoOutput->GetLargestPossibleTemporalRegion().GetFrameStart();
        frameIdx < videoOutput->GetLargestPossibleTemporalRegion().GetFrameDuration();
@@ -101,7 +101,7 @@ itkVectorImageToVideoTest(int argc, char * argv[])
                         inputImage->GetNumberOfComponentsPerPixel());
 
   // Iterate over 3D input + video output to verify pixel data matches across each slice/frame
-  using ImageIteratorType = typename itk::ImageLinearConstIteratorWithIndex<ImageType>;
+  using ImageIteratorType = itk::ImageLinearConstIteratorWithIndex<ImageType>;
   ImageIteratorType it(inputImage, inputImage->GetLargestPossibleRegion());
   it.SetDirection(1); // Slice direction
   it.GoToBegin();

--- a/Modules/Video/IO/include/itkVideoFileReader.h
+++ b/Modules/Video/IO/include/itkVideoFileReader.h
@@ -60,9 +60,9 @@ public:
   using SpacingType = typename FrameType::SpacingType;
   using DirectionType = typename FrameType::DirectionType;
 
-  using TemporalOffsetType = typename VideoIOBase::TemporalOffsetType;
-  using FrameOffsetType = typename VideoIOBase::FrameOffsetType;
-  using TemporalRatioType = typename VideoIOBase::TemporalRatioType;
+  using TemporalOffsetType = VideoIOBase::TemporalOffsetType;
+  using FrameOffsetType = VideoIOBase::FrameOffsetType;
+  using TemporalRatioType = VideoIOBase::TemporalRatioType;
 
   static constexpr unsigned int FrameDimension = FrameType::ImageDimension;
 

--- a/Modules/Video/IO/include/itkVideoFileWriter.h
+++ b/Modules/Video/IO/include/itkVideoFileWriter.h
@@ -48,9 +48,9 @@ public:
   using Pointer = SmartPointer<Self>;
 
   using IOBaseType = VideoIOBase;
-  using IOBasePointer = typename VideoIOBase::Pointer;
-  using SizeValueType = typename IOBaseType::SizeValueType;
-  using TemporalRatioType = typename IOBaseType::TemporalRatioType;
+  using IOBasePointer = VideoIOBase::Pointer;
+  using SizeValueType = IOBaseType::SizeValueType;
+  using TemporalRatioType = IOBaseType::TemporalRatioType;
 
   using VideoStreamType = TInputVideoStream;
   using VideoStreamPointer = typename VideoStreamType::Pointer;

--- a/Modules/Video/IO/include/itkVideoFileWriter.hxx
+++ b/Modules/Video/IO/include/itkVideoFileWriter.hxx
@@ -305,13 +305,11 @@ VideoFileWriter<TInputVideoStream>::PrintSelf(std::ostream & os, Indent indent) 
 
   os << indent << "OutputTemporalRegion: " << m_OutputTemporalRegion << std::endl;
 
-  os << indent
-     << "FramesPerSecond: " << static_cast<typename NumericTraits<TemporalRatioType>::PrintType>(m_FramesPerSecond)
+  os << indent << "FramesPerSecond: " << static_cast<NumericTraits<TemporalRatioType>::PrintType>(m_FramesPerSecond)
      << std::endl;
   os << indent << "FourCC: " << m_FourCC << std::endl;
   os << indent << "Dimensions: " << m_Dimensions << std::endl;
-  os << indent
-     << "NumberOfComponents: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfComponents)
+  os << indent << "NumberOfComponents: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfComponents)
      << std::endl;
   os << indent << "ComponentType: " << m_ComponentType << std::endl;
 }


### PR DESCRIPTION
Refactor code to remove redundant `typename` specifiers in type aliases
where unnecessary. Simplifies type definitions for improved readability
and consistency while adhering to modern C++ practices.

'typename; is redundant before non-dependent names as of c++17

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
