### PR TITLE
COMP: Suppress -Wzero-as-null-pointer-constant in HDF5 ITK wrapper headers

### DIFF
--- a/Modules/ThirdParty/HDF5/src/itk_H5Cpp.h.in
+++ b/Modules/ThirdParty/HDF5/src/itk_H5Cpp.h.in
@@ -21,10 +21,28 @@
 
 /* Use the hdf5 library configured for ITK.  */
 #cmakedefine ITK_USE_SYSTEM_HDF5
+
+/* Suppress -Wzero-as-null-pointer-constant warnings from HDF5 C++ headers
+ * that use NULL in default function arguments. This mirrors the pattern
+ * of ITK_CLANG_PRAGMA_PUSH / ITK_CLANG_SUPPRESS_Wzero_as_null_pointer_constant
+ * from itkMacro.h. */
+#if defined(__clang__) && defined(__has_warning)
+#  if __has_warning("-Wzero-as-null-pointer-constant")
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#    define ITK_H5CPP_SUPPRESS_Wzero_as_null_pointer_constant
+#  endif
+#endif
+
 #ifdef ITK_USE_SYSTEM_HDF5
 # include <H5Cpp.h>
 #else
 # include "itkhdf5/H5Cpp.h"
+#endif
+
+#ifdef ITK_H5CPP_SUPPRESS_Wzero_as_null_pointer_constant
+#  pragma clang diagnostic pop
+#  undef ITK_H5CPP_SUPPRESS_Wzero_as_null_pointer_constant
 #endif
 
 #endif

--- a/Modules/ThirdParty/HDF5/src/itk_hdf5.h.in
+++ b/Modules/ThirdParty/HDF5/src/itk_hdf5.h.in
@@ -21,10 +21,28 @@
 
 /* Use the hdf5 library configured for ITK.  */
 #cmakedefine ITK_USE_SYSTEM_HDF5
+
+/* Suppress -Wzero-as-null-pointer-constant warnings from HDF5 C headers
+ * that use NULL in default function arguments. This mirrors the pattern
+ * of ITK_CLANG_PRAGMA_PUSH / ITK_CLANG_SUPPRESS_Wzero_as_null_pointer_constant
+ * from itkMacro.h, implemented directly here for C compatibility. */
+#if defined(__clang__) && defined(__has_warning)
+#  if __has_warning("-Wzero-as-null-pointer-constant")
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#    define ITK_HDF5_SUPPRESS_Wzero_as_null_pointer_constant
+#  endif
+#endif
+
 #ifdef ITK_USE_SYSTEM_HDF5
 # include <hdf5.h>
 #else
 # include "itkhdf5/hdf5.h"
+#endif
+
+#ifdef ITK_HDF5_SUPPRESS_Wzero_as_null_pointer_constant
+#  pragma clang diagnostic pop
+#  undef ITK_HDF5_SUPPRESS_Wzero_as_null_pointer_constant
 #endif
 
 #endif


### PR DESCRIPTION
## Summary

HDF5 C and C++ headers use `NULL` as default function argument values, which triggers `-Wzero-as-null-pointer-constant` warnings on Clang when building with `-Weverything`. These warnings appear in the ITK nightly dashboard (e.g. `Mac13.x-AppleClang-dbg-Universal`) for HDF5 C++ headers such as `H5DataSet.h`, `H5Object.h`, `H5DcreatProp.h`, and `H5DataSpace.h`.

Example warning:

```
Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5DataSet.h:98:38: warning:
  zero as null pointer constant [-Wzero-as-null-pointer-constant]
      void *op_data = NULL);

Modules/ThirdParty/HDF5/src/itkhdf5/c++/src/H5Object.h:83:85: warning:
  zero as null pointer constant [-Wzero-as-null-pointer-constant]
```

## Changes

Add `#pragma clang diagnostic push/ignored/pop` guards in the two ITK HDF5 wrapper headers to suppress the warning around the HDF5 includes:

- `Modules/ThirdParty/HDF5/src/itk_hdf5.h.in` — C HDF5 header wrapper
- `Modules/ThirdParty/HDF5/src/itk_H5Cpp.h.in` — C++ HDF5 header wrapper

The pattern mirrors `ITK_CLANG_PRAGMA_PUSH` / `ITK_CLANG_SUPPRESS_Wzero_as_null_pointer_constant` from `itkMacro.h`, implemented inline here because these headers must remain compatible with C translation units.

A `__has_warning` guard ensures the diagnostic is only suppressed on Clang versions that recognise the flag, and a sentinel `#define` ensures the `pop` is only emitted when a `push` was actually performed.

## Testing

Built `ITKIOTransformHDF5` and `ITKIOMINC` locally with the `default` preset — zero warnings or errors with both targets.