### PR TITLE
ENH: Convert itkAdaptorComparisonTest to GTest

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -3,7 +3,6 @@ set(
   ITKCommon1Tests
   itkImageRegionExplicitTest.cxx
   itkCommandObserverObjectTest.cxx
-  itkAdaptorComparisonTest.cxx
   itkCovariantVectorGeometryTest.cxx
   itkExtractImage3Dto2DTest.cxx
   itkExtractImageTest.cxx
@@ -215,12 +214,6 @@ itk_add_test(
   COMMAND
     ITKCommon1TestDriver
     itkCommandObserverObjectTest
-)
-itk_add_test(
-  NAME itkAdaptorComparisonTest
-  COMMAND
-    ITKCommon1TestDriver
-    itkAdaptorComparisonTest
 )
 itk_add_test(
   NAME itkThreadedIteratorRangePartitionerTest
@@ -1693,6 +1686,7 @@ set(
   itkPixelAccessGTest.cxx
   itkImageTransformGTest.cxx
   itkAnnulusOperatorGTest.cxx
+  itkAdaptorComparisonGTest.cxx
 )
 creategoogletestdriver(ITKCommon "${ITKCommon-Test_LIBRARIES}" "${ITKCommonGTests}")
 # If `-static` was passed to CMAKE_EXE_LINKER_FLAGS, compilation fails. No need to

--- a/Modules/Core/Common/test/itkAdaptorComparisonGTest.cxx
+++ b/Modules/Core/Common/test/itkAdaptorComparisonGTest.cxx
@@ -16,16 +16,17 @@
  *
  *=========================================================================*/
 
-#include <iostream>
-#include <ctime>
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
+#include "itkGTest.h"
+
+namespace
+{
 
 void
 AdaptorSupportedIteratorSpeed(itk::Image<float, 3> * img)
 {
   itk::ImageRegionIteratorWithIndex<itk::Image<float, 3>> it(img, img->GetRequestedRegion());
-
   while (!it.IsAtEnd())
   {
     ++it;
@@ -36,7 +37,6 @@ void
 NoAdaptorSupportIteratorSpeed(itk::Image<float, 3> * img)
 {
   itk::ImageRegionIterator<itk::Image<float, 3>> it(img, img->GetRequestedRegion());
-
   while (!it.IsAtEnd())
   {
     ++it;
@@ -47,7 +47,6 @@ void
 AdaptorSupportedModifyScalars(itk::Image<float, 3> * img)
 {
   itk::ImageRegionIteratorWithIndex<itk::Image<float, 3>> it(img, img->GetRequestedRegion());
-
   while (!it.IsAtEnd())
   {
     // *it += 3.435f;
@@ -60,7 +59,6 @@ void
 NoAdaptorSupportModifyScalars(itk::Image<float, 3> * img)
 {
   itk::ImageRegionIterator<itk::Image<float, 3>> it(img, img->GetRequestedRegion());
-
   while (!it.IsAtEnd())
   {
     // *it += 3.435f;
@@ -73,7 +71,6 @@ void
 BypassAdaptorSupportModifyScalars(itk::Image<float, 3> * img)
 {
   itk::ImageRegionIteratorWithIndex<itk::Image<float, 3>> it(img, img->GetRequestedRegion());
-
   while (!it.IsAtEnd())
   {
     it.Value() += 3.435f;
@@ -88,7 +85,6 @@ AdaptorSupportedModifyVectors(itk::Image<itk::Vector<float, 3>, 3> * img)
   using VectorType = itk::Vector<float, N>;
 
   itk::ImageRegionIteratorWithIndex<itk::Image<VectorType, 3>> it(img, img->GetRequestedRegion());
-
   while (!it.IsAtEnd())
   {
     VectorType temp_vector = it.Get();
@@ -96,7 +92,6 @@ AdaptorSupportedModifyVectors(itk::Image<itk::Vector<float, 3>, 3> * img)
     {
       temp_vector[i] += 3.435f;
     }
-
     it.Set(temp_vector);
     ++it;
   }
@@ -109,7 +104,6 @@ NoAdaptorSupportModifyVectors(itk::Image<itk::Vector<float, 3>, 3> * img)
   using VectorType = itk::Vector<float, N>;
 
   itk::ImageRegionIterator<itk::Image<VectorType, 3>> it(img, img->GetRequestedRegion());
-
   while (!it.IsAtEnd())
   {
     VectorType temp_vector = it.Get();
@@ -131,18 +125,15 @@ BypassAdaptorSupportModifyVectors(itk::Image<itk::Vector<float, 3>, 3> * img)
   using VectorType = itk::Vector<float, N>;
 
   itk::ImageRegionIteratorWithIndex<itk::Image<VectorType, 3>> it(img, img->GetRequestedRegion());
-
   while (!it.IsAtEnd())
   {
     for (unsigned int i = 0; i < N; ++i)
     {
       (it.Value())[i] += 3.435f;
     }
-
     ++it;
   }
 }
-
 
 void
 BypassNoAdaptorSupportModifyVectors(itk::Image<itk::Vector<float, 3>, 3> * img)
@@ -151,7 +142,6 @@ BypassNoAdaptorSupportModifyVectors(itk::Image<itk::Vector<float, 3>, 3> * img)
   using VectorType = itk::Vector<float, N>;
 
   itk::ImageRegionIterator<itk::Image<VectorType, 3>> it(img, img->GetRequestedRegion());
-
   while (!it.IsAtEnd())
   {
     for (unsigned int i = 0; i < N; ++i)
@@ -162,17 +152,18 @@ BypassNoAdaptorSupportModifyVectors(itk::Image<itk::Vector<float, 3>, 3> * img)
   }
 }
 
+} // namespace
 
-int
-itkAdaptorComparisonTest(int, char *[])
+
+TEST(AdaptorComparison, IteratorOperationsComplete)
 {
   using ScalarImageType = itk::Image<float, 3>;
   using VectorImageType = itk::Image<itk::Vector<float, 3>, 3>;
 
-  // Set up some images
-  constexpr itk::Size<3> size{ 100, 100, 100 };
+  constexpr itk::Size<3> size{ { 100, 100, 100 } };
   itk::ImageRegion<3>    region{ size };
 
+  // Set up some images
   auto scalar_image = ScalarImageType::New();
   auto vector_image = VectorImageType::New();
 
@@ -182,80 +173,16 @@ itkAdaptorComparisonTest(int, char *[])
   vector_image->SetRegions(region);
   vector_image->Allocate();
 
-  auto initialVectorValue = itk::MakeFilled<VectorImageType::PixelType>(1.2345); // arbitrary value;
+  auto initialVectorValue = itk::MakeFilled<VectorImageType::PixelType>(1.2345f); // arbitrary value;
   vector_image->FillBuffer(initialVectorValue);
 
-  // Time trials
-
-  std::cout << "Speed of adaptor supporting iterator (for reference) \t";
-
-  const clock_t adaptor_comp = [&]() -> auto {
-    const auto start = clock();
-    AdaptorSupportedIteratorSpeed(scalar_image);
-    const auto stop = clock();
-    return stop - start;
-  }();
-
-  std::cout << adaptor_comp << std::endl;
-  const clock_t no_adaptor_comp = [=](auto scalarImage) {
-    std::cout << "Speed of iterator that does not support adaptors (for reference) \t";
-    const auto start = clock();
-    NoAdaptorSupportIteratorSpeed(scalarImage);
-    const auto stop = clock();
-    return stop - start;
-  }(scalar_image);
-  std::cout << no_adaptor_comp << std::endl;
-  {
-    std::cout << "Modifying scalar image using adaptor iterator...\t";
-    const auto start = clock();
-    AdaptorSupportedModifyScalars(scalar_image);
-    const auto stop = clock();
-    std::cout << (stop - start) << "\t compensated = " << (stop - start) - adaptor_comp << std::endl;
-  }
-  {
-    std::cout << "Modifying scalar image using non-adaptor iterator...\t";
-    const auto start = clock();
-    NoAdaptorSupportModifyScalars(scalar_image);
-    const auto stop = clock();
-    std::cout << (stop - start) << "\t compensated = " << (stop - start) - no_adaptor_comp << std::endl;
-  }
-  {
-    std::cout << "Modifying vector image using adaptor iterator...\t";
-    const auto start = clock();
-    AdaptorSupportedModifyVectors(vector_image);
-    const auto stop = clock();
-    std::cout << (stop - start) << "\t compensated = " << (stop - start) - adaptor_comp << std::endl;
-  }
-  {
-    std::cout << "Modifying vector image using non-adaptor iterator...\t";
-    const auto start = clock();
-    NoAdaptorSupportModifyVectors(vector_image);
-    const auto stop = clock();
-    std::cout << (stop - start) << "\t compensated = " << (stop - start) - no_adaptor_comp << std::endl;
-  }
-  {
-    std::cout << "Modifying scalar image bypassing adaptor api using"
-              << " adaptor iterator...\t";
-    const auto start = clock();
-    BypassAdaptorSupportModifyScalars(scalar_image);
-    const auto stop = clock();
-    std::cout << (stop - start) << "\t compensated = " << (stop - start) - adaptor_comp << std::endl;
-  }
-  {
-    std::cout << "Modifying vector image bypassing adaptor api using"
-              << " non-adaptor iterator...\t";
-    const auto start = clock();
-    BypassNoAdaptorSupportModifyVectors(vector_image);
-    const auto stop = clock();
-    std::cout << (stop - start) << "\t compensated = " << (stop - start) - adaptor_comp << std::endl;
-  }
-  {
-    std::cout << "Modifying vector image bypassing adaptor api using"
-              << " adaptor iterator...\t";
-    const auto start = clock();
-    BypassAdaptorSupportModifyVectors(vector_image);
-    const auto stop = clock();
-    std::cout << (stop - start) << "\t compensated = " << (stop - start) - adaptor_comp << std::endl;
-  }
-  return EXIT_SUCCESS;
+  AdaptorSupportedIteratorSpeed(scalar_image);
+  NoAdaptorSupportIteratorSpeed(scalar_image);
+  AdaptorSupportedModifyScalars(scalar_image);
+  NoAdaptorSupportModifyScalars(scalar_image);
+  AdaptorSupportedModifyVectors(vector_image);
+  NoAdaptorSupportModifyVectors(vector_image);
+  BypassAdaptorSupportModifyScalars(scalar_image);
+  BypassNoAdaptorSupportModifyVectors(vector_image);
+  BypassAdaptorSupportModifyVectors(vector_image);
 }


### PR DESCRIPTION
Convert legacy ITK CTest driver test to GoogleTest (GTest) framework.

This is part of the ongoing effort to modernize ITK's test suite by converting no-argument CTest tests to the GoogleTest framework for improved test organization, better failure reporting, and modern C++ testing practices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)