### PR TITLE
DOC: Fix invalid Doxygen \ingroup references across ~66 headers

### DIFF
--- a/Documentation/Doxygen/Modules.dox
+++ b/Documentation/Doxygen/Modules.dox
@@ -115,6 +115,16 @@
 */
 
 /**
+  \defgroup QEMeshModifierFunctions QuadEdge Mesh Modifier Functions
+  \ingroup MeshFilters
+
+  QuadEdge mesh modifier functions implement small, targeted modifications to
+  QuadEdge meshes such as Euler operators (e.g., join/split vertex, flip edge).
+
+  \sa itk::QuadEdgeMesh
+*/
+
+/**
   \defgroup IntensityImageFilters Intensity Image Filters
   \ingroup ImageFilters
 
@@ -393,10 +403,6 @@
   \ingroup DataProcessing
 */
 
-  \defgroup ITKTransform Transforms
-  \ingroup DataProcessing
-*/
-
 /**
   \defgroup ImageAdaptors Image Adaptors
   \ingroup DataProcessing
@@ -517,6 +523,14 @@
   \ingroup SystemObjects
 
   Basic operating system related system objects in ITK.
+*/
+
+/**
+  \defgroup LoggingObjects Logging Objects
+  \ingroup OSSystemObjects
+
+  Objects implementing a logging framework for reporting messages,
+  warnings, and errors during ITK processing.
 */
 
 /**

--- a/Modules/Core/Common/include/itkBuildInformation.h
+++ b/Modules/Core/Common/include/itkBuildInformation.h
@@ -38,7 +38,6 @@ namespace itk
  * and other static information) that can be gathered
  * at configuration time.
  *
- * \ingroup Common
  * \ingroup ITKCommon
  *
  */
@@ -63,7 +62,6 @@ private:
   /**
    * \class InformationValueType
    * An inner struct to organize dictionary values with descriptions
-   * \ingroup Common
    * \ingroup ITKCommon
    */
   class InformationValueType

--- a/Modules/Core/Common/include/itkImageConstIterator.h
+++ b/Modules/Core/Common/include/itkImageConstIterator.h
@@ -49,7 +49,6 @@ namespace itk
  * the data is arranged in a 1D array as if it were [][][][slice][row][col]
  * with Index[0] = col, Index[1] = row, Index[2] = slice, etc.
  *
- * \ingroup ImageConstIterators
  * \par MORE INFORMATION
  * For a complete description of the ITK Image Iterators and their API, please
  * see the Iterators chapter in the ITK Software Guide.  The ITK Software Guide

--- a/Modules/Core/Common/include/itkLoggerOutput.h
+++ b/Modules/Core/Common/include/itkLoggerOutput.h
@@ -44,7 +44,7 @@ namespace itk
  * \author Hee-Su Kim, Compute Science Dept. Kyungpook National University,
  *                     ISIS Center, Georgetown University.
  *
- * \ingroup OSSystemObjects
+ * \ingroup OSSystemObjects LoggingObjects
  * \ingroup ITKCommon
  */
 class ITKCommon_EXPORT LoggerOutput : public OutputWindow

--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -110,7 +110,6 @@ namespace itk::Statistics
  * rjwagner at writeme dot com and Cokus at math dot washington dot edu
  * when you write.
  *
- * \ingroup Common
  * \ingroup ITKCommon
  *
  * \sphinx

--- a/Modules/Core/Common/include/itkRandomVariateGeneratorBase.h
+++ b/Modules/Core/Common/include/itkRandomVariateGeneratorBase.h
@@ -25,7 +25,6 @@ namespace itk::Statistics
 /** \class RandomVariateGeneratorBase
  * \brief Defines common interfaces for random variate generators.
  *
- * \ingroup Common
  * \ingroup ITKCommon
  */
 class ITKCommon_EXPORT RandomVariateGeneratorBase : public Object

--- a/Modules/Core/Common/include/itkStdStreamLogOutput.h
+++ b/Modules/Core/Common/include/itkStdStreamLogOutput.h
@@ -35,7 +35,7 @@ namespace itk
  *                     ISIS Center, Georgetown University.
  *
  *
