### PR TITLE
STYLE: Simplify `bool` assignments by removing `if` and `else`

### DIFF
--- a/Modules/Core/Common/include/itkImageConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithIndex.hxx
@@ -132,14 +132,7 @@ ImageConstIteratorWithIndex<TImage>::GoToBegin()
   m_Position = m_Begin;
   m_PositionIndex = m_BeginIndex;
 
-  if (m_Region.GetNumberOfPixels() > 0)
-  {
-    m_Remaining = true;
-  }
-  else
-  {
-    m_Remaining = false;
-  }
+  m_Remaining = m_Region.GetNumberOfPixels() > 0;
 }
 
 //----------------------------------------------------------------------------
@@ -154,14 +147,7 @@ ImageConstIteratorWithIndex<TImage>::GoToReverseBegin()
     m_PositionIndex[i] = m_EndIndex[i] - 1;
   }
 
-  if (m_Region.GetNumberOfPixels() > 0)
-  {
-    m_Remaining = true;
-  }
-  else
-  {
-    m_Remaining = false;
-  }
+  m_Remaining = m_Region.GetNumberOfPixels() > 0;
 
   // Set the position at the end
   const InternalPixelType * buffer = m_Image->GetBufferPointer();

--- a/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.hxx
@@ -58,14 +58,7 @@ ImageConstIteratorWithOnlyIndex<TImage>::GoToBegin()
 
   m_PositionIndex = m_BeginIndex;
 
-  if (m_Region.GetNumberOfPixels() > 0)
-  {
-    m_Remaining = true;
-  }
-  else
-  {
-    m_Remaining = false;
-  }
+  m_Remaining = m_Region.GetNumberOfPixels() > 0;
 }
 
 //----------------------------------------------------------------------------
@@ -80,14 +73,7 @@ ImageConstIteratorWithOnlyIndex<TImage>::GoToReverseBegin()
     m_PositionIndex[i] = m_EndIndex[i] - 1;
   }
 
-  if (m_Region.GetNumberOfPixels() > 0)
-  {
-    m_Remaining = true;
-  }
-  else
-  {
-    m_Remaining = false;
-  }
+  m_Remaining = m_Region.GetNumberOfPixels() > 0;
 }
 
 } // end namespace itk

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -2148,14 +2148,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ComputeGradientJointE
     currentPatchVec[jj] = currentPatch.GetPixel(jj, isInBounds);
     patchWeightVec[jj].SetSize(m_NumIndependentComponents);
     patchWeightVec[jj].Fill(patchWeights[jj]);
-    if (isInBounds)
-    {
-      isInBoundsVec[jj] = true;
-    }
-    else
-    {
-      isInBoundsVec[jj] = false;
-    }
+    isInBoundsVec[jj] = isInBounds;
   }
 
   IndexType               lastSelectedIdx;

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
@@ -75,14 +75,7 @@ BSplineControlPointImageFilter<TInputImage, TOutputImage>::SetNumberOfLevels(Arr
   itkDebugMacro("Setting m_NumberOfLevels to " << this->m_NumberOfLevels);
   itkDebugMacro("Setting m_MaximumNumberOfLevels to " << this->m_MaximumNumberOfLevels);
 
-  if (this->m_MaximumNumberOfLevels > 1)
-  {
-    this->m_DoMultilevel = true;
-  }
-  else
-  {
-    this->m_DoMultilevel = false;
-  }
+  this->m_DoMultilevel = this->m_MaximumNumberOfLevels > 1;
   this->SetSplineOrder(this->m_SplineOrder);
   this->Modified();
 }

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -155,14 +155,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::SetNumb
   itkDebugMacro("Setting m_NumberOfLevels to " << this->m_NumberOfLevels);
   itkDebugMacro("Setting m_MaximumNumberOfLevels to " << this->m_MaximumNumberOfLevels);
 
