### PR TITLE
BUG: Make itkBresenhamLine::BuildLine finish at the correct end point

### DIFF
--- a/Modules/Core/Common/include/itkBresenhamLine.hxx
+++ b/Modules/Core/Common/include/itkBresenhamLine.hxx
@@ -41,7 +41,7 @@ BresenhamLine<VDimension>::BuildLine(LType Direction, IdentifierType length) -> 
   // compute actual line length because the shorter distance
   // the larger deviation due to rounding to integers
   const IdentifierType mainDirectionLen = length - 1;
-  const float          euclideanLineLen = mainDirectionLen / itk::Math::Absolute(Direction[maxDistanceDimension]);
+  const double         euclideanLineLen = mainDirectionLen / itk::Math::Absolute(Direction[maxDistanceDimension]);
 
   // we are going to start at 0
   constexpr IndexType StartIndex{ 0 };

--- a/Modules/Core/Common/include/itkBresenhamLine.hxx
+++ b/Modules/Core/Common/include/itkBresenhamLine.hxx
@@ -21,117 +21,109 @@
 #include "itkPoint.h"
 #include "itkMath.h"
 
+#include <algorithm>
+#include <iterator>
+
 namespace itk
 {
 template <unsigned int VDimension>
 auto
 BresenhamLine<VDimension>::BuildLine(LType Direction, IdentifierType length) -> OffsetArray
 {
-  // copied from the line iterator
-  /** Variables that drive the Bresenham-Algorithm */
-
   Direction.Normalize();
+
+  // The dimension with the largest absolute component
+  const unsigned int maxDistanceDimension = std::distance(
+    Direction.Begin(), std::max_element(Direction.Begin(), Direction.End(), [](const auto a, const auto b) {
+      return itk::Math::Absolute(a) < itk::Math::Absolute(b);
+    }));
+
+  // compute actual line length because the shorter distance
+  // the larger deviation due to rounding to integers
+  const IdentifierType mainDirectionLen = length - 1;
+  const float          euclideanLineLen = mainDirectionLen / itk::Math::Absolute(Direction[maxDistanceDimension]);
+
   // we are going to start at 0
   constexpr IndexType StartIndex{ 0 };
   IndexType           LastIndex;
   for (unsigned int i = 0; i < VDimension; ++i)
   {
-    LastIndex[i] = (IndexValueType)(length * Direction[i]);
+    // round to closest voxel center to minimize the deviation from Direction
+    LastIndex[i] = Math::RoundHalfIntegerUp<IndexValueType>(euclideanLineLen * Direction[i]);
   }
-  // Find the dominant direction
-  IndexValueType maxDistance = 0;
-  unsigned int   maxDistanceDimension = 0;
-  // Increment for the error for each step. Two times the difference between
-  // start and end
-  IndexType incrementError;
 
-  // Direction of increment. -1 or 1
-  IndexType overflowIncrement;
-  for (unsigned int i = 0; i < VDimension; ++i)
+  const IndexArray indices = this->BuildLine(StartIndex, LastIndex);
+  OffsetArray      offsets;
+  offsets.reserve(indices.size());
+  for (const IndexType & index : indices)
   {
-    auto distance = static_cast<long>(itk::Math::Absolute(LastIndex[i]));
-    if (distance > maxDistance)
-    {
-      maxDistance = distance;
-      maxDistanceDimension = i;
-    }
-    incrementError[i] = 2 * distance;
-    overflowIncrement[i] = (LastIndex[i] < 0 ? -1 : 1);
+    offsets.push_back(index - StartIndex);
   }
 
-  // The dimension with the largest difference between start and end
-  const unsigned int mainDirection = maxDistanceDimension;
-  // If enough is accumulated for a dimension, the index has to be
-  // incremented. Will be the number of pixels in the line
-  auto maximalError = MakeFilled<IndexType>(maxDistance);
-  // After an overflow, the accumulated error is reduced again. Will be
-  // two times the number of pixels in the line
-  auto reduceErrorAfterIncrement = MakeFilled<IndexType>(2 * maxDistance);
-  // Accumulated error for the other dimensions
-  auto accumulateError = MakeFilled<IndexType>(0);
-
-  OffsetArray result(length);
-  auto        currentImageIndex = MakeFilled<IndexType>(0);
-  result[0] = currentImageIndex - StartIndex;
-  unsigned int steps = 1;
-  while (steps < length)
-  {
-    // This part is from ++ in LineConstIterator
-    // We need to modify accumulateError, currentImageIndex, isAtEnd
-    for (unsigned int i = 0; i < VDimension; ++i)
-    {
-      if (i == mainDirection)
-      {
-        currentImageIndex[i] += overflowIncrement[i];
-      }
-      else
-      {
-        accumulateError[i] += incrementError[i];
-        if (accumulateError[i] >= maximalError[i])
-        {
-          currentImageIndex[i] += overflowIncrement[i];
-          accumulateError[i] -= reduceErrorAfterIncrement[i];
-        }
-      }
-    }
-
-    result[steps] = currentImageIndex - StartIndex; // produce an offset
-
-    ++steps;
-  }
-  return result;
+  return offsets;
 }
 
 template <unsigned int VDimension>
 auto
 BresenhamLine<VDimension>::BuildLine(IndexType p0, IndexType p1) -> IndexArray
 {
-  itk::Point<float, VDimension> point0;
-  itk::Point<float, VDimension> point1;
-  IdentifierType                maxDistance = 0;
+  // Integer-only N-dimensional Bresenham, guaranteeing exact start and end
+  // points. This avoids floating-point direction conversion entirely.
+  // Reference: classic Bresenham extended to N-D as used by scikit-image,
+  // OpenCV, and VTK.
+
+  // Compute displacements and find the dominant axis
+  IndexType      absDeltas;
+  IndexType      step; // +1 or -1 per dimension
+  IndexValueType maxAbsDelta = 0;
+  unsigned int   mainAxis = 0;
   for (unsigned int i = 0; i < VDimension; ++i)
   {
-    point0[i] = p0[i];
-    point1[i] = p1[i];
-    const IdentifierType distance = itk::Math::Absolute(p0[i] - p1[i]) + 1;
-    if (distance > maxDistance)
+    const IndexValueType delta = p1[i] - p0[i];
+    step[i] = (delta >= 0) ? 1 : -1;
+    absDeltas[i] = static_cast<IndexValueType>(itk::Math::Absolute(delta));
+
+    if (absDeltas[i] > maxAbsDelta)
     {
-      maxDistance = distance;
+      maxAbsDelta = absDeltas[i];
+      mainAxis = i;
     }
   }
 
-  OffsetArray offsets = this->BuildLine(point1 - point0, maxDistance + 1);
+  // Number of pixels = steps along dominant axis + 1
+  const IdentifierType numPixels = static_cast<IdentifierType>(maxAbsDelta) + 1;
 
   IndexArray indices;
-  indices.reserve(offsets.size()); // we might not have to use the last one
-  for (unsigned int i = 0; i < offsets.size(); ++i)
+  indices.reserve(numPixels);
+
+  // Error accumulators for each secondary axis (2 * absDelta[i] per step,
+  // overflow when accumulated error >= maxAbsDelta)
+  auto accumulateError = MakeFilled<IndexType>(0);
+  auto currentIndex = p0;
+
+  for (IdentifierType s = 0; s < numPixels; ++s)
   {
-    indices.push_back(p0 + offsets[i]);
-    if (indices.back() == p1)
+    indices.push_back(currentIndex);
+
+    // Advance along each dimension
+    for (unsigned int i = 0; i < VDimension; ++i)
     {
-      break;
+      if (i == mainAxis)
+      {
+        currentIndex[i] += step[i];
+      }
+      else
+      {
+        accumulateError[i] += 2 * absDeltas[i];
+        if (accumulateError[i] >= maxAbsDelta)
+        {
+          currentIndex[i] += step[i];
+          accumulateError[i] -= 2 * maxAbsDelta;
+        }
+      }
     }
   }
+
   return indices;
 }
 

--- a/Modules/Core/Common/test/itkBresenhamLineGTest.cxx
+++ b/Modules/Core/Common/test/itkBresenhamLineGTest.cxx
@@ -64,3 +64,436 @@ TEST(BresenhamLine, BuildLineFromIndices)
 
   std::cout << "Test Passed !" << std::endl;
 }
