### PR TITLE
STYLE: Replace `T v = T(a, b)` variable declarations with `T v(a, b)`

### DIFF
--- a/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
@@ -218,7 +218,7 @@ FFTConvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInternalPrec
     regionOfInterestSize[dim] = outputRequestedSize[dim] + 2 * kernelRadius[dim];
     regionOfInterestIndex[dim] = outputRequestedIndex[dim] - kernelRadius[dim];
   }
-  const InputRegionType regionOfInterest = InputRegionType(regionOfInterestIndex, regionOfInterestSize);
+  const InputRegionType regionOfInterest(regionOfInterestIndex, regionOfInterestSize);
 
   const InputImageType * regionOfInterestImage = kernelPaddedInput;
   if (outputRequestedRegion != inputLargestRegion)

--- a/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
@@ -158,12 +158,11 @@ NormalizedCorrelationImageFilter<TInputImage, TMaskImage, TOutputImage, TOperato
   auto realTemplateSize = static_cast<OutputPixelRealType>(templateSize);
   for (const auto & face : faceList)
   {
-    ConstNeighborhoodIterator<InputImageType> bit =
-      ConstNeighborhoodIterator<InputImageType>(normalizedTemplate.GetRadius(), input, face);
+    ConstNeighborhoodIterator<InputImageType> bit(normalizedTemplate.GetRadius(), input, face);
     bit.OverrideBoundaryCondition(this->GetBoundaryCondition());
     bit.GoToBegin();
 
-    ImageRegionIterator<OutputImageType> it = ImageRegionIterator<OutputImageType>(output, face);
+    ImageRegionIterator<OutputImageType> it(output, face);
 
     if (!mask)
     {
@@ -201,7 +200,7 @@ NormalizedCorrelationImageFilter<TInputImage, TMaskImage, TOutputImage, TOperato
     {
       // Mask is defined, use the same calculation as above but only
       // perform it under the mask
-      ImageRegionConstIterator<MaskImageType> mit = ImageRegionConstIterator<MaskImageType>(mask, face);
+      ImageRegionConstIterator<MaskImageType> mit(mask, face);
       while (!bit.IsAtEnd())
       {
         if (mit.Get())

--- a/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx
+++ b/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx
@@ -88,8 +88,8 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
       itkExceptionStringMacro("One or more input images do not contain matching RequestedRegions");
     }
 
-    IteratorType      in = IteratorType(this->GetInput(i), W->GetRequestedRegion());
-    FuzzyIteratorType out = FuzzyIteratorType(W, W->GetRequestedRegion());
+    IteratorType      in(this->GetInput(i), W->GetRequestedRegion());
+    FuzzyIteratorType out(W, W->GetRequestedRegion());
 
     while (!in.IsAtEnd())
     {
@@ -112,7 +112,7 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
   double N = 0.0;
   double g_t = 0.0;
   {
-    FuzzyIteratorType out = FuzzyIteratorType(W, W->GetRequestedRegion());
+    FuzzyIteratorType out(W, W->GetRequestedRegion());
     while (!out.IsAtEnd())
     {
       while (!out.IsAtEndOfLine())
@@ -132,8 +132,8 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
     // Now iterate on estimating specificity and sensitivity
     for (unsigned int i = 0; i < number_of_input_files; ++i)
     {
-      IteratorType      in = IteratorType(this->GetInput(i), W->GetRequestedRegion());
-      FuzzyIteratorType out = FuzzyIteratorType(W, W->GetRequestedRegion());
+      IteratorType      in(this->GetInput(i), W->GetRequestedRegion());
+      FuzzyIteratorType out(W, W->GetRequestedRegion());
 
       double p_num{};
       double p_denom{};
@@ -175,7 +175,7 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
       D_it[i] = IteratorType(this->GetInput(i), W->GetRequestedRegion());
     }
 
-    FuzzyIteratorType out = FuzzyIteratorType(W, W->GetRequestedRegion());
+    FuzzyIteratorType out(W, W->GetRequestedRegion());
     while (!out.IsAtEnd())
     {
       while (!out.IsAtEndOfLine())

--- a/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
@@ -259,9 +259,9 @@ BilateralImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   for (const auto & face : faceList)
   {
     // walk the boundary face and the corresponding section of the output
-    NeighborhoodIteratorType b_iter = NeighborhoodIteratorType(m_GaussianKernel.GetRadius(), this->GetInput(), face);
+    NeighborhoodIteratorType b_iter(m_GaussianKernel.GetRadius(), this->GetInput(), face);
     b_iter.OverrideBoundaryCondition(&BC);
-    ImageRegionIterator<OutputImageType> o_iter = ImageRegionIterator<OutputImageType>(this->GetOutput(), face);
+    ImageRegionIterator<OutputImageType> o_iter(this->GetOutput(), face);
 
     while (!b_iter.IsAtEnd())
     {

--- a/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.hxx
@@ -52,9 +52,8 @@ Hessian3DToVesselnessMeasureImageFilter<TPixel>::GenerateData()
 
   // walk the region of eigen values and get the vesselness measure
   EigenValueArrayType                                 eigenValue;
-  ImageRegionConstIterator<EigenValueOutputImageType> it =
-    ImageRegionConstIterator<EigenValueOutputImageType>(eigenImage, eigenImage->GetRequestedRegion());
-  ImageRegionIterator<OutputImageType> oit;
+  ImageRegionConstIterator<EigenValueOutputImageType> it(eigenImage, eigenImage->GetRequestedRegion());
+  ImageRegionIterator<OutputImageType>                oit;
   this->AllocateOutputs();
   oit = ImageRegionIterator<OutputImageType>(output, output->GetRequestedRegion());
   while (!it.IsAtEnd())

--- a/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.hxx
@@ -59,10 +59,9 @@ SimpleContourExtractorImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
   ZeroFluxNeumannBoundaryCondition<InputImageType> nbc;
   for (const auto & face : faceList)
   {
-    ConstNeighborhoodIterator<InputImageType> bit =
-      ConstNeighborhoodIterator<InputImageType>(this->GetRadius(), input, face);
-    const unsigned int                   neighborhoodSize = bit.Size();
-    ImageRegionIterator<OutputImageType> it = ImageRegionIterator<OutputImageType>(output, face);
+    ConstNeighborhoodIterator<InputImageType> bit(this->GetRadius(), input, face);
+    const unsigned int                        neighborhoodSize = bit.Size();
+    ImageRegionIterator<OutputImageType>      it(output, face);
 
     bit.OverrideBoundaryCondition(&nbc);
     bit.GoToBegin();

--- a/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.hxx
@@ -56,12 +56,11 @@ NoiseImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   // the edge of the buffer.
   for (const auto & face : faceList)
   {
-    ConstNeighborhoodIterator<InputImageType> bit =
-      ConstNeighborhoodIterator<InputImageType>(this->GetRadius(), input, face);
-    const unsigned int neighborhoodSize = bit.Size();
-    auto               num = static_cast<InputRealType>(bit.Size());
+    ConstNeighborhoodIterator<InputImageType> bit(this->GetRadius(), input, face);
+    const unsigned int                        neighborhoodSize = bit.Size();
+    auto                                      num = static_cast<InputRealType>(bit.Size());
 
-    ImageRegionIterator<OutputImageType> it = ImageRegionIterator<OutputImageType>(output, face);
+    ImageRegionIterator<OutputImageType> it(output, face);
     bit.OverrideBoundaryCondition(&nbc);
     bit.GoToBegin();
 

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapper.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapper.cxx
@@ -238,8 +238,8 @@ LinearSystemWrapper::CuthillMckeeOrdering(ColumnArray & newNumbering, int starti
   /* temp storage for re-mapping
                                of rows */
 
-  newNumbering = ColumnArray(this->m_Order);               /* new row numbering */
-  ColumnArray reverseMapping = ColumnArray(this->m_Order); /* allocate temp storage */
+  newNumbering = ColumnArray(this->m_Order); /* new row numbering */
+  ColumnArray reverseMapping(this->m_Order); /* allocate temp storage */
 
   /* find degrees of each row in matrix & initialize newNumbering vector */
   ColumnArray currentRow;               /* column indices of nonzero in

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.hxx
@@ -87,9 +87,8 @@ ConnectedComponentFunctorImageFilter<TInputImage, TOutputImage, TFunctor, TMaskI
 
   // along with a neighborhood iterator on the output, use a standard
   // iterator on the input and output
-  ImageRegionConstIterator<InputImageType> it =
-    ImageRegionConstIterator<InputImageType>(input, output->GetRequestedRegion());
-  ImageRegionIterator<OutputImageType> oit = ImageRegionIterator<OutputImageType>(output, output->GetRequestedRegion());
+  ImageRegionConstIterator<InputImageType> it(input, output->GetRequestedRegion());
+  ImageRegionIterator<OutputImageType>     oit(output, output->GetRequestedRegion());
 
   // Setup a progress reporter.  We have 2 stages to the algorithm so
   // pretend we have 2 times the number of pixels

--- a/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
@@ -152,7 +152,7 @@ ReinitializeLevelSetImageFilter<TLevelSet>::GenerateDataFull()
   m_Marcher->SetTrialPoints(m_Locator->GetOutsidePoints());
   m_Marcher->Update();
 
-  IteratorType tempIt = IteratorType(tempLevelSet, tempLevelSet->GetBufferedRegion());
+  IteratorType tempIt(tempLevelSet, tempLevelSet->GetBufferedRegion());
   while (!inputIt.IsAtEnd())
   {
     auto value = static_cast<double>(inputIt.Get());

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
@@ -338,7 +338,7 @@ Segmenter<TInputImage>::CollectBoundaryInformation(flat_region_table_t & flatReg
       // Grab all the labels of the boundary pixels.
       ImageRegionIterator<typename BoundaryType::face_t> faceIt =
         ImageRegionIterator<typename BoundaryType::face_t>(face, region);
-      ImageRegionIterator<OutputImageType> labelIt = ImageRegionIterator<OutputImageType>(output, region);
+      ImageRegionIterator<OutputImageType> labelIt(output, region);
       faceIt.GoToBegin();
       labelIt.GoToBegin();
       while (!faceIt.IsAtEnd())
@@ -443,9 +443,8 @@ Segmenter<TInputImage>::AnalyzeBoundaryFlow(InputImageTypePointer thresholdImage
       const typename BoundaryType::face_t::Pointer face = boundary->GetFace(idx);
       const ImageRegionType                        region = face->GetRequestedRegion();
 
-      ConstNeighborhoodIterator<InputImageType> searchIt =
-        ConstNeighborhoodIterator<InputImageType>(rad, thresholdImage, region);
-      NeighborhoodIterator<OutputImageType> labelIt = NeighborhoodIterator<OutputImageType>(rad, output, region);
+      ConstNeighborhoodIterator<InputImageType>          searchIt(rad, thresholdImage, region);
+      NeighborhoodIterator<OutputImageType>              labelIt(rad, output, region);
       ImageRegionIterator<typename BoundaryType::face_t> faceIt =
         ImageRegionIterator<typename BoundaryType::face_t>(face, region);
 


### PR DESCRIPTION
Replaced ` (\w+)([ ]+\w+) = \1(\(.+\);)` with ` $1$2$3` in `itk*.hxx` files, using regular expressions.

Aims to avoid having the very same type name twice in a single variable declaration, following the ["DRY principle"](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).