### PR TITLE
STYLE: Remove GoToBegin() calls from Iterator constructors

### DIFF
--- a/Modules/Core/Common/include/itkImageConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithIndex.hxx
@@ -51,6 +51,7 @@ ImageConstIteratorWithIndex<TImage>::ImageConstIteratorWithIndex(const TImage * 
   : m_Image(ptr)
   , m_BeginIndex(region.GetIndex())
   , m_Region(region)
+  , m_Remaining(region.GetNumberOfPixels() > 0)
 {
   const InternalPixelType * buffer = m_Image->GetBufferPointer();
   m_PositionIndex = m_BeginIndex;
@@ -69,15 +70,10 @@ ImageConstIteratorWithIndex<TImage>::ImageConstIteratorWithIndex(const TImage * 
   m_Position = m_Begin;
 
   // Compute the end offset
-  m_Remaining = false;
   IndexType pastEnd;
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     const SizeValueType size = region.GetSize()[i];
-    if (size > 0)
-    {
-      m_Remaining = true;
-    }
     m_EndIndex[i] = m_BeginIndex[i] + static_cast<OffsetValueType>(size);
     pastEnd[i] = m_BeginIndex[i] + static_cast<OffsetValueType>(size) - 1;
   }
@@ -86,8 +82,6 @@ ImageConstIteratorWithIndex<TImage>::ImageConstIteratorWithIndex(const TImage * 
   m_PixelAccessor = m_Image->GetPixelAccessor();
   m_PixelAccessorFunctor.SetPixelAccessor(m_PixelAccessor);
   m_PixelAccessorFunctor.SetBegin(buffer);
-
-  GoToBegin();
 }
 
 //----------------------------------------------------------------------

--- a/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.hxx
@@ -28,6 +28,7 @@ template <typename TImage>
 ImageConstIteratorWithOnlyIndex<TImage>::ImageConstIteratorWithOnlyIndex(const TImage *, const RegionType & region)
   : m_BeginIndex(region.GetIndex())
   , m_Region(region)
+  , m_Remaining(region.GetNumberOfPixels() > 0)
 {
   m_PositionIndex = m_BeginIndex;
 
@@ -35,14 +36,8 @@ ImageConstIteratorWithOnlyIndex<TImage>::ImageConstIteratorWithOnlyIndex(const T
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     const SizeValueType size = region.GetSize()[i];
-    if (size > 0)
-    {
-      m_Remaining = true;
-    }
     m_EndIndex[i] = m_BeginIndex[i] + static_cast<OffsetValueType>(size);
   }
-
-  GoToBegin();
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
The `Iterator(image, region)` constructors of ImageConstIteratorWithIndex and ImageConstIteratorWithOnlyIndex already initialize themselves at the begin, so it is not necessary for them to call GoToBegin().

Properly initialized `m_Remaining` in their member initializer lists.