### PR TITLE
BUG: Value-initialize cell data buffers in OBJ and OFF mesh IO

### DIFF
--- a/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
+++ b/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
@@ -19,7 +19,7 @@
 #include "itkOBJMeshIO.h"
 #include "itkNumericTraits.h"
 #include "itksys/SystemTools.hxx"
-#include "itkMakeUniqueForOverwrite.h"
+#include <memory>
 #include <locale>
 #include <vector>
 
@@ -235,7 +235,7 @@ OBJMeshIO::ReadCells(void * buffer)
   OpenFile();
 
   // Read and analyze the first line in the file
-  const auto    data = make_unique_for_overwrite<long[]>(this->m_CellBufferSize - this->m_NumberOfCells);
+  const auto    data = std::make_unique<long[]>(this->m_CellBufferSize - this->m_NumberOfCells);
   SizeValueType index = 0;
 
   std::string       line;

--- a/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
+++ b/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
@@ -286,7 +286,7 @@ OFFMeshIO::ReadPoints(void * buffer)
 void
 OFFMeshIO::ReadCells(void * buffer)
 {
-  const auto data = make_unique_for_overwrite<itk::uint32_t[]>(this->m_CellBufferSize - this->m_NumberOfCells);
+  const auto data = std::make_unique<itk::uint32_t[]>(this->m_CellBufferSize - this->m_NumberOfCells);
 
   if (this->m_FileType == IOFileEnum::ASCII)
   {


### PR DESCRIPTION
## Summary
- Replace `make_unique_for_overwrite<T[]>` with `std::make_unique<T[]>` in `OBJMeshIO::ReadCells` and `OFFMeshIO::ReadCells` to value-initialize cell data buffers, resolving `core.uninitialized.Assign` scan-build warnings
- Replace internal `itkMakeUniqueForOverwrite.h` include with standard `<memory>` in OBJMeshIO since the ITK-specific overwrite variant is no longer used

Addresses findings from issue #1261.

## Test plan
- [ ] Existing `itkOBJMeshIOTest` and `itkOFFMeshIOTest` pass
- [ ] CI builds clean on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)