-  if (this->m_MaximumNumberOfLevels > 1)
-  {
-    this->m_DoMultilevel = true;
-  }
-  else
-  {
-    this->m_DoMultilevel = false;
-  }
+  this->m_DoMultilevel = this->m_MaximumNumberOfLevels > 1;
   this->SetSplineOrder(this->m_SplineOrder);
   this->Modified();
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
@@ -1296,14 +1296,7 @@ FlatStructuringElement<VDimension>::FromImage(const ImageType * image)
   {
     const PixelType & val = image->GetPixel(centerIdx + res.GetOffset(j));
     // Neighborhood (therefore PixelType) in FlatStructuringElement is bool
-    if (val)
-    {
-      res[j] = true;
-    }
-    else
-    {
-      res[j] = false;
-    }
+    res[j] = val;
   }
 
   return res;

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -219,14 +219,7 @@ GiplImageIO::Read(void * buffer)
   bool success = false;
   if (m_IsCompressed)
   {
-    if (p != nullptr)
-    {
-      success = true;
-    }
-    else
-    {
-      success = false;
-    }
+    success = p != nullptr;
   }
   else
   {

--- a/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
+++ b/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
@@ -167,25 +167,11 @@ OBJMeshIO::ReadMeshInformation()
 
   this->m_PointDimension = 3;
 
-  // If number of points is not equal zero, update points
-  if (this->m_NumberOfPoints)
-  {
-    this->m_UpdatePoints = true;
-  }
-  else
-  {
-    this->m_UpdatePoints = false;
-  }
+  // If number of points is greater than zero, update points
+  this->m_UpdatePoints = this->m_NumberOfPoints > 0;
 
   // If number of cells is not equal zero, update points
-  if (this->m_NumberOfCells)
-  {
-    this->m_UpdateCells = true;
-  }
-  else
-  {
-    this->m_UpdateCells = false;
-  }
+  this->m_UpdateCells = this->m_NumberOfCells;
 
   // Set default point component type
   this->m_PointComponentType = IOComponentEnum::FLOAT;

--- a/Modules/IO/TIFF/src/itkTIFFReaderInternal.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFReaderInternal.cxx
@@ -262,18 +262,12 @@ TIFFReaderInternal::Initialize()
     TIFFGetFieldDefaulted(this->m_Image, TIFFTAG_PLANARCONFIG, &this->m_PlanarConfig);
     TIFFGetFieldDefaulted(this->m_Image, TIFFTAG_SAMPLEFORMAT, &this->m_SampleFormat);
 
-    // If TIFFGetField returns false, there's no Photometric Interpretation
+    // If TIFFGetField returns zero, there's no Photometric Interpretation
     // set for this image, but that's a required field so we set a warning flag.
     // (Because the "Photometrics" field is an enum, we can't rely on setting
     // this->m_Photometrics to some signal value.)
-    if (TIFFGetField(this->m_Image, TIFFTAG_PHOTOMETRIC, &this->m_Photometrics))
-    {
-      this->m_HasValidPhotometricInterpretation = true;
-    }
-    else
-    {
-      this->m_HasValidPhotometricInterpretation = false;
-    }
+    this->m_HasValidPhotometricInterpretation =
+      TIFFGetField(this->m_Image, TIFFTAG_PHOTOMETRIC, &this->m_Photometrics) != 0;
   }
 
   return 1;

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
@@ -446,14 +446,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::ApplyLoads(ImageSi
               ++CornerCounter;
             }
           }
-          if (CornerCounter == ImageDimension - 1)
-          {
-            EdgeFound = true;
-          }
-          else
-          {
-            EdgeFound = false;
-          }
+          EdgeFound = CornerCounter == ImageDimension - 1;
           if (EdgeFound)
           {
             for (unsigned int jj = 0; jj < ndofpernode; ++jj)

--- a/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest.cxx
@@ -201,14 +201,7 @@ GPUDemonsRegistrationFilterTestTemplate(int argc, char * argv[])
   // std::endl;
   // std::cout << "Total CPU time in seconds = " << m_CPUTime.GetMean() <<
   // std::endl;
-  if (avgDiff < 2)
-  {
-    passed = true;
-  }
-  else
-  {
-    passed = false;
-  }
+  passed = avgDiff < 2;
 
   if (!passed)
   {

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
@@ -301,14 +301,7 @@ DeformableSimplexMesh3DGradientConstraintForceFilter<TInputMesh, TOutputMesh>::C
 
           current = new ImageVoxel(vpos, pos, static_cast<double>(m_Image->GetPixel(index)), dist, ++i);
           m_Positive.push_back(current);
-          if (current->GetDistance() > m_Range)
-          {
-            stop = true;
-          }
-          else
-          {
-            stop = false;
-          }
+          stop = current->GetDistance() > m_Range;
         }
       }
     }
@@ -358,14 +351,7 @@ DeformableSimplexMesh3DGradientConstraintForceFilter<TInputMesh, TOutputMesh>::C
 
           current = new ImageVoxel(vpos, pos, static_cast<double>(m_Image->GetPixel(index)), dist, --ii);
           m_Negative.push_back(current);
-          if (current->GetDistance() > m_Range)
-          {
-            stop = true;
-          }
-          else
-          {
-            stop = false;
-          }
+          stop = current->GetDistance() > m_Range;
         }
       }
     }


### PR DESCRIPTION
Replaced code like `if (x) b = true; else b = false;` with `b = x;`

Using Notepad++, Replace in Files, doing:

    Find what: ^([ ]+ )if \((.+)\)\r\n\1{\r\n\1  (.+) = true;\r\n\1}\r\n\1else\r\n\1{\r\n\1  \3 = false;\r\n\1}
    Replace with: $1$3 = $2;
    Filters: itk*.*
    [v] Match case
    (*) Regular expression

Improved code readability by ensuring that the expression at the right hand side of each assignment is a Boolean expression, rather than an integer expression.