### PR TITLE
COMP: Add missing itkImageRegionIteratorWithIndex.h include

### DIFF
--- a/Modules/IO/TransformMINC/test/itkMINCTransformAdapterTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkMINCTransformAdapterTest.cxx
@@ -25,6 +25,7 @@
 #include "itkTransformFactory.h"
 #include "itksys/SystemTools.hxx"
 #include "itkDisplacementFieldTransform.h"
+#include "itkImageRegionIteratorWithIndex.h"
 #include "itkIOTestHelper.h"
 #include "itkMINCTransformAdapter.h"
 #include "itkMINCTransformIO.h"


### PR DESCRIPTION
## Summary

`itkMINCTransformAdapterTest.cxx` uses `itk::ImageRegionIteratorWithIndex` but was missing the corresponding header include, causing build failures reported on CDash:

https://open.cdash.org/builds/11108478/errors

## Errors Fixed

All 3 errors were in `Modules/IO/TransformMINC/test/itkMINCTransformAdapterTest.cxx:165`:

- `'ImageRegionIteratorWithIndex' is not a member of 'itk'`
- `expected primary-expression before '>' token`
- `'it' was not declared in this scope`

## Fix

Added `#include "itkImageRegionIteratorWithIndex.h"` to the test file's includes.