### PR TITLE
ENH: Convert itkCrossHelperTest to itkCrossHelperGTest

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -58,7 +58,6 @@ set(
   itkImageIteratorTest.cxx
   itkImageRegionIteratorTest.cxx
   itkImageScanlineIteratorTest1.cxx
-  itkCrossHelperTest.cxx
   itkImageIteratorWithIndexTest.cxx
   itkDirectoryTest.cxx
   itkObjectStoreTest.cxx
@@ -524,12 +523,6 @@ itk_add_test(
     itkGaussianSpatialFunctionTest
     19.0
     1
-)
-itk_add_test(
-  NAME itkCrossHelperTest
-  COMMAND
-    ITKCommon1TestDriver
-    itkCrossHelperTest
 )
 itk_add_test(
   NAME itkImageIteratorTest
@@ -1706,6 +1699,7 @@ set(
   itkImportContainerGTest.cxx
   itkPixelAccessGTest.cxx
   itkImageTransformGTest.cxx
+  itkCrossHelperGTest.cxx
 )
 creategoogletestdriver(ITKCommon "${ITKCommon-Test_LIBRARIES}" "${ITKCommonGTests}")
 # If `-static` was passed to CMAKE_EXE_LINKER_FLAGS, compilation fails. No need to

--- a/Modules/Core/Common/test/itkCrossHelperGTest.cxx
+++ b/Modules/Core/Common/test/itkCrossHelperGTest.cxx
@@ -17,12 +17,12 @@
  *=========================================================================*/
 #include "itkVector.h"
 #include "itkCrossHelper.h"
+#include "itkGTest.h"
 
 #include <iostream>
 
 
-int
-itkCrossHelperTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
+TEST(CrossHelper, ConvertedLegacyTest)
 {
   constexpr unsigned int Dimension2D{ 2 };
   constexpr unsigned int Dimension3D{ 3 };
@@ -51,11 +51,8 @@ itkCrossHelperTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
   v2d[0] = 0.;
   v2d[1] = 1.;
 
-  if (cross2d(u2d, v2d).GetNorm() > 1e-6)
-  {
-    std::cout << "cross product must return null vector is dimension is below 3" << std::endl;
-    return EXIT_FAILURE;
-  }
+  // cross product must return null vector when dimension is below 3
+  EXPECT_LT(cross2d(u2d, v2d).GetNorm(), 1e-6);
 
   Vector3DType u3d;
   u3d[0] = 1.;
@@ -72,23 +69,9 @@ itkCrossHelperTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
   w3d[1] = 0.;
   w3d[2] = 1.;
 
-  if ((cross3d(u3d, v3d) - w3d).GetNorm() > 1e-6)
-  {
-    std::cout << "cross3d( u3d, v3d ) != w3d" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  if ((cross3d(v3d, w3d) - u3d).GetNorm() > 1e-6)
-  {
-    std::cout << "cross3d( v3d, w3d ) != u3d" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  if ((cross3d(w3d, u3d) - v3d).GetNorm() > 1e-6)
-  {
-    std::cout << "cross3d( w3d, u3d ) != v3d" << std::endl;
-    return EXIT_FAILURE;
-  }
+  EXPECT_LT((cross3d(u3d, v3d) - w3d).GetNorm(), 1e-6);
+  EXPECT_LT((cross3d(v3d, w3d) - u3d).GetNorm(), 1e-6);
+  EXPECT_LT((cross3d(w3d, u3d) - v3d).GetNorm(), 1e-6);
 
   Vector4DType u4d;
   u4d[0] = 1.;
@@ -108,11 +91,5 @@ itkCrossHelperTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
   w4d[2] = 1.;
   w4d[3] = 0.;
 
-  if ((cross4d(u4d, v4d) - w4d).GetNorm() > 1e-6)
-  {
-    std::cout << "cross4d( u4d, v4d ) != w4d" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  return EXIT_SUCCESS;
+  EXPECT_LT((cross4d(u4d, v4d) - w4d).GetNorm(), 1e-6);
 }


### PR DESCRIPTION
Convert legacy ITK CTest driver test to GoogleTest (GTest) framework.

This is part of the ongoing effort to modernize ITK's test suite by converting no-argument CTest tests to the GoogleTest framework for improved test organization, better failure reporting, and modern C++ testing practices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)