### PR TITLE
ENH: Cleanup ImageRandomNonRepeatingIteratorWithIndexTest

### DIFF
--- a/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexTest.cxx
@@ -56,176 +56,193 @@ itkImageRandomNonRepeatingIteratorWithIndexTest(int, char *[])
   constexpr PriorityImageType::SizeType  subsize{ 3, 4, 5 };
   constexpr auto                         numberOfPixelsSub = subsize.CalculateProductOfElements();
 
-  auto                                priorityImage = PriorityImageType::New();
-  const PriorityImageType::RegionType priorityRegion{ prioritySize };
-  priorityImage->SetRegions(priorityRegion);
-  priorityImage->Allocate();
-  // we will make most of this image of ones, with a small region of
-  // zeros.  Then pixels from the zero region should be selected
-  // preferentially.
-  std::cout << "Building Priority image" << std::endl;
-  priorityImage->FillBuffer(1);
+  auto priorityImage = PriorityImageType::New();
+  {
+    const PriorityImageType::RegionType priorityRegion{ prioritySize };
+    priorityImage->SetRegions(priorityRegion);
+    priorityImage->Allocate();
+    // we will make most of this image of ones, with a small region of
+    // zeros.  Then pixels from the zero region should be selected
+    // preferentially.
+    std::cout << "Building Priority image" << std::endl;
+    priorityImage->FillBuffer(1);
+  }
 
   const PriorityImageType::RegionType subregion{ substart, subsize };
-  PriorityIteratorType                subit(priorityImage, subregion);
-  subit.GoToBegin();
-  while (!subit.IsAtEnd())
   {
-    subit.Set(0);
-    ++subit;
-  }
-
-  //********
-  std::cout << "Filling image with indices" << std::endl;
-
-  RandomIteratorType it(myImage, region0);
-  it.SetNumberOfSamples(numberOfPixelsSize0);
-  it.GoToBegin();
-  ImageType::IndexType index0;
-  // Because the random iterator does not repeat, this should
-  // fill the image with indices
-  while (!it.IsAtEnd())
-  {
-    index0 = it.GetIndex();
-    it.Set(index0);
-    ++it;
-  }
-
-  // Sample the image
-  IteratorType ot(myImage, region0);
-  ot.GoToBegin();
-  // if it repeated it is going to have missed a few.
-  std::cout << "Verifying iterators... ";
-  while (!ot.IsAtEnd())
-  {
-    index0 = ot.GetIndex();
-    if (ot.Get() != index0)
+    PriorityIteratorType subit(priorityImage, subregion);
+    subit.GoToBegin();
+    while (!subit.IsAtEnd())
     {
-      std::cerr << "Values don't correspond to what was stored " << std::endl;
-      std::cerr << "Test failed at index ";
-      std::cerr << index0 << std::endl;
+      subit.Set(0);
+      ++subit;
+    }
+  }
+
+  {
+    //********
+    std::cout << "Filling image with indices" << std::endl;
+
+    RandomIteratorType it(myImage, region0);
+    it.SetNumberOfSamples(numberOfPixelsSize0);
+    it.GoToBegin();
+    {
+      ImageType::IndexType indexFill0;
+      // Because the random iterator does not repeat, this should
+      // fill the image with indices
+      while (!it.IsAtEnd())
+      {
+        indexFill0 = it.GetIndex();
+        it.Set(indexFill0);
+        ++it;
+      }
+    }
+  }
+  {
+    // Sample the image
+    IteratorType ot(myImage, region0);
+    ot.GoToBegin();
+    // if it repeated it is going to have missed a few.
+    std::cout << "Verifying iterators... ";
+    ImageType::IndexType indexMatch;
+    while (!ot.IsAtEnd())
+    {
+      indexMatch = ot.GetIndex();
+      if (ot.Get() != indexMatch)
+      {
+        std::cerr << "Values don't correspond to what was stored " << std::endl;
+        std::cerr << "Test failed at index ";
+        std::cerr << indexMatch << std::endl;
+        return EXIT_FAILURE;
+      }
+      // std::cout <<".";
+      // std::cout << indexMatch << std::endl;
+      ++ot;
+    }
+    // Now we have walked through all the pixels of low priority,
+    // the next one should be outside the region.
+    if (subregion.IsInside(indexMatch))
+    {
+      std::cerr << "Iterator in priority region test failed" << std::endl;
+      std::cerr << indexMatch << " is outside the region (should be in)" << region0 << std::endl;
       return EXIT_FAILURE;
     }
-    // std::cout <<".";
-    // std::cout << index0 << std::endl;
-    ++ot;
+    std::cout << std::endl << "   Done ! " << std::endl;
   }