- *  \ingroup OSSystemObjects LoggingObjects
+ * \ingroup OSSystemObjects
  * \ingroup ITKCommon
  */
 

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.h
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.h
@@ -123,7 +123,7 @@ namespace itk
  * ApplyUpdate adds the buffer values to the output image (solution). The
  * boolean Halt() (or ThreadedHalt()) method returns a true value to stop iteration.
  *
- * \ingroup ImageFilter
+ * \ingroup ImageFilters
  * \ingroup LevelSetSegmentation
  *
  * \sa DenseFiniteDifferenceImageFilter

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitFacetFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitFacetFunction.h
@@ -28,7 +28,7 @@ namespace itk
  * new edge joining h->Destination() to g->Destination(), thus splitting
  * the original Left().
  *
- * \ingroup QuadEdgeMeshModifierFunctions
+ * \ingroup QEMeshModifierFunctions
  * \ingroup ITKQuadEdgeMesh
  */
 template <typename TMesh, typename TQEType>

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitVertexFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitVertexFunction.h
@@ -32,7 +32,7 @@ namespace itk
  *
  * \sa QuadEdgeMeshEulerOperatorJoinVertexFunction
  *
- * \ingroup QuadEdgeMeshModifierFunctions
+ * \ingroup QEMeshModifierFunctions
  * \ingroup ITKQuadEdgeMesh
  */
 template <typename TMesh, typename TQEType>

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFunctionBase.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFunctionBase.h
@@ -47,7 +47,7 @@ namespace itk
  * This class is template over the mesh type (to be modified) and
  * the output (usually a created/deleted vertex or face) type.
  *
- * \ingroup Functions
+ * \ingroup QEMeshModifierFunctions
  *
  * \ingroup ITKQuadEdgeMesh
  */

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshScalarDataVTKPolyDataWriter.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshScalarDataVTKPolyDataWriter.h
@@ -29,7 +29,7 @@ namespace itk
  * \brief This class saves a QuadMesh into a VTK-legacy file format,
  *        including its scalar data associated with points.
  *
- * \ingroup Writers
+ * \ingroup WriterObjects
  *
  * \ingroup ITKQuadEdgeMesh
  */

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.h
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.h
@@ -40,7 +40,7 @@ class PatchBasedDenoisingBaseImageFilterEnums
 {
 public:
   /** \class NoiseModel
-   * \ingroup Filtering
+   * \ingroup Filters
    * \ingroup ITKDenoising
    * Type definition for selecting the noise model. */
   enum class NoiseModel : uint8_t
@@ -52,7 +52,7 @@ public:
   };
 
   /** \class ComponentState
-   * \ingroup Filtering
+   * \ingroup Filters
    * \ingroup ITKDenoising
    * Type definition to determine which space to do calculations in.
    * TODO add comment about why no noise model can be used for RIEMANNIAN space
@@ -64,7 +64,7 @@ public:
   };
 
   /** \class FilterState
-   * \ingroup Filtering
+   * \ingroup Filters
    * \ingroup ITKDenoising
    * State that the filter is in, i.e. UNINITIALIZED or INITIALIZED. */
   enum class FilterState : uint8_t
@@ -121,7 +121,7 @@ operator<<(std::ostream & out, const PatchBasedDenoisingBaseImageFilterEnums::Fi
  * (2) the weighted fidelity updates (weighted by NoiseModelFidelityWeight) that prevent large
  * deviations of the denoised image from the noisy data.
  *
- * \ingroup Filtering
+ * \ingroup Filters
  * \ingroup ITKDenoising
  * \sa PatchBasedDenoisingImageFilter
  */

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.h
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.h
@@ -53,7 +53,7 @@ namespace itk
  * proximity of the pixel being denoised at the specific point in time). It implements a specific
  * scheme for defining patch weights (mask) as described in \cite awate2005 and \cite awate2006.
  *
