### PR TITLE
COMP: Let NthElementPixelAccessor follow the Rule of Zero

### DIFF
--- a/Modules/Core/ImageAdaptors/include/itkNthElementPixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkNthElementPixelAccessor.h
@@ -42,6 +42,9 @@ namespace itk
  * For performance, no bound checking is performed during
  * access to the n-th element.
  *
+ * \note NthElementPixelAccessor does not have any user-declared "special member function",
+ * following the C++ Rule of Zero: the compiler will generate them if necessary.
+ *
  * \sa ImageAdaptor
  * \sa PixelAccessor
  *
@@ -100,13 +103,6 @@ public:
   }
 
   ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
-
-  /** Assignment operator */
-  NthElementPixelAccessor &
-  operator=(const NthElementPixelAccessor & accessor) = default;
-
-  /** Constructor */
-  NthElementPixelAccessor() = default;
 
 private:
   // Identifier of the N-th element to be accessed


### PR DESCRIPTION
Removed its user-declared defaulted default-constructor and assignment operator, in order to address C++20 warnings, saying (on Linux/GCC 11.4.0):

    warning: implicitly-declared 'constexpr NthElementPixelAccessor::NthElementPixelAccessor(const NthElementPixelAccessor&)' is deprecated [-Wdeprecated-copy]

----

The warning can be found at https://open.cdash.org/builds/11081768/errors

Full text:
```
/.../s/Modules/Core/ImageAdaptors/include/itkNthElementPixelAccessor.h:208:3: note: because 'itk::NthElementPixelAccessor<float, itk::VariableLengthVector<float> >' has user-provided 'itk::NthElementPixelAccessor<TOutputPixelType, itk::VariableLengthVector<TPixelType> >& itk::NthElementPixelAccessor<TOutputPixelType, itk::VariableLengthVector<TPixelType> >::operator=(const itk::NthElementPixelAccessor<TOutputPixelType, itk::VariableLengthVector<TPixelType> >&) [with TOutputPixelType = float; TPixelType = float]'

/.../s/Modules/Core/ImageAdaptors/include/itkNthElementPixelAccessor.h:208:3: note: because 'itk::NthElementPixelAccessor<float, itk::VariableLengthVector<float> >' has user-provided 'itk::NthElementPixelAccessor<TOutputPixelType, itk::VariableLengthVector<TPixelType> >& itk::NthElementPixelAccessor<TOutputPixelType, itk::VariableLengthVector<TPixelType> >::operator=(const itk::NthElementPixelAccessor<TOutputPixelType, itk::VariableLengthVector<TPixelType> >&) [with TOutputPixelType = float; TPixelType = float]'  208 |   operator=(const NthElementPixelAccessor & accessor)
      |   ^~~~~~~~


/.../s/Modules/Core/Common/include/itkImageConstIterator.h:168:7: warning: implicitly-declared 'constexpr itk::NthElementPixelAccessor<float, itk::VariableLengthVector<float> >::NthElementPixelAccessor(const itk::NthElementPixelAccessor<float, itk::VariableLengthVector<float> >&)' is deprecated [-Wdeprecated-copy]
```