-  // Now we have walked through all the pixels of low priority,
-  // the next one should be outside the region.
-  if (subregion.IsInside(index0))
   {
-    std::cerr << "Iterator in priority region test failed" << std::endl;
-    std::cerr << index0 << " is outside the region (should be in)" << region0 << std::endl;
-    return EXIT_FAILURE;
-  }
-  std::cout << std::endl << "   Done ! " << std::endl;
+    // Verification
+    RandomConstIteratorType cot(myConstImage, region0);
+    cot.SetNumberOfSamples(numberOfSamples);
+    cot.GoToBegin();
 
-  // Verification
-  RandomConstIteratorType cot(myConstImage, region0);
-  cot.SetNumberOfSamples(numberOfSamples);
-  cot.GoToBegin();
-
-  std::cout << "Verifying const iterator... ";
-  std::cout << "Random walk of the Iterator over the image " << std::endl;
-  while (!cot.IsAtEnd())
-  {
-    index0 = cot.GetIndex();
-    if (cot.Get() != index0)
+    std::cout << "Verifying const iterator... ";
+    std::cout << "Random walk of the Iterator over the image " << std::endl;
+    ImageType::IndexType indexConstMatch;
+    while (!cot.IsAtEnd())
     {
-      std::cerr << "Values don't correspond to what was stored " << std::endl;
-      std::cerr << "Test failed at index ";
-      std::cerr << index0 << " value is " << cot.Get() << std::endl;
+      indexConstMatch = cot.GetIndex();
+      if (cot.Get() != indexConstMatch)
+      {
+        std::cerr << "Values don't correspond to what was stored " << std::endl;
+        std::cerr << "Test failed at index ";
+        std::cerr << indexConstMatch << " value is " << cot.Get() << std::endl;
+        return EXIT_FAILURE;
+      }
+      std::cout << indexConstMatch << std::endl;
+      ++cot;
+    }
+    // Now we have walked through all the pixels of low priority,
+    // the next one should be outside the region.
+    if (subregion.IsInside(indexConstMatch))
+    {
+      std::cerr << "Iterator in priority region test failed" << std::endl;
+      std::cerr << indexConstMatch << " is outside the region (should be in)" << region0 << std::endl;
       return EXIT_FAILURE;
     }
-    std::cout << index0 << std::endl;
-    ++cot;
+    std::cout << "   Done ! " << std::endl;
   }