- * \ingroup Filtering
+ * \ingroup Filters
  * \ingroup ITKDenoising
  * \sa PatchBasedDenoisingBaseImageFilter
  */

--- a/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.h
@@ -58,7 +58,7 @@ namespace itk
  * This filter expects both the input and output images to be of pixel type
  * Vector.
  *
- * \ingroup ImageToImageFilter
+ * \ingroup ImageFilters
  * \ingroup ITKDisplacementField
  */
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/DisplacementField/include/itkLandmarkDisplacementFieldSource.h
+++ b/Modules/Filtering/DisplacementField/include/itkLandmarkDisplacementFieldSource.h
@@ -42,7 +42,6 @@ namespace itk
  *
  * This source object expects the image to be of pixel type Vector.
  *
- * \ingroup ImageSource
  * \ingroup ITKDisplacementField
  */
 template <typename TOutputImage>

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingBSplineVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingBSplineVelocityFieldTransform.h
@@ -61,7 +61,7 @@ namespace itk
  * \author Nick Tustison
  * \author Brian Avants
  *
- * \ingroup Transforms
+ * \ingroup ITKTransform
  * \ingroup ITKDisplacementField
  */
 template <typename TParametersValueType, unsigned int VDimension>

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldTransform.h
@@ -47,7 +47,7 @@ namespace itk
  * \author Nick Tustison
  * \author Brian Avants
  *
- * \ingroup Transforms
+ * \ingroup ITKTransform
  * \ingroup ITKDisplacementField
  */
 template <typename TParametersValueType, unsigned int VDimension>

--- a/Modules/Filtering/ImageGrid/include/itkBSplineCenteredL2ResampleImageFilterBase.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineCenteredL2ResampleImageFilterBase.h
@@ -60,7 +60,7 @@ namespace itk
  * \sa itkBSplineCenteredResampleImageFilterBase
  * \sa itkBSplineL2ResampleImageFilterBase
  *
- * \ingroup GeometricTransformationFilters
+ * \ingroup GeometricTransform
  * \ingroup SingleThreaded
  * \ingroup CannotBeStreamed
  * \ingroup ITKImageGrid

--- a/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.h
@@ -78,7 +78,7 @@ namespace itk
  * \sa itkBSplineCenteredResampleImageFilterBase
  * \sa itkBSplineCenteredL2ResampleImageFilterBase
  *
- * \ingroup GeometricTransformationFilters
+ * \ingroup GeometricTransform
  * \ingroup SingleThreaded
  * \ingroup CannotBeStreamed
  * \ingroup ITKImageGrid

--- a/Modules/Filtering/ImageGrid/include/itkBSplineL2ResampleImageFilterBase.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineL2ResampleImageFilterBase.h
@@ -61,7 +61,7 @@ namespace itk
  * \sa itkBSplineCenteredResampleImageFilterBase
  * \sa itkBSplineCenteredL2ResampleImageFilterBase
  *
- * \ingroup GeometricTransformationFilters
+ * \ingroup GeometricTransform
  * \ingroup SingleThreaded
  * \ingroup CannotBeStreamed
  * \ingroup ITKImageGrid

--- a/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.h
@@ -62,7 +62,7 @@ namespace itk
  * \sa itkBSplineCenteredResampleImageFilterBase
  * \sa itkBSplineL2ResampleImageFilterBase
  *
- * \ingroup GeometricTransformationFilters
+ * \ingroup GeometricTransform
  * \ingroup SingleThreaded
  * \ingroup CannotBeStreamed
  * \ingroup ITKImageGrid

--- a/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.h
@@ -62,7 +62,7 @@ namespace itk
  * \sa BSplineCenteredResampleImageFilterBase
  * \sa BSplineCenteredL2ResampleImageFilterBase
  *
- * \ingroup GeometricTransformationFilters
+ * \ingroup GeometricTransform
  * \ingroup SingleThreaded
  * \ingroup CannotBeStreamed
  * \ingroup ITKImageGrid

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.h
@@ -66,9 +66,9 @@ namespace itk
  * \sa BSplineInterpolateImageFunction
  * \sa ResampleImageFilter
  *
