### PR TITLE
BUG: VTK Bridge publicly depends on ITKCommon

### DIFF
--- a/Modules/Bridge/VTK/itk-module.cmake
+++ b/Modules/Bridge/VTK/itk-module.cmake
@@ -16,7 +16,7 @@ into an itk::Image, all without having to duplicate their buffers."
 itk_module(
   ITKVTK
   ENABLE_SHARED
-  PRIVATE_DEPENDS
+  DEPENDS
     ITKCommon
   DESCRIPTION "${DOCUMENTATION}"
 )


### PR DESCRIPTION
Changes VTK Bridge module dependency from PRIVATE_DEPENDS to DEPENDS for ITKCommon, making it a public dependency as required.

The VTK Bridge module's headers include ITKCommon headers, which means ITKCommon must be a public dependency, not a private one. This ensures that consuming the ITKVTK module properly propagates the ITKCommon dependency.

Related to PR #5842

## Changes:
- Modified `Modules/Bridge/VTK/itk-module.cmake` to change `PRIVATE_DEPENDS` to `DEPENDS` for ITKCommon