-  // Now we have walked through all the pixels of low priority,
-  // the next one should be outside the region.
-  if (subregion.IsInside(index0))
   {
-    std::cerr << "Iterator in priority region test failed" << std::endl;
-    std::cerr << index0 << " is outside the region (should be in)" << region0 << std::endl;
-    return EXIT_FAILURE;
-  }
-  std::cout << "   Done ! " << std::endl;
-
-  // Verification
-  std::cout << "Verifying iterator in reverse direction... " << std::endl;
-  std::cout << "Should be a random walk too (a different one)" << std::endl;
-  RandomIteratorType ior(myImage, region0);
-  ior.SetNumberOfSamples(numberOfSamples);
-  ior.GoToEnd();
-  --ior;
-
-  while (!ior.IsAtBegin())
-  {
-    index0 = ior.GetIndex();
-    if (ior.Get() != index0)
-    {
-      std::cerr << "Values don't correspond to what was stored " << std::endl;
-      std::cerr << "Test failed at index ";
-      std::cerr << index0 << " value is " << ior.Get() << std::endl;
-      return EXIT_FAILURE;
-    }
-    std::cout << index0 << std::endl;
+    // Verification
+    std::cout << "Verifying iterator in reverse direction... " << std::endl;
+    std::cout << "Should be a random walk too (a different one)" << std::endl;
+    RandomIteratorType ior(myImage, region0);
+    ior.SetNumberOfSamples(numberOfSamples);
+    ior.GoToEnd();
     --ior;
+    ImageType::IndexType indexReverse;
+    while (!ior.IsAtBegin())
+    {
+      indexReverse = ior.GetIndex();
+      if (ior.Get() != indexReverse)
+      {
+        std::cerr << "Values don't correspond to what was stored " << std::endl;
+        std::cerr << "Test failed at index ";
+        std::cerr << indexReverse << " value is " << ior.Get() << std::endl;
+        return EXIT_FAILURE;
+      }
+      std::cout << indexReverse << std::endl;
+      --ior;
+    }
+    std::cout << indexReverse << std::endl; // print the value at the beginning index
+    std::cout << "   Done ! " << std::endl;
   }
-  std::cout << index0 << std::endl; // print the value at the beginning index
-  std::cout << "   Done ! " << std::endl;
-
-  // Verification
-  std::cout << "Verifying const iterator in reverse direction... ";
-  RandomConstIteratorType cor(myImage, region0);
-  cor.SetNumberOfSamples(numberOfSamples); // 0=x, 1=y, 2=z
-  cor.GoToEnd();
-  --cor; // start at the end position
-  while (!cor.IsAtBegin())
   {
-    index0 = cor.GetIndex();
-    if (cor.Get() != index0)
+    // Verification
+    std::cout << "Verifying const iterator in reverse direction... ";
+    RandomConstIteratorType cor(myImage, region0);
+    cor.SetNumberOfSamples(numberOfSamples); // 0=x, 1=y, 2=z
+    cor.GoToEnd();
+    --cor; // start at the end position
+    ImageType::IndexType indexConstReverse;
+    while (!cor.IsAtBegin())
     {
-      std::cerr << "Values don't correspond to what was stored " << std::endl;
-      std::cerr << "Test failed at index ";
-      std::cerr << index0 << " value is " << cor.Get() << std::endl;
-      return EXIT_FAILURE;
+      indexConstReverse = cor.GetIndex();
+      if (cor.Get() != indexConstReverse)
+      {
+        std::cerr << "Values don't correspond to what was stored " << std::endl;
+        std::cerr << "Test failed at index ";
+        std::cerr << indexConstReverse << " value is " << cor.Get() << std::endl;
+        return EXIT_FAILURE;
+      }
+      std::cout << indexConstReverse << std::endl;
+      --cor;
     }
-    std::cout << index0 << std::endl;
-    --cor;
+    std::cout << indexConstReverse << std::endl; // print the value at the beginning index
+    std::cout << "   Done ! " << std::endl;
   }
-  std::cout << index0 << std::endl; // print the value at the beginning index
-  std::cout << "   Done ! " << std::endl;
-  // Verification
-  std::cout << "Verifying const iterator in both directions... ";
-  RandomConstIteratorType dor(myImage, region0);
-  dor.SetNumberOfSamples(numberOfSamples); // 0=x, 1=y, 2=z
-  dor.GoToEnd();
-  --dor; // start at the last valid pixel position
-  for (unsigned int counter = 0; !dor.IsAtEnd(); ++counter)
   {
-    index0 = dor.GetIndex();
-    if (dor.Get() != index0)
+    // Verification
+    std::cout << "Verifying const iterator in both directions... ";
+    RandomConstIteratorType dor(myImage, region0);
+    dor.SetNumberOfSamples(numberOfSamples); // 0=x, 1=y, 2=z
+    dor.GoToEnd();
+    --dor; // start at the last valid pixel position
+    ImageType::IndexType indexBiDirectional;
+    for (unsigned int counter = 0; !dor.IsAtEnd(); ++counter)
     {
-      std::cerr << "Values don't correspond to what was stored " << std::endl;
-      std::cerr << "Test failed at index ";
-      std::cerr << index0 << " value is " << dor.Get() << std::endl;
-      return EXIT_FAILURE;
+      indexBiDirectional = dor.GetIndex();
+      if (dor.Get() != indexBiDirectional)
+      {
+        std::cerr << "Values don't correspond to what was stored " << std::endl;
+        std::cerr << "Test failed at index ";
+        std::cerr << indexBiDirectional << " value is " << dor.Get() << std::endl;
+        return EXIT_FAILURE;
+      }
+      std::cout << indexBiDirectional << std::endl;
+      if (counter < 6)
+      {
+        --dor;
+      }
+      else
+      {
+        ++dor;
+      }
     }
-    std::cout << index0 << std::endl;
-    if (counter < 6)
-    {
-      --dor;
-    }
-    else
-    {
-      ++dor;
-    }
+    std::cout << indexBiDirectional << std::endl; // print the value at the beginning index
+    std::cout << "   Done ! " << std::endl;
   }