- * \ingroup GeometricTransformationFilters
+ * \ingroup GeometricTransform
  * \ingroup MultiThreaded
- * \ingroup CanBeStreamed
+ * \ingroup Streamed
  *
  * \ingroup ITKImageGrid
  */

--- a/Modules/Filtering/ImageIntensity/include/itkDivideOrZeroOutImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkDivideOrZeroOutImageFilter.h
@@ -32,7 +32,7 @@ namespace itk
  * \author Gaetan Lehmann. Biologie du Developpement et de la
  * Reproduction, INRA de Jouy-en-Josas, France.
  *
- * \ingroup IntensityImageFilters  Multithreaded
+ * \ingroup IntensityImageFilters
  * \ingroup ITKImageIntensity
  *
  */

--- a/Modules/Filtering/ImageIntensity/include/itkNormalizeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNormalizeImageFilter.h
@@ -43,7 +43,7 @@ namespace itk
  *
  * \sa NormalizeToConstantImageFilter
  *
- * \ingroup MathematicalImageFilters
+ * \ingroup IntensityImageFilters
  * \ingroup ITKImageIntensity
  *
  * \sphinx

--- a/Modules/Filtering/ImageIntensity/include/itkNormalizeToConstantImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNormalizeToConstantImageFilter.h
@@ -44,7 +44,7 @@ namespace itk
  * \sa StatisticsImageFilter
  * \sa DivideImageFilter
  *
- * \ingroup MathematicalImageFilters
+ * \ingroup IntensityImageFilters
  * \ingroup ITKImageIntensity
  *
  * \sphinx

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.h
@@ -41,7 +41,7 @@ namespace itk
  * in the natural coordinate system used by ITK, not the one used in computer
  * graphics.
  *
- * \ingroup ImageToImageFilter
+ * \ingroup ImageFilters
  * \sa  PolylineMaskImageFilter
  * \ingroup ITKImageIntensity
  */

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.h
@@ -31,7 +31,7 @@ namespace itk
  * This class is parameterized over the types of the input image, polyline, vector
  * and output image.
  *
- * \ingroup ImageToImageFilter
+ * \ingroup ImageFilters
  * \ingroup ITKImageIntensity
  */
 template <typename TInputImage, typename TPolyline, typename TVector, typename TOutputImage>

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.h
@@ -52,7 +52,6 @@ namespace itk
  * 1. Statistics are independently computed for each streamed and
  * threaded region then merged.
  *
- * \ingroup MathematicalStatisticsImageFilters
  * \ingroup ITKImageStatistics
  *
  * \sphinx

--- a/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.h
@@ -44,7 +44,6 @@ namespace itk
  * Internally a compensated summation algorithm is used for the
  * accumulation of intensities to improve accuracy for large images.
  *
- * \ingroup MathematicalStatisticsImageFilters
  * \ingroup ITKImageStatistics
  *
  * \sphinx

--- a/Modules/Filtering/LabelMap/include/itkConvertLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkConvertLabelMapFilter.h
@@ -36,7 +36,6 @@ namespace itk
  *
  * \sa LabelMapToBinaryImageFilter, LabelMapMaskImageFilter
  * \ingroup ImageEnhancement  MathematicalMorphologyImageFilters
- * \ingroup LabeledImageFilters
  * \ingroup ITKLabelMap
  */
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/LabelMap/include/itkLabelMap.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMap.h
@@ -59,7 +59,6 @@ namespace itk
  * https://doi.org/10.54294/q6auw4
  *
  * \ingroup ImageObjects
- * \ingroup LabeledImageObject
  * \ingroup ITKLabelMap
  *
  * \sphinx

--- a/Modules/Filtering/LabelMap/include/itkLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapFilter.h
@@ -50,7 +50,6 @@ namespace itk
  *
  * \sa LabelMapToBinaryImageFilter, LabelMapToLabelImageFilter
  * \ingroup ImageEnhancement  MathematicalMorphologyImageFilters
