### PR TITLE
ENH: Add fix-nightly-warnings skill and CDash query scripts

### DIFF
--- a/.github/skills/fix-nightly-warnings/SKILL.md
+++ b/.github/skills/fix-nightly-warnings/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: fix-nightly-warnings
+description: 'Fix ITK nightly build errors or compilation warnings reported on CDash. Use when: addressing CDash nightly failures. Creates a branch, fixes warnings, and opens a PR upstream.'
+argument-hint: What warnings should this skill fix?
+---
+
+# Fix ITK Nightly Build Errors and Warnings
+
+Creates a focused branch containing fixes for errors or warnings reported on the ITK CDash nightly dashboard, then open a PR upstream.
+
+## When to Use
+
+- CDash nightly build reports new errors, warnings, or Doxygen warnings
+- User says "fix nightly errors", "address CDash warnings", or "there are new Doxygen warnings"
+
+## Available Scripts
+
+Scripts are located at `.github/skills/fix-nightly-warnings/scripts/` relative to the repository root. All `python3` commands below assume this directory as the working directory.
+
+- **`scripts/triage_nightly.py`** — Single-command triage: lists builds, fetches warnings, deduplicates by `(sourceFile, flag)`, and outputs an actionable summary grouped by flag. Best for agentic automation.
+- **`scripts/list_nightly_warnings.py`** — Lists CDash builds that have warnings or errors. Defaults to `Nightly` builds from the last 24 hours.
+- **`scripts/get_build_warnings.py`** — Fetches and summarizes warnings (or errors) for a specific CDash build ID, grouped by source file and warning flag.
+
+Run `python3 scripts/<script>.py --help` for full usage.
+
+## Procedure
+
+### 1. Identify the Warnings
+
+Use the provided scripts to fetch the current nightly builds and their warnings from CDash.
+
+**Step 1a — List nightly builds with warnings:**
+
+```bash
+python3 scripts/list_nightly_warnings.py --type Nightly --limit 25 --json | jq '.[] | select(.warnings > 0)'
+```
+
+Note: `list_nightly_warnings.py` returns the builds with the most errors then warnings.
+
+
+**Step 1b — Inspect warnings for a specific build:**
+
+```bash
+python3 scripts/get_build_warnings.py --limit 200 --json BUILD_ID | jq '.entries | map(select(.sourceFile | test("ThirdParty") | not)) | group_by(.flag) | .[] | {flag: .[0].flag, count: length}'
+```
+
+---
+
+For each build with errors and warnings, fetch the details and summarize the errors and warnings by type and source file.
+IGNORE ALL errors and warnings originating from `Modules/ThirdParty/` paths — always filter these out in jq pipelines or with the `--exclude-thirdparty` flag.
+
+
+If there are build errors, only fix those. If there are warnings, prioritize fixing the most common warning flag that affects the most files.
+
+**Deduplication:** Multiple CDash builds (e.g., GCC and Clang on different sites) often report the same warning from the same source file. Deduplicate warnings by `(sourceFile, flag)` across all builds before analyzing, to avoid redundant work.
+
+
+### 2. Analyze the Root Cause
+
+For each warning or error type identified in step 1, determine the root cause before editing files:
+- Look up the compiler flag (e.g. `-Wthread-safety-negative`) in the compiler documentation.
+- Read the affected source files to understand how they are structured.
+- Identify the minimal fix: a missing annotation, a suppression pragma, a corrected API usage, etc.
+- Confirm that warnings from `Modules/ThirdParty/` are skipped entirely.
+
+**Common warning fixes (quick reference):**
+
+| Flag | Typical Fix |
+|------|-------------|
+| `-Wshadow` | Rename local variable to avoid shadowing outer scope |
+| `-Wunused-parameter` | Add `(void)param;` or use `itkNotUsed()` macro |
+| `-Wunused-variable` | Remove the variable or add `[[maybe_unused]]` |
+| `-Wdeprecated-declarations` | Update to the replacement API |
+| `-Wsign-compare` | Use matching signed/unsigned types or cast explicitly |
+| `-Woverloaded-virtual` | Add `using Base::Method;` or `override` keyword |
+| `-Winconsistent-missing-override` | Add missing `override` keyword |
+| `C4805` (MSVC) | Avoid mixing `bool` and `int` in arithmetic |
+| `C4267` (MSVC) | Add explicit narrowing cast `static_cast<>()` |
+
+### 3. Create a New Branch
+
+```bash
+git fetch upstream
+git checkout -b fix-<warning-type>-warnings upstream/main
+```
+
+Example: `fix-doxygen-group-warnings`
+
+### 4. Fix the Source Files
+
+Determine the root cause of each error or warning. Apply the necessary fixes to the affected files to resolve the warnings. Make the minimal changes needed to fix the warnings, avoid changing unrelated documentation, coding or formatting.
+
+### 5. Verify No New Warnings Introduced
+
+Build the affected libraries locally to confirm that the fixes compile cleanly:
+
+```bash
+cmake --build build --target <affected-library-target> 2>&1 | grep -c "warning:"
+```
+
+If a local build is not feasible, rely on the draft PR's CI checks to verify. Note that some warnings are intentionally suppressed in `CMake/CTestCustom.cmake.in` — do not fix warnings that are already handled there.
+
+### 6. Commit the Changes
+
+Follow the ITK commit message standards. Include a clear description of the fix and include the error or warning message being addressed.
+
+### 7. Draft a Pull Request
+
+Do the following:
+- Draft a pull request description that includes a summary of the changes, the warnings or errors fixed, and reference the CDash build if applicable.
+- If running interactively, request the user to review and approve the description before submitting the PR. If running as a scheduled/agentic workflow, proceed directly.
+- Push the branch to the user's remote.
+- Create a DRAFT pull request against the current `upstream/main` branch.
+
+## Quality Checks
+
+Before declaring done:
+- [ ] All targeted warnings are fixed
+- [ ] No new warnings or errors introduced
+- [ ] Changes are limited to the files affected by the warnings
+- [ ] Commit message clearly describes the fix and references the CDash issue if applicable
+
+## Key Files for Reference
+
+| File | Purpose |
+|------|---------|
+| `Documentation/docs/contributing/index.md` | Contributing guidelines |
+| `CMake/CTestCustom.cmake.in` | Already-suppressed warning/error patterns — do not fix these |

