### PR TITLE
STYLE: Remove ImageRegionConstIteratorWithIndex from OpenCVVideoCapture

### DIFF
--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoCapture.hxx
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoCapture.hxx
@@ -19,7 +19,6 @@
 #define itkOpenCVVideoCapture_hxx
 
 #include "itkNumericTraits.h"
-#include "itkImageRegionConstIteratorWithIndex.h"
 
 #include "opencv2/core/version.hpp"
 #if !defined(CV_VERSION_EPOCH) // OpenCV >= 3.0
@@ -164,7 +163,6 @@ OpenCVVideoCapture<TVideoStream>::retrieve(cv::Mat & image, int itkNotUsed(chann
   int                          matrixType = CV_MAKETYPE(depth, channels);
 
   // Copy the pixels -- There is probably a faster way to do this
-  ImageRegionConstIteratorWithIndex<FrameType> itkIter(frame, frame->GetLargestPossibleRegion());
 
   // Currently only support mono and RGB (unsigned) char pixels
   IplImage * iplImg = cvCreateImage(cvSize(size[0], size[1]), IPL_DEPTH_8U, channels);


### PR DESCRIPTION
The declared local iterator variable `itkIter` appears unused.

----
 This local variable was introduced with commit 48aba9a7a771ce71ff63d9522cf0bde0c4ad1a02 (9 May 2011), but even then, it was unused: https://github.com/InsightSoftwareConsortium/ITK/blob/48aba9a7a771ce71ff63d9522cf0bde0c4ad1a02/Modules/VideoIO/OpenCV/include/itkOpenCVVideoCapture.txx#L152-L153
@gabehart Do you possibly still have a clue why the variable was introduced in the first place? I hope you agree with its removal, as hereby proposed!
