### PR TITLE
ENH: Convert itkDecoratorTest to itkDecoratorGTest

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -6,7 +6,6 @@ set(
   itkCommandObserverObjectTest.cxx
   itkAdaptorComparisonTest.cxx
   itkCovariantVectorGeometryTest.cxx
-  itkDecoratorTest.cxx
   itkExtractImage3Dto2DTest.cxx
   itkExtractImageTest.cxx
   itkFilterDispatchTest.cxx
@@ -298,12 +297,6 @@ itk_add_test(
   COMMAND
     ITKCommon1TestDriver
     itkCovariantVectorGeometryTest
-)
-itk_add_test(
-  NAME itkDecoratorTest
-  COMMAND
-    ITKCommon1TestDriver
-    itkDecoratorTest
 )
 itk_add_test(
   NAME itkExtractImage3Dto2DTest
@@ -1794,6 +1787,7 @@ set(
   itkAnatomicalOrientationGTest.cxx
   itkAutoPointerGTest.cxx
   itkStdStreamStateSaveGTest.cxx
+  itkDecoratorGTest.cxx
 )
 creategoogletestdriver(ITKCommon "${ITKCommon-Test_LIBRARIES}" "${ITKCommonGTests}")
 # If `-static` was passed to CMAKE_EXE_LINKER_FLAGS, compilation fails. No need to

--- a/Modules/Core/Common/test/itkDecoratorGTest.cxx
+++ b/Modules/Core/Common/test/itkDecoratorGTest.cxx
@@ -21,7 +21,7 @@
 #include "itkSimpleDataObjectDecorator.h"
 #include "itkDataObjectDecorator.h"
 #include "itkAutoPointerDataObjectDecorator.h"
-#include "itkTestingMacros.h"
+#include "itkGTest.h"
 
 namespace
 {
@@ -34,10 +34,8 @@ operator<<(std::basic_ostream<CharType, TraitsType> & os, const std::vector<Memb
 }
 } // namespace
 
-int
-itkDecoratorTest(int, char *[])
+TEST(Decorator, ConvertedLegacyTest)
 {
-
   using FloatObjectType = itk::SimpleDataObjectDecorator<float>;
 
   auto f = FloatObjectType::New();
@@ -59,16 +57,16 @@ itkDecoratorTest(int, char *[])
 
   const itk::ModifiedTimeType t1 = decoratedTransform->GetMTime();
   transformObject->Modified();
-  ITK_TEST_EXPECT_TRUE(t1 < decoratedTransform->GetMTime());
+  EXPECT_GT(decoratedTransform->GetMTime(), t1);
 
   auto decoratedTransform2 = TransformObjectType::New();
   decoratedTransform2->Graft(decoratedTransform);
 
-  ITK_TEST_EXPECT_EQUAL(decoratedTransform2->Get(), decoratedTransform->Get());
+  EXPECT_EQ(decoratedTransform2->Get(), decoratedTransform->Get());
 
   const itk::ModifiedTimeType t2 = decoratedTransform->GetMTime();
   decoratedTransform2->GetModifiable()->Modified();
-  ITK_TEST_EXPECT_TRUE(t2 < decoratedTransform->GetMTime());
+  EXPECT_GT(decoratedTransform->GetMTime(), t2);
 
 
   std::cout << "Value of decoratedTransform: ";
@@ -81,25 +79,25 @@ itkDecoratorTest(int, char *[])
   auto decoratedBaseTransform = TransformBaseObjectType::New();
   // NOTE: GetPointer is needed to force selection of the correct overloaded function signature.
   decoratedBaseTransform->Graft(decoratedTransform.GetPointer());
-  ITK_TEST_EXPECT_TRUE(decoratedBaseTransform->Get() != nullptr);
+  EXPECT_TRUE(decoratedBaseTransform->Get() != nullptr);
 
   decoratedBaseTransform->ReleaseData();
-  ITK_TEST_EXPECT_TRUE(decoratedBaseTransform->Get() == nullptr);
+  EXPECT_EQ(decoratedBaseTransform->Get(), nullptr);
   // NOTE: GetPointer is needed to force selection of the correct overloaded function signature.
   decoratedBaseTransform->Graft(f.GetPointer());
-  ITK_TEST_EXPECT_TRUE(decoratedBaseTransform->Get() == nullptr);
+  EXPECT_TRUE(decoratedBaseTransform->Get() == nullptr);
 
   decoratedBaseTransform->Graft(static_cast<itk::DataObject *>(nullptr));
   // NOTE: GetPointer is needed to force selection of the correct overloaded function signature.
   decoratedBaseTransform->Graft(decoratedTransform.GetPointer());
-  ITK_TEST_EXPECT_TRUE(decoratedBaseTransform->Get() != nullptr);
+  EXPECT_NE(decoratedBaseTransform->Get(), nullptr);
 
   decoratedBaseTransform->Graft(static_cast<itk::DataObject *>(nullptr));
-  ITK_TEST_EXPECT_TRUE(decoratedBaseTransform->Get() != nullptr);
+  EXPECT_TRUE(decoratedBaseTransform->Get() != nullptr);
 
   decoratedTransform->ReleaseData();
   decoratedTransform->Graft(decoratedBaseTransform);
-  ITK_TEST_EXPECT_TRUE(decoratedTransform->Get() == nullptr);
+  EXPECT_TRUE(decoratedTransform->Get() == nullptr);
 
   using VectorType = std::vector<float>;
   using VectorObjectType = itk::SimpleDataObjectDecorator<VectorType>;
@@ -149,5 +147,4 @@ itkDecoratorTest(int, char *[])
 
 
   std::cout << "Test finished." << std::endl;
-  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Convert legacy ITK CTest driver test to GoogleTest (GTest) framework.

This is part of the ongoing effort to modernize ITK's test suite by converting no-argument CTest tests to the GoogleTest framework for improved test organization, better failure reporting, and modern C++ testing practices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)