### PR TITLE
STYLE: Use CTAD for iterators "with index", in hxx files (follow-up)

### DIFF
--- a/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
@@ -117,7 +117,7 @@ GaussianInterpolateImageFunction<TImageType, TCoordinate>::EvaluateAtContinuousI
   dsum_me.Fill(0.0);
   dw.Fill(0.0);
 
-  for (ImageRegionConstIteratorWithIndex<InputImageType> It(this->GetInputImage(), region); !It.IsAtEnd(); ++It)
+  for (ImageRegionConstIteratorWithIndex It(this->GetInputImage(), region); !It.IsAtEnd(); ++It)
   {
     unsigned int j = It.GetIndex()[0] - region.GetIndex()[0];
     RealType     w = erfArray[0][j];

--- a/Modules/Core/ImageFunction/include/itkLabelImageGaussianInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkLabelImageGaussianInterpolateImageFunction.hxx
@@ -60,7 +60,7 @@ LabelImageGaussianInterpolateImageFunction<TInputImage, TCoordinate, TPixelCompa
   using WeightMapType = std::map<OutputType, RealType, TPixelCompare>;
   WeightMapType weightMap;
 
-  for (ImageRegionConstIteratorWithIndex<InputImageType> It(this->GetInputImage(), region); !It.IsAtEnd(); ++It)
+  for (ImageRegionConstIteratorWithIndex It(this->GetInputImage(), region); !It.IsAtEnd(); ++It)
   {
     unsigned int j = It.GetIndex()[0] - region.GetIndex()[0];
     RealType     w = erfArray[0][j];

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
@@ -583,8 +583,7 @@ BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::Comp
   const SizeValueType numberOfParametersPerDimension = this->GetNumberOfParametersPerDimension();
 
   unsigned long counter = 0;
-  for (ImageRegionConstIteratorWithIndex<ImageType> It(this->m_CoefficientImages[0], supportRegion); !It.IsAtEnd();
-       ++It)
+  for (ImageRegionConstIteratorWithIndex It(this->m_CoefficientImages[0], supportRegion); !It.IsAtEnd(); ++It)
   {
     typename ImageType::OffsetType currentIndex = It.GetIndex() - startIndex;
 

--- a/Modules/Core/Transform/include/itkBSplineTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransform.hxx
@@ -636,8 +636,7 @@ BSplineTransform<TParametersValueType, VDimension, VSplineOrder>::ComputeJacobia
   const SizeValueType numberOfParametersPerDimension = this->GetNumberOfParametersPerDimension();
 
   unsigned long counter = 0;
-  for (ImageRegionConstIteratorWithIndex<ImageType> It(this->m_CoefficientImages[0], supportRegion); !It.IsAtEnd();
-       ++It)
+  for (ImageRegionConstIteratorWithIndex It(this->m_CoefficientImages[0], supportRegion); !It.IsAtEnd(); ++It)
   {
     typename ImageType::OffsetType currentIndex = It.GetIndex() - startIndex;
 

--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
@@ -512,8 +512,7 @@ N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::UpdateB
   const MaskPixelType maskLabel = this->GetMaskLabel();
   const bool          useMaskLabel = this->GetUseMaskLabel();
 
-  ImageRegionConstIteratorWithIndex<RealImageType> It(parametricFieldEstimate,
-                                                      parametricFieldEstimate->GetRequestedRegion());
+  ImageRegionConstIteratorWithIndex It(parametricFieldEstimate, parametricFieldEstimate->GetRequestedRegion());
 
   for (size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue, ++It)
   {

--- a/Modules/Filtering/DisplacementField/include/itkComposeDisplacementFieldsImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkComposeDisplacementFieldsImageFilter.hxx
@@ -77,8 +77,8 @@ ComposeDisplacementFieldsImageFilter<InputImage, TOutputImage>::DynamicThreadedG
   const typename OutputFieldType::Pointer     output = this->GetOutput();
   const typename InputFieldType::ConstPointer warpingField = this->GetWarpingField();
 
-  ImageRegionConstIteratorWithIndex<InputFieldType> ItW(warpingField, region);
-  ImageRegionIterator<OutputFieldType>              ItF(output, region);
+  ImageRegionConstIteratorWithIndex    ItW(warpingField, region);
+  ImageRegionIterator<OutputFieldType> ItF(output, region);
 
   PointType pointIn1;
   PointType pointIn2;

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
@@ -183,8 +183,8 @@ DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>
 
   if (this->m_EnforceStationaryBoundary && !this->m_UseInputFieldToDefineTheBSplineDomain)
   {
-    ImageRegionConstIteratorWithIndex<OutputFieldType> ItB(bsplineParametricDomainField,
-                                                           bsplineParametricDomainField->GetBufferedRegion());
+    ImageRegionConstIteratorWithIndex ItB(bsplineParametricDomainField,
+                                          bsplineParametricDomainField->GetBufferedRegion());
 
     for (ItB.GoToBegin(); !ItB.IsAtEnd(); ++ItB)
     {
@@ -218,7 +218,7 @@ DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>
   {
     itkDebugMacro("Gathering information from the input displacement field. ");
 
-    ImageRegionConstIteratorWithIndex<InputFieldType> It(inputField, inputField->GetBufferedRegion());
+    ImageRegionConstIteratorWithIndex It(inputField, inputField->GetBufferedRegion());
 
     itkDebugMacro("Extracting points from input displacement field.");
 

--- a/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
@@ -182,7 +182,7 @@ InvertDisplacementFieldImageFilter<TInputImage, TOutputImage>::DynamicThreadedGe
 
   if (this->m_DoThreadedEstimateInverse)
   {
-    ImageRegionIteratorWithIndex<DisplacementFieldType> ItI(this->GetOutput(), region);
+    ImageRegionIteratorWithIndex ItI(this->GetOutput(), region);
 
     for (ItI.GoToBegin(), ItE.GoToBegin(), ItS.GoToBegin(); !ItI.IsAtEnd(); ++ItI, ++ItE, ++ItS)
     {

--- a/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.hxx
@@ -88,9 +88,9 @@ IterativeInverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::Generat
     // calculate the inverted field
     const double spacing = inputPtr->GetSpacing()[0];
 
-    ProgressReporter progress(this, 0, inputPtr->GetLargestPossibleRegion().GetNumberOfPixels());
-    ImageRegionIteratorWithIndex<OutputImageType> OutputIt(outputPtr, outputPtr->GetRequestedRegion());
-    const FieldInterpolatorPointer                inputFieldInterpolator = FieldInterpolatorType::New();
+    ProgressReporter               progress(this, 0, inputPtr->GetLargestPossibleRegion().GetNumberOfPixels());
+    ImageRegionIteratorWithIndex   OutputIt(outputPtr, outputPtr->GetRequestedRegion());
+    const FieldInterpolatorPointer inputFieldInterpolator = FieldInterpolatorType::New();
     inputFieldInterpolator->SetInputImage(inputPtr);
 
     double smallestError = 0;

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
@@ -143,7 +143,7 @@ TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDispl
 
   const typename DisplacementFieldType::Pointer outputField = this->GetOutput();
 
-  for (ImageRegionIteratorWithIndex<DisplacementFieldType> It(outputField, region); !It.IsAtEnd(); ++It)
+  for (ImageRegionIteratorWithIndex It(outputField, region); !It.IsAtEnd(); ++It)
   {
     PointType point;
     outputField->TransformIndexToPhysicalPoint(It.GetIndex(), point);

--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.hxx
@@ -88,7 +88,7 @@ MovingHistogramImageFilter<TInputImage, TOutputImage, TKernel, THistogram>::Dyna
   const OffsetListType * addedList = &this->m_AddedOffsets[offset];
   const OffsetListType * removedList = &this->m_RemovedOffsets[offset];
 
-  ImageLinearConstIteratorWithIndex<InputImageType> InLineIt(inputImage, outputRegionForThread);
+  ImageLinearConstIteratorWithIndex InLineIt(inputImage, outputRegionForThread);
   InLineIt.SetDirection(BestDirection);
 
   InLineIt.GoToBegin();

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
@@ -220,7 +220,7 @@ BSplineControlPointImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenera
     epsilon[i] = r * this->m_Spacing[i] * this->m_BSplineEpsilon;
   }
 
-  for (ImageRegionIteratorWithIndex<OutputImageType> It(outputPtr, region); !It.IsAtEnd(); ++It)
+  for (ImageRegionIteratorWithIndex It(outputPtr, region); !It.IsAtEnd(); ++It)
   {
     typename OutputImageType::IndexType idx = It.GetIndex();
     for (unsigned int i = 0; i < ImageDimension; ++i)
@@ -266,9 +266,7 @@ BSplineControlPointImageFilter<TInputImage, TOutputImage>::CollapsePhiLattice(Po
                                                                               const RealType       u,
                                                                               const unsigned int   dimension)
 {
-  for (ImageRegionIteratorWithIndex<PointDataImageType> It(collapsedLattice,
-                                                           collapsedLattice->GetLargestPossibleRegion());
-       !It.IsAtEnd();
+  for (ImageRegionIteratorWithIndex It(collapsedLattice, collapsedLattice->GetLargestPossibleRegion()); !It.IsAtEnd();
        ++It)
   {
     PointDataType                          data{};
@@ -426,8 +424,7 @@ BSplineControlPointImageFilter<TInputPointImage, TOutputImage>::RefineControlPoi
       sizePsi[i] = this->m_SplineOrder[i] + 1;
     }
 
-    ImageRegionIteratorWithIndex<ControlPointLatticeType> It(refinedLattice,
-                                                             refinedLattice->GetLargestPossibleRegion());
+    ImageRegionIteratorWithIndex It(refinedLattice, refinedLattice->GetLargestPossibleRegion());
 
     const TInputPointImage * input = this->GetInput();
 

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.hxx
@@ -238,8 +238,8 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::Evaluate(const Point
 
   OutputType data{};
 
-  for (ImageRegionIteratorWithIndex<RealImageType> ItW(this->m_NeighborhoodWeightImage,
-                                                       this->m_NeighborhoodWeightImage->GetLargestPossibleRegion());
+  for (ImageRegionIteratorWithIndex ItW(this->m_NeighborhoodWeightImage,
+                                        this->m_NeighborhoodWeightImage->GetLargestPossibleRegion());
        !ItW.IsAtEnd();
        ++ItW)
   {
@@ -342,8 +342,8 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateGradient(con
   gradient.SetSize(PixelType::GetNumberOfComponents(), ImageDimension);
   gradient.Fill(0.0);
 
-  ImageRegionIteratorWithIndex<RealImageType> ItW(this->m_NeighborhoodWeightImage,
-                                                  this->m_NeighborhoodWeightImage->GetLargestPossibleRegion());
+  ImageRegionIteratorWithIndex ItW(this->m_NeighborhoodWeightImage,
+                                   this->m_NeighborhoodWeightImage->GetLargestPossibleRegion());
 
   vnl_vector<CoordinateType> bsplineWeights[ImageDimension];
 
@@ -512,8 +512,8 @@ BSplineControlPointImageFunction<TInputImage, TCoordinate>::EvaluateHessian(cons
   hessian.SetSize(ImageDimension, ImageDimension);
   hessian.Fill(0.0);
 
-  ImageRegionIteratorWithIndex<RealImageType> ItW(this->m_NeighborhoodWeightImage,
-                                                  this->m_NeighborhoodWeightImage->GetLargestPossibleRegion());
+  ImageRegionIteratorWithIndex ItW(this->m_NeighborhoodWeightImage,
+                                   this->m_NeighborhoodWeightImage->GetLargestPossibleRegion());
 
   vnl_vector<CoordinateType> bsplineWeights[ImageDimension];
 

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -416,8 +416,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::Threade
   neighborhoodWeightImage->SetRegions(size);
   neighborhoodWeightImage->AllocateInitialized();
 
-  ImageRegionIteratorWithIndex<RealImageType> ItW(neighborhoodWeightImage,
-                                                  neighborhoodWeightImage->GetRequestedRegion());
+  ImageRegionIteratorWithIndex ItW(neighborhoodWeightImage, neighborhoodWeightImage->GetRequestedRegion());
 
   RealArrayType p;
   RealArrayType r;
@@ -596,7 +595,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::Threade
   const typename PointDataImageType::IndexType startPhiIndex =
     this->m_PhiLattice->GetLargestPossibleRegion().GetIndex();
 
-  for (ImageRegionIteratorWithIndex<ImageType> It(this->GetOutput(), region); !It.IsAtEnd(); ++It)
+  for (ImageRegionIteratorWithIndex It(this->GetOutput(), region); !It.IsAtEnd(); ++It)
   {
     typename ImageType::IndexType idx = It.GetIndex();
     for (unsigned int i = 0; i < ImageDimension; ++i)
@@ -761,7 +760,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::RefineC
     sizePsi[i] = this->m_SplineOrder[i] + 1;
   }
 
-  ImageRegionIteratorWithIndex<PointDataImageType> It(refinedLattice, refinedLattice->GetLargestPossibleRegion());
+  ImageRegionIteratorWithIndex It(refinedLattice, refinedLattice->GetLargestPossibleRegion());
 
   while (!It.IsAtEnd())
   {
@@ -980,9 +979,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::Collaps
   const RealType       u,
   const unsigned int   dimension)
 {
-  for (ImageRegionIteratorWithIndex<PointDataImageType> It(collapsedLattice,
-                                                           collapsedLattice->GetLargestPossibleRegion());
-       !It.IsAtEnd();
+  for (ImageRegionIteratorWithIndex It(collapsedLattice, collapsedLattice->GetLargestPossibleRegion()); !It.IsAtEnd();
        ++It)
   {
     PointDataType                          data{};

--- a/Modules/Filtering/ImageSources/include/itkGridImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGridImageSource.hxx
@@ -57,7 +57,7 @@ GridImageSource<TOutputImage>::BeforeThreadedGenerateData()
     pixels.fill(1);
     if (this->m_WhichDimensions[i])
     {
-      ImageLinearIteratorWithIndex<ImageType> It(output, output->GetRequestedRegion());
+      ImageLinearIteratorWithIndex It(output, output->GetRequestedRegion());
       It.SetDirection(i);
 
       // Add two extra functions in the front and one in the back to ensure
@@ -93,7 +93,7 @@ GridImageSource<TOutputImage>::DynamicThreadedGenerateData(const ImageRegionType
 
   TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
 
-  for (ImageRegionIteratorWithIndex<ImageType> It(output, outputRegionForThread); !It.IsAtEnd(); ++It)
+  for (ImageRegionIteratorWithIndex It(output, outputRegionForThread); !It.IsAtEnd(); ++It)
   {
     RealType                      val = 1.0;
     typename ImageType::IndexType index = It.GetIndex();

--- a/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
@@ -181,7 +181,7 @@ MaskedMovingHistogramImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel,
   const OffsetListType * addedList = &this->m_AddedOffsets[offset];
   const OffsetListType * removedList = &this->m_RemovedOffsets[offset];
 
-  ImageLinearConstIteratorWithIndex<InputImageType> InLineIt(inputImage, outputRegionForThread);
+  ImageLinearConstIteratorWithIndex InLineIt(inputImage, outputRegionForThread);
   InLineIt.SetDirection(BestDirection);
   InLineIt.GoToBegin();
   IndexType LineStart;

--- a/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.hxx
@@ -103,7 +103,7 @@ AttributeMorphologyBaseImageFilter<TInputImage, TOutputImage, TAttribute, TFunct
   m_AuxData = make_unique_for_overwrite<AttributeType[]>(buffsize);
 
   // copy the pixels to the sort buffer
-  ImageRegionConstIteratorWithIndex<TInputImage> RegIt(input, output->GetRequestedRegion());
+  ImageRegionConstIteratorWithIndex RegIt(input, output->GetRequestedRegion());
   // IndexType Origin = RegIt.GetIndex();
   {
     OffsetValueType pos = 0;

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.hxx
@@ -83,7 +83,7 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeHImage()
   // Iterator for the phi function
   ImageRegionConstIteratorWithIndex constIt(contourImage, contourImage->GetRequestedRegion());
 
-  ImageRegionIteratorWithIndex<InputImageType> It(hBuffer, hBuffer->GetRequestedRegion());
+  ImageRegionIteratorWithIndex It(hBuffer, hBuffer->GetRequestedRegion());
 
   It.GoToBegin(), constIt.GoToBegin();
 

--- a/Modules/Registration/RegistrationMethodsv4/include/itkBSplineSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkBSplineSyNImageRegistrationMethod.hxx
@@ -143,8 +143,8 @@ BSplineSyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform, T
 
     if (this->m_AverageMidPointGradients)
     {
-      for (ImageRegionIteratorWithIndex<DisplacementFieldType> ItF(
-             fixedToMiddleSmoothUpdateField, fixedToMiddleSmoothUpdateField->GetLargestPossibleRegion());
+      for (ImageRegionIteratorWithIndex ItF(fixedToMiddleSmoothUpdateField,
+                                            fixedToMiddleSmoothUpdateField->GetLargestPossibleRegion());
            !ItF.IsAtEnd();
            ++ItF)
       {

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
@@ -944,9 +944,7 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
           static_cast<unsigned long>(std::ceil(1.0 / this->m_MetricSamplingPercentagePerLevel[this->m_CurrentLevel]));
         unsigned long count =
           sampleCount; // Start at sampleCount to keep behavior backwards identical, using first element.
-        for (ImageRegionConstIteratorWithIndex<VirtualDomainImageType> It(virtualImage, virtualDomainRegion);
-             !It.IsAtEnd();
-             ++It)
+        for (ImageRegionConstIteratorWithIndex It(virtualImage, virtualDomainRegion); !It.IsAtEnd(); ++It)
         {
           if (count == sampleCount)
           {
@@ -975,7 +973,7 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
         const auto          sampleCount =
           static_cast<unsigned long>(static_cast<float>(totalVirtualDomainVoxels) *
                                      this->m_MetricSamplingPercentagePerLevel[this->m_CurrentLevel]);
-        ImageRandomConstIteratorWithIndex<VirtualDomainImageType> ItR(virtualImage, virtualDomainRegion);
+        ImageRandomConstIteratorWithIndex ItR(virtualImage, virtualDomainRegion);
         if (m_ReseedIterator)
         {
           ItR.ReinitializeSeed();

--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
@@ -193,8 +193,8 @@ SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform, TVirtual
 
     if (this->m_AverageMidPointGradients)
     {
-      for (ImageRegionIteratorWithIndex<DisplacementFieldType> ItF(
-             fixedToMiddleSmoothUpdateField, fixedToMiddleSmoothUpdateField->GetLargestPossibleRegion());
+      for (ImageRegionIteratorWithIndex ItF(fixedToMiddleSmoothUpdateField,
+                                            fixedToMiddleSmoothUpdateField->GetLargestPossibleRegion());
            !ItF.IsAtEnd();
            ++ItF)
       {
@@ -784,10 +784,8 @@ typename SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform,
   const typename DisplacementFieldType::SizeType   size = region.GetSize();
   const typename DisplacementFieldType::IndexType  startIndex = region.GetIndex();
 
-  ImageRegionIteratorWithIndex<DisplacementFieldType> ItS(smoothField, smoothField->GetLargestPossibleRegion());
-  for (ImageRegionConstIteratorWithIndex<DisplacementFieldType> ItF(field, field->GetLargestPossibleRegion());
-       !ItF.IsAtEnd();
-       ++ItF, ++ItS)
+  ImageRegionIteratorWithIndex ItS(smoothField, smoothField->GetLargestPossibleRegion());
+  for (ImageRegionConstIteratorWithIndex ItF(field, field->GetLargestPossibleRegion()); !ItF.IsAtEnd(); ++ItF, ++ItS)
   {
     typename DisplacementFieldType::IndexType index = ItF.GetIndex();
     bool                                      isOnBoundary = false;


### PR DESCRIPTION
Used class template argument deduction (CTAD) when declaring "IteratorWithIndex" variables.

Using Notepad++, Replace in Files, doing:

    Find what: ([^\w]Image\w+IteratorWithIndex)<\w+>[ ]*( \w+[\({])
    Replace with: $1$2
    Files: itk*.hxx
    [v] Match case
    (*) Regular expression

- Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/5932 commit 50210af9d3bc78b3bd84bed407af266d9683d50a

----

FYI, This pull request specifically takes care of variables whose variable name starts with an uppercase letter. 