### PR TITLE
COMP: Fix additional missing alias for iterator types

### DIFF
--- a/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.hxx
@@ -158,7 +158,7 @@ FFTWForward1DFFTImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(con
     outputIt.GoToBeginOfLine();
     while (!outputIt.IsAtEndOfLine())
     {
-      outputIt.Set(*(reinterpret_cast<typename OutputIteratorType::PixelType *>(outputBufferIt)));
+      outputIt.Set(*(reinterpret_cast<typename OutputImageType::PixelType *>(outputBufferIt)));
       ++outputIt;
       ++outputBufferIt;
     }


### PR DESCRIPTION
This complements 920c6818db15eaf60cf9bbf02eec74e235c02d04 which left the following error behind:
```
C:\src\itk\ITK-main\Modules\Filtering\FFT\include\itkFFTWForward1DFFTImageFilter.hxx(161,68): error C2061: syntax error : identifier 'PixelType' [C:\src\itk\2019-main-Shared-Debug-FFTWON\Modules\Filtering\FFT\src\ITKFFT.vcxproj]
```

Sorry, I don't know why it did not show up yesterday but here are the builds before and after the change:
https://my.cdash.org/builds/3397150/errors
https://my.cdash.org/builds/3399612/errors

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