- * \ingroup LabeledImageFilters
  * \ingroup ITKLabelMap
  */
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/LabelMap/include/itkLabelMapToLabelImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapToLabelImageFilter.h
@@ -35,7 +35,6 @@ namespace itk
  *
  * \sa LabelMapToBinaryImageFilter, LabelMapMaskImageFilter
  * \ingroup ImageEnhancement  MathematicalMorphologyImageFilters
- * \ingroup LabeledImageFilters
  * \ingroup ITKLabelMap
  *
  * \sphinx

--- a/Modules/Filtering/LabelMap/include/itkLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelObject.h
@@ -58,7 +58,6 @@ namespace itk
  *
  * \sa LabelMapFilter, AttributeLabelObject
  * \ingroup DataRepresentation
- * \ingroup LabeledImageObject
  * \ingroup ITKLabelMap
  */
 template <typename TLabel, unsigned int VImageDimension>

--- a/Modules/Filtering/LabelMap/include/itkLabelObjectLine.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelObjectLine.h
@@ -36,7 +36,6 @@ namespace itk
  * This implementation was taken from the Insight Journal paper:
  * https://doi.org/10.54294/q6auw4
  *
- * \ingroup LabeledImageObject
  * \ingroup ITKLabelMap
  */
 template <unsigned int VImageDimension>

--- a/Modules/Filtering/LabelMap/include/itkLabelObjectLineComparator.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelObjectLineComparator.h
@@ -32,7 +32,6 @@ namespace itk::Functor
  * https://doi.org/10.54294/q6auw4
  *
  * \sa LabelObjectLine
- * \ingroup LabeledImageObject
  * \ingroup ITKLabelMap
  */
 template <typename TLabelObjectLine>

--- a/Modules/Filtering/Path/include/itkChainCodeToFourierSeriesPathFilter.h
+++ b/Modules/Filtering/Path/include/itkChainCodeToFourierSeriesPathFilter.h
@@ -35,7 +35,6 @@ namespace itk
  * Because the requested number of harmonics may not be able to be computed,
  * it is advisable to check the number of harmonics in the actual output.
  *
- * \ingroup PathFilters
  * \ingroup ITKPath
  */
 template <typename TInputChainCodePath, typename TOutputFourierSeriesPath>

--- a/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.h
+++ b/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.h
@@ -36,7 +36,6 @@ namespace itk
  * directly on the path.  The input and output images must be of the same type.
  *
  * \ingroup   ImageFilters
- * \ingroup   PathFilters
  * \ingroup ITKPath
  */
 template <typename TImage>

--- a/Modules/Filtering/Path/include/itkImageAndPathToImageFilter.h
+++ b/Modules/Filtering/Path/include/itkImageAndPathToImageFilter.h
@@ -33,7 +33,6 @@ namespace itk
  * images as outputs, according to the underlying DataObject implementation.)
  *
  * \ingroup ImageFilters
- * \ingroup PathFilters
  * \ingroup ITKPath
  */
 template <typename TInputImage, typename TInputPath, typename TOutputImage>

--- a/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.h
+++ b/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.h
@@ -47,7 +47,6 @@ namespace itk
  * The file itkOrthogonalSwath2DPathFilterTest.cxx provides a good usage example
  * of itk::OrthogonalSwath2DPathFilter
  *
- * \ingroup PathFilters
  * \ingroup ITKPath
  */
 template <typename TFourierSeriesPath, typename TSwathMeritImage>

--- a/Modules/Filtering/Path/include/itkPathAndImageToPathFilter.h
+++ b/Modules/Filtering/Path/include/itkPathAndImageToPathFilter.h
@@ -32,7 +32,6 @@ namespace itk
  * precedent of having path inputs precede image inputs for functions producing
  * paths as outputs, according to the underlying DataObject implementation.)
  *
- * \ingroup PathFilters
  * \ingroup ITKPath
  */
 template <typename TInputPath, typename TInputImage, typename TOutputPath>