+
+TEST(BresenhamLine, FinishAtEndIndex)
+{
+  // Test BuildLine(Index, Index) to finish at the specified end index
+  const itk::Index<3> start{ { 0, 0, 0 } }, end{ { 250, 250, 1 } };
+
+  itk::BresenhamLine<3>            line;
+  const std::vector<itk::Index<3>> indices = line.BuildLine(start, end);
+  EXPECT_EQ(indices.back(), end);
+}
+
+TEST(BresenhamLine, FinishAtEndIndexNegativeDirection)
+{
+  // Test BuildLine(Index, Index) with reversed endpoints (negative direction)
+  const itk::Index<3> start{ { 250, 250, 1 } }, end{ { 0, 0, 0 } };
+
+  itk::BresenhamLine<3>            line;
+  const std::vector<itk::Index<3>> indices = line.BuildLine(start, end);
+  EXPECT_EQ(indices.front(), start);
+  EXPECT_EQ(indices.back(), end);
+}
+
+TEST(BresenhamLine, AxisAligned2D)
+{
+  // Horizontal and vertical lines must hit exact endpoints
+  itk::BresenhamLine<2> line;
+
+  const auto horiz = line.BuildLine(itk::Index<2>{ { 0, 5 } }, itk::Index<2>{ { 10, 5 } });
+  EXPECT_EQ(horiz.size(), 11u);
+  EXPECT_EQ(horiz.front(), (itk::Index<2>{ { 0, 5 } }));
+  EXPECT_EQ(horiz.back(), (itk::Index<2>{ { 10, 5 } }));
+  for (const auto & idx : horiz)
+  {
+    EXPECT_EQ(idx[1], 5);
+  }
+
+  const auto vert = line.BuildLine(itk::Index<2>{ { 3, 0 } }, itk::Index<2>{ { 3, 7 } });
+  EXPECT_EQ(vert.size(), 8u);
+  EXPECT_EQ(vert.front(), (itk::Index<2>{ { 3, 0 } }));
+  EXPECT_EQ(vert.back(), (itk::Index<2>{ { 3, 7 } }));
+  for (const auto & idx : vert)
+  {
+    EXPECT_EQ(idx[0], 3);
+  }
+}
+
+TEST(BresenhamLine, SinglePixelLine)
+{
+  // p0 == p1: line should contain exactly one pixel
+  itk::BresenhamLine<3> line;
+  const itk::Index<3>   p{ { 5, 10, 15 } };
+
+  const auto indices = line.BuildLine(p, p);
+  EXPECT_EQ(indices.size(), 1u);
+  EXPECT_EQ(indices[0], p);
+}
+
+TEST(BresenhamLine, Connectivity2D)
+{
+  // Every consecutive pair must be 8-connected (Chebyshev distance <= 1)
+  itk::BresenhamLine<2> line;
+  const auto            indices = line.BuildLine(itk::Index<2>{ { 0, 0 } }, itk::Index<2>{ { 100, 37 } });
+
+  for (size_t i = 1; i < indices.size(); ++i)
+  {
+    itk::IndexValueType maxStep = 0;
+    for (unsigned int d = 0; d < 2; ++d)
+    {
+      const auto s = static_cast<itk::IndexValueType>(itk::Math::Absolute(indices[i][d] - indices[i - 1][d]));
+      if (s > maxStep)
+      {
+        maxStep = s;
+      }
+    }
+    EXPECT_LE(maxStep, 1) << "Gap between pixels " << i - 1 << " and " << i;
+  }
+}
+
+TEST(BresenhamLine, Connectivity3D)
+{
+  // Every consecutive pair must be 26-connected (Chebyshev distance <= 1)
+  itk::BresenhamLine<3> line;
+  const auto            indices = line.BuildLine(itk::Index<3>{ { 0, 0, 0 } }, itk::Index<3>{ { 50, 80, 30 } });
+
+  for (size_t i = 1; i < indices.size(); ++i)
+  {
+    itk::IndexValueType maxStep = 0;
+    for (unsigned int d = 0; d < 3; ++d)
+    {
+      const auto s = static_cast<itk::IndexValueType>(itk::Math::Absolute(indices[i][d] - indices[i - 1][d]));
+      if (s > maxStep)
+      {
+        maxStep = s;
+      }
+    }
+    EXPECT_LE(maxStep, 1) << "Gap between pixels " << i - 1 << " and " << i;
+  }
+}
+
+TEST(BresenhamLine, PixelCountMatchesChebyshev)
+{
+  // Number of pixels should be Chebyshev distance + 1
+  itk::BresenhamLine<3> line;
+
+  struct TestCase
+  {
+    itk::Index<3> p0, p1;
+  };
+  const TestCase cases[] = { { { { 0, 0, 0 } }, { { 10, 0, 0 } } },
+                             { { { 0, 0, 0 } }, { { 10, 10, 0 } } },
+                             { { { 0, 0, 0 } }, { { 10, 10, 10 } } },
+                             { { { 0, 0, 0 } }, { { 100, 50, 25 } } },
+                             { { { 5, 5, 5 } }, { { 5, 5, 5 } } } };
+
+  for (const auto & tc : cases)
+  {
+    itk::IndexValueType chebyshev = 0;
+    for (unsigned int d = 0; d < 3; ++d)
+    {
+      const auto dist = static_cast<itk::IndexValueType>(itk::Math::Absolute(tc.p1[d] - tc.p0[d]));
+      if (dist > chebyshev)
+      {
+        chebyshev = dist;
+      }
+    }
+    const auto indices = line.BuildLine(tc.p0, tc.p1);
+    EXPECT_EQ(indices.size(), static_cast<size_t>(chebyshev + 1));
+  }
+}
+
+TEST(BresenhamLine, ReverseSymmetry)
+{
+  // Forward and reverse lines must have same length and hit same endpoints
+  itk::BresenhamLine<3> line;
+  const itk::Index<3>   a{ { 10, 20, 3 } }, b{ { 200, 50, 80 } };
+
+  const auto forward = line.BuildLine(a, b);
+  const auto reverse = line.BuildLine(b, a);
+
+  ASSERT_FALSE(forward.empty());
+  ASSERT_FALSE(reverse.empty());
+  ASSERT_EQ(forward.size(), reverse.size());
+  EXPECT_EQ(forward.front(), a);
+  EXPECT_EQ(forward.back(), b);
+  EXPECT_EQ(reverse.front(), b);
+  EXPECT_EQ(reverse.back(), a);
+
+  // Note: pixel-by-pixel reversal symmetry (forward[i] == reverse[N-1-i])
+  // is NOT guaranteed by integer Bresenham for all directions. The error
+  // accumulator tie-breaking can produce slightly different intermediate
+  // pixels when starting from opposite ends. Both paths are valid
+  // rasterizations of the same line segment — they have the same length,
+  // same endpoints, and maintain the same connectivity invariant.
+}
+
+TEST(BresenhamLine, SteepDiagonal3D)
+{
+  // Strongly diagonal line that triggered the original bug
+  itk::BresenhamLine<3> line;
+  const itk::Index<3>   start{ { 0, 0, 0 } }, end{ { 250, 250, 1 } };
+
+  const auto fwd = line.BuildLine(start, end);
+  EXPECT_EQ(fwd.front(), start);
+  EXPECT_EQ(fwd.back(), end);
+
+  const auto rev = line.BuildLine(end, start);
+  EXPECT_EQ(rev.front(), end);
+  EXPECT_EQ(rev.back(), start);
+
+  EXPECT_EQ(fwd.size(), rev.size());
+}
+
+// --- Tests below address gaps identified from OpenCV, scikit-image, ---
+// --- and Foley/van Dam "Computer Graphics: Principles and Practice" ---
+
+TEST(BresenhamLine, AllEightOctants2D)
+{
+  // Foley/van Dam: every Bresenham implementation must handle all 8 octants.
+  // scikit-image tests horizontal, vertical, and diagonal directions.
+  itk::BresenhamLine<2> line;
+
+  struct OctantCase
+  {
+    itk::Index<2> p0, p1;
+  };
+  // One representative line per octant, plus axis-aligned cases
+  const OctantCase cases[] = {
+    { { { 0, 0 } }, { { 10, 0 } } },   // +X (right)
+    { { { 0, 0 } }, { { -10, 0 } } },  // -X (left)
+    { { { 0, 0 } }, { { 0, 10 } } },   // +Y (down)
+    { { { 0, 0 } }, { { 0, -10 } } },  // -Y (up)
+    { { { 0, 0 } }, { { 10, 3 } } },   // octant 0: shallow +X +Y
+    { { { 0, 0 } }, { { 3, 10 } } },   // octant 1: steep +X +Y
+    { { { 0, 0 } }, { { -3, 10 } } },  // octant 2: steep -X +Y
+    { { { 0, 0 } }, { { -10, 3 } } },  // octant 3: shallow -X +Y
+    { { { 0, 0 } }, { { -10, -3 } } }, // octant 4: shallow -X -Y
+    { { { 0, 0 } }, { { -3, -10 } } }, // octant 5: steep -X -Y
+    { { { 0, 0 } }, { { 3, -10 } } },  // octant 6: steep +X -Y
+    { { { 0, 0 } }, { { 10, -3 } } },  // octant 7: shallow +X -Y
+  };
+
+  for (const auto & tc : cases)
+  {
+    const auto indices = line.BuildLine(tc.p0, tc.p1);
+
+    // Endpoints
+    EXPECT_EQ(indices.front(), tc.p0);
+    EXPECT_EQ(indices.back(), tc.p1);
+
+    // Connectivity: Chebyshev distance <= 1 between consecutive pixels
+    for (size_t i = 1; i < indices.size(); ++i)
+    {
+      for (unsigned int d = 0; d < 2; ++d)
+      {
+        const auto step = static_cast<itk::IndexValueType>(itk::Math::Absolute(indices[i][d] - indices[i - 1][d]));
+        EXPECT_LE(step, 1);
+      }
+    }
+
+    // Correct pixel count
+    itk::IndexValueType chebyshev = 0;
+    for (unsigned int d = 0; d < 2; ++d)
+    {
+      const auto dist = static_cast<itk::IndexValueType>(itk::Math::Absolute(tc.p1[d] - tc.p0[d]));
+      if (dist > chebyshev)
+      {
+        chebyshev = dist;
+      }
+    }
+    EXPECT_EQ(indices.size(), static_cast<size_t>(chebyshev + 1));
+  }
+}
+
+TEST(BresenhamLine, NoDuplicatePixels)
+{
+  // Foley/van Dam: every pixel in the output must be unique.
+  itk::BresenhamLine<3> line;
+
+  struct TestCase
+  {
+    itk::Index<3> p0, p1;
+  };
+  const TestCase cases[] = {
+    { { { 0, 0, 0 } }, { { 50, 30, 10 } } },
+    { { { 0, 0, 0 } }, { { 10, 10, 10 } } },
+    { { { 0, 0, 0 } }, { { 100, 1, 0 } } },
+    { { { 5, 5, 5 } }, { { -5, -5, -5 } } },
+  };
+
+  for (const auto & tc : cases)
+  {
+    const auto indices = line.BuildLine(tc.p0, tc.p1);
+    for (size_t i = 0; i < indices.size(); ++i)
+    {
+      for (size_t j = i + 1; j < indices.size(); ++j)
+      {
+        EXPECT_NE(indices[i], indices[j]) << "Duplicate pixel at positions " << i << " and " << j;
+      }
+    }
+  }
+}
+
+TEST(BresenhamLine, SingleStepAdjacentPixels)
+{
+  // Foley/van Dam: lines between adjacent pixels (1-step).
+  itk::BresenhamLine<2> line2d;
+  itk::BresenhamLine<3> line3d;
+
+  // 2D: all 8 neighbors
+  const itk::Index<2> origin2d{ { 5, 5 } };
+  const itk::Index<2> neighbors2d[] = { { { 6, 5 } }, { { 6, 6 } }, { { 5, 6 } }, { { 4, 6 } },
+                                        { { 4, 5 } }, { { 4, 4 } }, { { 5, 4 } }, { { 6, 4 } } };
+  for (const auto & nb : neighbors2d)
+  {
+    const auto indices = line2d.BuildLine(origin2d, nb);
+    EXPECT_EQ(indices.size(), 2u);
+    EXPECT_EQ(indices[0], origin2d);
+    EXPECT_EQ(indices[1], nb);
+  }
+
+  // 3D: face, edge, and corner neighbors
+  const itk::Index<3> origin3d{ { 5, 5, 5 } };
+  const itk::Index<3> neighbors3d[] = {
+    { { 6, 5, 5 } }, // face
+    { { 6, 6, 5 } }, // edge
+    { { 6, 6, 6 } }, // corner
+    { { 4, 5, 5 } }, // face (negative)
+    { { 4, 4, 4 } }, // corner (negative)
+  };
+  for (const auto & nb : neighbors3d)
+  {
+    const auto indices = line3d.BuildLine(origin3d, nb);
+    EXPECT_EQ(indices.size(), 2u);
+    EXPECT_EQ(indices[0], origin3d);
+    EXPECT_EQ(indices[1], nb);
+  }
+}
+
+TEST(BresenhamLine, NegativeCoordinates)
+{
+  // scikit-image tests line from (-1,-1) to (2,2).
+  // Foley/van Dam: lines crossing quadrant boundaries.
+  itk::BresenhamLine<2> line2d;
+  itk::BresenhamLine<3> line3d;
+
+  // Line entirely in negative coordinates
+  {
+    const auto indices = line2d.BuildLine(itk::Index<2>{ { -10, -10 } }, itk::Index<2>{ { -1, -1 } });
+    EXPECT_EQ(indices.size(), 10u);
+    EXPECT_EQ(indices.front(), (itk::Index<2>{ { -10, -10 } }));
+    EXPECT_EQ(indices.back(), (itk::Index<2>{ { -1, -1 } }));
+  }
+
+  // Line crossing origin
+  {
+    const auto indices = line2d.BuildLine(itk::Index<2>{ { -5, -3 } }, itk::Index<2>{ { 5, 3 } });
+    EXPECT_EQ(indices.front(), (itk::Index<2>{ { -5, -3 } }));
+    EXPECT_EQ(indices.back(), (itk::Index<2>{ { 5, 3 } }));
+    EXPECT_EQ(indices.size(), 11u);
+  }
+
+  // 3D negative
+  {
+    const auto indices = line3d.BuildLine(itk::Index<3>{ { -20, -10, -5 } }, itk::Index<3>{ { 20, 10, 5 } });
+    EXPECT_EQ(indices.front(), (itk::Index<3>{ { -20, -10, -5 } }));
+    EXPECT_EQ(indices.back(), (itk::Index<3>{ { 20, 10, 5 } }));
+    EXPECT_EQ(indices.size(), 41u);
+  }
+}
+
+TEST(BresenhamLine, AxisAligned3D)
+{
+  // Foley/van Dam: axis-aligned lines along each individual axis in 3D.
+  itk::BresenhamLine<3> line;
+
+  // Along X
+  {
+    const auto indices = line.BuildLine(itk::Index<3>{ { 0, 5, 10 } }, itk::Index<3>{ { 20, 5, 10 } });
+    EXPECT_EQ(indices.size(), 21u);
+    for (const auto & idx : indices)
+    {
+      EXPECT_EQ(idx[1], 5);
+      EXPECT_EQ(idx[2], 10);
+    }
+  }
+  // Along Y
+  {
+    const auto indices = line.BuildLine(itk::Index<3>{ { 3, 0, 7 } }, itk::Index<3>{ { 3, 15, 7 } });
+    EXPECT_EQ(indices.size(), 16u);
+    for (const auto & idx : indices)
+    {
+      EXPECT_EQ(idx[0], 3);
+      EXPECT_EQ(idx[2], 7);
+    }
+  }
+  // Along Z
+  {
+    const auto indices = line.BuildLine(itk::Index<3>{ { 1, 2, 0 } }, itk::Index<3>{ { 1, 2, 30 } });
+    EXPECT_EQ(indices.size(), 31u);
+    for (const auto & idx : indices)
+    {
+      EXPECT_EQ(idx[0], 1);
+      EXPECT_EQ(idx[1], 2);
+    }
+  }
+}
+
+TEST(BresenhamLine, SteepVsShallowSlopes)
+{
+  // Foley/van Dam: explicit steep (|dy|>|dx|) vs shallow (|dx|>|dy|) cases.
+  itk::BresenhamLine<2> line;
+
+  // Shallow slope: dx=20, dy=3
+  {
+    const auto indices = line.BuildLine(itk::Index<2>{ { 0, 0 } }, itk::Index<2>{ { 20, 3 } });
+    EXPECT_EQ(indices.size(), 21u);
+    EXPECT_EQ(indices.front(), (itk::Index<2>{ { 0, 0 } }));
+    EXPECT_EQ(indices.back(), (itk::Index<2>{ { 20, 3 } }));
+
+    // Dominant axis is X: every step must advance X by exactly 1
+    for (size_t i = 1; i < indices.size(); ++i)
+    {
+      EXPECT_EQ(indices[i][0] - indices[i - 1][0], 1);
+    }
+  }
+
+  // Steep slope: dx=3, dy=20
+  {
+    const auto indices = line.BuildLine(itk::Index<2>{ { 0, 0 } }, itk::Index<2>{ { 3, 20 } });
+    EXPECT_EQ(indices.size(), 21u);
+    EXPECT_EQ(indices.front(), (itk::Index<2>{ { 0, 0 } }));
+    EXPECT_EQ(indices.back(), (itk::Index<2>{ { 3, 20 } }));
+
+    // Dominant axis is Y: every step must advance Y by exactly 1
+    for (size_t i = 1; i < indices.size(); ++i)
+    {
+      EXPECT_EQ(indices[i][1] - indices[i - 1][1], 1);
+    }
+  }
+}
+
+TEST(BresenhamLine, VeryLongLine)
+{
+  // OpenCV tests very long lines (34204 to 46400). Foley/van Dam warns
+  // about accumulation error on long lines.
+  itk::BresenhamLine<2> line;
+  const itk::Index<2>   p0{ { 0, 0 } }, p1{ { 10000, 7777 } };
+
+  const auto indices = line.BuildLine(p0, p1);
+
+  // Correct endpoints
+  EXPECT_EQ(indices.front(), p0);
+  EXPECT_EQ(indices.back(), p1);
+
+  // Correct count
+  EXPECT_EQ(indices.size(), 10001u);
+
+  // Connectivity: no gaps anywhere in the line
+  for (size_t i = 1; i < indices.size(); ++i)
+  {
+    for (unsigned int d = 0; d < 2; ++d)
+    {
+      const auto s = static_cast<itk::IndexValueType>(itk::Math::Absolute(indices[i][d] - indices[i - 1][d]));
+      EXPECT_LE(s, 1) << "Gap at pixel " << i;
+    }
+  }
+
+  // Monotonicity: X must be non-decreasing since dx > 0
+  for (size_t i = 1; i < indices.size(); ++i)
+  {
+    EXPECT_GE(indices[i][0], indices[i - 1][0]);
+  }
+}


### PR DESCRIPTION
Overload of the BuildLine(Index, Index) function could end at index which is different from specified one. The issue was that when reconstructing LastIndex from the direction vector we didn't use actual Euclidean line length, but used Chebyshev distance instead. This led to rounding to integers closer to the line start, leading to bigger deviation at the line end.

The alternative approach would be to move the algorithm implementation to the BuildLine(Index, Index) and work fully on integers there, but this would require more code changes.
**UPDATE:** AI agent actually suggested code with algorithm implementation in BuildLine(Index, Index) overload. Since AI is allowed to do such modification, I'll proceed with it.

Bresenham line algorithm works on integer indices, and we cannot avoid rounding errors while having floating-point direction. But it's still possible to always finish at the user-specified point in the second function overload.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
