### PR TITLE
ENH: Update Cuberille remote module to fix compile warnings

### DIFF
--- a/Modules/Remote/Cuberille.remote.cmake
+++ b/Modules/Remote/Cuberille.remote.cmake
@@ -68,5 +68,5 @@ And the related:
 "
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKCuberille.git
-  GIT_TAG 50dea9ff966f7ce39ee2d5bf1ff10039185ed51a
+  GIT_TAG a152f89e5d45f7262523446555e1f4da86071a71
   )


### PR DESCRIPTION
ITK/Modules/Remote/Cuberille/test/CuberilleTest_Issue66.cxx:112:40: warning: unused parameter 'argv' [-Wunused-parameter]


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