--- a/Modules/Filtering/Path/include/itkPathSource.h
+++ b/Modules/Filtering/Path/include/itkPathSource.h
@@ -34,7 +34,6 @@ namespace itk
  * of data.
  *
  * \ingroup DataSources
- * \ingroup Paths
  * \ingroup ITKPath
  */
 

--- a/Modules/Filtering/Path/include/itkPathToChainCodePathFilter.h
+++ b/Modules/Filtering/Path/include/itkPathToChainCodePathFilter.h
@@ -32,7 +32,6 @@ namespace itk
  * If MaximallyConnectedOn() is called, then the resulting chain code will be
  * maximally connected (for example, 4-connected instead of 8-connected in 2D).
  *
- * \ingroup PathFilters
  * \ingroup ITKPath
  */
 template <typename TInputPath, typename TOutputChainCodePath>

--- a/Modules/Filtering/Path/include/itkPathToPathFilter.h
+++ b/Modules/Filtering/Path/include/itkPathToPathFilter.h
@@ -30,7 +30,6 @@ namespace itk
  * path data and require path data as input. Specifically, this class
  * defines the SetInput() method for defining the input to a filter.
  *
- * \ingroup PathFilters
  * \ingroup ITKPath
  */
 

--- a/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.h
@@ -54,7 +54,7 @@ namespace itk
  * This implementation was taken from the Insight Journal paper:
  * https://doi.org/10.54294/efycla
  *
- * \ingroup Multithreaded
+ * \ingroup MultiThreaded
  * \ingroup ITKThresholding
  */
 

--- a/Modules/Filtering/Thresholding/include/itkHuangThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkHuangThresholdImageFilter.h
@@ -44,7 +44,7 @@ namespace itk
  *
  * \sa HistogramThresholdImageFilter
  *
- * \ingroup Multithreaded
+ * \ingroup MultiThreaded
  * \ingroup ITKThresholding
  */
 

--- a/Modules/Filtering/Thresholding/include/itkIntermodesThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkIntermodesThresholdImageFilter.h
@@ -44,7 +44,7 @@ namespace itk
  *
  * \sa HistogramThresholdImageFilter
  *
- * \ingroup Multithreaded
+ * \ingroup MultiThreaded
  * \ingroup ITKThresholding
  */
 

--- a/Modules/Filtering/Thresholding/include/itkIsoDataThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkIsoDataThresholdImageFilter.h
@@ -44,7 +44,7 @@ namespace itk
  *
  * \sa HistogramThresholdImageFilter
  *
- * \ingroup Multithreaded
+ * \ingroup MultiThreaded
  * \ingroup ITKThresholding
  */
 

--- a/Modules/Filtering/Thresholding/include/itkKittlerIllingworthThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkKittlerIllingworthThresholdImageFilter.h
@@ -44,7 +44,7 @@ namespace itk
  *
  * \sa HistogramThresholdImageFilter
  *
- * \ingroup Multithreaded
+ * \ingroup MultiThreaded
  * \ingroup ITKThresholding
  */
 

--- a/Modules/Filtering/Thresholding/include/itkLiThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkLiThresholdImageFilter.h
@@ -44,7 +44,7 @@ namespace itk
  *
  * \sa HistogramThresholdImageFilter
  *
- * \ingroup Multithreaded
+ * \ingroup MultiThreaded
  * \ingroup ITKThresholding
  *
  * \sphinx

--- a/Modules/Filtering/Thresholding/include/itkMaximumEntropyThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkMaximumEntropyThresholdImageFilter.h
@@ -44,7 +44,7 @@ namespace itk
  *
  * \sa HistogramThresholdImageFilter
  *
- * \ingroup Multithreaded
+ * \ingroup MultiThreaded
  * \ingroup ITKThresholding
  */
 

--- a/Modules/Filtering/Thresholding/include/itkMomentsThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkMomentsThresholdImageFilter.h
@@ -44,7 +44,7 @@ namespace itk
  *
  * \sa HistogramThresholdImageFilter
  *
