### PR TITLE
COMP: Fix IntensityImageIteratorType is not a class or namespace name

### DIFF
--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -263,8 +263,6 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
 
     ImageRegionConstIteratorWithIndex<TIntensityImage> it(intensityImage, intensityImage->GetBufferedRegion());
 
-    typename IntensityImageIteratorType::IndexType index;
-
     labelIt.GoToBegin();
 
     while (!it.IsAtEnd())
@@ -273,7 +271,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
       auto mapIt = m_LabelGeometryMapper.find(label);
 
       value = static_cast<RealType>(it.Get());
-      index = it.GetIndex();
+      const auto & index = it.GetIndex();
 
       // INTEGRATED PIXEL VALUE
       mapIt->second.m_Sum += value;


### PR DESCRIPTION
The error message was: `T:\Dashboard\ITK\Modules\Nonunit\Review\include\itkLabelGeometryImageFilter.hxx(266,14): error C2653: 'IntensityImageIteratorType': is not a class or namespace name`

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

