### PR TITLE
ENH: Convert VNLSparseLUSolverTraitsTest to GTest

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -79,7 +79,6 @@ set(
   itkTimeProbeTest.cxx
   itkTimeProbeTest2.cxx
   itkSpatialOrientationTest.cxx
-  VNLSparseLUSolverTraitsTest.cxx
   itkSobelOperatorImageConvolutionTest.cxx
   itkSobelOperatorImageFilterTest.cxx
 )
@@ -372,12 +371,6 @@ itk_add_test(
   COMMAND
     ITKCommon1TestDriver
     itkSpatialOrientationTest
-)
-itk_add_test(
-  NAME VNLSparseLUSolverTraitsTest
-  COMMAND
-    ITKCommon1TestDriver
-    VNLSparseLUSolverTraitsTest
 )
 itk_add_test(
   NAME itkGaussianDerivativeOperatorTest
@@ -1694,6 +1687,7 @@ set(
   itkMetaDataDictionaryGTest.cxx
   itkSpatialOrientationAdaptorGTest.cxx
   itkAnatomicalOrientationGTest.cxx
+<<<<<<< HEAD
   itkAutoPointerGTest.cxx
   itkStdStreamStateSaveGTest.cxx
   itkDecoratorGTest.cxx
@@ -1706,6 +1700,7 @@ set(
   itkImportContainerGTest.cxx
   itkPixelAccessGTest.cxx
   itkImageTransformGTest.cxx
+  VNLSparseLUSolverTraitsGTest.cxx
 )
 creategoogletestdriver(ITKCommon "${ITKCommon-Test_LIBRARIES}" "${ITKCommonGTests}")
 # If `-static` was passed to CMAKE_EXE_LINKER_FLAGS, compilation fails. No need to

--- a/Modules/Core/Common/test/VNLSparseLUSolverTraitsGTest.cxx
+++ b/Modules/Core/Common/test/VNLSparseLUSolverTraitsGTest.cxx
@@ -18,9 +18,9 @@
 
 #include "VNLSparseLUSolverTraits.h"
 #include "itkMath.h" // itk::Math::Absolute
+#include "itkGTest.h"
 
 #include <iostream>
-#include <cstdlib>
 
 template <class TVector>
 bool
@@ -44,8 +44,7 @@ VectorsEquals(const TVector & v1, const TVector & v2, const typename TVector::el
   return true;
 }
 
-int
-VNLSparseLUSolverTraitsTest(int, char *[])
+TEST(VNLSparseLUSolverTraits, SolveLinearSystem)
 {
   /**
    * Define an sparse LU solver traits type that operates over sparse matrices and
@@ -109,10 +108,7 @@ VNLSparseLUSolverTraitsTest(int, char *[])
   {
     VectorType X = SolverTraits::InitializeVector(N);
     SolverTraits::Solve(A, Bx, X);
-    if (!VectorsEquals(X, Xexpected, tolerance))
-    {
-      return EXIT_FAILURE;
-    }
+    EXPECT_TRUE(VectorsEquals(X, Xexpected, tolerance));
   }
 
   /**
@@ -123,10 +119,8 @@ VNLSparseLUSolverTraitsTest(int, char *[])
     VectorType Y = SolverTraits::InitializeVector(N);
     SolverTraits::Solve(A, Bx, X);
     SolverTraits::Solve(A, By, Y);
-    if (!VectorsEquals(X, Xexpected, tolerance) || !VectorsEquals(Y, Yexpected, tolerance))
-    {
-      return EXIT_FAILURE;
-    }
+    EXPECT_TRUE(VectorsEquals(X, Xexpected, tolerance));
+    EXPECT_TRUE(VectorsEquals(Y, Yexpected, tolerance));
   }
 
   /**
@@ -139,11 +133,9 @@ VNLSparseLUSolverTraitsTest(int, char *[])
     SolverTraits::Solve(A, Bx, X);
     SolverTraits::Solve(A, By, Y);
     SolverTraits::Solve(A, Bz, Z);
-    if (!VectorsEquals(X, Xexpected, tolerance) || !VectorsEquals(Y, Yexpected, tolerance) ||
-        !VectorsEquals(Z, Zexpected, tolerance))
-    {
-      return EXIT_FAILURE;
-    }
+    EXPECT_TRUE(VectorsEquals(X, Xexpected, tolerance));
+    EXPECT_TRUE(VectorsEquals(Y, Yexpected, tolerance));
+    EXPECT_TRUE(VectorsEquals(Z, Zexpected, tolerance));
   }
 
   /**
@@ -155,17 +147,11 @@ VNLSparseLUSolverTraitsTest(int, char *[])
 
     // First back-substitution
     SolverTraits::Solve(solver, Bx, X);
-    if (!VectorsEquals(X, Xexpected, tolerance))
-    {
-      return EXIT_FAILURE;
-    }
+    EXPECT_TRUE(VectorsEquals(X, Xexpected, tolerance));
 
     // Second back-substitution (reusing the already factored matrix)
     SolverTraits::Solve(solver, Bx, X);
-    if (!VectorsEquals(X, Xexpected, tolerance))
-    {
-      return EXIT_FAILURE;
-    }
+    EXPECT_TRUE(VectorsEquals(X, Xexpected, tolerance));
   }
 
   /**
@@ -179,18 +165,14 @@ VNLSparseLUSolverTraitsTest(int, char *[])
     // First back-substitution
     SolverTraits::Solve(solver, Bx, X);
     SolverTraits::Solve(solver, By, Y);
-    if (!VectorsEquals(X, Xexpected, tolerance) || !VectorsEquals(Y, Yexpected, tolerance))
-    {
-      return EXIT_FAILURE;
-    }
+    EXPECT_TRUE(VectorsEquals(X, Xexpected, tolerance));
+    EXPECT_TRUE(VectorsEquals(Y, Yexpected, tolerance));
 
     // Second back-substitution (reusing the already factored matrix)
     SolverTraits::Solve(solver, Bx, X);
     SolverTraits::Solve(solver, By, Y);
-    if (!VectorsEquals(X, Xexpected, tolerance) || !VectorsEquals(Y, Yexpected, tolerance))
-    {
-      return EXIT_FAILURE;
-    }
+    EXPECT_TRUE(VectorsEquals(X, Xexpected, tolerance));
+    EXPECT_TRUE(VectorsEquals(Y, Yexpected, tolerance));
   }
 
   /**
@@ -207,22 +189,16 @@ VNLSparseLUSolverTraitsTest(int, char *[])
     SolverTraits::Solve(solver, Bx, X);
     SolverTraits::Solve(solver, By, Y);
     SolverTraits::Solve(solver, Bz, Z);
-    if (!VectorsEquals(X, Xexpected, tolerance) || !VectorsEquals(Y, Yexpected, tolerance) ||
-        !VectorsEquals(Z, Zexpected, tolerance))
-    {
-      return EXIT_FAILURE;
-    }
+    EXPECT_TRUE(VectorsEquals(X, Xexpected, tolerance));
+    EXPECT_TRUE(VectorsEquals(Y, Yexpected, tolerance));
+    EXPECT_TRUE(VectorsEquals(Z, Zexpected, tolerance));
 
     // Second back-substitution (reusing the already factored matrix)
     SolverTraits::Solve(solver, Bx, X);
     SolverTraits::Solve(solver, By, Y);
     SolverTraits::Solve(solver, Bz, Z);
-    if (!VectorsEquals(X, Xexpected, tolerance) || !VectorsEquals(Y, Yexpected, tolerance) ||
-        !VectorsEquals(Z, Zexpected, tolerance))
-    {
-      return EXIT_FAILURE;
-    }
+    EXPECT_TRUE(VectorsEquals(X, Xexpected, tolerance));
+    EXPECT_TRUE(VectorsEquals(Y, Yexpected, tolerance));
+    EXPECT_TRUE(VectorsEquals(Z, Zexpected, tolerance));
   }
-
-  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Convert legacy ITK CTest driver test to GoogleTest (GTest) framework.

This is part of the ongoing effort to modernize ITK's test suite by converting no-argument CTest tests to the GoogleTest framework for improved test organization, better failure reporting, and modern C++ testing practices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)