--- a/.github/skills/fix-nightly-warnings/scripts/get_build_warnings.py
+++ b/.github/skills/fix-nightly-warnings/scripts/get_build_warnings.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.8"
+# ///
+"""
+get_build_warnings.py — Fetch and summarize warnings or errors for a CDash build.
+
+Queries the CDash GraphQL API for all warning (or error) entries associated with
+a specific build ID, then groups them by source file and warning flag.
+
+Exit codes:
+  0  Success
+  1  Argument error
+  2  Network or API error
+"""
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+
+CDASH_GRAPHQL = "https://open.cdash.org/graphql"
+
+QUERY_TEMPLATE = """
+{
+  build(id: "%s") {
+    name stamp startTime buildWarningsCount buildErrorsCount
+    site { name }
+    buildErrors(filters: { eq: { type: %s } }, first: %d%s) {
+      pageInfo { hasNextPage endCursor }
+      edges {
+        node { sourceFile sourceLine stdError stdOutput }
+      }
+    }
+  }
+}
+"""
+
+WARNING_FLAG_RE = re.compile(r'\[(-W[^\]]+)\]')
+MSVC_FLAG_RE = re.compile(r'\b(C\d{4,5})\b')
+
+
+def graphql(query: str) -> dict:
+    payload = json.dumps({"query": query}).encode()
+    req = urllib.request.Request(
+        CDASH_GRAPHQL,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return json.loads(r.read())
+    except urllib.error.URLError as e:
+        print(f"Error: network request failed: {e}", file=sys.stderr)
+        sys.exit(2)
+
+
+def extract_flag(text: str) -> str:
+    m = WARNING_FLAG_RE.search(text)
+    if m:
+        return m.group(1)
+    m = MSVC_FLAG_RE.search(text)
+    if m:
+        return m.group(1)
+    return "?"
+
+
+def fetch_entries(build_id: str, error_type: str, limit: int) -> tuple[dict, list]:
+    """Fetch all entries up to limit, following pagination if needed."""
+    all_entries = []
+    cursor = None
+    build_meta = None
+
+    while True:
+        after_clause = f', after: "{cursor}"' if cursor else ""
+        query = QUERY_TEMPLATE % (build_id, error_type, min(limit, 200), after_clause)
+        data = graphql(query)
+
+        if "errors" in data:
+            print(f"Error: GraphQL returned errors: {data['errors']}", file=sys.stderr)
+            sys.exit(2)
+
+        build = data["data"]["build"]
+        if build_meta is None:
+            build_meta = {
+                "name": build["name"],
+                "stamp": build["stamp"],
+                "site": build["site"]["name"],
+                "buildWarningsCount": build["buildWarningsCount"],
+                "buildErrorsCount": build["buildErrorsCount"],
+            }
+
+        page = build["buildErrors"]
+        all_entries.extend(e["node"] for e in page["edges"])
+
+        if not page["pageInfo"]["hasNextPage"] or len(all_entries) >= limit:
+            break
+        cursor = page["pageInfo"]["endCursor"]
+
+    return build_meta, all_entries[:limit]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="get_build_warnings.py",
+        description="Fetch and summarize warnings or errors for a CDash build.",
+        epilog=(
+            "Examples:\n"
+            "  python3 scripts/get_build_warnings.py 11107692\n"
+            "  python3 scripts/get_build_warnings.py 11107692 --raw\n"
+            "  python3 scripts/get_build_warnings.py 11107692 --errors\n"
+            "  python3 scripts/get_build_warnings.py 11107692 --json | jq '.entries[] | select(.flag == \"-Wthread-safety-negative\")'\n"
+            "  python3 scripts/get_build_warnings.py 11107692 --limit 500"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "build_id",
+        metavar="BUILD_ID",
+        help="CDash build ID (integer from list_nightly_warnings.py output or CDash URL)",
+    )
+    parser.add_argument(
+        "--errors",
+        action="store_true",
+        help="Fetch build errors instead of warnings (default: warnings)",
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Print one entry per line with file:line, flag, and message snippet instead of grouping",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output as JSON: {build: {...}, entries: [...]} for programmatic use",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=200,
+        metavar="N",
+        help="Maximum number of entries to retrieve (default: 200)",
+    )
+    parser.add_argument(
+        "--exclude-thirdparty",
+        action="store_true",
+        help="Exclude warnings from Modules/ThirdParty/ paths",
+    )
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        metavar="PATTERN",
+        help="Exclude entries whose sourceFile contains PATTERN (may be repeated)",
+    )
+    args = parser.parse_args()
+
+    error_type = "ERROR" if args.errors else "WARNING"
+    label = "error" if args.errors else "warning"
+
+    build_meta, entries = fetch_entries(args.build_id, error_type, args.limit)
+    exclude_patterns = list(args.exclude)
+    if args.exclude_thirdparty:
+        exclude_patterns.append("ThirdParty")
+    if exclude_patterns:
+        entries = [
+            e for e in entries
+            if not any(p in (e.get("sourceFile") or "") for p in exclude_patterns)
+        ]
+    total = build_meta["buildErrorsCount" if args.errors else "buildWarningsCount"] or 0
+
+    if args.json_output:
+        output = {
+            "build": build_meta,
+            "type": error_type,
+            "totalCount": total,
+            "fetchedCount": len(entries),
+            "entries": [
+                {
+                    "sourceFile": n["sourceFile"],
+                    "sourceLine": n["sourceLine"],
+                    "flag": extract_flag(n["stdError"] or n["stdOutput"] or ""),
+                    "stdError": n["stdError"],
+                    "stdOutput": n["stdOutput"],
+                }
+                for n in entries
+            ],
+        }
+        print(json.dumps(output, indent=2))
+        return
+
+    # Diagnostics to stderr so stdout stays parseable
+    print(f"Build: {build_meta['name']}", file=sys.stderr)
+    print(f"Site:  {build_meta['site']}", file=sys.stderr)
+    print(f"Stamp: {build_meta['stamp']}", file=sys.stderr)
+    print(f"Total {label}s: {total}  (fetched: {len(entries)})", file=sys.stderr)
+    if total > len(entries):
+        print(
+            f"Note:  {total - len(entries)} entries not fetched; use --limit to increase.",
+            file=sys.stderr,
+        )
+    print(file=sys.stderr)
+
+    if args.raw:
+        print(f"{'FILE:LINE':<60}  {'FLAG':<35}  SNIPPET")
+        print("-" * 120)
+        for n in entries:
+            loc = f"{n['sourceFile']}:{n['sourceLine']}"
+            text = n["stdError"] or n["stdOutput"] or ""
+            flag = extract_flag(text)
+            # Extract a short message snippet after the flag
+            idx = text.find(flag)
+            if idx >= 0:
+                snippet = text[idx + len(flag):].strip().replace("\n", " ")[:80]
+            else:
+                snippet = text.replace("\n", " ")[:80]
+            print(f"{loc:<60}  {flag:<35}  {snippet}")
+    else:
+        # Group by (sourceFile, flag)
+        groups: dict = {}
+        for n in entries:
+            src = n["sourceFile"] or "<unknown>"
+            text = n["stdError"] or n["stdOutput"] or ""
+            flag = extract_flag(text)
+            key = (src, flag)
+            groups[key] = groups.get(key, 0) + 1
+
+        print(f"{'COUNT':>6}  {'FLAG':<35}  SOURCE FILE")
+        print("-" * 100)
+        for (src, flag), count in sorted(groups.items(), key=lambda x: (-x[1], x[0][0])):
+            print(f"{count:>6}  {flag:<35}  {src}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/fix-nightly-warnings/scripts/list_nightly_warnings.py
+++ b/.github/skills/fix-nightly-warnings/scripts/list_nightly_warnings.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.8"
+# ///
+"""
+list_nightly_warnings.py — List ITK CDash builds that have warnings or errors.
+
+Queries the CDash GraphQL API for recent builds of a given type in the Insight/ITK project
+and prints those with a non-zero warning or error count. By default, selects Nightly builds
+submitted since the project's nightly start time (CTEST_NIGHTLY_START). When `--since` is
+omitted the script uses a hard-coded ISO time `01:00:00+00:00` (matches CTestConfig.cmake),
+otherwise `--since N` selects builds from the last N hours.
+
+Build types visible on the CDash dashboard (https://open.cdash.org/index.php?project=Insight):
+  Nightly        — scheduled nightly builds (default)
+  Continuous     — CI builds triggered on commits
+  Experimental   — developer-submitted one-off builds
+
+Exit codes:
+  0  Success (results printed, possibly empty)
+  1  Argument error
+  2  Network or API error
+"""
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+
+CDASH_GRAPHQL = "https://open.cdash.org/graphql"
+INSIGHT_PROJECT_ID = "2"
+
+QUERY_TEMPLATE = """
+{
+  project(id: "%s") {
+    name
+    builds(first: %d, filters: { all: [
+      { contains: { stamp: "%s" } }
+      { gt: { startTime: "%s" } }
+    ]}) {
+      edges {
+        node {
+          id name stamp buildType buildWarningsCount buildErrorsCount startTime
+          site { name }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def graphql(query: str) -> dict:
+    payload = json.dumps({"query": query}).encode()
+    req = urllib.request.Request(
+        CDASH_GRAPHQL,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return json.loads(r.read())
+    except urllib.error.URLError as e:
+        print(f"Error: network request failed: {e}", file=sys.stderr)
+        sys.exit(2)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="list_nightly_warnings.py",
+        description="List ITK CDash builds that have warnings or errors.",
+        epilog=(
+            "Examples:\n"
+            "  python3 scripts/list_nightly_warnings.py\n"
+            "  python3 scripts/list_nightly_warnings.py --type Continuous\n"
+            "  python3 scripts/list_nightly_warnings.py --type Experimental --limit 100 --all\n"
+            "  python3 scripts/list_nightly_warnings.py --json | jq '.[] | select(.warnings > 10)'"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--type",
+        default="Nightly",
+        metavar="TYPE",
+        help=(
+            "Build type to filter by: Nightly (default), Continuous, Experimental, etc. "
+            "Matched as a substring of the build stamp (e.g. '20260310-0100-Nightly')."
+        ),
+    )
+    parser.add_argument(
+        "--since",
+        type=float,
+        default=None,
+        metavar="HOURS",
+        help=(
+            "Only show builds submitted in the last N hours. If omitted, uses the "
+            "project nightly start time (hard-coded to 01:00:00+00:00 in this script)."
+        ),
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        metavar="N",
+        help="Maximum number of builds to fetch from CDash (default: 100)",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Show all matching builds, not just those with warnings or errors",
+    )
+    parser.add_argument(
+        "--new-warnings-only",
+        action="store_true",
+        help=(
+            "Only show builds that have MORE warnings than the lowest warning "
+            "count among recent builds (i.e., regressions from a clean baseline)"
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output as a JSON array instead of a human-readable table",
+    )
+    args = parser.parse_args()
+
+    if args.since is None:
+        # Hard-coded nightly start time (matches CTestConfig.cmake project-level
+        # setting `CTEST_NIGHTLY_START_TIME` in the repository root). Update here
+        # if that value changes. Use an ISO-like time with UTC offset to simplify
+        # parsing (no manual tz mapping required): `HH:MM:SS+00:00`.
+        CTEST_NIGHTLY_START = "01:00:00+00:00"
+        # Build an aware datetime from today's date + the hard-coded time offset.
+        today = datetime.now(timezone.utc).date()
+        dt = datetime.fromisoformat(f"{today.isoformat()}T{CTEST_NIGHTLY_START}")
+        now_utc = datetime.now(timezone.utc)
+        since_dt = dt if now_utc >= dt else dt - timedelta(days=1)
+    else:
+        since_dt = datetime.now(timezone.utc) - timedelta(hours=args.since)
+
+    since_str = since_dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+
+    # Request more builds from the server than we may display so we can
+    # sort by errors/warnings client-side and then apply the display `--limit`.
+    fetch_count = max(args.limit, 500)
+    query = QUERY_TEMPLATE % (INSIGHT_PROJECT_ID, fetch_count, args.type, since_str)
+    data = graphql(query)
+
+    if "errors" in data:
+        print(f"Error: GraphQL returned errors: {data['errors']}", file=sys.stderr)
+        sys.exit(2)
+
+    edges = data["data"]["project"]["builds"]["edges"]
+    project_name = data["data"]["project"]["name"]
+
+    nodes = [e["node"] for e in edges]
+    if not args.all:
+        nodes = [
+            n
+            for n in nodes
+            if (n.get("buildWarningsCount") or 0) > 0
+            or (n.get("buildErrorsCount") or 0) > 0
+        ]
+
+    # Sort by number of errors (desc), then warnings (desc), then startTime (desc).
+    nodes.sort(
+        key=lambda n: (
+            n.get("buildErrorsCount") or 0,
+            n.get("buildWarningsCount") or 0,
+            n.get("startTime", ""),
+        ),
+        reverse=True,
+    )
+
+    if args.new_warnings_only and nodes:
+        # Find the minimum warning count as the "clean baseline" and keep
+        # only builds that exceed it, indicating regressions.
+        min_warnings = min(n.get("buildWarningsCount") or 0 for n in nodes)
+        nodes = [
+            n
+            for n in nodes
+            if (n.get("buildWarningsCount") or 0) > min_warnings
+            or (n.get("buildErrorsCount") or 0) > 0
+        ]
+
+    # Apply the display limit after sorting
+    nodes = nodes[: args.limit]
+
+    if args.json_output:
+        output = [
+            {
+                "id": n["id"],
+                "name": n["name"],
+                "stamp": n["stamp"],
+                "buildType": n["buildType"],
+                "warnings": n["buildWarningsCount"] or 0,
+                "errors": n["buildErrorsCount"] or 0,
+                "startTime": n["startTime"],
+                "site": n["site"]["name"],
+            }
+            for n in nodes
+        ]
+        print(json.dumps(output, indent=2))
+        return
+
+    print(
+        f"Project: {project_name}  |  type={args.type!r}  |  since={since_str}  |  "
+        f"Builds fetched: {len(edges)}  |  With warnings/errors: {len(nodes)}",
+        file=sys.stderr,
+    )
+    print(file=sys.stderr)
+    print(
+        f"{'BUILD_ID':>10}  {'W':>4}  {'E':>4}  {'STAMP':<25}  {'SITE':<25}  BUILD_NAME"
+    )
+    print("-" * 110)
+    for n in nodes:
+        warn = n["buildWarningsCount"] or 0
+        err = n["buildErrorsCount"] or 0
+        print(
+            f"{n['id']:>10}  {warn:>4}  {err:>4}  "
+            f"{n['stamp'][:24]:<25}  {n['site']['name'][:24]:<25}  {n['name']}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/fix-nightly-warnings/scripts/triage_nightly.py
+++ b/.github/skills/fix-nightly-warnings/scripts/triage_nightly.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.8"
+# ///
+"""
+triage_nightly.py — Single-command CDash nightly warning triage.
+
+Chains list_nightly_warnings and get_build_warnings to produce a
+deduplicated, actionable summary of warnings grouped by flag and
+source file. Designed for agentic automation: one tool call instead
+of multiple script invocations.
+
+Exit codes:
+  0  Success (results printed, possibly empty)
+  2  Network or API error
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Import sibling modules
+sys.path.insert(0, str(Path(__file__).parent))
+from get_build_warnings import extract_flag, fetch_entries
+from list_nightly_warnings import graphql, INSIGHT_PROJECT_ID, QUERY_TEMPLATE
+
+from datetime import datetime, timedelta, timezone
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="triage_nightly.py",
+        description="Triage CDash nightly warnings into an actionable summary.",
+        epilog=(
+            "Examples:\n"
+            "  python3 scripts/triage_nightly.py\n"
+            "  python3 scripts/triage_nightly.py --since 48\n"
+            "  python3 scripts/triage_nightly.py --json"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--type",
+        default="Nightly",
+        metavar="TYPE",
+        help="Build type to filter (default: Nightly)",
+    )
+    parser.add_argument(
+        "--since",
+        type=float,
+        default=None,
+        metavar="HOURS",
+        help="Only include builds from the last N hours (default: since nightly start)",
+    )
+    parser.add_argument(
+        "--limit-builds",
+        type=int,
+        default=25,
+        metavar="N",
+        help="Max builds to inspect (default: 25)",
+    )
+    parser.add_argument(
+        "--limit-warnings",
+        type=int,
+        default=200,
+        metavar="N",
+        help="Max warnings to fetch per build (default: 200)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output as JSON for programmatic use",
+    )
+    args = parser.parse_args()
+
+    # Determine time window
+    if args.since is None:
+        CTEST_NIGHTLY_START = "01:00:00+00:00"
+        today = datetime.now(timezone.utc).date()
+        dt = datetime.fromisoformat(f"{today.isoformat()}T{CTEST_NIGHTLY_START}")
+        now_utc = datetime.now(timezone.utc)
+        since_dt = dt if now_utc >= dt else dt - timedelta(days=1)
+    else:
+        since_dt = datetime.now(timezone.utc) - timedelta(hours=args.since)
+
+    since_str = since_dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+
+    # Step 1: List builds with warnings
+    query = QUERY_TEMPLATE % (INSIGHT_PROJECT_ID, 500, args.type, since_str)
+    data = graphql(query)
+
+    if "errors" in data:
+        print(f"Error: GraphQL returned errors: {data['errors']}", file=sys.stderr)
+        sys.exit(2)
+
+    edges = data["data"]["project"]["builds"]["edges"]
+    builds_with_warnings = [
+        e["node"]
+        for e in edges
+        if (e["node"].get("buildWarningsCount") or 0) > 0
+        or (e["node"].get("buildErrorsCount") or 0) > 0
+    ]
+    builds_with_warnings.sort(
+        key=lambda n: (
+            n.get("buildErrorsCount") or 0,
+            n.get("buildWarningsCount") or 0,
+        ),
+        reverse=True,
+    )
+    builds_with_warnings = builds_with_warnings[: args.limit_builds]
+
+    if not builds_with_warnings:
+        if args.json_output:
+            print(json.dumps({"builds_inspected": 0, "warnings_by_flag": []}, indent=2))
+        else:
+            print("No builds with warnings found.", file=sys.stderr)
+        return
+
+    # Step 2: Fetch warnings from each build and deduplicate
+    seen = {}  # (sourceFile, flag) -> {count, builds, sample_message}
+    builds_inspected = []
+
+    for build_node in builds_with_warnings:
+        build_id = build_node["id"]
+        build_name = build_node["name"]
+        site = build_node["site"]["name"]
+
+        builds_inspected.append({"id": build_id, "name": build_name, "site": site})
+
+        try:
+            _meta, entries = fetch_entries(
+                str(build_id), "WARNING", args.limit_warnings
+            )
+        except SystemExit:
+            continue
+
+        for e in entries:
+            src = e.get("sourceFile") or "<unknown>"
+            if "ThirdParty" in src:
+                continue
+            text = e.get("stdError") or e.get("stdOutput") or ""
+            flag = extract_flag(text)
+            key = (src, flag)
+            if key not in seen:
+                seen[key] = {
+                    "sourceFile": src,
+                    "flag": flag,
+                    "count": 0,
+                    "builds": [],
+                    "sample": text[:200],
+                }
+            seen[key]["count"] += 1
+            if build_name not in seen[key]["builds"]:
+                seen[key]["builds"].append(build_name)
+
+    # Step 3: Group by flag, sort by count
+    by_flag = {}
+    for info in seen.values():
+        flag = info["flag"]
+        if flag not in by_flag:
+            by_flag[flag] = {"flag": flag, "total_count": 0, "files": []}
+        by_flag[flag]["total_count"] += info["count"]
+        by_flag[flag]["files"].append(info)
+
+    result = sorted(by_flag.values(), key=lambda g: -g["total_count"])
+
+    if args.json_output:
+        print(
+            json.dumps(
+                {
+                    "builds_inspected": len(builds_inspected),
+                    "builds": builds_inspected,
+                    "warnings_by_flag": result,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(
+            f"Inspected {len(builds_inspected)} builds  |  "
+            f"{len(seen)} unique (file, flag) pairs  |  "
+            f"{len(by_flag)} distinct flags",
+            file=sys.stderr,
+        )
+        print(file=sys.stderr)
+        print(f"{'TOTAL':>6}  {'FILES':>6}  FLAG")
+        print("-" * 60)
+        for group in result:
+            print(
+                f"{group['total_count']:>6}  {len(group['files']):>6}  {group['flag']}"
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add a GitHub Copilot agent skill for fixing ITK nightly build warnings reported on CDash, with three helper Python scripts for querying the CDash GraphQL API. No production source changes; purely development tooling.

<details>
<summary>Scripts and capabilities</summary>

- **list_nightly_warnings.py** — list recent nightly builds and warning counts via CDash GraphQL; `--new-warnings-only` detects regressions from a clean baseline; `--limit` controls output size
- **get_build_warnings.py** — fetch detailed warning messages for a specific build ID; `--exclude-thirdparty` and repeatable `--exclude PATTERN` flags; MSVC warning code extraction (C4805, C4267, etc.)
- **triage_nightly.py** — single-command entry point that chains list → fetch → deduplicate into an actionable summary grouped by warning flag

</details>

<details>
<summary>SKILL.md contents</summary>

- Step-by-step procedure: fetch warnings, identify patterns, apply minimal fixes, verify, open draft PR
- Known-fix patterns table for common warnings (-Wshadow, -Wunused-parameter, MSVC C4805, etc.)
- Deduplication guidance and automation-compatible PR step
- CTestCustom.cmake.in cross-reference for already-suppressed warnings
- Concrete local verification build command

</details>

<!--
provenance: claude-code session 2026-04-14
squashed: 11 commits → 1 (Brad's original + Hans's incremental improvements)
files: .github/skills/fix-nightly-warnings/{SKILL.md,scripts/{get_build_warnings,list_nightly_warnings,triage_nightly}.py}
-->