### PR TITLE
PERF: Replace ComputeIndex with IndexRange in MathematicalMorphology

### DIFF
--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseImageFilter.hxx
@@ -19,9 +19,10 @@
 #define itkAnchorOpenCloseImageFilter_hxx
 
 #include "itkNeighborhoodAlgorithm.h"
-#include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkAnchorUtilities.h"
 #include "itkImageRegionIterator.h"
+#include "itkIndexRange.h"
+
 namespace itk
 {
 template <typename TImage, typename TKernel, typename TCompare1, typename TCompare2>
@@ -175,38 +176,23 @@ AnchorOpenCloseImageFilter<TImage, TKernel, TCompare1, TCompare2>::DoFaceOpen(
 {
   // iterate over the face
 
-  // we can't use an iterator with a region outside the image. All we need here
-  // is to
-  // iterate over all the indexes of the face, without accessing the content of
-  // the image.
-  // I can't find any cleaner way, so we use a dumb image, not even allocated,
-  // to iterate
-  // over all the indexes inside the region.
-  //
-  // using ItType = ImageRegionConstIteratorWithIndex<TImage>;
-  // ItType it(input, face);
-
-  auto dumbImg = TImage::New();
-  dumbImg->SetRegions(face);
-
   KernelLType NormLine = line;
   NormLine.Normalize();
   // set a generous tolerance
   const float tol = 1.0 / LineOffsets.size();
-  for (unsigned int it = 0; it < face.GetNumberOfPixels(); ++it)
+  for (const auto & index : MakeIndexRange(face))
   {
-    const typename TImage::IndexType Ind = dumbImg->ComputeIndex(it);
-    unsigned int                     start = 0;
-    unsigned int                     end = 0;
+    unsigned int start = 0;
+    unsigned int end = 0;
     if (FillLineBuffer<TImage, BresType, KernelLType>(
-          input, Ind, NormLine, tol, LineOffsets, AllImage, outbuffer, start, end))
+          input, index, NormLine, tol, LineOffsets, AllImage, outbuffer, start, end))
     {
       const unsigned int len = end - start + 1;
       // compat
       outbuffer[0] = border;
       outbuffer[len + 1] = border;
       AnchorLineOpen.DoLine(outbuffer, len + 2); // compat
-      CopyLineToImage<TImage, BresType>(output, Ind, LineOffsets, outbuffer, start, end);
+      CopyLineToImage<TImage, BresType>(output, index, LineOffsets, outbuffer, start, end);
     }
   }
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorUtilities.hxx
@@ -18,8 +18,8 @@
 #ifndef itkAnchorUtilities_hxx
 #define itkAnchorUtilities_hxx
 
-#include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkImageRegionConstIterator.h"
+#include "itkIndexRange.h"
 #include "itkNeighborhoodAlgorithm.h"
 
 namespace itk
@@ -45,30 +45,15 @@ DoAnchorFace(const TImage *                            input,
 {
   // iterate over the face
 
-  // we can't use an iterator with a region outside the image. All we need here
-  // is to
-  // iterate over all the indexes of the face, without accessing the content of
-  // the image.
-  // I can't find any cleaner way, so we use a dumb image, not even allocated,
-  // to iterate
-  // over all the indexes inside the region.
-  //
-  // using ItType = ImageRegionConstIteratorWithIndex<TImage>;
-  // ItType it(input, face);
-
-  auto dumbImg = TImage::New();
-  dumbImg->SetRegions(face);
-
   TLine NormLine = line;
   NormLine.Normalize();
   // set a generous tolerance
   const float tol = 1.0 / LineOffsets.size();
-  for (unsigned int it = 0; it < face.GetNumberOfPixels(); ++it)
+  for (const auto & index : MakeIndexRange(face))
   {
-    const typename TImage::IndexType Ind = dumbImg->ComputeIndex(it);
-    unsigned int                     start = 0;
-    unsigned int                     end = 0;
-    if (FillLineBuffer<TImage, TBres, TLine>(input, Ind, NormLine, tol, LineOffsets, AllImage, inbuffer, start, end))
+    unsigned int start = 0;
+    unsigned int end = 0;
+    if (FillLineBuffer<TImage, TBres, TLine>(input, index, NormLine, tol, LineOffsets, AllImage, inbuffer, start, end))
     {
       const unsigned int len = end - start + 1;
       // compat
@@ -76,7 +61,7 @@ DoAnchorFace(const TImage *                            input,
       inbuffer[len + 1] = border;
 
       AnchorLine.DoLine(outbuffer, inbuffer, len + 2); // compat
-      CopyLineToImage<TImage, TBres>(output, Ind, LineOffsets, outbuffer, start, end);
+      CopyLineToImage<TImage, TBres>(output, index, LineOffsets, outbuffer, start, end);
     }
   }
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanUtilities.hxx
@@ -18,8 +18,8 @@
 #ifndef itkVanHerkGilWermanUtilities_hxx
 #define itkVanHerkGilWermanUtilities_hxx
 
-#include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkImageRegionConstIterator.h"
+#include "itkIndexRange.h"
 #include "itkNeighborhoodAlgorithm.h"
 
 namespace itk
@@ -128,31 +128,16 @@ DoFace(typename TImage::ConstPointer             input,
 {
   // iterate over the face
 
-  // we can't use an iterator with a region outside the image. All we need here
-  // is to
-  // iterate over all the indexes of the face, without accessing the content of
-  // the image.
-  // I can't find any cleaner way, so we use a dumb image, not even allocated,
-  // to iterate
-  // over all the indexes inside the region.
-  //
-  // using ItType = ImageRegionConstIteratorWithIndex<TImage>;
-  // ItType it(input, face);
-
-  auto dumbImg = TImage::New();
-  dumbImg->SetRegions(face);
-
   TLine NormLine = line;
   NormLine.Normalize();
   // set a generous tolerance
   const float tol = 1.0 / LineOffsets.size();
   TFunction   m_TF;
-  for (unsigned int it = 0; it < face.GetNumberOfPixels(); ++it)
+  for (const auto & index : MakeIndexRange(face))
   {
-    const typename TImage::IndexType Ind = dumbImg->ComputeIndex(it);
-    unsigned int                     start = 0;
-    unsigned int                     end = 0;
-    if (FillLineBuffer<TImage, TBres, TLine>(input, Ind, NormLine, tol, LineOffsets, AllImage, pixbuffer, start, end))
+    unsigned int start = 0;
+    unsigned int end = 0;
+    if (FillLineBuffer<TImage, TBres, TLine>(input, index, NormLine, tol, LineOffsets, AllImage, pixbuffer, start, end))
     {
       const unsigned int len = end - start + 1;
       // compat
@@ -211,7 +196,7 @@ DoFace(typename TImage::ConstPointer             input,
           pixbuffer[j] = rExtBuffer[j - KernLen / 2];
         }
       }
-      CopyLineToImage<TImage, TBres>(output, Ind, LineOffsets, pixbuffer, start, end);
+      CopyLineToImage<TImage, TBres>(output, index, LineOffsets, pixbuffer, start, end);
     }
   }
 }


### PR DESCRIPTION
Replaced potentially expensive iterative `dumbImg->ComputeIndex(it)` calls with efficient `IndexRange` iteration.

Removed the dummy image (`dumbImg`).

----

Follow-up to commit a8fa92c562fcfdd10a22b4c253b433a3d9c426b4 "BUG: Image iterator was used to iterate over the indexes outside the image. Only the indexes are accessed here, not the pixels, so the image iterator was not the right thing to use.", Gaëtan Lehmann, May 8, 2009. @glehmann I hope it's OK to you!