### PR TITLE
STYLE: Remove Image and OffsetTable from ImageConstIteratorWithOnlyIndex

### DIFF
--- a/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.h
@@ -246,9 +246,7 @@ public:
     return m_Remaining;
   }
 
-protected: // made protected so other iterators can access
-  typename TImage::ConstPointer m_Image{};
-
+protected:                            // made protected so other iterators can access
   IndexType m_PositionIndex{ { 0 } }; // Index where we currently are
   IndexType m_BeginIndex{ { 0 } };    // Index to start iterating over
   IndexType m_EndIndex{ { 0 } };      // Index to finish iterating:
@@ -256,8 +254,6 @@ protected: // made protected so other iterators can access
                                       // row, col, slice, etc....
 
   RegionType m_Region{}; // region to iterate over
-
-  OffsetValueType m_OffsetTable[ImageDimension + 1]{};
 
   bool m_Remaining{ false };
 };

--- a/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.hxx
@@ -25,13 +25,11 @@ namespace itk
 //  Constructor
 //----------------------------------------------------------------------
 template <typename TImage>
-ImageConstIteratorWithOnlyIndex<TImage>::ImageConstIteratorWithOnlyIndex(const TImage * ptr, const RegionType & region)
-  : m_Image(ptr)
-  , m_BeginIndex(region.GetIndex())
+ImageConstIteratorWithOnlyIndex<TImage>::ImageConstIteratorWithOnlyIndex(const TImage *, const RegionType & region)
+  : m_BeginIndex(region.GetIndex())
   , m_Region(region)
 {
   m_PositionIndex = m_BeginIndex;
-  std::copy_n(m_Image->GetOffsetTable(), ImageDimension + 1, m_OffsetTable);
 
   // Compute the end offset
   for (unsigned int i = 0; i < ImageDimension; ++i)


### PR DESCRIPTION
Iterators "with only index" do not need to have access to the image or its offset table.

---

It appears that those apparently unnecessary data members were there already with the initial commit, [ENH: Add "WithOnlyIndex" iterators.](https://github.com/InsightSoftwareConsortium/ITK/commit/8703c0aa079d3d9fa20f4fe79d67c74ff13cb930), Michael Stauffer (@mgstauffer), 14 years ago:

https://github.com/InsightSoftwareConsortium/ITK/blob/8703c0aa079d3d9fa20f4fe79d67c74ff13cb930/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.h#L262

https://github.com/InsightSoftwareConsortium/ITK/blob/8703c0aa079d3d9fa20f4fe79d67c74ff13cb930/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.h#L272

@mgstauffer Do you possibly still have a clue why `ImageConstIteratorWithOnlyIndex` has those two data members?  Do you agree that they appear unnecessary?