### PR TITLE
STYLE: Use CTAD for iterators "with index", in hxx files

### DIFF
--- a/Modules/Core/Common/include/itkMinimumMaximumImageCalculator.hxx
+++ b/Modules/Core/Common/include/itkMinimumMaximumImageCalculator.hxx
@@ -32,7 +32,7 @@ MinimumMaximumImageCalculator<TInputImage>::Compute()
     m_Region = m_Image->GetRequestedRegion();
   }
 
-  ImageRegionConstIteratorWithIndex<TInputImage> it(m_Image, m_Region);
+  ImageRegionConstIteratorWithIndex it(m_Image, m_Region);
   m_Maximum = NumericTraits<PixelType>::NonpositiveMin();
   m_Minimum = NumericTraits<PixelType>::max();
 
@@ -61,7 +61,7 @@ MinimumMaximumImageCalculator<TInputImage>::ComputeMinimum()
   {
     m_Region = m_Image->GetRequestedRegion();
   }
-  ImageRegionConstIteratorWithIndex<TInputImage> it(m_Image, m_Region);
+  ImageRegionConstIteratorWithIndex it(m_Image, m_Region);
   m_Minimum = NumericTraits<PixelType>::max();
 
   while (!it.IsAtEnd())
@@ -84,7 +84,7 @@ MinimumMaximumImageCalculator<TInputImage>::ComputeMaximum()
   {
     m_Region = m_Image->GetRequestedRegion();
   }
-  ImageRegionConstIteratorWithIndex<TInputImage> it(m_Image, m_Region);
+  ImageRegionConstIteratorWithIndex it(m_Image, m_Region);
   m_Maximum = NumericTraits<PixelType>::NonpositiveMin();
 
   while (!it.IsAtEnd())

