### PR TITLE
STYLE: Remove `initGradIt` from GradientRecursiveGaussianImageFilter

### DIFF
--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
@@ -203,11 +203,6 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   m_DerivativeFilter->SetInput(inputImage);
 
-  // For variable length output pixel types
-  const ImageRegionIteratorWithIndex<OutputImageType> initGradIt(outputImage,
-                                                                 this->m_ImageAdaptor->GetRequestedRegion());
-
-
   for (unsigned int nc = 0; nc < nComponents; ++nc)
   {
     for (unsigned int dim = 0; dim < ImageDimension; ++dim)


### PR DESCRIPTION
Removed a local variable from GenerateData(), as it is no longer used.

---

For the record, the variable was introduced (and used) by commit 756c7b949c5a49e314357f817ae475d7a9928c5e, Jeffrey Duda (@jeffduda), Oct 17, 2012. It appears that it became unused with commit d4f421575c88233076c219fe5b6318787420f30b, Bradley Lowekamp (@blowekamp), Nov 16, 2012. And indeed, I think the variable is no longer necessary now that the filter has specialized code for `VectorImage`.