### PR TITLE
ENH: Use ITK policy version range in itkCheckPrivateDynamicCast

### DIFF
--- a/Modules/Core/Common/CMake/itkCheckPrivateDynamicCast.cmake
+++ b/Modules/Core/Common/CMake/itkCheckPrivateDynamicCast.cmake
@@ -69,17 +69,7 @@ int main(void)
     WRITE
     "${test_project_dir}/CMakeLists.txt"
     "
-cmake_minimum_required(VERSION 3.16.3 FATAL_ERROR)
-foreach(p
-    ## Only policies introduced after the cmake_minimum_required
-    ## version need to explicitly be set to NEW.
-    CMP0070 #3.10.0 Define ``file(GENERATE)`` behavior for relative paths.
-    CMP0071 #3.10.0 Let ``AUTOMOC`` and ``AUTOUIC`` process ``GENERATED`` files.
-    )
-  if(POLICY ${p})
-    cmake_policy(SET ${p} NEW)
-  endif()
-endforeach()
+cmake_minimum_required(VERSION ${ITK_OLDEST_VALIDATED_POLICIES_VERSION}...${ITK_NEWEST_VALIDATED_POLICIES_VERSION} FATAL_ERROR)
 project(support_private_dynamic_cast CXX)
 add_library(base SHARED \"base.cxx\")
 set_target_properties(base PROPERTIES CXX_VISIBILITY_PRESET hidden)


### PR DESCRIPTION
## Summary
- Replace hardcoded `cmake_minimum_required(VERSION 3.16.3)` in the generated test project with the project-wide `ITK_OLDEST/NEWEST_VALIDATED_POLICIES_VERSION` range (`3.22.1...3.29.0`)
- Remove vestigial `CMP0070`/`CMP0071` policy loop — both policies are from CMake 3.10, well below the 3.22.1 minimum, so they are already set to NEW automatically

## Test plan
- [ ] Verify CI builds pass (the generated test project in `itkCheckPrivateDynamicCast` should still compile and run correctly)
- [ ] Confirm `ITK_PRIVATE_DYNAMIC_CAST` is still detected properly on Linux/macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)