### PR TITLE
BUG: Fix intermittent itkSPSAOptimizerTest failure

### DIFF
--- a/Modules/Numerics/Optimizers/test/itkSPSAOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkSPSAOptimizerTest.cxx
@@ -16,6 +16,7 @@
  *
  *=========================================================================*/
 #include <set>
+#include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkSPSAOptimizer.h"
 #include "itkTestingMacros.h"
 
@@ -104,6 +105,14 @@ itkSPSAOptimizerTest(int, char *[])
 {
   std::cout << "SPSAOptimizer Test ";
   std::cout << std::endl << std::endl;
+
+  // Use a fixed seed so the stochastic optimization is deterministic.
+  // Without this, the singleton MersenneTwister RNG is seeded from wall-clock
+  // time, causing rare (~1-in-625) false-convergence failures when an unlucky
+  // perturbation sequence makes the StateOfConvergence heuristic declare
+  // convergence before the solution is within the 0.01 tolerance.
+  itk::Statistics::MersenneTwisterRandomVariateGenerator::GetInstance()->SetSeed(
+    itk::Statistics::MersenneTwisterRandomVariateGenerator::DefaultSeed);
 
   using OptimizerType = itk::SPSAOptimizer;
   using ScalesType = OptimizerType::ScalesType;


### PR DESCRIPTION
## Summary

Fix a flaky test (`itkSPSAOptimizerTest`) that fails approximately 1 in 625 CI
runs by seeding the global MersenneTwister RNG to a fixed value, making the test
fully deterministic.

## Root Cause Analysis

The `SPSAOptimizer` uses the **Simultaneous Perturbation Stochastic
Approximation** algorithm, which estimates gradients via random Bernoulli (±1)
perturbations drawn from the global `MersenneTwisterRandomVariateGenerator`
singleton (`GetInstance()`). This singleton is seeded from wall-clock time
(`time()` + `clock()`), so every test run produces a different random
perturbation sequence.

The optimizer's convergence check uses a `StateOfConvergence` heuristic — an
exponentially-decaying running average of `a_k × |gradient|`:

```
StateOfConvergence += a_k * GradientMagnitude    // AdvanceOneStep()
StateOfConvergence *= StateOfConvergenceDecayRate // ResumeOptimization() (0.5 in test)
```

This metric measures whether **the gradient is small**, NOT whether **the
position is close to the optimum**. With certain unlucky random perturbation
sequences, several consecutive gradient estimates can be anomalously small at a
point that is still far from the solution. Because `StateOfConvergenceDecayRate`
is 0.5 (aggressive exponential decay), a few such iterations drive the metric
below the tolerance, and the optimizer falsely declares `BelowTolerance`
convergence — even though the solution is still outside the test's 0.01
acceptance window.

### Diagnostic Evidence

**Sanitizer results (all clean — no memory/threading/UB issues):**
- AddressSanitizer + UndefinedBehaviorSanitizer: zero errors
- Valgrind memcheck (`--leak-check=full --track-origins=yes`): zero errors
- ThreadSanitizer: no data races (single-threaded test)

**Stress test (before fix) — 5,000 runs:**

| Run | Failures | Rate |
|-----|----------|------|
| Before fix | 8 / 5,000 | 1 in 625 (~0.16%) |

All 8 failures share the same pattern — **premature `BelowTolerance` stop**:

| # | Solution | Error | Iterations | Stop Reason |
|---|----------|-------|------------|-------------|
| 1 | (1.971, −1.977) | 0.038 | 36 | BelowTolerance |
| 2 | (2.025, −2.020) | 0.032 | 52 | BelowTolerance |
| 3 | (1.981, −1.985) | 0.023 | 46 | BelowTolerance |
| 4 | (2.012, −2.010) | 0.016 | 54 | BelowTolerance |
| 5 | (2.018, −2.014) | 0.023 | 43 | BelowTolerance |
| 6 | (2.029, −2.023) | 0.037 | 47 | BelowTolerance |
| 7 | (1.892, −1.914) | 0.134 | 43 | BelowTolerance |
| 8 | (1.941, −1.952) | 0.076 | 46 | BelowTolerance |

Successful runs typically converge at iteration 67–100 with solution error < 0.001.

## Fix

Seed the singleton RNG to `121212` (the `MersenneTwisterRandomVariateGenerator::DefaultSeed`)
at the start of the test. This makes the perturbation sequence deterministic
while preserving the stochastic nature of the algorithm being tested.

**Stress test (after fix) — 5,000 runs:**

| Run | Failures | Rate |
|-----|----------|------|
| After fix | 0 / 5,000 | 0% |

Every run produces identical output: solution (1.99999, −1.99998), 100
iterations, well within the 0.01 tolerance.

## AI Assistance

Claude Code (Opus) was used to:
- Analyze the `SPSAOptimizer` source, `MersenneTwisterRandomVariateGenerator`
  implementation, and test code to identify the root cause
- Build and run the test under ASan+UBSan, Valgrind, and TSan
- Execute 5,000-iteration stress tests before and after the fix
- Draft the one-line fix and this PR description

All analysis was reviewed and validated by the commit author.

## Testing

```bash
# Verified compilation (Release, Debug, ASan+UBSan) — all clean
cmake --build cmake-build-Release --target ITKOptimizersTestDriver
cmake --build cmake-build-Debug   --target ITKOptimizersTestDriver
cmake --build cmake-build-asan    --target ITKOptimizersTestDriver

# ASan+UBSan run — zero errors
UBSAN_OPTIONS="print_stacktrace=1" ASAN_OPTIONS="detect_leaks=1" \
  cmake-build-asan/bin/ITKOptimizersTestDriver itkSPSAOptimizerTest

# Valgrind — zero errors
valgrind --tool=memcheck --leak-check=full --track-origins=yes \
  cmake-build-Release/bin/ITKOptimizersTestDriver itkSPSAOptimizerTest

# Determinism — 10 consecutive runs produce identical output
# Stress test — 0 failures in 5,000 runs (vs 8/5,000 before fix)
```
