### PR TITLE
COMP: Make VariableLengthVector::AllocateElements ITK_FUTURE_DEPRECATED

### DIFF
--- a/Modules/Core/Common/include/itkVariableLengthVector.h
+++ b/Modules/Core/Common/include/itkVariableLengthVector.h
@@ -770,7 +770,8 @@ public:
    * parameter).
    * \deprecated Please consider calling `std::make_unique<TValue[]>(size)` instead.
    */
-  [[deprecated("Please consider calling `std::make_unique<TValue[]>(size)` instead.")]] [[nodiscard]] TValue *
+  ITK_FUTURE_DEPRECATED("Please consider calling `std::make_unique<TValue[]>(size)` instead.")
+  [[nodiscard]] TValue *
   AllocateElements(ElementIdentifier size) const;
 #endif
 


### PR DESCRIPTION
This member function is only marked `ITK_FUTURE_LEGACY_REMOVE`, so using this member function should only trigger a warning when legacy support is removed _and_ `ITK_LEGACY_SILENT` is off.

Aims to fix warnings like:

    itkVariableLengthVectorPython.cpp(5150): warning C4996: 'itk::VariableLengthVector::AllocateElements': Please consider calling `std::make_unique<TValue[]>(size)` instead.

At [Windows_NT-Build4935-main-Python](https://open.cdash.org/builds/11095793)

- As reported by Matt McCormick (@thewtex) at pull request #5863
