### PR TITLE
STYLE: Move region iterator declarations into `for` loops over faces

### DIFF
--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
@@ -171,7 +171,6 @@ DisplacementFieldJacobianDeterminantFilter<TInputImage, TRealType, TOutputImage>
 {
   ZeroFluxNeumannBoundaryCondition<RealVectorImageType> nbc;
   ConstNeighborhoodIteratorType                         bit;
-  ImageRegionIterator<TOutputImage>                     it;
 
   // Find the data-set boundary "faces"
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<RealVectorImageType>                              bC;
@@ -189,7 +188,7 @@ DisplacementFieldJacobianDeterminantFilter<TInputImage, TRealType, TOutputImage>
   {
     bit = ConstNeighborhoodIteratorType(
       m_NeighborhoodRadius, dynamic_cast<const RealVectorImageType *>(m_RealValuedInputImage.GetPointer()), face);
-    it = ImageRegionIterator(this->GetOutput(), face);
+    ImageRegionIterator it(this->GetOutput(), face);
     bit.OverrideBoundaryCondition(&nbc);
     bit.GoToBegin();
 

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
@@ -96,8 +96,6 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::ThreadedCompute2ndDeri
 {
   ZeroFluxNeumannBoundaryCondition<TInputImage> nbc;
 
-  ImageRegionIterator<TOutputImage> it;
-
   void * globalData = nullptr;
 
   // Here input is the result from the gaussian filter output is the update
@@ -118,7 +116,7 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::ThreadedCompute2ndDeri
   {
     NeighborhoodType bit(radius, input, face);
 
-    it = ImageRegionIterator(this->m_OutputImage, face);
+    ImageRegionIterator it(this->m_OutputImage, face);
     bit.OverrideBoundaryCondition(&nbc);
     bit.GoToBegin();
 
@@ -379,8 +377,6 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::ThreadedCompute2ndDeri
   ConstNeighborhoodIterator<TInputImage> bit;
   ConstNeighborhoodIterator<TInputImage> bit1;
 
-  ImageRegionIterator<TOutputImage> it;
-
   // Here input is the result from the gaussian filter
   //      input1 is the 2nd derivative result
   //      output is the gradient of 2nd derivative
@@ -416,7 +412,7 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::ThreadedCompute2ndDeri
   {
     bit = ConstNeighborhoodIterator<InputImageType>(radius, input, face);
     bit1 = ConstNeighborhoodIterator<InputImageType>(radius, input1, face);
-    it = ImageRegionIterator(output, face);
+    ImageRegionIterator it(output, face);
     bit.OverrideBoundaryCondition(&nbc);
     bit.GoToBegin();
     bit1.GoToBegin();

--- a/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.hxx
@@ -123,8 +123,6 @@ MaskNeighborhoodOperatorImageFilter<TInputImage, TMaskImage, TOutputImage, TOper
   // Process non-boundary region and each of the boundary faces.
   // These are N-d regions which border the edge of the buffer.
   ConstNeighborhoodIterator<InputImageType> bit;
-  ImageRegionIterator<OutputImageType>      it;
-  ImageRegionConstIterator<MaskImageType>   mit;
 
   for (const auto & face : faceList)
   {
@@ -132,8 +130,8 @@ MaskNeighborhoodOperatorImageFilter<TInputImage, TMaskImage, TOutputImage, TOper
     bit.OverrideBoundaryCondition(this->GetBoundaryCondition());
     bit.GoToBegin();
 
-    it = ImageRegionIterator(output, face);
-    mit = ImageRegionConstIterator(mask, face);
+    ImageRegionIterator      it(output, face);
+    ImageRegionConstIterator mit(mask, face);
     while (!bit.IsAtEnd())
     {
       if (mit.Get())

--- a/Modules/Filtering/ImageFilterBase/include/itkNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNeighborhoodOperatorImageFilter.hxx
@@ -92,8 +92,6 @@ NeighborhoodOperatorImageFilter<TInputImage, TOutputImage, TOperatorValueType>::
   // pixels that correspond to output pixels.
   const FaceListType faceList = faceCalculator(input, outputRegionForThread, m_Operator.GetRadius());
 
-  ImageRegionIterator<OutputImageType> it;
-
   TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
 
   // Process non-boundary region and each of the boundary faces.
@@ -103,7 +101,7 @@ NeighborhoodOperatorImageFilter<TInputImage, TOutputImage, TOperatorValueType>::
   {
     bit = ConstNeighborhoodIterator<InputImageType>(m_Operator.GetRadius(), input, face);
     bit.OverrideBoundaryCondition(m_BoundsCondition);
-    it = ImageRegionIterator(output, face);
+    ImageRegionIterator it(output, face);
     bit.GoToBegin();
     while (!bit.IsAtEnd())
     {

--- a/Modules/Filtering/ImageFilterBase/include/itkVectorNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkVectorNeighborhoodOperatorImageFilter.hxx
@@ -94,15 +94,13 @@ VectorNeighborhoodOperatorImageFilter<TInputImage, TOutputImage>::DynamicThreade
 
   TotalProgressReporter progress(this, output->GetRequestedRegion().GetNumberOfPixels());
 
-  ImageRegionIterator<OutputImageType> it;
-
   // Process non-boundary region and then each of the boundary faces.
   // These are N-d regions which border the edge of the buffer.
   ConstNeighborhoodIterator<InputImageType> bit;
   for (const auto & face : faceList)
   {
     bit = ConstNeighborhoodIterator<InputImageType>(m_Operator.GetRadius(), input, face);
-    it = ImageRegionIterator(output, face);
+    ImageRegionIterator it(output, face);
     bit.GoToBegin();
     while (!bit.IsAtEnd())
     {

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
@@ -100,7 +100,6 @@ GradientMagnitudeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerate
 
   ConstNeighborhoodIterator<TInputImage> nit;
   ConstNeighborhoodIterator<TInputImage> bit;
-  ImageRegionIterator<TOutputImage>      it;
 
   const NeighborhoodInnerProduct<TInputImage, RealType> SIP;
 
@@ -157,7 +156,7 @@ GradientMagnitudeImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerate
   for (const auto & face : faceList)
   {
     bit = ConstNeighborhoodIterator<InputImageType>(radius, input, face);
-    it = ImageRegionIterator(output, face);
+    ImageRegionIterator it(output, face);
     bit.OverrideBoundaryCondition(&nbc);
     bit.GoToBegin();
 

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
@@ -188,7 +188,6 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::Dynami
 {
   ZeroFluxNeumannBoundaryCondition<RealVectorImageType> nbc;
   ConstNeighborhoodIteratorType                         bit;
-  ImageRegionIterator<TOutputImage>                     it;
 
   // Find the data-set boundary "faces"
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<RealVectorImageType> bC;
@@ -204,7 +203,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::Dynami
   for (const auto & face : faceList)
   {
     bit = ConstNeighborhoodIteratorType(r1, m_RealValuedInputImage.GetPointer(), face);
-    it = ImageRegionIterator(this->GetOutput(), face);
+    ImageRegionIterator it(this->GetOutput(), face);
     bit.OverrideBoundaryCondition(&nbc);
     bit.GoToBegin();
 

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
@@ -272,12 +272,6 @@ GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::DynamicThreadedGe
   // iterator for the marker image
   // NeighborhoodIteratorType markerIt;
 
-  // iterator for the mask image
-  ImageRegionConstIterator<TInputImage> maskIt;
-
-  // output iterator
-  ImageRegionIterator<TOutputImage> oIt;
-
   // Find the boundary "faces". Structuring element is elementary
   // (face connected neighbors within a radius of 1).
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<MarkerImageType> fC;
@@ -290,8 +284,8 @@ GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::DynamicThreadedGe
   for (const auto & face : faceList)
   {
     NeighborhoodIteratorType markerIt(kernelRadius, this->GetMarkerImage(), face);
-    maskIt = ImageRegionConstIterator(this->GetMaskImage(), face);
-    oIt = ImageRegionIterator(this->GetOutput(), face);
+    ImageRegionConstIterator maskIt(this->GetMaskImage(), face);
+    ImageRegionIterator      oIt(this->GetOutput(), face);
 
     markerIt.OverrideBoundaryCondition(&BC);
     markerIt.GoToBegin();

--- a/Modules/Filtering/MathematicalMorphology/include/itkMorphologyImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMorphologyImageFilter.hxx
@@ -50,8 +50,6 @@ MorphologyImageFilter<TInputImage, TOutputImage, TKernel>::DynamicThreadedGenera
 
   TotalProgressReporter progress(this, this->GetOutput()->GetRequestedRegion().GetNumberOfPixels());
 
-  ImageRegionIterator<TOutputImage> o_iter;
-
   // Process the boundary faces, these are N-d regions which border the
   // edge of the buffer
 
@@ -62,7 +60,7 @@ MorphologyImageFilter<TInputImage, TOutputImage, TKernel>::DynamicThreadedGenera
   {
     b_iter = NeighborhoodIteratorType(this->GetKernel().GetRadius(), this->GetInput(), face);
 
-    o_iter = ImageRegionIterator(this->GetOutput(), face);
+    ImageRegionIterator o_iter(this->GetOutput(), face);
     b_iter.OverrideBoundaryCondition(m_BoundaryCondition);
     b_iter.GoToBegin();
 

--- a/Modules/Segmentation/LabelVoting/include/itkBinaryMedianImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkBinaryMedianImageFilter.hxx
@@ -92,7 +92,6 @@ BinaryMedianImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   ZeroFluxNeumannBoundaryCondition<InputImageType> nbc;
 
   ConstNeighborhoodIterator<InputImageType> bit;
-  ImageRegionIterator<OutputImageType>      it;
 
   // Allocate output
   const typename OutputImageType::Pointer     output = this->GetOutput();
@@ -110,7 +109,7 @@ BinaryMedianImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   for (const auto & face : faceList)
   {
     bit = ConstNeighborhoodIterator<InputImageType>(m_Radius, input, face);
-    it = ImageRegionIterator(output, face);
+    ImageRegionIterator it(output, face);
     bit.OverrideBoundaryCondition(&nbc);
     bit.GoToBegin();
 

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryHoleFillingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryHoleFillingImageFilter.hxx
@@ -79,7 +79,6 @@ VotingBinaryHoleFillingImageFilter<TInputImage, TOutputImage>::ThreadedGenerateD
   ZeroFluxNeumannBoundaryCondition<InputImageType> nbc;
 
   ConstNeighborhoodIterator<InputImageType> bit;
-  ImageRegionIterator<OutputImageType>      it;
 
   // Allocate output
   const typename OutputImageType::Pointer     output = this->GetOutput();
@@ -103,7 +102,7 @@ VotingBinaryHoleFillingImageFilter<TInputImage, TOutputImage>::ThreadedGenerateD
   for (const auto & face : faceList)
   {
     bit = ConstNeighborhoodIterator<InputImageType>(this->GetRadius(), input, face);
-    it = ImageRegionIterator(output, face);
+    ImageRegionIterator it(output, face);
     bit.OverrideBoundaryCondition(&nbc);
     bit.GoToBegin();
 

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.hxx
@@ -92,7 +92,6 @@ VotingBinaryImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   ZeroFluxNeumannBoundaryCondition<InputImageType> nbc;
 
   ConstNeighborhoodIterator<InputImageType> bit;
-  ImageRegionIterator<OutputImageType>      it;
 
   const typename OutputImageType::Pointer     output = this->GetOutput();
   const typename InputImageType::ConstPointer input = this->GetInput();
@@ -108,7 +107,7 @@ VotingBinaryImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   for (const auto & face : faceList)
   {
     bit = ConstNeighborhoodIterator<InputImageType>(m_Radius, input, face);
-    it = ImageRegionIterator(output, face);
+    ImageRegionIterator it(output, face);
     bit.OverrideBoundaryCondition(&nbc);
     bit.GoToBegin();
 


### PR DESCRIPTION
In these cases, a region iterator variable was default-constructed outside a `for` loop and then a newly constructed iterator was assigned to the variable inside the `for` loop.

The code was simplified by declaring this variable inside the `for` loop instead.

Following C++ Core Guidelines, Jul 8, 2025, [Keep scopes small](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#res-scope)

----

Just as a test, hereby trying out our new (pull request #6001) Greptile "ignore keyword": itk-skip-greptile-review