### PR TITLE
COMP: Use `ImageConstIterator::ComputeIndex()` in Review module

### DIFF
--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -212,7 +212,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
     // BOUNDING BOX
     // The bounding box is defined in (min, max) pairs, such as
     // (xmin,xmax,ymin,ymax,zmin,zmax).
-    typename ImageIteratorWithIndexType::IndexType index = labelIt.GetIndex();
+    typename ImageIteratorWithIndexType::IndexType index = labelIt.ComputeIndex();
     for (unsigned int i = 0; i < (2 * ImageDimension); i += 2)
     {
       // Update min

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseLevelSetFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseLevelSetFunction.hxx
@@ -113,7 +113,7 @@ ScalarChanAndVeseLevelSetFunction<TInputImage, TFeatureImage, TSharedData>::Comp
   while (!fIt.IsAtEnd())
   {
     featureVal = fIt.Get();
-    inputIndex = fIt.GetIndex();
+    inputIndex = fIt.ComputeIndex();
     InputPixelType prod = 1.;
 
     globalIndex = this->m_SharedData->m_LevelSetDataPointerVector[fId]->GetFeatureIndex(inputIndex);


### PR DESCRIPTION
Replaced function calls of the form `iterator.GetIndex()` with `iterator.ComputeIndex()`, for iterators derived from `ImageConstIterator`, in "Modules/Nonunit/Review"

Fixes compile errors that occur when compiling with `Module_ITKReview=ON` _and_ `ITK_FUTURE_LEGACY_REMOVE=ON`, like:

    error: no member named 'GetIndex' in 'itk::ImageRegionConstIterator'

As occurred at RogueResearch24/Mac13.x-AppleClang-dbg-Universal: https://open.cdash.org/viewBuildError.php?buildid=11052824

Reported by Bradley Lowekamp (@blowekamp) at
https://github.com/InsightSoftwareConsortium/ITK/pull/5803#issuecomment-3914814639