### PR TITLE
STYLE: Convert CreateTestDriver from macro to function

### DIFF
--- a/CMake/ITKModuleTest.cmake
+++ b/CMake/ITKModuleTest.cmake
@@ -1,4 +1,4 @@
-# This file contains CMake functions and macros used when testing ITK modules.
+# This file contains CMake functions used when testing ITK modules.
 
 #-----------------------------------------------------------------------------
 # Create source code, compile and link a test driver
@@ -11,7 +11,7 @@
 #   KitTests - a list of tests to be included in the test driver
 #   ADDITIONAL_SRC (optional) - additional source files, which don't contain tests
 
-macro(CreateTestDriver KIT KIT_LIBS KitTests)
+function(CreateTestDriver KIT KIT_LIBS KitTests)
   set(ADDITIONAL_SRC ${ARGN})
   if(EMSCRIPTEN)
     set(
@@ -91,7 +91,7 @@ EM_ASM(
       "$<$<AND:$<C_COMPILER_ID:AppleClang>,$<VERSION_GREATER_EQUAL:$<C_COMPILER_VERSION>,15.0>>:LINKER:-no_warn_duplicate_libraries>"
   )
   itk_module_target_label(${KIT}TestDriver)
-endmacro()
+endfunction()
 
 #-----------------------------------------------------------------------------
 # ITK wrapper for add_test that automatically sets the test's LABELS property


### PR DESCRIPTION
## Summary
- Convert `CreateTestDriver` from a CMake `macro()` to `function()` in `CMake/ITKModuleTest.cmake`
- Modern CMake recommends `function()` over `macro()` because functions have their own variable scope and prevent accidental variable leakage into the caller's scope
- Verified no callers depend on any variables leaking from the macro (`ADDITIONAL_SRC`, `Tests`, `CMAKE_TESTDRIVER_BEFORE_TESTMAIN`, `CMAKE_TESTDRIVER_AFTER_TESTMAIN`, `emscripten_before`, `emscripten_after`)
- `CreateGoogleTestDriver` already uses `function()` — this makes the two consistent

## Test plan
- [ ] Verify full ITK build completes successfully (all test drivers compile)
- [ ] Verify Emscripten cross-compile path still works (if applicable)
- [ ] Verify `ctest` runs pass (test discovery unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)