### PR TITLE
COMP: Suppress GCC -Wmaybe-uninitialized in Eigen3 SelfadjointMatrixVector

### DIFF
--- a/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Core/products/SelfadjointMatrixVector.h
+++ b/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Core/products/SelfadjointMatrixVector.h
@@ -13,6 +13,13 @@
 // IWYU pragma: private
 #include "../InternalHeaderCheck.h"
 
+// GCC on ARM (aarch64) emits false-positive -Wmaybe-uninitialized warnings
+// in the vectorized selfadjoint matrix-vector product kernel.
+#if defined(__GNUC__) && !defined(__clang__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 namespace Eigen {
 
 namespace internal {
@@ -249,5 +256,9 @@ struct selfadjoint_product_impl<Lhs, 0, true, Rhs, RhsMode, false> {
 }  // end namespace internal
 
 }  // end namespace Eigen
+
+#if defined(__GNUC__) && !defined(__clang__)
+#  pragma GCC diagnostic pop
+#endif
 
 #endif  // EIGEN_SELFADJOINT_MATRIX_VECTOR_H


### PR DESCRIPTION
## Summary
- Suppress false-positive GCC `-Wmaybe-uninitialized` warnings in Eigen3's `SelfadjointMatrixVector.h` on ARM (aarch64)
- Uses `#pragma GCC diagnostic push/pop` scoped to the file, guarded by `__GNUC__` and `!__clang__`

## Test plan
- [ ] ARM CI build passes without `-Wmaybe-uninitialized` warnings from this file
- [ ] Non-ARM and Clang builds are unaffected (guards exclude them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)