### PR TITLE
COMP: Replace raw pointers with std::unique_ptr in VoxBoCUBImageIO

### DIFF
--- a/Modules/Nonunit/Review/include/itkVoxBoCUBImageIO.h
+++ b/Modules/Nonunit/Review/include/itkVoxBoCUBImageIO.h
@@ -22,6 +22,7 @@
 #include <fstream>
 #include <string>
 #include <map>
+#include <memory>
 #include "itkImageIOBase.h"
 #include "itkSpatialOrientation.h"
 #include <cstdio>
@@ -103,13 +104,14 @@ private:
   bool
   CheckExtension(const char *, bool & isCompressed);
 
-  GenericCUBFileAdaptor *
+  std::unique_ptr<GenericCUBFileAdaptor>
   CreateReader(const char * filename);
 
-  GenericCUBFileAdaptor *
+  std::unique_ptr<GenericCUBFileAdaptor>
   CreateWriter(const char * filename);
 
-  GenericCUBFileAdaptor *m_Reader{ nullptr }, *m_Writer{ nullptr };
+  std::unique_ptr<GenericCUBFileAdaptor> m_Reader;
+  std::unique_ptr<GenericCUBFileAdaptor> m_Writer;
 
   // Initialize the orientation map (from strings to ITK)
   void

--- a/Modules/Nonunit/Review/src/itkVoxBoCUBImageIO.cxx
+++ b/Modules/Nonunit/Review/src/itkVoxBoCUBImageIO.cxx
@@ -330,14 +330,14 @@ VoxBoCUBImageIO::VoxBoCUBImageIO()
   m_ByteOrder = IOByteOrderEnum::BigEndian;
 }
 
-/** Destructor */
-VoxBoCUBImageIO::~VoxBoCUBImageIO()
-{
-  delete m_Reader;
-  delete m_Writer;
-}
+// Destructor must be defined in the .cxx where GenericCUBFileAdaptor is a
+// complete type, so that std::unique_ptr<GenericCUBFileAdaptor> can be
+// correctly destroyed. Defining ~VoxBoCUBImageIO() = default in the header
+// would instantiate ~unique_ptr<GenericCUBFileAdaptor> with an incomplete
+// type, causing undefined behavior or a compile error.
+VoxBoCUBImageIO::~VoxBoCUBImageIO() = default;
 
-GenericCUBFileAdaptor *
+std::unique_ptr<GenericCUBFileAdaptor>
 VoxBoCUBImageIO::CreateReader(const char * filename)
 {
   try
@@ -347,11 +347,11 @@ VoxBoCUBImageIO::CreateReader(const char * filename)
     {
       if (compressed)
       {
-        return new CompressedCUBFileAdaptor(filename, "rb");
+        return std::make_unique<CompressedCUBFileAdaptor>(filename, "rb");
       }
       else
       {
-        return new DirectCUBFileAdaptor(filename, "rb");
+        return std::make_unique<DirectCUBFileAdaptor>(filename, "rb");
       }
     }
     else
@@ -365,7 +365,7 @@ VoxBoCUBImageIO::CreateReader(const char * filename)
   }
 }
 
-GenericCUBFileAdaptor *
+std::unique_ptr<GenericCUBFileAdaptor>
 VoxBoCUBImageIO::CreateWriter(const char * filename)
 {
   try
@@ -375,11 +375,11 @@ VoxBoCUBImageIO::CreateWriter(const char * filename)
     {
       if (compressed)
       {
-        return new CompressedCUBFileAdaptor(filename, "wb");
+        return std::make_unique<CompressedCUBFileAdaptor>(filename, "wb");
       }
       else
       {
-        return new DirectCUBFileAdaptor(filename, "wb");
+        return std::make_unique<DirectCUBFileAdaptor>(filename, "wb");
       }
     }
     else
@@ -397,7 +397,7 @@ bool
 VoxBoCUBImageIO::CanReadFile(const char * filename)
 {
   // First check if the file can be read
-  GenericCUBFileAdaptor * reader = CreateReader(filename);
+  auto reader = CreateReader(filename);
 
   if (reader == nullptr)
   {
@@ -434,7 +434,6 @@ VoxBoCUBImageIO::CanReadFile(const char * filename)
     iscub = false;
   }
 
-  delete reader;
   return iscub;
 }
 
@@ -468,10 +467,7 @@ VoxBoCUBImageIO::Read(void * buffer)
 void
 VoxBoCUBImageIO::ReadImageInformation()
 {
-  // Make sure there is no other reader
-  delete m_Reader;
-
-  // Create a reader
+  // Create a reader (assignment releases any previous reader)
   m_Reader = CreateReader(m_FileName.c_str());
   if (m_Reader == nullptr)
   {
@@ -741,8 +737,7 @@ VoxBoCUBImageIO::Write(const void * buffer)
   m_Writer = CreateWriter(m_FileName.c_str());
   WriteImageInformation();
   m_Writer->WriteData(buffer, this->GetImageSizeInBytes());
-  delete m_Writer;
-  m_Writer = nullptr;
+  m_Writer.reset();
 }
 
 /** Print Self Method */


### PR DESCRIPTION
## Summary

Replace raw pointer ownership in `VoxBoCUBImageIO` with `std::unique_ptr`, following C++ Core Guidelines R.11 and R.20.

- Change `m_Reader` and `m_Writer` members from `GenericCUBFileAdaptor*` to `std::unique_ptr<GenericCUBFileAdaptor>`
- Change `CreateReader`/`CreateWriter` return types to `std::unique_ptr<GenericCUBFileAdaptor>`; use `std::make_unique` for polymorphic factory creation
- Default the destructor — no manual `delete` needed
- Call `m_Writer.reset()` at end of `Write()` to preserve the original close-on-write behaviour (flush/close the file immediately after writing, matching the original `delete m_Writer` call)
- Remove `{}` brace-initializers from the `unique_ptr` members to avoid a GCC 7 bug with brace-initialization of smart pointers to forward-declared classes (reported in #3877)
- Add `<memory>` include

## Test plan
- [ ] CI builds pass on all platforms (including GCC 7)
- [ ] VoxBoCUB IO tests pass (`ctest -R VoxBo`)

> Part of a series splitting out #5993
> Addresses review comment from @N-Dekker regarding GCC 7 compatibility of `{}` on smart pointers to forward-declared types

🤖 Generated with [Claude Code](https://claude.com/claude-code)