### PR TITLE
STYLE: remove redundant control fllow

### DIFF
--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -209,8 +209,6 @@ Object::SubjectImplementation::InvokeEventRecursion(const EventObject &         
 
     ++i;
   }
-
-  return;
 }
 
 Command *

--- a/Modules/Core/Mesh/include/itkMesh.hxx
+++ b/Modules/Core/Mesh/include/itkMesh.hxx
@@ -173,8 +173,6 @@ Mesh<TPixelType, VDimension, TMeshTraits>::CreateCell(int cellType, CellAutoPoin
     default:
       itkExceptionStringMacro("Unknown mesh cell");
   }
-
-  return;
 }
 
 template <typename TPixelType, unsigned int VDimension, typename TMeshTraits>

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
@@ -236,7 +236,6 @@ public:
     this->ComputeMatrixParameters();
     m_MatrixMTime.Modified();
     this->Modified();
-    return;
   }
 
   /** Get matrix of an MatrixOffsetTransformBase
@@ -266,7 +265,6 @@ public:
     m_Offset = offset;
     this->ComputeTranslation();
     this->Modified();
-    return;
   }
 
   /** Get offset of an MatrixOffsetTransformBase
@@ -308,7 +306,6 @@ public:
     m_Center = center;
     this->ComputeOffset();
     this->Modified();
-    return;
   }
 
   /** Get center of rotation of the MatrixOffsetTransformBase
@@ -335,7 +332,6 @@ public:
     m_Translation = translation;
     this->ComputeOffset();
     this->Modified();
-    return;
   }
 
   /** Get translation component of the MatrixOffsetTransformBase

--- a/Modules/Core/Transform/include/itkRigid3DPerspectiveTransform.h
+++ b/Modules/Core/Transform/include/itkRigid3DPerspectiveTransform.h
@@ -148,7 +148,6 @@ public:
   SetOffset(const OffsetType & offset)
   {
     m_Offset = offset;
-    return;
   }
 
   /** This method sets the rotation of an Rigid3DPerspectiveTransform to a

--- a/Modules/Core/Transform/include/itkTranslationTransform.h
+++ b/Modules/Core/Transform/include/itkTranslationTransform.h
@@ -124,7 +124,6 @@ public:
   SetOffset(const OutputVectorType & offset)
   {
     m_Offset = offset;
-    return;
   }
 
   /** Compose with another TranslationTransform. */

--- a/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
@@ -211,7 +211,6 @@ SliceImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
   }
 
   inputPtr->SetRequestedRegion(inputRequestedRegion);
-  return;
 }
 
 

--- a/Modules/IO/Bruker/include/itkBruker2dseqImageIO.h
+++ b/Modules/IO/Bruker/include/itkBruker2dseqImageIO.h
@@ -117,16 +117,12 @@ public:
   /** Not implemented. */
   void
   WriteImageInformation() override
-  {
-    return;
-  }
+  {}
 
   /** Not implemented - does nothing */
   void
   Write(const void * itkNotUsed(buffer)) override
-  {
-    return;
-  }
+  {}
 
 protected:
   Bruker2dseqImageIO();

--- a/Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIO.h
+++ b/Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIO.h
@@ -190,7 +190,6 @@ protected:
     EncapsulateMetaData<unsigned int>(metaDic, "numberOfLineIndices", numberOfLineIndices);
     EncapsulateMetaData<unsigned int>(metaDic, "numberOfPolygons", numberOfPolygons);
     EncapsulateMetaData<unsigned int>(metaDic, "numberOfPolygonIndices", numberOfPolygonIndices);
-    return;
   }
 
   template <typename T>
@@ -441,8 +440,6 @@ protected:
 
       outputFile << ConvertNumberToString(buffer[ii * this->m_PointDimension + this->m_PointDimension - 1]) << '\n';
     }
-
-    return;
   }
 
   template <typename T>
@@ -454,8 +451,6 @@ protected:
     itk::ByteSwapper<T>::SwapWriteRangeFromSystemToBigEndian(
       buffer, this->m_NumberOfPoints * this->m_PointDimension, &outputFile);
     outputFile << '\n';
-
-    return;
   }
 
   template <typename T>
@@ -800,8 +795,6 @@ protected:
         outputFile << ConvertNumberToString(buffer[ii * this->m_NumberOfPointPixelComponents + jj]) << '\n';
       }
     }
-
-    return;
   }
 
   template <typename T>
@@ -864,7 +857,6 @@ protected:
     itk::ByteSwapper<T>::SwapWriteRangeFromSystemToBigEndian(
       buffer, this->m_NumberOfPointPixels * this->m_NumberOfPointPixelComponents, &outputFile);
     outputFile << '\n';
-    return;
   }
 
   template <typename T>
@@ -990,8 +982,6 @@ protected:
         outputFile << buffer[ii * this->m_NumberOfCellPixelComponents + jj] << '\n';
       }
     }
-
-    return;
   }
 
   template <typename T>
@@ -1054,7 +1044,6 @@ protected:
     itk::ByteSwapper<T>::SwapWriteRangeFromSystemToBigEndian(
       buffer, this->m_NumberOfCells * this->m_NumberOfCellPixelComponents, &outputFile);
     outputFile << '\n';
-    return;
   }
 
   template <typename T>
@@ -1075,8 +1064,6 @@ protected:
 
       outputFile << '\n';
     }
-
-    return;
   }
 
   template <typename T>
@@ -1096,7 +1083,6 @@ protected:
 
     outputFile.write(reinterpret_cast<char *>(data.get()), numberOfElements);
     outputFile << '\n';
-    return;
   }
 
   /** Convert cells buffer for output cells buffer, it's user's responsibility to make sure

--- a/Modules/IO/RAW/include/itkRawImageIO.h
+++ b/Modules/IO/RAW/include/itkRawImageIO.h
@@ -116,9 +116,7 @@ public:
    * user of the class. */
   void
   ReadImageInformation() override
-  {
-    return;
-  }
+  {}
 
   /** Reads the data from disk into the memory buffer provided. */
   void
@@ -154,9 +152,7 @@ public:
   /** Binary files have no image information to read.  */
   void
   WriteImageInformation() override
-  {
-    return;
-  }
+  {}
 
   /** Writes the data to disk from the memory buffer provided. */
   void

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
@@ -804,8 +804,6 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Create
   N[1][2] = N[2][1] = M[0][1] + M[1][0];
   N[1][3] = N[3][1] = M[2][0] + M[0][2];
   N[2][3] = N[3][2] = M[1][2] + M[2][1];
-
-  return;
 }
 
 template <typename TTransform, typename TFixedImage, typename TMovingImage>

--- a/Modules/Registration/Common/test/itkImageToSpatialObjectRegistrationTest.cxx
+++ b/Modules/Registration/Common/test/itkImageToSpatialObjectRegistrationTest.cxx
@@ -158,9 +158,7 @@ public:
   /** Get the Derivatives of the Match Measure */
   void
   GetDerivative(const ParametersType &, DerivativeType &) const override
-  {
-    return;
-  }
+  {}
 
   /** Get the Value for SingleValue Optimizers */
   MeasureType


### PR DESCRIPTION
The clang-tidy check readability-redundant-control-flow looks for procedures
(functions returning no value) with return statements at the end of the
function. Such return statements are redundant.

Loop statements (for, while, do while) are checked for redundant continue
statements at the end of the loop body.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