--- a/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
@@ -231,8 +231,8 @@ GaussianBlurImageFunction<TInputImage, TOutput>::EvaluateAtIndex(const IndexType
   typename InternalImageType::RegionType regionS = region;
   regionS.Crop(inputImage->GetBufferedRegion());
 
-  ImageLinearConstIteratorWithIndex<InputImageType> it(inputImage, regionS);
-  ImageLinearIteratorWithIndex<InternalImageType>   itN(m_InternalImage, regionN);
+  ImageLinearConstIteratorWithIndex it(inputImage, regionS);
+  ImageLinearIteratorWithIndex      itN(m_InternalImage, regionN);
   it.SetDirection(1);
   itN.SetDirection(1);
   it.GoToBeginOfLine();
@@ -266,7 +266,7 @@ GaussianBlurImageFunction<TInputImage, TOutput>::EvaluateAtIndex(const IndexType
     m_OperatorInternalImageFunction->SetInputImage(m_InternalImage);
     m_OperatorInternalImageFunction->SetOperator(operatorArray[direction]);
 
-    ImageLinearIteratorWithIndex<InternalImageType> itr(m_InternalImage, region);
+    ImageLinearIteratorWithIndex itr(m_InternalImage, region);
 
     unsigned int dir = direction + 1;
     if (dir == Self::ImageDimension)

--- a/Modules/Core/Mesh/include/itkImageToParametricSpaceFilter.hxx
+++ b/Modules/Core/Mesh/include/itkImageToParametricSpaceFilter.hxx
@@ -121,7 +121,7 @@ ImageToParametricSpaceFilter<TInputImage, TOutputMesh>::GenerateData()
   {
     PointDataContainerIterator data = pointData->Begin();
     image = this->GetInput(0);
-    ImageRegionConstIteratorWithIndex<InputImageType> itr(image, image->GetRequestedRegion());
+    ImageRegionConstIteratorWithIndex itr(image, image->GetRequestedRegion());
     while (!itr.IsAtEnd())
     {
       //  The data at each point is the index

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.hxx
@@ -278,7 +278,7 @@ SpatialObjectToImageFilter<TInputSpatialObject, TOutputImage>::GenerateData()
   OutputImage->Allocate(); // allocate the image
 
 
-  ImageRegionIteratorWithIndex<OutputImageType> it(OutputImage, region);
+  ImageRegionIteratorWithIndex it(OutputImage, region);
 
   itk::Point<double, ObjectDimension>      objectPoint;
   itk::Point<double, OutputImageDimension> imagePoint;

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
@@ -114,11 +114,11 @@ SpatialObjectToImageStatisticsCalculator<TInputImage, TInputSpatialObject, TSamp
 
     const typename MaskImageType::ConstPointer maskImage = maskSpatialObject->GetImage();
 
-    ImageRegionConstIteratorWithIndex<MaskImageType> it(maskImage, maskImage->GetLargestPossibleRegion());
-    IndexType                                        ind;
-    PointType                                        pnt;
-    PointType                                        tPnt;
-    VectorType                                       mv;
+    ImageRegionConstIteratorWithIndex it(maskImage, maskImage->GetLargestPossibleRegion());
+    IndexType                         ind;
+    PointType                         pnt;
+    PointType                         tPnt;
+    VectorType                        mv;
     while (!it.IsAtEnd())
     {
       if (it.Get() > 0) // if inside the mask
@@ -179,10 +179,10 @@ SpatialObjectToImageStatisticsCalculator<TInputImage, TInputSpatialObject, TSamp
 
     const RegionType region(indMin, size);
 
-    ImageRegionConstIteratorWithIndex<ImageType> it(m_Image, region);
-    IndexType                                    ind;
-    PointType                                    pnt;
-    VectorType                                   mv;
+    ImageRegionConstIteratorWithIndex it(m_Image, region);
+    IndexType                         ind;
+    PointType                         pnt;
+    VectorType                        mv;
     while (!it.IsAtEnd())
     {
       ind = it.GetIndex();

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
@@ -169,7 +169,7 @@ BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   // because in that way we will take care carefully at boundary
   // pixels of output requested region.  Take care means that we will
   // check if a boundary pixel is or not a border pixel.
-  ImageRegionIteratorWithIndex<TempImageType> tmpRegIndexIt(tmpImage, tmpRequestedRegion);
+  ImageRegionIteratorWithIndex tmpRegIndexIt(tmpImage, tmpRequestedRegion);
 
   ConstNeighborhoodIterator<TempImageType> oNeighbIt(radius, tmpImage, tmpRequestedRegion);
 
@@ -383,7 +383,7 @@ BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   auto                                              vecEndIt = this->KernelCCVectorEnd();
 
   // iterator on output image
-  ImageRegionIteratorWithIndex<OutputImageType> ouRegIndexIt(output, outputRegion);
+  ImageRegionIteratorWithIndex ouRegIndexIt(output, outputRegion);
 
   // InputRegionForThread is the output region for thread padded by
   // kernel radius We must traverse this padded region because some

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
@@ -159,7 +159,7 @@ BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   // because in that way we will take care carefully at boundary
   // pixels of output requested region.  Take care means that we will
   // check if a boundary pixel is or not a border pixel.
-  ImageRegionIteratorWithIndex<TempImageType> tmpRegIndexIt(tmpImage, tmpRequestedRegion);
+  ImageRegionIteratorWithIndex tmpRegIndexIt(tmpImage, tmpRequestedRegion);
 
   ConstNeighborhoodIterator<TempImageType> oNeighbIt(radius, tmpImage, tmpRequestedRegion);
 
@@ -377,7 +377,7 @@ BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   auto                                              vecEndIt = this->KernelCCVectorEnd();
 
   // iterator on output image
-  ImageRegionIteratorWithIndex<OutputImageType> ouRegIndexIt(output, outputRegion);
+  ImageRegionIteratorWithIndex ouRegIndexIt(output, outputRegion);
 
   // InputRegionForThread is the output region for thread padded by
   // kernel radius We must traverse this padded region because some

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.hxx
@@ -133,7 +133,7 @@ BinaryMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::AnalyzeKernel()
 
   // Now look for connected component and record one SE element
   // position for each CC.
-  ImageRegionIteratorWithIndex<BoolImageType> kernelImageItIndex(tmpSEImage, tmpSEImage->GetRequestedRegion());
+  ImageRegionIteratorWithIndex kernelImageItIndex(tmpSEImage, tmpSEImage->GetRequestedRegion());
 
   // Neighborhood iterator on SE element temp image
   auto                                padBy = InputSizeType::Filled(1);

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -477,8 +477,7 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::InitializePatchWeight
   auto centerIndex = WeightsImageType::IndexType::Filled(patchRadius);
 
   unsigned int pos = 0;
-  for (ImageRegionIteratorWithIndex<WeightsImageType> pwIt(physicalWeightsImage, physicalRegion); !pwIt.IsAtEnd();
-       ++pwIt)
+  for (ImageRegionIteratorWithIndex pwIt(physicalWeightsImage, physicalRegion); !pwIt.IsAtEnd(); ++pwIt)
   {
     typename WeightsImageType::IndexType curIndex = pwIt.GetIndex();
     // Compute distances of each pixel from center pixel

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
@@ -197,7 +197,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
   {
     const typename ReferenceImageType::Pointer refImage =
       static_cast<ReferenceImageType *>(this->ProcessObject::GetInput(0));
-    ImageRegionConstIteratorWithIndex<ReferenceImageType> it(refImage, outputRegionForThread);
+    ImageRegionConstIteratorWithIndex it(refImage, outputRegionForThread);
 
     using GradientIteratorType = ImageRegionConstIterator<GradientImageType>;
     std::vector<GradientIteratorType *> gradientItContainer;
@@ -308,7 +308,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
     // The enum will ensure that an inappropriate cast is not done
     gradientImagePointer = itkDynamicCastInDebugMode<GradientImagesType *>(this->ProcessObject::GetInput(0));
 
-    ImageRegionConstIteratorWithIndex<GradientImagesType> git(gradientImagePointer, outputRegionForThread);
+    ImageRegionConstIteratorWithIndex git(gradientImagePointer, outputRegionForThread);
     git.GoToBegin();
 
     // Compute the indices of the baseline images and gradient images

--- a/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.hxx
@@ -194,9 +194,8 @@ GaussianExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::Gau
   const typename ConstantVelocityFieldType::SizeType   size = region.GetSize();
   const typename ConstantVelocityFieldType::IndexType  startIndex = region.GetIndex();
 
-  ImageRegionIteratorWithIndex<ConstantVelocityFieldType>      fieldIt(field, field->GetLargestPossibleRegion());
-  ImageRegionConstIteratorWithIndex<ConstantVelocityFieldType> smoothedFieldIt(smoothField,
-                                                                               smoothField->GetLargestPossibleRegion());
+  ImageRegionIteratorWithIndex      fieldIt(field, field->GetLargestPossibleRegion());
+  ImageRegionConstIteratorWithIndex smoothedFieldIt(smoothField, smoothField->GetLargestPossibleRegion());
   for (fieldIt.GoToBegin(), smoothedFieldIt.GoToBegin(); !fieldIt.IsAtEnd(); ++fieldIt, ++smoothedFieldIt)
   {
     typename ConstantVelocityFieldType::IndexType index = fieldIt.GetIndex();

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.hxx
@@ -186,9 +186,8 @@ GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimen
   const typename DisplacementFieldType::SizeType   size = region.GetSize();
   const typename DisplacementFieldType::IndexType  startIndex = region.GetIndex();
 
-  ImageRegionIteratorWithIndex<DisplacementFieldType>      fieldIt(field, field->GetLargestPossibleRegion());
-  ImageRegionConstIteratorWithIndex<DisplacementFieldType> smoothedFieldIt(smoothField,
-                                                                           smoothField->GetLargestPossibleRegion());
+  ImageRegionIteratorWithIndex      fieldIt(field, field->GetLargestPossibleRegion());
+  ImageRegionConstIteratorWithIndex smoothedFieldIt(smoothField, smoothField->GetLargestPossibleRegion());
   for (fieldIt.GoToBegin(), smoothedFieldIt.GoToBegin(); !fieldIt.IsAtEnd(); ++fieldIt, ++smoothedFieldIt)
   {
     typename DisplacementFieldType::IndexType index = fieldIt.GetIndex();

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.hxx
@@ -202,9 +202,8 @@ GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform<TParametersValueType,
   TimeVaryingVelocityFieldSizeType  size = field->GetLargestPossibleRegion().GetSize();
   TimeVaryingVelocityFieldIndexType startIndex = field->GetLargestPossibleRegion().GetIndex();
 
-  ImageRegionIteratorWithIndex<VelocityFieldType>      fieldIt(field, field->GetLargestPossibleRegion());
-  ImageRegionConstIteratorWithIndex<VelocityFieldType> smoothedFieldIt(smoothField,
-                                                                       smoothField->GetLargestPossibleRegion());
+  ImageRegionIteratorWithIndex      fieldIt(field, field->GetLargestPossibleRegion());
+  ImageRegionConstIteratorWithIndex smoothedFieldIt(smoothField, smoothField->GetLargestPossibleRegion());
   for (fieldIt.GoToBegin(), smoothedFieldIt.GoToBegin(); !fieldIt.IsAtEnd(); ++fieldIt, ++smoothedFieldIt)
   {
     TimeVaryingVelocityFieldIndexType index = fieldIt.GetIndex();

--- a/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.hxx
@@ -153,7 +153,7 @@ InverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::PrepareKernelBas
 
   unsigned int landmarkId = 0;
 
-  ImageRegionConstIteratorWithIndex<InputImageType> ot(sampledInput, subsampledRegion);
+  ImageRegionConstIteratorWithIndex ot(sampledInput, subsampledRegion);
 
   OutputPixelType               value;
   Point<double, ImageDimension> sourcePoint;
@@ -228,7 +228,7 @@ InverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::GenerateData()
   ProgressReporter progress(this, 0, region.GetNumberOfPixels(), 10);
 
   // Walk the output region
-  for (ImageRegionIteratorWithIndex<TOutputImage> outIt(outputPtr, region); !outIt.IsAtEnd(); ++outIt)
+  for (ImageRegionIteratorWithIndex outIt(outputPtr, region); !outIt.IsAtEnd(); ++outIt)
   {
     // Determine the index of the current output pixel
     outputIndex = outIt.GetIndex();

--- a/Modules/Filtering/DisplacementField/include/itkLandmarkDisplacementFieldSource.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkLandmarkDisplacementFieldSource.hxx
@@ -131,7 +131,7 @@ LandmarkDisplacementFieldSource<TOutputImage>::GenerateData()
   ProgressReporter progress(this, 0, region.GetNumberOfPixels(), 10);
 
   // Walk the output region
-  for (ImageRegionIteratorWithIndex<TOutputImage> outIt(outputPtr, region); !outIt.IsAtEnd(); ++outIt)
+  for (ImageRegionIteratorWithIndex outIt(outputPtr, region); !outIt.IsAtEnd(); ++outIt)
   {
     // Determine the index of the current output pixel
     outputIndex = outIt.GetIndex();

--- a/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
@@ -113,8 +113,8 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Prep
     maxLength = std::max(maxLength, size[dim]);
   }
 
-  ImageRegionConstIteratorWithIndex<InputImageType> it(inputImage, region);
-  ImageRegionIteratorWithIndex<VoronoiImageType>    ot(voronoiMap, region);
+  ImageRegionConstIteratorWithIndex it(inputImage, region);
+  ImageRegionIteratorWithIndex      ot(voronoiMap, region);
 
   itkDebugMacro("PrepareData: Copy input to output");
   if (m_InputIsBinary)
@@ -154,7 +154,7 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Prep
 
   distanceComponents->Allocate();
 
-  ImageRegionIteratorWithIndex<VectorImageType> ct(distanceComponents, region);
+  ImageRegionIteratorWithIndex ct(distanceComponents, region);
 
   OffsetType maxValue;
   OffsetType minValue;
@@ -198,9 +198,9 @@ DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::Comp
 
   const typename OutputImageType::RegionType region = voronoiMap->GetRequestedRegion();
 
-  ImageRegionIteratorWithIndex<VoronoiImageType> ot(voronoiMap, region);
-  ImageRegionIteratorWithIndex<VectorImageType>  ct(distanceComponents, region);
-  ImageRegionIteratorWithIndex<OutputImageType>  dt(distanceMap, region);
+  ImageRegionIteratorWithIndex ot(voronoiMap, region);
+  ImageRegionIteratorWithIndex ct(distanceComponents, region);
+  ImageRegionIteratorWithIndex dt(distanceMap, region);
 
   itkDebugMacro("ComputeVoronoiMap Region: " << region);
   while (!ot.IsAtEnd())

--- a/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.hxx
@@ -142,9 +142,9 @@ FFTWComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::ThreadedGenerat
   const typename OutputImageType::SizeType & outputSize = outputPtr->GetRequestedRegion().GetSize();
   const unsigned int                         lineSize = outputSize[this->m_Direction];
 
-  ImageLinearConstIteratorWithIndex<InputImageType> inputIt(inputPtr, outputRegion);
+  ImageLinearConstIteratorWithIndex inputIt(inputPtr, outputRegion);
   // the output region should be the same as the input region in the non-fft directions
-  ImageLinearIteratorWithIndex<OutputImageType> outputIt(outputPtr, outputRegion);
+  ImageLinearIteratorWithIndex outputIt(outputPtr, outputRegion);
 
   inputIt.SetDirection(this->m_Direction);
   outputIt.SetDirection(this->m_Direction);

--- a/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.hxx
@@ -130,8 +130,8 @@ FFTWForward1DFFTImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(con
   const InputImageType * inputPtr = this->GetInput();
   OutputImageType *      outputPtr = this->GetOutput();
 
-  ImageLinearConstIteratorWithIndex<InputImageType> inputIt(inputPtr, outputRegion);
-  ImageLinearIteratorWithIndex<OutputImageType>     outputIt(outputPtr, outputRegion);
+  ImageLinearConstIteratorWithIndex inputIt(inputPtr, outputRegion);
+  ImageLinearIteratorWithIndex      outputIt(outputPtr, outputRegion);
 
   inputIt.SetDirection(this->GetDirection());
   outputIt.SetDirection(this->GetDirection());

--- a/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.hxx
@@ -134,8 +134,8 @@ FFTWInverse1DFFTImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(con
   const typename OutputImageType::SizeType & outputSize = outputPtr->GetRequestedRegion().GetSize();
   const unsigned int                         lineSize = outputSize[this->m_Direction];
 
-  ImageLinearConstIteratorWithIndex<InputImageType> inputIt(inputPtr, outputRegion);
-  ImageLinearIteratorWithIndex<OutputImageType>     outputIt(outputPtr, outputRegion);
+  ImageLinearConstIteratorWithIndex inputIt(inputPtr, outputRegion);
+  ImageLinearIteratorWithIndex      outputIt(outputPtr, outputRegion);
 
   inputIt.SetDirection(this->m_Direction);
   outputIt.SetDirection(this->m_Direction);

--- a/Modules/Filtering/FFT/include/itkHalfToFullHermitianImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkHalfToFullHermitianImageFilter.hxx
@@ -131,7 +131,7 @@ HalfToFullHermitianImageFilter<TInputImage>::DynamicThreadedGenerateData(
     conjugateRegionSize[0] = outputRegionMaximumIndex[0] - conjugateRegionIndex[0];
     const OutputImageRegionType conjugateRegion(conjugateRegionIndex, conjugateRegionSize);
 
-    for (ImageRegionIteratorWithIndex<OutputImageType> oIt(outputPtr, conjugateRegion); !oIt.IsAtEnd(); ++oIt)
+    for (ImageRegionIteratorWithIndex oIt(outputPtr, conjugateRegion); !oIt.IsAtEnd(); ++oIt)
     {
       OutputImageIndexType conjugateIndex = oIt.GetIndex();
 

--- a/Modules/Filtering/FFT/include/itkVnlComplexToComplex1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlComplexToComplex1DFFTImageFilter.hxx
@@ -52,8 +52,8 @@ VnlComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
     direction,
     output->GetRequestedRegion(),
     [this, input, output, direction, vectorSize](const typename OutputImageType::RegionType & lambdaRegion) {
-      ImageLinearConstIteratorWithIndex<InputImageType> inputIt(input, lambdaRegion);
-      ImageLinearIteratorWithIndex<OutputImageType>     outputIt(output, lambdaRegion);
+      ImageLinearConstIteratorWithIndex inputIt(input, lambdaRegion);
+      ImageLinearIteratorWithIndex      outputIt(output, lambdaRegion);
 
       inputIt.SetDirection(direction);
       outputIt.SetDirection(direction);

--- a/Modules/Filtering/FFT/include/itkVnlForward1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlForward1DFFTImageFilter.hxx
@@ -58,8 +58,8 @@ VnlForward1DFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
     direction,
     output->GetRequestedRegion(),
     [input, output, direction, vectorSize](const typename OutputImageType::RegionType & lambdaRegion) {
-      ImageLinearConstIteratorWithIndex<InputImageType> inputIt(input, lambdaRegion);
-      ImageLinearIteratorWithIndex<OutputImageType>     outputIt(output, lambdaRegion);
+      ImageLinearConstIteratorWithIndex inputIt(input, lambdaRegion);
+      ImageLinearIteratorWithIndex      outputIt(output, lambdaRegion);
 
       inputIt.SetDirection(direction);
       outputIt.SetDirection(direction);

--- a/Modules/Filtering/FFT/include/itkVnlForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlForwardFFTImageFilter.hxx
@@ -72,8 +72,7 @@ VnlForwardFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
   vnlfft.transform(signal.data_block(), -1);
 
   // Copy the VNL output back to the ITK image.
-  for (ImageRegionIteratorWithIndex<TOutputImage> oIt(outputPtr, outputPtr->GetLargestPossibleRegion()); !oIt.IsAtEnd();
-       ++oIt)
+  for (ImageRegionIteratorWithIndex oIt(outputPtr, outputPtr->GetLargestPossibleRegion()); !oIt.IsAtEnd(); ++oIt)
   {
     const typename OutputImageType::IndexType       index = oIt.GetIndex();
     const typename OutputImageType::OffsetValueType offset = inputPtr->ComputeOffset(index);

--- a/Modules/Filtering/FFT/include/itkVnlHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -69,9 +69,7 @@ VnlHalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::Generate
 
   const OutputIndexValueType maxXIndex = inputIndex[0] + static_cast<OutputIndexValueType>(inputSize[0]);
   unsigned int               si = 0;
-  for (ImageRegionIteratorWithIndex<OutputImageType> oIt(outputPtr, outputPtr->GetLargestPossibleRegion());
-       !oIt.IsAtEnd();
-       ++oIt)
+  for (ImageRegionIteratorWithIndex oIt(outputPtr, outputPtr->GetLargestPossibleRegion()); !oIt.IsAtEnd(); ++oIt)
   {
     typename OutputImageType::IndexType index = oIt.GetIndex();
     if (index[0] >= maxXIndex)

--- a/Modules/Filtering/FFT/include/itkVnlInverse1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlInverse1DFFTImageFilter.hxx
@@ -52,8 +52,8 @@ VnlInverse1DFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
     direction,
     output->GetRequestedRegion(),
     [input, output, direction, vectorSize](const typename OutputImageType::RegionType & lambdaRegion) {
-      ImageLinearConstIteratorWithIndex<InputImageType> inputIt(input, lambdaRegion);
-      ImageLinearIteratorWithIndex<OutputImageType>     outputIt(output, lambdaRegion);
+      ImageLinearConstIteratorWithIndex inputIt(input, lambdaRegion);
+      ImageLinearIteratorWithIndex      outputIt(output, lambdaRegion);
 
       inputIt.SetDirection(direction);
       outputIt.SetDirection(direction);

--- a/Modules/Filtering/FFT/include/itkVnlRealToHalfHermitianForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlRealToHalfHermitianForwardFFTImageFilter.hxx
@@ -71,8 +71,7 @@ VnlRealToHalfHermitianForwardFFTImageFilter<TInputImage, TOutputImage>::Generate
   vnlfft.transform(signal.data_block(), -1);
 
   // Copy the VNL output back to the ITK image.
-  for (ImageRegionIteratorWithIndex<TOutputImage> oIt(outputPtr, outputPtr->GetLargestPossibleRegion()); !oIt.IsAtEnd();
-       ++oIt)
+  for (ImageRegionIteratorWithIndex oIt(outputPtr, outputPtr->GetLargestPossibleRegion()); !oIt.IsAtEnd(); ++oIt)
   {
     const typename OutputImageType::IndexType       index = oIt.GetIndex();
     const typename OutputImageType::OffsetValueType offset = inputPtr->ComputeOffset(index);

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageToNodePairContainerAdaptor.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageToNodePairContainerAdaptor.hxx
@@ -126,7 +126,7 @@ FastMarchingImageToNodePairContainerAdaptor<TInput, TOutput, TImage>::SetPointsF
   {
     const NodePairContainerPointer nodes = NodePairContainerType::New();
 
-    ImageRegionConstIteratorWithIndex<ImageType> it(image, image->GetBufferedRegion());
+    ImageRegionConstIteratorWithIndex it(image, image->GetBufferedRegion());
 
     if (iLabel == Traits::Alive || iLabel == Traits::InitialTrial ||
         (iLabel == Traits::Forbidden && !m_IsForbiddenImageBinaryMask))

--- a/Modules/Filtering/ImageCompare/include/itkCheckerBoardImageFilter.hxx
+++ b/Modules/Filtering/ImageCompare/include/itkCheckerBoardImageFilter.hxx
@@ -60,9 +60,9 @@ CheckerBoardImageFilter<TImage>::DynamicThreadedGenerateData(const ImageRegionTy
 
   // Create an iterator that will walk the output region for this thread.
 
-  ImageRegionIteratorWithIndex<OutputImageType>     outItr(outputPtr, outputRegionForThread);
-  ImageRegionConstIteratorWithIndex<InputImageType> in1Itr(input1Ptr, outputRegionForThread);
-  ImageRegionConstIteratorWithIndex<InputImageType> in2Itr(input2Ptr, outputRegionForThread);
+  ImageRegionIteratorWithIndex      outItr(outputPtr, outputRegionForThread);
+  ImageRegionConstIteratorWithIndex in1Itr(input1Ptr, outputRegionForThread);
+  ImageRegionConstIteratorWithIndex in2Itr(input2Ptr, outputRegionForThread);
 
   TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
@@ -319,7 +319,7 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::FollowEdge(IndexType  
 
   ConstNeighborhoodIterator<TOutputImage> oit(
     radius, multiplyImageFilterOutput, multiplyImageFilterOutput->GetRequestedRegion());
-  ImageRegionIteratorWithIndex<TOutputImage> uit(this->m_OutputImage, this->m_OutputImage->GetRequestedRegion());
+  ImageRegionIteratorWithIndex uit(this->m_OutputImage, this->m_OutputImage->GetRequestedRegion());
 
   uit.SetIndex(index);
   if (Math::ExactlyEquals(uit.Get(), NumericTraits<OutputImagePixelType>::OneValue()))

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -105,7 +105,7 @@ HoughTransform2DCirclesImageFilter<TInputPixelType, TOutputPixelType, TRadiusPix
   m_RadiusImage->SetDirection(inputImage->GetDirection());
   m_RadiusImage->AllocateInitialized();
 
-  ImageRegionConstIteratorWithIndex<InputImageType> image_it(inputImage, inputImage->GetRequestedRegion());
+  ImageRegionConstIteratorWithIndex image_it(inputImage, inputImage->GetRequestedRegion());
 
   const ImageRegion<2> & region = outputImage->GetRequestedRegion();
 

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
@@ -101,7 +101,7 @@ HoughTransform2DLinesImageFilter<TInputPixelType, TOutputPixelType>::GenerateDat
 
   const double nPI = 4.0 * std::atan(1.0);
 
-  ImageRegionConstIteratorWithIndex<InputImageType> image_it(inputImage, inputImage->GetRequestedRegion());
+  ImageRegionConstIteratorWithIndex image_it(inputImage, inputImage->GetRequestedRegion());
 
   Index<2> index;
 
@@ -158,7 +158,7 @@ HoughTransform2DLinesImageFilter<TInputPixelType, TOutputPixelType>::Simplify()
   typename OutputImageType::PixelType value;
   typename OutputImageType::PixelType valuemax;
 
-  ImageRegionConstIteratorWithIndex<InputImageType> image_it(inputImage, inputImage->GetRequestedRegion());
+  ImageRegionConstIteratorWithIndex image_it(inputImage, inputImage->GetRequestedRegion());
 
   const double nPI = 4.0 * std::atan(1.0);
 

--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilterBase.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilterBase.hxx
@@ -51,10 +51,10 @@ MovingHistogramImageFilterBase<TInputImage, TOutputImage, TKernel>::SetKernel(co
   auto tmpSEImage = BoolImageType::New();
   tmpSEImage->SetRegions(kernel.GetSize());
   tmpSEImage->Allocate();
-  const RegionType                            tmpSEImageRegion = tmpSEImage->GetRequestedRegion();
-  ImageRegionIteratorWithIndex<BoolImageType> kernelImageIt(tmpSEImage, tmpSEImageRegion);
-  KernelIteratorType                          kernel_it = kernel.Begin();
-  OffsetListType                              kernelOffsets;
+  const RegionType             tmpSEImageRegion = tmpSEImage->GetRequestedRegion();
+  ImageRegionIteratorWithIndex kernelImageIt(tmpSEImage, tmpSEImageRegion);
+  KernelIteratorType           kernel_it = kernel.Begin();
+  OffsetListType               kernelOffsets;
 
   // create a center index to compute the offset
   IndexType centerIndex;

--- a/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.hxx
@@ -245,8 +245,8 @@ RecursiveSeparableImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerat
 
   const RegionType region = outputRegionForThread;
 
-  ImageLinearConstIteratorWithIndex<TInputImage> inputIterator(inputImage, region);
-  ImageLinearIteratorWithIndex<TOutputImage>     outputIterator(outputImage, region);
+  ImageLinearConstIteratorWithIndex inputIterator(inputImage, region);
+  ImageLinearIteratorWithIndex      outputIterator(outputImage, region);
 
   inputIterator.SetDirection(this->m_Direction);
   outputIterator.SetDirection(this->m_Direction);

--- a/Modules/Filtering/ImageGradient/include/itkDifferenceOfGaussiansGradientImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkDifferenceOfGaussiansGradientImageFilter.hxx
@@ -63,7 +63,7 @@ DifferenceOfGaussiansGradientImageFilter<TInputImage, TDataType>::GenerateData()
 
   // Create an iterator that will walk the output region
 
-  ImageRegionIteratorWithIndex<TOutputImage> outIt(outputPtr, outputPtr->GetRequestedRegion());
+  ImageRegionIteratorWithIndex outIt(outputPtr, outputPtr->GetRequestedRegion());
 
   // Define a few indices that will be used to translate from an input pixel
   // to an output pixel

--- a/Modules/Filtering/ImageGrid/include/itkCyclicShiftImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkCyclicShiftImageFilter.hxx
@@ -63,8 +63,7 @@ CyclicShiftImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   TotalProgressReporter progress(this, this->GetOutput()->GetRequestedRegion().GetNumberOfPixels());
 
   // Now iterate over the pixels of the output region for this thread.
-  for (ImageRegionIteratorWithIndex<OutputImageType> outIt(this->GetOutput(), outputRegionForThread); !outIt.IsAtEnd();
-       ++outIt)
+  for (ImageRegionIteratorWithIndex outIt(this->GetOutput(), outputRegionForThread); !outIt.IsAtEnd(); ++outIt)
   {
     IndexType index = outIt.GetIndex();
 

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImageFilter.hxx
@@ -103,8 +103,8 @@ InterpolateImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()
   intermediateRegion.SetIndex(ImageDimension, 0);
   intermediateRegion.SetSize(ImageDimension, 1);
 
-  ImageRegionConstIteratorWithIndex<TInputImage>      inIter(this->GetInput1(), outputRegion);
-  ImageRegionIteratorWithIndex<IntermediateImageType> outIter(m_IntermediateImage, intermediateRegion);
+  ImageRegionConstIteratorWithIndex inIter(this->GetInput1(), outputRegion);
+  ImageRegionIteratorWithIndex      outIter(m_IntermediateImage, intermediateRegion);
 
   while (!inIter.IsAtEnd())
   {
@@ -157,7 +157,7 @@ InterpolateImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
   // Walk the output region
-  for (ImageRegionIteratorWithIndex<TOutputImage> outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); ++outIt)
+  for (ImageRegionIteratorWithIndex outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); ++outIt)
   {
     // Determine the intermediate image index
     outputIndex = outIt.GetIndex();

--- a/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
@@ -753,8 +753,7 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
         // Do the actual copy of the input pixels to the output pixels here.
         InputImageIndexType currentInputIndex;
         InputIterator       inIt(inputPtr, inputRegion);
-        for (ImageRegionIteratorWithIndex<TOutputImage> outIt(outputPtr, outputRegion); !outIt.IsAtEnd();
-             ++outIt, i++, ++inIt)
+        for (ImageRegionIteratorWithIndex outIt(outputPtr, outputRegion); !outIt.IsAtEnd(); ++outIt, i++, ++inIt)
         {
           OutputImageIndexType currentOutputIndex = outIt.GetIndex();
 

--- a/Modules/Filtering/ImageGrid/include/itkPadImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPadImageFilterBase.hxx
@@ -99,7 +99,7 @@ PadImageFilterBase<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
     progress.Completed(copyRegion.GetNumberOfPixels());
 
     // Use the boundary condition for pixels outside the input image region.
-    ImageRegionExclusionIteratorWithIndex<TOutputImage> outIter(outputPtr, outputRegionForThread);
+    ImageRegionExclusionIteratorWithIndex outIter(outputPtr, outputRegionForThread);
     outIter.SetExclusionRegion(copyRegion);
     outIter.GoToBegin();
     while (!outIter.IsAtEnd())
@@ -113,7 +113,7 @@ PadImageFilterBase<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   else
   {
     // There is no overlap. Apply to the boundary condition for every pixel.
-    ImageRegionIteratorWithIndex<TOutputImage> outIter(outputPtr, outputRegionForThread);
+    ImageRegionIteratorWithIndex outIter(outputPtr, outputRegionForThread);
     while (!outIter.IsAtEnd())
     {
       auto value = static_cast<OutputImagePixelType>(m_BoundaryCondition->GetPixel(outIter.GetIndex(), inputPtr));

--- a/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.hxx
@@ -199,7 +199,7 @@ PermuteAxesImageFilter<TImage>::DynamicThreadedGenerateData(const OutputImageReg
   typename TImage::IndexType outputIndex;
 
   // walk the output region, and sample the input image
-  for (ImageRegionIteratorWithIndex<TImage> outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); ++outIt)
+  for (ImageRegionIteratorWithIndex outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); ++outIt)
   {
     // determine the index of the output pixel
     outputIndex = outIt.GetIndex();

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -383,7 +383,7 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
   using OutputType = typename InterpolatorType::OutputType;
 
   // Walk the output region
-  for (ImageRegionIteratorWithIndex<TOutputImage> outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); ++outIt)
+  for (ImageRegionIteratorWithIndex outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); ++outIt)
   {
     // Determine the index of the current output pixel
 

--- a/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
@@ -143,7 +143,7 @@ ShrinkImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   // Define/declare an iterator that will walk the output region for this
   // thread.
 
-  for (ImageRegionIteratorWithIndex<TOutputImage> outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); ++outIt)
+  for (ImageRegionIteratorWithIndex outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); ++outIt)
   {
     // Determine the index and physical location of the output pixel
     outputIndex = outIt.GetIndex();

--- a/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
@@ -135,7 +135,7 @@ SliceImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   OutputIndexType destIndex;
   InputIndexType  srcIndex;
 
-  for (ImageRegionIteratorWithIndex<TOutputImage> outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); ++outIt)
+  for (ImageRegionIteratorWithIndex outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); ++outIt)
   {
     // Determine the index and physical location of the output pixel
     destIndex = outIt.GetIndex();

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
@@ -231,7 +231,7 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
   // Initialize the tile image with an image number for each tile. If
   // there is no corresponding input image for a tile, then set the
   // image number to -1.
-  ImageRegionIteratorWithIndex<TileImageType> it(m_TileImage, m_TileImage->GetBufferedRegion());
+  ImageRegionIteratorWithIndex it(m_TileImage, m_TileImage->GetBufferedRegion());
 
   unsigned int input = 0;
   TileInfo     info;
@@ -268,7 +268,7 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
     }
   }
 
-  ImageLinearConstIteratorWithIndex<TileImageType> tit(m_TileImage, m_TileImage->GetRequestedRegion());
+  ImageLinearConstIteratorWithIndex tit(m_TileImage, m_TileImage->GetRequestedRegion());
   for (unsigned int i = 0; i < OutputImageDimension; ++i)
   {
     tit.SetDirection(i);

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
@@ -282,10 +282,10 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::DynamicThreadedG
   TotalProgressReporter progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
   // iterator for the output image
-  ImageRegionIteratorWithIndex<OutputImageType> outputIt(outputPtr, outputRegionForThread);
-  IndexType                                     index{};
-  PointType                                     point{};
-  DisplacementType                              displacement{};
+  ImageRegionIteratorWithIndex outputIt(outputPtr, outputRegionForThread);
+  IndexType                    index{};
+  PointType                    point{};
+  DisplacementType             displacement{};
   NumericTraits<DisplacementType>::SetLength(displacement, ImageDimension);
   static_assert(PointType::Dimension == ImageDimension, "ERROR: Point type and ImageDimension must be the same!");
   if (this->m_DefFieldSameInformation)

--- a/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.hxx
@@ -145,8 +145,8 @@ WarpVectorImageFilter<TInputImage, TOutputImage, TDisplacementField>::DynamicThr
   const DisplacementFieldPointer fieldPtr = this->GetDisplacementField();
 
 
-  ImageRegionIteratorWithIndex<OutputImageType> outputIt(outputPtr, outputRegionForThread);
-  TotalProgressReporter                         progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
+  ImageRegionIteratorWithIndex outputIt(outputPtr, outputRegionForThread);
+  TotalProgressReporter        progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
   ImageRegionIterator<DisplacementFieldType> fieldIt(fieldPtr, outputRegionForThread);
 

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
@@ -121,7 +121,7 @@ PolylineMask2DImageFilter<TInputImage, TPolyline, TOutputImage>::GenerateData()
 
   ImageIndexType tmpImageIndex{};
 
-  ImageLinearIteratorWithIndex<TOutputImage> imit(outputImagePtr, outputImagePtr->GetLargestPossibleRegion());
+  ImageLinearIteratorWithIndex imit(outputImagePtr, outputImagePtr->GetLargestPossibleRegion());
   imit.SetDirection(0);
 
   itkDebugMacro("Generating the mask defined by the polyline.....");

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -355,8 +355,7 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
 
   using LineIteratorType = LineIterator<ProjectionImageType>;
 
-  ImageLinearIteratorWithIndex<ProjectionImageType> imit(projectionImagePtr,
-                                                         projectionImagePtr->GetLargestPossibleRegion());
+  ImageLinearIteratorWithIndex imit(projectionImagePtr, projectionImagePtr->GetLargestPossibleRegion());
   imit.SetDirection(0);
 
   while (piter != container->End())

--- a/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.hxx
@@ -118,7 +118,7 @@ VectorExpandImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   InterpolatedType interpolatedValue;
 
   // Walk the output region, and interpolate the input image
-  for (ImageRegionIteratorWithIndex<TOutputImage> outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); ++outIt)
+  for (ImageRegionIteratorWithIndex outIt(outputPtr, outputRegionForThread); !outIt.IsAtEnd(); ++outIt)
   {
     // Determine the index of the output pixel
     outputIndex = outIt.GetIndex();

--- a/Modules/Filtering/ImageSources/include/itkGaborImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGaborImageSource.hxx
@@ -58,9 +58,7 @@ GaborImageSource<TOutputImage>::GenerateData()
   ProgressReporter progress(this, 0, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
   // Walk the output image, evaluating the spatial function at each pixel
-  for (ImageRegionIteratorWithIndex<OutputImageType> outIt(outputPtr, outputPtr->GetRequestedRegion());
-       !outIt.IsAtEnd();
-       ++outIt)
+  for (ImageRegionIteratorWithIndex outIt(outputPtr, outputPtr->GetRequestedRegion()); !outIt.IsAtEnd(); ++outIt)
   {
     const typename OutputImageType::IndexType index = outIt.GetIndex();
     // The position at which the function is evaluated

--- a/Modules/Filtering/ImageSources/include/itkGaussianImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGaussianImageSource.hxx
@@ -99,8 +99,7 @@ GaussianImageSource<TOutputImage>::GenerateData()
 
   ProgressReporter progress(this, 0, outputPtr->GetRequestedRegion().GetNumberOfPixels());
   // Walk the output image, evaluating the spatial function at each pixel
-  for (ImageRegionIteratorWithIndex<TOutputImage> outIt(outputPtr, outputPtr->GetRequestedRegion()); !outIt.IsAtEnd();
-       ++outIt)
+  for (ImageRegionIteratorWithIndex outIt(outputPtr, outputPtr->GetRequestedRegion()); !outIt.IsAtEnd(); ++outIt)
   {
     const typename TOutputImage::IndexType index = outIt.GetIndex();
     // The position at which the function is evaluated

--- a/Modules/Filtering/ImageSources/include/itkPhysicalPointImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkPhysicalPointImageSource.hxx
@@ -51,9 +51,9 @@ PhysicalPointImageSource<TOutputImage>::DynamicThreadedGenerateData(const Region
 
   TotalProgressReporter progress(this, image->GetRequestedRegion().GetNumberOfPixels());
 
-  ImageRegionIteratorWithIndex<TOutputImage> it(image, outputRegionForThread);
-  PointType                                  pt;
-  PixelType                                  px;
+  ImageRegionIteratorWithIndex it(image, outputRegionForThread);
+  PointType                    pt;
+  PixelType                    px;
   NumericTraits<PixelType>::SetLength(px, TOutputImage::ImageDimension);
 
   for (; !it.IsAtEnd(); ++it)

--- a/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
@@ -150,7 +150,7 @@ AccumulateImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   // Accumulate over the Nth dimension ( = m_AccumulateDimension)
   // and divide by the size of the accumulated dimension.
-  ImageRegionIteratorWithIndex<TOutputImage> outputIter(outputImage, outputImage->GetBufferedRegion());
+  ImageRegionIteratorWithIndex outputIter(outputImage, outputImage->GetBufferedRegion());
   using inputIterType = ImageRegionConstIterator<TInputImage>;
 
   typename TInputImage::SizeType  AccumulatedSize = inputImage->GetLargestPossibleRegion().GetSize();

--- a/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.hxx
@@ -77,7 +77,7 @@ ImageMomentsCalculator<TImage>::Compute()
     return;
   }
 
-  ImageRegionConstIteratorWithIndex<ImageType> it(m_Image, m_Image->GetRequestedRegion());
+  ImageRegionConstIteratorWithIndex it(m_Image, m_Image->GetRequestedRegion());
 
   while (!it.IsAtEnd())
   {

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
@@ -169,7 +169,7 @@ LabelStatisticsImageFilter<TInputImage, TLabelImage>::ThreadedStreamedGenerateDa
     return;
   }
 
-  ImageLinearConstIteratorWithIndex<TInputImage> it(this->GetInput(), outputRegionForThread);
+  ImageLinearConstIteratorWithIndex it(this->GetInput(), outputRegionForThread);
 
   ImageScanlineConstIterator labelIt(this->GetLabelInput(), outputRegionForThread);
 

--- a/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.hxx
@@ -271,7 +271,7 @@ ProjectionImageFilter<TInputImage, TOutputImage, TAccumulator>::DynamicThreadedG
   const SizeValueType projectionSize = inputSize[m_ProjectionDimension];
 
   // create the iterators for input and output image
-  ImageLinearConstIteratorWithIndex<TInputImage> iIt(inputImage, inputRegionForThread);
+  ImageLinearConstIteratorWithIndex iIt(inputImage, inputRegionForThread);
   iIt.SetDirection(m_ProjectionDimension);
   iIt.GoToBegin();
 

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToLabelMapFilter.hxx
@@ -87,7 +87,7 @@ LabelImageToLabelMapFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
 {
   TotalProgressReporter progress(this, this->GetInput()->GetRequestedRegion().GetNumberOfPixels());
 
-  ImageLinearConstIteratorWithIndex<InputImageType> it(this->GetInput(), regionForThread);
+  ImageLinearConstIteratorWithIndex it(this->GetInput(), regionForThread);
   it.SetDirection(0);
 
   for (it.GoToBegin(); !it.IsAtEnd(); it.NextLine())

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.hxx
@@ -80,12 +80,10 @@ GrayscaleFillholeImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   // copy the borders of the input image to the marker image
   //
-  ImageRegionExclusionConstIteratorWithIndex<TInputImage> inputBoundaryIt(this->GetInput(),
-                                                                          this->GetInput()->GetRequestedRegion());
+  ImageRegionExclusionConstIteratorWithIndex inputBoundaryIt(this->GetInput(), this->GetInput()->GetRequestedRegion());
   inputBoundaryIt.SetExclusionRegionToInsetRegion();
 
-  ImageRegionExclusionIteratorWithIndex<TInputImage> markerBoundaryIt(markerPtr,
-                                                                      this->GetInput()->GetRequestedRegion());
+  ImageRegionExclusionIteratorWithIndex markerBoundaryIt(markerPtr, this->GetInput()->GetRequestedRegion());
   markerBoundaryIt.SetExclusionRegionToInsetRegion();
 
   // copy the boundary pixels

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.hxx
@@ -90,12 +90,10 @@ GrayscaleGrindPeakImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   // copy the borders of the input image to the marker image
   //
-  ImageRegionExclusionConstIteratorWithIndex<TInputImage> inputBoundaryIt(this->GetInput(),
-                                                                          this->GetInput()->GetRequestedRegion());
+  ImageRegionExclusionConstIteratorWithIndex inputBoundaryIt(this->GetInput(), this->GetInput()->GetRequestedRegion());
   inputBoundaryIt.SetExclusionRegionToInsetRegion();
 
-  ImageRegionExclusionIteratorWithIndex<TInputImage> markerBoundaryIt(markerPtr,
-                                                                      this->GetInput()->GetRequestedRegion());
+  ImageRegionExclusionIteratorWithIndex markerBoundaryIt(markerPtr, this->GetInput()->GetRequestedRegion());
   markerBoundaryIt.SetExclusionRegionToInsetRegion();
 
   // copy the boundary pixels

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
@@ -350,7 +350,7 @@ ContourExtractor2DImageFilter<TInputImage>::GenerateDataForLabels()
     }
     // We use ImageRegionConstIteratorWithIndex here instead of RegionRange because we want access to the GetIndex()
     // method.
-    for (ImageRegionConstIteratorWithIndex<TInputImage> inputIt{ input, inputRegion }; !inputIt.IsAtEnd(); ++inputIt)
+    for (ImageRegionConstIteratorWithIndex inputIt{ input, inputRegion }; !inputIt.IsAtEnd(); ++inputIt)
     {
       const auto &      index = inputIt.GetIndex();
       BoundingBoxType & bbox = labelBoundingBoxes[inputIt.Get()];

--- a/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.hxx
@@ -121,8 +121,7 @@ ExtractOrthogonalSwath2DImageFilter<TImage>::GenerateData()
   interpolator->SetInputImage(inputImagePtr);
 
   // Iterate through the output image
-  for (ImageRegionIteratorWithIndex<ImageType> outputIt(outputPtr, outputPtr->GetRequestedRegion());
-       !outputIt.IsAtEnd();
+  for (ImageRegionIteratorWithIndex outputIt(outputPtr, outputPtr->GetRequestedRegion()); !outputIt.IsAtEnd();
        ++outputIt)
   {
     ImageIndexType index = outputIt.GetIndex();

--- a/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
@@ -215,7 +215,7 @@ PathToImageFilter<TInputPath, TOutputImage>::GenerateData()
   OutputImage->SetOrigin(origin); //   and origin
   OutputImage->Allocate();        // allocate the image
 
-  for (ImageRegionIteratorWithIndex<OutputImageType> imageIt(OutputImage, region); !imageIt.IsAtEnd(); ++imageIt)
+  for (ImageRegionIteratorWithIndex imageIt(OutputImage, region); !imageIt.IsAtEnd(); ++imageIt)
   {
     imageIt.Set(m_BackgroundValue);
   }

--- a/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
@@ -125,8 +125,8 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
     this, 0, (outputPtr->GetRequestedRegion().GetNumberOfPixels()) * m_Repetitions * 2 * NDimensions);
 
   // Copy the input image to the temporary image
-  ImageRegionIteratorWithIndex<TTempImage> tempIt(tempPtr, tempPtr->GetRequestedRegion());
-  InputIterator                            inputIt(inputPtr, inputPtr->GetRequestedRegion());
+  ImageRegionIteratorWithIndex tempIt(tempPtr, tempPtr->GetRequestedRegion());
+  InputIterator                inputIt(inputPtr, inputPtr->GetRequestedRegion());
 
   for (inputIt.GoToBegin(), tempIt.GoToBegin(); !tempIt.IsAtEnd(); ++tempIt, ++inputIt)
   {
@@ -146,7 +146,7 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
     // blur each dimension
     for (unsigned int dim = 0; dim < NDimensions; ++dim)
     {
-      ImageRegionIteratorWithIndex<TTempImage> tempItDir(tempPtr, tempPtr->GetRequestedRegion());
+      ImageRegionIteratorWithIndex tempItDir(tempPtr, tempPtr->GetRequestedRegion());
       tempItDir.GoToBegin();
       while (!tempItDir.IsAtEnd())
       {

--- a/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilter.hxx
@@ -95,7 +95,7 @@ FFTDiscreteGaussianImageFilter<TInputImage, TOutputImage>::GenerateKernelImage()
     m_KernelImage->CopyInformation(this->GetInput());
 
     // Compute kernel image as product of vectors
-    ImageRegionIteratorWithIndex<RealImageType> kernelIt(m_KernelImage, region);
+    ImageRegionIteratorWithIndex kernelIt(m_KernelImage, region);
     while (!kernelIt.IsAtEnd())
     {
       auto   imageIndex = kernelIt.GetIndex();

--- a/Modules/Filtering/SpatialFunction/include/itkSpatialFunctionImageEvaluatorFilter.hxx
+++ b/Modules/Filtering/SpatialFunction/include/itkSpatialFunctionImageEvaluatorFilter.hxx
@@ -43,7 +43,7 @@ SpatialFunctionImageEvaluatorFilter<TSpatialFunction, TInputImage, TOutputImage>
 
   // Create an iterator that will walk the output region
 
-  ImageRegionIteratorWithIndex<TOutputImage> outIt(outputPtr, outputPtr->GetRequestedRegion());
+  ImageRegionIteratorWithIndex outIt(outputPtr, outputPtr->GetRequestedRegion());
 
   // The value produced by the spatial function
   // The type is the range of the spatial function

--- a/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageCalculator.hxx
@@ -46,7 +46,7 @@ KappaSigmaThresholdImageCalculator<TInputImage, TMaskImage>::Compute()
 
   for (unsigned int iteration = 0; iteration < this->m_NumberOfIterations; ++iteration)
   {
-    ImageRegionConstIteratorWithIndex<InputImageType> iIt(this->m_Image, this->m_Image->GetRequestedRegion());
+    ImageRegionConstIteratorWithIndex iIt(this->m_Image, this->m_Image->GetRequestedRegion());
 
     // Compute the mean
     iIt.GoToBegin();

--- a/Modules/Nonunit/Review/include/itkGridForwardWarpImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkGridForwardWarpImageFilter.hxx
@@ -52,7 +52,7 @@ GridForwardWarpImageFilter<TDisplacementField, TOutputImage>::GenerateData()
   IndexType LastIndex = fieldPtr->GetRequestedRegion().GetIndex() + fieldPtr->GetRequestedRegion().GetSize();
 
   // Iterator for the output image
-  ImageRegionIteratorWithIndex<OutputImageType> iter(outputPtr, outputPtr->GetRequestedRegion());
+  ImageRegionIteratorWithIndex iter(outputPtr, outputPtr->GetRequestedRegion());
 
   // Iterator for the deformation field
   using DisplacementFieldIterator = ImageRegionConstIterator<DisplacementFieldType>;

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -176,7 +176,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
   LabelPixelType label;
 
   // Iterator over the label image.
-  ImageRegionConstIteratorWithIndex<TLabelImage> labelIt(this->GetInput(), this->GetInput()->GetBufferedRegion());
+  ImageRegionConstIteratorWithIndex labelIt(this->GetInput(), this->GetInput()->GetBufferedRegion());
 
 
   // begin with empty m_LabelGeometryMapper and m_AllLabels
@@ -261,7 +261,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
 
     // Iterator over the intensity image.
 
-    ImageRegionConstIteratorWithIndex<TIntensityImage> it(intensityImage, intensityImage->GetBufferedRegion());
+    ImageRegionConstIteratorWithIndex it(intensityImage, intensityImage->GetBufferedRegion());
 
     labelIt.GoToBegin();
 

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.hxx
@@ -81,7 +81,7 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeHImage()
     this->m_SharedData->m_LevelSetDataPointerVector[this->m_FunctionId]->m_HeavisideFunctionOfLevelSetImage;
 
   // Iterator for the phi function
-  ImageRegionConstIteratorWithIndex<InputImageType> constIt(contourImage, contourImage->GetRequestedRegion());
+  ImageRegionConstIteratorWithIndex constIt(contourImage, contourImage->GetRequestedRegion());
 
   ImageRegionIteratorWithIndex<InputImageType> It(hBuffer, hBuffer->GetRequestedRegion());
 

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseLevelSetFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseLevelSetFunction.hxx
@@ -100,8 +100,7 @@ ScalarChanAndVeseLevelSetFunction<TInputImage, TFeatureImage, TSharedData>::Comp
   this->m_SharedData->m_LevelSetDataPointerVector[fId]->m_WeightedSumOfPixelValuesOutsideLevelSet = 0;
   this->m_SharedData->m_LevelSetDataPointerVector[fId]->m_BackgroundConstantValues = 0;
 
-  ImageRegionConstIteratorWithIndex<FeatureImageType> fIt(this->m_FeatureImage,
-                                                          this->m_FeatureImage->GetLargestPossibleRegion());
+  ImageRegionConstIteratorWithIndex fIt(this->m_FeatureImage, this->m_FeatureImage->GetLargestPossibleRegion());
 
   FeaturePixelType featureVal;
   FeatureIndexType globalIndex;

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
@@ -491,7 +491,7 @@ RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomainWithRegion(Vir
   this->m_SamplePoints.resize(total);
 
   /* Set up an iterator within the user specified virtual image region. */
-  ImageRegionConstIteratorWithIndex<VirtualImageType> regionIter(image, region);
+  ImageRegionConstIteratorWithIndex regionIter(image, region);
 
 
   /* Iterate over the image */
@@ -564,7 +564,7 @@ RegistrationParameterScalesEstimator<TMetric>::SampleVirtualDomainRandomly()
   this->m_SamplePoints.resize(m_NumberOfRandomSamples);
 
   // Set up a random iterator within the user specified virtual image region.
-  ImageRandomConstIteratorWithIndex<VirtualImageType> randIter(image, this->m_Metric->GetVirtualRegion());
+  ImageRandomConstIteratorWithIndex randIter(image, this->m_Metric->GetVirtualRegion());
 
   randIter.SetNumberOfSamples(this->m_NumberOfRandomSamples);
   randIter.GoToBegin();

--- a/Modules/Registration/Common/include/itkCompareHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkCompareHistogramImageToImageMetric.hxx
@@ -97,7 +97,7 @@ CompareHistogramImageToImageMetric<TFixedImage, TMovingImage>::FormTrainingHisto
   typename FixedImageType::IndexType index;
   typename HistogramType::IndexType  hIndex;
 
-  ImageRegionConstIteratorWithIndex<FixedImageType> ti(this->m_TrainingFixedImage, this->m_TrainingFixedImageRegion);
+  ImageRegionConstIteratorWithIndex ti(this->m_TrainingFixedImage, this->m_TrainingFixedImageRegion);
 
   int NumberOfPixelsCounted = 0;
 

--- a/Modules/Registration/Common/include/itkHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkHistogramImageToImageMetric.hxx
@@ -252,7 +252,7 @@ HistogramImageToImageMetric<TFixedImage, TMovingImage>::ComputeHistogram(const T
   HistogramType::IndexType            hIndex;
 
   fixedRegion = this->GetFixedImageRegion();
-  ImageRegionConstIteratorWithIndex<FixedImageType> ti(fixedImage, fixedRegion);
+  ImageRegionConstIteratorWithIndex ti(fixedImage, fixedRegion);
 
   this->m_NumberOfPixelsCounted = 0;
   this->SetTransformParameters(parameters);

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -461,7 +461,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImageRegion(FixedImage
   }
 
   // Set up a random iterator within the user specified fixed image region.
-  ImageRandomConstIteratorWithIndex<FixedImageType> randIter(m_FixedImage, GetFixedImageRegion());
+  ImageRandomConstIteratorWithIndex randIter(m_FixedImage, GetFixedImageRegion());
   randIter.ReinitializeSeed(Statistics::MersenneTwisterRandomVariateGenerator::GetInstance()->GetSeed());
   if (m_ReseedIterator)
   {
@@ -576,7 +576,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::SampleFullFixedImageRegion(FixedI
   }
 
   // Set up a region iterator within the user specified fixed image region.
-  ImageRegionConstIteratorWithIndex<FixedImageType> regionIter(m_FixedImage, GetFixedImageRegion());
+  ImageRegionConstIteratorWithIndex regionIter(m_FixedImage, GetFixedImageRegion());
 
   regionIter.GoToBegin();
 

--- a/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
@@ -51,8 +51,8 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetValue(const Tran
 
   // Get an iterator over the fixed image
   //
-  typename FixedImageType::IndexType                fixedIndex;
-  ImageRegionConstIteratorWithIndex<FixedImageType> fi(fixedImage, fixedImage->GetBufferedRegion());
+  typename FixedImageType::IndexType fixedIndex;
+  ImageRegionConstIteratorWithIndex  fi(fixedImage, fixedImage->GetBufferedRegion());
 
   // Get the moving image
   //
@@ -168,7 +168,7 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::GetDerivative(const
   const unsigned int ImageDimension = FixedImageType::ImageDimension;
 
 
-  ImageRegionConstIteratorWithIndex<FixedImageType> ti(fixedImage, this->GetFixedImageRegion());
+  ImageRegionConstIteratorWithIndex ti(fixedImage, this->GetFixedImageRegion());
 
   typename FixedImageType::IndexType index;
 
@@ -294,8 +294,8 @@ KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::ComputeGradient()
   tempGradientImage->Update();
 
 
-  ImageRegionIteratorWithIndex<GradientImageType>    git(tempGradientImage, tempGradientImage->GetBufferedRegion());
-  ImageRegionConstIteratorWithIndex<MovingImageType> mit(this->m_MovingImage, this->m_MovingImage->GetBufferedRegion());
+  ImageRegionIteratorWithIndex      git(tempGradientImage, tempGradientImage->GetBufferedRegion());
+  ImageRegionConstIteratorWithIndex mit(this->m_MovingImage, this->m_MovingImage->GetBufferedRegion());
 
   git.GoToBegin();
   mit.GoToBegin();

--- a/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
@@ -119,7 +119,7 @@ MatchCardinalityImageToImageMetric<TFixedImage, TMovingImage>::ThreadedGetValue(
     itkExceptionStringMacro("Fixed image has not been assigned");
   }
 
-  ImageRegionConstIteratorWithIndex<FixedImageType> ti(fixedImage, regionForThread);
+  ImageRegionConstIteratorWithIndex ti(fixedImage, regionForThread);
 
   MeasureType   threadMeasure{};
   SizeValueType threadNumberOfPixelsCounted = 0;

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -103,8 +103,8 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Initialize
     this->m_MovingImageTrueMax = NumericTraits<typename TMovingImage::PixelType>::NonpositiveMin();
 
     // We need to make robust measures only over the requested mask region
-    ImageRegionConstIteratorWithIndex<TFixedImage> fi(this->m_FixedImage, this->m_FixedImage->GetBufferedRegion());
-    const bool                                     fixedMaskIsPresent = !(this->m_FixedImageMask.IsNull());
+    ImageRegionConstIteratorWithIndex fi(this->m_FixedImage, this->m_FixedImage->GetBufferedRegion());
+    const bool                        fixedMaskIsPresent = !(this->m_FixedImageMask.IsNull());
     if (fixedMaskIsPresent)
     {
       typename TFixedImage::PointType fixedSpacePhysicalPoint;
@@ -133,8 +133,8 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::Initialize
     }
 
     {
-      ImageRegionConstIteratorWithIndex<TMovingImage> mi(this->m_MovingImage, this->m_MovingImage->GetBufferedRegion());
-      const bool                                      movingMaskIsPresent = !(this->m_MovingImageMask.IsNull());
+      ImageRegionConstIteratorWithIndex mi(this->m_MovingImage, this->m_MovingImage->GetBufferedRegion());
+      const bool                        movingMaskIsPresent = !(this->m_MovingImageMask.IsNull());
       if (movingMaskIsPresent)
       {
         typename TMovingImage::PointType movingSpacePhysicalPoint;

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
@@ -53,7 +53,7 @@ MeanReciprocalSquareDifferenceImageToImageMetric<TFixedImage, TMovingImage>::Get
     itkExceptionStringMacro("Fixed image has not been assigned");
   }
 
-  ImageRegionConstIteratorWithIndex<FixedImageType> ti(fixedImage, this->GetFixedImageRegion());
+  ImageRegionConstIteratorWithIndex ti(fixedImage, this->GetFixedImageRegion());
 
   typename FixedImageType::IndexType index;
 

--- a/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.hxx
@@ -83,7 +83,7 @@ void
 MutualInformationImageToImageMetric<TFixedImage, TMovingImage>::SampleFixedImageDomain(
   SpatialSampleContainer & samples) const
 {
-  ImageRandomConstIteratorWithIndex<FixedImageType> randIter(this->m_FixedImage, this->GetFixedImageRegion());
+  ImageRandomConstIteratorWithIndex randIter(this->m_FixedImage, this->GetFixedImageRegion());
   if (this->m_ReseedIterator)
   {
     randIter.ReinitializeSeed();

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
@@ -36,7 +36,7 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValue(
   }
 
 
-  ImageRegionConstIteratorWithIndex<FixedImageType> ti(fixedImage, this->GetFixedImageRegion());
+  ImageRegionConstIteratorWithIndex ti(fixedImage, this->GetFixedImageRegion());
 
   typename FixedImageType::IndexType index;
 
@@ -135,7 +135,7 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetDerivativ
   const unsigned int dimension = FixedImageType::ImageDimension;
 
 
-  ImageRegionConstIteratorWithIndex<FixedImageType> ti(fixedImage, this->GetFixedImageRegion());
+  ImageRegionConstIteratorWithIndex ti(fixedImage, this->GetFixedImageRegion());
 
   typename FixedImageType::IndexType index;
 
@@ -317,7 +317,7 @@ NormalizedCorrelationImageToImageMetric<TFixedImage, TMovingImage>::GetValueAndD
   const unsigned int dimension = FixedImageType::ImageDimension;
 
 
-  ImageRegionConstIteratorWithIndex<FixedImageType> ti(fixedImage, this->GetFixedImageRegion());
+  ImageRegionConstIteratorWithIndex ti(fixedImage, this->GetFixedImageRegion());
 
   typename FixedImageType::IndexType index;
 

--- a/Modules/Registration/FEM/include/itkMIRegistrationFunction.hxx
+++ b/Modules/Registration/FEM/include/itkMIRegistrationFunction.hxx
@@ -242,8 +242,8 @@ MIRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::ComputeUp
   {
     typename FixedImageType::RegionType region = img->GetLargestPossibleRegion();
 
-    ImageRandomIteratorWithIndex<FixedImageType> randasamit(img, region);
-    unsigned int                                 numberOfSamples = 20;
+    ImageRandomIteratorWithIndex randasamit(img, region);
+    unsigned int                 numberOfSamples = 20;
     randasamit.SetNumberOfSamples(numberOfSamples);
 
     indct = 0;

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -31,7 +31,7 @@ ImageToImageMetricv4GetValueAndDerivativeThreader<
 {
   const typename VirtualImageType::ConstPointer virtualImage = this->m_Associate->GetVirtualImage();
   VirtualPointType                              virtualPoint;
-  for (ImageRegionConstIteratorWithIndex<VirtualImageType> it(virtualImage, imageSubRegion); !it.IsAtEnd(); ++it)
+  for (ImageRegionConstIteratorWithIndex it(virtualImage, imageSubRegion); !it.IsAtEnd(); ++it)
   {
     const VirtualIndexType & virtualIndex = it.GetIndex();
     virtualImage->TransformIndexToPhysicalPoint(virtualIndex, virtualPoint);

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreader.hxx
@@ -31,9 +31,7 @@ JointHistogramMutualInformationComputeJointPDFThreader<
 {
   VirtualPointType virtualPoint;
   VirtualIndexType virtualIndex;
-  for (ImageRegionConstIteratorWithIndex<VirtualImageType> it(this->m_Associate->GetVirtualImage(), imageSubRegion);
-       !it.IsAtEnd();
-       ++it)
+  for (ImageRegionConstIteratorWithIndex it(this->m_Associate->GetVirtualImage(), imageSubRegion); !it.IsAtEnd(); ++it)
   {
     virtualIndex = it.GetIndex();
     this->m_Associate->TransformVirtualIndexToPhysicalPoint(virtualIndex, virtualPoint);

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
@@ -85,7 +85,7 @@ JointHistogramMutualInformationImageToImageMetricv4<TFixedImage,
 
   /** Iterate through the fixed image and set the true
    *  max and min for the fixed image. */
-  ImageRegionConstIteratorWithIndex<TFixedImage> fi(this->m_FixedImage, this->m_FixedImage->GetRequestedRegion());
+  ImageRegionConstIteratorWithIndex fi(this->m_FixedImage, this->m_FixedImage->GetRequestedRegion());
 
   /** \todo multi-thread me */
   while (!fi.IsAtEnd())
@@ -111,7 +111,7 @@ JointHistogramMutualInformationImageToImageMetricv4<TFixedImage,
   }
   /** Iterate through the moving image and set the true
    * max and min for the moving image. */
-  ImageRegionConstIteratorWithIndex<TMovingImage> mi(this->m_MovingImage, this->m_MovingImage->GetBufferedRegion());
+  ImageRegionConstIteratorWithIndex mi(this->m_MovingImage, this->m_MovingImage->GetBufferedRegion());
 
   while (!mi.IsAtEnd())
   {
@@ -252,7 +252,7 @@ JointHistogramMutualInformationImageToImageMetricv4<TFixedImage,
   }
 
   // Compute moving image marginal PDF by summing over fixed image bins.
-  ImageLinearIteratorWithIndex<JointPDFType> linearIter(m_JointPDF, m_JointPDF->GetBufferedRegion());
+  ImageLinearIteratorWithIndex linearIter(m_JointPDF, m_JointPDF->GetBufferedRegion());
   linearIter.SetDirection(0);
   linearIter.GoToBegin();
   unsigned int                                        fixedIndex = 0;

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
@@ -158,7 +158,7 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
       // A null mask implies entire space is to be used.
       if (!this->m_FixedImageMask.IsNull()) // use only masked samples.
       {
-        ImageRegionConstIteratorWithIndex<TFixedImage> fi(this->m_FixedImage, this->m_FixedImage->GetBufferedRegion());
+        ImageRegionConstIteratorWithIndex fi(this->m_FixedImage, this->m_FixedImage->GetBufferedRegion());
         while (!fi.IsAtEnd())
         {
           typename TFixedImage::PointType fixedSpacePhysicalPoint;
@@ -175,7 +175,7 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
       }
       else // use entire image for fixed image intensity range of joint histogram
       {
-        ImageRegionConstIteratorWithIndex<TFixedImage> fi(this->m_FixedImage, this->m_FixedImage->GetBufferedRegion());
+        ImageRegionConstIteratorWithIndex fi(this->m_FixedImage, this->m_FixedImage->GetBufferedRegion());
         while (!fi.IsAtEnd())
         {
           const typename TFixedImage::PixelType & currValue = fi.Value();
@@ -194,7 +194,7 @@ MattesMutualInformationImageToImageMetricv4<TFixedImage,
     this->m_MovingImageTrueMin = NumericTraits<typename TMovingImage::PixelType>::max();
     this->m_MovingImageTrueMax = NumericTraits<typename TMovingImage::PixelType>::NonpositiveMin();
     {
-      ImageRegionConstIteratorWithIndex<TMovingImage> mi(this->m_MovingImage, this->m_MovingImage->GetBufferedRegion());
+      ImageRegionConstIteratorWithIndex mi(this->m_MovingImage, this->m_MovingImage->GetBufferedRegion());
 
       if (!this->m_MovingImageMask.IsNull())
       { // A null mask implies entire space is to be used.

--- a/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.hxx
@@ -183,7 +183,7 @@ ScalarImageKmeansImageFilter<TInputImage, TOutputImage>::GenerateData()
   {
     // If a region is defined to constrain classification to, we need to label
     // pixels outside with numberOfClasses + 1.
-    ImageRegionExclusionIteratorWithIndex<OutputImageType> exIt(outputPtr, outputPtr->GetBufferedRegion());
+    ImageRegionExclusionIteratorWithIndex exIt(outputPtr, outputPtr->GetBufferedRegion());
     exIt.SetExclusionRegion(region);
     exIt.GoToBegin();
     if (m_UseNonContiguousLabels)

--- a/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
@@ -45,8 +45,8 @@ HardConnectedComponentImageFilter<TInputImage, TOutputImage>::GenerateData()
   output->SetRegions(region);
   output->Allocate();
 
-  ImageRegionConstIterator<TInputImage>      it(input, input->GetRequestedRegion());
-  ImageRegionIteratorWithIndex<TOutputImage> ot(output, output->GetRequestedRegion());
+  ImageRegionConstIterator<TInputImage> it(input, input->GetRequestedRegion());
+  ImageRegionIteratorWithIndex          ot(output, output->GetRequestedRegion());
 
   ProgressReporter progress(this, 0, output->GetRequestedRegion().GetNumberOfPixels());
   it.GoToBegin();

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionBase.hxx
@@ -151,8 +151,8 @@ LevelSetEvolutionBase<TEquationContainer, TLevelSet>::InitializeIteration()
     {
       // Iterator over the region for the current levelset overlap identifier.
       using LevelSetListImageDomainType = typename DomainMapImageFilterType::LevelSetDomain;
-      const LevelSetListImageDomainType &               levelSetListImageDomain = mapIt->second;
-      ImageRegionConstIteratorWithIndex<InputImageType> it(inputImage, *(levelSetListImageDomain.GetRegion()));
+      const LevelSetListImageDomainType & levelSetListImageDomain = mapIt->second;
+      ImageRegionConstIteratorWithIndex   it(inputImage, *(levelSetListImageDomain.GetRegion()));
 
       while (!it.IsAtEnd())
       {
@@ -178,8 +178,8 @@ LevelSetEvolutionBase<TEquationContainer, TLevelSet>::InitializeIteration()
   }
   else // assume there is one level set that covers the RequestedRegion of the InputImage
   {
-    const TermContainerPointer                        termContainer = this->m_EquationContainer->GetEquation(0);
-    ImageRegionConstIteratorWithIndex<InputImageType> it(inputImage, inputImage->GetRequestedRegion());
+    const TermContainerPointer        termContainer = this->m_EquationContainer->GetEquation(0);
+    ImageRegionConstIteratorWithIndex it(inputImage, inputImage->GetRequestedRegion());
     while (!it.IsAtEnd())
     {
       termContainer->Initialize(it.GetIndex());

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionComputeIterationThreader.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionComputeIterationThreader.hxx
@@ -41,7 +41,7 @@ LevelSetEvolutionComputeIterationThreader<LevelSetDenseImage<TImage>,
   const IndexType  index = imageSubRegion.GetIndex() - offset;
   const RegionType subRegion(index, imageSubRegion.GetSize());
 
-  ImageRegionConstIteratorWithIndex<LevelSetImageType> imageIt(levelSetImage, subRegion);
+  ImageRegionConstIteratorWithIndex imageIt(levelSetImage, subRegion);
 
   if (this->m_Associate->m_LevelSetContainer->HasDomainMap())
   {
@@ -116,7 +116,7 @@ LevelSetEvolutionComputeIterationThreader<
   typename DomainType::IteratorType mapIt = imageSubDomain.Begin();
   while (mapIt != imageSubDomain.End())
   {
-    ImageRegionConstIteratorWithIndex<InputImageType> it(inputImage, *(mapIt->second.GetRegion()));
+    ImageRegionConstIteratorWithIndex it(inputImage, *(mapIt->second.GetRegion()));
 
     while (!it.IsAtEnd())
     {


### PR DESCRIPTION
Used class template argument deduction when declaring "IteratorWithIndex" variables.

Using Notepad++, Replace in Files, doing:

    Find what: ([^\w]Image\w+IteratorWithIndex)<\w+>[ ]*( [a-z]\w*[\({])
    Replace with: $1$2
    Files: itk*.hxx
    [v] Match case
    (*) Regular expression