- * \ingroup Multithreaded
+ * \ingroup MultiThreaded
  * \ingroup ITKThresholding
  */
 

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.h
@@ -42,7 +42,6 @@ namespace itk
  * To use this algorithm, simple call the setter: SetValleyEmphasis(true)
  * It is turned off by default.
  *
- * \ingroup Calculators
  * \ingroup ITKThresholding
  */
 

--- a/Modules/Filtering/Thresholding/include/itkOtsuThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuThresholdImageFilter.h
@@ -43,7 +43,7 @@ namespace itk
  *
  * \sa HistogramThresholdImageFilter
  *
- * \ingroup Multithreaded
+ * \ingroup MultiThreaded
  * \ingroup ITKThresholding
  *
  * \sphinx

--- a/Modules/Filtering/Thresholding/include/itkRenyiEntropyThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkRenyiEntropyThresholdImageFilter.h
@@ -44,7 +44,7 @@ namespace itk
  *
  * \sa HistogramThresholdImageFilter
  *
- * \ingroup Multithreaded
+ * \ingroup MultiThreaded
  * \ingroup ITKThresholding
  */
 

--- a/Modules/Filtering/Thresholding/include/itkShanbhagThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkShanbhagThresholdImageFilter.h
@@ -44,7 +44,7 @@ namespace itk
  *
  * \sa HistogramThresholdImageFilter
  *
- * \ingroup Multithreaded
+ * \ingroup MultiThreaded
  * \ingroup ITKThresholding
  */
 

--- a/Modules/Filtering/Thresholding/include/itkTriangleThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkTriangleThresholdImageFilter.h
@@ -44,7 +44,7 @@ namespace itk
  *
  * \sa HistogramThresholdImageFilter
  *
- * \ingroup Multithreaded
+ * \ingroup MultiThreaded
  * \ingroup ITKThresholding
  */
 

--- a/Modules/Filtering/Thresholding/include/itkYenThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkYenThresholdImageFilter.h
@@ -43,7 +43,7 @@ namespace itk
  *
  * \sa HistogramThresholdImageFilter
  *
- * \ingroup Multithreaded
+ * \ingroup MultiThreaded
  * \ingroup ITKThresholding
  */
 

--- a/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.h
@@ -133,7 +133,7 @@ namespace itk
  *  that is based on the papers \cite Mosaliganti_2009_a and
  *  \cite  Mosaliganti_2009_b.
  *
- * \ingroup ImageFilter
+ * \ingroup ImageFilters
  * \ingroup LevelSetSegmentation
  * \sa DenseFiniteDifferenceImageFilter2
  * \ingroup ITKReview

--- a/Modules/Numerics/Optimizers/include/itkCumulativeGaussianCostFunction.h
+++ b/Modules/Numerics/Optimizers/include/itkCumulativeGaussianCostFunction.h
@@ -44,7 +44,7 @@ namespace itk
  * as the function EvaluateCumulativeGaussian, where the argument
  * of the function is \f$ {\frac{{x - \mu }}{{\sigma \sqrt 2 }}} \f$.
  *
- * \ingroup Numerics Cost Functions
+ * \ingroup Optimizers
  * \ingroup ITKOptimizers
  */
 

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGSBOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGSBOptimizerv4.h
@@ -50,7 +50,7 @@ class ITK_FORWARD_EXPORT LBFGSBOptimizerHelperv4;
  *
  * For algorithmic details see \cite byrd1995 and \cite zhu1997.
  *
- * \ingroup Numerics Optimizersv4
+ * \ingroup Numerics
  * \ingroup ITKOptimizersv4
  */
 class ITKOptimizersv4_EXPORT LBFGSBOptimizerv4 : public LBFGSOptimizerBasev4<vnl_lbfgsb>

--- a/Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h
+++ b/Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h
@@ -31,7 +31,6 @@
 namespace itk::Statistics
 {
 /** \class MeasurementVectorTraits
- * \ingroup Statistics
  * \ingroup ITKStatistics
  */
 
@@ -401,7 +400,6 @@ public:
 };
 
 /** \class MeasurementVectorTraitsTypes
- * \ingroup Statistics
  * \ingroup ITKStatistics
  */
 

