### PR TITLE
COMP: Use setter/getter macros for TemporalProcessObject members

### DIFF
--- a/Modules/Video/Core/test/itkVideoToVideoFilterGTest.cxx
+++ b/Modules/Video/Core/test/itkVideoToVideoFilterGTest.cxx
@@ -88,10 +88,10 @@ protected:
   /** Constructor */
   DummyVideoToVideoFilter()
   {
-    this->TemporalProcessObject::m_UnitInputNumberOfFrames = 2;
-    this->TemporalProcessObject::m_UnitOutputNumberOfFrames = 1;
-    this->TemporalProcessObject::m_FrameSkipPerOutput = 1;
-    this->TemporalProcessObject::m_InputStencilCurrentFrameIndex = 1;
+    this->SetUnitInputNumberOfFrames(2);
+    this->SetUnitOutputNumberOfFrames(1);
+    this->SetFrameSkipPerOutput(1);
+    this->SetInputStencilCurrentFrameIndex(1);
   }
 
   /** Override ThreadedGenerateData */
@@ -116,15 +116,15 @@ protected:
 
     // Just as a check, throw an exception if the durations aren't equal to the
     // unit output sizes
-    if (outputDuration != this->TemporalProcessObject::m_UnitOutputNumberOfFrames)
+    if (outputDuration != this->GetUnitOutputNumberOfFrames())
     {
-      itkExceptionMacro("Trying to generate output of non-unit size. Got: "
-                        << outputDuration << " Expected: " << this->TemporalProcessObject::m_UnitOutputNumberOfFrames);
+      itkExceptionMacro("Trying to generate output of non-unit size. Got: " << outputDuration << " Expected: "
+                                                                            << this->GetUnitOutputNumberOfFrames());
     }
-    if (inputDuration < this->TemporalProcessObject::m_UnitInputNumberOfFrames)
+    if (inputDuration < this->GetUnitInputNumberOfFrames())
     {
-      itkExceptionMacro("Input buffered region smaller than unit size. Got: "
-                        << inputDuration << " Expected: " << this->TemporalProcessObject::m_UnitInputNumberOfFrames);
+      itkExceptionMacro("Input buffered region smaller than unit size. Got: " << inputDuration << " Expected: "
+                                                                              << this->GetUnitInputNumberOfFrames());
     }
 
     // Get the two input frames and average them in the requested spatial region


### PR DESCRIPTION
## Summary
- Replace `this->TemporalProcessObject::m_*` direct member access with `Set*()`/`Get*()` macros in `DummyVideoToVideoFilter` test helper
- Fixes compilation error on compilers that cannot resolve grandparent class names through dependent template base classes (`TemporalProcessObject` is two levels up: `VideoToVideoFilter` → `VideoSource` → `TemporalProcessObject`)

## Test plan
- [x] `itkVideoToVideoFilterGTest` compiles and passes on all CI platforms
- [ ] No functional change — uses the same protected setter/getter macros already provided by `TemporalProcessObject`

🤖 Generated with [Claude Code](https://claude.com/claude-code)