### PR TITLE
WIP: Test `Math::Absolute(std::numeric_limits<int>::min())`

### DIFF
--- a/Modules/Core/Common/test/itkMathGTest.cxx
+++ b/Modules/Core/Common/test/itkMathGTest.cxx
@@ -334,6 +334,9 @@ TEST(itkMath, Abs)
   static_assert(itk::Math::Absolute<double>(-5.0) == 5.0);
   static_assert(itk::Math::Absolute<float>(-5.0f) == 5.0f);
 
+  // Note that `std::abs(int)` does not support `std::numeric_limits<int>::min()` as argument.
+  static_assert(itk::Math::Absolute(std::numeric_limits<int>::min()) == std::numeric_limits<int>::max() + 1U);
+
   constexpr auto cf = std::complex<float>(-3, -4);
   EXPECT_EQ(itk::Math::Absolute(cf), 5);
   constexpr auto cd = std::complex<double>(-3, -4);


### PR DESCRIPTION
Checks that `Absolute(INT_MIN)` returns `INT_MAX + 1U`.

Note that `std::abs(int)` does not support `INT_MIN` as argument.

----

Example at https://godbolt.org/z/dPTxjdqoK built with GCC (`-std=c++23`):

```c++
#include <climits>
#include <cmath>

constexpr auto absMax = std::abs(INT_MAX); // OK
constexpr auto absMin = std::abs(INT_MIN); // error: overflow in constant expression
```