### PR TITLE
STYLE: Replace Allocate(true) with AllocateInitialized()

### DIFF
--- a/Examples/DataRepresentation/Image/Image3.cxx
+++ b/Examples/DataRepresentation/Image/Image3.cxx
@@ -56,7 +56,7 @@ main(int, char *[])
 
   // Pixel data is allocated
   image->SetRegions(region);
-  image->Allocate(true); // initialize buffer to zero
+  image->AllocateInitialized();
 
 
   // Software Guide : BeginLatex

--- a/Examples/DataRepresentation/Image/Image4.cxx
+++ b/Examples/DataRepresentation/Image/Image4.cxx
@@ -93,7 +93,7 @@ main(int, char *[])
   region.SetIndex(start);
 
   image->SetRegions(region);
-  image->Allocate(true); // initialize buffer to zero
+  image->AllocateInitialized();
 
   // Software Guide : BeginLatex
   //

--- a/Examples/Filtering/DigitallyReconstructedRadiograph1.cxx
+++ b/Examples/Filtering/DigitallyReconstructedRadiograph1.cxx
@@ -381,7 +381,7 @@ main(int argc, char * argv[])
     region.SetIndex(start);
 
     image->SetRegions(region);
-    image->Allocate(true); // initialize to zero.
+    image->AllocateInitialized();
 
     image->Update();
 

--- a/Examples/Segmentation/HoughTransform2DCirclesImageFilter.cxx
+++ b/Examples/Segmentation/HoughTransform2DCirclesImageFilter.cxx
@@ -203,7 +203,7 @@ main(int argc, char * argv[])
   localOutputImage->SetRegions(region);
   localOutputImage->SetOrigin(localImage->GetOrigin());
   localOutputImage->SetSpacing(localImage->GetSpacing());
-  localOutputImage->Allocate(true); // initializes buffer to zero
+  localOutputImage->AllocateInitialized();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/Segmentation/HoughTransform2DLinesImageFilter.cxx
+++ b/Examples/Segmentation/HoughTransform2DLinesImageFilter.cxx
@@ -219,7 +219,7 @@ main(int argc, char * argv[])
     localImage->GetLargestPossibleRegion());
   localOutputImage->SetRegions(region);
   localOutputImage->CopyInformation(localImage);
-  localOutputImage->Allocate(true); // initialize buffer to zero
+  localOutputImage->AllocateInitialized();
   // Software Guide : EndCodeSnippet
 
 

--- a/Examples/SpatialObjects/ImageMaskSpatialObject.cxx
+++ b/Examples/SpatialObjects/ImageMaskSpatialObject.cxx
@@ -76,7 +76,7 @@ main(int, char *[])
   region.SetIndex(index);
 
   image->SetRegions(region);
-  image->Allocate(true); // initialize buffer to zero
+  image->AllocateInitialized();
 
   ImageType::RegionType          insideRegion;
   constexpr ImageType::SizeType  insideSize = { { 30, 30, 30 } };

--- a/Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx
+++ b/Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx
@@ -180,7 +180,7 @@ MINCTransformIOTemplate<TParametersValueType>::ReadOneTransform(VIO_General_tran
         {
           LPSgrid->CopyInformation(grid);
           LPSgrid->SetRegions(grid->GetBufferedRegion());
-          LPSgrid->Allocate(true);
+          LPSgrid->AllocateInitialized();
 
           itk::MultiThreaderBase::Pointer mt = itk::MultiThreaderBase::New();
           mt->ParallelizeImageRegion<3>(
@@ -361,7 +361,7 @@ MINCTransformIOTemplate<TParametersValueType>::WriteOneTransform(const int      
         typename GridImageType::Pointer rasGrid = GridImageType::New(); // flipped grid for RAS->LPS conversion
         rasGrid->CopyInformation(grid);
         rasGrid->SetRegions(grid->GetBufferedRegion());
-        rasGrid->Allocate(true);
+        rasGrid->AllocateInitialized();
 
         itk::MultiThreaderBase::Pointer mt = itk::MultiThreaderBase::New();
         mt->ParallelizeImageRegion<3>(


### PR DESCRIPTION
## Summary

Replaces all `->Allocate(true)` call sites with the self-documenting alias `->AllocateInitialized()` throughout `Modules/` and `Examples/`.

## Motivation

`Allocate(true)` zero-initializes the image buffer, but the boolean argument is easy to misread. `AllocateInitialized()` was added to `itkImageBase.h` specifically for readability:

> "AllocateInitialized() is equivalent to Allocate(true). It is just intended to make the code more readable."

The redundant trailing comments (`// initialize buffer to zero`) are also removed since the method name is now self-documenting.

## Scope

- `Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx` — 2 sites
- `Examples/` — 6 sites

`Allocate()` (no args) and `Allocate(false)` are **not** changed. The definition in `itkImageBase.h` is unchanged.

Pure mechanical substitution — no semantic change.

Suggested by @N-Dekker in https://github.com/InsightSoftwareConsortium/ITK/pull/6003#discussion_r3033225653