### PR TITLE
ENH: Convert itkFloodFillIteratorTest to GTest

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -1686,6 +1686,7 @@ set(
   itkPixelAccessGTest.cxx
   itkImageTransformGTest.cxx
   itkAnnulusOperatorGTest.cxx
+  itkCrossHelperGTest.cxx
   itkAdaptorComparisonGTest.cxx
 )
 creategoogletestdriver(ITKCommon "${ITKCommon-Test_LIBRARIES}" "${ITKCommonGTests}")

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -7,7 +7,6 @@ set(
   itkExtractImage3Dto2DTest.cxx
   itkExtractImageTest.cxx
   itkFloodFilledSpatialFunctionTest.cxx
-  itkFloodFillIteratorTest.cxx
   itkGaussianDerivativeOperatorTest.cxx
   itkMapContainerTest.cxx
   itkVectorContainerTest.cxx
@@ -269,12 +268,6 @@ itk_add_test(
   COMMAND
     ITKCommon1TestDriver
     itkFloodFilledSpatialFunctionTest
-)
-itk_add_test(
-  NAME itkFloodFillIteratorTest
-  COMMAND
-    ITKCommon1TestDriver
-    itkFloodFillIteratorTest
 )
 
 itk_add_test(
@@ -1688,6 +1681,7 @@ set(
   itkAnnulusOperatorGTest.cxx
   itkCrossHelperGTest.cxx
   itkAdaptorComparisonGTest.cxx
+  itkFloodFillIteratorGTest.cxx
 )
 creategoogletestdriver(ITKCommon "${ITKCommon-Test_LIBRARIES}" "${ITKCommonGTests}")
 # If `-static` was passed to CMAKE_EXE_LINKER_FLAGS, compilation fails. No need to

--- a/Modules/Core/Common/test/itkFloodFillIteratorGTest.cxx
+++ b/Modules/Core/Common/test/itkFloodFillIteratorGTest.cxx
@@ -16,60 +16,39 @@
  *
  *=========================================================================*/
 
-#include <iostream>
-
-// Native ITK stuff
 #include "itkImageRegionIterator.h"
-
-// Spatial function stuff
 #include "itkSphereSpatialFunction.h"
 #include "itkFloodFilledSpatialFunctionConditionalIterator.h"
+#include "itkGTest.h"
 
-int
-itkFloodFillIteratorTest(int, char *[])
+#include <iostream>
+
+
+TEST(FloodFillIterator, SphereFloodFill)
 {
   constexpr unsigned int dim{ 3 };
 
-  // Image type alias
   using TImageType = itk::Image<int, dim>;
 
-  //-----------------Create a new input image--------------------
-  // Image size and spacing parameters
   TImageType::SizeValueType    sourceImageSize[] = { 20, 20, 20 };
   TImageType::SpacingValueType sourceImageSpacing[] = { 1.0, 1.0, 1.0 };
   TImageType::PointValueType   sourceImageOrigin[] = { 0, 0, 0 };
 
-  // Creates the sourceImage (but doesn't set the size or allocate memory)
   auto sourceImage = TImageType::New();
   sourceImage->SetOrigin(sourceImageOrigin);
   sourceImage->SetSpacing(sourceImageSpacing);
 
-  std::cout << "New sourceImage created" << std::endl;
-
-  //-----The following block allocates the sourceImage-----
-
-  // Create a size object native to the sourceImage type
   TImageType::SizeType sourceImageSizeObject;
-  // Set the size object to the array defined earlier
   sourceImageSizeObject.SetSize(sourceImageSize);
-  // Create a region object native to the sourceImage type
   TImageType::RegionType largestPossibleRegion;
-  // Resize the region
   largestPossibleRegion.SetSize(sourceImageSizeObject);
-  // Set the largest legal region size (i.e. the size of the whole sourceImage), the buffered, and
-  // the requested region to what we just defined.
   sourceImage->SetRegions(largestPossibleRegion);
-  // Now allocate memory for the sourceImage
   sourceImage->AllocateInitialized();
 
-  std::cout << "New sourceImage allocated" << std::endl;
-
-  //---------Create and initialize a spatial function-----------
+  std::cout << "New sourceImage created and allocated" << std::endl;
 
   using TFunctionType = itk::SphereSpatialFunction<dim>;
   using TFunctionPositionType = TFunctionType::InputType;
-
-  // Create and initialize a new sphere function
 
   auto spatialFunc = TFunctionType::New();
   spatialFunc->SetRadius(5);
@@ -80,9 +59,6 @@ itkFloodFillIteratorTest(int, char *[])
   center[2] = 10;
   spatialFunc->SetCenter(center);
 
-  std::cout << "Sphere spatial function created" << std::endl;
-
-  //---------Create and initialize a spatial function iterator-----------
   TImageType::IndexType                seedPos;
   constexpr TImageType::IndexValueType pos[]{ 10, 10, 10 };
   seedPos.SetIndex(pos);
@@ -90,7 +66,6 @@ itkFloodFillIteratorTest(int, char *[])
   using TItType = itk::FloodFilledSpatialFunctionConditionalIterator<TImageType, TFunctionType>;
   TItType sfi(sourceImage, spatialFunc, seedPos);
 
-  // Iterate through the entire image and set interior pixels to 255
   for (; !(sfi.IsAtEnd()); ++sfi)
   {
 
@@ -99,6 +74,4 @@ itkFloodFillIteratorTest(int, char *[])
   }
 
   std::cout << "Spatial function iterator created, sphere drawn" << std::endl;
-
-  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Convert legacy ITK CTest driver test to GoogleTest (GTest) framework.

This is part of the ongoing effort to modernize ITK's test suite by converting no-argument CTest tests to the GoogleTest framework for improved test organization, better failure reporting, and modern C++ testing practices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)