### PR TITLE
ENH: Optimize GitHub Actions ccache strategy for faster C++ builds

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -94,9 +94,9 @@ jobs:
           echo "CCACHE_BASEDIR=${GITHUB_WORKSPACE}" >> "$GITHUB_ENV"
           echo "CCACHE_COMPILERCHECK=content" >> "$GITHUB_ENV"
           echo "CCACHE_NOHASHDIR=true" >> "$GITHUB_ENV"
-          echo "CCACHE_NODIRECT=1" >> "$GITHUB_ENV"
+          echo "CCACHE_SLOPPINESS=pch_defines,time_macros" >> "$GITHUB_ENV"
           echo "CCACHE_DIR=${{ runner.temp }}/ccache" >> "$GITHUB_ENV"
-          echo "CCACHE_MAXSIZE=2.4G" >> "$GITHUB_ENV"
+          echo "CCACHE_MAXSIZE=5G" >> "$GITHUB_ENV"
           if [ "$RUNNER_OS" == "Linux" ]; then
             sudo apt-get update -qq && sudo apt-get install -y ccache locales
             sudo locale-gen de_DE.UTF-8
@@ -109,7 +109,9 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ runner.temp }}/ccache
-          key: ccache-v1-${{ matrix.os }}-${{ matrix.name }}
+          key: ccache-v4-${{ runner.os }}-${{ matrix.name }}-${{ github.sha }}
+          restore-keys: |
+            ccache-v4-${{ runner.os }}-${{ matrix.name }}-
 
       - name: Show ccache configuration, stats and maintenance
         shell: bash
@@ -170,11 +172,11 @@ jobs:
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
       - name: Save compiler cache
-        if: github.ref == 'refs/heads/main'
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@v5
         with:
           path: ${{ runner.temp }}/ccache
-          key: ccache-v1-${{ matrix.os }}-${{ matrix.name }}
+          key: ccache-v4-${{ runner.os }}-${{ matrix.name }}-${{ github.sha }}
 
       - name: ccache stats
         if: always()

--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -53,9 +53,9 @@ jobs:
             echo "CCACHE_BASEDIR=${GITHUB_WORKSPACE}" >> "$GITHUB_ENV"
             echo "CCACHE_COMPILERCHECK=content" >> "$GITHUB_ENV"
             echo "CCACHE_NOHASHDIR=true" >> "$GITHUB_ENV"
-            echo "CCACHE_NODIRECT=1" >> "$GITHUB_ENV"
+            echo "CCACHE_SLOPPINESS=pch_defines,time_macros" >> "$GITHUB_ENV"
             echo "CCACHE_DIR=${{ runner.temp }}/ccache" >> "$GITHUB_ENV"
-            echo "CCACHE_MAXSIZE=2.4G" >> "$GITHUB_ENV"
+            echo "CCACHE_MAXSIZE=5G" >> "$GITHUB_ENV"
             if [ "$RUNNER_OS" == "Linux" ]; then
               sudo apt-get update -qq && sudo apt-get install -y ccache locales
               sudo locale-gen de_DE.UTF-8
@@ -70,7 +70,9 @@ jobs:
           uses: actions/cache/restore@v5
           with:
             path: ${{ runner.temp }}/ccache
-            key: ccache-v1-${{ matrix.os }}-pixi-cxx
+            key: ccache-v4-${{ runner.os }}-pixi-cxx-${{ github.sha }}
+            restore-keys: |
+              ccache-v4-${{ runner.os }}-pixi-cxx-
 
         - name: Show ccache configuration, stats and maintenance
           shell: bash
@@ -150,11 +152,11 @@ jobs:
             echo "****** df -h /"
             df -h /
         - name: Save compiler cache
-          if: github.ref == 'refs/heads/main'
+          if: ${{ !cancelled() }}
           uses: actions/cache/save@v5
           with:
             path: ${{ runner.temp }}/ccache
-            key: ccache-v1-${{ matrix.os }}-pixi-cxx
+            key: ccache-v4-${{ runner.os }}-pixi-cxx-${{ github.sha }}
 
         - name: ccache stats
           if: always()


### PR DESCRIPTION
## Summary

Use best practices now that we have a quota of 50GB for cache storage (Big enough so that we do not constantly evict PR's based on running over the 10GB limit).

Key knowlege:  Caches are not mutable. Once written, they can not be updated.  That is why the git sha is recommended with fallback patterns to gain the latest commit with the same prefix (to keep the cache warm).

- **Enable direct mode**: Remove `CCACHE_NODIRECT=1` so ccache skips the preprocessor for cache lookups (significantly faster on hits)
- **Add `CCACHE_SLOPPINESS=pch_defines,time_macros`**: Avoid cache misses from `__DATE__`/`__TIME__` macros that change every build (standard CI-safe setting)
- **Increase `CCACHE_MAXSIZE` from 2.4G to 5G**: ITK has ~4000 translation units; a larger cache retains more objects across incremental builds
- **SHA-based cache key with `restore-keys` fallback**: Each commit produces a unique cache entry (`ccache-v4-<os>-<config>-<sha>`), while `restore-keys` prefix match always restores the most recent cache for the same OS and configuration. Replaces the old static key that was immutable once written
- **Save on `!cancelled()` instead of main-only**: PR builds now persist their cache (success or failure), but cancelled runs skip saving potentially incomplete caches
- **Use `runner.os` instead of `matrix.os`** in cache keys for consistency across runner image updates

# GitHub Actions Cache Key Notes for ccache

## What does `if: ${{ !cancelled() }}` do?

Controls when a step runs based on the workflow's status:

| Condition | Success | Failure | Cancelled |
|-----------|---------|---------|-----------|
| *(default)* | runs | skips | skips |
| `if: always()` | runs | runs | runs |
| `if: ${{ !cancelled() }}` | runs | runs | skips |

For the ccache save step, `!cancelled()` saves the cache on both success and failure
(compilation progress is still valuable), but skips saving on cancellation to avoid
persisting an inconsistent mid-write cache.

## What is `${{ github.sha }}` and does it work with merged branches?

`${{ github.sha }}` is the full 40-character Git commit SHA that triggered the workflow.
Appending it to the cache key (e.g., `ccache-v4-Linux-name-<sha>`) makes each commit
produce a unique, immutable cache entry. The `restore-keys` prefix fallback ensures
each build restores the most recent cache for the same OS and configuration.

### Branch scope restriction

GitHub Actions caches are scoped by branch:

| Build runs on | Can restore caches from |
|---------------|------------------------|
| `main` | `main` only |
| PR branch | PR branch + `main` (base branch) |

After a PR is merged, the main branch build **cannot** access caches created on the
PR branch. It falls back to the most recent cache saved by a prior main build. This
means main does not benefit from incremental cache improvements made during PR CI,
but in practice, this is acceptable because the main builds frequently enough to keep its
own cache warm.


🤖 Generated with [Claude Code](https://claude.com/claude-code)