### PR TITLE
COMP: Free disk space between build and test in Pixi CI

### DIFF
--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -135,9 +135,20 @@ jobs:
             pixi run --skip-deps build
             echo "****** df -h /  -- post build"
             df -h /
+
+        - name: Free disk space after build
+          shell: bash
+          run: |
+            # Remove object files and static libraries (not needed for testing)
             find build -type f -name "*.o" -delete
             find build -type f -name "*.a" -delete
-            echo "****** df -h /  -- post .o .a cleanup"
+            # Remove downloaded data tarballs (already extracted)
+            rm -f InsightData-*.tar.gz
+            # Remove extracted source tarball directory
+            rm -rf InsightToolkit-${{ env.ExternalDataVersion }}
+            # Trim ccache to stay within CCACHE_MAXSIZE and remove orphaned entries
+            ccache --cleanup 2>/dev/null || true
+            echo "****** df -h /  -- post cleanup"
             df -h /
 
         - name: Test


### PR DESCRIPTION
## Problem

The `Pixi-Cxx (ubuntu-22.04)` job intermittently fails during the Test step with no error message — the runner is killed mid-test due to disk space exhaustion. The runner has 146GB total, and after a ~2 hour ITK build the remaining space is insufficient for CTest to run.

This affects PRs #6007, #6009, #6010 (and likely others). The successful main branch build completed in 2h07m, while failing PR builds ran 2h08m-2h55m before being killed ~3-4 minutes into testing.

## Fix

Move the existing `.o`/`.a` cleanup to a dedicated "Free disk space after build" step and add additional cleanup:
- Remove `InsightData-*.tar.gz` download (~200MB, already extracted)
- Remove extracted `InsightToolkit-*` source directory
- Flush ccache temp files
- Report `df -h` after cleanup for diagnostics

## Impact

No functional change — the removed files are not needed for testing. The `.o` files were already being deleted; this adds the tarball and source directory cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)