### PR TITLE
STYLE: Use CTAD for `ImageRegionConstIterator` variables in hxx files

### DIFF
--- a/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.hxx
@@ -109,7 +109,7 @@ FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPixel()
   // Now we search the input image for the first pixel which is inside
   // the function of interest
   m_Seeds.clear();
-  for (ImageRegionConstIterator<TImage> it(this->m_Image, this->m_Image->GetBufferedRegion()); !it.IsAtEnd(); ++it)
+  for (ImageRegionConstIterator it(this->m_Image, this->m_Image->GetBufferedRegion()); !it.IsAtEnd(); ++it)
   {
     if (this->IsPixelIncluded(it.GetIndex()))
     {
@@ -133,7 +133,7 @@ FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPixels()
   // the function of interest
   m_Seeds.clear();
   bool found = false;
-  for (ImageRegionConstIterator<TImage> it(this->m_Image, this->m_Image->GetBufferedRegion()); !it.IsAtEnd(); ++it)
+  for (ImageRegionConstIterator it(this->m_Image, this->m_Image->GetBufferedRegion()); !it.IsAtEnd(); ++it)
   {
     if (this->IsPixelIncluded(it.GetIndex()))
     {

--- a/Modules/Core/Common/include/itkImageAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkImageAlgorithm.hxx
@@ -53,8 +53,8 @@ ImageAlgorithm::ReferenceCopy(const InputImageType *                       inIma
     return;
   }
 
-  ImageRegionConstIterator<InputImageType> it(inImage, inRegion);
-  ImageRegionIterator                      ot(outImage, outRegion);
+  ImageRegionConstIterator it(inImage, inRegion);
+  ImageRegionIterator      ot(outImage, outRegion);
 
   while (!it.IsAtEnd())
   {

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
@@ -116,7 +116,7 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPi
   // Now we search the input image for the first pixel which is inside
   // the function of interest
   m_Seeds.clear();
-  for (ImageRegionConstIterator<TImage> it(this->m_Image, this->m_Image->GetBufferedRegion()); !it.IsAtEnd(); ++it)
+  for (ImageRegionConstIterator it(this->m_Image, this->m_Image->GetBufferedRegion()); !it.IsAtEnd(); ++it)
   {
     if (this->IsPixelIncluded(it.GetIndex()))
     {
@@ -140,7 +140,7 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPi
   // the function of interest
   m_Seeds.clear();
   bool found = false;
-  for (ImageRegionConstIterator<TImage> it(this->m_Image, this->m_Image->GetBufferedRegion()); !it.IsAtEnd(); ++it)
+  for (ImageRegionConstIterator it(this->m_Image, this->m_Image->GetBufferedRegion()); !it.IsAtEnd(); ++it)
   {
     if (this->IsPixelIncluded(it.GetIndex()))
     {

--- a/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
@@ -47,8 +47,8 @@ DenseFiniteDifferenceImageFilter<TInputImage, TOutputImage>::CopyInputToOutput()
     return;
   }
 
-  ImageRegionConstIterator<TInputImage> in(input, output->GetRequestedRegion());
-  ImageRegionIterator                   out(output, output->GetRequestedRegion());
+  ImageRegionConstIterator in(input, output->GetRequestedRegion());
+  ImageRegionIterator      out(output, output->GetRequestedRegion());
 
   while (!out.IsAtEnd())
   {

--- a/Modules/Core/Mesh/include/itkImageToParametricSpaceFilter.hxx
+++ b/Modules/Core/Mesh/include/itkImageToParametricSpaceFilter.hxx
@@ -104,7 +104,7 @@ ImageToParametricSpaceFilter<TInputImage, TOutputMesh>::GenerateData()
   for (unsigned int component = 0; component < PointDimension; ++component)
   {
     image = this->GetInput(component);
-    ImageRegionConstIterator<InputImageType> itr(image, image->GetRequestedRegion());
+    ImageRegionConstIterator itr(image, image->GetRequestedRegion());
 
     PointsContainerIterator point = points->Begin();
 

--- a/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
@@ -157,7 +157,7 @@ MetaImageConverter<VDimension, PixelType, TSpatialObjectType>::SpatialObjectToMe
   imageMO->ElementOrigin(origin);
   imageMO->ElementDirection(direction);
 
-  ImageRegionConstIterator<ImageType> it(SOImage, SOImage->GetLargestPossibleRegion());
+  ImageRegionConstIterator it(SOImage, SOImage->GetLargestPossibleRegion());
   for (unsigned int i = 0; !it.IsAtEnd(); i++, ++it)
   {
     imageMO->ElementData(i, it.Get());

--- a/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.hxx
@@ -128,9 +128,9 @@ ComparisonImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   // Process the internal face and each of the boundary faces.
   for (auto face = faceList.begin(); face != faceList.end(); ++face)
   {
-    SmartIterator                            test(radius, testImage, *face); // Iterate over test image.
-    ImageRegionConstIterator<InputImageType> valid(validImage, *face);       // Iterate over valid image.
-    ImageRegionIterator                      out(outputPtr, *face);          // Iterate over output image.
+    SmartIterator            test(radius, testImage, *face); // Iterate over test image.
+    ImageRegionConstIterator valid(validImage, *face);       // Iterate over valid image.
+    ImageRegionIterator      out(outputPtr, *face);          // Iterate over output image.
     if (!test.GetNeedToUseBoundaryCondition() || !m_IgnoreBoundaryPixels)
     {
       test.OverrideBoundaryCondition(&nbc);

--- a/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
@@ -251,8 +251,8 @@ ExtractSliceImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   this->CallCopyOutputRegionToInputRegion(inputRegionForThread, outputRegionForThread);
 
 
-  ImageRegionIterator                   outIt(outputPtr, outputRegionForThread);
-  ImageRegionConstIterator<TInputImage> inIt(inputPtr, inputRegionForThread);
+  ImageRegionIterator      outIt(outputPtr, outputRegionForThread);
+  ImageRegionConstIterator inIt(inputPtr, inputRegionForThread);
 
   // walk the output region, and sample the input image
   while (!outIt.IsAtEnd())

--- a/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.hxx
@@ -106,8 +106,8 @@ StretchIntensityImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateD
 
   const InputImageRegionType inputRegionForThread = outputRegionForThread;
 
-  ImageRegionConstIterator<TInputImage> inputIt(inputPtr, inputRegionForThread);
-  ImageRegionIterator                   outputIt(outputPtr, outputRegionForThread);
+  ImageRegionConstIterator inputIt(inputPtr, inputRegionForThread);
+  ImageRegionIterator      outputIt(outputPtr, outputRegionForThread);
 
   while (!inputIt.IsAtEnd())
   {

--- a/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.hxx
@@ -77,7 +77,7 @@ MRASlabIdentifier<TInputImage>::GenerateSlabRegions()
     index[m_SlicingDirection] = currentSlice;
     region.SetIndex(index);
 
-    ImageRegionConstIterator<TInputImage> iter(m_Image, region);
+    ImageRegionConstIterator iter(m_Image, region);
     iter.GoToBegin();
 
     std::priority_queue<ImagePixelType> mins;

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
@@ -83,8 +83,8 @@ BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   // except for pixels with DilateValue.  These pixels are initially
   // replaced with BackgroundValue and potentially replaced later with
   // DilateValue as the Minkowski sums are performed.
-  ImageRegionIterator                      outIt(output, outputRegion);
-  ImageRegionConstIterator<InputImageType> inIt(input, outputRegion);
+  ImageRegionIterator      outIt(output, outputRegion);
+  ImageRegionConstIterator inIt(input, outputRegion);
 
   for (inIt.GoToBegin(), outIt.GoToBegin(); !outIt.IsAtEnd(); ++outIt, ++inIt)
   {
@@ -140,7 +140,7 @@ BinaryDilateImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
 
   // Iterators on input and tmp image
   // iterator on input
-  ImageRegionConstIterator<TInputImage> iRegIt(input, requiredInputRegion);
+  ImageRegionConstIterator iRegIt(input, requiredInputRegion);
   // iterator on tmp image
   ImageRegionIterator tmpRegIt(tmpImage, requiredInputRegion);
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
@@ -84,7 +84,7 @@ BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   // replaced with BackgroundValue and potentially replaced later with
   // DilateValue as the Minkowski sums are performed.
   ImageRegionIterator outIt(output, outputRegion);
-  // ImageRegionConstIterator<InputImageType> inIt( input, outputRegion );
+  // ImageRegionConstIterator inIt( input, outputRegion );
 
   for (outIt.GoToBegin(); !outIt.IsAtEnd(); ++outIt)
   {
@@ -130,7 +130,7 @@ BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
 
   // Iterators on input and tmp image
   // iterator on input
-  ImageRegionConstIterator<TInputImage> iRegIt(input, requiredInputRegion);
+  ImageRegionConstIterator iRegIt(input, requiredInputRegion);
   // iterator on tmp image
   ImageRegionIterator tmpRegIt(tmpImage, requiredInputRegion);
 
@@ -446,7 +446,7 @@ BinaryErodeImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
   }
 
   // now, we must to restore the background values
-  ImageRegionConstIterator<InputImageType> inIt(input, outputRegion);
+  ImageRegionConstIterator inIt(input, outputRegion);
 
   for (inIt.GoToBegin(), outIt.GoToBegin(); !outIt.IsAtEnd(); ++outIt, ++inIt)
   {

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.hxx
@@ -132,7 +132,7 @@ BinaryMorphologicalClosingImageFilter<TInputImage, TOutputImage, TKernel>::Gener
   // finally copy background which should have been eroded
   //
   // iterator on input image
-  ImageRegionConstIterator<InputImageType> inIt(this->GetInput(), this->GetOutput()->GetRequestedRegion());
+  ImageRegionConstIterator inIt(this->GetInput(), this->GetOutput()->GetRequestedRegion());
   // iterator on output image
   ImageRegionIterator outIt(this->GetOutput(), this->GetOutput()->GetRequestedRegion());
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.hxx
@@ -64,8 +64,8 @@ BinaryPruningImageFilter<TInputImage, TOutputImage>::PrepareData()
 
   const typename OutputImageType::RegionType region = pruneImage->GetRequestedRegion();
 
-  ImageRegionConstIterator<TInputImage> it(inputImage, region);
-  ImageRegionIterator                   ot(pruneImage, region);
+  ImageRegionConstIterator it(inputImage, region);
+  ImageRegionIterator      ot(pruneImage, region);
 
   itkDebugMacro("PrepareData: Copy input to output");
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.hxx
@@ -66,8 +66,8 @@ BinaryThinningImageFilter<TInputImage, TOutputImage>::PrepareData()
 
   const typename OutputImageType::RegionType region = thinImage->GetRequestedRegion();
 
-  ImageRegionConstIterator<TInputImage> it(inputImage, region);
-  ImageRegionIterator                   ot(thinImage, region);
+  ImageRegionConstIterator it(inputImage, region);
+  ImageRegionIterator      ot(thinImage, region);
 
   itkDebugMacro("PrepareData: Copy input to output");
 

--- a/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.hxx
+++ b/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.hxx
@@ -69,7 +69,7 @@ ScalarToRGBColormapImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerat
 {
   if (this->m_UseInputImageExtremaForScaling)
   {
-    ImageRegionConstIterator<InputImageType> It(this->GetInput(), this->GetInput()->GetRequestedRegion());
+    ImageRegionConstIterator It(this->GetInput(), this->GetInput()->GetRequestedRegion());
 
     InputImagePixelType minimumValue = NumericTraits<InputImagePixelType>::max();
     InputImagePixelType maximumValue = NumericTraits<InputImagePixelType>::min();
@@ -109,8 +109,8 @@ ScalarToRGBColormapImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenera
 
   this->CallCopyOutputRegionToInputRegion(inputRegionForThread, outputRegionForThread);
 
-  ImageRegionConstIterator<TInputImage> inputIt(inputPtr, inputRegionForThread);
-  ImageRegionIterator                   outputIt(outputPtr, outputRegionForThread);
+  ImageRegionConstIterator inputIt(inputPtr, inputRegionForThread);
+  ImageRegionIterator      outputIt(outputPtr, outputRegionForThread);
 
   while (!inputIt.IsAtEnd())
   {

--- a/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
@@ -200,7 +200,7 @@ NormalizedCorrelationImageFilter<TInputImage, TMaskImage, TOutputImage, TOperato
     {
       // Mask is defined, use the same calculation as above but only
       // perform it under the mask
-      ImageRegionConstIterator<MaskImageType> mit(mask, face);
+      ImageRegionConstIterator mit(mask, face);
       while (!bit.IsAtEnd())
       {
         if (mit.Get())

--- a/Modules/Filtering/Deconvolution/include/itkParametricBlindLeastSquaresDeconvolutionImageFilter.hxx
+++ b/Modules/Filtering/Deconvolution/include/itkParametricBlindLeastSquaresDeconvolutionImageFilter.hxx
@@ -218,9 +218,9 @@ ParametricBlindLeastSquaresDeconvolutionImageFilter<TInputImage, TKernelImage, T
     // partial derivative image estimate, then multiply the result by
     // the Jacobian. We'll do this all in one loop to simplify things.
     const typename InternalKernelImageType::RegionType region(plusImage->GetLargestPossibleRegion());
-    ImageRegionConstIterator<InternalKernelImageType>  plusImageIter(plusImage, region);
-    ImageRegionConstIterator<InternalKernelImageType>  minusImageIter(minusImage, region);
-    ImageRegionConstIterator<InternalImageType>        jacobianImageIter(jacobianIFFT->GetOutput(), region);
+    ImageRegionConstIterator                           plusImageIter(plusImage, region);
+    ImageRegionConstIterator                           minusImageIter(minusImage, region);
+    ImageRegionConstIterator                           jacobianImageIter(jacobianIFFT->GetOutput(), region);
 
     double sum = 0.0;
     while (!plusImageIter.IsAtEnd())

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -537,8 +537,8 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::InitializePatchWeight
   resampler->Update();
 
   // Patch weights (mask) in voxel space
-  const typename WeightsImageType::Pointer   voxelWeightsImage = resampler->GetOutput();
-  ImageRegionConstIterator<WeightsImageType> vwIt(voxelWeightsImage, voxelWeightsImage->GetLargestPossibleRegion());
+  const typename WeightsImageType::Pointer voxelWeightsImage = resampler->GetOutput();
+  ImageRegionConstIterator                 vwIt(voxelWeightsImage, voxelWeightsImage->GetLargestPossibleRegion());
 
   // Disc-smooth patch weights in voxel space
   PatchWeightsType patchWeights;

--- a/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
@@ -302,8 +302,8 @@ ConstantVelocityFieldTransform<TParametersValueType, VDimension>::CopyDisplaceme
   rval->SetRegions(toCopy->GetLargestPossibleRegion());
   rval->Allocate();
 
-  ImageRegionConstIterator<DisplacementFieldType> dispIt(toCopy, toCopy->GetLargestPossibleRegion());
-  ImageRegionIterator                             cloneDispIt(rval, rval->GetLargestPossibleRegion());
+  ImageRegionConstIterator dispIt(toCopy, toCopy->GetLargestPossibleRegion());
+  ImageRegionIterator      cloneDispIt(rval, rval->GetLargestPossibleRegion());
   for (dispIt.GoToBegin(), cloneDispIt.GoToBegin(); !dispIt.IsAtEnd() && !cloneDispIt.IsAtEnd();
        ++dispIt, ++cloneDispIt)
   {
@@ -343,8 +343,8 @@ ConstantVelocityFieldTransform<TParametersValueType, VDimension>::InternalClone(
 
   // copy the VelocityField
   // SetFixedParameters allocates the VelocityField
-  ImageRegionConstIterator<ConstantVelocityFieldType> thisIt(this->m_ConstantVelocityField,
-                                                             this->m_ConstantVelocityField->GetLargestPossibleRegion());
+  ImageRegionConstIterator thisIt(this->m_ConstantVelocityField,
+                                  this->m_ConstantVelocityField->GetLargestPossibleRegion());
   ImageRegionIterator cloneIt(rval->m_ConstantVelocityField, rval->m_ConstantVelocityField->GetLargestPossibleRegion());
   for (thisIt.GoToBegin(), cloneIt.GoToBegin(); !thisIt.IsAtEnd() && !cloneIt.IsAtEnd(); ++thisIt, ++cloneIt)
   {

--- a/Modules/Filtering/DisplacementField/include/itkExponentialDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkExponentialDisplacementFieldImageFilter.hxx
@@ -88,7 +88,7 @@ ExponentialDisplacementFieldImageFilter<TInputImage, TOutputImage>::GenerateData
       }
     }
 
-    ImageRegionConstIterator<InputImageType> InputIt(inputPtr, inputPtr->GetRequestedRegion());
+    ImageRegionConstIterator InputIt(inputPtr, inputPtr->GetRequestedRegion());
 
     for (InputIt.GoToBegin(); !InputIt.IsAtEnd(); ++InputIt)
     {

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
@@ -229,8 +229,8 @@ VelocityFieldTransform<TParametersValueType, VDimension>::CopyDisplacementField(
   rval->SetRegions(toCopy->GetLargestPossibleRegion());
   rval->Allocate();
 
-  ImageRegionConstIterator<DisplacementFieldType> dispIt(toCopy, toCopy->GetLargestPossibleRegion());
-  ImageRegionIterator                             cloneDispIt(rval, rval->GetLargestPossibleRegion());
+  ImageRegionConstIterator dispIt(toCopy, toCopy->GetLargestPossibleRegion());
+  ImageRegionIterator      cloneDispIt(rval, rval->GetLargestPossibleRegion());
   for (dispIt.GoToBegin(), cloneDispIt.GoToBegin(); !dispIt.IsAtEnd() && !cloneDispIt.IsAtEnd();
        ++dispIt, ++cloneDispIt)
   {
@@ -270,9 +270,8 @@ VelocityFieldTransform<TParametersValueType, VDimension>::InternalClone() const
 
   // copy the VelocityField
   // SetFixedParameters allocates the VelocityField
-  ImageRegionConstIterator<VelocityFieldType> thisIt(this->m_VelocityField,
-                                                     this->m_VelocityField->GetLargestPossibleRegion());
-  ImageRegionIterator cloneIt(rval->m_VelocityField, rval->m_VelocityField->GetLargestPossibleRegion());
+  ImageRegionConstIterator thisIt(this->m_VelocityField, this->m_VelocityField->GetLargestPossibleRegion());
+  ImageRegionIterator      cloneIt(rval->m_VelocityField, rval->m_VelocityField->GetLargestPossibleRegion());
   for (thisIt.GoToBegin(), cloneIt.GoToBegin(); !thisIt.IsAtEnd() && !cloneIt.IsAtEnd(); ++thisIt, ++cloneIt)
   {
     cloneIt.Set(thisIt.Get());

--- a/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.hxx
@@ -190,7 +190,7 @@ ContourDirectedMeanDistanceImageFilter<TInputImage1, TInputImage2>::ThreadedGene
   // the edge of the buffer.
   for (const auto & face : faceList)
   {
-    ImageRegionConstIterator<DistanceMapType> it2(m_DistanceMap, face);
+    ImageRegionConstIterator it2(m_DistanceMap, face);
     bit = ConstNeighborhoodIterator<InputImage1Type>(radius, input, face);
     const unsigned int neighborhoodSize = bit.Size();
 

--- a/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
@@ -154,9 +154,9 @@ void
 DirectedHausdorffDistanceImageFilter<TInputImage1, TInputImage2>::DynamicThreadedGenerateData(
   const RegionType & regionForThread)
 {
-  const auto *                              inputPtr1 = this->GetInput1();
-  ImageRegionConstIterator<TInputImage1>    it1(inputPtr1, regionForThread);
-  ImageRegionConstIterator<DistanceMapType> it2(m_DistanceMap, regionForThread);
+  const auto *             inputPtr1 = this->GetInput1();
+  ImageRegionConstIterator it1(inputPtr1, regionForThread);
+  ImageRegionConstIterator it2(m_DistanceMap, regionForThread);
 
   RealType                 maxDistance{};
   CompensatedSummationType sum = 0.0;

--- a/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
@@ -279,7 +279,7 @@ FastChamferDistanceImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   ImageRegionIterator out(this->GetOutput(), m_RegionToProcess);
 
-  ImageRegionConstIterator<TOutputImage> in(this->GetInput(), m_RegionToProcess);
+  ImageRegionConstIterator in(this->GetInput(), m_RegionToProcess);
 
   for (in.GoToBegin(), out.GoToBegin(); !in.IsAtEnd(); ++in, ++out)
   {

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
@@ -176,8 +176,8 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
   const ImageConstPointer inputPtr = this->GetInput();
   const OutputPointer     outputPtr = this->GetOutput();
 
-  ImageRegionConstIterator<InputImageType> inIt(inputPtr, outputRegionForThread);
-  ImageRegionIterator                      outIt(outputPtr, outputRegionForThread);
+  ImageRegionConstIterator inIt(inputPtr, outputRegionForThread);
+  ImageRegionIterator      outIt(outputPtr, outputRegionForThread);
 
   const PixelType negFarValue = -m_FarValue;
 

--- a/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
@@ -250,8 +250,8 @@ SignedMaurerDistanceMapImageFilter<TInputImage, TOutputImage>::ThreadedGenerateD
 
     const typename OutputImageType::RegionType outputRegion = outputRegionForThread;
 
-    ImageRegionIterator                      Ot(outputPtr, outputRegion);
-    ImageRegionConstIterator<InputImageType> It(m_InputCache, outputRegion);
+    ImageRegionIterator      Ot(outputPtr, outputRegion);
+    ImageRegionConstIterator It(m_InputCache, outputRegion);
 
     Ot.GoToBegin();
     It.GoToBegin();

--- a/Modules/Filtering/GPUSmoothing/include/itkGPUDiscreteGaussianImageFilter.hxx
+++ b/Modules/Filtering/GPUSmoothing/include/itkGPUDiscreteGaussianImageFilter.hxx
@@ -103,7 +103,7 @@ GPUDiscreteGaussianImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
   if (filterDimensionality == 0)
   {
     // no smoothing, copy input to output
-    ImageRegionConstIterator<InputImageType> inIt(localInput, this->GetOutput()->GetRequestedRegion());
+    ImageRegionConstIterator inIt(localInput, this->GetOutput()->GetRequestedRegion());
 
     ImageRegionIterator outIt(output, this->GetOutput()->GetRequestedRegion());
 

--- a/Modules/Filtering/ImageCompare/include/itkSimilarityIndexImageFilter.hxx
+++ b/Modules/Filtering/ImageCompare/include/itkSimilarityIndexImageFilter.hxx
@@ -141,8 +141,8 @@ void
 SimilarityIndexImageFilter<TInputImage1, TInputImage2>::ThreadedGenerateData(const RegionType & outputRegionForThread,
                                                                              ThreadIdType       threadId)
 {
-  ImageRegionConstIterator<TInputImage1> it1(this->GetInput1(), outputRegionForThread);
-  ImageRegionConstIterator<TInputImage2> it2(this->GetInput2(), outputRegionForThread);
+  ImageRegionConstIterator it1(this->GetInput1(), outputRegionForThread);
+  ImageRegionConstIterator it2(this->GetInput2(), outputRegionForThread);
 
   // support progress methods/callbacks
   ProgressReporter progress(this, threadId, outputRegionForThread.GetNumberOfPixels());

--- a/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.hxx
@@ -51,9 +51,9 @@ Hessian3DToVesselnessMeasureImageFilter<TPixel>::GenerateData()
   const typename EigenValueOutputImageType::ConstPointer eigenImage = m_SymmetricEigenValueFilter->GetOutput();
 
   // walk the region of eigen values and get the vesselness measure
-  EigenValueArrayType                                 eigenValue;
-  ImageRegionConstIterator<EigenValueOutputImageType> it(eigenImage, eigenImage->GetRequestedRegion());
-  ImageRegionIterator<OutputImageType>                oit;
+  EigenValueArrayType                  eigenValue;
+  ImageRegionConstIterator             it(eigenImage, eigenImage->GetRequestedRegion());
+  ImageRegionIterator<OutputImageType> oit;
   this->AllocateOutputs();
   oit = ImageRegionIterator<OutputImageType>(output, output->GetRequestedRegion());
   while (!it.IsAtEnd())

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
@@ -64,8 +64,8 @@ HessianToObjectnessMeasureImageFilter<TInputImage, TOutputImage>::DynamicThreade
   const CalculatorType eigenCalculator;
 
   // Walk the region of eigen values and get the objectness measure
-  ImageRegionConstIterator<InputImageType> it(input, outputRegionForThread);
-  ImageRegionIterator                      oit(output, outputRegionForThread);
+  ImageRegionConstIterator it(input, outputRegionForThread);
+  ImageRegionIterator      oit(output, outputRegionForThread);
 
   while (!it.IsAtEnd())
   {

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -161,8 +161,8 @@ HoughTransform2DCirclesImageFilter<TInputPixelType, TOutputPixelType, TRadiusPix
   }
 
   // Compute the average radius
-  ImageRegionConstIterator<OutputImageType> output_it(outputImage, outputImage->GetLargestPossibleRegion());
-  ImageRegionIterator                       radius_it(m_RadiusImage, m_RadiusImage->GetLargestPossibleRegion());
+  ImageRegionConstIterator output_it(outputImage, outputImage->GetLargestPossibleRegion());
+  ImageRegionIterator      radius_it(m_RadiusImage, m_RadiusImage->GetLargestPossibleRegion());
   while (!output_it.IsAtEnd())
   {
     if (output_it.Get() > 1)

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
@@ -196,9 +196,8 @@ HoughTransform2DLinesImageFilter<TInputPixelType, TOutputPixelType>::Simplify()
     ++image_it;
   }
 
-  ImageRegionConstIterator<OutputImageType> accusimple_it(m_SimplifyAccumulator,
-                                                          m_SimplifyAccumulator->GetRequestedRegion());
-  ImageRegionIterator                       accu_it(outputImage, outputImage->GetRequestedRegion());
+  ImageRegionConstIterator accusimple_it(m_SimplifyAccumulator, m_SimplifyAccumulator->GetRequestedRegion());
+  ImageRegionIterator      accu_it(outputImage, outputImage->GetRequestedRegion());
 
   while (!accusimple_it.IsAtEnd())
   {

--- a/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
@@ -137,8 +137,8 @@ MaskFeaturePointSelectionFilter<TImage, TMask, TFeatures>::GenerateData()
   else
   {
     // copy mask into selectionMap
-    ImageRegionConstIterator<MaskType> maskItr(mask, region);
-    ImageRegionIterator                mapItr(selectionMap, region);
+    ImageRegionConstIterator maskItr(mask, region);
+    ImageRegionIterator      mapItr(selectionMap, region);
     for (maskItr.GoToBegin(), mapItr.GoToBegin(); !maskItr.IsAtEnd(); ++maskItr, ++mapItr)
     {
       mapItr.Set(static_cast<MapPixelType>(maskItr.Get()));

--- a/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
@@ -750,8 +750,8 @@ MirrorPadImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
         double decayFactor = 1.0;
 
         // Do the actual copy of the input pixels to the output pixels here.
-        InputImageIndexType                   currentInputIndex;
-        ImageRegionConstIterator<TInputImage> inIt(inputPtr, inputRegion);
+        InputImageIndexType      currentInputIndex;
+        ImageRegionConstIterator inIt(inputPtr, inputRegion);
         for (ImageRegionIteratorWithIndex outIt(outputPtr, outputRegion); !outIt.IsAtEnd(); ++outIt, i++, ++inIt)
         {
           OutputImageIndexType currentOutputIndex = outIt.GetIndex();

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
@@ -291,7 +291,7 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::DynamicThreadedG
   if (this->m_DefFieldSameInformation)
   {
     // iterator for the deformation field
-    ImageRegionConstIterator<DisplacementFieldType> fieldIt(fieldPtr, outputRegionForThread);
+    ImageRegionConstIterator fieldIt(fieldPtr, outputRegionForThread);
 
     while (!outputIt.IsAtEnd())
     {

--- a/Modules/Filtering/ImageIntensity/include/itkDiscreteGaussianDerivativeImageFunction.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkDiscreteGaussianDerivativeImageFunction.hxx
@@ -135,7 +135,7 @@ DiscreteGaussianDerivativeImageFunction<TInputImage, TOutput>::RecomputeGaussian
   m_DerivativeKernel.SetRadius(m_OperatorArray[0].GetRadius()[0]);
 
   // Copy kernel image to neighborhood. Do not copy boundaries.
-  ImageRegionConstIterator<KernelImageType> it(kernelImage, kernelRegion);
+  ImageRegionConstIterator it(kernelImage, kernelRegion);
   it.GoToBegin();
   unsigned int idx = 0;
 

--- a/Modules/Filtering/ImageIntensity/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
@@ -157,7 +157,7 @@ DiscreteGradientMagnitudeGaussianImageFunction<TInputImage, TOutput>::RecomputeG
     m_KernelArray[i].SetRadius(maxRadius);
 
     // Copy kernel image to neighborhood. Do not copy boundaries.
-    ImageRegionConstIterator<KernelImageType> it(kernelImage, kernelRegion);
+    ImageRegionConstIterator it(kernelImage, kernelRegion);
     it.GoToBegin();
     unsigned int idx = 0;
 

--- a/Modules/Filtering/ImageIntensity/include/itkDiscreteHessianGaussianImageFunction.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkDiscreteHessianGaussianImageFunction.hxx
@@ -163,7 +163,7 @@ DiscreteHessianGaussianImageFunction<TInputImage, TOutput>::RecomputeGaussianKer
       m_KernelArray[kernelidx].SetRadius(maxRadius);
 
       // Copy kernel image to neighborhood. Do not copy boundaries.
-      ImageRegionConstIterator<KernelImageType> it(kernelImage, kernelRegion);
+      ImageRegionConstIterator it(kernelImage, kernelRegion);
       it.GoToBegin();
       unsigned int idx = 0;
       while (!it.IsAtEnd())

--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
@@ -322,8 +322,8 @@ HistogramMatchingImageFilter<TInputImage, TOutputImage, THistogramMeasurement>::
 
   // Transform the source image and write to output.
 
-  ImageRegionConstIterator<InputImageType> inIter(input, outputRegionForThread);
-  ImageRegionIterator                      outIter(output, outputRegionForThread);
+  ImageRegionConstIterator inIter(input, outputRegionForThread);
+  ImageRegionIterator      outIter(output, outputRegionForThread);
 
   for (SizeValueType i = 0; !outIter.IsAtEnd(); ++inIter, ++outIter, i++)
   {
@@ -366,7 +366,7 @@ HistogramMatchingImageFilter<TInputImage, TOutputImage, THistogramMeasurement>::
   THistogramMeasurement & maxValue,
   THistogramMeasurement & meanValue)
 {
-  ImageRegionConstIterator<InputImageType> iter(image, image->GetBufferedRegion());
+  ImageRegionConstIterator iter(image, image->GetBufferedRegion());
 
   double        sum = 0.0;
   SizeValueType count = 0;
@@ -436,7 +436,7 @@ HistogramMatchingImageFilter<TInputImage, TOutputImage, THistogramMeasurement>::
 
   {
     // put each image pixel into the histogram
-    ImageRegionConstIterator<InputImageType> iter(image, image->GetBufferedRegion());
+    ImageRegionConstIterator iter(image, image->GetBufferedRegion());
 
     iter.GoToBegin();
     while (!iter.IsAtEnd())

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
@@ -211,8 +211,8 @@ PolylineMask2DImageFilter<TInputImage, TPolyline, TOutputImage>::GenerateData()
   }
 
   /* Mask the input image with the mask generated */
-  ImageRegionConstIterator<TInputImage> inputI(inputImagePtr, inputImagePtr->GetLargestPossibleRegion());
-  ImageRegionIterator                   outputI(outputImagePtr, outputImagePtr->GetLargestPossibleRegion());
+  ImageRegionConstIterator inputI(inputImagePtr, inputImagePtr->GetLargestPossibleRegion());
+  ImageRegionIterator      outputI(outputImagePtr, outputImagePtr->GetLargestPossibleRegion());
   while (!outputI.IsAtEnd())
   {
     if (outputI.Get() == f_val)

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -172,8 +172,8 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Generate
   outputImagePtr->SetLargestPossibleRegion(inputImagePtr->GetLargestPossibleRegion());
   outputImagePtr->AllocateInitialized();
 
-  ImageRegionConstIterator<TInputImage> inputIt(inputImagePtr, inputImagePtr->GetLargestPossibleRegion());
-  ImageRegionIterator                   outputIt(outputImagePtr, outputImagePtr->GetLargestPossibleRegion());
+  ImageRegionConstIterator inputIt(inputImagePtr, inputImagePtr->GetLargestPossibleRegion());
+  ImageRegionIterator      outputIt(outputImagePtr, outputImagePtr->GetLargestPossibleRegion());
 
   using InterpolatorType = NearestNeighborInterpolateImageFunction<TInputImage, double>;
   using InterpolatorPointType = typename InterpolatorType::PointType;

--- a/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.hxx
@@ -53,7 +53,7 @@ VectorRescaleIntensityImageFilter<TInputImage, TOutputImage>::BeforeThreadedGene
   const InputImagePointer inputImage = this->GetInput();
 
 
-  ImageRegionConstIterator<InputImageType> it(inputImage, inputImage->GetBufferedRegion());
+  ImageRegionConstIterator it(inputImage, inputImage->GetBufferedRegion());
 
   InputRealType maximumSquaredMagnitude{};
 

--- a/Modules/Filtering/ImageNoise/test/itkPeakSignalToNoiseRatioCalculator.hxx
+++ b/Modules/Filtering/ImageNoise/test/itkPeakSignalToNoiseRatioCalculator.hxx
@@ -52,8 +52,8 @@ PeakSignalToNoiseRatioCalculator<TInputImage>::Compute()
     return;
   }
 
-  ImageRegionConstIterator<InputImageType> iIt(m_Image, m_Image->GetRequestedRegion());
-  ImageRegionConstIterator<InputImageType> nIt(m_NoisyImage, m_NoisyImage->GetRequestedRegion());
+  ImageRegionConstIterator iIt(m_Image, m_Image->GetRequestedRegion());
+  ImageRegionConstIterator nIt(m_NoisyImage, m_NoisyImage->GetRequestedRegion());
 
   // init the values
   double         mse = 0;

--- a/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
@@ -180,7 +180,7 @@ AccumulateImageFilter<TInputImage, TOutputImage>::GenerateData()
       }
     }
     const typename TInputImage::RegionType AccumulatedRegion(AccumulatedIndex, AccumulatedSize);
-    ImageRegionConstIterator<TInputImage>  inputIter(inputImage, AccumulatedRegion);
+    ImageRegionConstIterator               inputIter(inputImage, AccumulatedRegion);
     inputIter.GoToBegin();
     AccumulateType Value{};
     while (!inputIter.IsAtEnd())

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.hxx
@@ -75,8 +75,8 @@ ImagePCADecompositionCalculator<TInputImage, TBasisImage>::CalculateBasisMatrix(
       itkExceptionStringMacro("All basis images must be the same size!");
     }
 
-    ImageRegionConstIterator<BasisImageType> image_it(*basis_it, (*basis_it)->GetRequestedRegion());
-    int                                      j = 0;
+    ImageRegionConstIterator image_it(*basis_it, (*basis_it)->GetRequestedRegion());
+    int                      j = 0;
     for (image_it.GoToBegin(); !image_it.IsAtEnd(); ++image_it)
     {
       m_BasisMatrix(i, j++) = image_it.Get();
@@ -96,8 +96,8 @@ ImagePCADecompositionCalculator<TInputImage, TBasisImage>::CalculateRecenteredIm
     itkExceptionStringMacro("Input image must be the same size as the basis images!");
   }
 
-  ImageRegionConstIterator<InputImageType> image_it(m_Image, m_Image->GetRequestedRegion());
-  typename BasisVectorType::iterator       vector_it;
+  ImageRegionConstIterator           image_it(m_Image, m_Image->GetRequestedRegion());
+  typename BasisVectorType::iterator vector_it;
   for (image_it.GoToBegin(), vector_it = m_ImageAsVector.begin(); !image_it.IsAtEnd(); ++image_it, ++vector_it)
   {
     *vector_it = static_cast<BasisPixelType>(image_it.Get());
@@ -105,7 +105,7 @@ ImagePCADecompositionCalculator<TInputImage, TBasisImage>::CalculateRecenteredIm
 
   if (m_MeanImage)
   {
-    ImageRegionConstIterator<BasisImageType> mimage_it(m_MeanImage, m_MeanImage->GetRequestedRegion());
+    ImageRegionConstIterator mimage_it(m_MeanImage, m_MeanImage->GetRequestedRegion());
     for (mimage_it.GoToBegin(), vector_it = m_ImageAsVector.begin(); !mimage_it.IsAtEnd(); ++mimage_it, ++vector_it)
     {
       *vector_it -= (mimage_it.Get());

--- a/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.hxx
@@ -80,8 +80,8 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::ThreadedStreamedGenerateData(const
 
   MapType localStatistics;
 
-  ImageRegionConstIterator<LabelImageType> itS(this->GetSourceImage(), outputRegionForThread);
-  ImageRegionConstIterator<LabelImageType> itT(this->GetTargetImage(), outputRegionForThread);
+  ImageRegionConstIterator itS(this->GetSourceImage(), outputRegionForThread);
+  ImageRegionConstIterator itT(this->GetTargetImage(), outputRegionForThread);
 
   // Support progress methods/callbacks
   TotalProgressReporter progress(this, this->GetSourceImage()->GetLargestPossibleRegion().GetNumberOfPixels());

--- a/Modules/Filtering/LabelMap/include/itkLabelMapToBinaryImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapToBinaryImageFilter.hxx
@@ -98,8 +98,8 @@ LabelMapToBinaryImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateD
   if (this->GetNumberOfIndexedInputs() == 2)
   {
     // fill the background with the background values from the background image
-    ImageRegionConstIterator<OutputImageType> bgIt(this->GetBackgroundImage(), outputRegionForThread);
-    ImageRegionIterator                       oIt(output, outputRegionForThread);
+    ImageRegionConstIterator bgIt(this->GetBackgroundImage(), outputRegionForThread);
+    ImageRegionIterator      oIt(output, outputRegionForThread);
 
     bgIt.GoToBegin();
     oIt.GoToBegin();

--- a/Modules/Filtering/MathematicalMorphology/include/itkClosingByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkClosingByReconstructionImageFilter.hxx
@@ -89,10 +89,10 @@ ClosingByReconstructionImageFilter<TInputImage, TOutputImage, TKernel>::Generate
 
     tempImage->Allocate();
 
-    ImageRegionConstIterator<TInputImage> inputIt(this->GetInput(), dilate->GetOutput()->GetBufferedRegion());
-    ImageRegionConstIterator<TInputImage> dilateIt(dilate->GetOutput(), erode->GetOutput()->GetBufferedRegion());
-    ImageRegionConstIterator<TInputImage> erodeIt(erode->GetOutput(), erode->GetOutput()->GetBufferedRegion());
-    ImageRegionIterator                   tempIt(tempImage, dilate->GetOutput()->GetBufferedRegion());
+    ImageRegionConstIterator inputIt(this->GetInput(), dilate->GetOutput()->GetBufferedRegion());
+    ImageRegionConstIterator dilateIt(dilate->GetOutput(), erode->GetOutput()->GetBufferedRegion());
+    ImageRegionConstIterator erodeIt(erode->GetOutput(), erode->GetOutput()->GetBufferedRegion());
+    ImageRegionIterator      tempIt(tempImage, dilate->GetOutput()->GetBufferedRegion());
     while (!dilateIt.IsAtEnd())
     {
       if (dilateIt.Get() == erodeIt.Get())

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
@@ -199,8 +199,8 @@ GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::GenerateData()
 
     // Check for convergence.  Compare the output of the single
     // iteration of the algorithm with the current marker image.
-    ImageRegionConstIterator<TInputImage> singleInIt(singleIteration->GetMarkerImage(),
-                                                     singleIteration->GetOutput()->GetRequestedRegion());
+    ImageRegionConstIterator singleInIt(singleIteration->GetMarkerImage(),
+                                        singleIteration->GetOutput()->GetRequestedRegion());
     ImageRegionIterator singleOutIt(singleIteration->GetOutput(), singleIteration->GetOutput()->GetRequestedRegion());
 
     done = true;

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
@@ -199,8 +199,8 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::GenerateData()
 
     // Check for convergence.  Compare the output of the single
     // iteration of the algorithm with the current marker image.
-    ImageRegionConstIterator<TInputImage> singleInIt(singleIteration->GetMarkerImage(),
-                                                     singleIteration->GetOutput()->GetRequestedRegion());
+    ImageRegionConstIterator singleInIt(singleIteration->GetMarkerImage(),
+                                        singleIteration->GetOutput()->GetRequestedRegion());
     ImageRegionIterator singleOutIt(singleIteration->GetOutput(), singleIteration->GetOutput()->GetRequestedRegion());
 
     done = true;
@@ -286,9 +286,9 @@ GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGen
   //
   for (const auto & face : faceList)
   {
-    NeighborhoodIteratorType              markerIt(kernelRadius, this->GetMarkerImage(), face);
-    ImageRegionConstIterator<TInputImage> maskIt(this->GetMaskImage(), face);
-    ImageRegionIterator                   oIt(this->GetOutput(), face);
+    NeighborhoodIteratorType markerIt(kernelRadius, this->GetMarkerImage(), face);
+    ImageRegionConstIterator maskIt(this->GetMaskImage(), face);
+    ImageRegionIterator      oIt(this->GetOutput(), face);
 
     markerIt.OverrideBoundaryCondition(&BC);
     markerIt.GoToBegin();

--- a/Modules/Filtering/MathematicalMorphology/include/itkOpeningByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkOpeningByReconstructionImageFilter.hxx
@@ -90,10 +90,10 @@ OpeningByReconstructionImageFilter<TInputImage, TOutputImage, TKernel>::Generate
 
     tempImage->Allocate();
 
-    ImageRegionConstIterator<TInputImage> inputIt(this->GetInput(), erode->GetOutput()->GetBufferedRegion());
-    ImageRegionConstIterator<TInputImage> erodeIt(erode->GetOutput(), erode->GetOutput()->GetBufferedRegion());
-    ImageRegionConstIterator<TInputImage> dilateIt(dilate->GetOutput(), erode->GetOutput()->GetBufferedRegion());
-    ImageRegionIterator                   tempIt(tempImage, erode->GetOutput()->GetBufferedRegion());
+    ImageRegionConstIterator inputIt(this->GetInput(), erode->GetOutput()->GetBufferedRegion());
+    ImageRegionConstIterator erodeIt(erode->GetOutput(), erode->GetOutput()->GetBufferedRegion());
+    ImageRegionConstIterator dilateIt(dilate->GetOutput(), erode->GetOutput()->GetBufferedRegion());
+    ImageRegionIterator      tempIt(tempImage, erode->GetOutput()->GetBufferedRegion());
     while (!erodeIt.IsAtEnd())
     {
       if (erodeIt.Get() == dilateIt.Get())

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.hxx
@@ -70,8 +70,8 @@ ValuedRegionalExtremaImageFilter<TInputImage, TOutputImage, TFunction1, TFunctio
 
   // copy input to output - isn't there a better way?
 
-  ImageRegionConstIterator<TInputImage> inIt(input, output->GetRequestedRegion());
-  ImageRegionIterator                   outIt(output, output->GetRequestedRegion());
+  ImageRegionConstIterator inIt(input, output->GetRequestedRegion());
+  ImageRegionIterator      outIt(output, output->GetRequestedRegion());
 
   const InputImagePixelType firstValue = inIt.Get();
   this->m_Flat = true;

--- a/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
@@ -123,8 +123,8 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
     this, 0, (outputPtr->GetRequestedRegion().GetNumberOfPixels()) * m_Repetitions * 2 * NDimensions);
 
   // Copy the input image to the temporary image
-  ImageRegionIteratorWithIndex          tempIt(tempPtr, tempPtr->GetRequestedRegion());
-  ImageRegionConstIterator<TInputImage> inputIt(inputPtr, inputPtr->GetRequestedRegion());
+  ImageRegionIteratorWithIndex tempIt(tempPtr, tempPtr->GetRequestedRegion());
+  ImageRegionConstIterator     inputIt(inputPtr, inputPtr->GetRequestedRegion());
 
   for (inputIt.GoToBegin(), tempIt.GoToBegin(); !tempIt.IsAtEnd(); ++tempIt, ++inputIt)
   {

--- a/Modules/Nonunit/Review/include/itkGridForwardWarpImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkGridForwardWarpImageFilter.hxx
@@ -55,7 +55,7 @@ GridForwardWarpImageFilter<TDisplacementField, TOutputImage>::GenerateData()
   ImageRegionIteratorWithIndex iter(outputPtr, outputPtr->GetRequestedRegion());
 
   // Iterator for the deformation field
-  ImageRegionConstIterator<DisplacementFieldType> fieldIt(fieldPtr, outputPtr->GetRequestedRegion());
+  ImageRegionConstIterator fieldIt(fieldPtr, outputPtr->GetRequestedRegion());
 
   // Bresenham line iterator
   using LineIteratorType = LineIterator<OutputImageType>;

--- a/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.hxx
@@ -58,8 +58,8 @@ MultiphaseDenseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputIm
       itkExceptionStringMacro("Either input and/or output is nullptr.");
     }
 
-    ImageRegionConstIterator<InputImageType> in(input, input->GetBufferedRegion());
-    ImageRegionIterator                      out(output, region);
+    ImageRegionConstIterator in(input, input->GetBufferedRegion());
+    ImageRegionIterator      out(output, region);
 
     // Fill the output pointer
     auto p = static_cast<OutputPixelType>(this->m_Lookup[i]);

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
@@ -1120,8 +1120,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
   {
     SparseDataStruct * sparsePtr = this->m_SparseData[fId];
 
-    ImageRegionConstIterator<StatusImageType> statusIt(sparsePtr->m_StatusImage,
-                                                       this->m_LevelSet[fId]->GetRequestedRegion());
+    ImageRegionConstIterator statusIt(sparsePtr->m_StatusImage, this->m_LevelSet[fId]->GetRequestedRegion());
 
     ImageRegionIterator outputIt(this->m_LevelSet[fId], this->m_LevelSet[fId]->GetRequestedRegion());
 

--- a/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdCalculator.hxx
+++ b/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdCalculator.hxx
@@ -37,8 +37,8 @@ RobustAutomaticThresholdCalculator<TInputImage, TGradientImage>::Compute()
     itkExceptionStringMacro("Input or gradient image(s) not set.");
   }
 
-  ImageRegionConstIterator<InputImageType>    iIt(m_Input, m_Input->GetRequestedRegion());
-  ImageRegionConstIterator<GradientImageType> gIt(m_Gradient, m_Gradient->GetRequestedRegion());
+  ImageRegionConstIterator iIt(m_Input, m_Input->GetRequestedRegion());
+  ImageRegionConstIterator gIt(m_Gradient, m_Gradient->GetRequestedRegion());
 
   // Init the values
   double n = 0;

--- a/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.hxx
+++ b/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.hxx
@@ -136,9 +136,9 @@ EigenAnalysis2DImageFilter<TInputImage, TEigenValueImage, TEigenVectorImage>::Ge
 
   const EigenValueImageRegionType region = outputPtr1->GetRequestedRegion();
 
-  ImageRegionConstIterator<TInputImage> inputIt1(inputPtr1, region);
-  ImageRegionConstIterator<TInputImage> inputIt2(inputPtr2, region);
-  ImageRegionConstIterator<TInputImage> inputIt3(inputPtr3, region);
+  ImageRegionConstIterator inputIt1(inputPtr1, region);
+  ImageRegionConstIterator inputIt2(inputPtr2, region);
+  ImageRegionConstIterator inputIt3(inputPtr3, region);
 
   ImageRegionIterator outputIt1(outputPtr1, region);
   ImageRegionIterator outputIt2(outputPtr2, region);

--- a/Modules/Numerics/Statistics/include/itkImageClassifierFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageClassifierFilter.hxx
@@ -146,8 +146,8 @@ ImageClassifierFilter<TSample, TInputImage, TOutputImage>::GenerateData()
   outputImage->SetRegions(inputImage->GetBufferedRegion());
   outputImage->Allocate();
 
-  ImageRegionConstIterator<InputImageType> inpItr(inputImage, inputImage->GetBufferedRegion());
-  ImageRegionIterator                      outItr(outputImage, outputImage->GetBufferedRegion());
+  ImageRegionConstIterator inpItr(inputImage, inputImage->GetBufferedRegion());
+  ImageRegionIterator      outItr(outputImage, outputImage->GetBufferedRegion());
 
   inpItr.GoToBegin();
   outItr.GoToBegin();

--- a/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.hxx
@@ -199,7 +199,7 @@ ImageToHistogramFilter<TImage>::ThreadedComputeMinimumAndMaximum(const RegionTyp
   HistogramMeasurementVectorType min(nbOfComponents);
   HistogramMeasurementVectorType max(nbOfComponents);
 
-  ImageRegionConstIterator<TImage> inputIt(this->GetInput(), inputRegionForThread);
+  ImageRegionConstIterator inputIt(this->GetInput(), inputRegionForThread);
   inputIt.GoToBegin();
   HistogramMeasurementVectorType m(nbOfComponents);
 
@@ -238,7 +238,7 @@ ImageToHistogramFilter<TImage>::ThreadedStreamedGenerateData(const RegionType & 
   histogram->Initialize(outputHistogram->GetSize(), m_Minimum, m_Maximum);
 
 
-  ImageRegionConstIterator<TImage> inputIt(this->GetInput(), inputRegionForThread);
+  ImageRegionConstIterator inputIt(this->GetInput(), inputRegionForThread);
   inputIt.GoToBegin();
   HistogramMeasurementVectorType m(nbOfComponents);
 

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleFilter.hxx
@@ -124,12 +124,12 @@ ImageToListSampleFilter<TImage, TMaskImage>::GenerateData()
 
   output->Clear();
 
-  ImageRegionConstIterator<ImageType> it(input, input->GetBufferedRegion());
+  ImageRegionConstIterator it(input, input->GetBufferedRegion());
   it.GoToBegin();
 
   if (maskImage) // mask specified
   {
-    ImageRegionConstIterator<MaskImageType> mit(maskImage, maskImage->GetBufferedRegion());
+    ImageRegionConstIterator mit(maskImage, maskImage->GetBufferedRegion());
     mit.GoToBegin();
     while (!it.IsAtEnd())
     {

--- a/Modules/Numerics/Statistics/include/itkMaskedImageToHistogramFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkMaskedImageToHistogramFilter.hxx
@@ -41,8 +41,8 @@ MaskedImageToHistogramFilter<TImage, TMaskImage>::ThreadedComputeMinimumAndMaxim
 
   const MaskPixelType maskValue = this->GetMaskValue();
 
-  ImageRegionConstIterator<TImage>     inputIt(this->GetInput(), inputRegionForThread);
-  ImageRegionConstIterator<TMaskImage> maskIt(this->GetMaskImage(), inputRegionForThread);
+  ImageRegionConstIterator inputIt(this->GetInput(), inputRegionForThread);
+  ImageRegionConstIterator maskIt(this->GetMaskImage(), inputRegionForThread);
   inputIt.GoToBegin();
   maskIt.GoToBegin();
   HistogramMeasurementVectorType m(nbOfComponents);
@@ -84,8 +84,8 @@ MaskedImageToHistogramFilter<TImage, TMaskImage>::ThreadedStreamedGenerateData(c
   histogram->SetMeasurementVectorSize(nbOfComponents);
   histogram->Initialize(outputHistogram->GetSize(), this->m_Minimum, this->m_Maximum);
 
-  ImageRegionConstIterator<TImage>     inputIt(this->GetInput(), inputRegionForThread);
-  ImageRegionConstIterator<TMaskImage> maskIt(this->GetMaskImage(), inputRegionForThread);
+  ImageRegionConstIterator inputIt(this->GetInput(), inputRegionForThread);
+  ImageRegionConstIterator maskIt(this->GetMaskImage(), inputRegionForThread);
   inputIt.GoToBegin();
   maskIt.GoToBegin();
   HistogramMeasurementVectorType m(nbOfComponents);

--- a/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
@@ -203,8 +203,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMovedGra
   for (iDimension = 0; iDimension < FixedImageDimension; ++iDimension)
   {
 
-    ImageRegionConstIterator<MovedGradientImageType> iterate(m_MovedSobelFilters[iDimension]->GetOutput(),
-                                                             this->GetFixedImageRegion());
+    ImageRegionConstIterator iterate(m_MovedSobelFilters[iDimension]->GetOutput(), this->GetFixedImageRegion());
 
     gradient = iterate.Get();
 
@@ -242,8 +241,7 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeVariance
   for (iDimension = 0; iDimension < FixedImageDimension; ++iDimension)
   {
 
-    ImageRegionConstIterator<FixedGradientImageType> iterate(m_FixedSobelFilters[iDimension]->GetOutput(),
-                                                             this->GetFixedImageRegion());
+    ImageRegionConstIterator iterate(m_FixedSobelFilters[iDimension]->GetOutput(), this->GetFixedImageRegion());
 
     // Calculate the mean gradients
 
@@ -330,12 +328,10 @@ GradientDifferenceImageToImageMetric<TFixedImage, TMovingImage>::ComputeMeasure(
     MovedGradientPixelType diff;
 
 
-    ImageRegionConstIterator<FixedGradientImageType> fixedIterator(m_FixedSobelFilters[iDimension]->GetOutput(),
-                                                                   this->GetFixedImageRegion());
+    ImageRegionConstIterator fixedIterator(m_FixedSobelFilters[iDimension]->GetOutput(), this->GetFixedImageRegion());
 
 
-    ImageRegionConstIterator<MovedGradientImageType> movedIterator(m_MovedSobelFilters[iDimension]->GetOutput(),
-                                                                   this->GetFixedImageRegion());
+    ImageRegionConstIterator movedIterator(m_MovedSobelFilters[iDimension]->GetOutput(), this->GetFixedImageRegion());
 
     m_FixedSobelFilters[iDimension]->UpdateLargestPossibleRegion();
     m_MovedSobelFilters[iDimension]->UpdateLargestPossibleRegion();

--- a/Modules/Registration/Common/include/itkHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkHistogramImageToImageMetric.hxx
@@ -87,8 +87,8 @@ HistogramImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
   if (!m_LowerBoundSetByUser || !m_UpperBoundSetByUser)
   {
     // Calculate min and max image values in fixed image.
-    const FixedImageConstPointerType         pFixedImage = this->m_FixedImage;
-    ImageRegionConstIterator<FixedImageType> fiIt(pFixedImage, pFixedImage->GetBufferedRegion());
+    const FixedImageConstPointerType pFixedImage = this->m_FixedImage;
+    ImageRegionConstIterator         fiIt(pFixedImage, pFixedImage->GetBufferedRegion());
     fiIt.GoToBegin();
     FixedImagePixelType minFixed = fiIt.Value();
     FixedImagePixelType maxFixed = fiIt.Value();
@@ -110,8 +110,8 @@ HistogramImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
     }
 
     // Calculate min and max image values in moving image.
-    const MovingImageConstPointerType         pMovingImage = this->m_MovingImage;
-    ImageRegionConstIterator<MovingImageType> miIt(pMovingImage, pMovingImage->GetBufferedRegion());
+    const MovingImageConstPointerType pMovingImage = this->m_MovingImage;
+    ImageRegionConstIterator          miIt(pMovingImage, pMovingImage->GetBufferedRegion());
     miIt.GoToBegin();
     MovingImagePixelType minMoving = miIt.Value();
     MovingImagePixelType maxMoving = miIt.Value();

--- a/Modules/Registration/Common/include/itkTimeVaryingBSplineVelocityFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkTimeVaryingBSplineVelocityFieldTransformParametersAdaptor.hxx
@@ -308,9 +308,9 @@ TimeVaryingBSplineVelocityFieldTransformParametersAdaptor<TTransform>::AdaptTran
     decompositionFilter->SetInput(upsampler->GetOutput());
     decompositionFilter->Update();
 
-    ImageRegionConstIterator<ComponentImageType> ItD(decompositionFilter->GetOutput(),
-                                                     decompositionFilter->GetOutput()->GetLargestPossibleRegion());
-    ImageRegionIterator                          ItL(requiredLattice, requiredLattice->GetLargestPossibleRegion());
+    ImageRegionConstIterator ItD(decompositionFilter->GetOutput(),
+                                 decompositionFilter->GetOutput()->GetLargestPossibleRegion());
+    ImageRegionIterator      ItL(requiredLattice, requiredLattice->GetLargestPossibleRegion());
 
     for (ItD.GoToBegin(), ItL.GoToBegin(); !ItD.IsAtEnd(); ++ItD, ++ItL)
     {

--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
@@ -647,9 +647,7 @@ typename SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform,
   typename DisplacementFieldType::SpacingType spacing = updateField->GetSpacing();
 
   RealType maxNorm = NumericTraits<RealType>::NonpositiveMin();
-  for (ImageRegionConstIterator<DisplacementFieldType> ItF(updateField, updateField->GetLargestPossibleRegion());
-       !ItF.IsAtEnd();
-       ++ItF)
+  for (ImageRegionConstIterator ItF(updateField, updateField->GetLargestPossibleRegion()); !ItF.IsAtEnd(); ++ItF)
   {
     DisplacementVectorType vector = ItF.Get();
 

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
@@ -73,7 +73,6 @@ BayesianClassifierInitializationImageFilter<TInputImage, TProbabilityPrecisionTy
 {
   // Typedefs for the KMeans filter, Covariance calculator...
   using KMeansFilterType = ScalarImageKmeansImageFilter<InputImageType>;
-  using KMeansOutputImageType = typename KMeansFilterType::OutputImageType;
 
   using CovarianceArrayType = Array<double>;
   using ClassCountArrayType = Array<double>;
@@ -111,24 +110,23 @@ BayesianClassifierInitializationImageFilter<TInputImage, TProbabilityPrecisionTy
 
   // find class covariances from the kmeans output to initialize the gaussian
   // density functions.
-  ImageRegionConstIterator<KMeansOutputImageType> itrKMeansImage(kmeansFilter->GetOutput(),
-                                                                 kmeansFilter->GetOutput()->GetBufferedRegion());
-  CovarianceArrayType                             sumsOfSquares(m_NumberOfClasses); // sum of the
-                                                                                    // square
-                                                                                    // intensities
-                                                                                    // for each
-                                                                                    // class
-  CovarianceArrayType sums(m_NumberOfClasses);                                      // sum of the
-                                                                                    // intensities
-                                                                                    // for each
-                                                                                    // class
-  ClassCountArrayType classCount(m_NumberOfClasses);                                // m_Number of
-                                                                                    // pixels
-                                                                                    // belonging to
-                                                                                    // each class
-  CovarianceArrayType estimatedCovariances(m_NumberOfClasses);                      // covariance
-                                                                                    // of each
-                                                                                    // class
+  ImageRegionConstIterator itrKMeansImage(kmeansFilter->GetOutput(), kmeansFilter->GetOutput()->GetBufferedRegion());
+  CovarianceArrayType      sumsOfSquares(m_NumberOfClasses);   // sum of the
+                                                               // square
+                                                               // intensities
+                                                               // for each
+                                                               // class
+  CovarianceArrayType sums(m_NumberOfClasses);                 // sum of the
+                                                               // intensities
+                                                               // for each
+                                                               // class
+  ClassCountArrayType classCount(m_NumberOfClasses);           // m_Number of
+                                                               // pixels
+                                                               // belonging to
+                                                               // each class
+  CovarianceArrayType estimatedCovariances(m_NumberOfClasses); // covariance
+                                                               // of each
+                                                               // class
 
   // initialize the arrays
   sumsOfSquares.Fill(0.0);

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.hxx
@@ -87,8 +87,8 @@ ConnectedComponentFunctorImageFilter<TInputImage, TOutputImage, TFunctor, TMaskI
 
   // along with a neighborhood iterator on the output, use a standard
   // iterator on the input and output
-  ImageRegionConstIterator<InputImageType> it(input, output->GetRequestedRegion());
-  ImageRegionIterator                      oit(output, output->GetRequestedRegion());
+  ImageRegionConstIterator it(input, output->GetRequestedRegion());
+  ImageRegionIterator      oit(output, output->GetRequestedRegion());
 
   // Setup a progress reporter.  We have 2 stages to the algorithm so
   // pretend we have 2 times the number of pixels
@@ -97,7 +97,7 @@ ConnectedComponentFunctorImageFilter<TInputImage, TOutputImage, TFunctor, TMaskI
   // if the mask is set mark pixels not under the mask as background
   if (const typename TMaskImage::ConstPointer mask = this->GetMaskImage())
   {
-    ImageRegionConstIterator<MaskImageType> mit(mask, output->GetRequestedRegion());
+    ImageRegionConstIterator mit(mask, output->GetRequestedRegion());
 
     mit.GoToBegin();
     oit.GoToBegin();

--- a/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
@@ -45,8 +45,8 @@ HardConnectedComponentImageFilter<TInputImage, TOutputImage>::GenerateData()
   output->SetRegions(region);
   output->Allocate();
 
-  ImageRegionConstIterator<TInputImage> it(input, input->GetRequestedRegion());
-  ImageRegionIteratorWithIndex          ot(output, output->GetRequestedRegion());
+  ImageRegionConstIterator     it(input, input->GetRequestedRegion());
+  ImageRegionIteratorWithIndex ot(output, output->GetRequestedRegion());
 
   ProgressReporter progress(this, 0, output->GetRequestedRegion().GetNumberOfPixels());
   it.GoToBegin();

--- a/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
@@ -46,8 +46,8 @@ LabelVotingImageFilter<TInputImage, TOutputImage>::ComputeMaximumInputValue() ->
 
   for (size_t i = 0; i < numberOfInputIndexes; ++i)
   {
-    const InputImageType *                inputImage = this->GetInput(i);
-    ImageRegionConstIterator<TInputImage> it(inputImage, inputImage->GetBufferedRegion());
+    const InputImageType *   inputImage = this->GetInput(i);
+    ImageRegionConstIterator it(inputImage, inputImage->GetBufferedRegion());
     for (it.GoToBegin(); !it.IsAtEnd(); ++it)
     {
       maxLabel = std::max(maxLabel, it.Get());

--- a/Modules/Segmentation/LevelSets/include/itkExtensionVelocitiesImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkExtensionVelocitiesImageFilter.hxx
@@ -145,8 +145,8 @@ ExtensionVelocitiesImageFilter<TLevelSet, TAuxValue, VAuxDimension>::GenerateDat
   // define iterators
   using LocalLevelSetImageType = typename LevelSetType::LevelSetImageType;
 
-  ImageRegionConstIterator<LocalLevelSetImageType> inputIt(inputPtr, inputPtr->GetBufferedRegion());
-  ImageRegionIterator                              outputIt(outputPtr, outputPtr->GetBufferedRegion());
+  ImageRegionConstIterator inputIt(inputPtr, inputPtr->GetBufferedRegion());
+  ImageRegionIterator      outputIt(outputPtr, outputPtr->GetBufferedRegion());
 
   ImageRegionIterator<LocalLevelSetImageType> tempIt;
 
@@ -275,9 +275,7 @@ ExtensionVelocitiesImageFilter<TLevelSet, TAuxValue, VAuxDimension>::GenerateDat
   const double inputBandwidth = this->GetInputNarrowBandwidth();
 
   // define iterators
-  using LocalLevelSetImageType = typename LevelSetType::LevelSetImageType;
-
-  ImageRegionConstIterator<LocalLevelSetImageType> inputIt(inputPtr, inputPtr->GetBufferedRegion());
+  ImageRegionConstIterator inputIt(inputPtr, inputPtr->GetBufferedRegion());
 
   ImageRegionIterator outputIt(outputPtr, outputPtr->GetBufferedRegion());
 

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
@@ -119,7 +119,7 @@ void
 LevelSetNeighborhoodExtractor<TLevelSet>::GenerateDataFull()
 {
 
-  ImageRegionConstIterator<LevelSetImageType> inIt(m_InputLevelSet, m_InputLevelSet->GetBufferedRegion());
+  ImageRegionConstIterator inIt(m_InputLevelSet, m_InputLevelSet->GetBufferedRegion());
 
   IndexType inputIndex;
 

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -622,11 +622,11 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::InitializeBac
   const ValueType outside_value = (max_layer + 1) * m_ConstantGradientValue;
   const ValueType inside_value = -(max_layer + 1) * m_ConstantGradientValue;
 
-  ImageRegionConstIterator<StatusImageType> statusIt(m_StatusImage, this->GetOutput()->GetRequestedRegion());
+  ImageRegionConstIterator statusIt(m_StatusImage, this->GetOutput()->GetRequestedRegion());
 
   ImageRegionIterator outputIt(this->GetOutput(), this->GetOutput()->GetRequestedRegion());
 
-  ImageRegionConstIterator<OutputImageType> shiftedIt(m_ShiftedImage, this->GetOutput()->GetRequestedRegion());
+  ImageRegionConstIterator shiftedIt(m_ShiftedImage, this->GetOutput()->GetRequestedRegion());
 
   for (outputIt.GoToBegin(), statusIt.GoToBegin(), shiftedIt.GoToBegin(); !outputIt.IsAtEnd();
        ++outputIt, ++statusIt, ++shiftedIt)
@@ -859,10 +859,10 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedIniti
   // This will make each thread be the FIRST to write to "it's" data in the new
   // images and hence the memory will get allocated
   // in the corresponding thread's memory-node.
-  ImageRegionConstIterator<StatusImageType> statusIt(m_StatusImage, ThreadRegion);
-  ImageRegionIterator                       statusItNew(m_StatusImageTemp, ThreadRegion);
-  ImageRegionConstIterator<OutputImageType> outputIt(m_OutputImage, ThreadRegion);
-  ImageRegionIterator                       outputItNew(m_OutputImageTemp, ThreadRegion);
+  ImageRegionConstIterator statusIt(m_StatusImage, ThreadRegion);
+  ImageRegionIterator      statusItNew(m_StatusImageTemp, ThreadRegion);
+  ImageRegionConstIterator outputIt(m_OutputImage, ThreadRegion);
+  ImageRegionIterator      outputItNew(m_OutputImageTemp, ThreadRegion);
 
   for (outputIt.GoToBegin(), statusIt.GoToBegin(), outputItNew.GoToBegin(), statusItNew.GoToBegin();
        !outputIt.IsAtEnd();
@@ -2307,8 +2307,8 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::ThreadedPostP
   const ValueType outside_value = (max_layer + 1) * m_ConstantGradientValue;
   const ValueType inside_value = -(max_layer + 1) * m_ConstantGradientValue;
 
-  ImageRegionConstIterator<StatusImageType> statusIt(m_StatusImage, regionToProcess);
-  ImageRegionIterator                       outputIt(m_OutputImage, regionToProcess);
+  ImageRegionConstIterator statusIt(m_StatusImage, regionToProcess);
+  ImageRegionIterator      outputIt(m_OutputImage, regionToProcess);
 
   for (outputIt.GoToBegin(), statusIt.GoToBegin(); !outputIt.IsAtEnd(); ++outputIt, ++statusIt)
   {

--- a/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
@@ -134,8 +134,8 @@ ReinitializeLevelSetImageFilter<TLevelSet>::GenerateDataFull()
 
   // define iterators
 
-  ImageRegionConstIterator<LevelSetImageType> inputIt(inputPtr, inputPtr->GetBufferedRegion());
-  ImageRegionIterator                         outputIt(outputPtr, outputPtr->GetBufferedRegion());
+  ImageRegionConstIterator inputIt(inputPtr, inputPtr->GetBufferedRegion());
+  ImageRegionIterator      outputIt(outputPtr, outputPtr->GetBufferedRegion());
 
   this->UpdateProgress(0.0);
 
@@ -199,7 +199,7 @@ ReinitializeLevelSetImageFilter<TLevelSet>::GenerateDataNarrowBand()
 
   // define iterators
 
-  ImageRegionConstIterator<LevelSetImageType> inputIt(inputPtr, inputPtr->GetBufferedRegion());
+  ImageRegionConstIterator inputIt(inputPtr, inputPtr->GetBufferedRegion());
 
   ImageRegionIterator outputIt(outputPtr, outputPtr->GetBufferedRegion());
 

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
@@ -140,7 +140,7 @@ SparseFieldFourthOrderLevelSetImageFilter<TInputImage, TOutputImage>::ComputeCur
   SparseImageType *       sparseImage) const
 {
 
-  ImageRegionConstIterator<OutputImageType> distanceImageIterator(distanceImage, distanceImage->GetRequestedRegion());
+  ImageRegionConstIterator distanceImageIterator(distanceImage, distanceImage->GetRequestedRegion());
   typename SparseImageIteratorType::RadiusType radius;
   for (unsigned int j = 0; j < ImageDimension; ++j)
   {

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -592,11 +592,11 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::InitializeBackgroundP
   const ValueType outside_value = (max_layer + 1) * m_ConstantGradientValue;
   const ValueType inside_value = -(max_layer + 1) * m_ConstantGradientValue;
 
-  ImageRegionConstIterator<StatusImageType> statusIt(m_StatusImage, this->GetOutput()->GetRequestedRegion());
+  ImageRegionConstIterator statusIt(m_StatusImage, this->GetOutput()->GetRequestedRegion());
 
   ImageRegionIterator outputIt(this->GetOutput(), this->GetOutput()->GetRequestedRegion());
 
-  ImageRegionConstIterator<OutputImageType> shiftedIt(m_ShiftedImage, this->GetOutput()->GetRequestedRegion());
+  ImageRegionConstIterator shiftedIt(m_ShiftedImage, this->GetOutput()->GetRequestedRegion());
 
   for (outputIt.GoToBegin(), statusIt.GoToBegin(); !outputIt.IsAtEnd(); ++outputIt, ++statusIt, ++shiftedIt)
   {
@@ -1055,7 +1055,7 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::PostProcessOutput()
   const ValueType inside_value = (max_layer + 1) * m_ConstantGradientValue;
   const ValueType outside_value = -(max_layer + 1) * m_ConstantGradientValue;
 
-  ImageRegionConstIterator<StatusImageType> statusIt(m_StatusImage, this->m_OutputImage->GetRequestedRegion());
+  ImageRegionConstIterator statusIt(m_StatusImage, this->m_OutputImage->GetRequestedRegion());
 
   ImageRegionIterator outputIt(this->m_OutputImage, this->m_OutputImage->GetRequestedRegion());
 

--- a/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetFunction.hxx
@@ -31,10 +31,9 @@ ThresholdSegmentationLevelSetFunction<TImageType, TFeatureImageType>::CalculateS
   auto diffusion = GradientAnisotropicDiffusionImageFilter<TFeatureImageType, TFeatureImageType>::New();
   auto laplacian = LaplacianImageFilter<TFeatureImageType, TFeatureImageType>::New();
 
-  ImageRegionIterator<FeatureImageType>      lit;
-  ImageRegionConstIterator<FeatureImageType> fit(this->GetFeatureImage(),
-                                                 this->GetFeatureImage()->GetRequestedRegion());
-  ImageRegionIterator                        sit(this->GetSpeedImage(), this->GetFeatureImage()->GetRequestedRegion());
+  ImageRegionIterator<FeatureImageType> lit;
+  ImageRegionConstIterator              fit(this->GetFeatureImage(), this->GetFeatureImage()->GetRequestedRegion());
+  ImageRegionIterator                   sit(this->GetSpeedImage(), this->GetFeatureImage()->GetRequestedRegion());
 
   if (m_EdgeWeight != 0.0)
   {

--- a/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetFunction.hxx
@@ -28,9 +28,8 @@ template <typename TImageType, typename TFeatureImageType>
 void
 VectorThresholdSegmentationLevelSetFunction<TImageType, TFeatureImageType>::CalculateSpeedImage()
 {
-  ImageRegionConstIterator<FeatureImageType> fit(this->GetFeatureImage(),
-                                                 this->GetFeatureImage()->GetRequestedRegion());
-  ImageRegionIterator                        sit(this->GetSpeedImage(), this->GetFeatureImage()->GetRequestedRegion());
+  ImageRegionConstIterator fit(this->GetFeatureImage(), this->GetFeatureImage()->GetRequestedRegion());
+  ImageRegionIterator      sit(this->GetSpeedImage(), this->GetFeatureImage()->GetRequestedRegion());
 
   ScalarValueType threshold;
   for (fit.GoToBegin(), sit.GoToBegin(); !fit.IsAtEnd(); ++sit, ++fit)

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionUpdateLevelSetsThreader.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionUpdateLevelSetsThreader.hxx
@@ -58,8 +58,8 @@ LevelSetEvolutionUpdateLevelSetsThreader<LevelSetDenseImage<TImage>,
   const typename LevelSetImageType::Pointer      levelSetImage = levelSet->GetModifiableImage();
   const typename LevelSetImageType::ConstPointer levelSetUpdateImage = levelSetUpdate->GetImage();
 
-  ImageRegionIterator                         levelSetImageIt(levelSetImage, imageSubRegion);
-  ImageRegionConstIterator<LevelSetImageType> levelSetUpdateImageIt(levelSetUpdateImage, imageSubRegion);
+  ImageRegionIterator      levelSetImageIt(levelSetImage, imageSubRegion);
+  ImageRegionConstIterator levelSetUpdateImageIt(levelSetUpdateImage, imageSubRegion);
   levelSetImageIt.GoToBegin();
   levelSetUpdateImageIt.GoToBegin();
 

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.hxx
@@ -88,8 +88,8 @@ VoronoiSegmentationImageFilter<TInputImage, TOutputImage, TBinaryPriorImage>::Ta
 {
   const RegionType region = this->GetInput()->GetRequestedRegion();
 
-  ImageRegionConstIterator<BinaryObjectImage> ait(aprior, region);
-  ImageRegionConstIterator<InputImageType>    iit(this->GetInput(), region);
+  ImageRegionConstIterator ait(aprior, region);
+  ImageRegionConstIterator iit(this->GetInput(), region);
 
   this->m_Size = this->GetInput()->GetRequestedRegion().GetSize();
 

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
@@ -89,10 +89,10 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::SetInput(const Inp
   m_WorkingImage->SetRegions(region);
   m_WorkingImage->Allocate();
 
-  ImageRegionIterator                      wit(m_WorkingImage, region);
-  ImageRegionConstIterator<InputImageType> iit(this->GetInput(), region);
-  PixelType                                ipixel;
-  RGBHCVPixel                              wpixel;
+  ImageRegionIterator      wit(m_WorkingImage, region);
+  ImageRegionConstIterator iit(this->GetInput(), region);
+  PixelType                ipixel;
+  RGBHCVPixel              wpixel;
 
 
   const double X0 = m_MaxValueOfRGB * 0.982;
@@ -192,8 +192,8 @@ VoronoiSegmentationRGBImageFilter<TInputImage, TOutputImage>::TakeAPrior(const B
 {
   const RegionType region = this->GetInput()->GetRequestedRegion();
 
-  ImageRegionConstIterator<BinaryObjectImage> ait(aprior, region);
-  ImageRegionIterator                         iit(m_WorkingImage, region);
+  ImageRegionConstIterator ait(aprior, region);
+  ImageRegionIterator      iit(m_WorkingImage, region);
 
   unsigned int minx = 0;
   unsigned int miny = 0;

--- a/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.hxx
@@ -67,8 +67,8 @@ TobogganImageFilter<TInputImage, TOutputImage>::GenerateData()
   outputImage->AllocateInitialized();
 
 
-  ImageRegionConstIterator<InputImageType>  inIt(inputImage, inputImage->GetRequestedRegion());
-  ImageRegionConstIterator<OutputImageType> outIt(outputImage, outputImage->GetRequestedRegion());
+  ImageRegionConstIterator inIt(inputImage, inputImage->GetRequestedRegion());
+  ImageRegionConstIterator outIt(outputImage, outputImage->GetRequestedRegion());
 
   // Walk through the image
   while (!inIt.IsAtEnd())

--- a/Modules/Segmentation/Watersheds/include/itkWatershedEquivalenceRelabeler.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedEquivalenceRelabeler.hxx
@@ -36,8 +36,8 @@ EquivalenceRelabeler<TScalar, TImageDimension>::GenerateData()
   //
   // Copy input to output
   //
-  ImageRegionConstIterator<ImageType> it_a(input, output->GetRequestedRegion());
-  ImageRegionIterator                 it_b(output, output->GetRequestedRegion());
+  ImageRegionConstIterator it_a(input, output->GetRequestedRegion());
+  ImageRegionIterator      it_b(output, output->GetRequestedRegion());
 
   it_a.GoToBegin();
   it_b.GoToBegin();

--- a/Modules/Video/Filtering/include/itkDecimateFramesVideoFilter.hxx
+++ b/Modules/Video/Filtering/include/itkDecimateFramesVideoFilter.hxx
@@ -99,8 +99,8 @@ DecimateFramesVideoFilter<TVideoStream>::ThreadedGenerateData(const FrameSpatial
   // than just copying memory.
 
   // Get iterators for requested region of input and output frames
-  ImageRegionConstIterator<FrameType> inIter(input->GetFrame(inFrameNum), outputRegionForThread);
-  ImageRegionIterator                 outIter(output->GetFrame(outFrameNum), outputRegionForThread);
+  ImageRegionConstIterator inIter(input->GetFrame(inFrameNum), outputRegionForThread);
+  ImageRegionIterator      outIter(output->GetFrame(outFrameNum), outputRegionForThread);
 
   // Pass the values from input to output
   while (!outIter.IsAtEnd())

--- a/Modules/Video/Filtering/include/itkFrameDifferenceVideoFilter.hxx
+++ b/Modules/Video/Filtering/include/itkFrameDifferenceVideoFilter.hxx
@@ -113,8 +113,8 @@ FrameDifferenceVideoFilter<TInputVideoStream, TOutputVideoStream>::ThreadedGener
   }
 
   // Get iterators for the input frames
-  ImageRegionConstIterator<InputFrameType> I0Iter(input->GetFrame(inputStart), outputRegionForThread);
-  ImageRegionConstIterator<InputFrameType> I1Iter(input->GetFrame(inputStart + numFrames - 1), outputRegionForThread);
+  ImageRegionConstIterator I0Iter(input->GetFrame(inputStart), outputRegionForThread);
+  ImageRegionConstIterator I1Iter(input->GetFrame(inputStart + numFrames - 1), outputRegionForThread);
 
   // Get the output frame and its iterator
   OutputFrameType *   outFrame = output->GetFrame(outputFrameNumber);


### PR DESCRIPTION
Used class template argument deduction (CTAD) when declaring variables of type `ImageRegionConstIterator<TImage>`

- Follow-up to pull request #5982