### PR TITLE
ENH: Convert itkFloodFilledSpatialFunctionTest to GTest

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -6,7 +6,6 @@ set(
   itkCovariantVectorGeometryTest.cxx
   itkExtractImage3Dto2DTest.cxx
   itkExtractImageTest.cxx
-  itkFloodFilledSpatialFunctionTest.cxx
   itkGaussianDerivativeOperatorTest.cxx
   itkMapContainerTest.cxx
   itkVectorContainerTest.cxx
@@ -262,13 +261,6 @@ itk_add_test(
     ITKCommon1TestDriver
     itkExtractImageTest
 )
-itk_add_test(
-  NAME itkFloodFilledSpatialFunctionTest
-  COMMAND
-    ITKCommon1TestDriver
-    itkFloodFilledSpatialFunctionTest
-)
-
 itk_add_test(
   NAME itkColorTableTest1
   COMMAND
@@ -1676,6 +1668,7 @@ set(
   itkAdaptorComparisonGTest.cxx
   itkFloodFillIteratorGTest.cxx
   itkDerivativeOperatorGTest.cxx
+  itkFloodFilledSpatialFunctionGTest.cxx
 )
 creategoogletestdriver(ITKCommon "${ITKCommon-Test_LIBRARIES}" "${ITKCommonGTests}")
 # If `-static` was passed to CMAKE_EXE_LINKER_FLAGS, compilation fails. No need to

--- a/Modules/Core/Common/test/itkFloodFilledSpatialFunctionGTest.cxx
+++ b/Modules/Core/Common/test/itkFloodFilledSpatialFunctionGTest.cxx
@@ -25,9 +25,10 @@ to itkFloodFilledSpatialFunctionConditionalIterator.
 #include "itkImageRegionIterator.h"
 #include "itkSphereSpatialFunction.h"
 #include "itkFloodFilledSpatialFunctionConditionalIterator.h"
+#include "itkGTest.h"
 
-int
-itkFloodFilledSpatialFunctionTest(int, char *[])
+
+TEST(FloodFilledSpatialFunction, InclusionStrategies)
 {
   constexpr unsigned int dim{ 2 };
 
@@ -129,6 +130,4 @@ itkFloodFilledSpatialFunctionTest(int, char *[])
     }
 
   } // end loop over iterator strategies
-
-  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Convert legacy ITK CTest driver test to GoogleTest (GTest) framework.

This is part of the ongoing effort to modernize ITK's test suite by converting no-argument CTest tests to the GoogleTest framework for improved test organization, better failure reporting, and modern C++ testing practices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)