### PR TITLE
STYLE: Remove redundant casting for same types

### DIFF
--- a/Modules/Core/Common/include/itkTotalProgressReporter.h
+++ b/Modules/Core/Common/include/itkTotalProgressReporter.h
@@ -102,7 +102,7 @@ public:
 
     if (count >= m_PixelsBeforeUpdate)
     {
-      const SizeValueType total = static_cast<SizeValueType>(m_PixelsPerUpdate - m_PixelsBeforeUpdate) + count;
+      const SizeValueType total = m_PixelsPerUpdate - m_PixelsBeforeUpdate + count;
       const SizeValueType numberOfUpdates = total / m_PixelsPerUpdate;
 
       m_PixelsBeforeUpdate = m_PixelsPerUpdate - total % m_PixelsPerUpdate;

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -667,7 +667,7 @@ ObjectFactoryBase::UnRegisterAllFactories()
   std::list<void *> libs;
   for (auto & registeredFactory : m_PimplGlobals->m_RegisteredFactories)
   {
-    libs.push_back(static_cast<void *>(registeredFactory->m_LibraryHandle));
+    libs.push_back(registeredFactory->m_LibraryHandle);
   }
   // Unregister each factory
   for (auto & registeredFactory : m_PimplGlobals->m_RegisteredFactories)

--- a/Modules/Core/Common/src/itkRealTimeStamp.cxx
+++ b/Modules/Core/Common/src/itkRealTimeStamp.cxx
@@ -237,7 +237,7 @@ RealTimeStamp::operator+=(const RealTimeInterval & difference)
   CARRY_UNITS_OVER_UNSIGNED(seconds, micro_seconds);
 
   this->m_Seconds = static_cast<SecondsCounterType>(seconds);
-  this->m_MicroSeconds = static_cast<MicroSecondsCounterType>(micro_seconds);
+  this->m_MicroSeconds = micro_seconds;
 
   return *this;
 }

--- a/Modules/Core/Common/test/itkMetaDataDictionaryTest.cxx
+++ b/Modules/Core/Common/test/itkMetaDataDictionaryTest.cxx
@@ -27,7 +27,7 @@ itkMetaDataDictionaryTest(int, char *[])
 
   //------------------------Testing of native types
   //-------Floats
-  itk::EncapsulateMetaData<float>(MyDictionary, "ASimpleFloatInitalized", static_cast<float>(1.234560F));
+  itk::EncapsulateMetaData<float>(MyDictionary, "ASimpleFloatInitalized", 1.234560F);
   {
     float      tempfloat = 0.0;
     const bool IsValidReturn = itk::ExposeMetaData<float>(MyDictionary, "ASimpleFloatInitalized", tempfloat);
@@ -41,8 +41,8 @@ itkMetaDataDictionaryTest(int, char *[])
     }
   }
 
-  itk::EncapsulateMetaData<float>(MyDictionary, "ASimpleFloatChanged", static_cast<float>(-1000.234560F));
-  itk::EncapsulateMetaData<double>(MyDictionary, "ASimpleFloatChanged", static_cast<float>(-0.000000001F));
+  itk::EncapsulateMetaData<float>(MyDictionary, "ASimpleFloatChanged", -1000.234560);
+  itk::EncapsulateMetaData<double>(MyDictionary, "ASimpleFloatChanged", -0.000000001);
 
   //-------Char pointers --  These can be tricky, so be careful!
   itk::EncapsulateMetaData<const char *>(MyDictionary, "charconst*", "Value String");

--- a/Modules/Core/Common/test/itkNumberToStringTest.cxx
+++ b/Modules/Core/Common/test/itkNumberToStringTest.cxx
@@ -47,7 +47,7 @@ itkNumberToStringTest(int, char *[])
   PrintValue("unsigned short", static_cast<unsigned short>(0));
   PrintValue("short", static_cast<short>(0));
   PrintValue("unsigned int", static_cast<unsigned int>(0));
-  PrintValue("int", static_cast<int>(0));
+  PrintValue("int", 0);
   PrintValue("unsigned long", static_cast<unsigned long>(0));
   PrintValue("long", static_cast<long>(0));
   PrintValue("float", static_cast<float>(0));

