### PR TITLE
PERF: Refine CI ccache behaviors

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -169,7 +169,7 @@ jobs:
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
       - name: Save compiler cache
-        if: steps.restore-ccache.outputs.cache-hit != 'true' || github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@v5
         with:
           path: ${{ runner.temp }}/ccache

--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -96,7 +96,7 @@ jobs:
           echo "CCACHE_NOHASHDIR=true" >> "$GITHUB_ENV"
           echo "CCACHE_NODIRECT=1" >> "$GITHUB_ENV"
           echo "CCACHE_DIR=${{ runner.temp }}/ccache" >> "$GITHUB_ENV"
-          echo "CCACHE_MAXSIZE=11G" >> "$GITHUB_ENV"
+          echo "CCACHE_MAXSIZE=2.4G" >> "$GITHUB_ENV"
           if [ "$RUNNER_OS" == "Linux" ]; then
             sudo apt-get update -qq && sudo apt-get install -y ccache
           elif [ "$RUNNER_OS" == "macOS" ]; then

--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -149,7 +149,7 @@ jobs:
             echo "****** df -h /"
             df -h /
         - name: Save compiler cache
-          if: steps.restore-ccache.outputs.cache-hit != 'true' || github.ref == 'refs/heads/main'
+          if: github.ref == 'refs/heads/main'
           uses: actions/cache/save@v5
           with:
             path: ${{ runner.temp }}/ccache

--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -55,7 +55,7 @@ jobs:
             echo "CCACHE_NOHASHDIR=true" >> "$GITHUB_ENV"
             echo "CCACHE_NODIRECT=1" >> "$GITHUB_ENV"
             echo "CCACHE_DIR=${{ runner.temp }}/ccache" >> "$GITHUB_ENV"
-            echo "CCACHE_MAXSIZE=11G" >> "$GITHUB_ENV"
+            echo "CCACHE_MAXSIZE=2.4G" >> "$GITHUB_ENV"
             if [ "$RUNNER_OS" == "Linux" ]; then
               sudo apt-get update -qq && sudo apt-get install -y ccache
             elif [ "$RUNNER_OS" == "macOS" ]; then

--- a/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
@@ -106,7 +106,7 @@ jobs:
         displayName: 'Build and test'
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
-          CCACHE_MAXSIZE: 11G
+          CCACHE_MAXSIZE: 2.4G
 
       - script: |
           ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml

--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -113,7 +113,7 @@ jobs:
       displayName: 'Build and test'
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-        CCACHE_MAXSIZE: 11G
+        CCACHE_MAXSIZE: 2.4G
 
     - script: |
         ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml
@@ -202,7 +202,7 @@ jobs:
       displayName: 'Build and test'
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-        CCACHE_MAXSIZE: 11G
+        CCACHE_MAXSIZE: 2.4G
 
     - script: |
         ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml
@@ -289,7 +289,7 @@ jobs:
       displayName: "Build and test"
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-        CCACHE_MAXSIZE: 11G
+        CCACHE_MAXSIZE: 2.4G
     - script: |
         ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml
       condition: succeededOrFailed()

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -120,7 +120,7 @@ jobs:
       displayName: 'Build and test'
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-        CCACHE_MAXSIZE: 11G
+        CCACHE_MAXSIZE: 2.4G
 
     - script: |
         ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -113,7 +113,7 @@ jobs:
       displayName: 'Build and test'
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-        CCACHE_MAXSIZE: 11G
+        CCACHE_MAXSIZE: 2.4G
 
     - script: |
         ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -122,7 +122,7 @@ jobs:
       displayName: 'Build and test'
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-        CCACHE_MAXSIZE: 11G
+        CCACHE_MAXSIZE: 2.4G
 
     - script: |
         ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml

--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -107,7 +107,7 @@ jobs:
       displayName: 'Build and test'
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-        CCACHE_MAXSIZE: 11G
+        CCACHE_MAXSIZE: 2.4G
 
     - script: |
         ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -117,7 +117,7 @@ jobs:
       displayName: 'Build and test'
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-        CCACHE_MAXSIZE: 11G
+        CCACHE_MAXSIZE: 2.4G
 
     - script: |
         ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml


### PR DESCRIPTION
## Summary
- Only save ccache on main branch pushes, preventing PR builds from creating cache entries that exceed the 10GB GitHub Actions cache limit
- Reduce `CCACHE_MAXSIZE` from 11G to 2.4G across all GitHub Actions and Azure Pipelines CI configurations to minimize storage of stale object files (2.4G is ~10% more than currently needed for the largest Python builds)

## Test plan
- [x] Verify GitHub Actions workflows pass on Linux, macOS, and ARM
- [x] Verify Azure Pipelines pass on Linux, macOS, and Windows (C++ and Python)
- [x] Confirm ccache hit rates remain acceptable after size reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)