### PR TITLE
COMP: Suppress deprecated VariableLengthVector::AllocateElements warnings in MSVC wrapping builds

### DIFF
--- a/Wrapping/macro_files/itk_end_wrap_module.cmake
+++ b/Wrapping/macro_files/itk_end_wrap_module.cmake
@@ -546,12 +546,13 @@ ${DO_NOT_WAIT_FOR_THREADS_CALLS}
       )
 
       if(MSVC)
-        # Disables 'conversion from 'type1' to 'type2', possible loss of data warnings
+        # /wd4244: Disables 'conversion from 'type1' to 'type2', possible loss of data warnings
+        # /wd4996: Disables deprecated declaration warnings in generated wrapper code
         set_target_properties(
           ${lib}
           PROPERTIES
             COMPILE_FLAGS
-              "/wd4244"
+              "/wd4244 /wd4996"
         )
       endif()
     else()


### PR DESCRIPTION
## Summary

- Add `/wd4996` to MSVC compile flags for SWIG-generated Python wrapper targets to suppress C4996 (deprecated declaration) warnings

## Background

After `VariableLengthVector::AllocateElements` was deprecated with `[[deprecated("Please consider calling std::make_unique<TValue[]>(size) instead.")]]`, the SWIG-generated Python wrapper code (`itkVariableLengthVectorPython.cpp`) triggers MSVC warning C4996 for each wrapped template instantiation:

```
itkVariableLengthVectorPython.cpp(5150): warning C4996: 'itk::VariableLengthVector<std::complex<float>>::AllocateElements'
itkVariableLengthVectorPython.cpp(7765): warning C4996: 'itk::VariableLengthVector<double>::AllocateElements'
itkVariableLengthVectorPython.cpp(10633): warning C4996: 'itk::VariableLengthVector<float>::AllocateElements'
itkVariableLengthVectorPython.cpp(13501): warning C4996: 'itk::VariableLengthVector<short>::AllocateElements'
itkVariableLengthVectorPython.cpp(16369): warning C4996: 'itk::VariableLengthVector<unsigned char>::AllocateElements'
```

This happens because SWIG auto-generates wrapper functions that directly call the now-deprecated `AllocateElements` method. The generated code cannot be modified to avoid these calls.

## Fix

Add `/wd4996` alongside the existing `/wd4244` in the MSVC compile flags for wrapping targets in `Wrapping/macro_files/itk_end_wrap_module.cmake`. This is consistent with GCC/Clang wrapping builds, which already suppress **all** warnings via the `-w` flag on the same targets. Deprecation warnings remain active for hand-written ITK C++ code; this only affects auto-generated SWIG wrapper compilation.