### PR TITLE
BUG: Remove C++23 specific `Absolute(x)` behavior to avoid ODR violation

### DIFF
--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -914,13 +914,9 @@ Absolute(T x) noexcept
   }
   else if constexpr (std::is_floating_point_v<T>) // floating point or complex<> types
   {                                               // floating point std::abs is constexpr in c++23 and later
-#if __cplusplus >= 202302L
-    return std::abs(x);
-#else
     // Note: +0.0 and -0.0 are considered equal, according to ExactlyEquals. They are both considered equal to T{}.
     // And they both have the same absolute value: +0.0.
     return ExactlyEquals(x, T{}) ? T{} : (x < 0) ? -x : x;
-#endif
   }
 }
 template <typename T>


### PR DESCRIPTION
The current behavior of `Absolute(x)` is slightly different in code compiled with C++23 or later than with C++17 or C++20.

Having a different implementation for a different C++ standard version may cause a violation the One Definition Rule (ODR), when user code and the ITK code are built with different C++ standard versions.

- Aims to fix #5823