### PR TITLE
WIP: BUG: Remove `std` distribution from ConnectedComponentImageFilter tests

### DIFF
--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
@@ -125,18 +125,17 @@ itkConnectedComponentImageFilterTest(int argc, char * argv[])
   std::vector<RGBPixelType> colormap;
   colormap.resize(numObjects + 1);
 
-  using RGBComponentType = RGBPixelType::ComponentType;
-  constexpr auto maxRGBComponentValue = std::numeric_limits<RGBComponentType>::max();
-
   constexpr std::mt19937::result_type randomSeed{ 1031571 };
   std::mt19937                        randomNumberEngine(randomSeed);
-  std::uniform_int_distribution<>     randomNumberDistribution(maxRGBComponentValue / 3, maxRGBComponentValue);
 
   for (auto & i : colormap)
   {
     RGBPixelType px;
-    std::generate(px.begin(), px.end(), [&randomNumberEngine, &randomNumberDistribution] {
-      return static_cast<RGBComponentType>(randomNumberDistribution(randomNumberEngine));
+    std::generate(px.begin(), px.end(), [&randomNumberEngine] {
+      using RGBComponentType = RGBPixelType::ComponentType;
+      constexpr uint32_t maxValue{ std::numeric_limits<RGBComponentType>::max() };
+      constexpr uint32_t minValue{ maxValue / 3 };
+      return static_cast<RGBComponentType>(randomNumberEngine() % (maxValue - minValue + 1) + minValue);
     });
 
     i = px;

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTestRGB.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTestRGB.cxx
@@ -105,17 +105,16 @@ itkConnectedComponentImageFilterTestRGB(int argc, char * argv[])
   RGBPixelType              px;
   colormap.resize(numObjects + 1);
 
-  using RGBComponentType = RGBPixelType::ComponentType;
-  constexpr auto maxRGBComponentValue = std::numeric_limits<RGBComponentType>::max();
-
   constexpr std::mt19937::result_type randomSeed{ 1031571 };
   std::mt19937                        randomNumberEngine(randomSeed);
-  std::uniform_int_distribution<>     randomNumberDistribution(maxRGBComponentValue / 3, maxRGBComponentValue);
 
   for (auto & i : colormap)
   {
-    std::generate(px.begin(), px.end(), [&randomNumberEngine, &randomNumberDistribution] {
-      return static_cast<RGBComponentType>(randomNumberDistribution(randomNumberEngine));
+    std::generate(px.begin(), px.end(), [&randomNumberEngine] {
+      using RGBComponentType = RGBPixelType::ComponentType;
+      constexpr uint32_t maxValue{ std::numeric_limits<RGBComponentType>::max() };
+      constexpr uint32_t minValue{ maxValue / 3 };
+      return static_cast<RGBComponentType>(randomNumberEngine() % (maxValue - minValue + 1) + minValue);
     });
 
     i = px;


### PR DESCRIPTION
`std::uniform_int_distribution` appears to produce different distributions on different platforms. For the ConnectedComponentImageFilter tests, it appears preferable to use the same sequence of random numbers on all platforms.

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/5725 commit 415d2ed579188fac6c94129da72d8222b4432665, "ENH: Replace "vnl_sample.h" with `<random>` in ConnectedComponent tests", Jan 9, 2026.

----

Work in progress: the baseline files still need to be adjusted. @CavRiley can you possibly help me again with the baseline files? 🙏 

Note: this is obviously just a quick-fix. But if these are the only tests that have this problem, maybe it's not worth it to create our own ITK-specific random number distributions 🤷  