### PR TITLE
BUG: Allow auto registering more than two factories in Python modules

### DIFF
--- a/Wrapping/Generators/Python/itk/support/base.py
+++ b/Wrapping/Generators/Python/itk/support/base.py
@@ -360,7 +360,7 @@ def load_factories(factory_name: str) -> None:
     import itk
 
     for module_name, data in itk_base_global_module_data.items():
-        for name, factory_class_prefix in data.get_module_factories()[:2]:
+        for name, factory_class_prefix in data.get_module_factories():
             if name == factory_name:
                 # Get the factory, loading new modules with itk_load_swig_module as necessary
                 namespace = dict()


### PR DESCRIPTION
If a module had more than two factories (as e.g. RTK), the list was truncated to the first two values which seemed to be arbitrary.

The commit was cherry picked from commit 5d6cc1979085e22a401ad5a0142b9f4ad1374d81

RTK's next release will be based on ITK 5.4; the truncation breaks IO factory registration in RTK users' environments. Backporting this fix prevents runtime IO failures for RTK users who must remain on the 5.4 release line.


