### PR TITLE
STYLE: Use CTAD for `ImageRegionIterator` variables in hxx files

### DIFF
--- a/Modules/Core/Common/include/itkImageAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkImageAlgorithm.hxx
@@ -54,7 +54,7 @@ ImageAlgorithm::ReferenceCopy(const InputImageType *                       inIma
   }
 
   ImageRegionConstIterator<InputImageType> it(inImage, inRegion);
-  ImageRegionIterator<OutputImageType>     ot(outImage, outRegion);
+  ImageRegionIterator                      ot(outImage, outRegion);
 
   while (!it.IsAtEnd())
   {

--- a/Modules/Core/Common/include/itkNeighborhoodIteratorTestCommon.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodIteratorTestCommon.hxx
@@ -65,11 +65,10 @@ void
 FillImage(itk::Image<itk::Index<VDimension>, VDimension> * img)
 {
   using IndexType = itk::Index<VDimension>;
-  using ImageType = itk::Image<IndexType, VDimension>;
   const itk::Size<VDimension> size = img->GetRequestedRegion().GetSize();
 
-  IndexType                           loop{};
-  itk::ImageRegionIterator<ImageType> it(img, img->GetRequestedRegion());
+  IndexType                loop{};
+  itk::ImageRegionIterator it(img, img->GetRequestedRegion());
 
   while (!it.IsAtEnd())
   {

--- a/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
@@ -48,7 +48,7 @@ DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::CopyInputToOutput()
   }
 
   ImageRegionConstIterator<TInputImage> in(input, output->GetRequestedRegion());
-  ImageRegionIterator<TOutputImage>     out(output, output->GetRequestedRegion());
+  ImageRegionIterator                   out(output, output->GetRequestedRegion());
 
   while (!out.IsAtEnd())
   {
@@ -188,8 +188,8 @@ DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::ThreadedApplyUpdate
   const ThreadRegionType & regionToProcess,
   ThreadIdType)
 {
-  ImageRegionIterator<UpdateBufferType> u(m_UpdateBuffer, regionToProcess);
-  ImageRegionIterator<OutputImageType>  o(this->GetOutput(), regionToProcess);
+  ImageRegionIterator u(m_UpdateBuffer, regionToProcess);
+  ImageRegionIterator o(this->GetOutput(), regionToProcess);
 
   while (!u.IsAtEnd())
   {
@@ -238,8 +238,8 @@ DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::ThreadedCalculateCh
   auto         fEnd = faceList.end();
 
   // Process the non-boundary region.
-  NeighborhoodIteratorType              nD(radius, output, *fIt);
-  ImageRegionIterator<UpdateBufferType> nU(m_UpdateBuffer, *fIt);
+  NeighborhoodIteratorType nD(radius, output, *fIt);
+  ImageRegionIterator      nU(m_UpdateBuffer, *fIt);
   nD.GoToBegin();
   while (!nD.IsAtEnd())
   {
@@ -251,8 +251,8 @@ DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::ThreadedCalculateCh
   // Process each of the boundary faces.
   for (++fIt; fIt != fEnd; ++fIt)
   {
-    NeighborhoodIteratorType              bD(radius, output, *fIt);
-    ImageRegionIterator<UpdateBufferType> bU(m_UpdateBuffer, *fIt);
+    NeighborhoodIteratorType bD(radius, output, *fIt);
+    ImageRegionIterator      bU(m_UpdateBuffer, *fIt);
 
     bD.GoToBegin();
     while (!bD.IsAtEnd())

--- a/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
@@ -104,7 +104,7 @@ MetaImageConverter<VDimension, PixelType, TSpatialObjectType>::MetaObjectToSpati
 
   this->MetaObjectToSpatialObjectBase(imageMO, imageSO);
 
-  ImageRegionIterator<ImageType> it(myImage, myImage->GetLargestPossibleRegion());
+  ImageRegionIterator it(myImage, myImage->GetLargestPossibleRegion());
   for (unsigned int i = 0; !it.IsAtEnd(); i++, ++it)
   {
     it.Set(static_cast<typename ImageType::PixelType>(imageMO->ElementData(i)));

--- a/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
+++ b/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
@@ -190,7 +190,7 @@ RandomImageSource<TOutputImage>::DynamicThreadedGenerateData(const OutputImageRe
   const auto dMin = static_cast<double>(m_Min);
   const auto dMax = static_cast<double>(m_Max);
 
-  for (ImageRegionIterator<TOutputImage> it(image, outputRegionForThread); !it.IsAtEnd(); ++it)
+  for (ImageRegionIterator it(image, outputRegionForThread); !it.IsAtEnd(); ++it)
   {
     sample_seed = (sample_seed * 16807) % 2147483647L;
     const double u = static_cast<double>(sample_seed) / 2147483711UL;

--- a/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.hxx
@@ -130,7 +130,7 @@ ComparisonImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   {
     SmartIterator                            test(radius, testImage, *face); // Iterate over test image.
     ImageRegionConstIterator<InputImageType> valid(validImage, *face);       // Iterate over valid image.
-    ImageRegionIterator<OutputImageType>     out(outputPtr, *face);          // Iterate over output image.
+    ImageRegionIterator                      out(outputPtr, *face);          // Iterate over output image.
     if (!test.GetNeedToUseBoundaryCondition() || !m_IgnoreBoundaryPixels)
     {
       test.OverrideBoundaryCondition(&nbc);

--- a/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
@@ -251,7 +251,7 @@ ExtractSliceImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   this->CallCopyOutputRegionToInputRegion(inputRegionForThread, outputRegionForThread);
 
 
-  ImageRegionIterator<TOutputImage>     outIt(outputPtr, outputRegionForThread);
+  ImageRegionIterator                   outIt(outputPtr, outputRegionForThread);
   ImageRegionConstIterator<TInputImage> inIt(inputPtr, inputRegionForThread);
 
   // walk the output region, and sample the input image

--- a/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.hxx
@@ -107,7 +107,7 @@ StretchIntensityImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateD
   const InputImageRegionType inputRegionForThread = outputRegionForThread;
 
   ImageRegionConstIterator<TInputImage> inputIt(inputPtr, inputRegionForThread);
-  ImageRegionIterator<TOutputImage>     outputIt(outputPtr, outputRegionForThread);
+  ImageRegionIterator                   outputIt(outputPtr, outputRegionForThread);
 
   while (!inputIt.IsAtEnd())
   {

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
@@ -252,8 +252,8 @@ BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::
   unsigned long    counter = 0;
 
 
-  ImageRegionIterator<ImageType> coeffIterator(this->m_CoefficientImages[0], supportRegion);
-  const ParametersValueType *    basePointer = this->m_CoefficientImages[0]->GetBufferPointer();
+  ImageRegionIterator         coeffIterator(this->m_CoefficientImages[0], supportRegion);
+  const ParametersValueType * basePointer = this->m_CoefficientImages[0]->GetBufferPointer();
   while (!coeffIterator.IsAtEnd())
   {
     indexes[counter] = &(coeffIterator.Value()) - basePointer;

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -81,7 +81,7 @@ MRIBiasEnergyFunction<TImage, TImageMask, TBiasField>::GetValue(const Parameters
 
   if (m_SamplingFactor[0] == 1 && m_SamplingFactor[1] == 1 && m_SamplingFactor[2] == 1)
   {
-    ImageRegionIterator<ImageType>             iIter(m_Image, m_Region);
+    ImageRegionIterator                        iIter(m_Image, m_Region);
     typename TBiasField::SimpleForwardIterator bIter(m_BiasField);
 
     bIter.Begin();
@@ -101,7 +101,7 @@ MRIBiasEnergyFunction<TImage, TImageMask, TBiasField>::GetValue(const Parameters
     }
     else
     {
-      ImageRegionIterator<MaskType> mIter(m_Mask, m_Region);
+      ImageRegionIterator mIter(m_Mask, m_Region);
       mIter.GoToBegin();
       while (!bIter.IsAtEnd())
       {
@@ -536,8 +536,8 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::CorrectImag
 {
   itkDebugMacro("Correcting the image ");
   using Pixel = InternalImagePixelType;
-  ImageRegionIterator<InternalImageType> iIter(m_InternalInput, region);
-  BiasFieldType::SimpleForwardIterator   bIter(&bias);
+  ImageRegionIterator                  iIter(m_InternalInput, region);
+  BiasFieldType::SimpleForwardIterator bIter(&bias);
 
   BiasFieldType::DomainSizeType biasSize;
   this->GetBiasFieldSize(region, biasSize);
@@ -546,7 +546,7 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::CorrectImag
   if (m_OutputMask.IsNotNull())
   {
     itkDebugMacro("Output mask is being used");
-    ImageRegionIterator<ImageMaskType> mIter(m_OutputMask, region);
+    ImageRegionIterator mIter(m_OutputMask, region);
     mIter.GoToBegin();
     while (!bIter.IsAtEnd())
     {
@@ -783,8 +783,8 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::Log1PImage(
 {
   const InternalImageRegionType region = source->GetRequestedRegion();
 
-  ImageRegionIterator<InternalImageType> s_iter(source, region);
-  ImageRegionIterator<InternalImageType> t_iter(target, region);
+  ImageRegionIterator s_iter(source, region);
+  ImageRegionIterator t_iter(target, region);
 
   InternalImagePixelType pixel;
   while (!s_iter.IsAtEnd())
@@ -812,8 +812,8 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::ExpImage(In
 {
   const InternalImageRegionType region = source->GetLargestPossibleRegion();
 
-  ImageRegionIterator<InternalImageType> s_iter(source, region);
-  ImageRegionIterator<InternalImageType> t_iter(target, region);
+  ImageRegionIterator s_iter(source, region);
+  ImageRegionIterator t_iter(target, region);
 
   while (!s_iter.IsAtEnd())
   {

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
@@ -83,7 +83,7 @@ BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   // except for pixels with DilateValue.  These pixels are initially
   // replaced with BackgroundValue and potentially replaced later with
   // DilateValue as the Minkowski sums are performed.
-  ImageRegionIterator<OutputImageType>     outIt(output, outputRegion);
+  ImageRegionIterator                      outIt(output, outputRegion);
   ImageRegionConstIterator<InputImageType> inIt(input, outputRegion);
 
   for (inIt.GoToBegin(), outIt.GoToBegin(); !outIt.IsAtEnd(); ++outIt, ++inIt)
@@ -142,7 +142,7 @@ BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   // iterator on input
   ImageRegionConstIterator<TInputImage> iRegIt(input, requiredInputRegion);
   // iterator on tmp image
-  ImageRegionIterator<TempImageType> tmpRegIt(tmpImage, requiredInputRegion);
+  ImageRegionIterator tmpRegIt(tmpImage, requiredInputRegion);
 
   for (iRegIt.GoToBegin(), tmpRegIt.GoToBegin(); !tmpRegIt.IsAtEnd(); ++iRegIt, ++tmpRegIt)
   {

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
@@ -83,7 +83,7 @@ BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   // except for pixels with DilateValue.  These pixels are initially
   // replaced with BackgroundValue and potentially replaced later with
   // DilateValue as the Minkowski sums are performed.
-  ImageRegionIterator<OutputImageType> outIt(output, outputRegion);
+  ImageRegionIterator outIt(output, outputRegion);
   // ImageRegionConstIterator<InputImageType> inIt( input, outputRegion );
 
   for (outIt.GoToBegin(); !outIt.IsAtEnd(); ++outIt)
@@ -132,7 +132,7 @@ BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   // iterator on input
   ImageRegionConstIterator<TInputImage> iRegIt(input, requiredInputRegion);
   // iterator on tmp image
-  ImageRegionIterator<TempImageType> tmpRegIt(tmpImage, requiredInputRegion);
+  ImageRegionIterator tmpRegIt(tmpImage, requiredInputRegion);
 
   for (iRegIt.GoToBegin(), tmpRegIt.GoToBegin(); !tmpRegIt.IsAtEnd(); ++iRegIt, ++tmpRegIt)
   {

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.hxx
@@ -134,7 +134,7 @@ BinaryMorphologicalClosingImageFilter<TInputImage, TOutputImage, TKernel>::Gener
   // iterator on input image
   ImageRegionConstIterator<InputImageType> inIt(this->GetInput(), this->GetOutput()->GetRequestedRegion());
   // iterator on output image
-  ImageRegionIterator<OutputImageType> outIt(this->GetOutput(), this->GetOutput()->GetRequestedRegion());
+  ImageRegionIterator outIt(this->GetOutput(), this->GetOutput()->GetRequestedRegion());
 
   ProgressReporter progress2(this, 0, this->GetOutput()->GetRequestedRegion().GetNumberOfPixels(), 20, 0.9, 0.1);
   while (!outIt.IsAtEnd())

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.hxx
@@ -65,7 +65,7 @@ BinaryPruningImageFilter<TInputImage, TOutputImage>::PrepareData()
   const typename OutputImageType::RegionType region = pruneImage->GetRequestedRegion();
 
   ImageRegionConstIterator<TInputImage> it(inputImage, region);
-  ImageRegionIterator<TOutputImage>     ot(pruneImage, region);
+  ImageRegionIterator                   ot(pruneImage, region);
 
   itkDebugMacro("PrepareData: Copy input to output");
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.hxx
@@ -67,7 +67,7 @@ BinaryThinningImageFilter<TInputImage, TOutputImage>::PrepareData()
   const typename OutputImageType::RegionType region = thinImage->GetRequestedRegion();
 
   ImageRegionConstIterator<TInputImage> it(inputImage, region);
-  ImageRegionIterator<TOutputImage>     ot(thinImage, region);
+  ImageRegionIterator                   ot(thinImage, region);
 
   itkDebugMacro("PrepareData: Copy input to output");
 

--- a/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.hxx
+++ b/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.hxx
@@ -110,7 +110,7 @@ ScalarToRGBColormapImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenera
   this->CallCopyOutputRegionToInputRegion(inputRegionForThread, outputRegionForThread);
 
   ImageRegionConstIterator<TInputImage> inputIt(inputPtr, inputRegionForThread);
-  ImageRegionIterator<TOutputImage>     outputIt(outputPtr, outputRegionForThread);
+  ImageRegionIterator                   outputIt(outputPtr, outputRegionForThread);
 
   while (!inputIt.IsAtEnd())
   {

--- a/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
@@ -162,7 +162,7 @@ NormalizedCorrelationImageFilter<TInputImage, TMaskImage, TOutputImage, TOperato
     bit.OverrideBoundaryCondition(this->GetBoundaryCondition());
     bit.GoToBegin();
 
-    ImageRegionIterator<OutputImageType> it(output, face);
+    ImageRegionIterator it(output, face);
 
     if (!mask)
     {

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
@@ -170,7 +170,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
   const typename OutputImageType::Pointer outputImage =
     static_cast<OutputImageType *>(this->ProcessObject::GetOutput(0));
 
-  ImageRegionIterator<OutputImageType> oit(outputImage, outputRegionForThread);
+  ImageRegionIterator oit(outputImage, outputRegionForThread);
 
   vnl_vector<double> B(m_NumberOfGradientDirections);
   vnl_vector<double> D(6);

--- a/Modules/Filtering/DisplacementField/include/itkComposeDisplacementFieldsImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkComposeDisplacementFieldsImageFilter.hxx
@@ -77,8 +77,8 @@ ComposeDisplacementFieldsImageFilter<InputImage, TOutputImage>::DynamicThreadedG
   const typename OutputFieldType::Pointer     output = this->GetOutput();
   const typename InputFieldType::ConstPointer warpingField = this->GetWarpingField();
 
-  ImageRegionConstIteratorWithIndex    ItW(warpingField, region);
-  ImageRegionIterator<OutputFieldType> ItF(output, region);
+  ImageRegionConstIteratorWithIndex ItW(warpingField, region);
+  ImageRegionIterator               ItF(output, region);
 
   PointType pointIn1;
   PointType pointIn2;

--- a/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
@@ -303,7 +303,7 @@ ConstantVelocityFieldTransform<TParametersValueType, VDimension>::CopyDisplaceme
   rval->Allocate();
 
   ImageRegionConstIterator<DisplacementFieldType> dispIt(toCopy, toCopy->GetLargestPossibleRegion());
-  ImageRegionIterator<DisplacementFieldType>      cloneDispIt(rval, rval->GetLargestPossibleRegion());
+  ImageRegionIterator                             cloneDispIt(rval, rval->GetLargestPossibleRegion());
   for (dispIt.GoToBegin(), cloneDispIt.GoToBegin(); !dispIt.IsAtEnd() && !cloneDispIt.IsAtEnd();
        ++dispIt, ++cloneDispIt)
   {
@@ -345,8 +345,7 @@ ConstantVelocityFieldTransform<TParametersValueType, VDimension>::InternalClone(
   // SetFixedParameters allocates the VelocityField
   ImageRegionConstIterator<ConstantVelocityFieldType> thisIt(this->m_ConstantVelocityField,
                                                              this->m_ConstantVelocityField->GetLargestPossibleRegion());
-  ImageRegionIterator<ConstantVelocityFieldType>      cloneIt(rval->m_ConstantVelocityField,
-                                                         rval->m_ConstantVelocityField->GetLargestPossibleRegion());
+  ImageRegionIterator cloneIt(rval->m_ConstantVelocityField, rval->m_ConstantVelocityField->GetLargestPossibleRegion());
   for (thisIt.GoToBegin(), cloneIt.GoToBegin(); !thisIt.IsAtEnd() && !cloneIt.IsAtEnd(); ++thisIt, ++cloneIt)
   {
     cloneIt.Set(thisIt.Get());

--- a/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
@@ -177,8 +177,8 @@ InvertDisplacementFieldImageFilter<TInputImage, TOutputImage>::DynamicThreadedGe
   const typename DisplacementFieldType::IndexType  startIndex = fullRegion.GetIndex();
   const typename DisplacementFieldType::PixelType  zeroVector{};
 
-  ImageRegionIterator<DisplacementFieldType> ItE(this->m_ComposedField, region);
-  ImageRegionIterator<RealImageType>         ItS(this->m_ScaledNormImage, region);
+  ImageRegionIterator ItE(this->m_ComposedField, region);
+  ImageRegionIterator ItS(this->m_ScaledNormImage, region);
 
   if (this->m_DoThreadedEstimateInverse)
   {

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
@@ -230,7 +230,7 @@ VelocityFieldTransform<TParametersValueType, VDimension>::CopyDisplacementField(
   rval->Allocate();
 
   ImageRegionConstIterator<DisplacementFieldType> dispIt(toCopy, toCopy->GetLargestPossibleRegion());
-  ImageRegionIterator<DisplacementFieldType>      cloneDispIt(rval, rval->GetLargestPossibleRegion());
+  ImageRegionIterator                             cloneDispIt(rval, rval->GetLargestPossibleRegion());
   for (dispIt.GoToBegin(), cloneDispIt.GoToBegin(); !dispIt.IsAtEnd() && !cloneDispIt.IsAtEnd();
        ++dispIt, ++cloneDispIt)
   {
@@ -272,8 +272,7 @@ VelocityFieldTransform<TParametersValueType, VDimension>::InternalClone() const
   // SetFixedParameters allocates the VelocityField
   ImageRegionConstIterator<VelocityFieldType> thisIt(this->m_VelocityField,
                                                      this->m_VelocityField->GetLargestPossibleRegion());
-  ImageRegionIterator<VelocityFieldType>      cloneIt(rval->m_VelocityField,
-                                                 rval->m_VelocityField->GetLargestPossibleRegion());
+  ImageRegionIterator cloneIt(rval->m_VelocityField, rval->m_VelocityField->GetLargestPossibleRegion());
   for (thisIt.GoToBegin(), cloneIt.GoToBegin(); !thisIt.IsAtEnd() && !cloneIt.IsAtEnd(); ++thisIt, ++cloneIt)
   {
     cloneIt.Set(thisIt.Get());

--- a/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
@@ -277,7 +277,7 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   m_RegionToProcess = this->GetInput()->GetRequestedRegion();
 
-  ImageRegionIterator<TOutputImage> out(this->GetOutput(), m_RegionToProcess);
+  ImageRegionIterator out(this->GetOutput(), m_RegionToProcess);
 
   ImageRegionConstIterator<TOutputImage> in(this->GetInput(), m_RegionToProcess);
 

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
@@ -177,7 +177,7 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
   const OutputPointer     outputPtr = this->GetOutput();
 
   ImageRegionConstIterator<InputImageType> inIt(inputPtr, outputRegionForThread);
-  ImageRegionIterator<OutputImageType>     outIt(outputPtr, outputRegionForThread);
+  ImageRegionIterator                      outIt(outputPtr, outputRegionForThread);
 
   const PixelType negFarValue = -m_FarValue;
 

--- a/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
@@ -250,7 +250,7 @@ SignedMaurerDistanceMapImageFilter<TInputImage, TOutputImage>::ThreadedGenerateD
 
     const typename OutputImageType::RegionType outputRegion = outputRegionForThread;
 
-    ImageRegionIterator<OutputImageType>     Ot(outputPtr, outputRegion);
+    ImageRegionIterator                      Ot(outputPtr, outputRegion);
     ImageRegionConstIterator<InputImageType> It(m_InputCache, outputRegion);
 
     Ot.GoToBegin();

--- a/Modules/Filtering/FFT/include/itkFFTWComplexToComplexFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWComplexToComplexFFTImageFilter.hxx
@@ -109,8 +109,8 @@ FFTWComplexToComplexFFTImageFilter<TInputImage, TOutputImage>::DynamicThreadedGe
   // Normalize the output if backward transform
   if (this->GetTransformDirection() == Superclass::TransformDirectionEnum::INVERSE)
   {
-    const SizeValueType                  totalOutputSize = this->GetOutput()->GetRequestedRegion().GetNumberOfPixels();
-    ImageRegionIterator<OutputImageType> it(this->GetOutput(), outputRegionForThread);
+    const SizeValueType totalOutputSize = this->GetOutput()->GetRequestedRegion().GetNumberOfPixels();
+    ImageRegionIterator it(this->GetOutput(), outputRegionForThread);
     while (!it.IsAtEnd())
     {
       PixelType val = it.Value();

--- a/Modules/Filtering/FFT/include/itkFFTWHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -126,8 +126,8 @@ void
 FFTWHalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   const OutputRegionType & outputRegionForThread)
 {
-  const unsigned long                  totalOutputSize = this->GetOutput()->GetRequestedRegion().GetNumberOfPixels();
-  ImageRegionIterator<OutputImageType> it(this->GetOutput(), outputRegionForThread);
+  const unsigned long totalOutputSize = this->GetOutput()->GetRequestedRegion().GetNumberOfPixels();
+  ImageRegionIterator it(this->GetOutput(), outputRegionForThread);
   while (!it.IsAtEnd())
   {
     it.Set(it.Value() / totalOutputSize);

--- a/Modules/Filtering/FFT/include/itkFFTWInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWInverseFFTImageFilter.hxx
@@ -104,8 +104,8 @@ void
 FFTWInverseFFTImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   const OutputImageRegionType & outputRegionForThread)
 {
-  const unsigned long                  totalOutputSize = this->GetOutput()->GetRequestedRegion().GetNumberOfPixels();
-  ImageRegionIterator<OutputImageType> it(this->GetOutput(), outputRegionForThread);
+  const unsigned long totalOutputSize = this->GetOutput()->GetRequestedRegion().GetNumberOfPixels();
+  ImageRegionIterator it(this->GetOutput(), outputRegionForThread);
   while (!it.IsAtEnd())
   {
     it.Set(it.Value() / totalOutputSize);

--- a/Modules/Filtering/FFT/include/itkVnlComplexToComplexFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlComplexToComplexFFTImageFilter.hxx
@@ -81,8 +81,8 @@ VnlComplexToComplexFFTImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
   // Normalize the output if backward transform
   if (this->GetTransformDirection() == Superclass::TransformDirectionEnum::INVERSE)
   {
-    const SizeValueType                  totalOutputSize = this->GetOutput()->GetRequestedRegion().GetNumberOfPixels();
-    ImageRegionIterator<OutputImageType> it(this->GetOutput(), outputRegionForThread);
+    const SizeValueType totalOutputSize = this->GetOutput()->GetRequestedRegion().GetNumberOfPixels();
+    ImageRegionIterator it(this->GetOutput(), outputRegionForThread);
     while (!it.IsAtEnd())
     {
       PixelType val = it.Value();

--- a/Modules/Filtering/GPUImageFilterBase/include/itkGPUNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/GPUImageFilterBase/include/itkGPUNeighborhoodOperatorImageFilter.hxx
@@ -136,8 +136,7 @@ GPUNeighborhoodOperatorImageFilter<TInputImage, TOutputImage, TOperatorValueType
   m_NeighborhoodGPUBuffer->Allocate();
 
   /** Copy coefficients */
-  ImageRegionIterator<NeighborhoodGPUBufferType> iit(m_NeighborhoodGPUBuffer,
-                                                     m_NeighborhoodGPUBuffer->GetLargestPossibleRegion());
+  ImageRegionIterator iit(m_NeighborhoodGPUBuffer, m_NeighborhoodGPUBuffer->GetLargestPossibleRegion());
 
   typename OutputNeighborhoodType::ConstIterator nit = p.Begin();
 

--- a/Modules/Filtering/GPUSmoothing/include/itkGPUDiscreteGaussianImageFilter.hxx
+++ b/Modules/Filtering/GPUSmoothing/include/itkGPUDiscreteGaussianImageFilter.hxx
@@ -105,7 +105,7 @@ GPUDiscreteGaussianImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
     // no smoothing, copy input to output
     ImageRegionConstIterator<InputImageType> inIt(localInput, this->GetOutput()->GetRequestedRegion());
 
-    ImageRegionIterator<OutputImageType> outIt(output, this->GetOutput()->GetRequestedRegion());
+    ImageRegionIterator outIt(output, this->GetOutput()->GetRequestedRegion());
 
     while (!inIt.IsAtEnd())
     {

--- a/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
@@ -177,10 +177,9 @@ BilateralImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()
   // copy this small Gaussian image into a neighborhood
   m_GaussianKernel.SetRadius(radius);
 
-  KernelIteratorType                     kernel_it;
-  ImageRegionIterator<GaussianImageType> git(gaussianImage->GetOutput(),
-                                             gaussianImage->GetOutput()->GetBufferedRegion());
-  double                                 norm = 0.0;
+  KernelIteratorType  kernel_it;
+  ImageRegionIterator git(gaussianImage->GetOutput(), gaussianImage->GetOutput()->GetBufferedRegion());
+  double              norm = 0.0;
   for (git.GoToBegin(); !git.IsAtEnd(); ++git)
   {
     norm += git.Get();
@@ -261,7 +260,7 @@ BilateralImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
     // walk the boundary face and the corresponding section of the output
     NeighborhoodIteratorType b_iter(m_GaussianKernel.GetRadius(), this->GetInput(), face);
     b_iter.OverrideBoundaryCondition(&BC);
-    ImageRegionIterator<OutputImageType> o_iter(this->GetOutput(), face);
+    ImageRegionIterator o_iter(this->GetOutput(), face);
 
     while (!b_iter.IsAtEnd())
     {

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
@@ -277,9 +277,9 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::HysteresisThresholding
   ListNodeType * node = nullptr;
 
   // fix me
-  ImageRegionIterator<TOutputImage> oit(input, input->GetRequestedRegion());
+  ImageRegionIterator oit(input, input->GetRequestedRegion());
 
-  ImageRegionIterator<TOutputImage> uit(this->m_OutputImage, this->m_OutputImage->GetRequestedRegion());
+  ImageRegionIterator uit(this->m_OutputImage, this->m_OutputImage->GetRequestedRegion());
   while (!uit.IsAtEnd())
   {
     uit.Value() = OutputImagePixelType{};

--- a/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
@@ -285,9 +285,9 @@ HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
       // on the output image of vectors
       m_ImageAdaptor->SelectNthElement(element++);
 
-      ImageRegionIterator<RealImageType> it(derivativeImage, derivativeImage->GetRequestedRegion());
+      ImageRegionIterator it(derivativeImage, derivativeImage->GetRequestedRegion());
 
-      ImageRegionIterator<OutputImageAdaptorType> ot(m_ImageAdaptor, m_ImageAdaptor->GetRequestedRegion());
+      ImageRegionIterator ot(m_ImageAdaptor, m_ImageAdaptor->GetRequestedRegion());
 
       const RealType spacingA = inputImage->GetSpacing()[dima];
       const RealType spacingB = inputImage->GetSpacing()[dimb];

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
@@ -65,7 +65,7 @@ HessianToObjectnessMeasureImageFilter<TInputImage, TOutputImage>::DynamicThreade
 
   // Walk the region of eigen values and get the objectness measure
   ImageRegionConstIterator<InputImageType> it(input, outputRegionForThread);
-  ImageRegionIterator<OutputImageType>     oit(output, outputRegionForThread);
+  ImageRegionIterator                      oit(output, outputRegionForThread);
 
   while (!it.IsAtEnd())
   {

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -162,7 +162,7 @@ HoughTransform2DCirclesImageFilter<TInputPixelType, TOutputPixelType, TRadiusPix
 
   // Compute the average radius
   ImageRegionConstIterator<OutputImageType> output_it(outputImage, outputImage->GetLargestPossibleRegion());
-  ImageRegionIterator<RadiusImageType>      radius_it(m_RadiusImage, m_RadiusImage->GetLargestPossibleRegion());
+  ImageRegionIterator                       radius_it(m_RadiusImage, m_RadiusImage->GetLargestPossibleRegion());
   while (!output_it.IsAtEnd())
   {
     if (output_it.Get() > 1)
@@ -214,9 +214,8 @@ HoughTransform2DCirclesImageFilter<TInputPixelType, TOutputPixelType, TRadiusPix
     gaussianFilter->Update();
     const InternalImageType::Pointer postProcessImage = gaussianFilter->GetOutput();
 
-    const auto minMaxCalculator = MinimumMaximumImageCalculator<InternalImageType>::New();
-    const ImageRegionIterator<InternalImageType> it_input(postProcessImage,
-                                                          postProcessImage->GetLargestPossibleRegion());
+    const auto                minMaxCalculator = MinimumMaximumImageCalculator<InternalImageType>::New();
+    const ImageRegionIterator it_input(postProcessImage, postProcessImage->GetLargestPossibleRegion());
 
     CirclesListSizeType circles = 0;
 

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
@@ -198,7 +198,7 @@ HoughTransform2DLinesImageFilter<TInputPixelType, TOutputPixelType>::Simplify()
 
   ImageRegionConstIterator<OutputImageType> accusimple_it(m_SimplifyAccumulator,
                                                           m_SimplifyAccumulator->GetRequestedRegion());
-  ImageRegionIterator<OutputImageType>      accu_it(outputImage, outputImage->GetRequestedRegion());
+  ImageRegionIterator                       accu_it(outputImage, outputImage->GetRequestedRegion());
 
   while (!accusimple_it.IsAtEnd())
   {
@@ -250,8 +250,8 @@ HoughTransform2DLinesImageFilter<TInputPixelType, TOutputPixelType>::GetLines() 
     const InternalImageType::Pointer postProcessImage = gaussianFilter->GetOutput();
 
     using MinMaxCalculatorType = MinimumMaximumImageCalculator<InternalImageType>;
-    auto                                   minMaxCalculator = MinMaxCalculatorType::New();
-    ImageRegionIterator<InternalImageType> it_input(postProcessImage, postProcessImage->GetLargestPossibleRegion());
+    auto                minMaxCalculator = MinMaxCalculatorType::New();
+    ImageRegionIterator it_input(postProcessImage, postProcessImage->GetLargestPossibleRegion());
 
 
     itk::Index<2> index;

--- a/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
@@ -137,8 +137,8 @@ MaskFeaturePointSelectionFilter<TImage, TMask, TFeatures>::GenerateData()
   else
   {
     // copy mask into selectionMap
-    ImageRegionConstIterator<MaskType>    maskItr(mask, region);
-    ImageRegionIterator<SelectionMapType> mapItr(selectionMap, region);
+    ImageRegionConstIterator<MaskType> maskItr(mask, region);
+    ImageRegionIterator                mapItr(selectionMap, region);
     for (maskItr.GoToBegin(), mapItr.GoToBegin(); !maskItr.IsAtEnd(); ++maskItr, ++mapItr)
     {
       mapItr.Set(static_cast<MapPixelType>(maskItr.Get()));
@@ -168,8 +168,8 @@ MaskFeaturePointSelectionFilter<TImage, TMask, TFeatures>::GenerateData()
   region = { safeIndex, safeSize };
 
   // iterators for variance computing loop
-  ImageRegionIterator<SelectionMapType> mapItr(selectionMap, region);
-  ConstNeighborhoodIterator<ImageType>  imageItr(m_BlockRadius, image, region);
+  ImageRegionIterator                  mapItr(selectionMap, region);
+  ConstNeighborhoodIterator<ImageType> imageItr(m_BlockRadius, image, region);
   using NeighborSizeType = typename ConstNeighborhoodIterator<ImageType>::NeighborIndexType;
   const NeighborSizeType numPixelsInNeighborhood = imageItr.Size();
 

--- a/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.hxx
@@ -188,10 +188,10 @@ MultiScaleHessianBasedMeasureImageFilter<TInputImage, THessianImage, TOutputImag
   // Write out the best response to the output image
   // we can assume that the meta-data should match between these two
   // image, therefore we iterate over the desired output region
-  const OutputRegionType                outputRegion = this->GetOutput()->GetBufferedRegion();
-  ImageRegionIterator<UpdateBufferType> it(m_UpdateBuffer, outputRegion);
+  const OutputRegionType outputRegion = this->GetOutput()->GetBufferedRegion();
+  ImageRegionIterator    it(m_UpdateBuffer, outputRegion);
 
-  ImageRegionIterator<TOutputImage> oit(this->GetOutput(), outputRegion);
+  ImageRegionIterator oit(this->GetOutput(), outputRegion);
 
   while (!oit.IsAtEnd())
   {
@@ -212,7 +212,7 @@ MultiScaleHessianBasedMeasureImageFilter<TInputImage, THessianImage, TOutputImag
   // iterate over the desired output region
   const OutputRegionType outputRegion = this->GetOutput()->GetBufferedRegion();
 
-  ImageRegionIterator<UpdateBufferType> oit(m_UpdateBuffer, outputRegion);
+  ImageRegionIterator oit(m_UpdateBuffer, outputRegion);
 
   const typename ScalesImageType::Pointer scalesImage =
     static_cast<ScalesImageType *>(this->ProcessObject::GetOutput(1));
@@ -233,10 +233,8 @@ MultiScaleHessianBasedMeasureImageFilter<TInputImage, THessianImage, TOutputImag
     ohit.GoToBegin();
   }
 
-  using HessianToMeasureOutputImageType = typename HessianToMeasureFilterType::OutputImageType;
-
-  ImageRegionIterator<HessianToMeasureOutputImageType> it(m_HessianToMeasureFilter->GetOutput(), outputRegion);
-  ImageRegionIterator<HessianImageType>                hit(m_HessianFilter->GetOutput(), outputRegion);
+  ImageRegionIterator it(m_HessianToMeasureFilter->GetOutput(), outputRegion);
+  ImageRegionIterator hit(m_HessianFilter->GetOutput(), outputRegion);
 
   while (!oit.IsAtEnd())
   {

--- a/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.hxx
@@ -61,7 +61,7 @@ SimpleContourExtractorImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
   {
     ConstNeighborhoodIterator<InputImageType> bit(this->GetRadius(), input, face);
     const unsigned int                        neighborhoodSize = bit.Size();
-    ImageRegionIterator<OutputImageType>      it(output, face);
+    ImageRegionIterator                       it(output, face);
 
     bit.OverrideBoundaryCondition(&nbc);
     bit.GoToBegin();

--- a/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.hxx
@@ -60,7 +60,7 @@ NoiseImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
     const unsigned int                        neighborhoodSize = bit.Size();
     auto                                      num = static_cast<InputRealType>(bit.Size());
 
-    ImageRegionIterator<OutputImageType> it(output, face);
+    ImageRegionIterator it(output, face);
     bit.OverrideBoundaryCondition(&nbc);
     bit.GoToBegin();
 

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
@@ -156,7 +156,7 @@ GradientImageFilter<TInputImage, TOperatorValueType, TOutputValueType, TOutputIm
   for (const auto & face : faceList)
   {
     nit = ConstNeighborhoodIterator<InputImageType>(radius, inputImage, face);
-    ImageRegionIterator<OutputImageType> it(outputImage, face);
+    ImageRegionIterator it(outputImage, face);
     nit.OverrideBoundaryCondition(m_BoundaryCondition.get());
     nit.GoToBegin();
 

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
@@ -238,9 +238,9 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
       // on the output image of vectors
       m_ImageAdaptor->SelectNthElement(nc * ImageDimension + dim);
 
-      ImageRegionIterator<RealImageType> it(derivativeImage, derivativeImage->GetRequestedRegion());
+      ImageRegionIterator it(derivativeImage, derivativeImage->GetRequestedRegion());
 
-      ImageRegionIterator<OutputImageAdaptorType> ot(m_ImageAdaptor, m_ImageAdaptor->GetRequestedRegion());
+      ImageRegionIterator ot(m_ImageAdaptor, m_ImageAdaptor->GetRequestedRegion());
 
       const ScalarRealType spacing = inputImage->GetSpacing()[dim];
 
@@ -271,8 +271,8 @@ GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateData()
   if (this->m_UseImageDirection)
   {
 
-    OutputImageType *                    gradientImage = outputImage;
-    ImageRegionIterator<OutputImageType> itr(gradientImage, gradientImage->GetRequestedRegion());
+    OutputImageType *   gradientImage = outputImage;
+    ImageRegionIterator itr(gradientImage, gradientImage->GetRequestedRegion());
 
     while (!itr.IsAtEnd())
     {

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -269,8 +269,8 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::Generat
       // this->AfterThreadedGenerateData();
       this->m_DoUpdateResidualValues = false;
 
-      ImageRegionIterator<PointDataImageType> ItPsi(this->m_PsiLattice, this->m_PsiLattice->GetLargestPossibleRegion());
-      ImageRegionIterator<PointDataImageType> ItPhi(this->m_PhiLattice, this->m_PhiLattice->GetLargestPossibleRegion());
+      ImageRegionIterator ItPsi(this->m_PsiLattice, this->m_PsiLattice->GetLargestPossibleRegion());
+      ImageRegionIterator ItPhi(this->m_PhiLattice, this->m_PhiLattice->GetLargestPossibleRegion());
       for (ItPsi.GoToBegin(), ItPhi.GoToBegin(); !ItPsi.IsAtEnd(); ++ItPsi, ++ItPhi)
       {
         ItPsi.Set(ItPhi.Get() + ItPsi.Get());
@@ -295,8 +295,8 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::Generat
       this->AfterThreadedGenerateData();
     }
 
-    ImageRegionIterator<PointDataImageType> ItPsi(this->m_PsiLattice, this->m_PsiLattice->GetLargestPossibleRegion());
-    ImageRegionIterator<PointDataImageType> ItPhi(this->m_PhiLattice, this->m_PhiLattice->GetLargestPossibleRegion());
+    ImageRegionIterator ItPsi(this->m_PsiLattice, this->m_PsiLattice->GetLargestPossibleRegion());
+    ImageRegionIterator ItPhi(this->m_PhiLattice, this->m_PhiLattice->GetLargestPossibleRegion());
     for (ItPsi.GoToBegin(), ItPhi.GoToBegin(); !ItPsi.IsAtEnd(); ++ItPsi, ++ItPhi)
     {
       ItPsi.Set(ItPhi.Get() + ItPsi.Get());
@@ -644,17 +644,17 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::AfterTh
     // Accumulate all the delta lattice and omega lattice values to
     // calculate the final phi lattice.
 
-    ImageRegionIterator<PointDataImageType> ItD(this->m_DeltaLatticePerThread[0],
-                                                this->m_DeltaLatticePerThread[0]->GetLargestPossibleRegion());
-    ImageRegionIterator<RealImageType>      ItO(this->m_OmegaLatticePerThread[0],
-                                           this->m_OmegaLatticePerThread[0]->GetLargestPossibleRegion());
+    ImageRegionIterator ItD(this->m_DeltaLatticePerThread[0],
+                            this->m_DeltaLatticePerThread[0]->GetLargestPossibleRegion());
+    ImageRegionIterator ItO(this->m_OmegaLatticePerThread[0],
+                            this->m_OmegaLatticePerThread[0]->GetLargestPossibleRegion());
 
     for (ThreadIdType n = 1; n < this->GetNumberOfWorkUnits(); ++n)
     {
-      ImageRegionIterator<PointDataImageType> Itd(this->m_DeltaLatticePerThread[n],
-                                                  this->m_DeltaLatticePerThread[n]->GetLargestPossibleRegion());
-      ImageRegionIterator<RealImageType>      Ito(this->m_OmegaLatticePerThread[n],
-                                             this->m_OmegaLatticePerThread[n]->GetLargestPossibleRegion());
+      ImageRegionIterator Itd(this->m_DeltaLatticePerThread[n],
+                              this->m_DeltaLatticePerThread[n]->GetLargestPossibleRegion());
+      ImageRegionIterator Ito(this->m_OmegaLatticePerThread[n],
+                              this->m_OmegaLatticePerThread[n]->GetLargestPossibleRegion());
 
       ItD.GoToBegin();
       ItO.GoToBegin();
@@ -690,7 +690,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::AfterTh
     this->m_PhiLattice->SetRegions(size);
     this->m_PhiLattice->AllocateInitialized();
 
-    ImageRegionIterator<PointDataImageType> ItP(this->m_PhiLattice, this->m_PhiLattice->GetLargestPossibleRegion());
+    ImageRegionIterator ItP(this->m_PhiLattice, this->m_PhiLattice->GetLargestPossibleRegion());
 
     for (ItP.GoToBegin(), ItO.GoToBegin(), ItD.GoToBegin(); !ItP.IsAtEnd(); ++ItP, ++ItO, ++ItD)
     {

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
@@ -65,7 +65,7 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateData()
   this->AllocateOutputs();
   output->FillBuffer(defaultPixelValue);
 
-  ImageRegionIterator<TileImageType> it(m_TileImage, m_TileImage->GetBufferedRegion());
+  ImageRegionIterator it(m_TileImage, m_TileImage->GetBufferedRegion());
 
   SizeValueType numPastes = 0;
   while (!it.IsAtEnd())

--- a/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.hxx
@@ -148,7 +148,7 @@ WarpVectorImageFilter<TInputImage, TOutputImage, TDisplacementField>::DynamicThr
   ImageRegionIteratorWithIndex outputIt(outputPtr, outputRegionForThread);
   TotalProgressReporter        progress(this, outputPtr->GetRequestedRegion().GetNumberOfPixels());
 
-  ImageRegionIterator<DisplacementFieldType> fieldIt(fieldPtr, outputRegionForThread);
+  ImageRegionIterator fieldIt(fieldPtr, outputRegionForThread);
 
   IndexType        index;
   PointType        point;

--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
@@ -323,7 +323,7 @@ HistogramMatchingImageFilter<TInputImage, TOutputImage, THistogramMeasurement>::
   // Transform the source image and write to output.
 
   ImageRegionConstIterator<InputImageType> inIter(input, outputRegionForThread);
-  ImageRegionIterator<OutputImageType>     outIter(output, outputRegionForThread);
+  ImageRegionIterator                      outIter(output, outputRegionForThread);
 
   for (SizeValueType i = 0; !outIter.IsAtEnd(); ++inIter, ++outIter, i++)
   {

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
@@ -212,7 +212,7 @@ PolylineMask2DImageFilter<TInputImage, TPolyline, TOutputImage>::GenerateData()
 
   /* Mask the input image with the mask generated */
   ImageRegionConstIterator<TInputImage> inputI(inputImagePtr, inputImagePtr->GetLargestPossibleRegion());
-  ImageRegionIterator<TOutputImage>     outputI(outputImagePtr, outputImagePtr->GetLargestPossibleRegion());
+  ImageRegionIterator                   outputI(outputImagePtr, outputImagePtr->GetLargestPossibleRegion());
   while (!outputI.IsAtEnd())
   {
     if (outputI.Get() == f_val)

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -173,7 +173,7 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
   outputImagePtr->AllocateInitialized();
 
   ImageRegionConstIterator<TInputImage> inputIt(inputImagePtr, inputImagePtr->GetLargestPossibleRegion());
-  ImageRegionIterator<TOutputImage>     outputIt(outputImagePtr, outputImagePtr->GetLargestPossibleRegion());
+  ImageRegionIterator                   outputIt(outputImagePtr, outputImagePtr->GetLargestPossibleRegion());
 
   using InterpolatorType = NearestNeighborInterpolateImageFunction<TInputImage, double>;
   using InterpolatorPointType = typename InterpolatorType::PointType;
@@ -321,8 +321,7 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
   projectionImagePtr->SetRegions(projectionRegion);
   projectionImagePtr->AllocateInitialized();
 
-  const ImageRegionIterator<ProjectionImageType> projectionIt(projectionImagePtr,
-                                                              projectionImagePtr->GetLargestPossibleRegion());
+  const ImageRegionIterator projectionIt(projectionImagePtr, projectionImagePtr->GetLargestPossibleRegion());
 
   itkDebugMacro("Rotation matrix" << m_RotationMatrix);
 

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
@@ -126,7 +126,7 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::GenerateData()
   // Fill the mean image first
 
   typename OutputImageType::RegionType region = this->GetOutput(0)->GetRequestedRegion();
-  ImageRegionIterator<OutputImageType> outIter(this->GetOutput(0), region);
+  ImageRegionIterator                  outIter(this->GetOutput(0), region);
 
   unsigned int i = 0;
   while (!outIter.IsAtEnd())
@@ -146,7 +146,7 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::GenerateData()
     m_OneEigenVector = m_EigenVectors.get_column(kthLargestPrincipalComp - 1);
 
     region = this->GetOutput(j)->GetRequestedRegion();
-    ImageRegionIterator<OutputImageType> outIterJ(this->GetOutput(j), region);
+    ImageRegionIterator outIterJ(this->GetOutput(j), region);
 
     unsigned int idx = 0;
     outIterJ.GoToBegin();
@@ -165,7 +165,7 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::GenerateData()
   for (; j < numberOfOutputs; ++j)
   {
     region = this->GetOutput(j)->GetRequestedRegion();
-    ImageRegionIterator<OutputImageType> outIterJ(this->GetOutput(j), region);
+    ImageRegionIterator outIterJ(this->GetOutput(j), region);
 
     outIterJ.GoToBegin();
     while (!outIterJ.IsAtEnd())

--- a/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.hxx
@@ -319,7 +319,7 @@ LabelMapMaskImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   }
   else
   {
-    ImageRegionIterator<OutputImageType> outputIt(output, outputRegionForThread);
+    ImageRegionIterator outputIt(output, outputRegionForThread);
 
     for (outputIt.GoToBegin(); !outputIt.IsAtEnd(); ++outputIt)
     {

--- a/Modules/Filtering/LabelMap/include/itkLabelMapToBinaryImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapToBinaryImageFilter.hxx
@@ -99,7 +99,7 @@ LabelMapToBinaryImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateD
   {
     // fill the background with the background values from the background image
     ImageRegionConstIterator<OutputImageType> bgIt(this->GetBackgroundImage(), outputRegionForThread);
-    ImageRegionIterator<OutputImageType>      oIt(output, outputRegionForThread);
+    ImageRegionIterator                       oIt(output, outputRegionForThread);
 
     bgIt.GoToBegin();
     oIt.GoToBegin();
@@ -122,7 +122,7 @@ LabelMapToBinaryImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateD
   else
   {
     // fill the background with the background value
-    ImageRegionIterator<OutputImageType> oIt(output, outputRegionForThread);
+    ImageRegionIterator oIt(output, outputRegionForThread);
     oIt.GoToBegin();
 
     while (!oIt.IsAtEnd())

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateImageFilter.hxx
@@ -107,8 +107,8 @@ AnchorErodeDilateImageFilter<TImage, TKernel, TFunction1>::DynamicThreadedGenera
   }
 
   // copy internal buffer to output
-  ImageRegionIterator<InputImageType> oit(this->GetOutput(), OReg);
-  ImageRegionIterator<InputImageType> iit(internalbuffer, OReg);
+  ImageRegionIterator oit(this->GetOutput(), OReg);
+  ImageRegionIterator iit(internalbuffer, OReg);
   for (oit.GoToBegin(), iit.GoToBegin(); !oit.IsAtEnd(); ++oit, ++iit)
   {
     oit.Set(iit.Get());

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseImageFilter.hxx
@@ -152,8 +152,8 @@ AnchorOpenCloseImageFilter<TImage, TKernel, TCompare1, TCompare2>::DynamicThread
   }
 
   // copy internal buffer to output
-  ImageRegionIterator<InputImageType> oit(this->GetOutput(), OReg);
-  ImageRegionIterator<InputImageType> iit(internalbuffer, OReg);
+  ImageRegionIterator oit(this->GetOutput(), OReg);
+  ImageRegionIterator iit(internalbuffer, OReg);
   for (oit.GoToBegin(), iit.GoToBegin(); !oit.IsAtEnd(); ++oit, ++iit)
   {
     oit.Set(iit.Get());

--- a/Modules/Filtering/MathematicalMorphology/include/itkClosingByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkClosingByReconstructionImageFilter.hxx
@@ -92,7 +92,7 @@ ClosingByReconstructionImageFilter<TInputImage, TOutputImage, TKernel>::Generate
     ImageRegionConstIterator<TInputImage> inputIt(this->GetInput(), dilate->GetOutput()->GetBufferedRegion());
     ImageRegionConstIterator<TInputImage> dilateIt(dilate->GetOutput(), erode->GetOutput()->GetBufferedRegion());
     ImageRegionConstIterator<TInputImage> erodeIt(erode->GetOutput(), erode->GetOutput()->GetBufferedRegion());
-    ImageRegionIterator<TInputImage>      tempIt(tempImage, dilate->GetOutput()->GetBufferedRegion());
+    ImageRegionIterator                   tempIt(tempImage, dilate->GetOutput()->GetBufferedRegion());
     while (!dilateIt.IsAtEnd())
     {
       if (dilateIt.Get() == erodeIt.Get())

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
@@ -949,7 +949,7 @@ FlatStructuringElement<VDimension>::Ball(RadiusType radius, bool radiusIsParamet
 
   // Set the background to be zero
   //
-  ImageRegionIterator<ImageType> it(sourceImage, region);
+  ImageRegionIterator it(sourceImage, region);
 
   for (it.GoToBegin(); !it.IsAtEnd(); ++it)
   {
@@ -1053,7 +1053,7 @@ FlatStructuringElement<VDimension>::Annulus(RadiusType   radius,
 
   // Set the background to be zero
   //
-  ImageRegionIterator<ImageType> it(kernelImage, region);
+  ImageRegionIterator it(kernelImage, region);
 
   for (it.GoToBegin(); !it.IsAtEnd(); ++it)
   {
@@ -1218,7 +1218,7 @@ FlatStructuringElement<VDimension>::ComputeBufferFromLines()
 
   // Set the background to be zero
   //
-  ImageRegionIterator<ImageType> it(sourceImage, region);
+  ImageRegionIterator it(sourceImage, region);
 
   for (it.GoToBegin(); !it.IsAtEnd(); ++it)
   {
@@ -1252,7 +1252,7 @@ FlatStructuringElement<VDimension>::ComputeBufferFromLines()
   dilate->Update();
 
   // copy back the image to the kernel
-  ImageRegionIterator<ImageType> oit(dilate->GetOutput(), region);
+  ImageRegionIterator oit(dilate->GetOutput(), region);
   for (oit.GoToBegin(), kernel_it = this->Begin(); !oit.IsAtEnd(); ++oit, ++kernel_it)
   {
     *kernel_it = oit.Get();

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
@@ -201,8 +201,7 @@ GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::GenerateData()
     // iteration of the algorithm with the current marker image.
     ImageRegionConstIterator<TInputImage> singleInIt(singleIteration->GetMarkerImage(),
                                                      singleIteration->GetOutput()->GetRequestedRegion());
-    ImageRegionIterator<TInputImage>      singleOutIt(singleIteration->GetOutput(),
-                                                 singleIteration->GetOutput()->GetRequestedRegion());
+    ImageRegionIterator singleOutIt(singleIteration->GetOutput(), singleIteration->GetOutput()->GetRequestedRegion());
 
     done = true;
     while (!singleOutIt.IsAtEnd())
@@ -243,9 +242,9 @@ GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::GenerateData()
   outputPtr->Allocate();
 
   // walk the output of the singleIteration
-  ImageRegionIterator<TInputImage> singleIt(singleIteration->GetOutput(), outputPtr->GetRequestedRegion());
+  ImageRegionIterator singleIt(singleIteration->GetOutput(), outputPtr->GetRequestedRegion());
   // walk the real output of the filter
-  ImageRegionIterator<TOutputImage> outIt(outputPtr, outputPtr->GetRequestedRegion());
+  ImageRegionIterator outIt(outputPtr, outputPtr->GetRequestedRegion());
 
   // cast and copy
   while (!outIt.IsAtEnd())

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
@@ -201,8 +201,7 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::GenerateData()
     // iteration of the algorithm with the current marker image.
     ImageRegionConstIterator<TInputImage> singleInIt(singleIteration->GetMarkerImage(),
                                                      singleIteration->GetOutput()->GetRequestedRegion());
-    ImageRegionIterator<TInputImage>      singleOutIt(singleIteration->GetOutput(),
-                                                 singleIteration->GetOutput()->GetRequestedRegion());
+    ImageRegionIterator singleOutIt(singleIteration->GetOutput(), singleIteration->GetOutput()->GetRequestedRegion());
 
     done = true;
     while (!singleOutIt.IsAtEnd())
@@ -243,9 +242,9 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::GenerateData()
   outputPtr->Allocate();
 
   // walk the output of the singleIteration
-  ImageRegionIterator<TInputImage> singleIt(singleIteration->GetOutput(), outputPtr->GetRequestedRegion());
+  ImageRegionIterator singleIt(singleIteration->GetOutput(), outputPtr->GetRequestedRegion());
   // walk the real output of the filter
-  ImageRegionIterator<TOutputImage> outIt(outputPtr, outputPtr->GetRequestedRegion());
+  ImageRegionIterator outIt(outputPtr, outputPtr->GetRequestedRegion());
 
   // cast and copy
   while (!outIt.IsAtEnd())
@@ -289,7 +288,7 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
   {
     NeighborhoodIteratorType              markerIt(kernelRadius, this->GetMarkerImage(), face);
     ImageRegionConstIterator<TInputImage> maskIt(this->GetMaskImage(), face);
-    ImageRegionIterator<TOutputImage>     oIt(this->GetOutput(), face);
+    ImageRegionIterator                   oIt(this->GetOutput(), face);
 
     markerIt.OverrideBoundaryCondition(&BC);
     markerIt.GoToBegin();

--- a/Modules/Filtering/MathematicalMorphology/include/itkOpeningByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkOpeningByReconstructionImageFilter.hxx
@@ -93,7 +93,7 @@ OpeningByReconstructionImageFilter<TInputImage, TOutputImage, TKernel>::Generate
     ImageRegionConstIterator<TInputImage> inputIt(this->GetInput(), erode->GetOutput()->GetBufferedRegion());
     ImageRegionConstIterator<TInputImage> erodeIt(erode->GetOutput(), erode->GetOutput()->GetBufferedRegion());
     ImageRegionConstIterator<TInputImage> dilateIt(dilate->GetOutput(), erode->GetOutput()->GetBufferedRegion());
-    ImageRegionIterator<TInputImage>      tempIt(tempImage, erode->GetOutput()->GetBufferedRegion());
+    ImageRegionIterator                   tempIt(tempImage, erode->GetOutput()->GetBufferedRegion());
     while (!erodeIt.IsAtEnd())
     {
       if (erodeIt.Get() == dilateIt.Get())

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.hxx
@@ -86,7 +86,7 @@ RegionalMaximaImageFilter<TInputImage, TOutputImage>::GenerateData()
   {
     ProgressReporter progress2(this, 0, output->GetRequestedRegion().GetNumberOfPixels(), 33, 0.67, 0.33);
 
-    ImageRegionIterator<TOutputImage> outIt(output, output->GetRequestedRegion());
+    ImageRegionIterator outIt(output, output->GetRequestedRegion());
 
     if (m_FlatIsMaxima)
     {

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.hxx
@@ -88,7 +88,7 @@ RegionalMinimaImageFilter<TInputImage, TOutputImage>::GenerateData()
     ProgressReporter progress2(this, 0, output->GetRequestedRegion().GetNumberOfPixels(), 33, 0.67, 0.33);
 
 
-    ImageRegionIterator<TOutputImage> outIt(output, output->GetRequestedRegion());
+    ImageRegionIterator outIt(output, output->GetRequestedRegion());
 
     if (m_FlatIsMinima)
     {

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.hxx
@@ -71,7 +71,7 @@ ValuedRegionalExtremaImageFilter<TInputImage, TOutputImage, TFunction1, TFunctio
   // copy input to output - isn't there a better way?
 
   ImageRegionConstIterator<TInputImage> inIt(input, output->GetRequestedRegion());
-  ImageRegionIterator<TOutputImage>     outIt(output, output->GetRequestedRegion());
+  ImageRegionIterator                   outIt(output, output->GetRequestedRegion());
 
   const InputImagePixelType firstValue = inIt.Get();
   this->m_Flat = true;

--- a/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
@@ -225,8 +225,8 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   // Now, copy the temporary image to the output image. Note that the temp
   // buffer iterator walks a region defined by the output
-  ImageRegionIterator<TOutputImage> outIt(outputPtr, outputPtr->GetRequestedRegion());
-  ImageRegionIterator<TTempImage>   tempIt2(tempPtr, outputPtr->GetRequestedRegion());
+  ImageRegionIterator outIt(outputPtr, outputPtr->GetRequestedRegion());
+  ImageRegionIterator tempIt2(tempPtr, outputPtr->GetRequestedRegion());
 
   for (outIt.GoToBegin(), tempIt2.GoToBegin(); !outIt.IsAtEnd(); ++outIt, ++tempIt2)
   {

--- a/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.hxx
@@ -172,7 +172,7 @@ AttributeMorphologyBaseImageFilter<TInputImage, TOutputImage, TAttribute, TFunct
 
   // resolving phase
   // copy pixels back
-  ImageRegionIterator<TOutputImage> ORegIt(output, output->GetRequestedRegion());
+  ImageRegionIterator ORegIt(output, output->GetRequestedRegion());
   ORegIt.GoToBegin();
 
   // fill Raw - worry about iteration details later.

--- a/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.hxx
@@ -59,7 +59,7 @@ MultiphaseDenseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputIm
     }
 
     ImageRegionConstIterator<InputImageType> in(input, input->GetBufferedRegion());
-    ImageRegionIterator<OutputImageType>     out(output, region);
+    ImageRegionIterator                      out(output, region);
 
     // Fill the output pointer
     auto p = static_cast<OutputPixelType>(this->m_Lookup[i]);
@@ -128,8 +128,8 @@ typename MultiphaseDenseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, 
     for (auto fIt = faceList.begin(); fIt != faceList.end(); ++fIt)
     {
       // Process the non-boundary region.
-      NeighborhoodIteratorType            nD(radius, levelset, *fIt);
-      ImageRegionIterator<InputImageType> nU(m_UpdateBuffers[i], *fIt);
+      NeighborhoodIteratorType nD(radius, levelset, *fIt);
+      ImageRegionIterator      nU(m_UpdateBuffers[i], *fIt);
 
       nD.GoToBegin();
       nU.GoToBegin();
@@ -203,8 +203,8 @@ MultiphaseDenseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputIm
     // it is this->m_LevelSet[i]->GetLargestPossibleRegion()
     InputRegionType region = this->m_LevelSet[i]->GetRequestedRegion();
 
-    ImageRegionIterator<InputImageType> u(m_UpdateBuffers[i], region);
-    ImageRegionIterator<InputImageType> o(this->m_LevelSet[i], region);
+    ImageRegionIterator u(m_UpdateBuffers[i], region);
+    ImageRegionIterator o(this->m_LevelSet[i], region);
 
     u.GoToBegin();
     o.GoToBegin();
@@ -235,7 +235,7 @@ MultiphaseDenseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputIm
       maurer->SetInsideIsPositive(false);
       maurer->Update();
 
-      ImageRegionIterator<InputImageType> it(maurer->GetOutput(), region);
+      ImageRegionIterator it(maurer->GetOutput(), region);
 
       rms_change_accumulator = 0;
 

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
@@ -134,9 +134,9 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
 
     // Compute Heaviside of input image
     // Copy input to temp
-    InputRegionType                     region = input->GetRequestedRegion();
-    ImageRegionIterator<InputImageType> lIt(input, region);
-    ImageRegionIterator<InputImageType> tIt(tempImage, region);
+    InputRegionType     region = input->GetRequestedRegion();
+    ImageRegionIterator lIt(input, region);
+    ImageRegionIterator tIt(tempImage, region);
 
     lIt.GoToBegin();
     tIt.GoToBegin();
@@ -157,7 +157,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
 
     // The levelset image has a 0 where the zero contour exists and + outside
     // and - inside
-    ImageRegionIterator<InputImageType> zIt(zeroCrossingFilter->GetOutput(), region);
+    ImageRegionIterator zIt(zeroCrossingFilter->GetOutput(), region);
 
     lIt.GoToBegin();
     zIt.GoToBegin();
@@ -1014,7 +1014,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
     {
       // For each region, set the pixel in m_StatusImage to
       // m_StatusBoundaryPixel
-      ImageRegionIterator<StatusImageType> statusIt(sparsePtr->m_StatusImage, *fit);
+      ImageRegionIterator statusIt(sparsePtr->m_StatusImage, *fit);
 
       statusIt.GoToBegin();
       while (!statusIt.IsAtEnd())
@@ -1123,7 +1123,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
     ImageRegionConstIterator<StatusImageType> statusIt(sparsePtr->m_StatusImage,
                                                        this->m_LevelSet[fId]->GetRequestedRegion());
 
-    ImageRegionIterator<InputImageType> outputIt(this->m_LevelSet[fId], this->m_LevelSet[fId]->GetRequestedRegion());
+    ImageRegionIterator outputIt(this->m_LevelSet[fId], this->m_LevelSet[fId]->GetRequestedRegion());
 
     outputIt.GoToBegin();
     statusIt.GoToBegin();
@@ -1315,7 +1315,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
     InputPointType    origin = input->GetOrigin();
 
     // Local iterator
-    ImageRegionIterator<InputImageType> inIt(this->m_LevelSet[fId], this->m_LevelSet[fId]->GetRequestedRegion());
+    ImageRegionIterator inIt(this->m_LevelSet[fId], this->m_LevelSet[fId]->GetRequestedRegion());
 
     // In the context of the global coordinates
     const OutputIndexType start = output->TransformPhysicalPointToIndex(origin);
@@ -1330,7 +1330,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
       itkExceptionStringMacro("Either input and/or output is nullptr.");
     }
 
-    ImageRegionIterator<OutputImageType> outIt(output, region);
+    ImageRegionIterator outIt(output, region);
 
     auto p = static_cast<OutputPixelType>(this->m_Lookup[fId]);
 

--- a/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.hxx
+++ b/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.hxx
@@ -140,9 +140,9 @@ EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::Ge
   ImageRegionConstIterator<TInputImage> inputIt2(inputPtr2, region);
   ImageRegionConstIterator<TInputImage> inputIt3(inputPtr3, region);
 
-  ImageRegionIterator<EigenValueImageType>  outputIt1(outputPtr1, region);
-  ImageRegionIterator<EigenValueImageType>  outputIt2(outputPtr2, region);
-  ImageRegionIterator<EigenVectorImageType> outputIt3(outputPtr3, region);
+  ImageRegionIterator outputIt1(outputPtr1, region);
+  ImageRegionIterator outputIt2(outputPtr2, region);
+  ImageRegionIterator outputIt3(outputPtr3, region);
 
   constexpr EigenVectorType nullVector{};
 

--- a/Modules/Numerics/FEM/include/itkFEMRobustSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMRobustSolver.hxx
@@ -1022,7 +1022,7 @@ RobustSolver<VDimension>::InitializeInterpolationGrid()
 
     // Initialize the iterator that will step over all grid points within
     // element boundary box.
-    ImageRegionIterator<InterpolationGridType> iter(this->m_InterpolationGrid, interRegion);
+    ImageRegionIterator iter(this->m_InterpolationGrid, interRegion);
 
     // Update the element pointers in the points defined within the region.
     VectorType global_point(NumberOfDimensions);

--- a/Modules/Numerics/FEM/include/itkFEMScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMScatteredDataPointSetToImageFilter.hxx
@@ -697,9 +697,9 @@ FEMScatteredDataPointSetToImageFilter<TInputPointSet,
 {
   // Produce deformation field based on the solution.
 
-  ImageType *                    output = this->GetOutput();
-  RegionType                     region = output->GetLargestPossibleRegion();
-  ImageRegionIterator<ImageType> iter(output, region);
+  ImageType *         output = this->GetOutput();
+  RegionType          region = output->GetLargestPossibleRegion();
+  ImageRegionIterator iter(output, region);
 
   PointType     point;
   unsigned int  solutionIndex = 0;

--- a/Modules/Numerics/FEM/include/itkFEMSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.hxx
@@ -826,7 +826,7 @@ Solver<VDimension>::FillInterpolationGrid()
 
     // Initialize the iterator that will step over all grid points within
     // element boundary box.
-    ImageRegionIterator<InterpolationGridType> iter(m_InterpolationGrid, region);
+    ImageRegionIterator iter(m_InterpolationGrid, region);
 
     //
     // Update the element pointers in the points defined within the region.

--- a/Modules/Numerics/Statistics/include/itkImageClassifierFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageClassifierFilter.hxx
@@ -147,7 +147,7 @@ ImageClassifierFilter<TSample, TInputImage, TOutputImage>::GenerateData()
   outputImage->Allocate();
 
   ImageRegionConstIterator<InputImageType> inpItr(inputImage, inputImage->GetBufferedRegion());
-  ImageRegionIterator<OutputImageType>     outItr(outputImage, outputImage->GetBufferedRegion());
+  ImageRegionIterator                      outItr(outputImage, outputImage->GetBufferedRegion());
 
   inpItr.GoToBegin();
   outItr.GoToBegin();

--- a/Modules/Registration/Common/include/itkTimeVaryingBSplineVelocityFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkTimeVaryingBSplineVelocityFieldTransformParametersAdaptor.hxx
@@ -308,10 +308,9 @@ TimeVaryingBSplineVelocityFieldTransformParametersAdaptor<TTransform>::AdaptTran
     decompositionFilter->SetInput(upsampler->GetOutput());
     decompositionFilter->Update();
 
-    ImageRegionConstIterator<ComponentImageType>                         ItD(decompositionFilter->GetOutput(),
+    ImageRegionConstIterator<ComponentImageType> ItD(decompositionFilter->GetOutput(),
                                                      decompositionFilter->GetOutput()->GetLargestPossibleRegion());
-    ImageRegionIterator<TimeVaryingVelocityFieldControlPointLatticeType> ItL(
-      requiredLattice, requiredLattice->GetLargestPossibleRegion());
+    ImageRegionIterator                          ItL(requiredLattice, requiredLattice->GetLargestPossibleRegion());
 
     for (ItD.GoToBegin(), ItL.GoToBegin(); !ItD.IsAtEnd(); ++ItD, ++ItL)
     {

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
@@ -182,7 +182,7 @@ GPUPDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField
     using GPUOutputImage = typename itk::GPUTraits<TDisplacementField>::Type;
     typename GPUOutputImage::Pointer output = dynamic_cast<GPUOutputImage *>(this->GetOutput());
 
-    ImageRegionIterator<OutputImageType> out(output, output->GetRequestedRegion());
+    ImageRegionIterator out(output, output->GetRequestedRegion());
 
     while (!out.IsAtEnd())
     {

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
@@ -124,8 +124,7 @@ JointHistogramMutualInformationComputeJointPDFThreaderBase<TDomainPartitioner,
     return;
   }
 
-  ImageRegionIterator<JointPDFType> jointPDFIt(this->m_Associate->m_JointPDF,
-                                               this->m_Associate->m_JointPDF->GetBufferedRegion());
+  ImageRegionIterator jointPDFIt(this->m_Associate->m_JointPDF, this->m_Associate->m_JointPDF->GetBufferedRegion());
   jointPDFIt.GoToBegin();
   std::vector<ImageRegionConstIterator<JointHistogramType>> jointHistogramPerThreadIts;
   for (ThreadIdType i = 0; i < numberOfWorkUnitsUsed; ++i)

--- a/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.hxx
@@ -169,7 +169,7 @@ PDEDeformableRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::
 
     const typename OutputImageType::Pointer output = this->GetOutput();
 
-    ImageRegionIterator<OutputImageType> out(output, output->GetRequestedRegion());
+    ImageRegionIterator out(output, output->GetRequestedRegion());
 
     while (!out.IsAtEnd())
     {

--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
@@ -621,9 +621,7 @@ typename SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform,
   gradientField->Allocate();
 
   SizeValueType count = 0;
-  for (ImageRegionIterator<DisplacementFieldType> ItG(gradientField, gradientField->GetRequestedRegion());
-       !ItG.IsAtEnd();
-       ++ItG)
+  for (ImageRegionIterator ItG(gradientField, gradientField->GetRequestedRegion()); !ItG.IsAtEnd(); ++ItG)
   {
     DisplacementVectorType displacement;
     for (SizeValueType d = 0; d < ImageDimension; ++d)

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
@@ -284,8 +284,7 @@ BayesianClassifierImageFilter<TInputVectorImage, TLabelsType, TPosteriorsPrecisi
       extractedComponentImage->Allocate();
 
       itrPosteriorImage.GoToBegin();
-      ImageRegionIterator<ExtractedComponentImageType> it(extractedComponentImage,
-                                                          extractedComponentImage->GetBufferedRegion());
+      ImageRegionIterator it(extractedComponentImage, extractedComponentImage->GetBufferedRegion());
 
       it.GoToBegin();
       while (!itrPosteriorImage.IsAtEnd())
@@ -301,8 +300,7 @@ BayesianClassifierImageFilter<TInputVectorImage, TLabelsType, TPosteriorsPrecisi
 
       itrPosteriorImage.GoToBegin();
 
-      ImageRegionIterator<ExtractedComponentImageType> sit(m_SmoothingFilter->GetOutput(),
-                                                           m_SmoothingFilter->GetOutput()->GetBufferedRegion());
+      ImageRegionIterator sit(m_SmoothingFilter->GetOutput(), m_SmoothingFilter->GetOutput()->GetBufferedRegion());
       sit.GoToBegin();
       while (!itrPosteriorImage.IsAtEnd())
       {

--- a/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.hxx
@@ -160,7 +160,7 @@ ScalarImageKmeansImageFilter<TInputImage, TOutputImage>::GenerateData()
     region = m_ImageRegion;
   }
 
-  ImageRegionIterator<OutputImageType> pixel(outputPtr, region);
+  ImageRegionIterator pixel(outputPtr, region);
   pixel.GoToBegin();
 
   using ClassifierOutputType = typename ClassifierType::MembershipSampleType;

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.hxx
@@ -88,7 +88,7 @@ ConnectedComponentFunctorImageFilter<TInputImage, TOutputImage, TFunctor, TMaskI
   // along with a neighborhood iterator on the output, use a standard
   // iterator on the input and output
   ImageRegionConstIterator<InputImageType> it(input, output->GetRequestedRegion());
-  ImageRegionIterator<OutputImageType>     oit(output, output->GetRequestedRegion());
+  ImageRegionIterator                      oit(output, output->GetRequestedRegion());
 
   // Setup a progress reporter.  We have 2 stages to the algorithm so
   // pretend we have 2 times the number of pixels

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.hxx
@@ -222,7 +222,7 @@ ConnectedComponentImageFilter<TInputImage, TOutputImage, TMaskImage>::ThreadedWr
   // Note - this is unnecessary if AllocateOutputs initializes to zero
 
   OutputImageType *                    output = this->GetOutput();
-  ImageRegionIterator<OutputImageType> oit(output, outputRegionForThread);
+  ImageRegionIterator                  oit(output, outputRegionForThread);
   ImageRegionIterator<OutputImageType> fstart = oit;
   ImageRegionIterator<OutputImageType> fend = oit;
   fend.GoToEnd();

--- a/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
@@ -103,7 +103,7 @@ LabelVotingImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
 
   std::vector<unsigned int> votesByLabel(this->m_TotalLabelCount);
 
-  for (ImageRegionIterator<TOutputImage> out(output, outputRegionForThread); !out.IsAtEnd(); ++out)
+  for (ImageRegionIterator out(output, outputRegionForThread); !out.IsAtEnd(); ++out)
   {
     // Reset number of votes per label for all labels
     std::fill_n(votesByLabel.begin(), this->m_TotalLabelCount, 0);

--- a/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetFunction.hxx
@@ -88,8 +88,8 @@ CurvesLevelSetFunction<TImageType, TFeatureImageType>::CalculateAdvectionImage()
   }
 
   /* copy negative gradient into the advection image. */
-  ImageRegionIterator<VectorImageType> dit(gradientImage, this->GetFeatureImage()->GetRequestedRegion());
-  ImageRegionIterator<VectorImageType> ait(this->GetAdvectionImage(), this->GetFeatureImage()->GetRequestedRegion());
+  ImageRegionIterator dit(gradientImage, this->GetFeatureImage()->GetRequestedRegion());
+  ImageRegionIterator ait(this->GetAdvectionImage(), this->GetFeatureImage()->GetRequestedRegion());
 
   for (dit.GoToBegin(), ait.GoToBegin(); !dit.IsAtEnd(); ++dit, ++ait)
   {

--- a/Modules/Segmentation/LevelSets/include/itkExtensionVelocitiesImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkExtensionVelocitiesImageFilter.hxx
@@ -146,7 +146,7 @@ ExtensionVelocitiesImageFilter<TLevelSet, TAuxValue, VAuxDimension>::GenerateDat
   using LocalLevelSetImageType = typename LevelSetType::LevelSetImageType;
 
   ImageRegionConstIterator<LocalLevelSetImageType> inputIt(inputPtr, inputPtr->GetBufferedRegion());
-  ImageRegionIterator<LocalLevelSetImageType>      outputIt(outputPtr, outputPtr->GetBufferedRegion());
+  ImageRegionIterator                              outputIt(outputPtr, outputPtr->GetBufferedRegion());
 
   ImageRegionIterator<LocalLevelSetImageType> tempIt;
 
@@ -279,7 +279,7 @@ ExtensionVelocitiesImageFilter<TLevelSet, TAuxValue, VAuxDimension>::GenerateDat
 
   ImageRegionConstIterator<LocalLevelSetImageType> inputIt(inputPtr, inputPtr->GetBufferedRegion());
 
-  ImageRegionIterator<LocalLevelSetImageType> outputIt(outputPtr, outputPtr->GetBufferedRegion());
+  ImageRegionIterator outputIt(outputPtr, outputPtr->GetBufferedRegion());
 
   PixelType posInfinity;
   PixelType negInfinity;

--- a/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourLevelSetFunction.hxx
@@ -77,8 +77,8 @@ GeodesicActiveContourLevelSetFunction<TImageType, TFeatureImageType>::CalculateA
   }
 
   // Copy negative gradient into the advection image
-  ImageRegionIterator<VectorImageType> dit(gradientImage, this->GetFeatureImage()->GetRequestedRegion());
-  ImageRegionIterator<VectorImageType> ait(this->GetAdvectionImage(), this->GetFeatureImage()->GetRequestedRegion());
+  ImageRegionIterator dit(gradientImage, this->GetFeatureImage()->GetRequestedRegion());
+  ImageRegionIterator ait(this->GetAdvectionImage(), this->GetFeatureImage()->GetRequestedRegion());
 
   for (dit.GoToBegin(), ait.GoToBegin(); !dit.IsAtEnd(); ++dit, ++ait)
   {

--- a/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourShapePriorLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourShapePriorLevelSetFunction.hxx
@@ -76,8 +76,8 @@ GeodesicActiveContourShapePriorLevelSetFunction<TImageType, TFeatureImageType>::
   }
 
   // Copy negative gradient into the advection image
-  ImageRegionIterator<VectorImageType> dit(gradientImage, this->GetFeatureImage()->GetRequestedRegion());
-  ImageRegionIterator<VectorImageType> ait(this->GetAdvectionImage(), this->GetFeatureImage()->GetRequestedRegion());
+  ImageRegionIterator dit(gradientImage, this->GetFeatureImage()->GetRequestedRegion());
+  ImageRegionIterator ait(this->GetAdvectionImage(), this->GetFeatureImage()->GetRequestedRegion());
 
   for (dit.GoToBegin(), ait.GoToBegin(); !dit.IsAtEnd(); ++dit, ++ait)
   {

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -211,7 +211,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::Initialize()
   m_StatusImage->Allocate();
 
   // Initialize the status image to contain all m_StatusNull values.
-  ImageRegionIterator<StatusImageType> statusIt(m_StatusImage, m_StatusImage->GetRequestedRegion());
+  ImageRegionIterator statusIt(m_StatusImage, m_StatusImage->GetRequestedRegion());
   for (statusIt.GoToBegin(); !statusIt.IsAtEnd(); ++statusIt)
   {
     statusIt.Set(m_StatusNull);
@@ -624,7 +624,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::InitializeBac
 
   ImageRegionConstIterator<StatusImageType> statusIt(m_StatusImage, this->GetOutput()->GetRequestedRegion());
 
-  ImageRegionIterator<OutputImageType> outputIt(this->GetOutput(), this->GetOutput()->GetRequestedRegion());
+  ImageRegionIterator outputIt(this->GetOutput(), this->GetOutput()->GetRequestedRegion());
 
   ImageRegionConstIterator<OutputImageType> shiftedIt(m_ShiftedImage, this->GetOutput()->GetRequestedRegion());
 
@@ -860,9 +860,9 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedIniti
   // images and hence the memory will get allocated
   // in the corresponding thread's memory-node.
   ImageRegionConstIterator<StatusImageType> statusIt(m_StatusImage, ThreadRegion);
-  ImageRegionIterator<StatusImageType>      statusItNew(m_StatusImageTemp, ThreadRegion);
+  ImageRegionIterator                       statusItNew(m_StatusImageTemp, ThreadRegion);
   ImageRegionConstIterator<OutputImageType> outputIt(m_OutputImage, ThreadRegion);
-  ImageRegionIterator<OutputImageType>      outputItNew(m_OutputImageTemp, ThreadRegion);
+  ImageRegionIterator                       outputItNew(m_OutputImageTemp, ThreadRegion);
 
   for (outputIt.GoToBegin(), statusIt.GoToBegin(), outputItNew.GoToBegin(), statusItNew.GoToBegin();
        !outputIt.IsAtEnd();
@@ -2308,7 +2308,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedPostP
   const ValueType inside_value = -(max_layer + 1) * m_ConstantGradientValue;
 
   ImageRegionConstIterator<StatusImageType> statusIt(m_StatusImage, regionToProcess);
-  ImageRegionIterator<OutputImageType>      outputIt(m_OutputImage, regionToProcess);
+  ImageRegionIterator                       outputIt(m_OutputImage, regionToProcess);
 
   for (outputIt.GoToBegin(), statusIt.GoToBegin(); !outputIt.IsAtEnd(); ++outputIt, ++statusIt)
   {

--- a/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
@@ -135,7 +135,7 @@ ReinitializeLevelSetImageFilter<TLevelSet>::GenerateDataFull()
   // define iterators
 
   ImageRegionConstIterator<LevelSetImageType> inputIt(inputPtr, inputPtr->GetBufferedRegion());
-  ImageRegionIterator<LevelSetImageType>      outputIt(outputPtr, outputPtr->GetBufferedRegion());
+  ImageRegionIterator                         outputIt(outputPtr, outputPtr->GetBufferedRegion());
 
   this->UpdateProgress(0.0);
 
@@ -150,7 +150,7 @@ ReinitializeLevelSetImageFilter<TLevelSet>::GenerateDataFull()
   m_Marcher->SetTrialPoints(m_Locator->GetOutsidePoints());
   m_Marcher->Update();
 
-  ImageRegionIterator<LevelSetImageType> tempIt(tempLevelSet, tempLevelSet->GetBufferedRegion());
+  ImageRegionIterator tempIt(tempLevelSet, tempLevelSet->GetBufferedRegion());
   while (!inputIt.IsAtEnd())
   {
     auto value = static_cast<double>(inputIt.Get());
@@ -201,7 +201,7 @@ ReinitializeLevelSetImageFilter<TLevelSet>::GenerateDataNarrowBand()
 
   ImageRegionConstIterator<LevelSetImageType> inputIt(inputPtr, inputPtr->GetBufferedRegion());
 
-  ImageRegionIterator<LevelSetImageType> outputIt(outputPtr, outputPtr->GetBufferedRegion());
+  ImageRegionIterator outputIt(outputPtr, outputPtr->GetBufferedRegion());
 
   PixelType posInfinity = NumericTraits<PixelType>::max();
   PixelType negInfinity = NumericTraits<PixelType>::NonpositiveMin();

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -503,7 +503,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::Initialize()
   m_StatusImage->Allocate();
 
   // Initialize the status image to contain all m_StatusNull values.
-  ImageRegionIterator<StatusImageType> statusIt(m_StatusImage, m_StatusImage->GetRequestedRegion());
+  ImageRegionIterator statusIt(m_StatusImage, m_StatusImage->GetRequestedRegion());
   for (statusIt.GoToBegin(); !statusIt.IsAtEnd(); ++statusIt)
   {
     statusIt.Set(m_StatusNull);
@@ -594,7 +594,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::InitializeBackgroundP
 
   ImageRegionConstIterator<StatusImageType> statusIt(m_StatusImage, this->GetOutput()->GetRequestedRegion());
 
-  ImageRegionIterator<OutputImageType> outputIt(this->GetOutput(), this->GetOutput()->GetRequestedRegion());
+  ImageRegionIterator outputIt(this->GetOutput(), this->GetOutput()->GetRequestedRegion());
 
   ImageRegionConstIterator<OutputImageType> shiftedIt(m_ShiftedImage, this->GetOutput()->GetRequestedRegion());
 
@@ -1057,7 +1057,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::PostProcessOutput()
 
   ImageRegionConstIterator<StatusImageType> statusIt(m_StatusImage, this->m_OutputImage->GetRequestedRegion());
 
-  ImageRegionIterator<OutputImageType> outputIt(this->m_OutputImage, this->m_OutputImage->GetRequestedRegion());
+  ImageRegionIterator outputIt(this->m_OutputImage, this->m_OutputImage->GetRequestedRegion());
 
   for (outputIt.GoToBegin(), statusIt.GoToBegin(); !outputIt.IsAtEnd(); ++outputIt, ++statusIt)
   {

--- a/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetFunction.hxx
@@ -34,7 +34,7 @@ ThresholdSegmentationLevelSetFunction<TImageType, TFeatureImageType>::CalculateS
   ImageRegionIterator<FeatureImageType>      lit;
   ImageRegionConstIterator<FeatureImageType> fit(this->GetFeatureImage(),
                                                  this->GetFeatureImage()->GetRequestedRegion());
-  ImageRegionIterator<ImageType>             sit(this->GetSpeedImage(), this->GetFeatureImage()->GetRequestedRegion());
+  ImageRegionIterator                        sit(this->GetSpeedImage(), this->GetFeatureImage()->GetRequestedRegion());
 
   if (m_EdgeWeight != 0.0)
   {

--- a/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetFunction.hxx
@@ -30,7 +30,7 @@ VectorThresholdSegmentationLevelSetFunction<TImageType, TFeatureImageType>::Calc
 {
   ImageRegionConstIterator<FeatureImageType> fit(this->GetFeatureImage(),
                                                  this->GetFeatureImage()->GetRequestedRegion());
-  ImageRegionIterator<ImageType>             sit(this->GetSpeedImage(), this->GetFeatureImage()->GetRequestedRegion());
+  ImageRegionIterator                        sit(this->GetSpeedImage(), this->GetFeatureImage()->GetRequestedRegion());
 
   ScalarValueType threshold;
   for (fit.GoToBegin(), sit.GoToBegin(); !fit.IsAtEnd(); ++sit, ++fit)

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.hxx
@@ -104,8 +104,8 @@ LevelSetEquationAdvectionTerm<TInput, TLevelSetContainer>::GenerateAdvectionImag
   }
 
   /* copy negative gradient into the advection image. */
-  ImageRegionIterator<AdvectionImageType> dit(gradientImage, this->m_Input->GetRequestedRegion());
-  ImageRegionIterator<AdvectionImageType> ait(this->m_AdvectionImage, this->m_AdvectionImage->GetRequestedRegion());
+  ImageRegionIterator dit(gradientImage, this->m_Input->GetRequestedRegion());
+  ImageRegionIterator ait(this->m_AdvectionImage, this->m_AdvectionImage->GetRequestedRegion());
 
   for (dit.GoToBegin(), ait.GoToBegin(); !dit.IsAtEnd(); ++dit, ++ait)
   {

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionUpdateLevelSetsThreader.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionUpdateLevelSetsThreader.hxx
@@ -58,7 +58,7 @@ LevelSetEvolutionUpdateLevelSetsThreader<LevelSetDenseImage<TImage>,
   const typename LevelSetImageType::Pointer      levelSetImage = levelSet->GetModifiableImage();
   const typename LevelSetImageType::ConstPointer levelSetUpdateImage = levelSetUpdate->GetImage();
 
-  ImageRegionIterator<LevelSetImageType>      levelSetImageIt(levelSetImage, imageSubRegion);
+  ImageRegionIterator                         levelSetImageIt(levelSetImage, imageSubRegion);
   ImageRegionConstIterator<LevelSetImageType> levelSetUpdateImageIt(levelSetUpdateImage, imageSubRegion);
   levelSetImageIt.GoToBegin();
   levelSetUpdateImageIt.GoToBegin();

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.hxx
@@ -92,7 +92,7 @@ VoronoiPartitioningImageFilter<TInputImage, TOutputImage>::MakeSegmentBoundary()
 {
   const RegionType region = this->GetInput()->GetRequestedRegion();
 
-  ImageRegionIterator<OutputImageType> oit(this->GetOutput(), region);
+  ImageRegionIterator oit(this->GetOutput(), region);
   while (!oit.IsAtEnd())
   {
     oit.Set(0);
@@ -120,7 +120,7 @@ VoronoiPartitioningImageFilter<TInputImage, TOutputImage>::MakeSegmentObject()
 {
   const RegionType region = this->GetInput()->GetRequestedRegion();
 
-  ImageRegionIterator<OutputImageType> oit(this->GetOutput(), region);
+  ImageRegionIterator oit(this->GetOutput(), region);
   while (!oit.IsAtEnd())
   {
     oit.Set(0);

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
@@ -519,7 +519,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
 {
   const RegionType region = this->GetInput()->GetRequestedRegion();
 
-  ImageRegionIterator<OutputImageType> oit(this->GetOutput(), region);
+  ImageRegionIterator oit(this->GetOutput(), region);
   while (!oit.IsAtEnd())
   {
     oit.Set(0);
@@ -548,7 +548,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
 {
   const RegionType region = this->GetInput()->GetRequestedRegion();
 
-  ImageRegionIterator<OutputImageType> oit(this->GetOutput(), region);
+  ImageRegionIterator oit(this->GetOutput(), region);
   while (!oit.IsAtEnd())
   {
     oit.Set(0);
@@ -923,7 +923,7 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
 {
   const RegionType region = this->GetInput()->GetRequestedRegion();
 
-  ImageRegionIterator<VDImage> vdit(result, region);
+  ImageRegionIterator vdit(result, region);
   while (!vdit.IsAtEnd())
   {
     vdit.Set(0);

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
@@ -89,7 +89,7 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::SetInput(const Inp
   m_WorkingImage->SetRegions(region);
   m_WorkingImage->Allocate();
 
-  ImageRegionIterator<RGBHCVImage>         wit(m_WorkingImage, region);
+  ImageRegionIterator                      wit(m_WorkingImage, region);
   ImageRegionConstIterator<InputImageType> iit(this->GetInput(), region);
   PixelType                                ipixel;
   RGBHCVPixel                              wpixel;
@@ -193,7 +193,7 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::TakeAPrior(const B
   const RegionType region = this->GetInput()->GetRequestedRegion();
 
   ImageRegionConstIterator<BinaryObjectImage> ait(aprior, region);
-  ImageRegionIterator<RGBHCVImage>            iit(m_WorkingImage, region);
+  ImageRegionIterator                         iit(m_WorkingImage, region);
 
   unsigned int minx = 0;
   unsigned int miny = 0;

--- a/Modules/Segmentation/Watersheds/include/itkIsolatedWatershedImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkIsolatedWatershedImageFilter.hxx
@@ -145,8 +145,8 @@ IsolatedWatershedImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   ProgressReporter progress(this, 0, region.GetNumberOfPixels(), 100, cumulatedProgress, progressWeight);
 
-  ImageRegionIterator<OutputImageType>                         ot(outputImage, region);
-  ImageRegionIterator<typename WatershedType::OutputImageType> it(m_Watershed->GetOutput(), region);
+  ImageRegionIterator ot(outputImage, region);
+  ImageRegionIterator it(m_Watershed->GetOutput(), region);
 
   const IdentifierType seed1Label = m_Watershed->GetOutput()->GetPixel(m_Seed1);
   const IdentifierType seed2Label = m_Watershed->GetOutput()->GetPixel(m_Seed2);

--- a/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.hxx
@@ -32,7 +32,6 @@ BoundaryResolver<TPixelType, TDimension>::GenerateData()
   //       See itkWatershedSegmenter for details. City-block style connectivity
   //       is assumed (ie 4-, 6- for 2d, 3d). jc 11/14/01
   //
-  using FaceType = typename BoundaryType::face_t;
   typename BoundaryType::IndexType idxA;
   typename BoundaryType::IndexType idxB;
 
@@ -65,9 +64,9 @@ BoundaryResolver<TPixelType, TDimension>::GenerateData()
   // This constructs equivalencies between both flat regions and
   // non-flat regions.
   //
-  ImageRegionIterator<FaceType> itA(boundaryA->GetFace(idxA), boundaryA->GetFace(idxA)->GetRequestedRegion());
+  ImageRegionIterator itA(boundaryA->GetFace(idxA), boundaryA->GetFace(idxA)->GetRequestedRegion());
 
-  ImageRegionIterator<FaceType> itB(boundaryB->GetFace(idxB), boundaryB->GetFace(idxB)->GetRequestedRegion());
+  ImageRegionIterator itB(boundaryB->GetFace(idxB), boundaryB->GetFace(idxB)->GetRequestedRegion());
 
   for (itA.GoToBegin(), itB.GoToBegin(); !itA.IsAtEnd(); ++itA, ++itB)
   {

--- a/Modules/Segmentation/Watersheds/include/itkWatershedEquivalenceRelabeler.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedEquivalenceRelabeler.hxx
@@ -37,7 +37,7 @@ EquivalenceRelabeler<TScalar, TImageDimension>::GenerateData()
   // Copy input to output
   //
   ImageRegionConstIterator<ImageType> it_a(input, output->GetRequestedRegion());
-  ImageRegionIterator<ImageType>      it_b(output, output->GetRequestedRegion());
+  ImageRegionIterator                 it_b(output, output->GetRequestedRegion());
 
   it_a.GoToBegin();
   it_b.GoToBegin();

--- a/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.hxx
@@ -54,8 +54,8 @@ Relabeler<TScalar, TImageDimension>::GenerateData()
   //
   // Copy input to output
   //
-  ImageRegionIterator<ImageType> it_a(input, output->GetRequestedRegion());
-  ImageRegionIterator<ImageType> it_b(output, output->GetRequestedRegion());
+  ImageRegionIterator it_a(input, output->GetRequestedRegion());
+  ImageRegionIterator it_b(output, output->GetRequestedRegion());
   it_a.GoToBegin();
   it_b.GoToBegin();
   while (!it_a.IsAtEnd())

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
@@ -338,7 +338,7 @@ Segmenter<TInputImage>::CollectBoundaryInformation(flat_region_table_t & flatReg
       // Grab all the labels of the boundary pixels.
       ImageRegionIterator<typename BoundaryType::face_t> faceIt =
         ImageRegionIterator<typename BoundaryType::face_t>(face, region);
-      ImageRegionIterator<OutputImageType> labelIt(output, region);
+      ImageRegionIterator labelIt(output, region);
       faceIt.GoToBegin();
       labelIt.GoToBegin();
       while (!faceIt.IsAtEnd())
@@ -815,7 +815,7 @@ Segmenter<TInputImage>::GradientDescent(InputImageTypePointer img, ImageRegionTy
   // pixels to a labeled region
   //
   std::stack<IdentifierType *> updateStack;
-  for (ImageRegionIterator<OutputImageType> it(output, region); !it.IsAtEnd(); ++it)
+  for (ImageRegionIterator it(output, region); !it.IsAtEnd(); ++it)
   {
     if (it.Get() == NULL_LABEL)
     {
@@ -1016,7 +1016,7 @@ template <typename TInputImage>
 void
 Segmenter<TInputImage>::SetInputImageValues(InputImageTypePointer img, ImageRegionType region, InputPixelType value)
 {
-  ImageRegionIterator<InputImageType> it(img, region);
+  ImageRegionIterator it(img, region);
   it.GoToBegin();
   while (!it.IsAtEnd())
   {
@@ -1029,7 +1029,7 @@ template <typename TInputImage>
 void
 Segmenter<TInputImage>::SetOutputImageValues(OutputImageTypePointer img, ImageRegionType region, IdentifierType value)
 {
-  ImageRegionIterator<OutputImageType> it(img, region);
+  ImageRegionIterator it(img, region);
   it.GoToBegin();
   while (!it.IsAtEnd())
   {
@@ -1045,7 +1045,7 @@ Segmenter<TInputImage>::MinMax(InputImageTypePointer img,
                                InputPixelType &      min,
                                InputPixelType &      max)
 {
-  ImageRegionIterator<InputImageType> it(img, region);
+  ImageRegionIterator it(img, region);
   it.GoToBegin();
   min = it.Value();
   max = it.Value();
@@ -1100,7 +1100,7 @@ Segmenter<TInputImage>::RelabelImage(OutputImageTypePointer    img,
                                      EquivalencyTable::Pointer eqTable)
 {
   eqTable->Flatten();
-  ImageRegionIterator<OutputImageType> it(img, region);
+  ImageRegionIterator it(img, region);
 
   it.GoToBegin();
   while (!it.IsAtEnd())
@@ -1122,8 +1122,8 @@ Segmenter<TInputImage>::Threshold(InputImageTypePointer destination,
                                   const ImageRegionType destination_region,
                                   InputPixelType        threshold)
 {
-  ImageRegionIterator<InputImageType> dIt(destination, destination_region);
-  ImageRegionIterator<InputImageType> sIt(source, source_region);
+  ImageRegionIterator dIt(destination, destination_region);
+  ImageRegionIterator sIt(source, source_region);
 
   dIt.GoToBegin();
   sIt.GoToBegin();

--- a/Modules/Video/Filtering/include/itkDecimateFramesVideoFilter.hxx
+++ b/Modules/Video/Filtering/include/itkDecimateFramesVideoFilter.hxx
@@ -100,7 +100,7 @@ DecimateFramesVideoFilter<TVideoStream>::ThreadedGenerateData(const FrameSpatial
 
   // Get iterators for requested region of input and output frames
   ImageRegionConstIterator<FrameType> inIter(input->GetFrame(inFrameNum), outputRegionForThread);
-  ImageRegionIterator<FrameType>      outIter(output->GetFrame(outFrameNum), outputRegionForThread);
+  ImageRegionIterator                 outIter(output->GetFrame(outFrameNum), outputRegionForThread);
 
   // Pass the values from input to output
   while (!outIter.IsAtEnd())

--- a/Modules/Video/Filtering/include/itkFrameAverageVideoFilter.hxx
+++ b/Modules/Video/Filtering/include/itkFrameAverageVideoFilter.hxx
@@ -117,8 +117,8 @@ FrameAverageVideoFilter<TInputVideoStream, TOutputVideoStream>::ThreadedGenerate
   }
 
   // Get the output frame and its iterator
-  OutputFrameType *                    outFrame = output->GetFrame(outputFrameNumber);
-  ImageRegionIterator<OutputFrameType> outIter(outFrame, outputRegionForThread);
+  OutputFrameType *   outFrame = output->GetFrame(outputFrameNumber);
+  ImageRegionIterator outIter(outFrame, outputRegionForThread);
 
   // Average the input frames at each pixel of the output region
   using OutputPixelRealType = typename NumericTraits<OutputPixelType>::RealType;

--- a/Modules/Video/Filtering/include/itkFrameDifferenceVideoFilter.hxx
+++ b/Modules/Video/Filtering/include/itkFrameDifferenceVideoFilter.hxx
@@ -117,8 +117,8 @@ FrameDifferenceVideoFilter<TInputVideoStream, TOutputVideoStream>::ThreadedGener
   ImageRegionConstIterator<InputFrameType> I1Iter(input->GetFrame(inputStart + numFrames - 1), outputRegionForThread);
 
   // Get the output frame and its iterator
-  OutputFrameType *                    outFrame = output->GetFrame(outputFrameNumber);
-  ImageRegionIterator<OutputFrameType> outIter(outFrame, outputRegionForThread);
+  OutputFrameType *   outFrame = output->GetFrame(outputFrameNumber);
+  ImageRegionIterator outIter(outFrame, outputRegionForThread);
 
   // Average the input frames at each pixel of the output region
   using InputPixelRealType = typename NumericTraits<InputPixelType>::RealType;


### PR DESCRIPTION
Used class template argument deduction (CTAD) when declaring variables of type `ImageRegionIterator<TImage>`

Using Notepad++, Replace in Files, doing:

    Find what: ([^\w]ImageRegionIterator)<.+>[ ]*( \w*[\({])
    Replace with: $1$2
    Files: itk*.hxx
    [v] Match case
    (*) Regular expression

Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/5932 commit 50210af9d3bc78b3bd84bed407af266d9683d50a
"STYLE: Use CTAD for iterators "with index", in hxx files"