### PR TITLE
ENH: Convert itkThreadedImageRegionPartitionerTest to GTest

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -83,7 +83,6 @@ set(
   itkThreadedIteratorRangePartitionerTest.cxx
   itkThreadedIteratorRangePartitionerTest2.cxx
   itkThreadedIteratorRangePartitionerTest3.cxx
-  itkThreadedImageRegionPartitionerTest.cxx
   itkThreadLoggerTest.cxx
   itkLoggerThreadWrapperTest.cxx
   itkThreadDefsTest.cxx
@@ -236,12 +235,6 @@ itk_add_test(
   COMMAND
     ITKCommon1TestDriver
     itkImageAdaptorPipeLineTest
-)
-itk_add_test(
-  NAME itkThreadedImageRegionPartitionerTest
-  COMMAND
-    ITKCommon2TestDriver
-    itkThreadedImageRegionPartitionerTest
 )
 itk_add_test(
   NAME itkCovariantVectorGeometryTest
@@ -1669,6 +1662,7 @@ set(
   itkFloodFillIteratorGTest.cxx
   itkDerivativeOperatorGTest.cxx
   itkFloodFilledSpatialFunctionGTest.cxx
+  itkThreadedImageRegionPartitionerGTest.cxx
 )
 creategoogletestdriver(ITKCommon "${ITKCommon-Test_LIBRARIES}" "${ITKCommonGTests}")
 # If `-static` was passed to CMAKE_EXE_LINKER_FLAGS, compilation fails. No need to

--- a/Modules/Core/Common/test/itkThreadedImageRegionPartitionerGTest.cxx
+++ b/Modules/Core/Common/test/itkThreadedImageRegionPartitionerGTest.cxx
@@ -16,13 +16,12 @@
  *
  *=========================================================================*/
 #include "itkThreadedImageRegionPartitioner.h"
-#include "itkTestingMacros.h"
+#include "itkGTest.h"
 
-/*
- * Main test entry function
- */
-int
-itkThreadedImageRegionPartitionerTest(int, char *[])
+#include <vector>
+
+
+TEST(ThreadedImageRegionPartitioner, PartitionDomain)
 {
   constexpr unsigned int Dimension{ 2 };
 
@@ -30,7 +29,7 @@ itkThreadedImageRegionPartitionerTest(int, char *[])
   const ThreadedImageRegionPartitionerType::Pointer threadedImageRegionPartitioner =
     ThreadedImageRegionPartitionerType::New();
 
-  ITK_EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_GTEST_EXERCISE_BASIC_OBJECT_METHODS(
     threadedImageRegionPartitioner, ThreadedImageRegionPartitioner, ThreadedDomainPartitioner);
 
 
@@ -71,14 +70,6 @@ itkThreadedImageRegionPartitionerTest(int, char *[])
   {
     threadedImageRegionPartitioner->PartitionDomain(i, totalThreads, completeRegion, subRegion);
     std::cout << "The resulting subregion for thread: " << i << " is : " << subRegion << std::endl;
-
-    if (expectedSubRegions[i] != subRegion)
-    {
-      std::cerr << "The calculated sub-region, " << subRegion
-                << " did not match the expected region: " << expectedSubRegions[i] << std::endl;
-      return EXIT_FAILURE;
-    }
+    EXPECT_EQ(subRegion, expectedSubRegions[i]) << "Mismatch at thread " << i;
   }
-
-  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Convert legacy ITK CTest driver test to GoogleTest (GTest) framework.

This is part of the ongoing effort to modernize ITK's test suite by converting no-argument CTest tests to the GoogleTest framework for improved test organization, better failure reporting, and modern C++ testing practices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)