### PR TITLE
ENH: Convert itkWindowConvergenceMonitoringFunctionTest to GTest

### DIFF
--- a/Modules/Numerics/Optimizersv4/test/CMakeLists.txt
+++ b/Modules/Numerics/Optimizersv4/test/CMakeLists.txt
@@ -17,7 +17,6 @@ set(
   itkRegistrationParameterScalesFromJacobianTest.cxx
   itkAutoScaledGradientDescentRegistrationTest.cxx
   itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
-  itkWindowConvergenceMonitoringFunctionTest.cxx
   itkQuasiNewtonOptimizerv4Test.cxx
   itkObjectToObjectMetricBaseTest.cxx
   itkLBFGSOptimizerv4Test.cxx
@@ -36,12 +35,8 @@ set(TEMP ${ITK_TEST_OUTPUT_DIR})
 
 createtestdriver(ITKOptimizersv4 "${ITKOptimizersv4-Test_LIBRARIES}" "${ITKOptimizersv4Tests}")
 
-itk_add_test(
-  NAME itkWindowConvergenceMonitoringFunctionTest
-  COMMAND
-    ITKOptimizersv4TestDriver
-    itkWindowConvergenceMonitoringFunctionTest
-)
+set(ITKOptimizersv4GTests itkWindowConvergenceMonitoringFunctionGTest.cxx)
+creategoogletestdriver(ITKOptimizersv4 "${ITKOptimizersv4-Test_LIBRARIES}" "${ITKOptimizersv4GTests}")
 
 itk_add_test(
   NAME itkObjectToObjectOptimizerBaseTest

--- a/Modules/Numerics/Optimizersv4/test/itkWindowConvergenceMonitoringFunctionGTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkWindowConvergenceMonitoringFunctionGTest.cxx
@@ -31,7 +31,9 @@ TEST(WindowConvergenceMonitoringFunction, ConvertedLegacyTest)
   for (RealType x = 0.0; x < 20; x += 1.0)
   {
     convergenceMonitoring->AddEnergyValue(std::pow(static_cast<RealType>(2.0), -x));
-    EXPECT_NO_THROW(std::cout << "convergence value: " << convergenceMonitoring->GetConvergenceValue() << std::endl);
+    RealType convergenceValue;
+    EXPECT_NO_THROW(convergenceValue = convergenceMonitoring->GetConvergenceValue());
+    std::cout << "convergence value: " << convergenceValue << std::endl;
   }
 
   convergenceMonitoring->GetWindowSize();

--- a/Modules/Numerics/Optimizersv4/test/itkWindowConvergenceMonitoringFunctionGTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkWindowConvergenceMonitoringFunctionGTest.cxx
@@ -17,9 +17,9 @@
  *=========================================================================*/
 
 #include "itkWindowConvergenceMonitoringFunction.h"
+#include "itkGTest.h"
 
-int
-itkWindowConvergenceMonitoringFunctionTest(int itkNotUsed(argc), char *[])
+TEST(WindowConvergenceMonitoringFunction, ConvertedLegacyTest)
 {
   using RealType = float;
 
@@ -31,19 +31,9 @@ itkWindowConvergenceMonitoringFunctionTest(int itkNotUsed(argc), char *[])
   for (RealType x = 0.0; x < 20; x += 1.0)
   {
     convergenceMonitoring->AddEnergyValue(std::pow(static_cast<RealType>(2.0), -x));
-    try
-    {
-      std::cout << "convergence value: " << convergenceMonitoring->GetConvergenceValue() << std::endl;
-    }
-    catch (...)
-    {
-      std::cout << "GetConvergenceValue() failed." << std::endl;
-      return EXIT_FAILURE;
-    }
+    EXPECT_NO_THROW(std::cout << "convergence value: " << convergenceMonitoring->GetConvergenceValue() << std::endl);
   }
 
   convergenceMonitoring->GetWindowSize();
   convergenceMonitoring->Print(std::cout, 3);
-
-  return EXIT_SUCCESS;
 }

--- a/Modules/Numerics/Optimizersv4/test/itkWindowConvergenceMonitoringFunctionGTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkWindowConvergenceMonitoringFunctionGTest.cxx
@@ -31,7 +31,7 @@ TEST(WindowConvergenceMonitoringFunction, ConvertedLegacyTest)
   for (RealType x = 0.0; x < 20; x += 1.0)
   {
     convergenceMonitoring->AddEnergyValue(std::pow(static_cast<RealType>(2.0), -x));
-    RealType convergenceValue;
+    RealType convergenceValue{};
     EXPECT_NO_THROW(convergenceValue = convergenceMonitoring->GetConvergenceValue());
     std::cout << "convergence value: " << convergenceValue << std::endl;
   }


### PR DESCRIPTION
## Summary

- Converts `itkWindowConvergenceMonitoringFunctionTest` (no-argument CTest) to GoogleTest format
- Adds GTest driver infrastructure to `ITKOptimizersv4` module
- `try/catch` returning `EXIT_FAILURE` → `EXPECT_NO_THROW`
- Mechanical conversion: behavior identical to original test

## Test plan

- [x] Verify `ITKOptimizersv4GTestDriver` builds without errors
- [x] Verify `WindowConvergenceMonitoringFunction.ConvertedLegacyTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)