### PR TITLE
ENH: Convert itkSimplexMeshWithFloatCoordRepTest to GTest

### DIFF
--- a/Modules/Segmentation/DeformableMesh/test/CMakeLists.txt
+++ b/Modules/Segmentation/DeformableMesh/test/CMakeLists.txt
@@ -4,10 +4,12 @@ set(
   itkDeformableSimplexMesh3DFilterTest.cxx
   itkDeformableSimplexMesh3DBalloonForceFilterTest.cxx
   itkDeformableSimplexMesh3DGradientConstraintForceFilterTest.cxx
-  itkSimplexMeshWithFloatCoordRepTest.cxx
 )
 
 createtestdriver(ITKDeformableMesh "${ITKDeformableMesh-Test_LIBRARIES}" "${ITKDeformableMeshTests}")
+
+set(ITKDeformableMeshGTests itkSimplexMeshWithFloatCoordRepGTest.cxx)
+creategoogletestdriver(ITKDeformableMesh "${ITKDeformableMesh-Test_LIBRARIES}" "${ITKDeformableMeshGTests}")
 
 itk_add_test(
   NAME itkDeformableSimplexMesh3DFilterTest
@@ -27,10 +29,4 @@ itk_add_test(
   COMMAND
     ITKDeformableMeshTestDriver
     itkDeformableSimplexMesh3DGradientConstraintForceFilterTest
-)
-itk_add_test(
-  NAME itkSimplexMeshWithFloatCoordRepTest
-  COMMAND
-    ITKDeformableMeshTestDriver
-    itkSimplexMeshWithFloatCoordRepTest
 )

--- a/Modules/Segmentation/DeformableMesh/test/itkSimplexMeshWithFloatCoordRepGTest.cxx
+++ b/Modules/Segmentation/DeformableMesh/test/itkSimplexMeshWithFloatCoordRepGTest.cxx
@@ -17,9 +17,9 @@
  *=========================================================================*/
 #include "itkDefaultDynamicMeshTraits.h"
 #include "itkDeformableSimplexMesh3DFilter.h"
+#include "itkGTest.h"
 
-int
-itkSimplexMeshWithFloatCoordRepTest(int, char *[])
+TEST(SimplexMeshWithFloatCoordRep, ConvertedLegacyTest)
 {
   constexpr unsigned int Dimension{ 3 };
 
@@ -31,5 +31,4 @@ itkSimplexMeshWithFloatCoordRepTest(int, char *[])
 
   auto deform = DeformType::New();
   deform->Print(std::cout);
-  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary

- Converts `itkSimplexMeshWithFloatCoordRepTest` (no-argument CTest) to GoogleTest format
- Adds GTest driver infrastructure to `ITKDeformableMesh` module
- Mechanical conversion: behavior identical to original test

## Test plan

- [ ] Verify `ITKDeformableMeshGTestDriver` builds without errors
- [ ] Verify `SimplexMeshWithFloatCoordRep.ConvertedLegacyTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)