### PR TITLE
COMP: Fix syntax error: identifier 'ImageRegionIteratorWithIndex'

### DIFF
--- a/Modules/Nonunit/Review/test/itkWarpJacobianDeterminantFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkWarpJacobianDeterminantFilterTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkDisplacementFieldJacobianDeterminantFilter.h"
+#include "itkImageRegionIteratorWithIndex.h"
 
 
 int


### PR DESCRIPTION
The error message was: `T:\Dashboard\ITK\Modules\Nonunit\Review\test\itkWarpJacobianDeterminantFilterTest.cxx(38,35): error C2061: syntax error: identifier 'ImageRegionIteratorWithIndex' [T:\Dashboard\ITK-build\Modules\Nonunit\Review\test\ITKReviewTestDriver.vcxproj]`

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
