### PR TITLE
COMP: Fix compilation and style issues in GPU modules

### DIFF
--- a/Modules/Core/GPUCommon/include/itkGPUReduction.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUReduction.hxx
@@ -188,12 +188,12 @@ GPUReduction<TElement>::RandomTest()
   this->InitializeKernel(size);
 
   unsigned int bytes = size * sizeof(TElement);
-  auto *       h_idata = (TElement *)malloc(bytes);
+  auto *       h_idata = static_cast<TElement *>(malloc(bytes));
 
   for (int i = 0; i < size; ++i)
   {
     // Keep the numbers small so we don't get truncation error in the sum
-    h_idata[i] = (TElement)(rand() & 0xFF);
+    h_idata[i] = static_cast<TElement>(rand() & 0xFF);
   }
 
   this->AllocateGPUInputBuffer(h_idata);
@@ -260,7 +260,7 @@ GPUReduction<TElement>::GPUGenerateData()
   }
 
   // allocate output data for the result
-  auto * h_odata = (TElement *)malloc(numBlocks * sizeof(TElement));
+  auto * h_odata = static_cast<TElement *>(malloc(numBlocks * sizeof(TElement)));
 
   GPUDataPointer odata = GPUDataManager::New();
   odata->SetBufferSize(numBlocks * sizeof(TElement));
