### PR TITLE
ENH: Convert itkAutoPointerTest to itkAutoPointerGTest

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -130,7 +130,6 @@ set(
   itkConstNeighborhoodIteratorTest.cxx
   itkShapedNeighborhoodIteratorTest.cxx
   itkMatrixTest.cxx
-  itkAutoPointerTest.cxx
   itkNeighborhoodIteratorTest.cxx
   itkLoggerManagerTest.cxx
   itkBSplineInterpolationWeightFunctionTest.cxx
@@ -436,12 +435,6 @@ itk_add_test(
   COMMAND
     ITKCommon1TestDriver
     itkArray2DTest
-)
-itk_add_test(
-  NAME itkAutoPointerTest
-  COMMAND
-    ITKCommon2TestDriver
-    itkAutoPointerTest
 )
 itk_add_test(
   NAME itkBSplineInterpolationWeightFunctionTest
@@ -1806,6 +1799,7 @@ set(
   itkMetaDataDictionaryGTest.cxx
   itkSpatialOrientationAdaptorGTest.cxx
   itkAnatomicalOrientationGTest.cxx
+  itkAutoPointerGTest.cxx
 )
 creategoogletestdriver(ITKCommon "${ITKCommon-Test_LIBRARIES}" "${ITKCommonGTests}")
 # If `-static` was passed to CMAKE_EXE_LINKER_FLAGS, compilation fails. No need to

--- a/Modules/Core/Common/test/itkAutoPointerGTest.cxx
+++ b/Modules/Core/Common/test/itkAutoPointerGTest.cxx
@@ -16,9 +16,10 @@
  *
  *=========================================================================*/
 
-#include <iostream>
-
 #include "itkAutoPointer.h"
+#include "itkGTest.h"
+
+#include <iostream>
 
 class TestObject
 {
@@ -36,32 +37,36 @@ public:
 };
 
 
-int
-itkAutoPointerTest(int, char *[])
+TEST(AutoPointer, OwnershipTransfer)
 {
-
   auto * obj = new TestObject;
 
   TestObject::AutoPointer ptr1;
   ptr1.TakeOwnership(obj);
 
   std::cout << "after assignment from raw pointer" << std::endl;
+  EXPECT_TRUE(ptr1.IsOwner());
   std::cout << "ptr1 IsOwner = " << ptr1.IsOwner() << std::endl;
 
+  EXPECT_STREQ(ptr1->GetClassName(), "my Class name is TestObject");
   std::cout << ptr1->GetClassName() << std::endl;
 
   TestObject::AutoPointer ptr2(ptr1);
 
   std::cout << "after copy constructor " << std::endl;
+  EXPECT_FALSE(ptr1.IsOwner());
   std::cout << "ptr1 IsOwner = " << ptr1.IsOwner() << std::endl;
+  EXPECT_TRUE(ptr2.IsOwner());
   std::cout << "ptr2 IsOwner = " << ptr2.IsOwner() << std::endl;
 
   ptr2.Reset();
   std::cout << "after Reset " << std::endl;
+  EXPECT_FALSE(ptr2.IsOwner());
   std::cout << "ptr2 IsOwner = " << ptr2.IsOwner() << std::endl;
 
   ptr1.TakeOwnership(new TestObject);
   std::cout << "after assignment from raw pointer" << std::endl;
+  EXPECT_TRUE(ptr1.IsOwner());
   std::cout << "ptr1 IsOwner = " << ptr1.IsOwner() << std::endl;
 
   // The following test exercise the methods but don't validate the results
@@ -84,7 +89,4 @@ itkAutoPointerTest(int, char *[])
 
 
   const TestObject::ConstAutoPointer cptr2(cptr1);
-
-
-  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Convert legacy ITK CTest driver test to GoogleTest (GTest) framework.

This is part of the ongoing effort to modernize ITK's test suite by converting no-argument CTest tests to the GoogleTest framework for improved test organization, better failure reporting, and modern C++ testing practices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)