### PR TITLE
COMP: Suppress GCC -Waggressive-loop-optimizations false positive

### DIFF
--- a/CMake/CTestCustom.cmake.in
+++ b/CMake/CTestCustom.cmake.in
@@ -129,6 +129,9 @@ set(CTEST_CUSTOM_WARNING_EXCEPTION
   # ignore -Wunused-template warnings in third party DoubleConversion.
   ".*Modules/ThirdParty/DoubleConversion/.*warning:.*Wunused-template"
 
+  # GCC false positive: template-parameterized loops over FixedArray-based types
+  "warning:.*iteration.*invokes undefined behavior.*-Waggressive-loop-optimizations"
+
   # ignore some third party warnings
   ".*Modules/ThirdParty/.*warning:.*Wzero-as-null-pointer-constant"
   ".*Modules/ThirdParty/Eigen3/.*warning:.*"


### PR DESCRIPTION
## Summary
- Suppress GCC 11.4 false positive `-Waggressive-loop-optimizations` warnings in CDash nightly builds
- Affects `itkWarpImageFilter.hxx` and `itkESMDemonsRegistrationFunction.hxx` where template-parameterized loops over `FixedArray`-based types trigger "iteration 2 invokes undefined behavior"
- Suppressed via `CTEST_CUSTOM_WARNING_EXCEPTION` in `CTestCustom.cmake.in`

## CDash Reference
Build 11129866 (Ubuntu-22.04-gcc11.4-Rel-Python, corista.kitware)

## Test plan
- [ ] CDash nightly builds no longer report these warnings
- [ ] No new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)