### PR TITLE
BUG: Fix itk_expat.h not found when ITK_USE_SYSTEM_EXPAT is ON

### DIFF
--- a/Modules/ThirdParty/Expat/CMakeLists.txt
+++ b/Modules/ThirdParty/Expat/CMakeLists.txt
@@ -10,7 +10,10 @@ mark_as_advanced(ITK_USE_SYSTEM_EXPAT)
 
 if(ITK_USE_SYSTEM_EXPAT)
   find_package(EXPAT REQUIRED)
-  set(ITKExpat_INCLUDE_DIRS ${ITKExpat_BINARY_DIR}/src)
+  set(
+    ITKExpat_INCLUDE_DIRS
+    ${ITKExpat_BINARY_DIR} # <- for itk_expat.h
+  )
   set(ITKExpat_SYSTEM_INCLUDE_DIRS "${EXPAT_INCLUDE_DIR}")
   set(ITKExpat_LIBRARIES "${EXPAT_LIBRARY}")
   set(ITKExpat_NO_SRC 1)
@@ -44,6 +47,10 @@ else()
 endif()
 
 configure_file(itk_expat.h.in ${ITKExpat_BINARY_DIR}/itk_expat.h)
+# Remove stale itk_expat.h from pre-bfc8e07d build trees that generated it
+# into the src/ subdirectory.  A leftover copy can shadow the current file
+# and confuse incremental builds.
+file(REMOVE ${ITKExpat_BINARY_DIR}/src/itk_expat.h)
 if(NOT ITK_USE_SYSTEM_EXPAT AND NOT ITK_FUTURE_LEGACY_REMOVE)
   # Configure a file with the name <expat.h> as was the default in ITKv5 and earlier
   # so that "#include <expat.h>" finds the itk mangled symbols during linkage stage.


### PR DESCRIPTION
## Summary

- Fix `itk_expat.h` not found when building with `ITK_USE_SYSTEM_EXPAT=ON` (or `ITK_USE_SYSTEM_LIBRARIES=ON`)
- Remove stale `src/itk_expat.h` from pre-bfc8e07d build trees to prevent incremental build confusion

## Root Cause

Commit bfc8e07d moved the `configure_file` output for `itk_expat.h` from
`${ITKExpat_BINARY_DIR}/src/itk_expat.h` to `${ITKExpat_BINARY_DIR}/itk_expat.h`
and updated the vendored (`ITK_USE_SYSTEM_EXPAT=OFF`) include path to match.

However, the `ITK_USE_SYSTEM_EXPAT=ON` branch was **not updated** — it still
set `ITKExpat_INCLUDE_DIRS` to `${ITKExpat_BINARY_DIR}/src`, which no longer
contains `itk_expat.h`. This causes:

```
gdcm/Utilities/gdcm_expat.h:20:11: fatal error: 'itk_expat.h' file not found
   20 | # include "itk_expat.h"
      |           ^~~~~~~~~~~~~
```

## Fix

1. Update `ITKExpat_INCLUDE_DIRS` in the system-expat branch to point to
   `${ITKExpat_BINARY_DIR}` where `itk_expat.h` is now generated
2. Add `file(REMOVE ...)` to clean up stale `src/itk_expat.h` from older
   build trees that generated it in the old location

## Test plan

- [ ] CI builds pass on all platforms
- [ ] Verify with `ITK_USE_SYSTEM_EXPAT=ON` that GDCM compiles without `itk_expat.h` errors
- [ ] Verify incremental build from a pre-bfc8e07d build tree works correctly

Reported by @seanm in https://github.com/InsightSoftwareConsortium/ITK/pull/5838#issuecomment-4144692236

🤖 Generated with [Claude Code](https://claude.com/claude-code)