@@ -331,13 +331,13 @@ GPUReduction<TElement>::GPUReduce(cl_int         n,
 
 #ifdef CPU_VERIFY
   idata->SetCPUDirtyFlag(true);
-  TElement * h_idata = (TElement *)idata->GetCPUBufferPointer(); // debug
+  TElement * h_idata = static_cast<TElement *>(idata->GetCPUBufferPointer()); // debug
   if (!h_idata)
   {
-    h_idata = (TElement *)malloc(sizeof(TElement) * n);
+    h_idata = static_cast<TElement *>(malloc(sizeof(TElement) * n));
     idata->SetCPUBufferPointer(h_idata);
     idata->SetCPUDirtyFlag(true);
-    h_idata = (TElement *)idata->GetCPUBufferPointer(); // debug
+    h_idata = static_cast<TElement *>(idata->GetCPUBufferPointer()); // debug
   }
 
   TElement CPUSum = this->CPUGenerateData(h_idata, n);

--- a/Modules/Core/GPUCommon/src/itkGPUContextManager.cxx
+++ b/Modules/Core/GPUCommon/src/itkGPUContextManager.cxx
@@ -65,7 +65,7 @@ GPUContextManager::GPUContextManager()
   OpenCLCheckError(errid, __FILE__, __LINE__, ITK_LOCATION);
 
   // create command queues
-  m_CommandQueue = (cl_command_queue *)malloc(m_NumberOfDevices * sizeof(cl_command_queue));
+  m_CommandQueue = static_cast<cl_command_queue *>(malloc(m_NumberOfDevices * sizeof(cl_command_queue)));
   for (unsigned int i = 0; i < m_NumberOfDevices; ++i)
   {
     m_CommandQueue[i] = clCreateCommandQueue(m_Context, m_Devices[i], 0, &errid);

--- a/Modules/Core/GPUCommon/src/itkGPUKernelManager.cxx
+++ b/Modules/Core/GPUCommon/src/itkGPUKernelManager.cxx
@@ -83,7 +83,7 @@ GPUKernelManager::LoadProgramFromFile(const char * filename, const char * cPream
   fseek(pFileStream, 0, SEEK_SET);
 
   // allocate a buffer for the source code string and read it in
-  char * cSourceString = (char *)malloc(szSourceLength + szPreambleLength + 1000);
+  char * cSourceString = static_cast<char *>(malloc(szSourceLength + szPreambleLength + 1000));
   if (szPreambleLength > 0)
   {
     memcpy(cSourceString, cPreamble, szPreambleLength);
@@ -130,7 +130,7 @@ GPUKernelManager::LoadProgramFromFile(const char * filename, const char * cPream
     // get error message size
     clGetProgramBuildInfo(m_Program, m_Manager->GetDeviceId(0), CL_PROGRAM_BUILD_LOG, 0, nullptr, &paramValueSize);
 
-    char * paramValue = (char *)malloc(paramValueSize);
+    char * paramValue = static_cast<char *>(malloc(paramValueSize));
 
     // get error message
     clGetProgramBuildInfo(
@@ -169,7 +169,7 @@ GPUKernelManager::LoadProgramFromString(const char * cSource, const char * cPrea
   szFinalLength = szSourceLength + szPreambleLength;
 
   // allocate a buffer for the source code string and read it in
-  char * cSourceString = (char *)malloc(szFinalLength + 1);
+  char * cSourceString = static_cast<char *>(malloc(szFinalLength + 1));
   if (szPreambleLength > 0)
   {
     memcpy(cSourceString, cPreamble, szPreambleLength);
@@ -207,7 +207,7 @@ GPUKernelManager::LoadProgramFromString(const char * cSource, const char * cPrea
     // get error message size
     clGetProgramBuildInfo(m_Program, m_Manager->GetDeviceId(0), CL_PROGRAM_BUILD_LOG, 0, nullptr, &paramValueSize);
 
-    char * paramValue = (char *)malloc(paramValueSize);
+    char * paramValue = static_cast<char *>(malloc(paramValueSize));
 
     // get error message
     clGetProgramBuildInfo(

--- a/Modules/Core/GPUCommon/src/itkOpenCLUtil.cxx
+++ b/Modules/Core/GPUCommon/src/itkOpenCLUtil.cxx
@@ -57,7 +57,7 @@ OpenCLGetAvailableDevices(cl_platform_id platform, cl_device_type devType, cl_ui
   cl_int errid = clGetDeviceIDs(platform, devType, 0, nullptr, &totalNumDevices);
   OpenCLCheckError(errid, __FILE__, __LINE__, ITK_LOCATION);
 
-  auto * totalDevices = (cl_device_id *)malloc(totalNumDevices * sizeof(cl_device_id));
+  auto * totalDevices = static_cast<cl_device_id *>(malloc(totalNumDevices * sizeof(cl_device_id)));
   errid = clGetDeviceIDs(platform, devType, totalNumDevices, totalDevices, nullptr);
   OpenCLCheckError(errid, __FILE__, __LINE__, ITK_LOCATION);
 
@@ -75,7 +75,7 @@ OpenCLGetAvailableDevices(cl_platform_id platform, cl_device_type devType, cl_ui
     }
   }
 
-  availableDevices = (cl_device_id *)malloc(*numAvailableDevices * sizeof(cl_device_id));
+  availableDevices = static_cast<cl_device_id *>(malloc(*numAvailableDevices * sizeof(cl_device_id)));
 
   int idx = 0;
   for (cl_uint i = 0; i < totalNumDevices; ++i)
@@ -105,7 +105,7 @@ OpenCLGetMaxFlopsDev(cl_context cxGPUContext)
 
   // get the list of GPU devices associated with context
   clGetContextInfo(cxGPUContext, CL_CONTEXT_DEVICES, 0, nullptr, &szParmDataBytes);
-  cdDevices = (cl_device_id *)malloc(szParmDataBytes);
+  cdDevices = static_cast<cl_device_id *>(malloc(szParmDataBytes));
   size_t device_count = szParmDataBytes / sizeof(cl_device_id);
 
   clGetContextInfo(cxGPUContext, CL_CONTEXT_DEVICES, szParmDataBytes, cdDevices, nullptr);
@@ -216,7 +216,7 @@ OpenCLSelectPlatform(const char * name)
     else
     {
       // if there's a platform or more, make space for ID's
-      if ((clPlatformIDs = (cl_platform_id *)malloc(num_platforms * sizeof(cl_platform_id))) == nullptr)
+      if ((clPlatformIDs = static_cast<cl_platform_id *>(malloc(num_platforms * sizeof(cl_platform_id)))) == nullptr)
       {
         printf("Failed to allocate memory for cl_platform ID's!\n\n");
       }

--- a/Modules/Core/GPUCommon/test/itkGPUReductionTest.cxx
+++ b/Modules/Core/GPUCommon/test/itkGPUReductionTest.cxx
@@ -44,7 +44,7 @@ itkGPUReductionTest(int argc, char * argv[])
   itk::GPUReduction<ElementType>::Pointer summer = itk::GPUReduction<ElementType>::New();
   summer->InitializeKernel(numPixels);
   unsigned int bytes = numPixels * sizeof(ElementType);
-  auto *       h_idata = (ElementType *)malloc(bytes);
+  auto *       h_idata = static_cast<ElementType *>(malloc(bytes));
 
   for (int ii = 0; ii < numPixels; ++ii)
   {

--- a/Modules/Filtering/GPUImageFilterBase/include/itkGPUCastImageFilter.h
+++ b/Modules/Filtering/GPUImageFilterBase/include/itkGPUCastImageFilter.h
@@ -52,9 +52,9 @@ template <typename TInput, typename TOutput>
 class ITK_TEMPLATE_EXPORT GPUCast : public GPUFunctorBase
 {
 public:
-  GPUCast() {}
+  GPUCast() = default;
 
-  ~GPUCast() {}
+  ~GPUCast() = default;
 
   /** Setup GPU kernel arguments for this functor.
    * Returns current argument index to set additional arguments in the GPU kernel.
@@ -105,7 +105,7 @@ public:
 
 protected:
   GPUCastImageFilter();
-  ~GPUCastImageFilter() override {}
+  ~GPUCastImageFilter() override = default;
 
   /** Unlike CPU version, GPU version of binary threshold filter is not
   multi-threaded */

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
@@ -97,7 +97,7 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Pr
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "ZeroUpdateReturn: " << static_cast<NumericTraits<PixelType>::PrintType>(m_ZeroUpdateReturn)
+  os << indent << "ZeroUpdateReturn: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_ZeroUpdateReturn)
      << std::endl;
   os << indent << "Normalizer: " << m_Normalizer << std::endl;
 
@@ -108,7 +108,7 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Pr
 
   itkPrintSelfObjectMacro(MovingImageInterpolator);
 
-  os << indent << "TimeStep: " << static_cast<NumericTraits<TimeStepType>::PrintType>(m_TimeStep) << std::endl;
+  os << indent << "TimeStep: " << static_cast<typename NumericTraits<TimeStepType>::PrintType>(m_TimeStep) << std::endl;
 
   os << indent << "DenominatorThreshold: " << m_DenominatorThreshold << std::endl;
   os << indent << "IntensityDifferenceThreshold: " << m_IntensityDifferenceThreshold << std::endl;


### PR DESCRIPTION
## Summary

Fix a compilation error and address style issues in the GPU modules. These
modules are rarely compiled or tested due to GPU availability, so they missed
updates during the ITKv5-to-v6 transition.

## Commits

Each commit is isolated and addresses a single category of changes:

### 1. `COMP: Add missing typename in GPUDemonsRegistrationFunction`
Adds the required `typename` keyword before two dependent type names
(`NumericTraits<PixelType>::PrintType` and `NumericTraits<TimeStepType>::PrintType`)
in `PrintSelf()`. Without this, GCC refuses to compile the
`ITKGPUPDEDeformableRegistrationTestDriver`, making all 3 Demons GPU tests
unable to run.

### 2. `STYLE: Use = default for empty GPU constructor/destructor bodies`
Replaces empty `{}` constructor/destructor bodies with `= default` in
`GPUCast` and `GPUCastImageFilter`, consistent with ITKv6 style.

### 3. `STYLE: Replace C-style casts with static_cast in GPU modules`
Replaces all C-style casts of `malloc()` return values with `static_cast<>()`
across `itkGPUKernelManager.cxx`, `itkOpenCLUtil.cxx`,
`itkGPUContextManager.cxx`, `itkGPUReduction.hxx`, and
`itkGPUReductionTest.cxx`. ITK coding standards prohibit C-style casts.

## Codebase Audit

A comprehensive audit of all 32 GPU header files and all GPU `.cxx`/`.hxx`
implementation files was performed. The following ITKv6 patterns were verified
to already be correct across the GPU modules:
- `itkOverrideGetNameOfClassMacro` (no legacy `itkTypeMacro` found)
- `ITK_DISALLOW_COPY_AND_MOVE` (no legacy `ITK_DISALLOW_COPY_AND_ASSIGN`)
- `static constexpr` (no legacy `itkStaticConstMacro`)
- `using` type aliases (no legacy `typedef`)
- `nullptr` (no legacy `NULL` or `ITK_NULLPTR`)
- `override` on all virtual methods
- Proper `ConstPointer` type aliases

## AI Assistance

Claude Code (Opus) was used to:
- Audit all 32 GPU header files and all implementation files for ITKv6 patterns
- Identify and fix the modernization issues
- Build and test all changes against both Debug and Release configurations
- Draft this PR description

All analysis and changes were reviewed and validated by the commit author.

## Testing

```bash
# All GPU test drivers build cleanly (Release and Debug)
cmake --build cmake-build-Release --target \
  ITKGPUCommonTestDriver ITKGPUAnisotropicSmoothingTestDriver \
  ITKGPUImageFilterBaseTestDriver ITKGPUSmoothingTestDriver \
  ITKGPUThresholdingTestDriver ITKGPUPDEDeformableRegistrationTestDriver

# 33/33 GPU tests pass on NVIDIA RTX 6000 Ada Generation
cd cmake-build-Release && ctest -R GPU  # 100% tests passed, 0 tests failed out of 33
cd cmake-build-Debug   && ctest -R GPU  # 100% tests passed, 0 tests failed out of 33
```