### PR TITLE
BUG: Restore itkCrossHelperGTest.cxx to ITKCommonGTests build list

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -1686,6 +1686,7 @@ set(
   itkPixelAccessGTest.cxx
   itkImageTransformGTest.cxx
   itkAnnulusOperatorGTest.cxx
+  itkCrossHelperGTest.cxx
   itkAdaptorComparisonGTest.cxx
 )
 creategoogletestdriver(ITKCommon "${ITKCommon-Test_LIBRARIES}" "${ITKCommonGTests}")


### PR DESCRIPTION
## Summary
- `itkCrossHelperGTest.cxx` was dropped from the `ITKCommonGTests` set in `CMakeLists.txt` when PR #5887 resolved a rebase conflict by replacing the CrossHelper entry with the AnnulusOperator entry rather than keeping both
- The file exists in the repository but was not being compiled or run
- This adds the single missing line back to restore the test to the build

## Root Cause
PR #5887 conflict resolution inadvertently replaced rather than accumulated:
```
-  itkCrossHelperGTest.cxx
+  itkAnnulusOperatorGTest.cxx
```
Should have been:
```
   itkAnnulusOperatorGTest.cxx
+  itkCrossHelperGTest.cxx
```

## Test plan
- [x] Verify `itkCrossHelperGTest.cxx` compiles as part of `ITKCommonGTestDriver`
- [x] Run `ctest -R CrossHelper` confirms test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)