### PR TITLE
COMP: Fix -Wreserved-identifier warnings in several source files

### DIFF
--- a/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.h
+++ b/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.h
@@ -79,7 +79,7 @@ public:
   /** @ITKStartGrouping */
   itkGetConstMacro(Orientation, InputType);
   virtual void
-  SetOrientation(const InputType _Orientation);
+  SetOrientation(const InputType orientation);
   /** @ITKEndGrouping */
   /** Evaluates the function at a given position. */
   OutputType

--- a/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.hxx
@@ -39,12 +39,12 @@ FiniteCylinderSpatialFunction<VDimension, TInput>::FiniteCylinderSpatialFunction
 
 template <unsigned int VDimension, typename TInput>
 void
-FiniteCylinderSpatialFunction<VDimension, TInput>::SetOrientation(const InputType _Orientation)
+FiniteCylinderSpatialFunction<VDimension, TInput>::SetOrientation(const InputType orientation)
 {
-  itkDebugMacro("setting Orientation to " << _Orientation);
-  if (this->m_Orientation != _Orientation)
+  itkDebugMacro("setting Orientation to " << orientation);
+  if (this->m_Orientation != orientation)
   {
-    this->m_Orientation = _Orientation;
+    this->m_Orientation = orientation;
     //
     // save normalizedOrientation, so it doesn't need to be recomputed
     // in every call of Evaluate.

--- a/Modules/Core/Common/include/itkImageAlgorithm.h
+++ b/Modules/Core/Common/include/itkImageAlgorithm.h
@@ -86,14 +86,14 @@ struct ImageAlgorithm
        const typename Image<TPixel1, VImageDimension>::RegionType & inRegion,
        const typename Image<TPixel2, VImageDimension>::RegionType & outRegion)
   {
-    using _ImageType1 = Image<TPixel1, VImageDimension>;
-    using _ImageType2 = Image<TPixel2, VImageDimension>;
+    using ImageType1 = Image<TPixel1, VImageDimension>;
+    using ImageType2 = Image<TPixel2, VImageDimension>;
     ImageAlgorithm::DispatchedCopy(
       inImage,
       outImage,
       inRegion,
       outRegion,
-      std::is_convertible<typename _ImageType1::PixelType, typename _ImageType2::PixelType>());
+      std::is_convertible<typename ImageType1::PixelType, typename ImageType2::PixelType>());
   }
 
   template <typename TPixel1, typename TPixel2, unsigned int VImageDimension>
@@ -103,14 +103,14 @@ struct ImageAlgorithm
        const typename VectorImage<TPixel1, VImageDimension>::RegionType & inRegion,
        const typename VectorImage<TPixel2, VImageDimension>::RegionType & outRegion)
   {
-    using _ImageType1 = VectorImage<TPixel1, VImageDimension>;
-    using _ImageType2 = VectorImage<TPixel2, VImageDimension>;
+    using ImageType1 = VectorImage<TPixel1, VImageDimension>;
+    using ImageType2 = VectorImage<TPixel2, VImageDimension>;
     ImageAlgorithm::DispatchedCopy(
       inImage,
       outImage,
       inRegion,
       outRegion,
-      std::is_convertible<typename _ImageType1::PixelType, typename _ImageType2::PixelType>());
+      std::is_convertible<typename ImageType1::PixelType, typename ImageType2::PixelType>());
   }
 
   /// \endcond

