### PR TITLE
ENH: Convert itkAbortProcessObjectTest to itkAbortProcessObjectGTest

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -2,7 +2,6 @@ itk_module_test()
 set(
   ITKCommon1Tests
   itkImageRegionExplicitTest.cxx
-  itkAbortProcessObjectTest.cxx
   itkCommandObserverObjectTest.cxx
   itkAdaptorComparisonTest.cxx
   itkCovariantVectorGeometryTest.cxx
@@ -224,12 +223,6 @@ if(ITK_BUILD_SHARED_LIBS)
   add_dependencies(ITKCommon2TestDriver FactoryTestLib)
 endif()
 
-itk_add_test(
-  NAME itkAbortProcessObjectTest
-  COMMAND
-    ITKCommon1TestDriver
-    itkAbortProcessObjectTest
-)
 itk_add_test(
   NAME itkCommandObserverObjectTest
   COMMAND
@@ -1781,6 +1774,7 @@ set(
   itkAutoPointerGTest.cxx
   itkStdStreamStateSaveGTest.cxx
   itkDecoratorGTest.cxx
+  itkAbortProcessObjectGTest.cxx
 )
 creategoogletestdriver(ITKCommon "${ITKCommon-Test_LIBRARIES}" "${ITKCommonGTests}")
 # If `-static` was passed to CMAKE_EXE_LINKER_FLAGS, compilation fails. No need to

--- a/Modules/Core/Common/test/itkAbortProcessObjectGTest.cxx
+++ b/Modules/Core/Common/test/itkAbortProcessObjectGTest.cxx
@@ -99,15 +99,6 @@ TEST(AbortProcessObject, ConvertedLegacyTest)
 
   std::cout << extract << std::endl;
 
-  bool exceptionCaught = false;
-  try
-  {
-    extract->UpdateLargestPossibleRegion();
-  }
-  catch (const itk::ProcessAborted &)
-  {
-    exceptionCaught = true;
-  }
-  EXPECT_TRUE(exceptionCaught) << "Expected ProcessAborted exception to be thrown.";
+  EXPECT_THROW(extract->UpdateLargestPossibleRegion(), itk::ProcessAborted);
   EXPECT_TRUE(onAbortCalled) << "Expected Abort Event callback to be called.";
 }

--- a/Modules/Core/Common/test/itkAbortProcessObjectGTest.cxx
+++ b/Modules/Core/Common/test/itkAbortProcessObjectGTest.cxx
@@ -16,11 +16,11 @@
  *
  *=========================================================================*/
 
-#include <iostream>
 #include "itkExtractImageFilter.h"
-#include "itkTestingMacros.h"
-
+#include "itkGTest.h"
 #include "itkCommand.h"
+
+#include <iostream>
 
 //
 // This test ensures the abort event occurs and the ProcessAborted
@@ -56,8 +56,7 @@ onAbort(itk::Object *, const itk::EventObject &, void *)
 
 } // namespace
 
-int
-itkAbortProcessObjectTest(int, char *[])
+TEST(AbortProcessObject, ConvertedLegacyTest)
 {
   // type alias to simplify the syntax
   using ShortImage = itk::Image<short, 2>;
@@ -99,19 +98,16 @@ itkAbortProcessObjectTest(int, char *[])
   extract->AddObserver(itk::AbortEvent(), abortCmd);
 
   std::cout << extract << std::endl;
+
+  bool exceptionCaught = false;
   try
   {
     extract->UpdateLargestPossibleRegion();
   }
   catch (const itk::ProcessAborted &)
   {
-    if (onAbortCalled)
-    {
-      std::cout << "PASS: Abort event occurred and exception was thrown." << std::endl;
-      return EXIT_SUCCESS;
-    }
-    std::cout << "Caught expected abort exception, but didn't get Abort Event!";
+    exceptionCaught = true;
   }
-  std::cout << "Test FAILED!" << std::endl;
-  return EXIT_FAILURE;
+  EXPECT_TRUE(exceptionCaught) << "Expected ProcessAborted exception to be thrown.";
+  EXPECT_TRUE(onAbortCalled) << "Expected Abort Event callback to be called.";
 }


### PR DESCRIPTION
Convert legacy ITK CTest driver test to GoogleTest (GTest) framework.

This is part of the ongoing effort to modernize ITK's test suite by converting no-argument CTest tests to the GoogleTest framework for improved test organization, better failure reporting, and modern C++ testing practices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)