### PR TITLE
BUG: Fix undefined behavior in itkQuadEdgeMeshCellInterfaceTest

### DIFF
--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshCellInterfaceTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshCellInterfaceTest.cxx
@@ -120,7 +120,10 @@ TestCellInterface(const std::string_view name, TCell * aCell)
   std::vector<PointIdentifier> pointIds(numberOfPoints * 2);
   std::iota(pointIds.begin(), pointIds.end(), PointIdentifier{});
 
-  cell->SetPointIds(pointIds.data());
+  if (numberOfPoints > 0)
+  {
+    cell->SetPointIds(pointIds.data());
+  }
   // exercising the const GetPointIds() method
   // null for QE Cells
   if (cell2->GetPointIds())
@@ -142,7 +145,10 @@ TestCellInterface(const std::string_view name, TCell * aCell)
   }
   std::cout << std::endl;
 
-  cell->SetPointIds(&pointIds[numberOfPoints], &pointIds[numberOfPoints * 2]);
+  if (numberOfPoints > 0)
+  {
+    cell->SetPointIds(&pointIds[numberOfPoints], &pointIds[numberOfPoints * 2]);
+  }
   std::cout << "    Iterator test: PointIds for populated cell: ";
   typename TCell::PointIdIterator pxpointId = cell->PointIdsBegin();
   typename TCell::PointIdIterator pxendId = cell->PointIdsEnd();

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshCellInterfaceTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshCellInterfaceTest.cxx
@@ -120,7 +120,7 @@ TestCellInterface(const std::string_view name, TCell * aCell)
   std::vector<PointIdentifier> pointIds(numberOfPoints * 2);
   std::iota(pointIds.begin(), pointIds.end(), PointIdentifier{});
 
-  if (numberOfPoints > 0)
+  if (!pointIds.empty())
   {
     cell->SetPointIds(pointIds.data());
   }
@@ -130,7 +130,7 @@ TestCellInterface(const std::string_view name, TCell * aCell)
   {
     cell->SetPointIds(cell2->GetPointIds());
   }
-  if (numberOfPoints > 0)
+  if (!pointIds.empty())
   {
     cell->SetPointId(0, 100);
   }
@@ -145,7 +145,7 @@ TestCellInterface(const std::string_view name, TCell * aCell)
   }
   std::cout << std::endl;
 
-  if (numberOfPoints > 0)
+  if (!pointIds.empty())
   {
     cell->SetPointIds(pointIds.data() + numberOfPoints, pointIds.data() + numberOfPoints * 2);
   }

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshCellInterfaceTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshCellInterfaceTest.cxx
@@ -147,7 +147,7 @@ TestCellInterface(const std::string_view name, TCell * aCell)
 
   if (numberOfPoints > 0)
   {
-    cell->SetPointIds(&pointIds[numberOfPoints], &pointIds[numberOfPoints * 2]);
+    cell->SetPointIds(pointIds.data() + numberOfPoints, pointIds.data() + numberOfPoints * 2);
   }
   std::cout << "    Iterator test: PointIds for populated cell: ";
   typename TCell::PointIdIterator pxpointId = cell->PointIdsBegin();


### PR DESCRIPTION
## Summary
- Guard `SetPointIds` calls with `numberOfPoints > 0` checks to prevent undefined behavior when testing cells with 0 vertices (e.g., `PolygonCell(0)`)
- UndefinedBehaviorSanitizer detected `reference-binding-to-null` in `std::vector::operator[]` when accessing elements of an empty vector
- Reproduces the crash seen in [CDash build 11129930](https://open.cdash.org/builds/11129930) (Mac26.x-ClangMain-dbg-arm64)

## Root cause
Introduced by fd770224ea (`ENH: Use std::vector instead of raw new[] in QuadEdgeMesh test`). The original code used `new PointIdentifier[numberOfPoints * 2]{}`, which returns a valid non-null pointer even for zero-sized allocations per the C++ standard. The conversion to `std::vector` changed the behavior: `&pointIds[numberOfPoints]` becomes `&pointIds[0]` on an empty vector, which is undefined behavior via `operator[]`. The sibling function `TestQECellInterface` already had a `numberOfPoints > 0` guard, but `TestCellInterface` did not.

## Test plan
- [x] Reproduced with UBSan-enabled debug build matching CDash configuration
- [x] Verified fix passes `itkQuadEdgeMeshCellInterfaceTest` with UBSan (`halt_on_error=1`) — no sanitizer errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)