### PR TITLE
ENH: Convert itkImageTransformTest to GTest

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -134,7 +134,6 @@ set(
   itkMinimumMaximumImageCalculatorTest.cxx
   itkSliceIteratorTest.cxx
   itkImageRegionExclusionIteratorWithIndexTest.cxx
-  itkImageTransformTest.cxx
   itkImageFillBufferTest.cxx
   itkMemoryLeakTest.cxx
   itkVectorGeometryTest.cxx
@@ -343,12 +342,6 @@ itk_add_test(
     ITKCommon1TestDriver
     itkMultipleLogOutputTest
     ${TEMP}/test_multi.txt
-)
-itk_add_test(
-  NAME itkImageTransformTest
-  COMMAND
-    ITKCommon2TestDriver
-    itkImageTransformTest
 )
 itk_add_test(
   NAME itkMinimumMaximumImageCalculatorTest
@@ -1712,6 +1705,7 @@ set(
   itkImportImageGTest.cxx
   itkImportContainerGTest.cxx
   itkPixelAccessGTest.cxx
+  itkImageTransformGTest.cxx
 )
 creategoogletestdriver(ITKCommon "${ITKCommon-Test_LIBRARIES}" "${ITKCommonGTests}")
 # If `-static` was passed to CMAKE_EXE_LINKER_FLAGS, compilation fails. No need to

--- a/Modules/Core/Common/test/itkImageTransformGTest.cxx
+++ b/Modules/Core/Common/test/itkImageTransformGTest.cxx
@@ -17,9 +17,12 @@
  *=========================================================================*/
 
 #include "itkImage.h"
+#include "itkGTest.h"
 
 #include <iostream>
-#include <fstream>
+
+namespace
+{
 
 template <unsigned int TDimension>
 void
@@ -31,7 +34,6 @@ TestTransform()
   auto orientedImage = ImageType::New();
 
   typename ImageType::PointType origin;
-
   for (unsigned int i = 0; i < TDimension; ++i)
   {
     origin[i] = static_cast<double>(i * 100);
@@ -41,26 +43,21 @@ TestTransform()
 
   using RegionType = itk::ImageRegion<TDimension>;
   using IndexType = typename RegionType::IndexType;
-  using SizeType = typename RegionType::SizeType;
 
   typename ImageType::PointType point;
-  RegionType                    region;
-
-  auto size = SizeType::Filled(10);
-  region.SetSize(size);
 
   auto index = IndexType::Filled(5);
 
-  std::cout << "TransformIndexToPhysicalPoint..." << std::endl;
+  std::cout << "TransformIndexToPhysicalPoint (dim=" << TDimension << ")..." << std::endl;
   orientedImage->TransformIndexToPhysicalPoint(index, point);
-  std::cout << "    Image: " << index << " -> " << point << std::endl;
+  std::cout << "    OrientedImage: " << index << " -> " << point << std::endl;
 
   image->TransformIndexToPhysicalPoint(index, point);
   std::cout << "    Image:         " << index << " -> " << point << std::endl;
 
-  std::cout << "TransformPhysicalPointToIndex..." << std::endl;
+  std::cout << "TransformPhysicalPointToIndex (dim=" << TDimension << ")..." << std::endl;
   const bool isInsideOrientedImage = orientedImage->TransformPhysicalPointToIndex(point, index);
-  std::cout << "    Image: " << point << " -> " << index << (isInsideOrientedImage ? " inside" : " outside")
+  std::cout << "    OrientedImage: " << point << " -> " << index << (isInsideOrientedImage ? " inside" : " outside")
             << std::endl;
 
   const bool isInsideImage = image->TransformPhysicalPointToIndex(point, index);
@@ -68,13 +65,13 @@ TestTransform()
             << std::endl;
 }
 
-int
-itkImageTransformTest(int, char *[])
+} // namespace
+
+
+TEST(ImageTransform, TransformIndexAndPoint)
 {
   TestTransform<8>();
   TestTransform<3>();
   TestTransform<2>();
   TestTransform<1>();
-
-  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Convert legacy ITK CTest driver test to GoogleTest (GTest) framework.

This is part of the ongoing effort to modernize ITK's test suite by converting no-argument CTest tests to the GoogleTest framework for improved test organization, better failure reporting, and modern C++ testing practices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)