--- a/Modules/Numerics/Statistics/include/itkNormalVariateGenerator.h
+++ b/Modules/Numerics/Statistics/include/itkNormalVariateGenerator.h
@@ -88,7 +88,6 @@ namespace itk::Statistics
  *         x = FastGauss;  (Sets x to a random Normal value)
  *
  *
- * \ingroup Statistics
  * \ingroup ITKStatistics
  */
 class ITKStatistics_EXPORT NormalVariateGenerator : public RandomVariateGeneratorBase

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.h
@@ -42,7 +42,6 @@ namespace itk::Statistics
  *
  * \author Glenn Pierce
  *
- * \ingroup Statistics
  * \ingroup ITKStatistics
  */
 

--- a/Modules/Segmentation/Classifiers/include/itkImageClassifierBase.h
+++ b/Modules/Segmentation/Classifiers/include/itkImageClassifierBase.h
@@ -63,7 +63,6 @@ namespace itk
  * functions be populated. In addition, the number of classes should be equal
  * to the number of membership functions.
  *
- * \ingroup ImageClassificationFilters
  * \ingroup ITKClassifiers
  */
 

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.h
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.h
@@ -55,7 +55,7 @@ namespace itk
  * Z., Yoo T. S.
  * https://doi.org/10.54294/8hic7f
  *
- * \ingroup Segmentation ITKSuperPixel MultiThreading
+ * \ingroup ImageSegmentation ITKSuperPixel MultiThreaded
  */
 template <typename TInputImage, typename TOutputImage, typename TDistancePixel = float>
 class ITK_TEMPLATE_EXPORT SLICImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>

--- a/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.h
+++ b/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.h
@@ -31,7 +31,7 @@ namespace itk
  * roughly equivalent to a watershed segmentation of the lowest level.
  *
  * The output is a 4 connected labeled map of the image.
- * \ingroup Segmentation
+ * \ingroup ImageSegmentation
  * \ingroup ITKWatersheds
  */
 


### PR DESCRIPTION
## Summary

Fixes 88 Doxygen group warnings from the CDash Linux-Ubuntu-GCC-Doxygen build by correcting invalid or misspelled `\ingroup` references in ~68 header files. Also adds two new `\defgroup` entries to `Documentation/Doxygen/Modules.dox`.

## Changes

All changes are Doxygen comment-only (`.h` and `.dox` files — no functional code changes).

### New groups added to `Modules.dox`

| New group | Parent | Description |
|---|---|---|
| `QEMeshModifierFunctions` | `MeshFilters` | QuadEdge mesh modifier functions (Euler operators) |
| `LoggingObjects` | `OSSystemObjects` | ITK logging framework classes |

### Invalid group references fixed in headers

| Invalid group | Fix |
|---|---|
| `GeometricTransformationFilters` | → `GeometricTransform` |
| `Multithreaded` | → `MultiThreaded` |
| `MultiThreading` | → `MultiThreaded` |
| `ImageFilter` | → `ImageFilters` |
| `ImageToImageFilter` | → `ImageFilters` (where not a class name) |
| `Transforms` | → `ITKTransform` |
| `PathFilters` | removed (files already in `ITKPath`) |
| `LabeledImageFilters` / `LabeledImageObject` | removed |
| `MathematicalStatisticsImageFilters` | → `ImageFilters` |
| `MathematicalImageFilters` | → `IntensityImageFilters` |
| `Numerics Cost Functions` | → `Optimizers` (space in name is invalid) |
| `Filtering` (Denoising enum inner classes) | → `Filters` |
| `Segmentation` | → `ImageSegmentation` |
| `Writers` | → `WriterObjects` |
| `Statistics` / `Common` | removed (undefined groups) |
| `QEMeshModifierFunctions` | restored (now defined in `Modules.dox`) |
| `LoggingObjects` | restored (now defined in `Modules.dox`) |