--- a/Modules/Core/Common/test/itkNumericTraitsTest.cxx
+++ b/Modules/Core/Common/test/itkNumericTraitsTest.cxx
@@ -395,7 +395,7 @@ itkNumericTraitsTest(int, char *[])
 {
   bool testPassedStatus = true;
 
-  CheckTraits("char", static_cast<char>('a'));
+  CheckTraits("char", 'a');
   CheckTraits("signed char", static_cast<signed char>('a'));
   CheckTraits("unsigned char", static_cast<unsigned char>('a'));
 
@@ -403,8 +403,8 @@ itkNumericTraitsTest(int, char *[])
   CheckTraits("signed short", static_cast<short>(-1));
   CheckTraits("unsigned short", static_cast<unsigned short>(1));
 
-  CheckTraits("int", static_cast<int>(0));
-  CheckTraits("signed int", static_cast<int>(0));
+  CheckTraits("int", 0);
+  CheckTraits("signed int", 0);
   CheckTraits("unsigned int", static_cast<unsigned int>(0));
 
   CheckTraits("long", static_cast<long>(0));

--- a/Modules/Core/Common/test/itkObjectFactoryTest2.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryTest2.cxx
@@ -170,7 +170,7 @@ itkObjectFactoryTest2(int argc, char * argv[])
 
   MakeImage(10, static_cast<short>(0));
   MakeImage(10, static_cast<unsigned char>(0));
-  MakeImage(10, static_cast<int>(0));
+  MakeImage(10, 0);
   MakeImage(10, static_cast<long long>(0));
   {
     MakeImage(10, static_cast<float>(0));

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
@@ -204,9 +204,9 @@ SimplexMeshVolumeCalculator<TInputMesh>::CalculateTriangleVolume(InputPointType 
   const double yavg = (p1[1] + p2[1] + p3[1]) / 3.0;
   const double xavg = (p1[0] + p2[0] + p3[0]) / 3.0;
 
-  m_VolumeX += (area * static_cast<double>(u[2]) * static_cast<double>(zavg));
-  m_VolumeY += (area * static_cast<double>(u[1]) * static_cast<double>(yavg));
-  m_VolumeZ += (area * static_cast<double>(u[0]) * static_cast<double>(xavg));
+  m_VolumeX += (area * u[2] * zavg);
+  m_VolumeY += (area * u[1] * yavg);
+  m_VolumeZ += (area * u[0] * xavg);
 
   m_Area += area;
 

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorAnisotropicDiffusionFunction.hxx
@@ -112,7 +112,7 @@ VectorAnisotropicDiffusionFunction<TImage>::CalculateAverageGradientMagnitudeSqu
     ++fit;
   }
 
-  this->SetAverageGradientMagnitudeSquared(static_cast<double>(accumulator) / counter);
+  this->SetAverageGradientMagnitudeSquared(accumulator / counter);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
@@ -252,7 +252,7 @@ MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>
   m_MaximumNumberOfOverlappingPixels = static_cast<SizeValueType>(calculator->GetMaximum());
   if (m_RequiredNumberOfOverlappingPixels > m_MaximumNumberOfOverlappingPixels)
   {
-    m_RequiredNumberOfOverlappingPixels = (SizeValueType)m_MaximumNumberOfOverlappingPixels;
+    m_RequiredNumberOfOverlappingPixels = m_MaximumNumberOfOverlappingPixels;
   }
 
   // The user can either specify the required number of overlapping pixels or the required fraction of overlapping

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
@@ -243,7 +243,7 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const Dispatch<2> &, const
     return threshold;
   }
 
-  gradMagnitude = std::sqrt(static_cast<double>(gradMagnitude)) / static_cast<PixelType>(m_StencilRadius);
+  gradMagnitude = std::sqrt(gradMagnitude) / static_cast<PixelType>(m_StencilRadius);
 
   for (double & j : gradient)
   {

--- a/Modules/Filtering/ImageCompare/test/itkSTAPLEImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkSTAPLEImageFilterTest.cxx
@@ -263,7 +263,7 @@ itkSTAPLEImageFilterTest(int argc, char * argv[])
   stapler->SetMaximumIterations(maximumIterations);
   ITK_TEST_SET_GET_VALUE(maximumIterations, stapler->GetMaximumIterations());
 
-  auto confidenceWeight = static_cast<double>(std::stod(argv[5]));
+  auto confidenceWeight = std::stod(argv[5]);
   stapler->SetConfidenceWeight(confidenceWeight);
   ITK_TEST_SET_GET_VALUE(confidenceWeight, stapler->GetConfidenceWeight());
 

--- a/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
@@ -286,7 +286,7 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::Expand1DImage(const s
     for (int outK = 0; outK < static_cast<int>(outTraverseSize); ++outK)
     {
       double outVal = 0.0;
-      for (int k = (outK % 2); k < static_cast<int>(m_HSize); k += 2)
+      for (int k = (outK % 2); k < m_HSize; k += 2)
       {
         int i1 = (outK - k) / 2;
         if (i1 < 0)
@@ -298,7 +298,7 @@ BSplineResampleImageFilterBase<TInputImage, TOutputImage>::Expand1DImage(const s
         }
         outVal = outVal + m_H[k] * in[i1];
       }
-      for (int k = 2 - (outK % 2); k < static_cast<int>(m_HSize); k += 2)
+      for (int k = 2 - (outK % 2); k < m_HSize; k += 2)
       {
         int i2 = (outK + k) / 2;
         if (i2 > inModK)

--- a/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.hxx
@@ -70,7 +70,7 @@ VectorRescaleIntensityImageFilter<TInputImage, TOutputImage>::BeforeThreadedGene
 
   m_InputMaximumMagnitude = std::sqrt(maximumSquaredMagnitude);
 
-  m_Scale = static_cast<InputRealType>(m_OutputMaximumMagnitude) / static_cast<InputRealType>(m_InputMaximumMagnitude);
+  m_Scale = static_cast<InputRealType>(m_OutputMaximumMagnitude) / m_InputMaximumMagnitude;
 
   // Set up the functor values
   this->GetFunctor().SetFactor(m_Scale);

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSmoothingQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSmoothingQuadEdgeMeshFilter.hxx
@@ -108,7 +108,7 @@ SmoothingQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
           qe_it = qe_it->GetOnext();
         } while (qe_it != qe);
 
-        OutputCoordType den = 1.0 / static_cast<OutputCoordType>(sum_coeff);
+        OutputCoordType den = 1.0 / sum_coeff;
         v *= den;
 
         r += m_RelaxationFactor * v;

--- a/Modules/Filtering/Thresholding/test/itkKappaSigmaThresholdImageCalculatorTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkKappaSigmaThresholdImageCalculatorTest.cxx
@@ -59,7 +59,7 @@ itkKappaSigmaThresholdImageCalculatorTest(int argc, char * argv[])
   calculator->SetMaskValue(maskValue);
   ITK_TEST_SET_GET_VALUE(maskValue, calculator->GetMaskValue());
 
-  auto sigmaFactor = static_cast<double>(std::stod(argv[4]));
+  auto sigmaFactor = std::stod(argv[4]);
   calculator->SetSigmaFactor(sigmaFactor);
   ITK_TEST_SET_GET_VALUE(sigmaFactor, calculator->GetSigmaFactor());
 

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -794,11 +794,11 @@ GiplImageIO::Write(const void * buffer)
       auto value = static_cast<float>(m_Spacing[i]);
       if (m_ByteOrder == IOByteOrderEnum::BigEndian)
       {
-        ByteSwapper<float>::SwapFromSystemToBigEndian(static_cast<float *>(&value));
+        ByteSwapper<float>::SwapFromSystemToBigEndian(&value);
       }
       if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
       {
-        ByteSwapper<float>::SwapFromSystemToLittleEndian(static_cast<float *>(&value));
+        ByteSwapper<float>::SwapFromSystemToLittleEndian(&value);
       }
       if (m_IsCompressed)
       {

--- a/Modules/IO/Meta/test/itkMetaImageIOTest2.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageIOTest2.cxx
@@ -49,7 +49,7 @@ TestUnknowMetaDataBug(const std::string & fname)
 
     itk::MetaDataDictionary & dict = image->GetMetaDataDictionary();
 
-    itk::EncapsulateMetaData<float>(dict, "ASimpleFloatInitalized", static_cast<float>(1.234560F));
+    itk::EncapsulateMetaData<float>(dict, "ASimpleFloatInitalized", 1.234560F);
     itk::EncapsulateMetaData<std::complex<float>>(
       dict, "AnUnsuportedComplexInitalized", std::complex<float>(1.234560F));
 

--- a/Modules/IO/Meta/test/testMetaImage.cxx
+++ b/Modules/IO/Meta/test/testMetaImage.cxx
@@ -270,31 +270,31 @@ testMetaImage(int, char *[])
   {
     return EXIT_FAILURE;
   }
-  if (ReadWriteCompare<int, 3>(static_cast<int>(-3141592), "int"))
+  if (ReadWriteCompare<int, 3>(-3141592, "int"))
   {
     return EXIT_FAILURE;
   }
-  if (ReadWriteCompare<unsigned long, 3>(static_cast<unsigned long>(27182818), "unsigned long"))
+  if (ReadWriteCompare<unsigned long, 3>(27182818ul, "unsigned long"))
   {
     return EXIT_FAILURE;
   }
-  if (ReadWriteCompare<long, 3>(static_cast<long>(-31415926), "long"))
+  if (ReadWriteCompare<long, 3>(-31415926l, "long"))
   {
     return EXIT_FAILURE;
   }
-  if (ReadWriteCompare<unsigned long long, 3>(static_cast<unsigned long long>(8589934592ull), "unsigned long long"))
+  if (ReadWriteCompare<unsigned long long, 3>(8589934592ull, "unsigned long long"))
   {
     return EXIT_FAILURE;
   }
-  if (ReadWriteCompare<long long, 3>(static_cast<long long>(-8589934592ll), "long long"))
+  if (ReadWriteCompare<long long, 3>(-8589934592ll, "long long"))
   {
     return EXIT_FAILURE;
   }
-  if (ReadWriteCompare<float, 3>(static_cast<float>(1.23456), "float"))
+  if (ReadWriteCompare<float, 3>(1.23456F, "float"))
   {
     return EXIT_FAILURE;
   }
-  if (ReadWriteCompare<double, 3>(static_cast<double>(7.891011121314), "double"))
+  if (ReadWriteCompare<double, 3>(7.891011121314, "double"))
   {
     return EXIT_FAILURE;
   }

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -1255,8 +1255,8 @@ NiftiImageIO::WriteImageInformation()
   // external tools believe that the time units must be set, even if there
   // is only one dataset.  Having the time specified for a purely spatial
   // image has no consequence, so go ahead and set it to seconds.
-  m_Holder->ptr->xyz_units = int{ NIFTI_UNITS_MM };
-  m_Holder->ptr->time_units = int{ NIFTI_UNITS_SEC };
+  m_Holder->ptr->xyz_units = NIFTI_UNITS_MM;
+  m_Holder->ptr->time_units = NIFTI_UNITS_SEC;
   m_Holder->ptr->dim[7] = m_Holder->ptr->nw = 1;
   m_Holder->ptr->dim[6] = m_Holder->ptr->nv = 1;
   m_Holder->ptr->dim[5] = m_Holder->ptr->nu = 1;

--- a/Modules/IO/Siemens/src/itkSiemensVisionImageIO.cxx
+++ b/Modules/IO/Siemens/src/itkSiemensVisionImageIO.cxx
@@ -158,9 +158,9 @@ SiemensVisionImageIO::ReadHeader(const char * FileNameToRead)
   DB(hdr->sliceThickness);
   int tmpInt = 0;
   this->GetIntAt(f, HDR_DISPLAY_SIZE, &tmpInt, sizeof(int));
-  hdr->imageXsize = static_cast<int>(tmpInt);
+  hdr->imageXsize = tmpInt;
   DB(hdr->imageXsize);
-  hdr->imageYsize = static_cast<int>(tmpInt);
+  hdr->imageYsize = tmpInt;
   DB(hdr->imageYsize);
 
   this->GetStringAt(f, TEXT_ACQ_MTRX_FREQ, tmpStr, TEXT_ACQ_MTRX_FREQ_LEN);
@@ -302,7 +302,7 @@ SiemensVisionImageIO::ReadHeader(const char * FileNameToRead)
 
   this->GetStringAt(f, TEXT_ECHO_NUM, tmpStr, TEXT_ECHO_NUM_LEN);
   tmpStr[TEXT_ECHO_NUM_LEN] = '\0';
-  hdr->echoNumber = static_cast<int>(std::stoi(tmpStr));
+  hdr->echoNumber = std::stoi(tmpStr);
   DB(hdr->echoNumber);
 
   this->GetDoubleAt(f, HDR_FLIP_ANGLE, &tmpDble, sizeof(double));

--- a/Modules/Numerics/Optimizers/src/itkInitializationBiasedParticleSwarmOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkInitializationBiasedParticleSwarmOptimizer.cxx
@@ -48,7 +48,7 @@ InitializationBiasedParticleSwarmOptimizer::UpdateSwarm()
     Statistics::MersenneTwisterRandomVariateGenerator::GetInstance();
   ParametersType initialPosition = GetInitialPosition();
 
-  const auto n = static_cast<unsigned int>((GetCostFunction())->GetNumberOfParameters());
+  const auto n = (GetCostFunction())->GetNumberOfParameters();
   // linear decrease in the weight of the initial parameter values
   const double initializationCoefficient =
     this->m_InitializationCoefficient *

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizer.cxx
@@ -48,7 +48,7 @@ ParticleSwarmOptimizer::UpdateSwarm()
   const itk::Statistics::MersenneTwisterRandomVariateGenerator::Pointer randomGenerator =
     Statistics::MersenneTwisterRandomVariateGenerator::GetInstance();
 
-  const auto n = static_cast<unsigned int>((GetCostFunction())->GetNumberOfParameters());
+  const auto n = GetCostFunction()->GetNumberOfParameters();
 
   for (unsigned int j = 0; j < m_NumberOfParticles; ++j)
   {

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
@@ -219,7 +219,7 @@ ParticleSwarmOptimizerBase::StartOptimization()
   InvokeEvent(StartEvent());
 
   // run the simulation
-  const auto n = static_cast<unsigned int>((GetCostFunction())->GetNumberOfParameters());
+  const auto n = GetCostFunction()->GetNumberOfParameters();
   for (this->m_IterationIndex = 1; m_IterationIndex < m_MaximalNumberOfIterations && !converged; ++m_IterationIndex)
   {
 
@@ -295,7 +295,7 @@ ParticleSwarmOptimizerBase::ValidateSettings()
   }
   // if we got here it is safe to get the number of parameters the cost
   // function expects
-  const auto n = static_cast<unsigned int>((GetCostFunction())->GetNumberOfParameters());
+  const auto n = GetCostFunction()->GetNumberOfParameters();
 
   // check that the number of parameters match
   ParametersType initialPosition = GetInitialPosition();

--- a/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.hxx
+++ b/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.hxx
@@ -179,14 +179,14 @@ ExpectationMaximizationMixtureModelEstimator<TSample>::CalculateDensities()
 
       for (unsigned int componentIndex = 0; componentIndex < numberOfComponents; ++componentIndex)
       {
-        double temp = tempWeights[static_cast<unsigned int>(componentIndex)];
+        double temp = tempWeights[componentIndex];
 
         // just to make sure temp does not blow up!
         if (densitySum > NumericTraits<double>::epsilon())
         {
           temp /= densitySum;
         }
-        m_ComponentVector[static_cast<unsigned int>(componentIndex)]->SetWeight(measurementVectorIndex, temp);
+        m_ComponentVector[componentIndex]->SetWeight(measurementVectorIndex, temp);
       }
     }
     else

--- a/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.hxx
@@ -55,7 +55,7 @@ JensenHavrdaCharvatTsallisPointSetToPointSetMetricv4<TPointSet, TInternalComputa
   // Pre-calculate some values for efficiency
   this->m_TotalNumberOfPoints = static_cast<RealType>(
     this->m_NumberOfValidPoints + this->m_MovingDensityFunction->GetInputPointSet()->GetNumberOfPoints());
-  this->m_Prefactor0 = -1.0 / static_cast<RealType>(this->m_TotalNumberOfPoints);
+  this->m_Prefactor0 = -1.0 / this->m_TotalNumberOfPoints;
   if (this->m_Alpha != 1.0)
   {
     this->m_Prefactor0 /= (this->m_Alpha - 1.0);

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -263,8 +263,8 @@ MattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader<
     }
   }
   // Move the pointer to the first affected bin
-  OffsetValueType       pdfMovingIndex = static_cast<OffsetValueType>(movingImageParzenWindowIndex) - 1;
-  const OffsetValueType pdfMovingIndexMax = static_cast<OffsetValueType>(movingImageParzenWindowIndex) + 2;
+  OffsetValueType       pdfMovingIndex = movingImageParzenWindowIndex - 1;
+  const OffsetValueType pdfMovingIndexMax = movingImageParzenWindowIndex + 2;
 
   const OffsetValueType fixedImageParzenWindowIndex =
     this->m_MattesAssociate->ComputeSingleFixedImageParzenWindowIndex(fixedImageValue);

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
@@ -205,7 +205,7 @@ itkEuclideanDistancePointSetMetricRegistrationTest(int argc, char * argv[])
   int finalResult = EXIT_SUCCESS;
 
   unsigned int numberOfIterations = 100;
-  auto         maximumPhysicalStepSize = static_cast<double>(2.0);
+  auto         maximumPhysicalStepSize = 2.0;
   if (argc > 1)
   {
     numberOfIterations = std::stoi(argv[1]);
@@ -215,7 +215,7 @@ itkEuclideanDistancePointSetMetricRegistrationTest(int argc, char * argv[])
     maximumPhysicalStepSize = std::stod(argv[2]);
   }
 
-  auto pointMax = static_cast<double>(100.0);
+  auto pointMax = 100.0;
 
   //
   // Test with affine transform

--- a/Modules/Registration/Metricsv4/test/itkMultiStartImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMultiStartImageToImageMetricv4RegistrationTest.cxx
@@ -206,7 +206,7 @@ itkMultiStartImageToImageMetricv4RegistrationTest(int argc, char * argv[])
   {
     auto aff = AffineTransformType::New();
     aff->SetIdentity();
-    const float rad = static_cast<float>(i) * itk::Math::pi / 180.0;
+    const float rad = i * static_cast<float>(itk::Math::pi) / 180.0F;
     aff->Translate(moffset);
     aff->Rotate2D(rad);
     aff->Translate(foffset);

--- a/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
@@ -148,7 +148,7 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::Allocate()
     // Initialize m_Codebook to 0 (it now has only one row)
     m_Codebook.fill(0);
   }
-  const auto finalCodebookSize = (SizeValueType)m_NumberOfCodewords;
+  const auto finalCodebookSize = m_NumberOfCodewords;
 
   // Allocate scratch memory for the centroid, codebook histogram
   // and the codebook distortion

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -698,7 +698,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ComputeInitia
           }
         }
         //
-        m_Boundary[i] = static_cast<unsigned int>((j + k / 2));
+        m_Boundary[i] = j + k / 2;
       }
       break;
     }

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -440,8 +440,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::UpdateActiveLayerValu
   }
   else
   {
-    this->SetRMSChange(
-      static_cast<double>(std::sqrt(static_cast<double>(rms_change_accumulator / static_cast<ValueType>(counter)))));
+    this->SetRMSChange(std::sqrt(static_cast<double>(rms_change_accumulator / static_cast<ValueType>(counter))));
   }
 }
 

