### PR TITLE
BUG: `Math::Absolute(-0.0)` should return "plus zero" (`+0.0`)

### DIFF
--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -937,7 +937,9 @@ Absolute(T x) noexcept
 #if __cplusplus >= 202302L
     return std::abs(x);
 #else
-    return (x < 0) ? -x : x;
+    // Note: +0.0 and -0.0 are considered equal, according to ExactlyEquals. They are both considered equal to T{}.
+    // And they both have the same absolute value: +0.0.
+    return ExactlyEquals(x, T{}) ? T{} : (x < 0) ? -x : x;
 #endif
   }
 }

--- a/Modules/Core/Common/test/itkMathGTest.cxx
+++ b/Modules/Core/Common/test/itkMathGTest.cxx
@@ -355,6 +355,25 @@ TEST(itkMath, Abs)
   EXPECT_EQ(itk::Math::Absolute(-5), 5);
 }
 
+
+// Checks that `Math::Absolute(-0.0)` returns `+0.0`.
+TEST(itkMath, AbsoluteMinusZeroReturnsPlusZero)
+{
+  constexpr auto expectAbsoluteReturnsPlusZero = [](const auto minusZero) {
+    // Sanity check beforehand: assert that `minusZero` has indeed a minus sign.
+    ASSERT_TRUE(std::signbit(minusZero));
+
+    const auto absoluteValue = itk::Math::Absolute(minusZero);
+    EXPECT_FALSE(std::signbit(absoluteValue));
+    EXPECT_EQ(absoluteValue, 0);
+  };
+
+  // Check both float and double:
+  expectAbsoluteReturnsPlusZero(-0.0F);
+  expectAbsoluteReturnsPlusZero(-0.0);
+}
+
+
 TEST(itkMath, ConstexprTests)
 {
   static_assert(itk::Math::ExactlyEquals(5, 5));


### PR DESCRIPTION
Adjusted `Absolute(T)` to ensure that `Absolute(-0.0)` returns `+0.0`.

Added a unit test, `AbsoluteMinusZeroReturnsPlusZero`.
