### PR TITLE
ENH: Convert itkThreadedIteratorRangePartitionerTest{,2,3} to GTest

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -73,7 +73,6 @@ set(
 set(
   ITKCommon2Tests
   itkSTLThreadTest.cxx
-  itkThreadedIteratorRangePartitionerTest2.cxx
   itkThreadedIteratorRangePartitionerTest3.cxx
   itkThreadLoggerTest.cxx
   itkLoggerThreadWrapperTest.cxx
@@ -197,12 +196,6 @@ if(ITK_BUILD_SHARED_LIBS)
   add_dependencies(ITKCommon2TestDriver FactoryTestLib)
 endif()
 
-itk_add_test(
-  NAME itkThreadedIteratorRangePartitionerTest2
-  COMMAND
-    ITKCommon2TestDriver
-    itkThreadedIteratorRangePartitionerTest2
-)
 itk_add_test(
   NAME itkThreadedIteratorRangePartitionerTest3
   COMMAND
@@ -1612,6 +1605,7 @@ set(
   itkFloodFilledSpatialFunctionGTest.cxx
   itkThreadedImageRegionPartitionerGTest.cxx
   itkThreadedIteratorRangePartitionerGTest.cxx
+  itkThreadedIteratorRangePartitionerGTest2.cxx
 )
 creategoogletestdriver(ITKCommon "${ITKCommon-Test_LIBRARIES}" "${ITKCommonGTests}")
 # If `-static` was passed to CMAKE_EXE_LINKER_FLAGS, compilation fails. No need to

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -73,7 +73,6 @@ set(
 set(
   ITKCommon2Tests
   itkSTLThreadTest.cxx
-  itkThreadedIteratorRangePartitionerTest.cxx
   itkThreadedIteratorRangePartitionerTest2.cxx
   itkThreadedIteratorRangePartitionerTest3.cxx
   itkThreadLoggerTest.cxx
@@ -198,12 +197,6 @@ if(ITK_BUILD_SHARED_LIBS)
   add_dependencies(ITKCommon2TestDriver FactoryTestLib)
 endif()
 
-itk_add_test(
-  NAME itkThreadedIteratorRangePartitionerTest
-  COMMAND
-    ITKCommon2TestDriver
-    itkThreadedIteratorRangePartitionerTest
-)
 itk_add_test(
   NAME itkThreadedIteratorRangePartitionerTest2
   COMMAND
@@ -1618,6 +1611,7 @@ set(
   itkDerivativeOperatorGTest.cxx
   itkFloodFilledSpatialFunctionGTest.cxx
   itkThreadedImageRegionPartitionerGTest.cxx
+  itkThreadedIteratorRangePartitionerGTest.cxx
 )
 creategoogletestdriver(ITKCommon "${ITKCommon-Test_LIBRARIES}" "${ITKCommonGTests}")
 # If `-static` was passed to CMAKE_EXE_LINKER_FLAGS, compilation fails. No need to

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -73,7 +73,6 @@ set(
 set(
   ITKCommon2Tests
   itkSTLThreadTest.cxx
-  itkThreadedIteratorRangePartitionerTest3.cxx
   itkThreadLoggerTest.cxx
   itkLoggerThreadWrapperTest.cxx
   itkThreadDefsTest.cxx
@@ -195,13 +194,6 @@ if(ITK_BUILD_SHARED_LIBS)
   )
   add_dependencies(ITKCommon2TestDriver FactoryTestLib)
 endif()
-
-itk_add_test(
-  NAME itkThreadedIteratorRangePartitionerTest3
-  COMMAND
-    ITKCommon2TestDriver
-    itkThreadedIteratorRangePartitionerTest3
-)
 
 itk_add_test(
   NAME itkImageAdaptorPipeLineTest
@@ -1606,6 +1598,7 @@ set(
   itkThreadedImageRegionPartitionerGTest.cxx
   itkThreadedIteratorRangePartitionerGTest.cxx
   itkThreadedIteratorRangePartitionerGTest2.cxx
+  itkThreadedIteratorRangePartitionerGTest3.cxx
 )
 creategoogletestdriver(ITKCommon "${ITKCommon-Test_LIBRARIES}" "${ITKCommonGTests}")
 # If `-static` was passed to CMAKE_EXE_LINKER_FLAGS, compilation fails. No need to

--- a/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerGTest.cxx
+++ b/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerGTest.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 #include "itkDomainThreader.h"
 #include "itkThreadedIteratorRangePartitioner.h"
+#include "itkGTest.h"
 
 namespace
 {
@@ -121,7 +122,7 @@ private:
 };
 
 
-int
+void
 ThreadedIteratorRangePartitionerRunTest(
   IteratorRangeDomainThreaderAssociate &                                       enclosingClass,
   itk::ThreadIdType                                                            numberOfThreads,
@@ -136,22 +137,11 @@ ThreadedIteratorRangePartitionerRunTest(
   domainThreader->GetMultiThreader();
   domainThreader->SetMaximumNumberOfThreads(numberOfThreads);
   // Possible if numberOfThreads > GlobalMaximumNumberOfThreads
-  if (domainThreader->GetMaximumNumberOfThreads() < numberOfThreads)
-  {
-    std::cerr << "Failed setting requested number of threads: " << numberOfThreads << std::endl
-              << "domainThreader->GetMaximumNumberOfThreads(): " << domainThreader->GetMaximumNumberOfThreads()
-              << std::endl;
-    return EXIT_FAILURE;
-  }
+  EXPECT_GE(domainThreader->GetMaximumNumberOfThreads(), numberOfThreads);
 
   domainThreader->SetNumberOfWorkUnits(numberOfThreads);
   // Possible if numberOfThreads > GlobalMaximumNumberOfThreads
-  if (domainThreader->GetNumberOfWorkUnits() != numberOfThreads)
-  {
-    std::cerr << "Failed setting requested number of work units: " << numberOfThreads << std::endl
-              << "domainThreader->GetNumberOfWorkUnits(): " << domainThreader->GetNumberOfWorkUnits() << std::endl;
-    return EXIT_FAILURE;
-  }
+  EXPECT_EQ(domainThreader->GetNumberOfWorkUnits(), numberOfThreads);
 
   enclosingClass.Execute(fullDomain);
 
@@ -169,41 +159,27 @@ ThreadedIteratorRangePartitionerRunTest(
   {
     BorderValuesType subRange = domainInThreadedExecution[i];
     /* Check that the sub range was assigned something at all */
-    if (subRange[0] == -1 || subRange[1] == -1)
-    {
-      std::cerr << "Error: subRange " << i << " is was not set: " << subRange[i];
-      return EXIT_FAILURE;
-    }
+    EXPECT_NE(subRange[0], -1);
+    EXPECT_NE(subRange[1], -1);
     /* Check that we got the begin of the range */
-    if (i == 0 && subRange[0] != *(fullDomain.Begin()))
+    if (i == 0)
     {
-      std::cerr << "Error: subRange[0][0] should be " << *(fullDomain.Begin()) << ", but it's " << subRange[0] << '.';
-      return EXIT_FAILURE;
+      EXPECT_EQ(subRange[0], *(fullDomain.Begin()));
     }
     /* Check that we got the end of the range */
     BorderValuesType::const_iterator fullIt = fullDomain.End();
     --fullIt;
-    if (i == numberOfThreads - 1 && subRange[1] != *fullIt)
+    if (i == numberOfThreads - 1)
     {
-      std::cerr << "Error: subRange[N-1][1] should be " << *fullIt << ", but it's " << subRange[1] << '.';
-      return EXIT_FAILURE;
+      EXPECT_EQ(subRange[1], *fullIt);
     }
     /* Check that the sub-range endings and beginnings are continuous */
     if (i > 0)
     {
-      if (previousEndIndex + 1 != subRange[0])
-      {
-        std::cerr << "Error: subRange " << i << " is not continuous with "
-                  << "previous subRange." << std::endl
-                  << "previousEndIndex: " << previousEndIndex << std::endl
-                  << "subRange[0]: " << subRange[0] << std::endl;
-        return EXIT_FAILURE;
-      }
+      EXPECT_EQ(previousEndIndex + 1, subRange[0]);
     }
     previousEndIndex = subRange[1];
   }
-
-  return EXIT_SUCCESS;
 }
 
 // Helper function.
@@ -236,8 +212,7 @@ setStartEnd(const unsigned int                                                  
 }
 } // namespace
 
-int
-itkThreadedIteratorRangePartitionerTest(int, char *[])
+TEST(ThreadedIteratorRangePartitioner, ConvertedLegacyTest)
 {
   IteratorRangeDomainThreaderAssociate                                         enclosingClass;
   const IteratorRangeDomainThreaderAssociate::TestDomainThreader::ConstPointer domainThreader =
@@ -262,18 +237,12 @@ itkThreadedIteratorRangePartitionerTest(int, char *[])
   /* Test with single thread */
   setStartEnd(0, 103, container, fullDomain);
   itk::ThreadIdType numberOfThreads = 1;
-  if (ThreadedIteratorRangePartitionerRunTest(enclosingClass, numberOfThreads, fullDomain) != EXIT_SUCCESS)
-  {
-    return EXIT_FAILURE;
-  }
+  ThreadedIteratorRangePartitionerRunTest(enclosingClass, numberOfThreads, fullDomain);
 
   /* Test with range that doesn't start at 0 */
   setStartEnd(2, 105, container, fullDomain);
   numberOfThreads = 1;
-  if (ThreadedIteratorRangePartitionerRunTest(enclosingClass, numberOfThreads, fullDomain) != EXIT_SUCCESS)
-  {
-    return EXIT_FAILURE;
-  }
+  ThreadedIteratorRangePartitionerRunTest(enclosingClass, numberOfThreads, fullDomain);
 
   /* Test with multiple threads */
   if (domainThreader->GetMultiThreader()->GetGlobalMaximumNumberOfThreads() > 1)
@@ -281,19 +250,13 @@ itkThreadedIteratorRangePartitionerTest(int, char *[])
     /* Test with default number of threads. */
     setStartEnd(6, 109, container, fullDomain);
     numberOfThreads = domainThreader->GetMultiThreader()->GetGlobalDefaultNumberOfThreads();
-    if (ThreadedIteratorRangePartitionerRunTest(enclosingClass, numberOfThreads, fullDomain) != EXIT_SUCCESS)
-    {
-      return EXIT_FAILURE;
-    }
+    ThreadedIteratorRangePartitionerRunTest(enclosingClass, numberOfThreads, fullDomain);
 
     /* Test with max number of threads and check that we only used as
      * many as is reasonable. */
     const itk::ThreadIdType maxNumberOfThreads = domainThreader->GetMultiThreader()->GetGlobalMaximumNumberOfThreads();
     setStartEnd(6, 6 + maxNumberOfThreads, container, fullDomain);
-    if (ThreadedIteratorRangePartitionerRunTest(enclosingClass, maxNumberOfThreads, fullDomain) != EXIT_SUCCESS)
-    {
-      return EXIT_FAILURE;
-    }
+    ThreadedIteratorRangePartitionerRunTest(enclosingClass, maxNumberOfThreads, fullDomain);
     if (domainThreader->GetNumberOfWorkUnitsUsed() != maxNumberOfThreads)
     {
       std::cerr << "Error: Expected to use " << maxNumberOfThreads << "threads, but used "
@@ -304,6 +267,4 @@ itkThreadedIteratorRangePartitionerTest(int, char *[])
   {
     std::cout << "No multi-threading available. " << std::endl;
   }
-
-  return EXIT_SUCCESS;
 }

--- a/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerGTest.cxx
+++ b/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerGTest.cxx
@@ -218,6 +218,7 @@ TEST(ThreadedIteratorRangePartitioner, ConvertedLegacyTest)
   const IteratorRangeDomainThreaderAssociate::TestDomainThreader::ConstPointer domainThreader =
     enclosingClass.GetDomainThreader();
 
+  ASSERT_NE(domainThreader->GetMultiThreader(), nullptr);
   /* Check # of threads */
   std::cout << "GetGlobalMaximumNumberOfThreads: "
             << domainThreader->GetMultiThreader()->GetGlobalMaximumNumberOfThreads() << std::endl;
@@ -257,11 +258,7 @@ TEST(ThreadedIteratorRangePartitioner, ConvertedLegacyTest)
     const itk::ThreadIdType maxNumberOfThreads = domainThreader->GetMultiThreader()->GetGlobalMaximumNumberOfThreads();
     setStartEnd(6, 6 + maxNumberOfThreads, container, fullDomain);
     ThreadedIteratorRangePartitionerRunTest(enclosingClass, maxNumberOfThreads, fullDomain);
-    if (domainThreader->GetNumberOfWorkUnitsUsed() != maxNumberOfThreads)
-    {
-      std::cerr << "Error: Expected to use " << maxNumberOfThreads << "threads, but used "
-                << domainThreader->GetNumberOfWorkUnitsUsed() << '.' << std::endl;
-    }
+    EXPECT_EQ(domainThreader->GetNumberOfWorkUnitsUsed(), maxNumberOfThreads);
   }
   else
   {

--- a/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerGTest2.cxx
+++ b/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerGTest2.cxx
@@ -266,11 +266,7 @@ TEST(ThreadedIteratorRangePartitioner2, ConvertedLegacyTest)
     const itk::ThreadIdType maxNumberOfThreads = domainThreader->GetMultiThreader()->GetGlobalMaximumNumberOfThreads();
     setStartEnd(6, 6 + maxNumberOfThreads, container, fullDomain);
     ThreadedIteratorRangePartitionerRunTest(enclosingClass, maxNumberOfThreads, fullDomain);
-    if (domainThreader->GetNumberOfWorkUnitsUsed() != maxNumberOfThreads)
-    {
-      std::cerr << "Error: Expected to use only " << maxNumberOfThreads << "threads, but used "
-                << domainThreader->GetNumberOfWorkUnitsUsed() << '.' << std::endl;
-    }
+    EXPECT_EQ(domainThreader->GetNumberOfWorkUnitsUsed(), maxNumberOfThreads);
   }
   else
   {

--- a/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerGTest2.cxx
+++ b/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerGTest2.cxx
@@ -19,6 +19,7 @@
 #include "itkDomainThreader.h"
 #include "itkThreadedIteratorRangePartitioner.h"
 #include "itkVectorContainer.h"
+#include "itkGTest.h"
 
 namespace
 {
@@ -124,7 +125,7 @@ private:
 };
 
 
-int
+void
 ThreadedIteratorRangePartitionerRunTest(
   IteratorRangeDomainThreaderAssociate &                                       enclosingClass,
   itk::ThreadIdType                                                            numberOfThreads,
@@ -139,22 +140,11 @@ ThreadedIteratorRangePartitionerRunTest(
   domainThreader->GetMultiThreader();
   domainThreader->SetMaximumNumberOfThreads(numberOfThreads);
   // Possible if numberOfThreads > GlobalMaximumNumberOfThreads
-  if (domainThreader->GetMaximumNumberOfThreads() < numberOfThreads)
-  {
-    std::cerr << "Failed setting requested number of threads: " << numberOfThreads << std::endl
-              << "domainThreader->GetMaximumNumberOfThreads(): " << domainThreader->GetMaximumNumberOfThreads()
-              << std::endl;
-    return EXIT_FAILURE;
-  }
+  EXPECT_GE(domainThreader->GetMaximumNumberOfThreads(), numberOfThreads);
 
   domainThreader->SetNumberOfWorkUnits(numberOfThreads);
   // Possible if numberOfThreads > GlobalMaximumNumberOfThreads
-  if (domainThreader->GetNumberOfWorkUnits() != numberOfThreads)
-  {
-    std::cerr << "Failed setting requested number of work units: " << numberOfThreads << std::endl
-              << "domainThreader->GetNumberOfWorkUnits(): " << domainThreader->GetNumberOfWorkUnits() << std::endl;
-    return EXIT_FAILURE;
-  }
+  EXPECT_EQ(domainThreader->GetNumberOfWorkUnits(), numberOfThreads);
 
   enclosingClass.Execute(fullDomain);
 
@@ -172,44 +162,29 @@ ThreadedIteratorRangePartitionerRunTest(
   {
     BorderValuesType subRange = domainInThreadedExecution[i];
     /* Check that the sub range was assigned something at all */
-    if (subRange[0] == -1 || subRange[1] == -1)
-    {
-      std::cerr << "Error: subRange " << i << " is was not set: " << subRange[i];
-      return EXIT_FAILURE;
-    }
+    EXPECT_NE(subRange[0], -1);
+    EXPECT_NE(subRange[1], -1);
     /* Check that we got the begin of the range */
-    if (i == 0 && subRange[0] != (fullDomain.Begin()).Value())
+    if (i == 0)
     {
-      std::cerr << "Error: subRange[0][0] should be " << (fullDomain.Begin()).Value() << ", but it's " << subRange[0]
-                << '.';
-      return EXIT_FAILURE;
+      EXPECT_EQ(subRange[0], (fullDomain.Begin()).Value());
     }
 
     /* Check that we got the end of the range */
     using DomainType = IteratorRangeDomainThreaderAssociate::TestDomainThreader::DomainType;
     DomainType::IteratorType fullIt = fullDomain.End();
     --fullIt;
-    if (i == numberOfThreads - 1 && subRange[1] != fullIt.Value())
+    if (i == numberOfThreads - 1)
     {
-      std::cerr << "Error: subRange[N-1][1] should be " << fullIt.Value() << ", but it's " << subRange[1] << '.';
-      return EXIT_FAILURE;
+      EXPECT_EQ(subRange[1], fullIt.Value());
     }
     /* Check that the sub-range endings and beginnings are continuous */
     if (i > 0)
     {
-      if (previousEndIndex + 1 != subRange[0])
-      {
-        std::cerr << "Error: subRange " << i << " is not continuous with "
-                  << "previous subRange." << std::endl
-                  << "previousEndIndex: " << previousEndIndex << std::endl
-                  << "subRange[0]: " << subRange[0] << std::endl;
-        return EXIT_FAILURE;
-      }
+      EXPECT_EQ(previousEndIndex + 1, subRange[0]);
     }
     previousEndIndex = subRange[1];
   }
-
-  return EXIT_SUCCESS;
 }
 
 // Helper function.
@@ -242,28 +217,20 @@ setStartEnd(const unsigned int                                                  
 }
 } // namespace
 
-int
-itkThreadedIteratorRangePartitionerTest2(int, char *[])
+TEST(ThreadedIteratorRangePartitioner2, ConvertedLegacyTest)
 {
   IteratorRangeDomainThreaderAssociate                                         enclosingClass;
   const IteratorRangeDomainThreaderAssociate::TestDomainThreader::ConstPointer domainThreader =
     enclosingClass.GetDomainThreader();
 
-  if (domainThreader->GetMultiThreader())
-  {
-    /* Check # of threads */
-    std::cout << "GetGlobalMaximumNumberOfThreads: "
-              << domainThreader->GetMultiThreader()->GetGlobalMaximumNumberOfThreads() << std::endl;
-    std::cout << "GetGlobalDefaultNumberOfThreads: "
-              << domainThreader->GetMultiThreader()->GetGlobalDefaultNumberOfThreads() << std::endl;
-    std::cout << "domainThreader->GetMultiThreader()->NumberOfWorkUnits(): "
-              << domainThreader->GetMultiThreader()->GetNumberOfWorkUnits() << std::endl;
-  }
-  else
-  {
-    std::cerr << "domainThreader->GetMultiThreader() is NULL" << std::endl;
-    return EXIT_FAILURE;
-  }
+  ASSERT_NE(domainThreader->GetMultiThreader(), nullptr);
+  /* Check # of threads */
+  std::cout << "GetGlobalMaximumNumberOfThreads: "
+            << domainThreader->GetMultiThreader()->GetGlobalMaximumNumberOfThreads() << std::endl;
+  std::cout << "GetGlobalDefaultNumberOfThreads: "
+            << domainThreader->GetMultiThreader()->GetGlobalDefaultNumberOfThreads() << std::endl;
+  std::cout << "domainThreader->GetMultiThreader()->NumberOfWorkUnits(): "
+            << domainThreader->GetMultiThreader()->GetNumberOfWorkUnits() << std::endl;
 
   using DomainType = IteratorRangeDomainThreaderAssociate::TestDomainThreader::DomainType;
   using DomainContainerType = IteratorRangeDomainThreaderAssociate::DomainContainerType;
@@ -279,18 +246,12 @@ itkThreadedIteratorRangePartitionerTest2(int, char *[])
   /* Test with single thread */
   setStartEnd(0, 103, container, fullDomain);
   itk::ThreadIdType numberOfThreads = 1;
-  if (ThreadedIteratorRangePartitionerRunTest(enclosingClass, numberOfThreads, fullDomain) != EXIT_SUCCESS)
-  {
-    return EXIT_FAILURE;
-  }
+  ThreadedIteratorRangePartitionerRunTest(enclosingClass, numberOfThreads, fullDomain);
 
   /* Test with range that doesn't start at 0 */
   setStartEnd(2, 105, container, fullDomain);
   numberOfThreads = 1;
-  if (ThreadedIteratorRangePartitionerRunTest(enclosingClass, numberOfThreads, fullDomain) != EXIT_SUCCESS)
-  {
-    return EXIT_FAILURE;
-  }
+  ThreadedIteratorRangePartitionerRunTest(enclosingClass, numberOfThreads, fullDomain);
 
   /* Test with multiple threads */
   if (domainThreader->GetMultiThreader()->GetGlobalMaximumNumberOfThreads() > 1)
@@ -298,19 +259,13 @@ itkThreadedIteratorRangePartitionerTest2(int, char *[])
     /* Test with default number of threads. */
     setStartEnd(6, 109, container, fullDomain);
     numberOfThreads = domainThreader->GetMultiThreader()->GetGlobalDefaultNumberOfThreads();
-    if (ThreadedIteratorRangePartitionerRunTest(enclosingClass, numberOfThreads, fullDomain) != EXIT_SUCCESS)
-    {
-      return EXIT_FAILURE;
-    }
+    ThreadedIteratorRangePartitionerRunTest(enclosingClass, numberOfThreads, fullDomain);
 
     /* Test with max number of threads and check that we only used as
      * many as is reasonable. */
     const itk::ThreadIdType maxNumberOfThreads = domainThreader->GetMultiThreader()->GetGlobalMaximumNumberOfThreads();
     setStartEnd(6, 6 + maxNumberOfThreads, container, fullDomain);
-    if (ThreadedIteratorRangePartitionerRunTest(enclosingClass, maxNumberOfThreads, fullDomain) != EXIT_SUCCESS)
-    {
-      return EXIT_FAILURE;
-    }
+    ThreadedIteratorRangePartitionerRunTest(enclosingClass, maxNumberOfThreads, fullDomain);
     if (domainThreader->GetNumberOfWorkUnitsUsed() != maxNumberOfThreads)
     {
       std::cerr << "Error: Expected to use only " << maxNumberOfThreads << "threads, but used "
@@ -321,6 +276,4 @@ itkThreadedIteratorRangePartitionerTest2(int, char *[])
   {
     std::cout << "No multi-threading available. " << std::endl;
   }
-
-  return EXIT_SUCCESS;
 }

--- a/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerGTest3.cxx
+++ b/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerGTest3.cxx
@@ -19,6 +19,7 @@
 #include "itkDomainThreader.h"
 #include "itkThreadedIteratorRangePartitioner.h"
 #include "itkMapContainer.h"
+#include "itkGTest.h"
 
 namespace
 {
@@ -124,7 +125,7 @@ private:
 };
 
 
-int
+void
 ThreadedIteratorRangePartitionerRunTest(
   IteratorRangeDomainThreaderAssociate &                                       enclosingClass,
   itk::ThreadIdType                                                            numberOfThreads,
@@ -139,22 +140,11 @@ ThreadedIteratorRangePartitionerRunTest(
   domainThreader->GetMultiThreader();
   domainThreader->SetMaximumNumberOfThreads(numberOfThreads);
   // Possible if numberOfThreads > GlobalMaximumNumberOfThreads
-  if (domainThreader->GetMaximumNumberOfThreads() < numberOfThreads)
-  {
-    std::cerr << "Failed setting requested number of threads: " << numberOfThreads << std::endl
-              << "domainThreader->GetMaximumNumberOfThreads(): " << domainThreader->GetMaximumNumberOfThreads()
-              << std::endl;
-    return EXIT_FAILURE;
-  }
+  EXPECT_GE(domainThreader->GetMaximumNumberOfThreads(), numberOfThreads);
 
   domainThreader->SetNumberOfWorkUnits(numberOfThreads);
   // Possible if numberOfThreads > GlobalMaximumNumberOfThreads
-  if (domainThreader->GetNumberOfWorkUnits() != numberOfThreads)
-  {
-    std::cerr << "Failed setting requested number of work units: " << numberOfThreads << std::endl
-              << "domainThreader->GetNumberOfWorkUnits(): " << domainThreader->GetNumberOfWorkUnits() << std::endl;
-    return EXIT_FAILURE;
-  }
+  EXPECT_EQ(domainThreader->GetNumberOfWorkUnits(), numberOfThreads);
 
   enclosingClass.Execute(fullDomain);
 
@@ -172,44 +162,29 @@ ThreadedIteratorRangePartitionerRunTest(
   {
     BorderValuesType subRange = domainInThreadedExecution[i];
     /* Check that the sub range was assigned something at all */
-    if (subRange[0] == -1 || subRange[1] == -1)
-    {
-      std::cerr << "Error: subRange " << i << " is was not set: " << subRange[i];
-      return EXIT_FAILURE;
-    }
+    EXPECT_NE(subRange[0], -1);
+    EXPECT_NE(subRange[1], -1);
     /* Check that we got the begin of the range */
-    if (i == 0 && subRange[0] != (fullDomain.Begin()).Index())
+    if (i == 0)
     {
-      std::cerr << "Error: subRange[0][0] should be " << (fullDomain.Begin()).Index() << ", but it's " << subRange[0]
-                << '.';
-      return EXIT_FAILURE;
+      EXPECT_EQ(subRange[0], (fullDomain.Begin()).Index());
     }
 
     /* Check that we got the end of the range */
     using DomainType = IteratorRangeDomainThreaderAssociate::TestDomainThreader::DomainType;
     DomainType::IteratorType fullIt = fullDomain.End();
     --fullIt;
-    if (i == numberOfThreads - 1 && subRange[1] != fullIt.Index())
+    if (i == numberOfThreads - 1)
     {
-      std::cerr << "Error: subRange[N-1][1] should be " << fullIt.Index() << ", but it's " << subRange[1] << '.';
-      return EXIT_FAILURE;
+      EXPECT_EQ(subRange[1], fullIt.Index());
     }
     /* Check that the sub-range endings and beginnings are continuous */
     if (i > 0)
     {
-      if (previousEndIndex + 2 != subRange[0])
-      {
-        std::cerr << "Error: subRange " << i << " is not continuous with "
-                  << "previous subRange." << std::endl
-                  << "previousEndIndex: " << previousEndIndex << std::endl
-                  << "subRange[0]: " << subRange[0] << std::endl;
-        return EXIT_FAILURE;
-      }
+      EXPECT_EQ(previousEndIndex + 2, static_cast<int>(subRange[0]));
     }
     previousEndIndex = subRange[1];
   }
-
-  return EXIT_SUCCESS;
 }
 
 // Helper function.
@@ -242,28 +217,20 @@ setStartEnd(const unsigned int                                                  
 }
 } // namespace
 
-int
-itkThreadedIteratorRangePartitionerTest3(int, char *[])
+TEST(ThreadedIteratorRangePartitioner3, ConvertedLegacyTest)
 {
   IteratorRangeDomainThreaderAssociate                                         enclosingClass;
   const IteratorRangeDomainThreaderAssociate::TestDomainThreader::ConstPointer domainThreader =
     enclosingClass.GetDomainThreader();
 
-  if (domainThreader->GetMultiThreader())
-  {
-    /* Check # of threads */
-    std::cout << "GetGlobalMaximumNumberOfThreads: "
-              << domainThreader->GetMultiThreader()->GetGlobalMaximumNumberOfThreads() << std::endl;
-    std::cout << "GetGlobalDefaultNumberOfThreads: "
-              << domainThreader->GetMultiThreader()->GetGlobalDefaultNumberOfThreads() << std::endl;
-    std::cout << "domainThreader->GetMultiThreader()->NumberOfWorkUnits(): "
-              << domainThreader->GetMultiThreader()->GetNumberOfWorkUnits() << std::endl;
-  }
-  else
-  {
-    std::cerr << "domainThreader->GetMultiThreader() is NULL" << std::endl;
-    return EXIT_FAILURE;
-  }
+  ASSERT_NE(domainThreader->GetMultiThreader(), nullptr);
+  /* Check # of threads */
+  std::cout << "GetGlobalMaximumNumberOfThreads: "
+            << domainThreader->GetMultiThreader()->GetGlobalMaximumNumberOfThreads() << std::endl;
+  std::cout << "GetGlobalDefaultNumberOfThreads: "
+            << domainThreader->GetMultiThreader()->GetGlobalDefaultNumberOfThreads() << std::endl;
+  std::cout << "domainThreader->GetMultiThreader()->NumberOfWorkUnits(): "
+            << domainThreader->GetMultiThreader()->GetNumberOfWorkUnits() << std::endl;
 
   using DomainType = IteratorRangeDomainThreaderAssociate::TestDomainThreader::DomainType;
   using DomainContainerType = IteratorRangeDomainThreaderAssociate::DomainContainerType;
@@ -279,18 +246,12 @@ itkThreadedIteratorRangePartitionerTest3(int, char *[])
   /* Test with single thread */
   setStartEnd(0, 100, container, fullDomain);
   itk::ThreadIdType numberOfThreads = 1;
-  if (ThreadedIteratorRangePartitionerRunTest(enclosingClass, numberOfThreads, fullDomain) != EXIT_SUCCESS)
-  {
-    return EXIT_FAILURE;
-  }
+  ThreadedIteratorRangePartitionerRunTest(enclosingClass, numberOfThreads, fullDomain);
 
   /* Test with range that doesn't start at 0 */
   setStartEnd(5, 100, container, fullDomain);
   numberOfThreads = 1;
-  if (ThreadedIteratorRangePartitionerRunTest(enclosingClass, numberOfThreads, fullDomain) != EXIT_SUCCESS)
-  {
-    return EXIT_FAILURE;
-  }
+  ThreadedIteratorRangePartitionerRunTest(enclosingClass, numberOfThreads, fullDomain);
 
   /* Test with multiple threads */
   if (domainThreader->GetMultiThreader()->GetGlobalMaximumNumberOfThreads() > 1)
@@ -298,19 +259,13 @@ itkThreadedIteratorRangePartitionerTest3(int, char *[])
     /* Test with default number of threads. */
     setStartEnd(6, 89, container, fullDomain);
     numberOfThreads = domainThreader->GetMultiThreader()->GetGlobalDefaultNumberOfThreads();
-    if (ThreadedIteratorRangePartitionerRunTest(enclosingClass, numberOfThreads, fullDomain) != EXIT_SUCCESS)
-    {
-      return EXIT_FAILURE;
-    }
+    ThreadedIteratorRangePartitionerRunTest(enclosingClass, numberOfThreads, fullDomain);
 
     /* Test with max number of threads and check that we only used as
      * many as is reasonable. */
     const itk::ThreadIdType maxNumberOfThreads = domainThreader->GetMultiThreader()->GetGlobalMaximumNumberOfThreads();
     setStartEnd(6, 6 + maxNumberOfThreads, container, fullDomain);
-    if (ThreadedIteratorRangePartitionerRunTest(enclosingClass, maxNumberOfThreads, fullDomain) != EXIT_SUCCESS)
-    {
-      return EXIT_FAILURE;
-    }
+    ThreadedIteratorRangePartitionerRunTest(enclosingClass, maxNumberOfThreads, fullDomain);
     if (domainThreader->GetNumberOfWorkUnitsUsed() != maxNumberOfThreads)
     {
       std::cerr << "Error: Expected to use only " << maxNumberOfThreads << "threads, but used "
@@ -321,6 +276,4 @@ itkThreadedIteratorRangePartitionerTest3(int, char *[])
   {
     std::cout << "No multi-threading available. " << std::endl;
   }
-
-  return EXIT_SUCCESS;
 }

--- a/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerGTest3.cxx
+++ b/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerGTest3.cxx
@@ -266,11 +266,7 @@ TEST(ThreadedIteratorRangePartitioner3, ConvertedLegacyTest)
     const itk::ThreadIdType maxNumberOfThreads = domainThreader->GetMultiThreader()->GetGlobalMaximumNumberOfThreads();
     setStartEnd(6, 6 + maxNumberOfThreads, container, fullDomain);
     ThreadedIteratorRangePartitionerRunTest(enclosingClass, maxNumberOfThreads, fullDomain);
-    if (domainThreader->GetNumberOfWorkUnitsUsed() != maxNumberOfThreads)
-    {
-      std::cerr << "Error: Expected to use only " << maxNumberOfThreads << "threads, but used "
-                << domainThreader->GetNumberOfWorkUnitsUsed() << '.' << std::endl;
-    }
+    EXPECT_EQ(domainThreader->GetNumberOfWorkUnitsUsed(), maxNumberOfThreads);
   }
   else
   {


### PR DESCRIPTION
## Summary

Converts three no-argument CTests that test `itk::ThreadedIteratorRangePartitioner` with different container types to GoogleTest format. Each file is a separate commit.

- `itkThreadedIteratorRangePartitionerTest` → `itkThreadedIteratorRangePartitionerGTest.cxx` (`std::vector<int>`, dereference access)
- `itkThreadedIteratorRangePartitionerTest2` → `itkThreadedIteratorRangePartitionerGTest2.cxx` (`itk::VectorContainer<int>`, `.Value()` access)
- `itkThreadedIteratorRangePartitionerTest3` → `itkThreadedIteratorRangePartitionerGTest3.cxx` (`itk::MapContainer<int,unsigned int>`, `.Index()` access, step-2 continuity)

Each conversion:
- Uses `git mv` to rename the file
- Replaces `if (...) return EXIT_FAILURE` with `EXPECT_*`/`ASSERT_*` assertions
- Wraps the test body in `TEST(ThreadedIteratorRangePartitioner{,2,3}, ConvertedLegacyTest)`
- Removes the entry from `ITKCommon2Tests` and the `itk_add_test` block
- Adds the new filename to `ITKCommonGTests`

The three test fixtures use distinct names (`ThreadedIteratorRangePartitioner`, `ThreadedIteratorRangePartitioner2`, `ThreadedIteratorRangePartitioner3`) to avoid duplicate test names in the shared `ITKCommonGTestDriver` binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)