### PR TITLE
ENH: Convert itkDerivativeOperatorTest to itkDerivativeOperatorGTest

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -39,7 +39,6 @@ set(
   itkStreamingImageFilterTest2.cxx
   itkStreamingImageFilterTest3.cxx
   itkLoggerTest.cxx
-  itkDerivativeOperatorTest.cxx
   itkColorTableTest.cxx
   itkNumericTraitsTest.cxx
   itkImageRegionTest.cxx
@@ -307,12 +306,6 @@ itk_add_test(
     ITKCommon1TestDriver
     itkDirectoryTest
     ${TEMP}
-)
-itk_add_test(
-  NAME itkDerivativeOperatorTest
-  COMMAND
-    ITKCommon1TestDriver
-    itkDerivativeOperatorTest
 )
 itk_add_test(
   NAME itkMultipleLogOutputTest
@@ -1682,6 +1675,7 @@ set(
   itkCrossHelperGTest.cxx
   itkAdaptorComparisonGTest.cxx
   itkFloodFillIteratorGTest.cxx
+  itkDerivativeOperatorGTest.cxx
 )
 creategoogletestdriver(ITKCommon "${ITKCommon-Test_LIBRARIES}" "${ITKCommonGTests}")
 # If `-static` was passed to CMAKE_EXE_LINKER_FLAGS, compilation fails. No need to

--- a/Modules/Core/Common/test/itkDerivativeOperatorGTest.cxx
+++ b/Modules/Core/Common/test/itkDerivativeOperatorGTest.cxx
@@ -16,10 +16,10 @@
  *
  *=========================================================================*/
 
-
-#include "itkMath.h"
+// First include the header file to be tested:
 #include "itkDerivativeOperator.h"
-#include "itkTestingMacros.h"
+#include "itkMath.h"
+#include "itkGTest.h"
 
 namespace itk
 {
@@ -58,8 +58,8 @@ public:
 };
 } // namespace itk
 
-int
-itkDerivativeOperatorTest(int, char *[])
+
+TEST(DerivativeOperator, ConvertedLegacyTest)
 {
   constexpr unsigned int Dimension{ 1 };
   using PixelType = float;
@@ -67,9 +67,10 @@ itkDerivativeOperatorTest(int, char *[])
   // Exercise object basic methods
   using DerivativeOperatorType = itk::DerivativeOperator<PixelType, Dimension>;
 
-  DerivativeOperatorType derivativeOperator;
+  DerivativeOperatorType   derivativeOperator;
+  DerivativeOperatorType * derivativeOperatorPtr = &derivativeOperator;
 
-  ITK_EXERCISE_BASIC_OBJECT_METHODS((&derivativeOperator), DerivativeOperator, NeighborhoodOperator);
+  ITK_GTEST_EXERCISE_BASIC_OBJECT_METHODS(derivativeOperatorPtr, DerivativeOperator, NeighborhoodOperator);
 
 
   // Test other methods using the helper
@@ -79,48 +80,33 @@ itkDerivativeOperatorTest(int, char *[])
 
   unsigned int order = 1;
   op1.SetOrder(order);
-  ITK_TEST_SET_GET_VALUE(order, op1.GetOrder());
+  EXPECT_EQ(op1.GetOrder(), order);
 
   order = 2;
   op1.SetOrder(order);
-  ITK_TEST_SET_GET_VALUE(order, op1.GetOrder());
+  EXPECT_EQ(op1.GetOrder(), order);
 
   order = 1;
   op1.SetOrder(order);
-  ITK_TEST_SET_GET_VALUE(order, op1.GetOrder());
+  EXPECT_EQ(op1.GetOrder(), order);
 
 
   OperatorType::CoefficientVector expected1{ 0.5, 0.0, -0.5 };
 
   // Check actual coefficient values
-  if (!op1.CheckCoefficients(expected1))
-  {
-    std::cerr << "Test failed!" << std::endl;
-    std::cerr << "Error in coefficients" << std::endl;
-    return EXIT_FAILURE;
-  }
+  EXPECT_TRUE(op1.CheckCoefficients(expected1));
 
   // Test copy constructor
   OperatorType op1b(op1);
 
   // Check actual coefficient values
-  if (!op1b.CheckCoefficients(expected1))
-  {
-    std::cerr << "Test failed!" << std::endl;
-    std::cerr << "Copy constructor failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+  EXPECT_TRUE(op1b.CheckCoefficients(expected1));
 
   // Test operator assignment
   OperatorType op1c(op1);
 
   // Check actual coefficient values
-  if (!op1c.CheckCoefficients(expected1))
-  {
-    std::cerr << "Test failed!" << std::endl;
-    std::cerr << "Operator assignment failed" << std::endl;
-    return EXIT_FAILURE;
-  }
+  EXPECT_TRUE(op1c.CheckCoefficients(expected1));
 
   // Test second order
   OperatorType::CoefficientVector expected2{ 1, -2, 1 };
@@ -130,14 +116,5 @@ itkDerivativeOperatorTest(int, char *[])
   op2.SetOrder(2);
 
   // Check actual coefficient values
-  if (!op2.CheckCoefficients(expected2))
-  {
-    std::cerr << "Test failed!" << std::endl;
-    std::cerr << "Error in coefficients" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-
-  std::cout << "Test finished." << std::endl;
-  return EXIT_SUCCESS;
+  EXPECT_TRUE(op2.CheckCoefficients(expected2));
 }


### PR DESCRIPTION
Convert legacy ITK CTest driver test to GoogleTest (GTest) framework.

This is part of the ongoing effort to modernize ITK's test suite by converting no-argument CTest tests to the GoogleTest framework for improved test organization, better failure reporting, and modern C++ testing practices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)