### PR TITLE
COMP: Remove `NthElementPixelAccessor::operator=` for VariableLengthVector

### DIFF
--- a/Modules/Core/ImageAdaptors/include/itkNthElementPixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkNthElementPixelAccessor.h
@@ -199,15 +199,6 @@ public:
 
   ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
 
-  /** Assignment operator */
-  NthElementPixelAccessor &
-  operator=(const NthElementPixelAccessor & accessor)
-  {
-    m_ElementNumber = accessor.m_ElementNumber;
-    this->SetVectorLength(accessor.GetVectorLength());
-    return *this;
-  }
-
 protected:
   using Superclass = DefaultVectorPixelAccessor<TPixelType>;
 


### PR DESCRIPTION
Let the assignment operator be implicitly defaulted (compiler generated), for the VariableLengthVector specific template specialization of NthElementPixelAccessor.

Aims to address warnings appearing on Linux/GCC 11.4.0 saying:

    warning: implicitly-declared 'constexpr NthElementPixelAccessor::NthElementPixelAccessor(const NthElementPixelAccessor&)' is deprecated [-Wdeprecated-copy]

- Follow-up to pull request #5849 commit 00ead18cd1cd03983681a0f37da420f7f5fe7a76