### PR TITLE
COMP: Uninstall Homebrew LLVM on macOS CI to fix linker warnings

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -57,6 +57,13 @@ jobs:
 
     - bash: |
         set -x
+        # Remove Homebrew LLVM to prevent its libunwind from
+        # shadowing the system libunwind and producing linker warnings.
+        # See https://github.com/actions/runner-images/issues/13816
+        llvm_pkgs=$(brew ls -1 | grep llvm || true)
+        if [ -n "$llvm_pkgs" ]; then
+          brew uninstall --ignore-dependencies $llvm_pkgs
+        fi
         sudo python3 -m pip install ninja
         sudo python3 -m pip install --upgrade setuptools
         sudo python3 -m pip install scikit-ci-addons

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -58,6 +58,13 @@ jobs:
 
     - bash: |
         set -x
+        # Remove Homebrew LLVM to prevent its libunwind from
+        # shadowing the system libunwind and producing linker warnings.
+        # See https://github.com/actions/runner-images/issues/13816
+        llvm_pkgs=$(brew ls -1 | grep llvm || true)
+        if [ -n "$llvm_pkgs" ]; then
+          brew uninstall --ignore-dependencies $llvm_pkgs
+        fi
         sudo pip3 install ninja numpy
         sudo pip3 install ninja numpy>=1.20 typing-extensions
         sudo python3 -m pip install --upgrade setuptools


### PR DESCRIPTION
## Summary
- Uninstall all Homebrew LLVM packages on macOS CI agents before building
- LLVM 18+ bundles `libunwind` in its `lib/` directory, which shadows the system `libunwind` re-exported through `libSystem.dylib`, producing ~199 identical linker warnings per build
- These warnings exceed CDash's `CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS` threshold (199), causing false CI failures on both `ITK.macOS` and `ITK.macOS.Python` pipelines
- ITK's macOS CI uses Apple Clang, not Homebrew LLVM, so the Homebrew LLVM installation is unnecessary

## Background
The newest `macos-15` runner image (20260317.0278) has additional breakage where Homebrew clang shadows Apple clang on ARM ([actions/runner-images#13816](https://github.com/actions/runner-images/issues/13816), [actions/runner-images#13827](https://github.com/actions/runner-images/issues/13827)).

The upstream fix in newer Homebrew/MacPorts LLVM packages moves `libunwind` into `lib/unwind/` to keep it off the default linker path ([MacPorts #71052](https://trac.macports.org/ticket/71052)), but the CI agent images have not yet been updated.

## Test plan
- [ ] `ITK.macOS` CI passes without the 199 linker warnings
- [ ] `ITK.macOS.Python` CI passes without the 199 linker warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)