--- a/Modules/Core/Common/include/itkImageAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkImageAlgorithm.hxx
@@ -94,8 +94,8 @@ ImageAlgorithm::DispatchedCopy(const InputImageType *                       inIm
                                const typename OutputImageType::RegionType & outRegion,
                                TrueType)
 {
-  using _RegionType = typename InputImageType::RegionType;
-  using _IndexType = typename InputImageType::IndexType;
+  using RegionType = typename InputImageType::RegionType;
+  using IndexType = typename InputImageType::IndexType;
 
   // Get the number of bytes of each pixel in the buffer.
   const size_t NumberOfInternalComponents = ImageAlgorithm::PixelSize<InputImageType>::Get(inImage);
@@ -112,8 +112,8 @@ ImageAlgorithm::DispatchedCopy(const InputImageType *                       inIm
   const typename InputImageType::InternalPixelType * in = inImage->GetBufferPointer();
   typename OutputImageType::InternalPixelType *      out = outImage->GetBufferPointer();
 
-  const _RegionType & inBufferedRegion = inImage->GetBufferedRegion();
-  const _RegionType & outBufferedRegion = outImage->GetBufferedRegion();
+  const RegionType & inBufferedRegion = inImage->GetBufferedRegion();
+  const RegionType & outBufferedRegion = outImage->GetBufferedRegion();
 
   // Compute the number of continuous pixel which can be copied.
   size_t       numberOfPixel = 1;
@@ -125,15 +125,15 @@ ImageAlgorithm::DispatchedCopy(const InputImageType *                       inIm
   }
   // The copy regions must extend to the full buffered region, to
   // ensure continuity of pixels between dimensions.
-  while (movingDirection < _RegionType::ImageDimension &&
+  while (movingDirection < RegionType::ImageDimension &&
          inRegion.GetSize(movingDirection - 1) == inBufferedRegion.GetSize(movingDirection - 1) &&
          outRegion.GetSize(movingDirection - 1) == outBufferedRegion.GetSize(movingDirection - 1) &&
          inBufferedRegion.GetSize(movingDirection - 1) == outBufferedRegion.GetSize(movingDirection - 1));
 
   const size_t sizeOfChunkInInternalComponents = numberOfPixel * NumberOfInternalComponents;
 
-  _IndexType inCurrentIndex = inRegion.GetIndex();
-  _IndexType outCurrentIndex = outRegion.GetIndex();
+  IndexType inCurrentIndex = inRegion.GetIndex();
+  IndexType outCurrentIndex = outRegion.GetIndex();
 
   while (inRegion.IsInside(inCurrentIndex))
   {
@@ -143,7 +143,7 @@ ImageAlgorithm::DispatchedCopy(const InputImageType *                       inIm
     size_t inSubDimensionQuantity = 1; // in pixels
     size_t outSubDimensionQuantity = 1;
 
-    for (unsigned int i = 0; i < _RegionType::ImageDimension; ++i)
+    for (unsigned int i = 0; i < RegionType::ImageDimension; ++i)
     {
       inOffset += inSubDimensionQuantity * static_cast<size_t>(inCurrentIndex[i] - inBufferedRegion.GetIndex(i));
       inSubDimensionQuantity *= inBufferedRegion.GetSize(i);
@@ -157,14 +157,14 @@ ImageAlgorithm::DispatchedCopy(const InputImageType *                       inIm
 
     CopyHelper(inBuffer, inBuffer + sizeOfChunkInInternalComponents, outBuffer);
 
-    if (movingDirection == _RegionType::ImageDimension)
+    if (movingDirection == RegionType::ImageDimension)
     {
       break;
     }
 
     // increment index to next chunk
     ++inCurrentIndex[movingDirection];
-    for (unsigned int i = movingDirection; i + 1 < _RegionType::ImageDimension; ++i)
+    for (unsigned int i = movingDirection; i + 1 < RegionType::ImageDimension; ++i)
     {
       // When reaching the end of the moving index in the copy region
       // dimension, carry to higher dimensions.
@@ -177,7 +177,7 @@ ImageAlgorithm::DispatchedCopy(const InputImageType *                       inIm
 
     // increment index to next chunk
     ++outCurrentIndex[movingDirection];
-    for (unsigned int i = movingDirection; i + 1 < _RegionType::ImageDimension; ++i)
+    for (unsigned int i = movingDirection; i + 1 < RegionType::ImageDimension; ++i)
     {
       if (static_cast<SizeValueType>(outCurrentIndex[i] - outRegion.GetIndex(i)) >= outRegion.GetSize(i))
       {

--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.hxx
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.hxx
@@ -174,8 +174,8 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ReduceToTridiagonalMatri
 
     e2[i] = scale * scale * h;
     double       f = d[l];
-    const double d__1 = std::sqrt(h);
-    double       g = (-1.0) * itk::Math::sgn0(f) * itk::Math::Absolute(d__1);
+    const double d1 = std::sqrt(h);
+    double       g = (-1.0) * itk::Math::sgn0(f) * itk::Math::Absolute(d1);
     e[i] = scale * g;
     h -= f * g;
     d[l] = f - g;
@@ -288,8 +288,8 @@ SymmetricEigenAnalysis<TMatrix, TVector, TEigenMatrix>::ReduceToTridiagonalMatri
       }
 
       double       f = d[l];
-      const double d__1 = std::sqrt(h);
-      double       g = (-1.0) * itk::Math::sgn0(f) * itk::Math::Absolute(d__1);
+      const double d1 = std::sqrt(h);
+      double       g = (-1.0) * itk::Math::sgn0(f) * itk::Math::Absolute(d1);
       e[i] = scale * g;
       h -= f * g;
       d[l] = f - g;

--- a/Modules/IO/IPL/include/itkIPLFileNameList.h
+++ b/Modules/IO/IPL/include/itkIPLFileNameList.h
@@ -152,12 +152,12 @@ public:
   }
 
   IPLFileSortInfo *
-  operator[](unsigned int __n)
+  operator[](unsigned int n)
   {
     auto it = begin();
     auto itend = end();
 
-    for (unsigned int i = 0; it != itend && i != __n; it++, i++)
+    for (unsigned int i = 0; it != itend && i != n; it++, i++)
     {
     }
     if (it == itend)

--- a/Modules/IO/Meta/src/itkMetaImageIO.cxx
+++ b/Modules/IO/Meta/src/itkMetaImageIO.cxx
@@ -30,7 +30,7 @@
 // Function to join strings with a delimiter similar to python's ' '.join([1, 2, 3 ])
 template <typename ContainerType, typename DelimiterType, typename StreamType>
 static auto
-_join(const ContainerType & elements, const DelimiterType & delimiter, StreamType & strs) -> void
+joinElements(const ContainerType & elements, const DelimiterType & delimiter, StreamType & strs) -> void
 {
   for (size_t i = 0; i < elements.size(); ++i)
   {
@@ -510,7 +510,7 @@ MetaImageIO::WriteImageInformation()
     }
     else if (ExposeMetaData<std::vector<double>>(metaDict, key, vval))
     {
-      _join(vval, ' ', strs);
+      joinElements(vval, ' ', strs);
     }
     else if (WriteMatrixInMetaData<1>(strs, metaDict, key) || WriteMatrixInMetaData<2>(strs, metaDict, key) ||
              WriteMatrixInMetaData<3>(strs, metaDict, key) || WriteMatrixInMetaData<4>(strs, metaDict, key) ||

--- a/Modules/IO/TIFF/include/itkTIFFImageIO.h
+++ b/Modules/IO/TIFF/include/itkTIFFImageIO.h
@@ -169,9 +169,9 @@ public:
    * 100 is the highest quality. Default is 75 */
   /** @ITKStartGrouping */
   virtual void
-  SetJPEGQuality(int _JPEGQuality)
+  SetJPEGQuality(int jpegQuality)
   {
-    this->SetCompressionLevel(_JPEGQuality);
+    this->SetCompressionLevel(jpegQuality);
   }
   virtual int
   GetJPEGQuality() const


### PR DESCRIPTION
## Summary

Fixes `-Wreserved-identifier` warnings reported on the ITK CDash nightly build for `Mac15.x-AppleClang-dbg-ASanUBSan` (build ID [11107731](https://open.cdash.org/build/11107731), 2026-03-10).

## Changes

Rename local variables, type aliases, and parameters that used identifiers reserved by the C++ standard (containing `__` or starting with `_` followed by a capital letter, or starting with `_` at global scope):

| File | Old Name | New Name | Reason |
|------|----------|----------|--------|
| `Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.h/.hxx` | `_Orientation` | `orientation` | starts with `_` followed by capital letter |
| `Modules/Core/Common/include/itkImageAlgorithm.h` | `_ImageType1`, `_ImageType2` | `ImageType1`, `ImageType2` | starts with `_` followed by capital letter |
| `Modules/Core/Common/include/itkImageAlgorithm.hxx` | `_RegionType`, `_IndexType` | `RegionType`, `IndexType` | starts with `_` followed by capital letter |
| `Modules/Core/Common/include/itkSymmetricEigenAnalysis.hxx` | `d__1` | `d1` | contains `__` |
| `Modules/IO/IPL/include/itkIPLFileNameList.h` | `__n` | `n` | starts with `__` |
| `Modules/IO/Meta/src/itkMetaImageIO.cxx` | `_join` (file-scope helper) | `joinElements` | starts with `_` at global scope |
| `Modules/IO/TIFF/include/itkTIFFImageIO.h` | `_JPEGQuality` | `jpegQuality` | starts with `_` followed by capital letter |

## Notes

- The `TIFFImageIOFactoryRegister__Private` function name in `itkTIFFImageIOFactory.cxx` also triggers this warning but is **intentionally not changed** here — it is part of the CMake-generated factory registration infrastructure (`ITKFactoryRegistration.cmake`) and would require a coordinated change across all IO factories and the generation logic.
- No functional changes; only identifier renames.