### PR TITLE
ENH: Support "itk-skip-greptile-review" to skip Greptile reviewing

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,3 @@
+{
+  "ignoreKeywords": "itk-skip-greptile-review"
+}


### PR DESCRIPTION
The Greptile code review bot should ignore pull requests that have "itk-skip-greptile-review" in their title or description (or possibly in their last commit message), according to:

https://www.greptile.com/docs/code-review-bot/trigger-code-review

https://www.greptile.com/docs/code-review-bot/greptile-json#configuration-parameters

----

This pull request is inspired by the discussion we had, starting at https://github.com/InsightSoftwareConsortium/ITK/pull/5998#issuecomment-4170090605 on how to avoid wasting CI CPU/GPU cycles. Greptile _did_ review that pull request, even though it appeared that we already agreed to have it merged. The Greptile review was then ignored anyway, so it might as well be suppressed entirely.
