### PR TITLE
Revert "BUG: Use std::forward instead of std::move on forwarding references"

### DIFF
--- a/Modules/Core/Common/test/itkArray2DGTest.cxx
+++ b/Modules/Core/Common/test/itkArray2DGTest.cxx
@@ -70,7 +70,7 @@ TEST(Array2D, MoveConstruct)
     const auto * const * const originalDataArray{ original.data_array() };
     const unsigned int         originalSize{ original.size() };
 
-    const auto moveConstructed = std::forward<decltype(original)>(original);
+    const auto moveConstructed = std::move(original);
 
     // After the "move", the move-constructed object has retrieved the original data.
     EXPECT_EQ(moveConstructed.data_array(), originalDataArray);

--- a/Modules/Core/Common/test/itkRangeGTestUtilities.h
+++ b/Modules/Core/Common/test/itkRangeGTestUtilities.h
@@ -94,7 +94,7 @@ public:
   ExpectMoveConstructedRangeHasSameIteratorsAsOriginalBeforeMove(TRange && originalRange)
   {
     const TRange originalRangeBeforeMove = originalRange;
-    TRange       moveConstructedRange(std::forward<TRange>(originalRange));
+    TRange       moveConstructedRange(std::move(originalRange));
 
     ExpectRangesHaveEqualBeginAndEnd(moveConstructedRange, originalRangeBeforeMove);
   }
@@ -107,7 +107,7 @@ public:
     const TRange originalRangeBeforeMove = originalRange;
 
     TRange moveAssignedRange;
-    moveAssignedRange = std::forward<TRange>(originalRange);
+    moveAssignedRange = std::move(originalRange);
 
     ExpectRangesHaveEqualBeginAndEnd(moveAssignedRange, originalRangeBeforeMove);
   }


### PR DESCRIPTION
This reverts commit 14c265b8f96a01176f5a3424f5977445243f2128.

The tests are just testing move-semantics

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
