### PR TITLE
ENH: Convert itkMathematicalMorphologyEnumsTest to GTest

### DIFF
--- a/Modules/Filtering/MathematicalMorphology/test/CMakeLists.txt
+++ b/Modules/Filtering/MathematicalMorphology/test/CMakeLists.txt
@@ -35,7 +35,6 @@ set(
   itkMapGrayscaleErodeImageFilterTest.cxx
   itkMapGrayscaleMorphologicalClosingImageFilterTest.cxx
   itkMapGrayscaleMorphologicalOpeningImageFilterTest.cxx
-  itkMathematicalMorphologyEnumsTest.cxx
   itkGrayscaleDilateImageFilterTest.cxx
   itkGrayscaleErodeImageFilterTest.cxx
   itkGrayscaleMorphologicalClosingImageFilterTest2.cxx
@@ -54,6 +53,13 @@ set(
 
 createtestdriver(ITKMathematicalMorphology "${ITKMathematicalMorphology-Test_LIBRARIES}"
                  "${ITKMathematicalMorphologyTests}"
+)
+
+set(ITKMathematicalMorphologyGTests itkMathematicalMorphologyEnumsGTest.cxx)
+creategoogletestdriver(
+  ITKMathematicalMorphology
+  "${ITKMathematicalMorphology-Test_LIBRARIES}"
+  "${ITKMathematicalMorphologyGTests}"
 )
 
 itk_add_test(
@@ -870,13 +876,6 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalOpeningImageFilterTestVHGWSafeBorder.png
     ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalOpeningImageFilterTestAnchorSafeBorder.png
     1
-)
-
-itk_add_test(
-  NAME itkMathematicalMorphologyEnumsTest
-  COMMAND
-    ITKMathematicalMorphologyTestDriver
-    itkMathematicalMorphologyEnumsTest
 )
 
 itk_add_test(

--- a/Modules/Filtering/MathematicalMorphology/test/itkMathematicalMorphologyEnumsGTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMathematicalMorphologyEnumsGTest.cxx
@@ -16,14 +16,13 @@
  *
  *=========================================================================*/
 
-#include <set>
 #include "itkMathematicalMorphologyEnums.h"
+#include "itkGTest.h"
 
+#include <set>
 
-int
-itkMathematicalMorphologyEnumsTest(int, char *[])
+TEST(MathematicalMorphologyEnums, ConvertedLegacyTest)
 {
-
   // Test streaming enumeration for MathematicalMorphologyEnums::Algorithm elements
   const std::set<itk::MathematicalMorphologyEnums::Algorithm> allAlgorithm{
     itk::MathematicalMorphologyEnums::Algorithm::BASIC,
@@ -35,8 +34,4 @@ itkMathematicalMorphologyEnumsTest(int, char *[])
   {
     std::cout << "STREAMED ENUM VALUE MathematicalMorphologyEnums::Algorithm: " << ee << std::endl;
   }
-
-
-  std::cout << "Test finished" << std::endl;
-  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary

- Converts `itkMathematicalMorphologyEnumsTest` (no-argument CTest) to GoogleTest format
- Adds GTest driver infrastructure to `ITKMathematicalMorphology` module
- Mechanical conversion: behavior identical to original test

## Test plan

- [ ] Verify `ITKMathematicalMorphologyGTestDriver` builds without errors
- [ ] Verify `MathematicalMorphologyEnums.ConvertedLegacyTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)