### PR TITLE
PERF: Use `ImageRegionIterator<OutputImageAdaptorType>` without index

### DIFF
--- a/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
@@ -19,7 +19,6 @@
 #define itkHessianRecursiveGaussianImageFilter_hxx
 
 #include "itkImageRegionIterator.h"
-#include "itkImageRegionIteratorWithIndex.h"
 #include "itkProgressAccumulator.h"
 #include <algorithm> // For generate.
 
@@ -288,7 +287,7 @@ HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
 
       ImageRegionIterator<RealImageType> it(derivativeImage, derivativeImage->GetRequestedRegion());
 
-      ImageRegionIteratorWithIndex<OutputImageAdaptorType> ot(m_ImageAdaptor, m_ImageAdaptor->GetRequestedRegion());
+      ImageRegionIterator<OutputImageAdaptorType> ot(m_ImageAdaptor, m_ImageAdaptor->GetRequestedRegion());
 
       const RealType spacingA = inputImage->GetSpacing()[dima];
       const RealType spacingB = inputImage->GetSpacing()[dimb];

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkGradientRecursiveGaussianImageFilter_hxx
 #define itkGradientRecursiveGaussianImageFilter_hxx
 
-#include "itkImageRegionIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionConstIterator.h"
 #include "itkPrintHelper.h"
@@ -241,7 +240,7 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
 
       ImageRegionIterator<RealImageType> it(derivativeImage, derivativeImage->GetRequestedRegion());
 
-      ImageRegionIteratorWithIndex<OutputImageAdaptorType> ot(m_ImageAdaptor, m_ImageAdaptor->GetRequestedRegion());
+      ImageRegionIterator<OutputImageAdaptorType> ot(m_ImageAdaptor, m_ImageAdaptor->GetRequestedRegion());
 
       const ScalarRealType spacing = inputImage->GetSpacing()[dim];
 


### PR DESCRIPTION
- Following pull request https://github.com/InsightSoftwareConsortium/ITK/pull/5848 commit 3180a2f1f453f36bb908fbf5cfed06567d85aa5f
"PERF: Use ImageRegionIterator without "WithIndex" in `*.hxx` files"

- Note that this improvement is only possible because of the following fix: pull request https://github.com/InsightSoftwareConsortium/ITK/pull/5872 commit 1e3a8833514971e28853d637862a11c7fd87a425
"BUG: Add ImageAdaptor::ComputeOffset, to fix ImageRegionIterator support"