### PR TITLE
BUG: Fix overflow `Math::Absolute` on a minimum signed integer argument

### DIFF
--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -31,6 +31,7 @@
 #include <cassert>
 #include <complex>
 #include <cmath>
+#include <limits>
 #include <type_traits>
 #include "itkMathDetail.h"
 #include "itkConceptChecking.h"
@@ -888,35 +889,13 @@ Absolute(T x) noexcept
   {
     if constexpr (std::is_signed_v<T>)
     {
-      // Using promotion to std::int32_t instead of std::make_unsigned_t<T>
-      // to avoid potential overflow when T is a signed 8bit minimum (value -128)
-      // or signed 15 bit minimum (value -32768).
-      // Note that -(-128) is still -128 for an 8-bit signed char.
-      if constexpr (sizeof(T) <= sizeof(int))
-      {
-#if __cplusplus >= 202302L
-        return static_cast<std::make_unsigned_t<T>>(std::abs(static_cast<int>(x)));
-#else
-        return static_cast<std::make_unsigned_t<T>>((x < T(0)) ? -x : x);
-#endif
-      }
-      else if constexpr (sizeof(T) <= sizeof(long int))
-      {
-#if __cplusplus >= 202302L
-        return static_cast<std::make_unsigned_t<T>>(std::abs(static_cast<long int>(x)));
-#else
-        return static_cast<std::make_unsigned_t<T>>((x < T(0)) ? -x : x);
-#endif
-      }
-      else if constexpr (sizeof(T) == sizeof(long long int))
-      {
-        // NOTE: overflow is not resolved if LONG_LONG_INT_MIN value is converted
-#if __cplusplus >= 202302L
-        return static_cast<std::make_unsigned_t<T>>(std::abs(static_cast<long long int>(x)));
-#else
-        return static_cast<std::make_unsigned_t<T>>((x < T(0)) ? -x : x);
-#endif
-      }
+      using UnsignedType = std::make_unsigned_t<T>;
+      using Limits = std::numeric_limits<T>;
+
+      // The absolute value of the minimum integer value, having a two's complement signed integer representation.
+      constexpr UnsignedType absoluteValueOfMin{ UnsignedType{ Limits::max() } + UnsignedType{ 1 } };
+
+      return static_cast<UnsignedType>((x < 0) ? (x == Limits::min()) ? absoluteValueOfMin : -x : x);
     }
     else
     { // In C++17, the std::abs() integer overloads are only for : int, long, and long long.

--- a/Modules/Core/Common/test/itkMathGTest.cxx
+++ b/Modules/Core/Common/test/itkMathGTest.cxx
@@ -353,6 +353,25 @@ TEST(itkMath, Abs)
   EXPECT_EQ(itk::Math::Absolute<double>(-5.0), 5.0);
   EXPECT_EQ(itk::Math::Absolute<float>(-5.0f), 5.0f);
   EXPECT_EQ(itk::Math::Absolute(-5), 5);
+
+  // Check using the minimum possible value of signed integer types as argument:
+  {
+    constexpr auto minValue = std::numeric_limits<std::int8_t>::min();
+    static_assert(itk::Math::Absolute(minValue) == std::uint8_t{ -std::int16_t{ minValue } });
+  }
+  {
+    constexpr auto minValue = std::numeric_limits<std::int16_t>::min();
+    static_assert(itk::Math::Absolute(minValue) == std::uint16_t{ -std::int32_t{ minValue } });
+  }
+  {
+    constexpr auto minValue = std::numeric_limits<std::int32_t>::min();
+    static_assert(itk::Math::Absolute(minValue) == std::uint32_t{ -std::int64_t{ minValue } });
+  }
+  {
+    using Limits = std::numeric_limits<std::int64_t>;
+    static_assert(itk::Math::Absolute(Limits::min()) ==
+                  std::uint64_t{ std::uint64_t{ Limits::max() } + std::uint64_t{ 1 } });
+  }
 }
 
 


### PR DESCRIPTION
An attempt to evaluate `Math::Absolute(INT_MIN)` at compile-time caused a compile error triggered by the expression `-x`, saying:

    value 2147483648 is outside the range of representable values of type 'int'

`std::abs(INT_MIN)` also has integer overflow.

Fixed by having `Math::Absolute(T x)` specifically take care of the case when its argument is a signed integer with value `std::numeric_limits<T>::min()`.

----

- Aims to supersede pull request #5914
- Partially (!) addresses issue #5823