### PR TITLE
BUG: Use std::forward instead of std::move on forwarding references

### DIFF
--- a/Modules/Core/Common/test/itkArray2DGTest.cxx
+++ b/Modules/Core/Common/test/itkArray2DGTest.cxx
@@ -70,7 +70,7 @@ TEST(Array2D, MoveConstruct)
     const auto * const * const originalDataArray{ original.data_array() };
     const unsigned int         originalSize{ original.size() };
 
-    const auto moveConstructed = std::move(original);
+    const auto moveConstructed = std::forward<decltype(original)>(original);
 
     // After the "move", the move-constructed object has retrieved the original data.
     EXPECT_EQ(moveConstructed.data_array(), originalDataArray);

--- a/Modules/Core/Common/test/itkRangeGTestUtilities.h
+++ b/Modules/Core/Common/test/itkRangeGTestUtilities.h
@@ -94,7 +94,7 @@ public:
   ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove(TRange && originalRange)
   {
     const TRange originalRangeBeforeMove = originalRange;
-    TRange       moveConstructedRange(std::move(originalRange));
+    TRange       moveConstructedRange(std::forward<TRange>(originalRange));
 
     ExpectRangesHaveEqualBeginAndEnd(moveConstructedRange, originalRangeBeforeMove);
   }
@@ -107,7 +107,7 @@ public:
     const TRange originalRangeBeforeMove = originalRange;
 
     TRange moveAssignedRange;
-    moveAssignedRange = std::move(originalRange);
+    moveAssignedRange = std::forward<TRange>(originalRange);
 
     ExpectRangesHaveEqualBeginAndEnd(moveAssignedRange, originalRangeBeforeMove);
   }


### PR DESCRIPTION
## Summary
- Replace `std::move` with `std::forward` on forwarding references (`T&&` where `T` is a deduced template type) in test utilities
- `itkArray2DGTest.cxx`: Fix `std::move` on `decltype(original)` forwarding reference in move-construct test
- `itkRangeGTestUtilities.h`: Fix `std::move` on `TRange&&` forwarding references in `ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove` and `ExpectMoveAssignedRangeHasSameIteratorsAsOriginalBeforeMove`

Detected by `bugprone-move-forwarding-reference` clang-tidy check (LLVM 22).

## Test plan
- [ ] `itkArray2DGTest` passes
- [ ] All range GTests pass
- [ ] CI builds clean with no `bugprone-move-forwarding-reference` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)