### PR TITLE
COMP: Silence nodiscard warnings for Future.get() in PoolMultiThreader

### DIFF
--- a/Modules/Core/Common/src/itkPoolMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkPoolMultiThreader.cxx
@@ -145,7 +145,7 @@ PoolMultiThreader::SingleMethodExecute()
   // so now it waits for each of the other work units to finish
   for (threadLoop = 1; threadLoop < m_NumberOfWorkUnits; ++threadLoop)
   {
-    exceptionHandler.TryAndCatch([this, threadLoop] { m_ThreadInfoArray[threadLoop].Future.get(); });
+    exceptionHandler.TryAndCatch([this, threadLoop] { (void)m_ThreadInfoArray[threadLoop].Future.get(); });
   }
 
   exceptionHandler.RethrowFirstCaughtException();
@@ -300,7 +300,7 @@ PoolMultiThreader::ParallelizeImageRegion(unsigned int         dimension,
               filter->IncrementProgress(0);
             }
           } while (status != std::future_status::ready);
-          m_ThreadInfoArray[i].Future.get();
+          (void)m_ThreadInfoArray[i].Future.get();
           reporter.CompletedPixel();
         });
       }


### PR DESCRIPTION
## Summary
- Cast `Future.get()` return values to `(void)` in `itkPoolMultiThreader.cxx` where the call is only used for its side effect of waiting for thread completion and propagating exceptions

Fixes:
```
ITK/Modules/Core/Common/src/itkPoolMultiThreader.cxx:148:55: warning:
  ignoring return value of function declared with 'nodiscard'
  attribute [-Wunused-result]
    exceptionHandler.TryAndCatch([this, threadLoop] { m_ThreadInfoArray[threadLoop].Future.get(); });
                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ITK/Modules/Core/Common/src/itkPoolMultiThreader.cxx:303:11: warning:
  ignoring return value of function declared with 'nodiscard'
  attribute [-Wunused-result]
          m_ThreadInfoArray[i].Future.get();
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Test plan
- [ ] CI builds clean with no `-Wunused-result` warnings
- [ ] No functional change — `(void)` cast only suppresses the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)