### PR TITLE
Remove `itk::`, when using Iterator type in `itk` namespace

### DIFF
--- a/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.hxx
@@ -105,7 +105,7 @@ void
 FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPixel()
 {
   // Create an iterator that will walk the input image
-  using IRIType = itk::ImageRegionConstIterator<TImage>;
+  using IRIType = ImageRegionConstIterator<TImage>;
 
   // Now we search the input image for the first pixel which is inside
   // the function of interest
@@ -129,7 +129,7 @@ void
 FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPixels()
 {
   // Create an iterator that will walk the input image
-  using IRIType = itk::ImageRegionConstIterator<TImage>;
+  using IRIType = ImageRegionConstIterator<TImage>;
 
   // Now we search the input image for the first pixel which is inside
   // the function of interest

--- a/Modules/Core/Common/include/itkImageAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkImageAlgorithm.hxx
@@ -36,8 +36,8 @@ ImageAlgorithm::ReferenceCopy(const InputImageType *                       inIma
 {
   if (inRegion.GetSize()[0] == outRegion.GetSize()[0])
   {
-    itk::ImageScanlineConstIterator<InputImageType> it(inImage, inRegion);
-    itk::ImageScanlineIterator                      ot(outImage, outRegion);
+    ImageScanlineConstIterator<InputImageType> it(inImage, inRegion);
+    ImageScanlineIterator                      ot(outImage, outRegion);
 
     while (!it.IsAtEnd())
     {
@@ -53,8 +53,8 @@ ImageAlgorithm::ReferenceCopy(const InputImageType *                       inIma
     return;
   }
 
-  itk::ImageRegionConstIterator<InputImageType> it(inImage, inRegion);
-  itk::ImageRegionIterator<OutputImageType>     ot(outImage, outRegion);
+  ImageRegionConstIterator<InputImageType> it(inImage, inRegion);
+  ImageRegionIterator<OutputImageType>     ot(outImage, outRegion);
 
   while (!it.IsAtEnd())
   {

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
@@ -112,7 +112,7 @@ void
 ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPixel()
 {
   // Create an iterator that will walk the input image
-  using IRIType = itk::ImageRegionConstIterator<TImage>;
+  using IRIType = ImageRegionConstIterator<TImage>;
 
   // Now we search the input image for the first pixel which is inside
   // the function of interest
@@ -136,7 +136,7 @@ void
 ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPixels()
 {
   // Create an iterator that will walk the input image
-  using IRIType = itk::ImageRegionConstIterator<TImage>;
+  using IRIType = ImageRegionConstIterator<TImage>;
 
   // Now we search the input image for the first pixel which is inside
   // the function of interest

--- a/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
@@ -231,8 +231,8 @@ GaussianBlurImageFunction<TInputImage, TOutput>::EvaluateAtIndex(const IndexType
   typename InternalImageType::RegionType regionS = region;
   regionS.Crop(inputImage->GetBufferedRegion());
 
-  itk::ImageLinearConstIteratorWithIndex<InputImageType> it(inputImage, regionS);
-  itk::ImageLinearIteratorWithIndex<InternalImageType>   itN(m_InternalImage, regionN);
+  ImageLinearConstIteratorWithIndex<InputImageType> it(inputImage, regionS);
+  ImageLinearIteratorWithIndex<InternalImageType>   itN(m_InternalImage, regionN);
   it.SetDirection(1);
   itN.SetDirection(1);
   it.GoToBeginOfLine();
@@ -266,7 +266,7 @@ GaussianBlurImageFunction<TInputImage, TOutput>::EvaluateAtIndex(const IndexType
     m_OperatorInternalImageFunction->SetInputImage(m_InternalImage);
     m_OperatorInternalImageFunction->SetOperator(operatorArray[direction]);
 
-    itk::ImageLinearIteratorWithIndex<InternalImageType> itr(m_InternalImage, region);
+    ImageLinearIteratorWithIndex<InternalImageType> itr(m_InternalImage, region);
 
     unsigned int dir = direction + 1;
     if (dir == Self::ImageDimension)

--- a/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
@@ -105,7 +105,7 @@ MetaImageConverter<VDimension, PixelType, TSpatialObjectType>::MetaObjectToSpati
 
   this->MetaObjectToSpatialObjectBase(imageMO, imageSO);
 
-  itk::ImageRegionIteratorWithIndex<ImageType> it(myImage, myImage->GetLargestPossibleRegion());
+  ImageRegionIteratorWithIndex<ImageType> it(myImage, myImage->GetLargestPossibleRegion());
   for (unsigned int i = 0; !it.IsAtEnd(); i++, ++it)
   {
     it.Set(static_cast<typename ImageType::PixelType>(imageMO->ElementData(i)));
@@ -158,7 +158,7 @@ MetaImageConverter<VDimension, PixelType, TSpatialObjectType>::SpatialObjectToMe
   imageMO->ElementOrigin(origin);
   imageMO->ElementDirection(direction);
 
-  itk::ImageRegionConstIterator<ImageType> it(SOImage, SOImage->GetLargestPossibleRegion());
+  ImageRegionConstIterator<ImageType> it(SOImage, SOImage->GetLargestPossibleRegion());
   for (unsigned int i = 0; !it.IsAtEnd(); i++, ++it)
   {
     imageMO->ElementData(i, it.Get());

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.hxx
@@ -277,7 +277,7 @@ SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::GenerateData()
   OutputImage->SetDirection(m_Direction);
   OutputImage->Allocate(); // allocate the image
 
-  using myIteratorType = itk::ImageRegionIteratorWithIndex<OutputImageType>;
+  using myIteratorType = ImageRegionIteratorWithIndex<OutputImageType>;
 
   myIteratorType it(OutputImage, region);
 

--- a/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.hxx
@@ -142,8 +142,8 @@ FFTWComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::ThreadedGenerat
   const typename OutputImageType::SizeType & outputSize = outputPtr->GetRequestedRegion().GetSize();
   const unsigned int                         lineSize = outputSize[this->m_Direction];
 
-  using InputIteratorType = itk::ImageLinearConstIteratorWithIndex<InputImageType>;
-  using OutputIteratorType = itk::ImageLinearIteratorWithIndex<OutputImageType>;
+  using InputIteratorType = ImageLinearConstIteratorWithIndex<InputImageType>;
+  using OutputIteratorType = ImageLinearIteratorWithIndex<OutputImageType>;
   InputIteratorType inputIt(inputPtr, outputRegion);
   // the output region should be the same as the input region in the non-fft directions
   OutputIteratorType outputIt(outputPtr, outputRegion);

--- a/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.hxx
@@ -130,8 +130,8 @@ FFTWForward1DFFTImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(con
   const InputImageType * inputPtr = this->GetInput();
   OutputImageType *      outputPtr = this->GetOutput();
 
-  using InputIteratorType = itk::ImageLinearConstIteratorWithIndex<InputImageType>;
-  using OutputIteratorType = itk::ImageLinearIteratorWithIndex<OutputImageType>;
+  using InputIteratorType = ImageLinearConstIteratorWithIndex<InputImageType>;
+  using OutputIteratorType = ImageLinearIteratorWithIndex<OutputImageType>;
   InputIteratorType  inputIt(inputPtr, outputRegion);
   OutputIteratorType outputIt(outputPtr, outputRegion);
 

--- a/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.hxx
@@ -134,8 +134,8 @@ FFTWInverse1DFFTImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(con
   const typename OutputImageType::SizeType & outputSize = outputPtr->GetRequestedRegion().GetSize();
   const unsigned int                         lineSize = outputSize[this->m_Direction];
 
-  using InputIteratorType = itk::ImageLinearConstIteratorWithIndex<InputImageType>;
-  using OutputIteratorType = itk::ImageLinearIteratorWithIndex<OutputImageType>;
+  using InputIteratorType = ImageLinearConstIteratorWithIndex<InputImageType>;
+  using OutputIteratorType = ImageLinearIteratorWithIndex<OutputImageType>;
   InputIteratorType  inputIt(inputPtr, outputRegion);
   OutputIteratorType outputIt(outputPtr, outputRegion);
 

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
@@ -250,9 +250,8 @@ HoughTransform2DLinesImageFilter<TInputPixelType, TOutputPixelType>::GetLines() 
     const InternalImageType::Pointer postProcessImage = gaussianFilter->GetOutput();
 
     using MinMaxCalculatorType = MinimumMaximumImageCalculator<InternalImageType>;
-    auto                                        minMaxCalculator = MinMaxCalculatorType::New();
-    itk::ImageRegionIterator<InternalImageType> it_input(postProcessImage,
-                                                         postProcessImage->GetLargestPossibleRegion());
+    auto                                   minMaxCalculator = MinMaxCalculatorType::New();
+    ImageRegionIterator<InternalImageType> it_input(postProcessImage, postProcessImage->GetLargestPossibleRegion());
 
 
     itk::Index<2> index;

--- a/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilter.hxx
@@ -95,7 +95,7 @@ FFTDiscreteGaussianImageFilter<TInputImage, TOutputImage>::GenerateKernelImage()
     m_KernelImage->CopyInformation(this->GetInput());
 
     // Compute kernel image as product of vectors
-    itk::ImageRegionIteratorWithIndex<RealImageType> kernelIt(m_KernelImage, region);
+    ImageRegionIteratorWithIndex<RealImageType> kernelIt(m_KernelImage, region);
     while (!kernelIt.IsAtEnd())
     {
       auto   imageIndex = kernelIt.GetIndex();

--- a/Modules/Registration/Common/include/itkCompareHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkCompareHistogramImageToImageMetric.hxx
@@ -94,7 +94,7 @@ CompareHistogramImageToImageMetric<TFixedImage, TMovingImage>::FormTrainingHisto
   this->m_TrainingHistogram->SetMeasurementVectorSize(2);
   this->m_TrainingHistogram->Initialize(
     this->Superclass::m_HistogramSize, this->Superclass::m_LowerBound, this->Superclass::m_UpperBound);
-  using TrainingFixedIteratorType = itk::ImageRegionConstIteratorWithIndex<FixedImageType>;
+  using TrainingFixedIteratorType = ImageRegionConstIteratorWithIndex<FixedImageType>;
   typename FixedImageType::IndexType index;
   typename HistogramType::IndexType  hIndex;
 

--- a/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
@@ -202,7 +202,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMovedGra
 
   for (iDimension = 0; iDimension < FixedImageDimension; ++iDimension)
   {
-    using IteratorType = itk::ImageRegionConstIteratorWithIndex<MovedGradientImageType>;
+    using IteratorType = ImageRegionConstIteratorWithIndex<MovedGradientImageType>;
 
     IteratorType iterate(m_MovedSobelFilters[iDimension]->GetOutput(), this->GetFixedImageRegion());
 
@@ -241,7 +241,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeVariance
 
   for (iDimension = 0; iDimension < FixedImageDimension; ++iDimension)
   {
-    using IteratorType = itk::ImageRegionConstIteratorWithIndex<FixedGradientImageType>;
+    using IteratorType = ImageRegionConstIteratorWithIndex<FixedGradientImageType>;
 
     IteratorType iterate(m_FixedSobelFilters[iDimension]->GetOutput(), this->GetFixedImageRegion());
 
@@ -329,11 +329,11 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMeasure(
 
     MovedGradientPixelType diff;
 
-    using FixedIteratorType = itk::ImageRegionConstIteratorWithIndex<FixedGradientImageType>;
+    using FixedIteratorType = ImageRegionConstIteratorWithIndex<FixedGradientImageType>;
 
     FixedIteratorType fixedIterator(m_FixedSobelFilters[iDimension]->GetOutput(), this->GetFixedImageRegion());
 
-    using MovedIteratorType = itk::ImageRegionConstIteratorWithIndex<MovedGradientImageType>;
+    using MovedIteratorType = ImageRegionConstIteratorWithIndex<MovedGradientImageType>;
 
     MovedIteratorType movedIterator(m_MovedSobelFilters[iDimension]->GetOutput(), this->GetFixedImageRegion());
 

--- a/Modules/Registration/Common/include/itkHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkHistogramImageToImageMetric.hxx
@@ -246,7 +246,7 @@ HistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputeHistogram(const T
     itkExceptionStringMacro("Fixed image has not been assigned");
   }
 
-  using FixedIteratorType = itk::ImageRegionConstIteratorWithIndex<FixedImageType>;
+  using FixedIteratorType = ImageRegionConstIteratorWithIndex<FixedImageType>;
 
   typename FixedImageType::IndexType  index;
   typename FixedImageType::RegionType fixedRegion;

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -103,8 +103,8 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Initialize
     this->m_MovingImageTrueMax = NumericTraits<typename TMovingImage::PixelType>::NonpositiveMin();
 
     // We need to make robust measures only over the requested mask region
-    itk::ImageRegionConstIteratorWithIndex<TFixedImage> fi(this->m_FixedImage, this->m_FixedImage->GetBufferedRegion());
-    const bool                                          fixedMaskIsPresent = !(this->m_FixedImageMask.IsNull());
+    ImageRegionConstIteratorWithIndex<TFixedImage> fi(this->m_FixedImage, this->m_FixedImage->GetBufferedRegion());
+    const bool                                     fixedMaskIsPresent = !(this->m_FixedImageMask.IsNull());
     if (fixedMaskIsPresent)
     {
       typename TFixedImage::PointType fixedSpacePhysicalPoint;
@@ -133,9 +133,8 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Initialize
     }
 
     {
-      itk::ImageRegionConstIteratorWithIndex<TMovingImage> mi(this->m_MovingImage,
-                                                              this->m_MovingImage->GetBufferedRegion());
-      const bool                                           movingMaskIsPresent = !(this->m_MovingImageMask.IsNull());
+      ImageRegionConstIteratorWithIndex<TMovingImage> mi(this->m_MovingImage, this->m_MovingImage->GetBufferedRegion());
+      const bool                                      movingMaskIsPresent = !(this->m_MovingImageMask.IsNull());
       if (movingMaskIsPresent)
       {
         typename TMovingImage::PointType movingSpacePhysicalPoint;

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
@@ -52,7 +52,7 @@ MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Get
   {
     itkExceptionStringMacro("Fixed image has not been assigned");
   }
-  using FixedIteratorType = itk::ImageRegionConstIteratorWithIndex<FixedImageType>;
+  using FixedIteratorType = ImageRegionConstIteratorWithIndex<FixedImageType>;
 
   FixedIteratorType ti(fixedImage, this->GetFixedImageRegion());
 

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
@@ -35,7 +35,7 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
     itkExceptionStringMacro("Fixed image has not been assigned");
   }
 
-  using FixedIteratorType = itk::ImageRegionConstIteratorWithIndex<FixedImageType>;
+  using FixedIteratorType = ImageRegionConstIteratorWithIndex<FixedImageType>;
 
   FixedIteratorType ti(fixedImage, this->GetFixedImageRegion());
 
@@ -135,7 +135,7 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivativ
 
   const unsigned int dimension = FixedImageType::ImageDimension;
 
-  using FixedIteratorType = itk::ImageRegionConstIteratorWithIndex<FixedImageType>;
+  using FixedIteratorType = ImageRegionConstIteratorWithIndex<FixedImageType>;
 
   FixedIteratorType ti(fixedImage, this->GetFixedImageRegion());
 
@@ -318,7 +318,7 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndD
 
   const unsigned int dimension = FixedImageType::ImageDimension;
 
-  using FixedIteratorType = itk::ImageRegionConstIteratorWithIndex<FixedImageType>;
+  using FixedIteratorType = ImageRegionConstIteratorWithIndex<FixedImageType>;
 
   FixedIteratorType ti(fixedImage, this->GetFixedImageRegion());
 

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
@@ -85,7 +85,7 @@ JointHistogramMutualInformationImageToImageMetricv4<TFixedImage,
 
   /** Iterate through the fixed image and set the true
    *  max and min for the fixed image. */
-  itk::ImageRegionConstIteratorWithIndex<TFixedImage> fi(this->m_FixedImage, this->m_FixedImage->GetRequestedRegion());
+  ImageRegionConstIteratorWithIndex<TFixedImage> fi(this->m_FixedImage, this->m_FixedImage->GetRequestedRegion());
 
   /** \todo multi-thread me */
   while (!fi.IsAtEnd())
@@ -111,8 +111,7 @@ JointHistogramMutualInformationImageToImageMetricv4<TFixedImage,
   }
   /** Iterate through the moving image and set the true
    * max and min for the moving image. */
-  itk::ImageRegionConstIteratorWithIndex<TMovingImage> mi(this->m_MovingImage,
-                                                          this->m_MovingImage->GetBufferedRegion());
+  ImageRegionConstIteratorWithIndex<TMovingImage> mi(this->m_MovingImage, this->m_MovingImage->GetBufferedRegion());
 
   while (!mi.IsAtEnd())
   {

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
@@ -158,8 +158,7 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
       // A null mask implies entire space is to be used.
       if (!this->m_FixedImageMask.IsNull()) // use only masked samples.
       {
-        itk::ImageRegionConstIteratorWithIndex<TFixedImage> fi(this->m_FixedImage,
-                                                               this->m_FixedImage->GetBufferedRegion());
+        ImageRegionConstIteratorWithIndex<TFixedImage> fi(this->m_FixedImage, this->m_FixedImage->GetBufferedRegion());
         while (!fi.IsAtEnd())
         {
           typename TFixedImage::PointType fixedSpacePhysicalPoint;
@@ -176,8 +175,7 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
       }
       else // use entire image for fixed image intensity range of joint histogram
       {
-        itk::ImageRegionConstIteratorWithIndex<TFixedImage> fi(this->m_FixedImage,
-                                                               this->m_FixedImage->GetBufferedRegion());
+        ImageRegionConstIteratorWithIndex<TFixedImage> fi(this->m_FixedImage, this->m_FixedImage->GetBufferedRegion());
         while (!fi.IsAtEnd())
         {
           const typename TFixedImage::PixelType & currValue = fi.Value();
@@ -196,8 +194,7 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
     this->m_MovingImageTrueMin = NumericTraits<typename TMovingImage::PixelType>::max();
     this->m_MovingImageTrueMax = NumericTraits<typename TMovingImage::PixelType>::NonpositiveMin();
     {
-      itk::ImageRegionConstIteratorWithIndex<TMovingImage> mi(this->m_MovingImage,
-                                                              this->m_MovingImage->GetBufferedRegion());
+      ImageRegionConstIteratorWithIndex<TMovingImage> mi(this->m_MovingImage, this->m_MovingImage->GetBufferedRegion());
 
       if (!this->m_MovingImageMask.IsNull())
       { // A null mask implies entire space is to be used.

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
@@ -282,7 +282,7 @@ BayesianClassifierImageFilter<TInputVectorImage, TLabelsType, TPosteriorsPrecisi
       extractedComponentImage->SetBufferedRegion(this->GetPosteriorImage()->GetBufferedRegion());
       extractedComponentImage->SetRequestedRegion(this->GetPosteriorImage()->GetRequestedRegion());
       extractedComponentImage->Allocate();
-      using IteratorType = itk::ImageRegionIterator<ExtractedComponentImageType>;
+      using IteratorType = ImageRegionIterator<ExtractedComponentImageType>;
 
       itrPosteriorImage.GoToBegin();
       IteratorType it(extractedComponentImage, extractedComponentImage->GetBufferedRegion());

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.hxx
@@ -92,7 +92,7 @@ VoronoiPartitioningImageFilter<TInputImage, TOutputImage>::MakeSegmentBoundary()
 {
   const RegionType region = this->GetInput()->GetRequestedRegion();
 
-  itk::ImageRegionIteratorWithIndex<OutputImageType> oit(this->GetOutput(), region);
+  ImageRegionIteratorWithIndex<OutputImageType> oit(this->GetOutput(), region);
   while (!oit.IsAtEnd())
   {
     oit.Set(0);
@@ -120,7 +120,7 @@ VoronoiPartitioningImageFilter<TInputImage, TOutputImage>::MakeSegmentObject()
 {
   const RegionType region = this->GetInput()->GetRequestedRegion();
 
-  itk::ImageRegionIteratorWithIndex<OutputImageType> oit(this->GetOutput(), region);
+  ImageRegionIteratorWithIndex<OutputImageType> oit(this->GetOutput(), region);
   while (!oit.IsAtEnd())
   {
     oit.Set(0);

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.hxx
@@ -88,8 +88,8 @@ VoronoiSegmentationImageFilter<TInputImage, TOutputImage, TBinaryPriorImage>::Ta
 {
   const RegionType region = this->GetInput()->GetRequestedRegion();
 
-  itk::ImageRegionConstIteratorWithIndex<BinaryObjectImage> ait(aprior, region);
-  itk::ImageRegionConstIteratorWithIndex<InputImageType>    iit(this->GetInput(), region);
+  ImageRegionConstIteratorWithIndex<BinaryObjectImage> ait(aprior, region);
+  ImageRegionConstIteratorWithIndex<InputImageType>    iit(this->GetInput(), region);
 
   this->m_Size = this->GetInput()->GetRequestedRegion().GetSize();
 

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
@@ -519,7 +519,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
 {
   const RegionType region = this->GetInput()->GetRequestedRegion();
 
-  itk::ImageRegionIteratorWithIndex<OutputImageType> oit(this->GetOutput(), region);
+  ImageRegionIteratorWithIndex<OutputImageType> oit(this->GetOutput(), region);
   while (!oit.IsAtEnd())
   {
     oit.Set(0);
@@ -548,7 +548,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
 {
   const RegionType region = this->GetInput()->GetRequestedRegion();
 
-  itk::ImageRegionIteratorWithIndex<OutputImageType> oit(this->GetOutput(), region);
+  ImageRegionIteratorWithIndex<OutputImageType> oit(this->GetOutput(), region);
   while (!oit.IsAtEnd())
   {
     oit.Set(0);
@@ -923,7 +923,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
 {
   const RegionType region = this->GetInput()->GetRequestedRegion();
 
-  itk::ImageRegionIteratorWithIndex<VDImage> vdit(result, region);
+  ImageRegionIteratorWithIndex<VDImage> vdit(result, region);
   while (!vdit.IsAtEnd())
   {
     vdit.Set(0);

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
@@ -89,10 +89,10 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::SetInput(const Inp
   m_WorkingImage->SetRegions(region);
   m_WorkingImage->Allocate();
 
-  itk::ImageRegionIteratorWithIndex<RGBHCVImage>         wit(m_WorkingImage, region);
-  itk::ImageRegionConstIteratorWithIndex<InputImageType> iit(this->GetInput(), region);
-  PixelType                                              ipixel;
-  RGBHCVPixel                                            wpixel;
+  ImageRegionIteratorWithIndex<RGBHCVImage>         wit(m_WorkingImage, region);
+  ImageRegionConstIteratorWithIndex<InputImageType> iit(this->GetInput(), region);
+  PixelType                                         ipixel;
+  RGBHCVPixel                                       wpixel;
 
 
   const double X0 = m_MaxValueOfRGB * 0.982;
@@ -192,8 +192,8 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::TakeAPrior(const B
 {
   const RegionType region = this->GetInput()->GetRequestedRegion();
 
-  itk::ImageRegionConstIteratorWithIndex<BinaryObjectImage> ait(aprior, region);
-  itk::ImageRegionIteratorWithIndex<RGBHCVImage>            iit(m_WorkingImage, region);
+  ImageRegionConstIteratorWithIndex<BinaryObjectImage> ait(aprior, region);
+  ImageRegionIteratorWithIndex<RGBHCVImage>            iit(m_WorkingImage, region);
 
   unsigned int minx = 0;
   unsigned int miny = 0;

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoCapture.hxx
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoCapture.hxx
@@ -164,7 +164,7 @@ OpenCVVideoCapture<TVideoStream>::retrieve(cv::Mat & image, int itkNotUsed(chann
   int                          matrixType = CV_MAKETYPE(depth, channels);
 
   // Copy the pixels -- There is probably a faster way to do this
-  using ITKIterType = itk::ImageRegionConstIteratorWithIndex<FrameType>;
+  using ITKIterType = ImageRegionConstIteratorWithIndex<FrameType>;
   ITKIterType itkIter(frame, frame->GetLargestPossibleRegion());
 
   // Currently only support mono and RGB (unsigned) char pixels

--- a/Modules/Video/Filtering/include/itkFrameAverageVideoFilter.hxx
+++ b/Modules/Video/Filtering/include/itkFrameAverageVideoFilter.hxx
@@ -118,8 +118,8 @@ FrameAverageVideoFilter<TInputVideoStream, TOutputVideoStream>::ThreadedGenerate
   }
 
   // Get the output frame and its iterator
-  OutputFrameType *                         outFrame = output->GetFrame(outputFrameNumber);
-  itk::ImageRegionIterator<OutputFrameType> outIter(outFrame, outputRegionForThread);
+  OutputFrameType *                    outFrame = output->GetFrame(outputFrameNumber);
+  ImageRegionIterator<OutputFrameType> outIter(outFrame, outputRegionForThread);
 
   // Average the input frames at each pixel of the output region
   using OutputPixelRealType = typename NumericTraits<OutputPixelType>::RealType;

--- a/Modules/Video/Filtering/include/itkFrameDifferenceVideoFilter.hxx
+++ b/Modules/Video/Filtering/include/itkFrameDifferenceVideoFilter.hxx
@@ -118,8 +118,8 @@ FrameDifferenceVideoFilter<TInputVideoStream, TOutputVideoStream>::ThreadedGener
   ConstIterType I1Iter(input->GetFrame(inputStart + numFrames - 1), outputRegionForThread);
 
   // Get the output frame and its iterator
-  OutputFrameType *                         outFrame = output->GetFrame(outputFrameNumber);
-  itk::ImageRegionIterator<OutputFrameType> outIter(outFrame, outputRegionForThread);
+  OutputFrameType *                    outFrame = output->GetFrame(outputFrameNumber);
+  ImageRegionIterator<OutputFrameType> outIter(outFrame, outputRegionForThread);
 
   // Average the input frames at each pixel of the output region
   using InputPixelRealType = typename NumericTraits<InputPixelType>::RealType;


### PR DESCRIPTION
- Using Notepad++, Replace in Files, doing

```
    Find what: itk::(Image\w+Iterator)
    Replace with: $1
    Filters: itk*.hxx
    [v] Match case
    (*) Regular expression

```
Manually excluded "itkNeighborhoodIteratorTestCommon.hxx"

- Removed `typename` from `ImageRegionConstIterator<TImage>;` following pull request https://github.com/InsightSoftwareConsortium/ITK/pull/5804 by Hans (@hjmjohnson) 