### PR TITLE
BUG: Fix divide-by-zero and integer truncation in CalculateFitError

### DIFF
--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianCostFunction.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianCostFunction.cxx
@@ -43,7 +43,7 @@ CumulativeGaussianCostFunction::CalculateFitError(MeasureType * setTestArray)
   // Use root mean square error as a measure of fit quality.
   const unsigned int numberOfElements = m_OriginalDataArray.GetNumberOfElements();
 
-  if (numberOfElements != setTestArray->GetNumberOfElements())
+  if (numberOfElements != setTestArray->GetNumberOfElements() || numberOfElements == 0)
   {
     return 1;
   }
@@ -52,7 +52,7 @@ CumulativeGaussianCostFunction::CalculateFitError(MeasureType * setTestArray)
   {
     fitError += Math::sqr(setTestArray->get(i) - m_OriginalDataArray.get(i));
   }
-  return (std::sqrt((1 / numberOfElements) * fitError));
+  return std::sqrt(fitError / static_cast<double>(numberOfElements));
 }
 
 double


### PR DESCRIPTION
## Summary

Fixes two bugs in `CumulativeGaussianCostFunction::CalculateFitError()` detected by clang-22 `scan-build` (`core.DivideZero` checker, line 55):

**Bug 1 — Divide by zero:** If `m_OriginalDataArray` has zero elements, `numberOfElements` is 0 and the division `1 / numberOfElements` is undefined behavior. The existing size-mismatch early-return guard now also covers this case.

**Bug 2 — Integer truncation (silent wrong result):** The expression `(1 / numberOfElements) * fitError` performs integer division first. For any `numberOfElements > 1`, `1 / numberOfElements` truncates to `0`, making `CalculateFitError()` always return `0.0` — silently reporting a perfect fit regardless of actual error. The corrected RMSE formula is `sqrt(fitError / numberOfElements)`.

## Test plan

- [x] Existing `itkCumulativeGaussianOptimizerTest` continues to pass
- [x] Verify `CalculateFitError` returns non-zero for arrays that differ

Detected via clang-22 `analyze-build` — see https://github.com/InsightSoftwareConsortium/ITK/issues/1261#issuecomment-4023451241

🤖 Generated with [Claude Code](https://claude.com/claude-code)