--- a/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetFunction.hxx
@@ -76,7 +76,7 @@ ThresholdSegmentationLevelSetFunction<TImageType, TFeatureImageType>::CalculateS
     }
     else
     {
-      sit.Set(static_cast<ScalarValueType>(threshold));
+      sit.Set(threshold);
     }
   }
 }

--- a/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetFunction.hxx
@@ -36,7 +36,7 @@ VectorThresholdSegmentationLevelSetFunction<TImageType, TFeatureImageType>::Calc
   for (fit.GoToBegin(), sit.GoToBegin(); !fit.IsAtEnd(); ++sit, ++fit)
   {
     threshold = m_Threshold - std::sqrt(m_Mahalanobis->Evaluate(fit.Get()));
-    sit.Set(static_cast<ScalarValueType>(threshold));
+    sit.Set(threshold);
   }
 }
 } // end namespace itk

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -541,7 +541,7 @@ VoronoiDiagram2DGenerator<TCoordinate>::PQbucket(FortuneHalfEdge * task)
   {
     bucket = m_PQhashsize - 1;
   }
-  if (bucket < static_cast<int>(m_PQmin))
+  if (bucket < m_PQmin)
   {
     m_PQmin = bucket;
   }


### PR DESCRIPTION
STYLE: Remove redundant casting for same types

Remove explicit type casting operations that involve the same source and
destination types. Covers a range of explicit casting operations,
including static_cast, const_cast, C-style casts, and
reinterpret_cast. Its primary objective is to enhance code
readability and maintainability by eliminating unnecessary
type casting.

Cases found by clang-tidy
https://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-casting.html

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
