### PR TITLE
STYLE: Replace `push_back(T(a, b, c))` with `emplace_back(a, b, c)`

### DIFF
--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.hxx
@@ -47,7 +47,7 @@ QuadEdgeMeshFrontBaseIterator<TMesh, TQE>::QuadEdgeMeshFrontBaseIterator(MeshTyp
     }
   }
   m_Front = new FrontType;
-  m_Front->push_back(FrontAtom(seed, 0));
+  m_Front->emplace_back(seed, 0);
   m_IsPointVisited = IsVisitedContainerType::New();
   m_IsPointVisited->SetElement(seed->GetOrigin(), true);
   m_IsPointVisited->SetElement(seed->GetDestination(), true);
@@ -107,7 +107,7 @@ QuadEdgeMeshFrontBaseIterator<TMesh, TQE>::operator++()
     const CoordinateType oCost = this->GetCost(oEdge) + fit->m_Cost;
 
     // Push the Sym() on the front:
-    m_Front->push_back(FrontAtom(oEdge->GetSym(), oCost));
+    m_Front->emplace_back(oEdge->GetSym(), oCost);
 
     // We still want to handle oEdge
     m_CurrentEdge = oEdge;

--- a/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.hxx
+++ b/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.hxx
@@ -158,7 +158,7 @@ BinaryContourImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData
           ++outLineIt;
         }
         // create the run length object to go in the vector
-        fgLine.push_back(RunLength(length, thisIndex));
+        fgLine.emplace_back(length, thisIndex);
       }
       else
       {
@@ -174,7 +174,7 @@ BinaryContourImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData
           ++outLineIt;
         }
         // create the run length object to go in the vector
-        bgLine.push_back(RunLength(length, thisIndex));
+        bgLine.emplace_back(length, thisIndex);
       }
     }
 

--- a/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
@@ -135,7 +135,7 @@ LabelObject<TLabel, VImageDimension>::RemoveIndex(const IndexType & idx)
         IndexType newIdx = idx;
         ++newIdx[0];
         const LengthType newLength = orgLineLength - it->GetLength() - 1;
-        m_LineContainer.push_back(LineType(newIdx, newLength));
+        m_LineContainer.emplace_back(newIdx, newLength);
         return true;
       }
     }

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
@@ -255,12 +255,12 @@ LaplacianDeformationQuadEdgeMeshFilter<TInputMesh, TOutputMesh, TSolverTraits>::
           w *= t.m_Weight;
           ww -= w;
 
-          todo.push_back(Triple(temp->GetDestination(), w, degree - 1));
+          todo.emplace_back(temp->GetDestination(), w, degree - 1);
 
           temp = temp->GetOnext();
         } while (temp != qe);
 
-        todo.push_back(Triple(vId, ww, degree - 1));
+        todo.emplace_back(vId, ww, degree - 1);
       }
     }
   }

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
@@ -626,10 +626,10 @@ const typename PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointS
   for (PointIdentifier p = 1; p < nWorkUnits; ++p)
   {
     const PointIdentifier endRange = (p * nPoints) / static_cast<double>(nWorkUnits);
-    ranges.push_back(PointIdentifierPair(startRange, endRange));
+    ranges.emplace_back(startRange, endRange);
     startRange = endRange;
   }
-  ranges.push_back(PointIdentifierPair(startRange, nPoints));
+  ranges.emplace_back(startRange, nPoints);
 
   return ranges;
 }

--- a/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
@@ -104,10 +104,10 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::AllocateConfus
     // the confusion matrix has as many rows as there are input labels, and
     // one more column to accommodate "reject" classifications by the combined
     // classifier.
-    this->m_ConfusionMatrixArray.push_back(ConfusionMatrixType(static_cast<unsigned int>(this->m_TotalLabelCount) + 1,
-                                                               static_cast<unsigned int>(this->m_TotalLabelCount)));
-    this->m_UpdatedConfusionMatrixArray.push_back(ConfusionMatrixType(
-      static_cast<unsigned int>(this->m_TotalLabelCount) + 1, static_cast<unsigned int>(this->m_TotalLabelCount)));
+    this->m_ConfusionMatrixArray.emplace_back(static_cast<unsigned int>(this->m_TotalLabelCount) + 1,
+                                              static_cast<unsigned int>(this->m_TotalLabelCount));
+    this->m_UpdatedConfusionMatrixArray.emplace_back(static_cast<unsigned int>(this->m_TotalLabelCount) + 1,
+                                                     static_cast<unsigned int>(this->m_TotalLabelCount));
   }
 }
 

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionComputeIterationThreader.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionComputeIterationThreader.hxx
@@ -192,7 +192,7 @@ LevelSetEvolutionComputeIterationThreader<
 
     const auto temp_update = static_cast<LevelSetOutputType>(termContainer->Evaluate(inputIndex, characteristics));
 
-    this->m_NodePairsPerThread[threadId].push_back(NodePairType(levelsetIndex, temp_update));
+    this->m_NodePairsPerThread[threadId].emplace_back(levelsetIndex, temp_update);
 
     ++listIt;
   }

--- a/Modules/Video/Filtering/include/itkFrameAverageVideoFilter.hxx
+++ b/Modules/Video/Filtering/include/itkFrameAverageVideoFilter.hxx
@@ -114,7 +114,7 @@ FrameAverageVideoFilter<TInputVideoStream, TOutputVideoStream>::ThreadedGenerate
   std::vector<IterType> inputIters;
   for (SizeValueType i = inputStart; i < inputStart + numFrames; ++i)
   {
-    inputIters.push_back(IterType(input->GetFrame(i), outputRegionForThread));
+    inputIters.emplace_back(input->GetFrame(i), outputRegionForThread);
   }
 
   // Get the output frame and its iterator


### PR DESCRIPTION
- Follow-up to pull request #5409 commit 87e58d774119e008a7a16e7a93f76cc6afde6ff6
"PERF: emplace_back method results in potentially more efficient code", Hans Johnson (@hjmjohnson), Jun 18, 2025

Following https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-emplace.html

Cases found by regular expression `push_back\(\w+\(`.