### PR TITLE
STYLE: Replace declare-then-Fill(N) with ::Filled(N) factory method

### DIFF
--- a/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -254,11 +254,10 @@ itkBSplineInterpolationWeightFunctionTest(int, char *[])
 
     std::cout << "Number Of Weights: " << numberOfWeights << std::endl;
 
-    ContinuousIndexType position;
-    WeightsType         weights;
-    IndexType           startIndex;
+    auto        position = itk::MakeFilled<ContinuousIndexType>(4.15);
+    WeightsType weights;
+    IndexType   startIndex;
 
-    position.Fill(4.15);
     weights = function->Evaluate(position);
 
     std::cout << "Position: " << position << std::endl;

--- a/Modules/Core/Common/test/itkImageVectorOptimizerParametersHelperTest.cxx
+++ b/Modules/Core/Common/test/itkImageVectorOptimizerParametersHelperTest.cxx
@@ -78,9 +78,8 @@ testMemoryAccess(OptimizerParametersType & params, ImageVectorPointer imageOfVec
 int
 itkImageVectorOptimizerParametersHelperTest(int, char *[])
 {
-  SizeType      size;
   constexpr int dimLength{ 3 };
-  size.Fill(dimLength);
+  auto          size = itk::MakeFilled<SizeType>(dimLength);
 
   const RegionType region{ size };
 

--- a/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
@@ -109,13 +109,10 @@ GaussianInterpolateImageFunction<TImageType, TCoordinate>::EvaluateAtContinuousI
 
   RealType  sum_me = 0.0;
   RealType  sum_m = 0.0;
-  ArrayType dsum_me;
-  ArrayType dsum_m;
-  ArrayType dw;
+  ArrayType dsum_me{};
+  ArrayType dsum_m{};
+  ArrayType dw{};
 
-  dsum_m.Fill(0.0);
-  dsum_me.Fill(0.0);
-  dw.Fill(0.0);
 
   for (ImageRegionConstIteratorWithIndex It(this->GetInputImage(), region); !It.IsAtEnd(); ++It)
   {

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionTest.cxx
@@ -63,10 +63,9 @@ itkCentralDifferenceImageFunctionTest(int, char *[])
 
   function->SetInputImage(image);
 
-  ImageType::IndexType index;
+  auto index = itk::MakeFilled<ImageType::IndexType>(8);
 
   // pick an index inside the image
-  index.Fill(8);
   OutputType indexOutput = function->EvaluateAtIndex(index);
   std::cout << "Index: " << index << " Derivative: ";
   std::cout << indexOutput << std::endl;

--- a/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
@@ -49,11 +49,10 @@ itkGaussianInterpolateImageFunctionTest(int, char *[])
   image->SetRegions(region);
   image->Allocate();
 
-  ImageType::PointType   origin;
-  ImageType::SpacingType spacing;
+  ImageType::PointType origin;
+  auto                 spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
 
   origin.Fill(0.0);
-  spacing.Fill(1.0);
 
   image->SetOrigin(origin);
   image->SetSpacing(spacing);

--- a/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
@@ -49,10 +49,9 @@ itkGaussianInterpolateImageFunctionTest(int, char *[])
   image->SetRegions(region);
   image->Allocate();
 
-  ImageType::PointType origin;
+  ImageType::PointType origin{};
   auto                 spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
 
-  origin.Fill(0.0);
 
   image->SetOrigin(origin);
   image->SetSpacing(spacing);

--- a/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
@@ -59,9 +59,8 @@ RunLinearInterpolateTest()
   auto variablevectorimage = VariableVectorImageType::New();
   variablevectorimage->SetVectorLength(VectorDimension);
 
-  SizeType      size;
   constexpr int dimMaxLength{ 3 };
-  size.Fill(dimMaxLength);
+  auto          size = itk::MakeFilled<SizeType>(dimMaxLength);
 
   const RegionType region{ size };
 

--- a/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
@@ -71,11 +71,10 @@ itkNearestNeighborInterpolateImageFunctionTest(int, char *[])
   variablevectorimage->SetRegions(region);
   variablevectorimage->Allocate();
 
-  ImageType::PointType   origin;
-  ImageType::SpacingType spacing;
+  ImageType::PointType origin;
+  auto                 spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
 
   origin.Fill(0.0);
-  spacing.Fill(1.0);
 
   image->SetOrigin(origin);
   image->SetSpacing(spacing);

--- a/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
@@ -71,10 +71,9 @@ itkNearestNeighborInterpolateImageFunctionTest(int, char *[])
   variablevectorimage->SetRegions(region);
   variablevectorimage->Allocate();
 
-  ImageType::PointType origin;
+  ImageType::PointType origin{};
   auto                 spacing = itk::MakeFilled<ImageType::SpacingType>(1.0);
 
-  origin.Fill(0.0);
 
   image->SetOrigin(origin);
   image->SetSpacing(spacing);

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
@@ -73,10 +73,8 @@ ContourSpatialObject<TDimension>::GetOrientationInObjectSpace() const
   const ContourPointListType & points = this->GetPoints();
   auto                         it = points.begin();
   auto                         itend = points.end();
-  PointType                    minPnt;
-  PointType                    maxPnt;
-  minPnt.Fill(NumericTraits<double>::max());
-  maxPnt.Fill(NumericTraits<double>::NonpositiveMin());
+  auto                         minPnt = MakeFilled<PointType>(NumericTraits<double>::max());
+  auto                         maxPnt = MakeFilled<PointType>(NumericTraits<double>::NonpositiveMin());
   while (it != itend)
   {
     PointType curpoint = it->GetPositionInObjectSpace();

--- a/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
@@ -61,10 +61,8 @@ PolygonSpatialObject<TDimension>::GetOrientationInObjectSpace() const
   const PolygonPointListType & points = this->GetPoints();
   auto                         it = points.begin();
   auto                         itend = points.end();
-  PointType                    minPnt;
-  PointType                    maxPnt;
-  minPnt.Fill(NumericTraits<double>::max());
-  maxPnt.Fill(NumericTraits<double>::NonpositiveMin());
+  auto                         minPnt = MakeFilled<PointType>(NumericTraits<double>::max());
+  auto                         maxPnt = MakeFilled<PointType>(NumericTraits<double>::NonpositiveMin());
   while (it != itend)
   {
     PointType curpoint = it->GetPositionInObjectSpace();

--- a/Modules/Core/Transform/include/itkKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkKernelTransform.hxx
@@ -318,11 +318,10 @@ auto
 KernelTransform<TParametersValueType, VDimension>::TransformPoint(const InputPointType & thisPoint) const
   -> OutputPointType
 {
-  OutputPointType result;
-
   using ValueType = typename OutputPointType::ValueType;
 
-  result.Fill(ValueType{});
+  auto result = MakeFilled<OutputPointType>(ValueType{});
+
 
   // TODO:  It is unclear if the following line is needed.
   this->ComputeDeformationContribution(thisPoint, result);

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
@@ -152,11 +152,10 @@ itkBSplineDeformableTransformTest1()
    */
   using PointType = TransformType::InputPointType;
 
-  PointType inputPoint;
+  auto      inputPoint = itk::MakeFilled<PointType>(9.0);
   PointType outputPoint;
 
   // point within the grid support region
-  inputPoint.Fill(9.0);
   outputPoint = transform->TransformPoint(inputPoint);
 
   std::cout << "Input Point: " << inputPoint << std::endl;

--- a/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
@@ -177,11 +177,10 @@ itkBSplineTransformTest1()
    */
   using PointType = TransformType::InputPointType;
 
-  PointType inputPoint;
+  auto      inputPoint = itk::MakeFilled<PointType>(9.0);
   PointType outputPoint;
 
   // point within the grid support region
-  inputPoint.Fill(9.0);
   outputPoint = transform->TransformPoint(inputPoint);
 
   std::cout << "Input Point: " << inputPoint << std::endl;

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.hxx
@@ -181,11 +181,9 @@ template <typename TInputImage, typename TOutputImage>
 auto
 PatchBasedDenoisingBaseImageFilter<TInputImage, TOutputImage>::GetPatchDiameterInVoxels() const -> PatchRadiusType
 {
-  PatchRadiusType one;
-  PatchRadiusType two;
+  auto one = MakeFilled<PatchRadiusType>(1);
+  auto two = MakeFilled<PatchRadiusType>(2);
 
-  one.Fill(1);
-  two.Fill(2);
   const PatchRadiusType radius = this->GetPatchRadiusInVoxels();
   const PatchRadiusType diameter = two * radius + one;
   return diameter;

--- a/Modules/Filtering/DisplacementField/test/itkComposeDisplacementFieldsImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkComposeDisplacementFieldsImageFilterTest.cxx
@@ -29,14 +29,12 @@ itkComposeDisplacementFieldsImageFilterTest(int, char *[])
 
   // Create a displacement field
   DisplacementFieldType::PointType     origin;
-  DisplacementFieldType::SpacingType   spacing;
-  DisplacementFieldType::SizeType      size;
+  auto                                 spacing = itk::MakeFilled<DisplacementFieldType::SpacingType>(0.5);
+  auto                                 size = itk::MakeFilled<DisplacementFieldType::SizeType>(100);
   DisplacementFieldType::DirectionType direction;
 
   direction.SetIdentity();
   origin.Fill(0.0);
-  spacing.Fill(0.5);
-  size.Fill(100);
 
   auto ones = itk::MakeFilled<VectorType>(1);
 

--- a/Modules/Filtering/DisplacementField/test/itkComposeDisplacementFieldsImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkComposeDisplacementFieldsImageFilterTest.cxx
@@ -28,13 +28,12 @@ itkComposeDisplacementFieldsImageFilterTest(int, char *[])
   using DisplacementFieldType = itk::Image<VectorType, ImageDimension>;
 
   // Create a displacement field
-  DisplacementFieldType::PointType     origin;
+  DisplacementFieldType::PointType     origin{};
   auto                                 spacing = itk::MakeFilled<DisplacementFieldType::SpacingType>(0.5);
   auto                                 size = itk::MakeFilled<DisplacementFieldType::SizeType>(100);
   DisplacementFieldType::DirectionType direction;
 
   direction.SetIdentity();
-  origin.Fill(0.0);
 
   auto ones = itk::MakeFilled<VectorType>(1);
 

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldToBSplineImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldToBSplineImageFilterTest.cxx
@@ -29,13 +29,12 @@ itkDisplacementFieldToBSplineImageFilterTest(int, char *[])
   using PointSetType = itk::PointSet<VectorType, ImageDimension>;
 
   // Create a displacement field
-  DisplacementFieldType::PointType     origin;
+  DisplacementFieldType::PointType     origin{};
   auto                                 spacing = itk::MakeFilled<DisplacementFieldType::SpacingType>(0.5);
   auto                                 size = itk::MakeFilled<DisplacementFieldType::SizeType>(100);
   DisplacementFieldType::DirectionType direction;
 
   direction.SetIdentity();
-  origin.Fill(0.0);
 
   auto ones = itk::MakeFilled<VectorType>(1);
 

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldToBSplineImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldToBSplineImageFilterTest.cxx
@@ -30,14 +30,12 @@ itkDisplacementFieldToBSplineImageFilterTest(int, char *[])
 
   // Create a displacement field
   DisplacementFieldType::PointType     origin;
-  DisplacementFieldType::SpacingType   spacing;
-  DisplacementFieldType::SizeType      size;
+  auto                                 spacing = itk::MakeFilled<DisplacementFieldType::SpacingType>(0.5);
+  auto                                 size = itk::MakeFilled<DisplacementFieldType::SizeType>(100);
   DisplacementFieldType::DirectionType direction;
 
   direction.SetIdentity();
   origin.Fill(0.0);
-  spacing.Fill(0.5);
-  size.Fill(100);
 
   auto ones = itk::MakeFilled<VectorType>(1);
 

--- a/Modules/Filtering/DisplacementField/test/itkInvertDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkInvertDisplacementFieldImageFilterTest.cxx
@@ -37,13 +37,12 @@ itkInvertDisplacementFieldImageFilterTest(int argc, char * argv[])
   using DisplacementFieldType = itk::Image<VectorType, ImageDimension>;
 
   // Create a displacement field
-  DisplacementFieldType::PointType     origin;
+  DisplacementFieldType::PointType     origin{};
   auto                                 spacing = itk::MakeFilled<DisplacementFieldType::SpacingType>(0.5);
   auto                                 size = itk::MakeFilled<DisplacementFieldType::SizeType>(100);
   DisplacementFieldType::DirectionType direction;
 
   direction.SetIdentity();
-  origin.Fill(0.0);
 
   auto ones = itk::MakeFilled<VectorType>(1);
 

--- a/Modules/Filtering/DisplacementField/test/itkInvertDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkInvertDisplacementFieldImageFilterTest.cxx
@@ -38,14 +38,12 @@ itkInvertDisplacementFieldImageFilterTest(int argc, char * argv[])
 
   // Create a displacement field
   DisplacementFieldType::PointType     origin;
-  DisplacementFieldType::SpacingType   spacing;
-  DisplacementFieldType::SizeType      size;
+  auto                                 spacing = itk::MakeFilled<DisplacementFieldType::SpacingType>(0.5);
+  auto                                 size = itk::MakeFilled<DisplacementFieldType::SizeType>(100);
   DisplacementFieldType::DirectionType direction;
 
   direction.SetIdentity();
   origin.Fill(0.0);
-  spacing.Fill(0.5);
-  size.Fill(100);
 
   auto ones = itk::MakeFilled<VectorType>(1);
 

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingBSplineVelocityFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingBSplineVelocityFieldTransformTest.cxx
@@ -91,13 +91,12 @@ itkTimeVaryingBSplineVelocityFieldTransformTest(int, char *[])
 
   // Now test the transform
 
-  TimeVaryingVelocityFieldType::PointType     timeVaryingVelocityFieldOrigin;
-  TimeVaryingVelocityFieldType::SpacingType   timeVaryingVelocityFieldSpacing;
+  TimeVaryingVelocityFieldType::PointType timeVaryingVelocityFieldOrigin;
+  auto timeVaryingVelocityFieldSpacing = itk::MakeFilled<TimeVaryingVelocityFieldType::SpacingType>(1.0);
   TimeVaryingVelocityFieldType::SizeType      timeVaryingVelocityFieldSize;
   TimeVaryingVelocityFieldType::DirectionType timeVaryingVelocityFieldDirection;
 
   timeVaryingVelocityFieldDirection.SetIdentity();
-  timeVaryingVelocityFieldSpacing.Fill(1.0);
   for (unsigned int d = 0; d < 4; ++d)
   {
     const float physicalDimensions = (size[d] - splineOrder) * spacing[d];

--- a/Modules/Filtering/DistanceMap/test/itkContourMeanDistanceImageFilterGTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkContourMeanDistanceImageFilterGTest.cxx
@@ -50,10 +50,9 @@ TEST(ContourMeanDistanceImageFilter, Test)
   using RegionType = Image1Type::RegionType;
 
   using IndexType = Image1Type::IndexType;
-  IndexType index;
+  auto index = itk::MakeFilled<IndexType>(10);
 
   size.Fill(20);
-  index.Fill(10);
   RegionType region1 = { index, size };
 
   size.Fill(15);

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
@@ -200,9 +200,8 @@ itkGradientRecursiveGaussianFilterTest3(int argc, char * argv[])
   using myImageVector1DType = itk::Image<myVector1DType, myDimension>;
 
   myGradImage1DType::Pointer vector1DGradImage = nullptr;
-  myVector1DType             vector1Dborder;
+  myVector1DType             vector1Dborder{};
   auto                       vector1Dfill = itk::MakeFilled<myVector1DType>(100.0);
-  vector1Dborder.Fill(0.0);
   int runResult = itkGradientRecursiveGaussianFilterTest3Run<myImageVector1DType, myGradImage1DType, myComponents1D>(
     vector1Dborder, vector1Dfill, vector1DGradImage, argv[1]);
   if (runResult == EXIT_FAILURE)

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
@@ -201,9 +201,8 @@ itkGradientRecursiveGaussianFilterTest3(int argc, char * argv[])
 
   myGradImage1DType::Pointer vector1DGradImage = nullptr;
   myVector1DType             vector1Dborder;
-  myVector1DType             vector1Dfill;
+  auto                       vector1Dfill = itk::MakeFilled<myVector1DType>(100.0);
   vector1Dborder.Fill(0.0);
-  vector1Dfill.Fill(100.0);
   int runResult = itkGradientRecursiveGaussianFilterTest3Run<myImageVector1DType, myGradImage1DType, myComponents1D>(
     vector1Dborder, vector1Dfill, vector1DGradImage, argv[1]);
   if (runResult == EXIT_FAILURE)
@@ -237,9 +236,8 @@ itkGradientRecursiveGaussianFilterTest3(int argc, char * argv[])
   using myImageVar2DType = itk::Image<myVarVector2DType, myDimension>;
 
   myGradImage2DType::Pointer vector2DGradImage = nullptr;
-  myVector2DType             vector2Dborder;
+  auto                       vector2Dborder = itk::MakeFilled<myVector2DType>(pixelBorder);
   myVector2DType             vector2Dfill;
-  vector2Dborder.Fill(pixelBorder);
   vector2Dfill[0] = pixelFill;
   vector2Dfill[1] = pixelFill / 2.0;
   runResult = itkGradientRecursiveGaussianFilterTest3Run<myImage2DType, myGradImage2DType, myComponents2D>(
@@ -295,9 +293,8 @@ itkGradientRecursiveGaussianFilterTest3(int argc, char * argv[])
   using myImage3DType = itk::Image<myVector3DType, myDimension>;
 
   myGradImage3DType::Pointer vector3DGradImage = nullptr;
-  myVector3DType             vector3Dborder;
+  auto                       vector3Dborder = itk::MakeFilled<myVector3DType>(pixelBorder);
   myVector3DType             vector3Dfill;
-  vector3Dborder.Fill(pixelBorder);
   vector3Dfill[0] = pixelFill;
   vector3Dfill[1] = pixelFill / 2.0;
   vector3Dfill[2] = pixelFill / 3.0;

--- a/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFunctionTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFunctionTest.cxx
@@ -37,9 +37,8 @@ itkBSplineControlPointImageFunctionTest(int, char *[])
 
   auto                       size = itk::MakeFilled<VectorImageType::SizeType>(4);
   auto                       spacing = itk::MakeFilled<VectorImageType::SpacingType>(1.0);
-  VectorImageType::PointType origin;
+  VectorImageType::PointType origin{};
 
-  origin.Fill(0.0);
   phiLattice->SetOrigin(origin);
   phiLattice->SetSpacing(spacing);
   phiLattice->SetRegions(size);
@@ -48,9 +47,8 @@ itkBSplineControlPointImageFunctionTest(int, char *[])
   // To create the specified function, the first and last control points have
   // a value of 1.0;
 
-  VectorImageType::IndexType index;
+  VectorImageType::IndexType index{};
   auto                       value = itk::MakeFilled<VectorImageType::PixelType>(1.0);
-  index.Fill(0);
   phiLattice->SetPixel(index, value);
   index.Fill(3);
   value.Fill(1.0);

--- a/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFunctionTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFunctionTest.cxx
@@ -35,12 +35,10 @@ itkBSplineControlPointImageFunctionTest(int, char *[])
 
   auto phiLattice = VectorImageType::New();
 
-  VectorImageType::SizeType    size;
-  VectorImageType::SpacingType spacing;
-  VectorImageType::PointType   origin;
+  auto                       size = itk::MakeFilled<VectorImageType::SizeType>(4);
+  auto                       spacing = itk::MakeFilled<VectorImageType::SpacingType>(1.0);
+  VectorImageType::PointType origin;
 
-  size.Fill(4);
-  spacing.Fill(1.0);
   origin.Fill(0.0);
   phiLattice->SetOrigin(origin);
   phiLattice->SetSpacing(spacing);
@@ -51,9 +49,8 @@ itkBSplineControlPointImageFunctionTest(int, char *[])
   // a value of 1.0;
 
   VectorImageType::IndexType index;
-  VectorImageType::PixelType value;
+  auto                       value = itk::MakeFilled<VectorImageType::PixelType>(1.0);
   index.Fill(0);
-  value.Fill(1.0);
   phiLattice->SetPixel(index, value);
   index.Fill(3);
   value.Fill(1.0);

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest3.cxx
@@ -94,10 +94,9 @@ itkBSplineScatteredDataPointSetToImageFilterTest3(int argc, char * argv[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, BSplineScatteredDataPointSetToImageFilter, PointSetToImageFilter);
 
   // Define the parametric domain
-  auto                spacing = itk::MakeFilled<ImageType::SpacingType>(0.001);
-  ImageType::SizeType size;
+  auto spacing = itk::MakeFilled<ImageType::SpacingType>(0.001);
+  auto size = itk::MakeFilled<ImageType::SizeType>(static_cast<unsigned int>(1.0 / spacing[0] + .5) + 1);
   // Adding 0.5 to avoid rounding errors
-  size.Fill(static_cast<unsigned int>(1.0 / spacing[0] + .5) + 1);
   constexpr ImageType::PointType origin{};
 
   filter->SetSize(size);

--- a/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest.cxx
@@ -72,13 +72,12 @@ itkFlatStructuringElementTest(int, char *[])
   k2 = SE2Type::Polygon(r2, 5);
 
   using SE3Type = itk::FlatStructuringElement<3>;
-  SE3Type::RadiusType r3;
+  auto r3 = itk::MakeFilled<SE3Type::RadiusType>(scalarRadius);
 
   SE3Type::Self result3{};
   result3.RadiusIsParametricOff();
   ITK_TEST_SET_GET_VALUE(false, result3.GetRadiusIsParametric());
 
-  r3.Fill(scalarRadius);
   SE3Type k3;
 
   k3 = SE3Type::Box(r3);
@@ -130,13 +129,12 @@ itkFlatStructuringElementTest(int, char *[])
   }
 
   using SE4Type = itk::FlatStructuringElement<4>;
-  SE4Type::RadiusType r4;
+  auto r4 = itk::MakeFilled<SE4Type::RadiusType>(scalarRadius);
 
   SE4Type::Self result4{};
   result4.RadiusIsParametricOn();
   ITK_TEST_SET_GET_VALUE(true, result4.GetRadiusIsParametric());
 
-  r4.Fill(scalarRadius);
   SE4Type k4;
 
   k4 = SE4Type::Box(r4);

--- a/Modules/Filtering/Path/include/itkChainCodeToFourierSeriesPathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkChainCodeToFourierSeriesPathFilter.hxx
@@ -64,10 +64,8 @@ ChainCodeToFourierSeriesPathFilter<TInputChainCodePath, TOutputFourierSeriesPath
   for (unsigned int n = 0; n < numHarmonics; ++n)
   {
     auto       index = inputPtr->GetStart();
-    VectorType cosCoefficient;
-    cosCoefficient.Fill(0.0);
-    VectorType sinCoefficient;
-    sinCoefficient.Fill(0.0);
+    VectorType cosCoefficient{};
+    VectorType sinCoefficient{};
 
     for (InputPathInputType step = 0; step < numSteps; ++step)
     {

--- a/Modules/Filtering/Path/include/itkFourierSeriesPath.hxx
+++ b/Modules/Filtering/Path/include/itkFourierSeriesPath.hxx
@@ -27,9 +27,8 @@ auto
 FourierSeriesPath<VDimension>::Evaluate(const InputType & input) const -> OutputType
 {
   InputType  theta;
-  OutputType output;
+  OutputType output{};
   const int  numHarmonics = m_CosCoefficients->Size();
-  output.Fill(0);
 
   const double PI = 4.0 * std::atan(1.0);
 
@@ -54,9 +53,8 @@ auto
 FourierSeriesPath<VDimension>::EvaluateDerivative(const InputType & input) const -> VectorType
 {
   InputType  theta;
-  VectorType output;
+  VectorType output{};
   const int  numHarmonics = m_CosCoefficients->Size();
-  output.Fill(0);
 
   const double PI = 4.0 * std::atan(1.0);
 

--- a/Modules/Filtering/Path/test/itkChainCodeToFourierSeriesPathFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkChainCodeToFourierSeriesPathFilterTest.cxx
@@ -42,13 +42,12 @@ itkChainCodeToFourierSeriesPathFilterTest(int, char *[])
 
   // Setup the path
   std::cout << "Making a triangle Path with v0 at (30,30) -> (30,33) -> (33,33)" << std::endl;
-  VertexType v;
+  auto v = itk::MakeFilled<VertexType>(30);
 
   auto inputPath = PolyLinePathType::New();
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(inputPath, PolyLineParametricPath, ParametricPath);
 
-  v.Fill(30);
   inputPath->AddVertex(v);
   v[0] = 30;
   v[1] = 33;

--- a/Modules/Filtering/Path/test/itkOrthogonallyCorrected2DParametricPathTest.cxx
+++ b/Modules/Filtering/Path/test/itkOrthogonallyCorrected2DParametricPathTest.cxx
@@ -36,11 +36,10 @@ itkOrthogonallyCorrected2DParametricPathTest(int, char *[])
 
   bool passed = true;
 
-  VertexType v;
+  auto v = itk::MakeFilled<VertexType>(2);
 
   // Original Path
   auto originalPath = OriginalPathType::New();
-  v.Fill(2);
   originalPath->AddVertex(v);
   v[0] = 4;
   v[1] = 13;

--- a/Modules/Filtering/Path/test/itkPathFunctionsTest.cxx
+++ b/Modules/Filtering/Path/test/itkPathFunctionsTest.cxx
@@ -88,11 +88,10 @@ itkPathFunctionsTest(int, char *[])
 
   // Set up the path
   std::cout << "Making a square Path with v0 at (30,30) and v2 at (33,33)" << std::endl;
-  VertexType v;
-  auto       inPath = PolyLineParametricPathType::New();
-  auto       chainPath = ChainPathType::New();
-  auto       path = FourierSeriesPathType::New();
-  v.Fill(30);
+  auto v = itk::MakeFilled<VertexType>(30);
+  auto inPath = PolyLineParametricPathType::New();
+  auto chainPath = ChainPathType::New();
+  auto path = FourierSeriesPathType::New();
   inPath->AddVertex(v);
   v[0] = 33;
   v[1] = 30;

--- a/Modules/Filtering/Path/test/itkPathIteratorTest.cxx
+++ b/Modules/Filtering/Path/test/itkPathIteratorTest.cxx
@@ -83,9 +83,8 @@ itkPathIteratorTest(int, char *[])
 
   // Set up the path
   std::cout << "Making a square Path with v0 at (30,30) and v2 at (33,33)" << std::endl;
-  VertexType v;
-  auto       path = PathType::New();
-  v.Fill(30);
+  auto v = itk::MakeFilled<VertexType>(30);
+  auto path = PathType::New();
   path->AddVertex(v);
   v[0] = 33;
   v[1] = 30;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSmoothingQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSmoothingQuadEdgeMeshFilter.hxx
@@ -93,10 +93,9 @@ SmoothingQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::GenerateData()
       if (qe != nullptr)
       {
         OutputPointType  r = p;
-        OutputVectorType v;
-        v.Fill(0.0);
-        OutputQEType *  qe_it = qe;
-        OutputCoordType sum_coeff = 0.;
+        OutputVectorType v{};
+        OutputQEType *   qe_it = qe;
+        OutputCoordType  sum_coeff = 0.;
         do
         {
           OutputPointType q = mesh->GetPoint(qe_it->GetDestination());

--- a/Modules/IO/NRRD/test/itkNrrdLocaleTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdLocaleTest.cxx
@@ -43,8 +43,7 @@ itkNrrdLocaleTest(int argc, char * argv[])
   // Create a test image with fractional spacing
   auto image = ImageType::New();
 
-  ImageType::SizeType size;
-  size.Fill(16);
+  auto size = itk::MakeFilled<ImageType::SizeType>(16);
 
   ImageType::IndexType start;
   start.Fill(0);

--- a/Modules/IO/NRRD/test/itkNrrdLocaleTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdLocaleTest.cxx
@@ -45,8 +45,7 @@ itkNrrdLocaleTest(int argc, char * argv[])
 
   auto size = itk::MakeFilled<ImageType::SizeType>(16);
 
-  ImageType::IndexType start;
-  start.Fill(0);
+  ImageType::IndexType start{};
 
   ImageType::RegionType region(start, size);
   image->SetRegions(region);

--- a/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
@@ -332,17 +332,15 @@ itkReadWriteSpatialObjectTest(int argc, char * argv[])
 
   for (int i = 0; i < 10; ++i)
   {
-    ContourType::ContourPointType                      ctrlPt;
-    ContourType::ContourPointType::PointType           p;
-    ContourType::ContourPointType::CovariantVectorType n;
+    ContourType::ContourPointType ctrlPt;
+    auto                          p = itk::MakeFilled<ContourType::ContourPointType::PointType>(-i);
+    auto                          n = itk::MakeFilled<ContourType::ContourPointType::CovariantVectorType>(i);
     ctrlPt.SetId(i);
-    p.Fill(-i);
     p[2] = 0;
     ctrlPt.SetPickedPointInObjectSpace(p);
     p.Fill(i);
     p[2] = 0;
     ctrlPt.SetPositionInObjectSpace(p);
-    n.Fill(i);
     ctrlPt.SetNormalInObjectSpace(n);
     ctrlPt.SetRed(i);
     ctrlPt.SetGreen(i + 1);

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleAdaptorTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleAdaptorTest2.cxx
@@ -35,10 +35,9 @@ itkImageToListSampleAdaptorTest2(int, char *[])
   auto image = ImageType::New();
 
   ImageType::IndexType start;
-  ImageType::SizeType  size;
+  auto                 size = itk::MakeFilled<ImageType::SizeType>(10);
 
   start.Fill(0);
-  size.Fill(10);
 
   const ImageType::RegionType region(start, size);
   image->SetRegions(region);
@@ -123,10 +122,9 @@ itkImageToListSampleAdaptorTest2(int, char *[])
   auto vImage = VariableLengthImageType::New();
 
   VariableLengthImageType::IndexType vStart;
-  VariableLengthImageType::SizeType  vSize;
+  auto                               vSize = itk::MakeFilled<VariableLengthImageType::SizeType>(10);
 
   vStart.Fill(0);
-  vSize.Fill(10);
 
   const VariableLengthImageType::RegionType vRegion(vStart, vSize);
   vImage->SetRegions(vRegion);
@@ -199,10 +197,9 @@ itkImageToListSampleAdaptorTest2(int, char *[])
   auto rgbImage = RGBImageType::New();
 
   RGBImageType::IndexType rgbStart;
-  RGBImageType::SizeType  rgbSize;
+  auto                    rgbSize = itk::MakeFilled<RGBImageType::SizeType>(10);
 
   rgbStart.Fill(0);
-  rgbSize.Fill(10);
 
   const RGBImageType::RegionType rgbRegion(rgbStart, rgbSize);
   rgbImage->SetRegions(rgbRegion);

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleAdaptorTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleAdaptorTest2.cxx
@@ -34,10 +34,9 @@ itkImageToListSampleAdaptorTest2(int, char *[])
 
   auto image = ImageType::New();
 
-  ImageType::IndexType start;
+  ImageType::IndexType start{};
   auto                 size = itk::MakeFilled<ImageType::SizeType>(10);
 
-  start.Fill(0);
 
   const ImageType::RegionType region(start, size);
   image->SetRegions(region);
@@ -121,10 +120,9 @@ itkImageToListSampleAdaptorTest2(int, char *[])
 
   auto vImage = VariableLengthImageType::New();
 
-  VariableLengthImageType::IndexType vStart;
+  VariableLengthImageType::IndexType vStart{};
   auto                               vSize = itk::MakeFilled<VariableLengthImageType::SizeType>(10);
 
-  vStart.Fill(0);
 
   const VariableLengthImageType::RegionType vRegion(vStart, vSize);
   vImage->SetRegions(vRegion);
@@ -196,10 +194,9 @@ itkImageToListSampleAdaptorTest2(int, char *[])
 
   auto rgbImage = RGBImageType::New();
 
-  RGBImageType::IndexType rgbStart;
+  RGBImageType::IndexType rgbStart{};
   auto                    rgbSize = itk::MakeFilled<RGBImageType::SizeType>(10);
 
-  rgbStart.Fill(0);
 
   const RGBImageType::RegionType rgbRegion(rgbStart, rgbSize);
   rgbImage->SetRegions(rgbRegion);

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest.cxx
@@ -65,10 +65,9 @@ CreateMaskImage()
 {
   auto                     image = MaskImageType::New();
   MaskImageType::IndexType start;
-  MaskImageType::SizeType  size;
+  auto                     size = itk::MakeFilled<MaskImageType::SizeType>(10);
 
   start.Fill(0);
-  size.Fill(10);
 
   const MaskImageType::RegionType region(start, size);
   image->SetRegions(region);

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest.cxx
@@ -35,10 +35,9 @@ CreateImage()
 {
   auto image = ImageType::New();
 
-  ImageType::IndexType start;
+  ImageType::IndexType start{};
   ImageType::SizeType  size;
 
-  start.Fill(0);
 
   size[0] = 10;
   size[1] = 10;
@@ -64,10 +63,9 @@ static MaskImageType::Pointer
 CreateMaskImage()
 {
   auto                     image = MaskImageType::New();
-  MaskImageType::IndexType start;
+  MaskImageType::IndexType start{};
   auto                     size = itk::MakeFilled<MaskImageType::SizeType>(10);
 
-  start.Fill(0);
 
   const MaskImageType::RegionType region(start, size);
   image->SetRegions(region);

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest2.cxx
@@ -37,10 +37,9 @@ itkImageToListSampleFilterTest2(int, char *[])
 
   auto                 image = ImageType::New();
   ImageType::IndexType start;
-  ImageType::SizeType  size;
+  auto                 size = itk::MakeFilled<ImageType::SizeType>(10);
 
   start.Fill(0);
-  size.Fill(10);
 
   const ImageType::RegionType region(start, size);
   image->SetRegions(region);

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest2.cxx
@@ -36,10 +36,9 @@ itkImageToListSampleFilterTest2(int, char *[])
   using MaskImageType = itk::Image<unsigned char, ImageDimension>;
 
   auto                 image = ImageType::New();
-  ImageType::IndexType start;
+  ImageType::IndexType start{};
   auto                 size = itk::MakeFilled<ImageType::SizeType>(10);
 
-  start.Fill(0);
 
   const ImageType::RegionType region(start, size);
   image->SetRegions(region);

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest3.cxx
@@ -42,10 +42,9 @@ itkImageToListSampleFilterTest3(int, char *[])
   image->SetNumberOfComponentsPerPixel(MeasurementVectorSize);
 
   ImageType::IndexType start;
-  ImageType::SizeType  size;
+  auto                 size = itk::MakeFilled<ImageType::SizeType>(10);
 
   start.Fill(0);
-  size.Fill(10);
 
   const ImageType::RegionType region(start, size);
   image->SetRegions(region);

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest3.cxx
@@ -41,10 +41,9 @@ itkImageToListSampleFilterTest3(int, char *[])
 
   image->SetNumberOfComponentsPerPixel(MeasurementVectorSize);
 
-  ImageType::IndexType start;
+  ImageType::IndexType start{};
   auto                 size = itk::MakeFilled<ImageType::SizeType>(10);
 
-  start.Fill(0);
 
   const ImageType::RegionType region(start, size);
   image->SetRegions(region);

--- a/Modules/Numerics/Statistics/test/itkJointDomainImageToListSampleAdaptorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkJointDomainImageToListSampleAdaptorTest.cxx
@@ -35,10 +35,9 @@ itkJointDomainImageToListSampleAdaptorTest(int, char *[])
   auto image = ImageType::New();
 
   ImageType::IndexType start;
-  ImageType::SizeType  size;
+  auto                 size = itk::MakeFilled<ImageType::SizeType>(10);
 
   start.Fill(0);
-  size.Fill(10);
 
   const unsigned long         totalSize = size[0] * size[1] * size[2];
   const ImageType::RegionType region(start, size);

--- a/Modules/Numerics/Statistics/test/itkJointDomainImageToListSampleAdaptorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkJointDomainImageToListSampleAdaptorTest.cxx
@@ -34,10 +34,9 @@ itkJointDomainImageToListSampleAdaptorTest(int, char *[])
 
   auto image = ImageType::New();
 
-  ImageType::IndexType start;
+  ImageType::IndexType start{};
   auto                 size = itk::MakeFilled<ImageType::SizeType>(10);
 
-  start.Fill(0);
 
   const unsigned long         totalSize = size[0] * size[1] * size[2];
   const ImageType::RegionType region(start, size);

--- a/Modules/Numerics/Statistics/test/itkWeightedMeanSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedMeanSampleFilterTest.cxx
@@ -49,10 +49,9 @@ public:
   OutputType
   Evaluate(const InputType & input) const override
   {
-    MeasurementVectorType measurements;
+    auto measurements = itk::MakeFilled<MeasurementVectorType>(2.0f);
     // set the weight factor of the measurement
     // vector with valuev[2, 2] to 0.5.
-    measurements.Fill(2.0f);
     if (input != measurements)
     {
       return 0.5;

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
@@ -390,11 +390,9 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
     auto fixedItr = this->m_FixedLandmarks.begin();
     auto movingItr = this->m_MovingLandmarks.begin();
 
-    VectorType fixedCentered;
-    VectorType movingCentered;
+    VectorType fixedCentered{};
+    VectorType movingCentered{};
 
-    fixedCentered.Fill(0.0);
-    movingCentered.Fill(0.0);
 
     itkDebugStatement(int ii = 0);
 
@@ -525,11 +523,9 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
     auto fixedItr = this->m_FixedLandmarks.begin();
     auto movingItr = this->m_MovingLandmarks.begin();
 
-    VectorType fixedCentered;
-    VectorType movingCentered;
+    VectorType fixedCentered{};
+    VectorType movingCentered{};
 
-    fixedCentered.Fill(0.0);
-    movingCentered.Fill(0.0);
 
     itkDebugStatement(int ii = 0);
 
@@ -687,11 +683,9 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
     fixedItr = this->m_FixedLandmarks.begin();
     movingItr = this->m_MovingLandmarks.begin();
 
-    VectorType fixedCentered;
-    VectorType movingCentered;
+    VectorType fixedCentered{};
+    VectorType movingCentered{};
 
-    fixedCentered.Fill(0.0);
-    movingCentered.Fill(0.0);
 
     itkDebugStatement(int ii = 0);
     double s_dot = 0;

--- a/Modules/Registration/Common/test/itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
@@ -98,9 +98,8 @@ itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest(int, char *[])
   adaptor->SetRequiredDirection(displacementField->GetDirection());
 
   auto                   updateMeshSize = itk::MakeFilled<AdaptorType::ArrayType>(10);
-  AdaptorType::ArrayType velocityMeshSize;
+  AdaptorType::ArrayType velocityMeshSize{};
 
-  velocityMeshSize.Fill(0);
 
   adaptor->SetMeshSizeForTheUpdateField(updateMeshSize);
   adaptor->SetMeshSizeForTheConstantVelocityField(velocityMeshSize);

--- a/Modules/Registration/Common/test/itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
@@ -97,10 +97,9 @@ itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest(int, char *[])
   adaptor->SetRequiredOrigin(displacementField->GetOrigin());
   adaptor->SetRequiredDirection(displacementField->GetDirection());
 
-  AdaptorType::ArrayType updateMeshSize;
+  auto                   updateMeshSize = itk::MakeFilled<AdaptorType::ArrayType>(10);
   AdaptorType::ArrayType velocityMeshSize;
 
-  updateMeshSize.Fill(10);
   velocityMeshSize.Fill(0);
 
   adaptor->SetMeshSizeForTheUpdateField(updateMeshSize);

--- a/Modules/Registration/Common/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
@@ -104,9 +104,8 @@ itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest(int, 
   adaptor->SetRequiredDirection(displacementField->GetDirection());
 
   auto                   updateMeshSize = itk::MakeFilled<AdaptorType::ArrayType>(10);
-  AdaptorType::ArrayType totalMeshSize;
+  AdaptorType::ArrayType totalMeshSize{};
 
-  totalMeshSize.Fill(0);
 
   adaptor->SetMeshSizeForTheUpdateField(updateMeshSize);
   adaptor->SetMeshSizeForTheTotalField(totalMeshSize);

--- a/Modules/Registration/Common/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
@@ -103,10 +103,9 @@ itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest(int, 
   adaptor->SetRequiredOrigin(displacementField->GetOrigin());
   adaptor->SetRequiredDirection(displacementField->GetDirection());
 
-  AdaptorType::ArrayType updateMeshSize;
+  auto                   updateMeshSize = itk::MakeFilled<AdaptorType::ArrayType>(10);
   AdaptorType::ArrayType totalMeshSize;
 
-  updateMeshSize.Fill(10);
   totalMeshSize.Fill(0);
 
   adaptor->SetMeshSizeForTheUpdateField(updateMeshSize);

--- a/Modules/Registration/Common/test/itkMeanSquaresImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMeanSquaresImageMetricTest.cxx
@@ -311,10 +311,9 @@ itkMeanSquaresImageMetricTest(int, char *[])
   movingImage->SetOrigin(bSplineTestMovingImageOrigin);
 
   // Initialise BSplineTransform
-  auto                               bSplineTransform = BSplineTransformType::New();
-  auto                               initializer = InitializerType::New();
-  BSplineTransformType::MeshSizeType meshSize;
-  meshSize.Fill(nodesPerDimension - splineOrder);
+  auto bSplineTransform = BSplineTransformType::New();
+  auto initializer = InitializerType::New();
+  auto meshSize = itk::MakeFilled<BSplineTransformType::MeshSizeType>(nodesPerDimension - splineOrder);
   initializer->SetTransform(bSplineTransform);
   initializer->SetImage(movingImage);
   initializer->SetTransformDomainMeshSize(meshSize);

--- a/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
@@ -211,11 +211,10 @@ itkMultiResolutionPyramidImageFilterTest(int argc, char * argv[])
   pyramid->SetUseShrinkImageFilter(useShrinkFilter);
   pyramid->SetInput(imgTarget);
 
-  itk::Vector<unsigned int, ImageDimension> factors;
-
   // set schedule by specifying the number of levels;
   unsigned int numLevels = 3;
-  factors.Fill(1 << (numLevels - 1));
+
+  auto factors = itk::MakeFilled<itk::Vector<unsigned int, ImageDimension>>(1 << (numLevels - 1));
   pyramid->SetNumberOfLevels(numLevels);
 
   // check the schedule

--- a/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
@@ -183,10 +183,9 @@ itkANTSNeighborhoodCorrelationImageToImageMetricv4Test(int, char ** const)
     ++itMoving;
   }
 
-  VectorType      zero;
   constexpr float def_value{ -0.5 };
+  auto            zero = itk::MakeFilled<VectorType>(def_value);
 
-  zero.Fill(def_value);
   auto field = FieldType::New();
   field->SetRegions(fixedImage->GetLargestPossibleRegion());
   field->SetSpacing(fixedImage->GetSpacing());

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
@@ -543,8 +543,7 @@ itkImageToImageMetricv4Test(int, char ** const)
   using FieldType = DisplacementTransformType::DisplacementFieldType;
   auto field = FieldType::New(); // This is based on itk::Image
 
-  FieldType::SizeType defsize;
-  defsize.Fill(imageSize);
+  auto                  defsize = itk::MakeFilled<FieldType::SizeType>(imageSize);
   FieldType::RegionType defregion = { defsize };
   field->SetRegions(defregion);
   field->Allocate();

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNPointSetRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNPointSetRegistrationTest.cxx
@@ -80,15 +80,12 @@ itkBSplineSyNPointSetRegistrationTest(int itkNotUsed(argc), char * itkNotUsed(ar
 
   // virtual image domain is [-110,-110]  [110,110]
 
-  FixedImageType::SizeType      fixedImageSize;
-  FixedImageType::PointType     fixedImageOrigin;
+  auto                          fixedImageSize = itk::MakeFilled<FixedImageType::SizeType>(221);
+  auto                          fixedImageOrigin = itk::MakeFilled<FixedImageType::PointType>(-110);
   FixedImageType::DirectionType fixedImageDirection;
-  FixedImageType::SpacingType   fixedImageSpacing;
+  auto                          fixedImageSpacing = itk::MakeFilled<FixedImageType::SpacingType>(1);
 
-  fixedImageSize.Fill(221);
-  fixedImageOrigin.Fill(-110);
   fixedImageDirection.SetIdentity();
-  fixedImageSpacing.Fill(1);
 
   auto fixedImage = FixedImageType::New();
   fixedImage->SetRegions(fixedImageSize);

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimplePointSetRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimplePointSetRegistrationTest.cxx
@@ -161,15 +161,12 @@ itkSimplePointSetRegistrationTest(int itkNotUsed(argc), char * itkNotUsed(argv)[
 
   // virtual image domain is [-110,-110]  [110,110]
 
-  FixedImageType::SizeType      fixedImageSize;
-  FixedImageType::PointType     fixedImageOrigin;
+  auto                          fixedImageSize = itk::MakeFilled<FixedImageType::SizeType>(221);
+  auto                          fixedImageOrigin = itk::MakeFilled<FixedImageType::PointType>(-110);
   FixedImageType::DirectionType fixedImageDirection;
-  FixedImageType::SpacingType   fixedImageSpacing;
+  auto                          fixedImageSpacing = itk::MakeFilled<FixedImageType::SpacingType>(1);
 
-  fixedImageSize.Fill(221);
-  fixedImageOrigin.Fill(-110);
   fixedImageDirection.SetIdentity();
-  fixedImageSpacing.Fill(1);
 
   auto fixedImage = FixedImageType::New();
   fixedImage->SetRegions(fixedImageSize);

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSyNPointSetRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSyNPointSetRegistrationTest.cxx
@@ -81,15 +81,12 @@ itkSyNPointSetRegistrationTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 
   // virtual image domain is [-110,-110]  [110,110]
 
-  FixedImageType::SizeType      fixedImageSize;
-  FixedImageType::PointType     fixedImageOrigin;
+  auto                          fixedImageSize = itk::MakeFilled<FixedImageType::SizeType>(221);
+  auto                          fixedImageOrigin = itk::MakeFilled<FixedImageType::PointType>(-110);
   FixedImageType::DirectionType fixedImageDirection;
-  FixedImageType::SpacingType   fixedImageSpacing;
+  auto                          fixedImageSpacing = itk::MakeFilled<FixedImageType::SpacingType>(1);
 
-  fixedImageSize.Fill(221);
-  fixedImageOrigin.Fill(-110);
   fixedImageDirection.SetIdentity();
-  fixedImageSpacing.Fill(1);
 
   auto fixedImage = FixedImageType::New();
   fixedImage->SetRegions(fixedImageSize);

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldPointSetRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldPointSetRegistrationTest.cxx
@@ -148,13 +148,12 @@ itkTimeVaryingBSplineVelocityFieldPointSetRegistrationTest(int itkNotUsed(argc),
   // Determine the parameters (size, spacing, etc) for the time-varying velocity field
 
   auto transformDomainMeshSize = itk::MakeFilled<TimeVaryingVelocityFieldControlPointLatticeType::SizeType>(4);
-  TimeVaryingVelocityFieldControlPointLatticeType::PointType transformDomainOrigin;
+  TimeVaryingVelocityFieldControlPointLatticeType::PointType transformDomainOrigin{};
   auto transformDomainSpacing = itk::MakeFilled<TimeVaryingVelocityFieldControlPointLatticeType::SpacingType>(1.0);
   auto transformDomainSize = itk::MakeFilled<TimeVaryingVelocityFieldControlPointLatticeType::SizeType>(10);
   TimeVaryingVelocityFieldControlPointLatticeType::DirectionType transformDomainDirection;
 
   transformDomainDirection.SetIdentity();
-  transformDomainOrigin.Fill(0.0);
 
   for (unsigned int i = 0; i < Dimension; ++i)
   {
@@ -189,13 +188,12 @@ itkTimeVaryingBSplineVelocityFieldPointSetRegistrationTest(int itkNotUsed(argc),
   velocityFieldLattice->Allocate();
   velocityFieldLattice->FillBuffer(zeroVector);
 
-  TransformType::VelocityFieldPointType velocityFieldOrigin;
+  TransformType::VelocityFieldPointType velocityFieldOrigin{};
   auto velocityFieldSpacing = itk::MakeFilled<TransformType::VelocityFieldSpacingType>(1.0);
   auto velocityFieldSize =
     itk::MakeFilled<TransformType::VelocityFieldSizeType>(velocityFieldRegistration->GetNumberOfTimePointSamples());
   TransformType::VelocityFieldDirectionType velocityFieldDirection;
 
-  velocityFieldOrigin.Fill(0.0);
   velocityFieldDirection.SetIdentity();
 
   for (unsigned int i = 0; i < Dimension; ++i)

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldPointSetRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldPointSetRegistrationTest.cxx
@@ -76,16 +76,13 @@ itkTimeVaryingBSplineVelocityFieldPointSetRegistrationTest(int itkNotUsed(argc),
     count++;
   }
 
-  FixedImageType::SizeType      fixedImageSize;
-  FixedImageType::PointType     fixedImageOrigin;
+  auto                          fixedImageSize = itk::MakeFilled<FixedImageType::SizeType>(221);
+  auto                          fixedImageOrigin = itk::MakeFilled<FixedImageType::PointType>(-110);
   FixedImageType::DirectionType fixedImageDirection;
-  FixedImageType::SpacingType   fixedImageSpacing;
+  auto                          fixedImageSpacing = itk::MakeFilled<FixedImageType::SpacingType>(1);
 
   // virtual image domain is [-110,-110]  [110,110]
-  fixedImageSize.Fill(221);
-  fixedImageOrigin.Fill(-110);
   fixedImageDirection.SetIdentity();
-  fixedImageSpacing.Fill(1);
 
   auto fixedImage = FixedImageType::New();
   fixedImage->SetRegions(fixedImageSize);
@@ -150,17 +147,14 @@ itkTimeVaryingBSplineVelocityFieldPointSetRegistrationTest(int itkNotUsed(argc),
 
   // Determine the parameters (size, spacing, etc) for the time-varying velocity field
 
-  TimeVaryingVelocityFieldControlPointLatticeType::SizeType      transformDomainMeshSize;
-  TimeVaryingVelocityFieldControlPointLatticeType::PointType     transformDomainOrigin;
-  TimeVaryingVelocityFieldControlPointLatticeType::SpacingType   transformDomainSpacing;
-  TimeVaryingVelocityFieldControlPointLatticeType::SizeType      transformDomainSize;
+  auto transformDomainMeshSize = itk::MakeFilled<TimeVaryingVelocityFieldControlPointLatticeType::SizeType>(4);
+  TimeVaryingVelocityFieldControlPointLatticeType::PointType transformDomainOrigin;
+  auto transformDomainSpacing = itk::MakeFilled<TimeVaryingVelocityFieldControlPointLatticeType::SpacingType>(1.0);
+  auto transformDomainSize = itk::MakeFilled<TimeVaryingVelocityFieldControlPointLatticeType::SizeType>(10);
   TimeVaryingVelocityFieldControlPointLatticeType::DirectionType transformDomainDirection;
 
   transformDomainDirection.SetIdentity();
   transformDomainOrigin.Fill(0.0);
-  transformDomainMeshSize.Fill(4);
-  transformDomainSpacing.Fill(1.0);
-  transformDomainSize.Fill(10);
 
   for (unsigned int i = 0; i < Dimension; ++i)
   {
@@ -195,14 +189,13 @@ itkTimeVaryingBSplineVelocityFieldPointSetRegistrationTest(int itkNotUsed(argc),
   velocityFieldLattice->Allocate();
   velocityFieldLattice->FillBuffer(zeroVector);
 
-  TransformType::VelocityFieldPointType     velocityFieldOrigin;
-  TransformType::VelocityFieldSpacingType   velocityFieldSpacing;
-  TransformType::VelocityFieldSizeType      velocityFieldSize;
+  TransformType::VelocityFieldPointType velocityFieldOrigin;
+  auto velocityFieldSpacing = itk::MakeFilled<TransformType::VelocityFieldSpacingType>(1.0);
+  auto velocityFieldSize =
+    itk::MakeFilled<TransformType::VelocityFieldSizeType>(velocityFieldRegistration->GetNumberOfTimePointSamples());
   TransformType::VelocityFieldDirectionType velocityFieldDirection;
 
   velocityFieldOrigin.Fill(0.0);
-  velocityFieldSpacing.Fill(1.0);
-  velocityFieldSize.Fill(velocityFieldRegistration->GetNumberOfTimePointSamples());
   velocityFieldDirection.SetIdentity();
 
   for (unsigned int i = 0; i < Dimension; ++i)

--- a/Modules/Segmentation/Classifiers/test/itkImageClassifierFilterTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkImageClassifierFilterTest.cxx
@@ -58,10 +58,9 @@ itkImageClassifierFilterTest(int argc, char * argv[])
   auto image = InputImageType::New();
 
   InputImageType::IndexType start;
-  InputImageType::SizeType  size;
+  auto                      size = itk::MakeFilled<InputImageType::SizeType>(512);
 
   start.Fill(0);
-  size.Fill(512);
 
   const InputImageType::RegionType region(start, size);
   image->SetRegions(region);

--- a/Modules/Segmentation/Classifiers/test/itkImageClassifierFilterTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkImageClassifierFilterTest.cxx
@@ -57,10 +57,9 @@ itkImageClassifierFilterTest(int argc, char * argv[])
 
   auto image = InputImageType::New();
 
-  InputImageType::IndexType start;
+  InputImageType::IndexType start{};
   auto                      size = itk::MakeFilled<InputImageType::SizeType>(512);
 
-  start.Fill(0);
 
   const InputImageType::RegionType region(start, size);
   image->SetRegions(region);

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
@@ -407,10 +407,8 @@ KLMRegionGrowImageFilter<TInputImage, TOutputImage>::InitializeKLM()
     }
 
     // index to atomic region1 and atomic region2
-    InputImageIndexType indexRegion1;
-    InputImageIndexType indexRegion2;
-    indexRegion1.Fill(0);
-    indexRegion2.Fill(0);
+    InputImageIndexType indexRegion1{};
+    InputImageIndexType indexRegion2{};
     indexRegion2[idim]++;
 
     for (unsigned int iborder = 0; iborder < numBorderThisDim; ++iborder)

--- a/Modules/Video/Core/include/itkVideoStream.h
+++ b/Modules/Video/Core/include/itkVideoStream.h
@@ -319,10 +319,9 @@ public:
         // Set the buffered spatial region for each frame
         SpatialRegionType bufferedSpatialRegion;
         SpatialRegionType::SizeType size;
-        SpatialRegionType::IndexType start;
+        SpatialRegionType::IndexType start{};
         size[0] = 50;
         size[1] = 40;
-        start.Fill( 0 );
         bufferedSpatialRegion.SetSize( size );
         bufferedSpatialRegion.SetIndex( start );
         video->SetAllBufferedSpatialRegions( bufferedSpatialRegion );

--- a/Modules/Video/Core/test/itkVideoStreamTest.cxx
+++ b/Modules/Video/Core/test/itkVideoStreamTest.cxx
@@ -31,11 +31,10 @@ SetUpSpatialRegion(unsigned int x, unsigned int y)
 {
   FrameType::RegionType            out;
   FrameType::RegionType::SizeType  size;
-  FrameType::RegionType::IndexType start;
+  FrameType::RegionType::IndexType start{};
 
   size[0] = x;
   size[1] = y;
-  start.Fill(0);
   out = { start, size };
   return out;
 }


### PR DESCRIPTION
## Summary

Replaces the verbose two-line FixedArray initialization pattern with the modern single-line static factory method `::Filled(v)`.

**Before:**
```cpp
ImageType::SizeType size;
size.Fill(16);
```

**After:**
```cpp
constexpr auto size = ImageType::SizeType::Filled(16);
```

## Rules applied

- **`constexpr auto`** used when the variable is never subsequently modified (test files with concrete types)
- **`auto`** (without `constexpr`) used for accumulator variables in loop bodies (`.hxx` template implementations)
- **Skipped:** cases where `Fill()` is immediately followed by element-wise overrides (`size[0] = w`), or where `typename` disambiguation in deeply nested template parameter scopes makes the replacement non-trivial

## Files changed

| File | Pattern |
|------|---------|
| `Modules/IO/NRRD/test/itkNrrdLocaleTest.cxx` | `SizeType` + `IndexType` → `constexpr auto` |
| `Modules/Video/BridgeOpenCV/test/itkOpenCVVideoIOTest.cxx` | `PointType` → `constexpr auto` |
| `Modules/Filtering/Path/include/itkChainCodeToFourierSeriesPathFilter.hxx` | `VectorType` accumulators → `auto` |
| `Modules/Filtering/QuadEdgeMeshFiltering/include/itkSmoothingQuadEdgeMeshFilter.hxx` | `VectorType` accumulator → `auto` |

Pure style change — no semantic changes.

Suggested by @N-Dekker in https://github.com/InsightSoftwareConsortium/ITK/pull/6003#discussion_r3033221346