-  std::cout << index0 << std::endl; // print the value at the beginning index
-  std::cout << "   Done ! " << std::endl;
-
-  // Verification of the Iterator in a subregion of the image
   {
+    // Verification of the Iterator in a subregion of the image
     std::cout << "Verifying Iterator in a Region smaller than the whole image... " << std::endl;
     const ImageType::RegionType region{ start, size };
     RandomIteratorType          cbot(myImage, region);
@@ -250,11 +267,22 @@ itkImageRandomNonRepeatingIteratorWithIndexTest(int, char *[])
       std::cout << index << std::endl;
       ++cbot;
     }
+    {
+      // Now we have walked through all the pixels of low priority,
+      // the next one should be outside the region.
+      ImageType::IndexType indexOnePast = cbot.GetIndex();
+      if (subregion.IsInside(indexOnePast))
+      {
+        std::cerr << "Iterator in priority region test failed" << std::endl;
+        std::cerr << indexOnePast << " is outside the region (should be in)" << region0 << "\n"
+                  << __FILE__ << ":" << __LINE__ << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
     std::cout << "   Done ! " << std::endl;
   }
-
-  // Verification of the Const Iterator in a subregion of the image
   {
+    // Verification of the Const Iterator in a subregion of the image
     std::cout << "Verifying Const Iterator in a Region smaller than the whole image... " << std::endl;
     const ImageType::RegionType region{ start, size };
     RandomConstIteratorType     cbot(myImage, region);
@@ -279,13 +307,22 @@ itkImageRandomNonRepeatingIteratorWithIndexTest(int, char *[])
       std::cout << index << std::endl;
       ++cbot;
     }
+    {
+      ImageType::IndexType indexConstOnePast = cbot.GetIndex();
+      // Now we have walked through all the pixels of low priority,
+      // the next one should be outside the region.
+      if (subregion.IsInside(indexConstOnePast))
+      {
+        std::cerr << "Iterator in priority region test failed" << std::endl;
+        std::cerr << indexConstOnePast << " is outside the region (should be in)" << region0 << "\n"
+                  << __FILE__ << ":" << __LINE__ << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
     std::cout << "   Done ! " << std::endl;
   }
-
-
-  // Verifying iterator works with the priority image
-
   {
+    // Verifying iterator works with the priority image
     std::cout << "Verifying Iterator with respect to priority image... " << std::endl;
 
     RandomIteratorType cbot(myImage, region0);


### PR DESCRIPTION
- **BUG: Fix incorrect priority region iterator test logic**
- **STYLE: Use `constexpr` for region and size initialization**
- **STYLE: Add scoped blocks to improve readability and structure**

A code review of this test indicated that some of the testing
was not occuring in a way that was consistent with the comments
and cout reporting.

Moved testing that was out of place closer to where the variables
being tested were mutated, and fixed a bug where two tests
were testing the same unmutated variable. By moving the tests
to locations where they matched the diagnostic comments, the two
tests become independant.

Added more testing cases to ensure that iterating to the end
results in a value that is not isInside() the valid region.


## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
