### PR TITLE
COMP: Fix missing alias for iterator types

### DIFF
--- a/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.hxx
@@ -154,8 +154,7 @@ FFTWComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::ThreadedGenerat
   {
     // copy the input line into our buffer
     inputIt.GoToBeginOfLine();
-    typename InputIteratorType::PixelType * inputBufferIt =
-      reinterpret_cast<typename InputIteratorType::PixelType *>(m_InputBufferArray[threadID]);
+    auto * inputBufferIt = reinterpret_cast<typename InputImageType::PixelType *>(m_InputBufferArray[threadID]);
     while (!inputIt.IsAtEndOfLine())
     {
       *inputBufferIt = inputIt.Get();
@@ -169,8 +168,7 @@ FFTWComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::ThreadedGenerat
     if (this->m_TransformDirection == Superclass::DIRECT)
     {
       // copy the output from the buffer into our line
-      typename OutputIteratorType::PixelType * outputBufferIt =
-        reinterpret_cast<typename OutputIteratorType::PixelType *>(m_OutputBufferArray[threadID]);
+      auto * outputBufferIt = reinterpret_cast<typename OutputImageType::PixelType *>(m_OutputBufferArray[threadID]);
       outputIt.GoToBeginOfLine();
       while (!outputIt.IsAtEndOfLine())
       {
@@ -182,11 +180,11 @@ FFTWComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::ThreadedGenerat
     else // m_TransformDirection == INVERSE
     {
       // copy the output from the buffer into our line
-      inputBufferIt = reinterpret_cast<typename OutputIteratorType::PixelType *>(m_OutputBufferArray[threadID]);
+      inputBufferIt = reinterpret_cast<typename OutputImageType::PixelType *>(m_OutputBufferArray[threadID]);
       outputIt.GoToBeginOfLine();
       while (!outputIt.IsAtEndOfLine())
       {
-        outputIt.Set(*inputBufferIt / static_cast<typename OutputIteratorType::PixelType>(lineSize));
+        outputIt.Set(*inputBufferIt / static_cast<typename OutputImageType::PixelType>(lineSize));
         ++outputIt;
         ++inputBufferIt;
       }

--- a/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.hxx
@@ -145,8 +145,7 @@ FFTWInverse1DFFTImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(con
   {
     // copy the input line into our buffer
     inputIt.GoToBeginOfLine();
-    typename InputIteratorType::PixelType * inputBufferIt =
-      reinterpret_cast<typename InputIteratorType::PixelType *>(m_InputBufferArray[threadID]);
+    auto * inputBufferIt = reinterpret_cast<typename InputImageType::PixelType *>(m_InputBufferArray[threadID]);
     while (!inputIt.IsAtEndOfLine())
     {
       *inputBufferIt = inputIt.Get();


### PR DESCRIPTION
Fixes #5857, i.e. compile errors introduced by cfd3cad35d4496b2482141c0f0cba899ffb073d5, e.g.:
```
C:\src\itk\ITK-main\Modules\Filtering\FFT\include\itkFFTWComplexToComplex1DFFTImageFilter.hxx(191,11): error C2065: 'inputBufferIt' : undeclared identifier [C:\src\itk\2019-main-Shared-Debug-FFTWON\Modules\Filtering\FFT\src\ITKFFT.vcxproj
C:\src\itk\ITK-main\Modules\Filtering\FFT\include\itkFFTWComplexToComplex1DFFTImageFilter.hxx(189,80): error C2061: syntax error : identifier 'PixelType' [C:\src\itk\2019-main-Shared-Debug-FFTWON\Modules\Filtering\FFT\src\ITKFFT.vcxproj]
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
