### PR TITLE
STYLE: Alphabetize source-file entries in CMake set()/list(APPEND) commands

### DIFF
--- a/Modules/Bridge/VtkGlue/test/CMakeLists.txt
+++ b/Modules/Bridge/VtkGlue/test/CMakeLists.txt
@@ -1,8 +1,8 @@
 itk_module_test()
 set(
   ITKVtkGlueTests
-  itkImageToVTKImageFilterTest.cxx
   itkImageToVTKImageFilterRGBTest.cxx
+  itkImageToVTKImageFilterTest.cxx
   itkVTKImageToImageFilterTest.cxx
 )
 if(NOT VTK_RENDERING_BACKEND STREQUAL "None")

--- a/Modules/Core/Common/src/CMakeLists.txt
+++ b/Modules/Core/Common/src/CMakeLists.txt
@@ -60,102 +60,102 @@ configure_file(
 set(
   ITKCommon_SRCS
   ${ITKCommon_BINARY_DIR}/itkBuildInformation.cxx
-  itkCommonEnums.cxx
-  itkMemoryProbesCollectorBase.cxx
-  itkCreateObjectFunction.cxx
-  itkLogger.cxx
-  itkLogOutput.cxx
-  itkLoggerOutput.cxx
-  itkNumericLocale.cxx
-  itkProgressAccumulator.cxx
-  itkTotalProgressReporter.cxx
-  itkNumericTraits.cxx
-  itkHexahedronCellTopology.cxx
-  itkIndent.cxx
-  itkEventObject.cxx
-  itkFileOutputWindow.cxx
-  itkSimpleFilterWatcher.cxx
-  itkNumericTraitsVectorPixel.cxx
-  itkObject.cxx
-  itkQuadrilateralCellTopology.cxx
-  itkIterationReporter.cxx
-  itkMemoryProbe.cxx
-  itkTextOutput.cxx
-  itkNumericTraitsTensorPixel2.cxx
-  itkNumericTraitsFixedArrayPixel2.cxx
-  itkProcessObject.cxx
-  itkStreamingProcessObject.cxx
-  itkSpatialOrientationAdapter.cxx
-  itkRealTimeInterval.cxx
-  itkOctreeNode.cxx
-  itkNumericTraitsFixedArrayPixel.cxx
-  itkMultiThreaderBase.cxx
-  itkPlatformMultiThreader.cxx
-  itkMetaDataObject.cxx
-  itkMetaDataDictionary.cxx
-  itkDataObject.cxx
-  itkThreadLogger.cxx
-  itkNumericTraitsTensorPixel.cxx
+  itkAnatomicalOrientation.cxx
+  itkArrayOutputSpecialization.cxx
   itkCommand.cxx
-  itkNumericTraitsPointPixel.cxx
-  itkLightObject.cxx
-  itkStdStreamLogOutput.cxx
-  itkLightProcessObject.cxx
-  itkRegion.cxx
+  itkCommonEnums.cxx
+  itkCompensatedSummation.cxx
+  itkCovariantVector.cxx
+  itkCreateObjectFunction.cxx
+  itkDataObject.cxx
+  itkDirectory.cxx
+  itkEquivalencyTable.cxx
+  itkEventObject.cxx
+  itkExceptionObject.cxx
+  itkExtractImageFilter.cxx
+  itkFileOutputWindow.cxx
+  itkFloatingPointExceptions.cxx
+  itkFrustumSpatialFunction.cxx
+  itkGaussianDerivativeOperator.cxx
+  itkHexahedronCellTopology.cxx
   itkImageIORegion.cxx
-  itkImageSourceCommon.cxx
-  itkImageToImageFilterCommon.cxx
   itkImageRegionSplitterBase.cxx
-  itkImageRegionSplitterSlowDimension.cxx
   itkImageRegionSplitterDirection.cxx
   itkImageRegionSplitterMultidimensional.cxx
-  itkVersion.cxx
-  itkNumericTraitsRGBAPixel.cxx
-  itkRealTimeClock.cxx
-  itkMetaDataObjectBase.cxx
-  itkCovariantVector.cxx
+  itkImageRegionSplitterSlowDimension.cxx
+  itkImageSourceCommon.cxx
+  itkImageToImageFilterCommon.cxx
+  itkIndent.cxx
+  itkIterationReporter.cxx
+  itkLightObject.cxx
+  itkLightProcessObject.cxx
+  itkLogger.cxx
+  itkLoggerBase.cxx
+  itkLoggerManager.cxx
+  itkLoggerOutput.cxx
+  itkLoggerThreadWrapper.cxx
+  itkLogOutput.cxx
+  itkMemoryProbe.cxx
+  itkMemoryProbesCollectorBase.cxx
   itkMemoryUsageObserver.cxx
   itkMersenneTwisterRandomVariateGenerator.cxx
-  itkLoggerBase.cxx
-  itkNumericTraitsCovariantVectorPixel.cxx
-  itkProgressReporter.cxx
-  itkExceptionObject.cxx
+  itkMetaDataDictionary.cxx
+  itkMetaDataObject.cxx
+  itkMetaDataObjectBase.cxx
   itkMultipleLogOutput.cxx
+  itkMultiThreaderBase.cxx
+  itkNumberToString.cxx
+  itkNumericLocale.cxx
+  itkNumericTraits.cxx
+  itkNumericTraitsCovariantVectorPixel.cxx
+  itkNumericTraitsDiffusionTensor3DPixel.cxx
+  itkNumericTraitsFixedArrayPixel.cxx
+  itkNumericTraitsFixedArrayPixel2.cxx
+  itkNumericTraitsPointPixel.cxx
+  itkNumericTraitsRGBAPixel.cxx
+  itkNumericTraitsRGBPixel.cxx
+  itkNumericTraitsTensorPixel.cxx
+  itkNumericTraitsTensorPixel2.cxx
+  itkNumericTraitsVectorPixel.cxx
+  itkObject.cxx
+  itkObjectFactoryBase.cxx
+  itkObjectStore.cxx
+  itkOctreeNode.cxx
+  itkOutputWindow.cxx
+  itkPlatformMultiThreader.cxx
+  itkProcessObject.cxx
+  itkProgressAccumulator.cxx
+  itkProgressReporter.cxx
+  itkProgressTransformer.cxx
   itkQuadraticTriangleCellTopology.cxx
-  itkTimeProbesCollectorBase.cxx
+  itkQuadrilateralCellTopology.cxx
+  itkRandomVariateGeneratorBase.cxx
+  itkRealTimeClock.cxx
+  itkRealTimeInterval.cxx
+  itkRealTimeStamp.cxx
+  itkRegion.cxx
+  itkSimpleFilterWatcher.cxx
+  itkSingleton.cxx
   itkSmapsFileParser.cxx
+  itkSpatialOrientation.cxx
+  itkSpatialOrientationAdapter.cxx
+  itkStdStreamLogOutput.cxx
+  itkStoppingCriterionBase.cxx
+  itkStreamingProcessObject.cxx
+  itkSymmetricEigenAnalysis.cxx
+  itkTetrahedronCellTopology.cxx
+  itkTextOutput.cxx
+  itkThreadedIndexedContainerPartitioner.cxx
+  itkThreadLogger.cxx
+  itkTimeProbe.cxx
+  itkTimeProbesCollectorBase.cxx
+  itkTimeStamp.cxx
+  itkTotalProgressReporter.cxx
   itkTriangleCellTopology.cxx
   itkVector.cxx
-  itkRealTimeStamp.cxx
-  itkDirectory.cxx
-  itkLoggerManager.cxx
-  itkTimeProbe.cxx
-  itkNumericTraitsRGBPixel.cxx
-  itkTimeStamp.cxx
-  itkSingleton.cxx
-  itkTetrahedronCellTopology.cxx
-  itkThreadedIndexedContainerPartitioner.cxx
-  itkObjectFactoryBase.cxx
-  itkFloatingPointExceptions.cxx
-  itkOutputWindow.cxx
-  itkNumericTraitsDiffusionTensor3DPixel.cxx
-  itkEquivalencyTable.cxx
+  itkVersion.cxx
   itkXMLFileOutputWindow.cxx
   itkXMLFilterWatcher.cxx
-  itkStoppingCriterionBase.cxx
-  itkCompensatedSummation.cxx
-  itkArrayOutputSpecialization.cxx
-  itkNumberToString.cxx
-  itkRandomVariateGeneratorBase.cxx
-  itkProgressTransformer.cxx
-  itkSymmetricEigenAnalysis.cxx
-  itkExtractImageFilter.cxx
-  itkLoggerThreadWrapper.cxx
-  itkFrustumSpatialFunction.cxx
-  itkObjectStore.cxx
-  itkGaussianDerivativeOperator.cxx
-  itkSpatialOrientation.cxx
-  itkAnatomicalOrientation.cxx
 )
 
 if(ITK_WRAP_PYTHON)

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -1,74 +1,74 @@
 itk_module_test()
 set(
   ITKCommon1Tests
-  itkImageRegionExplicitTest.cxx
+  itkColorTableTest.cxx
+  itkDataObjectTest.cxx
+  itkDirectoryTest.cxx
+  itkExceptionObjectTest.cxx
   itkExtractImage3Dto2DTest.cxx
   itkExtractImageTest.cxx
-  itkMapContainerTest.cxx
-  itkVectorContainerTest.cxx
-  itkIteratorTests.cxx
-  itkImageReverseIteratorTest.cxx
+  itkFileOutputWindowTest.cxx
+  itkFixedArrayTest2.cxx
+  itkFloatingPointExceptionsTest.cxx
+  itkGaussianSpatialFunctionTest.cxx
+  itkImageAdaptorPipeLineTest.cxx
   itkImageComputeOffsetAndIndexTest.cxx
   itkImageDuplicatorTest.cxx
   itkImageDuplicatorTest2.cxx
   itkImageIteratorsForwardBackwardTest.cxx
+  itkImageIteratorTest.cxx
+  itkImageIteratorWithIndexTest.cxx
   itkImageLinearIteratorTest.cxx
-  itkImageAdaptorPipeLineTest.cxx
   itkImageRandomIteratorTest.cxx
   itkImageRandomIteratorTest2.cxx
-  itkImageSliceIteratorTest.cxx
-  itkRGBPixelTest.cxx
-  itkLightObjectTest.cxx
-  itkSparseImageTest.cxx
-  itkSimpleFilterWatcherTest.cxx
-  itkSymmetricEllipsoidInteriorExteriorSpatialFunctionTest.cxx
-  itkSymmetricSecondRankTensorImageReadTest.cxx
-  itkSymmetricSecondRankTensorImageWriteReadTest.cxx
-  itkFloatingPointExceptionsTest.cxx
-  itkFixedArrayTest2.cxx
-  itkNeighborhoodAlgorithmTest.cxx
-  itkPhasedArray3DSpecialCoordinatesImageTest.cxx
-  itkPriorityQueueTest.cxx
-  itkFileOutputWindowTest.cxx
-  itkSymmetricEigenAnalysisTest.cxx
-  itkStreamingImageFilterTest.cxx
-  itkStreamingImageFilterTest2.cxx
-  itkStreamingImageFilterTest3.cxx
-  itkLoggerTest.cxx
-  itkColorTableTest.cxx
-  itkNumericTraitsTest.cxx
-  itkImageRegionTest.cxx
-  itkExceptionObjectTest.cxx
-  itkNeighborhoodOperatorTest.cxx
-  itkNumericsTest.cxx
-  itkLineIteratorTest.cxx
-  itkGaussianSpatialFunctionTest.cxx
-  itkRealTimeClockTest.cxx
-  itkRealTimeIntervalTest.cxx
-  itkRealTimeStampTest.cxx
-  itkImageIteratorTest.cxx
+  itkImageRegionExplicitTest.cxx
   itkImageRegionIteratorTest.cxx
+  itkImageRegionTest.cxx
+  itkImageReverseIteratorTest.cxx
   itkImageScanlineIteratorTest1.cxx
-  itkImageIteratorWithIndexTest.cxx
-  itkDirectoryTest.cxx
-  itkObjectStoreTest.cxx
-  itkObjectFactoryTest.cxx
-  itkMultipleLogOutputTest.cxx
-  itkVectorTest.cxx
+  itkImageSliceIteratorTest.cxx
   itkImageTest.cxx
+  itkIteratorTests.cxx
+  itkLightObjectTest.cxx
+  itkLineIteratorTest.cxx
+  itkLoggerTest.cxx
+  itkMapContainerTest.cxx
+  itkMultipleLogOutputTest.cxx
+  itkNeighborhoodAlgorithmTest.cxx
+  itkNeighborhoodOperatorTest.cxx
+  itkNumberToStringTest.cxx
+  itkNumericsTest.cxx
+  itkNumericTraitsTest.cxx
+  itkObjectFactoryTest.cxx
+  itkObjectStoreTest.cxx
+  itkPhasedArray3DSpecialCoordinatesImageTest.cxx
+  itkPointGeometryTest.cxx
   itkPointSetTest.cxx
   itkPointSetToImageFilterTest1.cxx
   itkPointSetToImageFilterTest2.cxx
-  itkSparseFieldLayerTest.cxx
-  itkDataObjectTest.cxx
-  itkPointGeometryTest.cxx
-  itkNumberToStringTest.cxx
-  itkTimeProbeTest.cxx
-  itkTimeProbeTest2.cxx
-  itkSpatialOrientationTest.cxx
-  VNLSparseLUSolverTraitsTest.cxx
+  itkPriorityQueueTest.cxx
+  itkRealTimeClockTest.cxx
+  itkRealTimeIntervalTest.cxx
+  itkRealTimeStampTest.cxx
+  itkRGBPixelTest.cxx
+  itkSimpleFilterWatcherTest.cxx
   itkSobelOperatorImageConvolutionTest.cxx
   itkSobelOperatorImageFilterTest.cxx
+  itkSparseFieldLayerTest.cxx
+  itkSparseImageTest.cxx
+  itkSpatialOrientationTest.cxx
+  itkStreamingImageFilterTest.cxx
+  itkStreamingImageFilterTest2.cxx
+  itkStreamingImageFilterTest3.cxx
+  itkSymmetricEigenAnalysisTest.cxx
+  itkSymmetricEllipsoidInteriorExteriorSpatialFunctionTest.cxx
+  itkSymmetricSecondRankTensorImageReadTest.cxx
+  itkSymmetricSecondRankTensorImageWriteReadTest.cxx
+  itkTimeProbeTest.cxx
+  itkTimeProbeTest2.cxx
+  itkVectorContainerTest.cxx
+  itkVectorTest.cxx
+  VNLSparseLUSolverTraitsTest.cxx
 )
 set(
   ITKCommon2Tests
@@ -1507,45 +1507,75 @@ endif()
 
 set(
   ITKCommonGTests
-  itkArrayGTest.cxx
-  itkArray2DGTest.cxx
+  itkAbortProcessObjectGTest.cxx
+  itkAdaptorComparisonGTest.cxx
   itkAggregateTypesGTest.cxx
+  itkAnatomicalOrientationGTest.cxx
+  itkAnnulusOperatorGTest.cxx
+  itkArray2DGTest.cxx
+  itkArrayGTest.cxx
+  itkAutoPointerGTest.cxx
   itkBitCastGTest.cxx
   itkBooleanStdVectorGTest.cxx
+  itkBoundaryConditionGTest.cxx
+  itkBoundingBoxGTest.cxx
+  itkBresenhamLineGTest.cxx
   itkBSplineKernelFunctionGTest.cxx
   itkBuildInformationGTest.cxx
+  itkByteSwapGTest.cxx
   itkCommandObserverObjectGTest.cxx
+  itkCommonTypeTraitsGTest.cxx
   itkConnectedImageNeighborhoodShapeGTest.cxx
   itkConstantBoundaryImageNeighborhoodPixelAccessPolicyGTest.cxx
   itkCopyGTest.cxx
   itkCovariantVectorGTest.cxx
+  itkCrossHelperGTest.cxx
+  itkDataTypeGTest.cxx
+  itkDecoratorGTest.cxx
   itkDerefGTest.cxx
+  itkDerivativeOperatorGTest.cxx
   itkDiffusionTensor3DGTest.cxx
+  itkEventObjectGTest.cxx
   itkExceptionObjectGTest.cxx
+  itkFilterDispatchGTest.cxx
   itkFixedArrayGTest.cxx
+  itkFloodFilledSpatialFunctionGTest.cxx
+  itkFloodFillIteratorGTest.cxx
   itkGaussianDerivativeOperatorGTest.cxx
-  itkImageNeighborhoodOffsetsGTest.cxx
-  itkImageGTest.cxx
+  itkHashTableGTest.cxx
+  itkHeavisideStepFunctionGTest.cxx
   itkImageBaseGTest.cxx
   itkImageBufferRangeGTest.cxx
-  itkImageIteratorsGTest.cxx
-  itkImageRegionRangeGTest.cxx
+  itkImageGTest.cxx
   itkImageIORegionGTest.cxx
+  itkImageIteratorsGTest.cxx
+  itkImageNeighborhoodOffsetsGTest.cxx
   itkImageRandomConstIteratorWithIndexGTest.cxx
   itkImageRandomNonRepeatingIteratorWithIndexGTest.cxx
   itkImageRegionGTest.cxx
+  itkImageRegionRangeGTest.cxx
+  itkImageTransformGTest.cxx
+  itkImportContainerGTest.cxx
+  itkImportImageGTest.cxx
   itkIndexGTest.cxx
   itkIndexRangeGTest.cxx
+  itkIntTypesGTest.cxx
   itkLightObjectGTest.cxx
   itkMakeUniqueForOverwriteGTest.cxx
+  itkMathCastWithRangeCheckGTest.cxx
+  itkMathGTest.cxx
+  itkMathRoundGTest.cxx
   itkMatrixGTest.cxx
   itkMersenneTwisterRandomVariateGeneratorGTest.cxx
+  itkMetaDataDictionaryGTest.cxx
+  itkModifiedTimeGTest.cxx
   itkNeighborhoodAllocatorGTest.cxx
   itkNumberToStringGTest.cxx
   itkNumericLocaleGTest.cxx
   itkObjectFactoryBaseGTest.cxx
   itkOffsetGTest.cxx
   itkOptimizerParametersGTest.cxx
+  itkPixelAccessGTest.cxx
   itkPointGTest.cxx
   itkPointSetGTest.cxx
   itkPrintHelperGTest.cxx
@@ -1555,50 +1585,20 @@ set(
   itkSizeGTest.cxx
   itkSmartPointerGTest.cxx
   itkSobelOperatorGTest.cxx
-  itkSymmetricSecondRankTensorGTest.cxx
-  itkVariableLengthVectorGTest.cxx
-  itkVectorContainerGTest.cxx
-  itkVectorGTest.cxx
-  itkWeakPointerGTest.cxx
-  itkCommonTypeTraitsGTest.cxx
-  itkMathGTest.cxx
-  itkDataTypeGTest.cxx
-  itkBoundaryConditionGTest.cxx
-  itkBoundingBoxGTest.cxx
-  itkTimeStampGTest.cxx
-  itkEventObjectGTest.cxx
-  itkByteSwapGTest.cxx
-  itkIntTypesGTest.cxx
-  itkMathCastWithRangeCheckGTest.cxx
-  itkMathRoundGTest.cxx
-  itkModifiedTimeGTest.cxx
-  itkVersionGTest.cxx
-  itkMetaDataDictionaryGTest.cxx
   itkSpatialOrientationAdaptorGTest.cxx
-  itkAnatomicalOrientationGTest.cxx
-  itkAutoPointerGTest.cxx
   itkStdStreamStateSaveGTest.cxx
-  itkDecoratorGTest.cxx
-  itkAbortProcessObjectGTest.cxx
-  itkBresenhamLineGTest.cxx
-  itkFilterDispatchGTest.cxx
-  itkThreadedIndexedContainerPartitionerGTest.cxx
-  itkHashTableGTest.cxx
-  itkHeavisideStepFunctionGTest.cxx
-  itkImportImageGTest.cxx
-  itkImportContainerGTest.cxx
-  itkPixelAccessGTest.cxx
-  itkImageTransformGTest.cxx
-  itkAnnulusOperatorGTest.cxx
-  itkCrossHelperGTest.cxx
-  itkAdaptorComparisonGTest.cxx
-  itkFloodFillIteratorGTest.cxx
-  itkDerivativeOperatorGTest.cxx
-  itkFloodFilledSpatialFunctionGTest.cxx
+  itkSymmetricSecondRankTensorGTest.cxx
   itkThreadedImageRegionPartitionerGTest.cxx
+  itkThreadedIndexedContainerPartitionerGTest.cxx
   itkThreadedIteratorRangePartitionerGTest.cxx
   itkThreadedIteratorRangePartitionerGTest2.cxx
   itkThreadedIteratorRangePartitionerGTest3.cxx
+  itkTimeStampGTest.cxx
+  itkVariableLengthVectorGTest.cxx
+  itkVectorContainerGTest.cxx
+  itkVectorGTest.cxx
+  itkVersionGTest.cxx
+  itkWeakPointerGTest.cxx
 )
 creategoogletestdriver(ITKCommon "${ITKCommon-Test_LIBRARIES}" "${ITKCommonGTests}")
 # If `-static` was passed to CMAKE_EXE_LINKER_FLAGS, compilation fails. No need to

--- a/Modules/Core/ImageFunction/test/CMakeLists.txt
+++ b/Modules/Core/ImageFunction/test/CMakeLists.txt
@@ -1,36 +1,36 @@
 itk_module_test()
 set(
   ITKImageFunctionTests
-  itkGaussianBlurImageFunctionTest.cxx
-  itkVectorInterpolateImageFunctionTest.cxx
-  itkVarianceImageFunctionTest.cxx
-  itkMedianImageFunctionTest.cxx
   itkBinaryThresholdImageFunctionTest.cxx
   itkBSplineDecompositionImageFilterTest.cxx
   itkBSplineInterpolateImageFunctionTest.cxx
   itkBSplineResampleImageFunctionTest.cxx
-  itkScatterMatrixImageFunctionTest.cxx
-  itkMeanImageFunctionTest.cxx
-  itkGaussianDerivativeImageFunctionTest.cxx
-  itkCentralDifferenceImageFunctionTest.cxx
-  itkCentralDifferenceImageFunctionOnVectorTest.cxx
-  itkImageAdaptorInterpolateImageFunctionTest.cxx
-  itkCovarianceImageFunctionTest.cxx
-  itkRayCastInterpolateImageFunctionTest.cxx
-  itkNearestNeighborExtrapolateImageFunctionTest.cxx
-  itkVectorMeanImageFunctionTest.cxx
-  itkMahalanobisDistanceThresholdImageFunctionTest.cxx
-  itkInterpolateTest.cxx
-  itkRGBInterpolateImageFunctionTest.cxx
-  itkWindowedSincInterpolateImageFunctionTest.cxx
-  itkLinearInterpolateImageFunctionTest.cxx
-  itkNeighborhoodOperatorImageFunctionTest.cxx
-  itkNearestNeighborInterpolateImageFunctionTest.cxx
-  itkGaussianInterpolateImageFunctionTest.cxx
-  itkLabelImageGaussianInterpolateImageFunctionTest.cxx
-  itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunctionTest.cxx
-  itkCentralDifferenceImageFunctionSpeedTest.cxx
   itkCentralDifferenceImageFunctionOnVectorSpeedTest.cxx
+  itkCentralDifferenceImageFunctionOnVectorTest.cxx
+  itkCentralDifferenceImageFunctionSpeedTest.cxx
+  itkCentralDifferenceImageFunctionTest.cxx
+  itkCovarianceImageFunctionTest.cxx
+  itkGaussianBlurImageFunctionTest.cxx
+  itkGaussianDerivativeImageFunctionTest.cxx
+  itkGaussianInterpolateImageFunctionTest.cxx
+  itkImageAdaptorInterpolateImageFunctionTest.cxx
+  itkInterpolateTest.cxx
+  itkLabelImageGaussianInterpolateImageFunctionTest.cxx
+  itkLinearInterpolateImageFunctionTest.cxx
+  itkMahalanobisDistanceThresholdImageFunctionTest.cxx
+  itkMeanImageFunctionTest.cxx
+  itkMedianImageFunctionTest.cxx
+  itkNearestNeighborExtrapolateImageFunctionTest.cxx
+  itkNearestNeighborInterpolateImageFunctionTest.cxx
+  itkNeighborhoodOperatorImageFunctionTest.cxx
+  itkRayCastInterpolateImageFunctionTest.cxx
+  itkRGBInterpolateImageFunctionTest.cxx
+  itkScatterMatrixImageFunctionTest.cxx
+  itkVarianceImageFunctionTest.cxx
+  itkVectorInterpolateImageFunctionTest.cxx
+  itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunctionTest.cxx
+  itkVectorMeanImageFunctionTest.cxx
+  itkWindowedSincInterpolateImageFunctionTest.cxx
 )
 
 createtestdriver(ITKImageFunction "${ITKImageFunction-Test_LIBRARIES}" "${ITKImageFunctionTests}")

--- a/Modules/Core/Mesh/test/CMakeLists.txt
+++ b/Modules/Core/Mesh/test/CMakeLists.txt
@@ -2,43 +2,43 @@ itk_module_test()
 set(
   ITKMeshTests
   itkAutomaticTopologyMeshSourceTest.cxx
+  itkBinaryMask3DMeshSourceTest.cxx
+  itkCellInterfaceTest.cxx
+  itkConnectedRegionsMeshFilterTest1.cxx
+  itkConnectedRegionsMeshFilterTest2.cxx
+  itkDynamicMeshTest.cxx
   itkImageToParametricSpaceFilterTest.cxx
   itkInteriorExteriorMeshFilterTest.cxx
+  itkMeshCellDataTest.cxx
+  itkMeshFstreamTest.cxx
   itkMeshRegionTest.cxx
+  itkMeshSourceGraftOutputTest.cxx
+  itkMeshSpatialObjectIOTest.cxx
+  itkMeshTest.cxx
+  itkNewTest.cxx
   itkParametricSpaceToImageSpaceMeshFilterTest.cxx
+  itkQuadrilateralCellTest.cxx
   itkRegularSphereMeshSourceTest.cxx
   itkRegularSphereMeshSourceTest2.cxx
-  itkSimplexMeshTest.cxx
   itkSimplexMeshAdaptTopologyFilterTest.cxx
+  itkSimplexMeshTest.cxx
   itkSimplexMeshToTriangleMeshFilterTest.cxx
   itkSimplexMeshVolumeCalculatorTest.cxx
   itkSphereMeshSourceTest.cxx
   itkTransformMeshFilterTest.cxx
+  itkTriangleCellTest.cxx
+  itkTriangleMeshCurvatureCalculatorTest.cxx
   itkTriangleMeshToBinaryImageFilterTest.cxx
   itkTriangleMeshToBinaryImageFilterTest1.cxx
   itkTriangleMeshToBinaryImageFilterTest2.cxx
   itkTriangleMeshToBinaryImageFilterTest3.cxx
   itkTriangleMeshToBinaryImageFilterTest4.cxx
+  itkTriangleMeshToSimplexMeshFilter2Test.cxx
   itkTriangleMeshToSimplexMeshFilterTest.cxx
   itkVTKPolyDataReaderTest.cxx
   itkVTKPolyDataWriterTest01.cxx
   itkVTKPolyDataWriterTest02.cxx
   itkWarpMeshFilterTest.cxx
-  itkMeshTest.cxx
-  itkBinaryMask3DMeshSourceTest.cxx
-  itkDynamicMeshTest.cxx
-  itkConnectedRegionsMeshFilterTest1.cxx
-  itkConnectedRegionsMeshFilterTest2.cxx
-  itkMeshFstreamTest.cxx
-  itkMeshSourceGraftOutputTest.cxx
-  itkMeshSpatialObjectIOTest.cxx
-  itkTriangleMeshToSimplexMeshFilter2Test.cxx
-  itkCellInterfaceTest.cxx
-  itkNewTest.cxx
-  itkQuadrilateralCellTest.cxx
-  itkTriangleCellTest.cxx
-  itkMeshCellDataTest.cxx
-  itkTriangleMeshCurvatureCalculatorTest.cxx
 )
 
 set(ITKMesh-Test_LIBRARIES ${ITKMesh-Test_LIBRARIES})

--- a/Modules/Core/QuadEdgeMesh/test/CMakeLists.txt
+++ b/Modules/Core/QuadEdgeMesh/test/CMakeLists.txt
@@ -1,14 +1,7 @@
 itk_module_test()
 set(
   ITKQuadEdgeMeshTests
-  itkQuadEdgeMeshPointTest1.cxx
-  itkQuadEdgeMeshTest1.cxx
-  itkQuadEdgeMeshTest2.cxx
-  itkQuadEdgeMeshTest3.cxx
-  itkQuadEdgeMeshPolygonCellTest.cxx
-  itkQuadEdgeMeshFrontIteratorTest.cxx
-  itkQuadEdgeMeshScalarDataVTKPolyDataWriterTest1.cxx
-  itkQuadEdgeTest1.cxx
+  itkDynamicQuadEdgeMeshTest.cxx
   itkGeometricalQuadEdgeTest1.cxx
   itkQuadEdgeMeshAddFaceTest1.cxx
   itkQuadEdgeMeshAddFaceTest2.cxx
@@ -25,11 +18,18 @@ set(
   itkQuadEdgeMeshEulerOperatorSplitEdgeTest.cxx
   itkQuadEdgeMeshEulerOperatorSplitFaceTest.cxx
   itkQuadEdgeMeshEulerOperatorSplitVertexTest.cxx
+  itkQuadEdgeMeshFrontIteratorTest.cxx
   itkQuadEdgeMeshIteratorTest.cxx
   itkQuadEdgeMeshNoPointConstTest.cxx
+  itkQuadEdgeMeshPointTest1.cxx
+  itkQuadEdgeMeshPolygonCellTest.cxx
+  itkQuadEdgeMeshScalarDataVTKPolyDataWriterTest1.cxx
+  itkQuadEdgeMeshTest1.cxx
+  itkQuadEdgeMeshTest2.cxx
+  itkQuadEdgeMeshTest3.cxx
+  itkQuadEdgeTest1.cxx
   itkVTKPolyDataIOQuadEdgeMeshTest.cxx
   itkVTKPolyDataReaderQuadEdgeMeshTest.cxx
-  itkDynamicQuadEdgeMeshTest.cxx
 )
 
 createtestdriver(ITKQuadEdgeMesh "${ITKQuadEdgeMesh-Test_LIBRARIES}" "${ITKQuadEdgeMeshTests}")

--- a/Modules/Core/SpatialObjects/src/CMakeLists.txt
+++ b/Modules/Core/SpatialObjects/src/CMakeLists.txt
@@ -1,10 +1,10 @@
 set(
   ITKSpatialObjects_SRCS
+  itkContourSpatialObject.cxx
+  itkDTITubeSpatialObjectPoint.cxx
   itkMetaEvent.cxx
   itkSpatialObjectFactoryBase.cxx
   itkSpatialObjectProperty.cxx
-  itkDTITubeSpatialObjectPoint.cxx
-  itkContourSpatialObject.cxx
 )
 
 itk_module_add_library(ITKSpatialObjects ${ITKSpatialObjects_SRCS})

--- a/Modules/Core/SpatialObjects/test/CMakeLists.txt
+++ b/Modules/Core/SpatialObjects/test/CMakeLists.txt
@@ -1,35 +1,35 @@
 itk_module_test()
 set(
   ITKSpatialObjectsTests
+  itkArrowSpatialObjectTest.cxx
+  itkBlobSpatialObjectTest.cxx
+  itkBoxSpatialObjectTest.cxx
   itkCastSpatialObjectFilterTest.cxx
   itkContourSpatialObjectPointTest.cxx
-  itkSpatialObjectToImageFilterTest.cxx
-  itkLandmarkSpatialObjectTest.cxx
-  itkImageSpatialObjectTest.cxx
-  itkSpatialObjectToImageStatisticsCalculatorTest.cxx
+  itkContourSpatialObjectTest.cxx
+  itkDTITubeSpatialObjectTest.cxx
+  itkEllipseSpatialObjectTest.cxx
+  itkGaussianSpatialObjectTest.cxx
   itkImageMaskSpatialObjectTest.cxx
   itkImageMaskSpatialObjectTest2.cxx
   itkImageMaskSpatialObjectTest3.cxx
   itkImageMaskSpatialObjectTest4.cxx
   itkImageMaskSpatialObjectTest5.cxx
-  itkBlobSpatialObjectTest.cxx
-  itkContourSpatialObjectTest.cxx
-  itkSurfaceSpatialObjectTest.cxx
+  itkImageSpatialObjectTest.cxx
+  itkLandmarkSpatialObjectTest.cxx
+  itkLineSpatialObjectTest.cxx
+  itkMeshSpatialObjectTest.cxx
   itkMetaArrowConverterTest.cxx
   itkMetaGaussianConverterTest.cxx
-  itkTubeSpatialObjectTest.cxx
-  itkDTITubeSpatialObjectTest.cxx
-  itkSpatialObjectToPointSetFilterTest.cxx
-  itkSpatialObjectDuplicatorTest.cxx
-  itkBoxSpatialObjectTest.cxx
-  itkGaussianSpatialObjectTest.cxx
-  itkPolygonSpatialObjectTest.cxx
-  itkPolygonSpatialObjectIsInsideInObjectSpaceTest.cxx
-  itkEllipseSpatialObjectTest.cxx
-  itkMeshSpatialObjectTest.cxx
-  itkArrowSpatialObjectTest.cxx
-  itkLineSpatialObjectTest.cxx
   itkNewMetaObjectTypeTest.cxx
+  itkPolygonSpatialObjectIsInsideInObjectSpaceTest.cxx
+  itkPolygonSpatialObjectTest.cxx
+  itkSpatialObjectDuplicatorTest.cxx
+  itkSpatialObjectToImageFilterTest.cxx
+  itkSpatialObjectToImageStatisticsCalculatorTest.cxx
+  itkSpatialObjectToPointSetFilterTest.cxx
+  itkSurfaceSpatialObjectTest.cxx
+  itkTubeSpatialObjectTest.cxx
 )
 
 createtestdriver(ITKSpatialObjects "${ITKSpatialObjects-Test_LIBRARIES}" "${ITKSpatialObjectsTests}")

--- a/Modules/Core/TestKernel/src/CMakeLists.txt
+++ b/Modules/Core/TestKernel/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(
   ITKTestKernel_SRCS
-  itkTestDriverIncludeRequiredFactories.cxx
   itkTestDriverInclude.cxx
+  itkTestDriverIncludeRequiredFactories.cxx
   itkTestingExtractSliceImageFilter.cxx
   itkTestingHashImageFilter.cxx
 )

--- a/Modules/Core/Transform/test/CMakeLists.txt
+++ b/Modules/Core/Transform/test/CMakeLists.txt
@@ -1,45 +1,45 @@
 itk_module_test()
 set(
   ITKTransformTests
-  itkFixedCenterOfRotationAffineTransformTest.cxx
   itkAffineTransformTest.cxx
-  itkScaleSkewVersor3DTransformTest.cxx
-  itkComposeScaleSkewVersor3DTransformTest.cxx
-  itkEuler3DTransformTest.cxx
-  itkCenteredRigid2DTransformTest.cxx
-  itkEuler2DTransformTest.cxx
-  itkRigid3DTransformTest.cxx
-  itkScaleVersor3DTransformTest.cxx
-  itkTransformTest.cxx
-  itkRigid3DPerspectiveTransformTest.cxx
-  itkSimilarity2DTransformTest.cxx
-  itkTranslationTransformTest.cxx
-  itkIdentityTransformTest.cxx
-  itkCenteredAffineTransformTest.cxx
-  itkRigid2DTransformTest.cxx
-  itkScaleLogarithmicTransformTest.cxx
-  itkQuaternionRigidTransformTest.cxx
-  itkScaleTransformTest.cxx
-  itkSimilarity3DTransformTest.cxx
   itkAzimuthElevationToCartesianTransformTest.cxx
-  itkCenteredEuler3DTransformTest.cxx
-  itkTransformsSetParametersTest.cxx
   itkBSplineDeformableTransformTest.cxx
   itkBSplineDeformableTransformTest2.cxx
   itkBSplineDeformableTransformTest3.cxx
+  itkBSplineTransformInitializerTest1.cxx
+  itkBSplineTransformInitializerTest2.cxx
   itkBSplineTransformTest.cxx
   itkBSplineTransformTest2.cxx
   itkBSplineTransformTest3.cxx
-  itkBSplineTransformInitializerTest1.cxx
-  itkBSplineTransformInitializerTest2.cxx
+  itkCenteredAffineTransformTest.cxx
+  itkCenteredEuler3DTransformTest.cxx
+  itkCenteredRigid2DTransformTest.cxx
+  itkComposeScaleSkewVersor3DTransformTest.cxx
+  itkCompositeTransformTest.cxx
+  itkEuler2DTransformTest.cxx
+  itkEuler3DTransformTest.cxx
+  itkFixedCenterOfRotationAffineTransformTest.cxx
+  itkIdentityTransformTest.cxx
+  itkMultiTransformTest.cxx
+  itkQuaternionRigidTransformTest.cxx
+  itkRigid2DTransformTest.cxx
+  itkRigid3DPerspectiveTransformTest.cxx
+  itkRigid3DTransformTest.cxx
+  itkScaleLogarithmicTransformTest.cxx
+  itkScaleSkewVersor3DTransformTest.cxx
+  itkScaleTransformTest.cxx
+  itkScaleVersor3DTransformTest.cxx
+  itkSimilarity2DTransformTest.cxx
+  itkSimilarity3DTransformTest.cxx
+  itkSplineKernelTransformTest.cxx
+  itkTestTransformGetInverse.cxx
+  itkTransformCloneTest.cxx
+  itkTransformGeometryImageFilterTest.cxx
+  itkTransformsSetParametersTest.cxx
+  itkTransformTest.cxx
+  itkTranslationTransformTest.cxx
   itkVersorRigid3DTransformTest.cxx
   itkVersorTransformTest.cxx
-  itkSplineKernelTransformTest.cxx
-  itkCompositeTransformTest.cxx
-  itkTransformCloneTest.cxx
-  itkMultiTransformTest.cxx
-  itkTestTransformGetInverse.cxx
-  itkTransformGeometryImageFilterTest.cxx
 )
 
 createtestdriver(ITKTransform "${ITKTransform-Test_LIBRARIES}" "${ITKTransformTests}")

--- a/Modules/Filtering/AnisotropicSmoothing/test/CMakeLists.txt
+++ b/Modules/Filtering/AnisotropicSmoothing/test/CMakeLists.txt
@@ -1,11 +1,11 @@
 itk_module_test()
 set(
   ITKAnisotropicSmoothingTests
-  itkGradientAnisotropicDiffusionImageFilterTest.cxx
   itkCurvatureAnisotropicDiffusionImageFilterTest.cxx
+  itkGradientAnisotropicDiffusionImageFilterTest.cxx
+  itkGradientAnisotropicDiffusionImageFilterTest2.cxx
   itkMinMaxCurvatureFlowImageFilterTest.cxx
   itkVectorAnisotropicDiffusionImageFilterTest.cxx
-  itkGradientAnisotropicDiffusionImageFilterTest2.cxx
 )
 
 createtestdriver(ITKAnisotropicSmoothing "${ITKAnisotropicSmoothing-Test_LIBRARIES}" "${ITKAnisotropicSmoothingTests}")

--- a/Modules/Filtering/BiasCorrection/src/CMakeLists.txt
+++ b/Modules/Filtering/BiasCorrection/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(
   ITKBiasCorrection_SRCS
-  itkCompositeValleyFunction.cxx
   itkCacheableScalarFunction.cxx
+  itkCompositeValleyFunction.cxx
 )
 
 itk_module_add_library(ITKBiasCorrection ${ITKBiasCorrection_SRCS})

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/CMakeLists.txt
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/CMakeLists.txt
@@ -3,7 +3,6 @@ set(
   ITKBinaryMathematicalMorphologyTests
   itkBinaryClosingByReconstructionImageFilterTest.cxx
   itkBinaryDilateImageFilterTest.cxx
-  itkFastIncrementalBinaryDilateImageFilterTest.cxx
   itkBinaryDilateImageFilterTest3.cxx
   itkBinaryErodeImageFilterTest.cxx
   itkBinaryErodeImageFilterTest3.cxx
@@ -12,6 +11,7 @@ set(
   itkBinaryOpeningByReconstructionImageFilterTest.cxx
   itkBinaryThinningImageFilterTest.cxx
   itkErodeObjectMorphologyImageFilterTest.cxx
+  itkFastIncrementalBinaryDilateImageFilterTest.cxx
 )
 
 createtestdriver(ITKBinaryMathematicalMorphology "${ITKBinaryMathematicalMorphology-Test_LIBRARIES}"

--- a/Modules/Filtering/Convolution/test/CMakeLists.txt
+++ b/Modules/Filtering/Convolution/test/CMakeLists.txt
@@ -1,17 +1,17 @@
 itk_module_test()
 set(
   ITKConvolutionTests
-  itkConvolutionImageFilterTest.cxx
-  itkConvolutionImageFilterTestInt.cxx
   itkConvolutionImageFilterDeltaFunctionTest.cxx
   itkConvolutionImageFilterStreamingTest.cxx
   itkConvolutionImageFilterSubregionTest.cxx
+  itkConvolutionImageFilterTest.cxx
+  itkConvolutionImageFilterTestInt.cxx
+  itkFFTConvolutionImageFilterDeltaFunctionTest.cxx
   itkFFTConvolutionImageFilterTest.cxx
   itkFFTConvolutionImageFilterTestInt.cxx
-  itkFFTConvolutionImageFilterDeltaFunctionTest.cxx
-  itkNormalizedCorrelationImageFilterTest.cxx
-  itkMaskedFFTNormalizedCorrelationImageFilterTest.cxx
   itkFFTNormalizedCorrelationImageFilterTest.cxx
+  itkMaskedFFTNormalizedCorrelationImageFilterTest.cxx
+  itkNormalizedCorrelationImageFilterTest.cxx
 )
 
 createtestdriver(ITKConvolution "${ITKConvolution-Test_LIBRARIES}" "${ITKConvolutionTests}")

--- a/Modules/Filtering/Denoising/test/CMakeLists.txt
+++ b/Modules/Filtering/Denoising/test/CMakeLists.txt
@@ -1,8 +1,8 @@
 itk_module_test()
 set(
   ITKDenoisingTests
-  itkPatchBasedDenoisingImageFilterTest.cxx
   itkPatchBasedDenoisingImageFilterDefaultTest.cxx
+  itkPatchBasedDenoisingImageFilterTest.cxx
 )
 
 createtestdriver(ITKDenoising "${ITKDenoising-Test_LIBRARIES}" "${ITKDenoisingTests}")

--- a/Modules/Filtering/DiffusionTensorImage/test/CMakeLists.txt
+++ b/Modules/Filtering/DiffusionTensorImage/test/CMakeLists.txt
@@ -1,10 +1,10 @@
 itk_module_test()
 set(
   ITKDiffusionTensorImageTests
-  itkDiffusionTensor3DTest.cxx
   itkDiffusionTensor3DReconstructionImageFilterTest.cxx
-  itkTensorRelativeAnisotropyImageFilterTest.cxx
+  itkDiffusionTensor3DTest.cxx
   itkTensorFractionalAnisotropyImageFilterTest.cxx
+  itkTensorRelativeAnisotropyImageFilterTest.cxx
 )
 
 createtestdriver(ITKDiffusionTensorImage "${ITKDiffusionTensorImage-Test_LIBRARIES}" "${ITKDiffusionTensorImageTests}")

--- a/Modules/Filtering/DisplacementField/test/CMakeLists.txt
+++ b/Modules/Filtering/DisplacementField/test/CMakeLists.txt
@@ -1,25 +1,25 @@
 itk_module_test()
 set(
   ITKDisplacementFieldTests
+  itkBSplineExponentialDiffeomorphicTransformTest.cxx
+  itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest.cxx
   itkComposeDisplacementFieldsImageFilterTest.cxx
   itkDisplacementFieldJacobianDeterminantFilterTest.cxx
-  itkIterativeInverseDisplacementFieldImageFilterTest.cxx
-  itkLandmarkDisplacementFieldSourceTest.cxx
+  itkDisplacementFieldToBSplineImageFilterTest.cxx
+  itkDisplacementFieldTransformCloneTest.cxx
+  itkDisplacementFieldTransformTest.cxx
+  itkExponentialDisplacementFieldImageFilterTest.cxx
+  itkGaussianExponentialDiffeomorphicTransformTest.cxx
+  itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest.cxx
   itkInverseDisplacementFieldImageFilterTest.cxx
   itkInvertDisplacementFieldImageFilterTest.cxx
-  itkDisplacementFieldToBSplineImageFilterTest.cxx
-  itkDisplacementFieldTransformTest.cxx
-  itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest.cxx
-  itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest.cxx
-  itkGaussianExponentialDiffeomorphicTransformTest.cxx
-  itkBSplineExponentialDiffeomorphicTransformTest.cxx
-  itkTimeVaryingVelocityFieldTransformTest.cxx
-  itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
+  itkIterativeInverseDisplacementFieldImageFilterTest.cxx
+  itkLandmarkDisplacementFieldSourceTest.cxx
   itkTimeVaryingBSplineVelocityFieldTransformTest.cxx
+  itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
+  itkTimeVaryingVelocityFieldTransformTest.cxx
   itkTransformToDisplacementFieldFilterTest.cxx
   itkTransformToDisplacementFieldFilterTest1.cxx
-  itkDisplacementFieldTransformCloneTest.cxx
-  itkExponentialDisplacementFieldImageFilterTest.cxx
 )
 
 createtestdriver(ITKDisplacementField "${ITKDisplacementField-Test_LIBRARIES}" "${ITKDisplacementFieldTests}")

--- a/Modules/Filtering/DistanceMap/test/CMakeLists.txt
+++ b/Modules/Filtering/DistanceMap/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 itk_module_test()
 set(
   ITKDistanceMapTests
+  itkApproximateSignedDistanceMapImageFilterTest.cxx
   itkDanielssonDistanceMapImageFilterTest1.cxx
   itkDanielssonDistanceMapImageFilterTest2.cxx
   itkDirectedHausdorffDistanceImageFilterTest.cxx
@@ -8,7 +9,6 @@ set(
   itkSignedDanielssonDistanceMapImageFilterTest1.cxx
   itkSignedDanielssonDistanceMapImageFilterTest2.cxx
   itkSignedMaurerDistanceMapImageFilterTest.cxx
-  itkApproximateSignedDistanceMapImageFilterTest.cxx
 )
 
 createtestdriver(ITKDistanceMap "${ITKDistanceMap-Test_LIBRARIES}" "${ITKDistanceMapTests}")

--- a/Modules/Filtering/FFT/test/CMakeLists.txt
+++ b/Modules/Filtering/FFT/test/CMakeLists.txt
@@ -11,9 +11,9 @@ set(
   itkFullToHalfHermitianImageFilterTest.cxx
   itkHalfToFullHermitianImageFilterTest.cxx
   itkInverse1DFFTImageFilterTest.cxx
+  itkVnlComplexToComplexFFTImageFilterTest.cxx
   itkVnlFFTTest.cxx
   itkVnlRealFFTTest.cxx
-  itkVnlComplexToComplexFFTImageFilterTest.cxx
 )
 
 if(ITK_USE_FFTWF)

--- a/Modules/Filtering/FastMarching/src/CMakeLists.txt
+++ b/Modules/Filtering/FastMarching/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 set(
   ITKFastMarching_SRCS
   itkFastMarchingBase.cxx
-  itkFastMarchingReachedTargetNodesStoppingCriterion.cxx
   itkFastMarchingImageFilter.cxx
+  itkFastMarchingReachedTargetNodesStoppingCriterion.cxx
   itkFastMarchingUpwindGradientImageFilter.cxx
 )
 

--- a/Modules/Filtering/ImageCompare/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageCompare/test/CMakeLists.txt
@@ -2,13 +2,13 @@ itk_module_test()
 set(
   ITKImageCompareTests
   itkAbsoluteValueDifferenceImageFilterTest.cxx
-  itkSquaredDifferenceImageFilterTest.cxx
   itkCheckerBoardImageFilterTest.cxx
   itkConstrainedValueDifferenceImageFilterTest.cxx
+  itkImageFileReaderIOToRequestedRegionMismatchTest.cxx
   itkSimilarityIndexImageFilterTest.cxx
+  itkSquaredDifferenceImageFilterTest.cxx
   itkSTAPLEImageFilterTest.cxx
   itkTestingComparisonImageFilterTest.cxx
-  itkImageFileReaderIOToRequestedRegionMismatchTest.cxx
 )
 
 createtestdriver(ITKImageCompare "${ITKImageCompare-Test_LIBRARIES}" "${ITKImageCompareTests}")

--- a/Modules/Filtering/ImageCompose/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageCompose/test/CMakeLists.txt
@@ -2,17 +2,17 @@ itk_module_test()
 set(
   ITKImageComposeTests
   itkCompose2DCovariantVectorImageFilterTest.cxx
-  itkCompose3DVectorImageFilterTest.cxx
-  itkCompose3DCovariantVectorImageFilterTest.cxx
   itkCompose2DVectorImageFilterTest.cxx
-  itkComposeRGBImageFilterTest.cxx
+  itkCompose3DCovariantVectorImageFilterTest.cxx
+  itkCompose3DVectorImageFilterTest.cxx
   itkComposeBigVectorImageFilterTest.cxx
-  itkImageToVectorImageFilterTest.cxx
-  itkImageReadRealAndImaginaryWriteComplexTest.cxx
   itkComposeRGBAImageFilterTest.cxx
-  itkJoinSeriesImageFilterTest.cxx
-  itkJoinSeriesImageFilterStreamingTest.cxx
+  itkComposeRGBImageFilterTest.cxx
+  itkImageReadRealAndImaginaryWriteComplexTest.cxx
+  itkImageToVectorImageFilterTest.cxx
   itkJoinImageFilterTest.cxx
+  itkJoinSeriesImageFilterStreamingTest.cxx
+  itkJoinSeriesImageFilterTest.cxx
 )
 
 createtestdriver(ITKImageCompose "${ITKImageCompose-Test_LIBRARIES}" "${ITKImageComposeTests}")

--- a/Modules/Filtering/ImageFeature/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageFeature/test/CMakeLists.txt
@@ -1,32 +1,32 @@
 itk_module_test()
 set(
   ITKImageFeatureTests
-  itkZeroCrossingBasedEdgeDetectionImageFilterTest.cxx
-  itkLaplacianImageFilterTest.cxx
-  itkSobelEdgeDetectionImageFilterTest.cxx
-  itkHessian3DToVesselnessMeasureImageFilterTest.cxx
-  itkHessianToObjectnessMeasureImageFilterTest.cxx
-  itkHessianRecursiveGaussianFilterScaleSpaceTest.cxx
-  itkHessianRecursiveGaussianFilterTest.cxx
-  itkHoughTransform2DCirclesImageTest.cxx
-  itkHoughTransform2DLinesImageTest.cxx
-  itkCannyEdgeDetectionImageFilterTest.cxx
   itkBilateralImageFilterTest.cxx
   itkBilateralImageFilterTest2.cxx
   itkBilateralImageFilterTest3.cxx
-  itkGradientVectorFlowImageFilterTest.cxx
-  itkSimpleContourExtractorImageFilterTest.cxx
-  itkZeroCrossingImageFilterTest.cxx
+  itkCannyEdgeDetectionImageFilterTest.cxx
   itkCannyEdgeDetectionImageFilterTest2.cxx
   itkDerivativeImageFilterTest.cxx
+  itkDiscreteGaussianDerivativeImageFilterScaleSpaceTest.cxx
+  itkDiscreteGaussianDerivativeImageFilterTest.cxx
+  itkGradientVectorFlowImageFilterTest.cxx
+  itkHessian3DToVesselnessMeasureImageFilterTest.cxx
+  itkHessianRecursiveGaussianFilterScaleSpaceTest.cxx
+  itkHessianRecursiveGaussianFilterTest.cxx
+  itkHessianToObjectnessMeasureImageFilterTest.cxx
+  itkHoughTransform2DCirclesImageTest.cxx
+  itkHoughTransform2DLinesImageTest.cxx
+  itkLaplacianImageFilterTest.cxx
   itkLaplacianRecursiveGaussianImageFilterTest.cxx
   itkLaplacianSharpeningImageFilterTest.cxx
   itkMaskFeaturePointSelectionFilterTest.cxx
-  itkUnsharpMaskImageFilterTestSimple.cxx
-  itkUnsharpMaskImageFilterTest.cxx
-  itkDiscreteGaussianDerivativeImageFilterScaleSpaceTest.cxx
-  itkDiscreteGaussianDerivativeImageFilterTest.cxx
   itkMultiScaleHessianBasedMeasureImageFilterTest.cxx
+  itkSimpleContourExtractorImageFilterTest.cxx
+  itkSobelEdgeDetectionImageFilterTest.cxx
+  itkUnsharpMaskImageFilterTest.cxx
+  itkUnsharpMaskImageFilterTestSimple.cxx
+  itkZeroCrossingBasedEdgeDetectionImageFilterTest.cxx
+  itkZeroCrossingImageFilterTest.cxx
 )
 
 createtestdriver(ITKImageFeature "${ITKImageFeature-Test_LIBRARIES}" "${ITKImageFeatureTests}")

--- a/Modules/Filtering/ImageFilterBase/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageFilterBase/test/CMakeLists.txt
@@ -1,11 +1,11 @@
 itk_module_test()
 set(
   ITKImageFilterBaseTests
-  itkNeighborhoodOperatorImageFilterTest.cxx
-  itkImageToImageFilterTest.cxx
-  itkVectorNeighborhoodOperatorImageFilterTest.cxx
-  itkMaskNeighborhoodOperatorImageFilterTest.cxx
   itkCastImageFilterTest.cxx
+  itkImageToImageFilterTest.cxx
+  itkMaskNeighborhoodOperatorImageFilterTest.cxx
+  itkNeighborhoodOperatorImageFilterTest.cxx
+  itkVectorNeighborhoodOperatorImageFilterTest.cxx
 )
 
 # Disable optimization on the tests below to avoid possible

--- a/Modules/Filtering/ImageFusion/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageFusion/test/CMakeLists.txt
@@ -1,16 +1,16 @@
 itk_module_test()
 set(
   ITKImageFusionTests
-  itkLabelOverlayImageFilterTest.cxx
-  itkLabelToRGBImageFilterTest.cxx
-  itkLabelMapToRGBImageFilterTest1.cxx
-  itkLabelMapToRGBImageFilterTest2.cxx
   itkLabelMapContourOverlayImageFilterTest1.cxx
   itkLabelMapContourOverlayImageFilterTest2.cxx
   itkLabelMapContourOverlayImageFilterTest3.cxx
   itkLabelMapOverlayImageFilterTest1.cxx
   itkLabelMapOverlayImageFilterTest2.cxx
   itkLabelMapOverlayImageFilterTest3.cxx
+  itkLabelMapToRGBImageFilterTest1.cxx
+  itkLabelMapToRGBImageFilterTest2.cxx
+  itkLabelOverlayImageFilterTest.cxx
+  itkLabelToRGBImageFilterTest.cxx
 )
 
 createtestdriver(ITKImageFusion "${ITKImageFusion-Test_LIBRARIES}" "${ITKImageFusionTests}")

--- a/Modules/Filtering/ImageGradient/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageGradient/test/CMakeLists.txt
@@ -1,19 +1,19 @@
 itk_module_test()
 set(
   ITKImageGradientTests
+  itkDifferenceOfGaussiansGradientTest.cxx
   itkGradientImageFilterTest.cxx
   itkGradientImageFilterTest2.cxx
-  itkVectorGradientMagnitudeImageFilterTest1.cxx
-  itkVectorGradientMagnitudeImageFilterTest2.cxx
-  itkVectorGradientMagnitudeImageFilterTest3.cxx
   itkGradientMagnitudeImageFilterTest.cxx
   itkGradientMagnitudeRecursiveGaussianFilterTest.cxx
+  itkGradientRecursiveGaussianFilterSpeedTest.cxx
   itkGradientRecursiveGaussianFilterTest.cxx
   itkGradientRecursiveGaussianFilterTest2.cxx
   itkGradientRecursiveGaussianFilterTest3.cxx
   itkGradientRecursiveGaussianFilterTest4.cxx
-  itkDifferenceOfGaussiansGradientTest.cxx
-  itkGradientRecursiveGaussianFilterSpeedTest.cxx
+  itkVectorGradientMagnitudeImageFilterTest1.cxx
+  itkVectorGradientMagnitudeImageFilterTest2.cxx
+  itkVectorGradientMagnitudeImageFilterTest3.cxx
 )
 
 createtestdriver(ITKImageGradient "${ITKImageGradient-Test_LIBRARIES}" "${ITKImageGradientTests}")

--- a/Modules/Filtering/ImageGrid/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageGrid/test/CMakeLists.txt
@@ -4,40 +4,37 @@ set(
   itkBasicArchitectureTest.cxx
   itkBinShrinkImageFilterTest1.cxx
   itkBinShrinkImageFilterTest2.cxx
+  itkBSplineControlPointImageFilterTest.cxx
+  itkBSplineControlPointImageFunctionTest.cxx
+  itkBSplineDownsampleImageFilterTest.cxx
+  itkBSplineResampleImageFilterTest.cxx
   itkBSplineScatteredDataPointSetToImageFilterTest.cxx
   itkBSplineScatteredDataPointSetToImageFilterTest2.cxx
   itkBSplineScatteredDataPointSetToImageFilterTest3.cxx
   itkBSplineScatteredDataPointSetToImageFilterTest4.cxx
   itkBSplineScatteredDataPointSetToImageFilterTest5.cxx
-  itkBSplineControlPointImageFilterTest.cxx
-  itkBSplineControlPointImageFunctionTest.cxx
+  itkBSplineUpsampleImageFilterTest.cxx
   itkChangeInformationImageFilterTest.cxx
   itkConstantPadImageTest.cxx
   itkCoxDeBoorBSplineKernelFunctionTest.cxx
   itkCoxDeBoorBSplineKernelFunctionTest2.cxx
+  itkCropImageFilter3DTest.cxx
+  itkCropImageFilterTest.cxx
   itkCyclicReferences.cxx
   itkCyclicShiftImageFilterTest.cxx
-  itkInterpolateImagePointsFilterTest.cxx
-  itkCropImageFilterTest.cxx
-  itkCropImageFilter3DTest.cxx
-  itkFlipImageFilterTest.cxx
   itkExpandImageFilterTest.cxx
   itkExpandImageFilterTest2.cxx
-  itkRegionOfInterestImageFilterTest.cxx
-  itkBSplineUpsampleImageFilterTest.cxx
-  itkBSplineResampleImageFilterTest.cxx
-  itkBSplineDownsampleImageFilterTest.cxx
-  itkTileImageFilterTest.cxx
+  itkFlipImageFilterTest.cxx
   itkInterpolateImageFilterTest.cxx
+  itkInterpolateImagePointsFilterTest.cxx
+  itkMirrorPadImageFilterTest.cxx
+  itkMirrorPadImageTest.cxx
+  itkOrientImageFilterTest.cxx
+  itkPadImageFilterTest.cxx
   itkPasteImageFilterTest.cxx
   itkPermuteAxesImageFilterTest.cxx
-  itkOrientImageFilterTest.cxx
-  itkWarpImageFilterTest.cxx
-  itkWarpImageFilterTest2.cxx
-  itkWarpVectorImageFilterTest.cxx
-  itkWrapPadImageTest.cxx
-  itkMirrorPadImageTest.cxx
-  itkMirrorPadImageFilterTest.cxx
+  itkPushPopTileImageFilterTest.cxx
+  itkRegionOfInterestImageFilterTest.cxx
   itkResampleImageTest.cxx
   itkResampleImageTest2.cxx
   itkResampleImageTest2Streaming.cxx
@@ -48,12 +45,15 @@ set(
   itkResampleImageTest7.cxx
   itkResampleImageTest8.cxx
   itkResamplePhasedArray3DSpecialCoordinatesImageTest.cxx
-  itkPushPopTileImageFilterTest.cxx
   itkShrinkImageStreamingTest.cxx
   itkShrinkImageTest.cxx
-  itkZeroFluxNeumannPadImageFilterTest.cxx
   itkSliceBySliceImageFilterTest.cxx
-  itkPadImageFilterTest.cxx
+  itkTileImageFilterTest.cxx
+  itkWarpImageFilterTest.cxx
+  itkWarpImageFilterTest2.cxx
+  itkWarpVectorImageFilterTest.cxx
+  itkWrapPadImageTest.cxx
+  itkZeroFluxNeumannPadImageFilterTest.cxx
 )
 
 if(NOT ITK_FUTURE_LEGACY_REMOVE)
@@ -671,10 +671,10 @@ itk_add_test(
 set(
   ITKImageGridGTests
   itkChangeInformationImageFilterGTest.cxx
+  itkPasteImageFilterGTest.cxx
   itkResampleImageFilterGTest.cxx
   itkSliceImageFilterTest.cxx
   itkTileImageFilterGTest.cxx
-  itkPasteImageFilterGTest.cxx
 )
 
 creategoogletestdriver(ITKImageGrid "${ITKImageGrid-Test_LIBRARIES}" "${ITKImageGridGTests}")

--- a/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
@@ -1,88 +1,88 @@
 itk_module_test()
 set(
   ITKImageIntensityTests
-  itkBoundedReciprocalImageFilterTest.cxx
-  itkCosImageFilterAndAdaptorTest.cxx
-  itkDiscreteHessianGaussianImageFunctionTest.cxx
-  itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
-  itkDiscreteGaussianDerivativeImageFunctionTest.cxx
-  itkExpImageFilterAndAdaptorTest.cxx
-  itkVectorRescaleIntensityImageFilterTest.cxx
-  itkTernaryMagnitudeSquaredImageFilterTest.cxx
-  itkTernaryOperatorImageFilterTest.cxx
-  itkMinimumImageFilterTest.cxx
-  itkLog10ImageFilterAndAdaptorTest.cxx
-  itkVectorIndexSelectionCastImageFilterTest.cxx
-  itkInvertIntensityImageFilterTest.cxx
-  itkSymmetricEigenAnalysisImageFilterTest.cxx
-  itkEdgePotentialImageFilterTest.cxx
-  itkComplexToModulusFilterAndAdaptorTest.cxx
-  itkAddImageAdaptorTest.cxx
-  itkAndImageFilterTest.cxx
+  itkAbsImageFilterAndAdaptorTest.cxx
+  itkAcosImageFilterAndAdaptorTest.cxx
+  itkAdaptImageFilterTest.cxx
   itkAdaptImageFilterTest2.cxx
-  itkLogImageFilterAndAdaptorTest.cxx
-  itkNotImageFilterTest.cxx
-  itkImageAdaptorNthElementTest.cxx
-  itkConstrainedValueAdditionImageFilterTest.cxx
-  itkAtanImageFilterAndAdaptorTest.cxx
-  itkMaskNegatedImageFilterTest.cxx
+  itkAddImageAdaptorTest.cxx
+  itkAddImageFilterFrameTest.cxx
   itkAddImageFilterTest.cxx
   itkAddImageFilterTest2.cxx
-  itkAddImageFilterFrameTest.cxx
-  itkPowImageFilterTest.cxx
-  itkMultiplyImageFilterTest.cxx
-  itkWeightedAddImageFilterTest.cxx
-  itkRescaleIntensityImageFilterTest.cxx
-  itkNormalizeImageFilterTest.cxx
-  itkNaryAddImageFilterTest.cxx
-  itkShiftScaleImageFilterTest.cxx
-  itkComplexToPhaseFilterAndAdaptorTest.cxx
-  itkIntensityWindowingImageFilterTest.cxx
-  itkTernaryMagnitudeImageFilterTest.cxx
-  itkAbsImageFilterAndAdaptorTest.cxx
-  itkMaximumImageFilterTest.cxx
-  itkBinaryMagnitudeImageFilterTest.cxx
-  itkMatrixIndexSelectionImageFilterTest.cxx
-  itkSquareImageFilterTest.cxx
-  itkRGBToVectorAdaptImageFilterTest.cxx
-  itkComplexToRealFilterAndAdaptorTest.cxx
-  itkNaryMaximumImageFilterTest.cxx
-  itkAtan2ImageFilterTest.cxx
-  itkSqrtImageFilterAndAdaptorTest.cxx
+  itkAndImageFilterTest.cxx
   itkAsinImageFilterAndAdaptorTest.cxx
-  itkMaskImageFilterTest.cxx
-  itkHistogramMatchingImageFilterTest.cxx
-  itkAcosImageFilterAndAdaptorTest.cxx
-  itkExpNegativeImageFilterAndAdaptorTest.cxx
-  itkTanImageFilterAndAdaptorTest.cxx
-  itkSigmoidImageFilterTest.cxx
+  itkAtan2ImageFilterTest.cxx
+  itkAtanImageFilterAndAdaptorTest.cxx
+  itkBinaryMagnitudeImageFilterTest.cxx
+  itkBoundedReciprocalImageFilterTest.cxx
+  itkClampImageFilterTest.cxx
+  itkComplexToImaginaryFilterAndAdaptorTest.cxx
+  itkComplexToModulusFilterAndAdaptorTest.cxx
+  itkComplexToPhaseFilterAndAdaptorTest.cxx
+  itkComplexToRealFilterAndAdaptorTest.cxx
+  itkConstrainedValueAdditionImageFilterTest.cxx
+  itkCosImageFilterAndAdaptorTest.cxx
+  itkDiscreteGaussianDerivativeImageFunctionTest.cxx
+  itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
+  itkDiscreteHessianGaussianImageFunctionTest.cxx
   itkDivideImageFilterTest.cxx
   itkDivideImageFilterTest2.cxx
   itkDivideOrZeroOutImageFilterTest.cxx
-  itkAdaptImageFilterTest.cxx
-  itkOrImageFilterTest.cxx
-  itkRGBToLuminanceImageFilterAndAdaptorTest.cxx
-  itkXorImageFilterTest.cxx
-  itkSubtractImageFilterTest.cxx
-  itkComplexToImaginaryFilterAndAdaptorTest.cxx
-  itkVectorToRGBImageAdaptorTest.cxx
-  itkSinImageFilterAndAdaptorTest.cxx
-  itkPolylineMask2DImageFilterTest.cxx
-  itkPolylineMaskImageFilterTest.cxx
-  itkPromoteDimensionImageTest.cxx
-  itkModulusImageFilterTest.cxx
-  itkVectorMagnitudeImageFilterTest.cxx
-  itkNormalizeToConstantImageFilterTest.cxx
+  itkEdgePotentialImageFilterTest.cxx
   itkEqualTest.cxx
-  itkNotEqualTest.cxx
+  itkExpImageFilterAndAdaptorTest.cxx
+  itkExpNegativeImageFilterAndAdaptorTest.cxx
   itkGreaterEqualTest.cxx
   itkGreaterTest.cxx
+  itkHistogramMatchingImageFilterTest.cxx
+  itkImageAdaptorNthElementTest.cxx
+  itkIntensityWindowingImageFilterTest.cxx
+  itkInvertIntensityImageFilterTest.cxx
   itkLessEqualTest.cxx
   itkLessTest.cxx
-  itkClampImageFilterTest.cxx
-  itkNthElementPixelAccessorTest2.cxx
+  itkLog10ImageFilterAndAdaptorTest.cxx
+  itkLogImageFilterAndAdaptorTest.cxx
   itkMagnitudeAndPhaseToComplexImageFilterTest.cxx
+  itkMaskImageFilterTest.cxx
+  itkMaskNegatedImageFilterTest.cxx
+  itkMatrixIndexSelectionImageFilterTest.cxx
+  itkMaximumImageFilterTest.cxx
+  itkMinimumImageFilterTest.cxx
+  itkModulusImageFilterTest.cxx
+  itkMultiplyImageFilterTest.cxx
+  itkNaryAddImageFilterTest.cxx
+  itkNaryMaximumImageFilterTest.cxx
+  itkNormalizeImageFilterTest.cxx
+  itkNormalizeToConstantImageFilterTest.cxx
+  itkNotEqualTest.cxx
+  itkNotImageFilterTest.cxx
+  itkNthElementPixelAccessorTest2.cxx
+  itkOrImageFilterTest.cxx
+  itkPolylineMask2DImageFilterTest.cxx
+  itkPolylineMaskImageFilterTest.cxx
+  itkPowImageFilterTest.cxx
+  itkPromoteDimensionImageTest.cxx
+  itkRescaleIntensityImageFilterTest.cxx
+  itkRGBToLuminanceImageFilterAndAdaptorTest.cxx
+  itkRGBToVectorAdaptImageFilterTest.cxx
   itkRoundImageFilterTest.cxx
+  itkShiftScaleImageFilterTest.cxx
+  itkSigmoidImageFilterTest.cxx
+  itkSinImageFilterAndAdaptorTest.cxx
+  itkSqrtImageFilterAndAdaptorTest.cxx
+  itkSquareImageFilterTest.cxx
+  itkSubtractImageFilterTest.cxx
+  itkSymmetricEigenAnalysisImageFilterTest.cxx
+  itkTanImageFilterAndAdaptorTest.cxx
+  itkTernaryMagnitudeImageFilterTest.cxx
+  itkTernaryMagnitudeSquaredImageFilterTest.cxx
+  itkTernaryOperatorImageFilterTest.cxx
+  itkVectorIndexSelectionCastImageFilterTest.cxx
+  itkVectorMagnitudeImageFilterTest.cxx
+  itkVectorRescaleIntensityImageFilterTest.cxx
+  itkVectorToRGBImageAdaptorTest.cxx
+  itkWeightedAddImageFilterTest.cxx
+  itkXorImageFilterTest.cxx
 )
 
 if(NOT ITK_LEGACY_REMOVE)
@@ -821,8 +821,8 @@ itk_add_test(
 
 set(
   ITKImageIntensityGTests
-  itkBitwiseOpsFunctorsTest.cxx
   itkArithmeticOpsFunctorsTest.cxx
+  itkBitwiseOpsFunctorsTest.cxx
 )
 
 if(MSVC)

--- a/Modules/Filtering/ImageNoise/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageNoise/test/CMakeLists.txt
@@ -2,10 +2,10 @@ itk_module_test()
 set(
   ITKImageNoiseTests
   itkAdditiveGaussianNoiseImageFilterTest.cxx
+  itkPeakSignalToNoiseRatioCalculatorTest.cxx
+  itkSaltAndPepperNoiseImageFilterTest.cxx
   itkShotNoiseImageFilterTest.cxx
   itkSpeckleNoiseImageFilterTest.cxx
-  itkSaltAndPepperNoiseImageFilterTest.cxx
-  itkPeakSignalToNoiseRatioCalculatorTest.cxx
 )
 
 createtestdriver(ITKImageNoise "${ITKImageNoise-Test_LIBRARIES}" "${ITKImageNoiseTests}")

--- a/Modules/Filtering/ImageStatistics/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageStatistics/test/CMakeLists.txt
@@ -1,21 +1,10 @@
 itk_module_test()
 set(
   ITKImageStatisticsTests
-  itkStatisticsImageFilterTest.cxx
-  itkLabelStatisticsImageFilterTest.cxx
-  itkSumProjectionImageFilterTest.cxx
-  itkStandardDeviationProjectionImageFilterTest.cxx
-  itkImageMomentsTest.cxx
-  itkMinimumMaximumImageFilterTest.cxx
-  itkImagePCAShapeModelEstimatorTest.cxx
-  itkMinimumProjectionImageFilterTest.cxx
-  itkMeanProjectionImageFilterTest.cxx
-  itkImagePCADecompositionCalculatorTest.cxx
-  itkMaximumProjectionImageFilterTest.cxx
-  itkMaximumProjectionImageFilterTest2.cxx
-  itkMaximumProjectionImageFilterTest3.cxx
-  itkMaximumProjectionImageFilterTest4.cxx
-  itkMedianProjectionImageFilterTest.cxx
+  itkAccumulateImageFilterTest.cxx
+  itkAdaptiveHistogramEqualizationImageFilterTest.cxx
+  itkBinaryProjectionImageFilterTest.cxx
+  itkGetAverageSliceImageFilterTest.cxx
   itkHistogramToEntropyImageFilterTest1.cxx
   itkHistogramToEntropyImageFilterTest2.cxx
   itkHistogramToIntensityImageFilterTest1.cxx
@@ -24,12 +13,23 @@ set(
   itkHistogramToLogProbabilityImageFilterTest2.cxx
   itkHistogramToProbabilityImageFilterTest1.cxx
   itkHistogramToProbabilityImageFilterTest2.cxx
-  itkAccumulateImageFilterTest.cxx
-  itkAdaptiveHistogramEqualizationImageFilterTest.cxx
-  itkGetAverageSliceImageFilterTest.cxx
-  itkBinaryProjectionImageFilterTest.cxx
-  itkProjectionImageFilterTest.cxx
+  itkImageMomentsTest.cxx
+  itkImagePCADecompositionCalculatorTest.cxx
+  itkImagePCAShapeModelEstimatorTest.cxx
   itkLabelOverlapMeasuresImageFilterTest.cxx
+  itkLabelStatisticsImageFilterTest.cxx
+  itkMaximumProjectionImageFilterTest.cxx
+  itkMaximumProjectionImageFilterTest2.cxx
+  itkMaximumProjectionImageFilterTest3.cxx
+  itkMaximumProjectionImageFilterTest4.cxx
+  itkMeanProjectionImageFilterTest.cxx
+  itkMedianProjectionImageFilterTest.cxx
+  itkMinimumMaximumImageFilterTest.cxx
+  itkMinimumProjectionImageFilterTest.cxx
+  itkProjectionImageFilterTest.cxx
+  itkStandardDeviationProjectionImageFilterTest.cxx
+  itkStatisticsImageFilterTest.cxx
+  itkSumProjectionImageFilterTest.cxx
 )
 
 createtestdriver(ITKImageStatistics "${ITKImageStatistics-Test_LIBRARIES}" "${ITKImageStatisticsTests}")

--- a/Modules/Filtering/MathematicalMorphology/test/CMakeLists.txt
+++ b/Modules/Filtering/MathematicalMorphology/test/CMakeLists.txt
@@ -4,50 +4,50 @@ set(
   itkAnchorErodeDilateImageFilterTest.cxx
   itkAnchorOpenCloseImageFilterTest.cxx
   itkClosingByReconstructionImageFilterTest.cxx
+  itkDoubleThresholdImageFilterTest.cxx
   itkFlatStructuringElementTest.cxx
   itkFlatStructuringElementTest2.cxx
   itkFlatStructuringElementTest3.cxx
   itkGrayscaleConnectedClosingImageFilterTest.cxx
   itkGrayscaleConnectedOpeningImageFilterTest.cxx
+  itkGrayscaleDilateImageFilterTest.cxx
+  itkGrayscaleErodeImageFilterTest.cxx
   itkGrayscaleFillholeImageFilterTest.cxx
   itkGrayscaleFunctionDilateImageFilterTest.cxx
   itkGrayscaleFunctionErodeImageFilterTest.cxx
-  itkGrayscaleMorphologicalClosingImageFilterTest.cxx
-  itkGrayscaleMorphologicalOpeningImageFilterTest.cxx
   itkGrayscaleGeodesicErodeDilateImageFilterTest.cxx
   itkGrayscaleGrindPeakImageFilterTest.cxx
+  itkGrayscaleMorphologicalClosingImageFilterTest.cxx
+  itkGrayscaleMorphologicalClosingImageFilterTest2.cxx
+  itkGrayscaleMorphologicalOpeningImageFilterTest.cxx
+  itkGrayscaleMorphologicalOpeningImageFilterTest2.cxx
   itkHConcaveImageFilterTest.cxx
-  itkHConvexImageFilterTest.cxx
   itkHConvexConcaveImageFilterTest.cxx
+  itkHConvexImageFilterTest.cxx
   itkHMaximaImageFilterTest.cxx
-  itkHMinimaImageFilterTest.cxx
   itkHMaximaMinimaImageFilterTest.cxx
-  itkMorphologicalGradientImageFilterTest.cxx
-  itkMovingHistogramMorphologyImageFilterTest.cxx
-  itkOpeningByReconstructionImageFilterTest.cxx
-  itkOpeningByReconstructionImageFilterTest2.cxx
-  itkDoubleThresholdImageFilterTest.cxx
-  itkRemoveBoundaryObjectsTest.cxx
-  itkRemoveBoundaryObjectsTest2.cxx
-  itkShapedIteratorFromStructuringElementTest.cxx
-  itkTopHatImageFilterTest.cxx
+  itkHMinimaImageFilterTest.cxx
   itkMapGrayscaleDilateImageFilterTest.cxx
   itkMapGrayscaleErodeImageFilterTest.cxx
   itkMapGrayscaleMorphologicalClosingImageFilterTest.cxx
   itkMapGrayscaleMorphologicalOpeningImageFilterTest.cxx
-  itkGrayscaleDilateImageFilterTest.cxx
-  itkGrayscaleErodeImageFilterTest.cxx
-  itkGrayscaleMorphologicalClosingImageFilterTest2.cxx
-  itkGrayscaleMorphologicalOpeningImageFilterTest2.cxx
-  itkMorphologicalGradientImageFilterTest2.cxx
-  itkRegionalMaximaImageFilterTest.cxx
-  itkRegionalMinimaImageFilterTest.cxx
-  itkValuedRegionalMaximaImageFilterTest.cxx
-  itkValuedRegionalMinimaImageFilterTest.cxx
-  itkMaskedRankImageFilterTest.cxx
-  itkRankImageFilterTest.cxx
   itkMapMaskedRankImageFilterTest.cxx
   itkMapRankImageFilterTest.cxx
+  itkMaskedRankImageFilterTest.cxx
+  itkMorphologicalGradientImageFilterTest.cxx
+  itkMorphologicalGradientImageFilterTest2.cxx
+  itkMovingHistogramMorphologyImageFilterTest.cxx
+  itkOpeningByReconstructionImageFilterTest.cxx
+  itkOpeningByReconstructionImageFilterTest2.cxx
+  itkRankImageFilterTest.cxx
+  itkRegionalMaximaImageFilterTest.cxx
+  itkRegionalMinimaImageFilterTest.cxx
+  itkRemoveBoundaryObjectsTest.cxx
+  itkRemoveBoundaryObjectsTest2.cxx
+  itkShapedIteratorFromStructuringElementTest.cxx
+  itkTopHatImageFilterTest.cxx
+  itkValuedRegionalMaximaImageFilterTest.cxx
+  itkValuedRegionalMinimaImageFilterTest.cxx
   itkVanHerkGilWermanErodeDilateImageFilterTest.cxx
 )
 

--- a/Modules/Filtering/Path/test/CMakeLists.txt
+++ b/Modules/Filtering/Path/test/CMakeLists.txt
@@ -1,20 +1,20 @@
 itk_module_test()
 set(
   ITKPathTests
-  itkPathIteratorTest.cxx
-  itkChainCodePathTest.cxx
   itkChainCodePath2DTest.cxx
+  itkChainCodePathTest.cxx
+  itkChainCodeToFourierSeriesPathFilterTest.cxx
+  itkContourExtractor2DImageFilterTest.cxx
+  itkExtractOrthogonalSwath2DImageFilterTest.cxx
+  itkFourierSeriesPathTest.cxx
   itkHilbertPathTest.cxx
   itkOrthogonallyCorrected2DParametricPathTest.cxx
-  itkPathToImageFilterTest.cxx
-  itkPathToChainCodePathFilterTest.cxx
-  itkFourierSeriesPathTest.cxx
-  itkPathFunctionsTest.cxx
-  itkPolyLineParametricPathTest.cxx
-  itkChainCodeToFourierSeriesPathFilterTest.cxx
-  itkExtractOrthogonalSwath2DImageFilterTest.cxx
   itkOrthogonalSwath2DPathFilterTest.cxx
-  itkContourExtractor2DImageFilterTest.cxx
+  itkPathFunctionsTest.cxx
+  itkPathIteratorTest.cxx
+  itkPathToChainCodePathFilterTest.cxx
+  itkPathToImageFilterTest.cxx
+  itkPolyLineParametricPathTest.cxx
 )
 
 createtestdriver(ITKPath "${ITKPath-Test_LIBRARIES}" "${ITKPathTests}")

--- a/Modules/Filtering/QuadEdgeMeshFiltering/src/CMakeLists.txt
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 set(
   ITKQuadEdgeMeshFiltering_SRCS
-  itkNormalQuadEdgeMeshFilter.cxx
   itkBorderQuadEdgeMeshFilter.cxx
   itkLaplacianDeformationQuadEdgeMeshFilter.cxx
+  itkNormalQuadEdgeMeshFilter.cxx
 )
 
 itk_module_add_library(ITKQuadEdgeMeshFiltering ${ITKQuadEdgeMeshFiltering_SRCS})

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/CMakeLists.txt
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/CMakeLists.txt
@@ -2,23 +2,23 @@ itk_module_test()
 set(
   ITKQuadEdgeMeshFilteringTests
   itkAutomaticTopologyQuadEdgeMeshSourceTest.cxx
+  itkBinaryMask3DQuadEdgeMeshSourceTest.cxx
   itkBorderQuadEdgeMeshFilterTest.cxx
   itkBorderQuadEdgeMeshFilterTest2.cxx
-  itkBinaryMask3DQuadEdgeMeshSourceTest.cxx
   itkCleanQuadEdgeMeshFilterTest.cxx
   itkDelaunayConformingQuadEdgeMeshFilterTest.cxx
   itkDiscreteGaussianCurvatureQuadEdgeMeshFilterTest.cxx
   itkDiscreteMaximumCurvatureQuadEdgeMeshFilterTest.cxx
   itkDiscreteMeanCurvatureQuadEdgeMeshFilterTest.cxx
   itkDiscreteMinimumCurvatureQuadEdgeMeshFilterTest.cxx
+  itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest.cxx
+  itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest.cxx
   itkNormalQuadEdgeMeshFilterTest.cxx
   itkParameterizationQuadEdgeMeshFilterTest.cxx
   itkQuadricDecimationQuadEdgeMeshFilterTest.cxx
   itkRegularSphereQuadEdgeMeshSourceTest.cxx
   itkSmoothingQuadEdgeMeshFilterTest.cxx
   itkSquaredEdgeLengthDecimationQuadEdgeMeshFilterTest.cxx
-  itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest.cxx
-  itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest.cxx
 )
 
 createtestdriver(ITKQuadEdgeMeshFiltering "${ITKQuadEdgeMeshFiltering-Test_LIBRARIES}"

--- a/Modules/Filtering/Smoothing/test/CMakeLists.txt
+++ b/Modules/Filtering/Smoothing/test/CMakeLists.txt
@@ -3,20 +3,20 @@ set(
   ITKSmoothingTests
   itkBoxMeanImageFilterTest.cxx
   itkBoxSigmaImageFilterTest.cxx
-  itkDiscreteGaussianImageFilterTest2.cxx
-  itkFFTDiscreteGaussianImageFilterTest.cxx
-  itkFFTDiscreteGaussianImageFilterFactoryTest.cxx
-  itkSmoothingRecursiveGaussianImageFilterTest.cxx
-  itkSmoothingRecursiveGaussianImageFilterOnVectorImageTest.cxx
-  itkSmoothingRecursiveGaussianImageFilterOnImageOfVectorTest.cxx
-  itkSmoothingRecursiveGaussianImageFilterOnImageAdaptorTest.cxx
-  itkMeanImageFilterTest.cxx
   itkDiscreteGaussianImageFilterTest.cxx
+  itkDiscreteGaussianImageFilterTest2.cxx
+  itkFFTDiscreteGaussianImageFilterFactoryTest.cxx
+  itkFFTDiscreteGaussianImageFilterTest.cxx
+  itkMeanImageFilterTest.cxx
   itkMedianImageFilterTest.cxx
   itkRecursiveGaussianImageFilterOnTensorsTest.cxx
   itkRecursiveGaussianImageFilterOnVectorImageTest.cxx
   itkRecursiveGaussianImageFilterTest.cxx
   itkRecursiveGaussianScaleSpaceTest1.cxx
+  itkSmoothingRecursiveGaussianImageFilterOnImageAdaptorTest.cxx
+  itkSmoothingRecursiveGaussianImageFilterOnImageOfVectorTest.cxx
+  itkSmoothingRecursiveGaussianImageFilterOnVectorImageTest.cxx
+  itkSmoothingRecursiveGaussianImageFilterTest.cxx
 )
 
 createtestdriver(ITKSmoothing "${ITKSmoothing-Test_LIBRARIES}" "${ITKSmoothingTests}")

--- a/Modules/IO/BMP/test/CMakeLists.txt
+++ b/Modules/IO/BMP/test/CMakeLists.txt
@@ -1,8 +1,8 @@
 itk_module_test()
 set(
   ITKIOBMPTests
-  itkBMPImageIOTest2.cxx
   itkBMPImageIOTest.cxx
+  itkBMPImageIOTest2.cxx
   itkBMPImageIOTest3.cxx
   itkBMPImageIOTest4.cxx
   itkBMPImageIOTest5.cxx

--- a/Modules/IO/BioRad/src/CMakeLists.txt
+++ b/Modules/IO/BioRad/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(
   ITKIOBioRad_SRCS
-  itkBioRadImageIOFactory.cxx
   itkBioRadImageIO.cxx
+  itkBioRadImageIOFactory.cxx
 )
 
 itk_module_add_library(ITKIOBioRad ${ITKIOBioRad_SRCS})

--- a/Modules/IO/Bruker/src/CMakeLists.txt
+++ b/Modules/IO/Bruker/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(
   ITKIOBruker2dseq_SRCS
-  itkBruker2dseqImageIOFactory.cxx
   itkBruker2dseqImageIO.cxx
+  itkBruker2dseqImageIOFactory.cxx
 )
 
 itk_module_add_library(ITKIOBruker ${ITKIOBruker2dseq_SRCS})

--- a/Modules/IO/DCMTK/src/CMakeLists.txt
+++ b/Modules/IO/DCMTK/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(
   ITKIODCMTK_SRC
-  itkDCMTKImageIO.cxx
   itkDCMTKFileReader.cxx
+  itkDCMTKImageIO.cxx
   itkDCMTKImageIOFactory.cxx
   itkDCMTKSeriesFileNames.cxx
 )

--- a/Modules/IO/DCMTK/test/CMakeLists.txt
+++ b/Modules/IO/DCMTK/test/CMakeLists.txt
@@ -1,17 +1,17 @@
 itk_module_test()
 set(
   ITKIODCMTKTests
+  itkDCMTKImageIOMultiFrameImageTest.cxx
+  itkDCMTKImageIONoPreambleTest.cxx
+  itkDCMTKImageIOOrthoDirTest.cxx
+  itkDCMTKImageIOSlopeInterceptTest.cxx
+  itkDCMTKImageIOSpacingTest.cxx
   itkDCMTKImageIOTest.cxx
+  itkDCMTKLoggerTest.cxx
+  itkDCMTKMultiFrame4DTest.cxx
   itkDCMTKRGBImageIOTest.cxx
   itkDCMTKSeriesReadImageWrite.cxx
   itkDCMTKSeriesStreamReadImageWrite.cxx
-  itkDCMTKImageIOOrthoDirTest.cxx
-  itkDCMTKMultiFrame4DTest.cxx
-  itkDCMTKLoggerTest.cxx
-  itkDCMTKImageIOSlopeInterceptTest.cxx
-  itkDCMTKImageIOMultiFrameImageTest.cxx
-  itkDCMTKImageIONoPreambleTest.cxx
-  itkDCMTKImageIOSpacingTest.cxx
 )
 
 createtestdriver(ITKIODCMTK "${ITKIODCMTK-Test_LIBRARIES}" "${ITKIODCMTKTests}")

--- a/Modules/IO/GDCM/test/CMakeLists.txt
+++ b/Modules/IO/GDCM/test/CMakeLists.txt
@@ -1,19 +1,19 @@
 itk_module_test()
 set(
   ITKIOGDCMTests
+  itkGDCMImageIO32bitsStoredTest.cxx
+  itkGDCMImageIONoCrashTest.cxx
+  itkGDCMImageIONoPreambleTest.cxx
+  itkGDCMImageIOOrthoDirTest.cxx
   itkGDCMImageIOTest.cxx
   itkGDCMImageIOTest2.cxx
-  itkGDCMImageIONoCrashTest.cxx
+  itkGDCMImageOrientationPatientTest.cxx
+  itkGDCMImagePositionPatientTest.cxx
   itkGDCMImageReadSeriesWriteTest.cxx
   itkGDCMImageReadWriteTest.cxx
-  itkGDCMSeriesStreamReadImageWriteTest.cxx
-  itkGDCMImagePositionPatientTest.cxx
-  itkGDCMImageIOOrthoDirTest.cxx
-  itkGDCMImageOrientationPatientTest.cxx
-  itkGDCMLoadImageSpacingTest.cxx
   itkGDCMLegacyMultiFrameTest.cxx
-  itkGDCMImageIONoPreambleTest.cxx
-  itkGDCMImageIO32bitsStoredTest.cxx
+  itkGDCMLoadImageSpacingTest.cxx
+  itkGDCMSeriesStreamReadImageWriteTest.cxx
 )
 
 createtestdriver(ITKIOGDCM "${ITKIOGDCM-Test_LIBRARIES}" "${ITKIOGDCMTests}")

--- a/Modules/IO/GE/src/CMakeLists.txt
+++ b/Modules/IO/GE/src/CMakeLists.txt
@@ -1,11 +1,11 @@
 set(
   ITKIOGE_SRCS
+  itkGE4ImageIO.cxx
+  itkGE4ImageIOFactory.cxx
+  itkGE5ImageIO.cxx
   itkGE5ImageIOFactory.cxx
   itkGEAdwImageIO.cxx
-  itkGE4ImageIO.cxx
   itkGEAdwImageIOFactory.cxx
-  itkGE5ImageIO.cxx
-  itkGE4ImageIOFactory.cxx
 )
 
 itk_module_add_library(ITKIOGE ${ITKIOGE_SRCS})

--- a/Modules/IO/GIPL/src/CMakeLists.txt
+++ b/Modules/IO/GIPL/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(
   ITKIOGIPL_SRCS
-  itkGiplImageIOFactory.cxx
   itkGiplImageIO.cxx
+  itkGiplImageIOFactory.cxx
 )
 
 itk_module_add_library(ITKIOGIPL ${ITKIOGIPL_SRCS})

--- a/Modules/IO/HDF5/src/CMakeLists.txt
+++ b/Modules/IO/HDF5/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(
   ITKIOHDF5_SRCS
-  itkHDF5ImageIOFactory.cxx
   itkHDF5ImageIO.cxx
+  itkHDF5ImageIOFactory.cxx
 )
 
 itk_module_add_library(ITKIOHDF5 ${ITKIOHDF5_SRCS})

--- a/Modules/IO/HDF5/test/CMakeLists.txt
+++ b/Modules/IO/HDF5/test/CMakeLists.txt
@@ -1,8 +1,8 @@
 itk_module_test()
 set(
   ITKIOHDF5Tests
-  itkHDF5ImageIOTest.cxx
   itkHDF5ImageIOStreamingReadWriteTest.cxx
+  itkHDF5ImageIOTest.cxx
 )
 
 createtestdriver(ITKIOHDF5 "${ITKIOHDF5-Test_LIBRARIES}" "${ITKIOHDF5Tests}")

--- a/Modules/IO/ImageBase/test/CMakeLists.txt
+++ b/Modules/IO/ImageBase/test/CMakeLists.txt
@@ -1,27 +1,23 @@
 itk_module_test()
 set(
   ITKIOImageBaseTests
+  itk64bitTest.cxx
+  itkArchetypeSeriesFileNamesTest.cxx
   itkConvertBufferTest.cxx
   itkConvertBufferTest2.cxx
-  itkImageFileReaderTest1.cxx
-  itkImageFileWriterTest.cxx
-  itkIOCommonTest.cxx
-  itkIOCommonTest2.cxx
-  itkNumericSeriesFileNamesTest.cxx
-  itkRegularExpressionSeriesFileNamesTest.cxx
-  itkArchetypeSeriesFileNamesTest.cxx
-  itkLargeImageWriteConvertReadTest.cxx
-  itkLargeImageWriteReadTest.cxx
   itkImageFileReaderDimensionsTest.cxx
+  itkImageFileReaderManyComponentVectorTest.cxx
   itkImageFileReaderPositiveSpacingTest.cxx
   itkImageFileReaderStreamingTest.cxx
   itkImageFileReaderStreamingTest2.cxx
+  itkImageFileReaderTest1.cxx
   itkImageFileWriterPastingTest1.cxx
   itkImageFileWriterPastingTest2.cxx
   itkImageFileWriterPastingTest3.cxx
   itkImageFileWriterStreamingPastingCompressingTest1.cxx
   itkImageFileWriterStreamingTest1.cxx
   itkImageFileWriterStreamingTest2.cxx
+  itkImageFileWriterTest.cxx
   itkImageFileWriterTest2.cxx
   itkImageFileWriterUpdateLargestPossibleRegionTest.cxx
   itkImageIOBaseTest.cxx
@@ -32,13 +28,17 @@ set(
   itkImageSeriesReaderSamplingTest.cxx
   itkImageSeriesReaderVectorTest.cxx
   itkImageSeriesWriterTest.cxx
+  itkIOCommonTest.cxx
+  itkIOCommonTest2.cxx
   itkIOPluginTest.cxx
-  itkNoiseImageFilterTest.cxx
+  itkLargeImageWriteConvertReadTest.cxx
+  itkLargeImageWriteReadTest.cxx
   itkMatrixImageWriteReadTest.cxx
+  itkNoiseImageFilterTest.cxx
+  itkNumericSeriesFileNamesTest.cxx
   itkReadWriteImageWithDictionaryTest.cxx
+  itkRegularExpressionSeriesFileNamesTest.cxx
   itkVectorImageReadWriteTest.cxx
-  itk64bitTest.cxx
-  itkImageFileReaderManyComponentVectorTest.cxx
 )
 
 createtestdriver(ITKIOImageBase "${ITKIOImageBase-Test_LIBRARIES}" "${ITKIOImageBaseTests}")

--- a/Modules/IO/JPEG/src/CMakeLists.txt
+++ b/Modules/IO/JPEG/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(
   ITKIOJPEG_SRCS
-  itkJPEGImageIOFactory.cxx
   itkJPEGImageIO.cxx
+  itkJPEGImageIOFactory.cxx
 )
 
 itk_module_add_library(ITKIOJPEG ${ITKIOJPEG_SRCS})

--- a/Modules/IO/JPEG/test/CMakeLists.txt
+++ b/Modules/IO/JPEG/test/CMakeLists.txt
@@ -1,11 +1,11 @@
 itk_module_test()
 set(
   ITKIOJPEGTests
-  itkJPEGImageIOTest.cxx
-  itkJPEGImageIOTest2.cxx
-  itkJPEGImageIODegenerateCasesTest.cxx
   itkJPEGImageIOBrokenCasesTest.cxx
   itkJPEGImageIOCMYKTest.cxx
+  itkJPEGImageIODegenerateCasesTest.cxx
+  itkJPEGImageIOTest.cxx
+  itkJPEGImageIOTest2.cxx
 )
 
 createtestdriver(ITKIOJPEG "${ITKIOJPEG-Test_LIBRARIES}" "${ITKIOJPEGTests}")

--- a/Modules/IO/JPEG2000/src/CMakeLists.txt
+++ b/Modules/IO/JPEG2000/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(
   ITKIOJPEG2000_SRCS
-  itkJPEG2000ImageIOFactory.cxx
   itkJPEG2000ImageIO.cxx
+  itkJPEG2000ImageIOFactory.cxx
 )
 
 itk_module_add_library(ITKIOJPEG2000 ${ITKIOJPEG2000_SRCS})

--- a/Modules/IO/LSM/src/CMakeLists.txt
+++ b/Modules/IO/LSM/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(
   ITKIOLSM_SRCS
-  itkLSMImageIOFactory.cxx
   itkLSMImageIO.cxx
+  itkLSMImageIOFactory.cxx
 )
 
 itk_module_add_library(ITKIOLSM ${ITKIOLSM_SRCS})

--- a/Modules/IO/MeshVTK/test/CMakeLists.txt
+++ b/Modules/IO/MeshVTK/test/CMakeLists.txt
@@ -3,8 +3,8 @@ itk_module_test()
 set(
   ITKIOMeshVTKTests
   itkMeshFileReadWriteTest.cxx
-  itkMeshFileWriteReadTensorTest.cxx
   itkMeshFileReadWriteVectorAttributeTest.cxx
+  itkMeshFileWriteReadTensorTest.cxx
   itkPolylineReadWriteTest.cxx
   itkVTKPolyDataMeshCanReadImageTest.cxx
   itkVTKPolyDataMeshIOTest.cxx

--- a/Modules/IO/Meta/src/CMakeLists.txt
+++ b/Modules/IO/Meta/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 set(
   ITKIOMeta_SRCS
+  itkMetaArrayReader.cxx
   itkMetaArrayWriter.cxx
   itkMetaImageIO.cxx
-  itkMetaArrayReader.cxx
   itkMetaImageIOFactory.cxx
 )
 

--- a/Modules/IO/Meta/test/CMakeLists.txt
+++ b/Modules/IO/Meta/test/CMakeLists.txt
@@ -1,19 +1,19 @@
 itk_module_test()
 set(
   ITKIOMetaTests
-  itkMetaImageIOMetaDataTest.cxx
+  itkLargeMetaImageWriteReadTest.cxx
   itkMetaImageIOGzTest.cxx
+  itkMetaImageIOMetaDataTest.cxx
   itkMetaImageIOTest.cxx
   itkMetaImageIOTest2.cxx
-  itkLargeMetaImageWriteReadTest.cxx
+  itkMetaImageStreamingIOTest.cxx
+  itkMetaImageStreamingWriterIOTest.cxx
+  itkMetaTestLongFilename.cxx
   testMetaArray.cxx
   testMetaCommand.cxx
   testMetaGroup.cxx
   testMetaImage.cxx
   testMetaMesh.cxx
-  itkMetaImageStreamingIOTest.cxx
-  itkMetaImageStreamingWriterIOTest.cxx
-  itkMetaTestLongFilename.cxx
 )
 
 createtestdriver(ITKIOMeta "${ITKIOMeta-Test_LIBRARIES}" "${ITKIOMetaTests}")

--- a/Modules/IO/NIFTI/src/CMakeLists.txt
+++ b/Modules/IO/NIFTI/src/CMakeLists.txt
@@ -7,8 +7,8 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
 set(
   ITKIONIFTI_SRCS
-  itkNiftiImageIOFactory.cxx
   itkNiftiImageIO.cxx
+  itkNiftiImageIOFactory.cxx
 )
 
 itk_module_add_library(ITKIONIFTI ${ITKIONIFTI_SRCS})

--- a/Modules/IO/NIFTI/test/CMakeLists.txt
+++ b/Modules/IO/NIFTI/test/CMakeLists.txt
@@ -1,7 +1,13 @@
 itk_module_test()
 set(
   ITKIONIFTITests
+  itkExtractSlice.cxx
   itkNiftiImageIOTest.cxx
+  itkNiftiImageIOTest10.cxx
+  itkNiftiImageIOTest11.cxx
+  itkNiftiImageIOTest12.cxx
+  itkNiftiImageIOTest13.cxx
+  itkNiftiImageIOTest14.cxx
   itkNiftiImageIOTest2.cxx
   itkNiftiImageIOTest3.cxx
   itkNiftiImageIOTest4.cxx
@@ -10,15 +16,9 @@ set(
   itkNiftiImageIOTest7.cxx
   itkNiftiImageIOTest8.cxx
   itkNiftiImageIOTest9.cxx
-  itkNiftiImageIOTest10.cxx
-  itkNiftiImageIOTest11.cxx
-  itkNiftiImageIOTest12.cxx
-  itkNiftiImageIOTest13.cxx
-  itkNiftiImageIOTest14.cxx
   itkNiftiLargeImageRegionReadTest.cxx
   itkNiftiReadAnalyzeTest.cxx
   itkNiftiReadWriteDirectionTest.cxx
-  itkExtractSlice.cxx
   itkNiftiWriteCoerceOrthogonalDirectionTest.cxx
 )
 

--- a/Modules/IO/NRRD/src/CMakeLists.txt
+++ b/Modules/IO/NRRD/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(
   ITKIONRRD_SRCS
-  itkNrrdImageIOFactory.cxx
   itkNrrdImageIO.cxx
+  itkNrrdImageIOFactory.cxx
 )
 
 itk_module_add_library(ITKIONRRD ${ITKIONRRD_SRCS})

--- a/Modules/IO/NRRD/test/CMakeLists.txt
+++ b/Modules/IO/NRRD/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 itk_module_test()
 set(
   ITKIONRRDTests
-  itkNrrdImageIOTest.cxx
+  itkNrrd5dVectorImageReadWriteTest.cxx
   itkNrrdComplexImageReadTest.cxx
   itkNrrdComplexImageReadWriteTest.cxx
   itkNrrdCovariantVectorImageReadTest.cxx
@@ -9,15 +9,15 @@ set(
   itkNrrdDiffusionTensor3DImageReadTensorDoubleWriteTensorDoubleTest.cxx
   itkNrrdDiffusionTensor3DImageReadTest.cxx
   itkNrrdDiffusionTensor3DImageReadWriteTest.cxx
+  itkNrrdImageIOTest.cxx
   itkNrrdImageReadWriteTest.cxx
+  itkNrrdLocaleTest.cxx
+  itkNrrdMetaDataTest.cxx
   itkNrrdRGBAImageReadWriteTest.cxx
   itkNrrdRGBImageReadWriteTest.cxx
   itkNrrdVectorImageReadTest.cxx
   itkNrrdVectorImageReadWriteTest.cxx
   itkNrrdVectorImageUnitLabelReadTest.cxx
-  itkNrrd5dVectorImageReadWriteTest.cxx
-  itkNrrdMetaDataTest.cxx
-  itkNrrdLocaleTest.cxx
 )
 
 # For itkNrrdImageIOTest.h.

--- a/Modules/IO/PNG/src/CMakeLists.txt
+++ b/Modules/IO/PNG/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(
   ITKIOPNG_SRCS
-  itkPNGImageIOFactory.cxx
   itkPNGImageIO.cxx
+  itkPNGImageIOFactory.cxx
 )
 
 itk_module_add_library(ITKIOPNG ${ITKIOPNG_SRCS})

--- a/Modules/IO/PhilipsREC/test/CMakeLists.txt
+++ b/Modules/IO/PhilipsREC/test/CMakeLists.txt
@@ -1,9 +1,9 @@
 itk_module_test()
 set(
   ITKIOPhilipsRECTests
-  itkPhilipsRECImageIOTest.cxx
   itkPhilipsRECImageIOOrientationTest.cxx
   itkPhilipsRECImageIOPrintTest.cxx
+  itkPhilipsRECImageIOTest.cxx
 )
 
 createtestdriver(ITKIOPhilipsREC "${ITKIOPhilipsREC-Test_LIBRARIES}" "${ITKIOPhilipsRECTests}")

--- a/Modules/IO/Siemens/src/CMakeLists.txt
+++ b/Modules/IO/Siemens/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(
   ITKIOSiemens_SRCS
-  itkSiemensVisionImageIOFactory.cxx
   itkSiemensVisionImageIO.cxx
+  itkSiemensVisionImageIOFactory.cxx
 )
 
 itk_module_add_library(ITKIOSiemens ${ITKIOSiemens_SRCS})

--- a/Modules/IO/SpatialObjects/test/CMakeLists.txt
+++ b/Modules/IO/SpatialObjects/test/CMakeLists.txt
@@ -3,8 +3,8 @@ itk_module_test()
 set(
   ITKIOSpatialObjectsTests
   itkPolygonGroupSpatialObjectXMLFileTest.cxx
-  itkReadWriteSpatialObjectTest.cxx
   itkReadVesselTubeSpatialObjectTest.cxx
+  itkReadWriteSpatialObjectTest.cxx
 )
 
 createtestdriver(ITKIOSpatialObjects "${ITKIOSpatialObjects-Test_LIBRARIES}" "${ITKIOSpatialObjectsTests}")

--- a/Modules/IO/TIFF/src/CMakeLists.txt
+++ b/Modules/IO/TIFF/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 set(
   ITKIOTIFF_SRCS
   itkTIFFImageIO.cxx
-  itkTIFFReaderInternal.cxx
   itkTIFFImageIOFactory.cxx
+  itkTIFFReaderInternal.cxx
 )
 
 itk_module_add_library(ITKIOTIFF ${ITKIOTIFF_SRCS})

--- a/Modules/IO/TIFF/test/CMakeLists.txt
+++ b/Modules/IO/TIFF/test/CMakeLists.txt
@@ -1,13 +1,13 @@
 itk_module_test()
 set(
   ITKIOTIFFTests
+  itkLargeTIFFImageWriteReadTest.cxx
+  itkTIFFImageIOCompressionTest.cxx
+  itkTIFFImageIOInfoTest.cxx
+  itkTIFFImageIOIntPixelTest.cxx
   itkTIFFImageIOTest.cxx
   itkTIFFImageIOTest2.cxx
-  itkTIFFImageIOCompressionTest.cxx
-  itkLargeTIFFImageWriteReadTest.cxx
-  itkTIFFImageIOInfoTest.cxx
   itkTIFFImageIOTestPalette.cxx
-  itkTIFFImageIOIntPixelTest.cxx
 )
 
 createtestdriver(ITKIOTIFF "${ITKIOTIFF-Test_LIBRARIES}" "${ITKIOTIFFTests}")

--- a/Modules/IO/TransformFactory/src/CMakeLists.txt
+++ b/Modules/IO/TransformFactory/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 set(
   ITKTransformFactory_SRCS
   itkTransformFactoryBase.cxx
-  itkTransformFactoryBaseRegisterFloatParameters.cxx
   itkTransformFactoryBaseRegisterDoubleParameters.cxx
+  itkTransformFactoryBaseRegisterFloatParameters.cxx
 )
 
 itk_module_add_library(ITKTransformFactory ${ITKTransformFactory_SRCS})

--- a/Modules/IO/TransformInsightLegacy/test/CMakeLists.txt
+++ b/Modules/IO/TransformInsightLegacy/test/CMakeLists.txt
@@ -1,8 +1,8 @@
 itk_module_test()
 set(
   ITKIOTransformInsightLegacyTests
-  itkIOTransformTxtTest.cxx
   itkIOEuler3DTransformTxtTest.cxx
+  itkIOTransformTxtTest.cxx
 )
 
 createtestdriver(ITKIOTransformInsightLegacy "${ITKIOTransformInsightLegacy-Test_LIBRARIES}"

--- a/Modules/IO/VTK/src/CMakeLists.txt
+++ b/Modules/IO/VTK/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(
   ITKIOVTK_SRCS
-  itkVTKImageIOFactory.cxx
   itkVTKImageIO.cxx
+  itkVTKImageIOFactory.cxx
 )
 
 itk_module_add_library(ITKIOVTK ${ITKIOVTK_SRCS})

--- a/Modules/IO/VTK/test/CMakeLists.txt
+++ b/Modules/IO/VTK/test/CMakeLists.txt
@@ -2,12 +2,12 @@ itk_module_test()
 set(
   ITKIOVTKTests
   itkVTKImageIO2Test.cxx
-  itkVTKImageIOTest.cxx
   itkVTKImageIO2Test2.cxx
+  itkVTKImageIOFileReadTest.cxx
+  itkVTKImageIOStreamTest.cxx
+  itkVTKImageIOTest.cxx
   itkVTKImageIOTest2.cxx
   itkVTKImageIOTest3.cxx
-  itkVTKImageIOStreamTest.cxx
-  itkVTKImageIOFileReadTest.cxx
 )
 
 createtestdriver(ITKIOVTK "${ITKIOVTK-Test_LIBRARIES}" "${ITKIOVTKTests}")

--- a/Modules/IO/XML/src/CMakeLists.txt
+++ b/Modules/IO/XML/src/CMakeLists.txt
@@ -1,11 +1,11 @@
 set(
   ITKIOXML_SRCS
-  itkXMLFile.cxx
   itkDOMNode.cxx
   itkDOMNodeXMLReader.cxx
   itkDOMNodeXMLWriter.cxx
-  itkStringTools.cxx
   itkFancyString.cxx
+  itkStringTools.cxx
+  itkXMLFile.cxx
 )
 
 itk_module_add_library(ITKIOXML ${ITKIOXML_SRCS})

--- a/Modules/Numerics/FEM/src/CMakeLists.txt
+++ b/Modules/Numerics/FEM/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(
   ITKFEM_SRCS
-  itkFEMSolution.cxx
+  dsrc2c.c
   itkFEMElement2DC0LinearLine.cxx
   itkFEMElement2DC0LinearLineStress.cxx
   itkFEMElement2DC0LinearQuadrilateral.cxx
@@ -33,20 +33,20 @@ set(
   itkFEMLinearSystemWrapperDenseVNL.cxx
   itkFEMLinearSystemWrapperItpack.cxx
   itkFEMLinearSystemWrapperVNL.cxx
+  itkFEMLoadBase.cxx
   itkFEMLoadBC.cxx
   itkFEMLoadBCMFC.cxx
-  itkFEMLoadBase.cxx
   itkFEMLoadEdge.cxx
   itkFEMLoadElementBase.cxx
   itkFEMLoadGrav.cxx
   itkFEMLoadLandmark.cxx
-  itkFEMLoadNoisyLandmark.cxx
   itkFEMLoadNode.cxx
+  itkFEMLoadNoisyLandmark.cxx
   itkFEMLoadPoint.cxx
   itkFEMMaterialBase.cxx
   itkFEMMaterialLinearElasticity.cxx
+  itkFEMSolution.cxx
   itkFEMUtility.cxx
-  dsrc2c.c
 )
 
 itk_module_add_library(ITKFEM ${ITKFEM_SRCS})

--- a/Modules/Numerics/NarrowBand/test/CMakeLists.txt
+++ b/Modules/Numerics/NarrowBand/test/CMakeLists.txt
@@ -1,8 +1,8 @@
 itk_module_test()
 set(
   ITKNarrowBandTests
-  itkNarrowBandTest.cxx
   itkNarrowBandImageFilterBaseTest.cxx
+  itkNarrowBandTest.cxx
 )
 
 createtestdriver(ITKNarrowBand "${ITKNarrowBand-Test_LIBRARIES}" "${ITKNarrowBandTests}")

--- a/Modules/Numerics/Optimizers/src/CMakeLists.txt
+++ b/Modules/Numerics/Optimizers/src/CMakeLists.txt
@@ -1,35 +1,35 @@
 set(
   ITKOptimizers_SRCS
-  itkNonLinearOptimizer.cxx
-  itkMultipleValuedCostFunction.cxx
-  itkSingleValuedCostFunction.cxx
-  itkConjugateGradientOptimizer.cxx
-  itkRegularStepGradientDescentOptimizer.cxx
-  itkLBFGSOptimizer.cxx
-  itkExhaustiveOptimizer.cxx
-  itkLevenbergMarquardtOptimizer.cxx
-  itkSingleValuedNonLinearVnlOptimizer.cxx
-  itkQuaternionRigidTransformGradientDescentOptimizer.cxx
-  itkSPSAOptimizer.cxx
-  itkSingleValuedVnlCostFunctionAdaptor.cxx
-  itkMultipleValuedNonLinearVnlOptimizer.cxx
-  itkPowellOptimizer.cxx
-  itkVersorTransformOptimizer.cxx
-  itkOnePlusOneEvolutionaryOptimizer.cxx
-  itkMultipleValuedNonLinearOptimizer.cxx
-  itkLBFGSBOptimizer.cxx
-  itkCumulativeGaussianOptimizer.cxx
   itkAmoebaOptimizer.cxx
+  itkConjugateGradientOptimizer.cxx
   itkCumulativeGaussianCostFunction.cxx
-  itkOptimizer.cxx
+  itkCumulativeGaussianOptimizer.cxx
+  itkExhaustiveOptimizer.cxx
   itkFRPROptimizer.cxx
   itkGradientDescentOptimizer.cxx
-  itkSingleValuedNonLinearOptimizer.cxx
-  itkRegularStepGradientDescentBaseOptimizer.cxx
-  itkMultipleValuedVnlCostFunctionAdaptor.cxx
-  itkParticleSwarmOptimizerBase.cxx
-  itkParticleSwarmOptimizer.cxx
   itkInitializationBiasedParticleSwarmOptimizer.cxx
+  itkLBFGSBOptimizer.cxx
+  itkLBFGSOptimizer.cxx
+  itkLevenbergMarquardtOptimizer.cxx
+  itkMultipleValuedCostFunction.cxx
+  itkMultipleValuedNonLinearOptimizer.cxx
+  itkMultipleValuedNonLinearVnlOptimizer.cxx
+  itkMultipleValuedVnlCostFunctionAdaptor.cxx
+  itkNonLinearOptimizer.cxx
+  itkOnePlusOneEvolutionaryOptimizer.cxx
+  itkOptimizer.cxx
+  itkParticleSwarmOptimizer.cxx
+  itkParticleSwarmOptimizerBase.cxx
+  itkPowellOptimizer.cxx
+  itkQuaternionRigidTransformGradientDescentOptimizer.cxx
+  itkRegularStepGradientDescentBaseOptimizer.cxx
+  itkRegularStepGradientDescentOptimizer.cxx
+  itkSingleValuedCostFunction.cxx
+  itkSingleValuedNonLinearOptimizer.cxx
+  itkSingleValuedNonLinearVnlOptimizer.cxx
+  itkSingleValuedVnlCostFunctionAdaptor.cxx
+  itkSPSAOptimizer.cxx
+  itkVersorTransformOptimizer.cxx
 )
 
 itk_module_add_library(ITKOptimizers ${ITKOptimizers_SRCS})

--- a/Modules/Numerics/Optimizers/test/CMakeLists.txt
+++ b/Modules/Numerics/Optimizers/test/CMakeLists.txt
@@ -1,24 +1,24 @@
 itk_module_test()
 set(
   ITKOptimizersTests
-  itkFRPROptimizerTest.cxx
-  itkPowellOptimizerTest.cxx
-  itkGradientDescentOptimizerTest.cxx
-  itkVersorTransformOptimizerTest.cxx
-  itkSPSAOptimizerTest.cxx
-  itkOptimizersHierarchyTest.cxx
-  itkExhaustiveOptimizerTest.cxx
-  itkLBFGSBOptimizerTest.cxx
-  itkConjugateGradientOptimizerTest.cxx
-  itkLBFGSOptimizerTest.cxx
-  itkCumulativeGaussianOptimizerTest.cxx
-  itkRegularStepGradientDescentOptimizerTest.cxx
-  itkLevenbergMarquardtOptimizerTest.cxx
-  itkVersorRigid3DTransformOptimizerTest.cxx
   itkAmoebaOptimizerTest.cxx
-  itkOnePlusOneEvolutionaryOptimizerTest.cxx
-  itkParticleSwarmOptimizerTest.cxx
+  itkConjugateGradientOptimizerTest.cxx
+  itkCumulativeGaussianOptimizerTest.cxx
+  itkExhaustiveOptimizerTest.cxx
+  itkFRPROptimizerTest.cxx
+  itkGradientDescentOptimizerTest.cxx
   itkInitializationBiasedParticleSwarmOptimizerTest.cxx
+  itkLBFGSBOptimizerTest.cxx
+  itkLBFGSOptimizerTest.cxx
+  itkLevenbergMarquardtOptimizerTest.cxx
+  itkOnePlusOneEvolutionaryOptimizerTest.cxx
+  itkOptimizersHierarchyTest.cxx
+  itkParticleSwarmOptimizerTest.cxx
+  itkPowellOptimizerTest.cxx
+  itkRegularStepGradientDescentOptimizerTest.cxx
+  itkSPSAOptimizerTest.cxx
+  itkVersorRigid3DTransformOptimizerTest.cxx
+  itkVersorTransformOptimizerTest.cxx
 )
 
 createtestdriver(ITKOptimizers "${ITKOptimizers-Test_LIBRARIES}" "${ITKOptimizersTests}")

--- a/Modules/Numerics/Optimizersv4/src/CMakeLists.txt
+++ b/Modules/Numerics/Optimizersv4/src/CMakeLists.txt
@@ -1,15 +1,15 @@
 set(
   ITKOptimizersv4_SRCS
-  itkObjectToObjectOptimizerBase.cxx
-  itkSingleValuedNonLinearVnlOptimizerv4.cxx
-  itkSingleValuedVnlCostFunctionAdaptorv4.cxx
-  itkLBFGSOptimizerv4Base.cxx
-  itkLBFGSOptimizerv4.cxx
+  itkAmoebaOptimizerv4.cxx
   itkLBFGS2Optimizerv4.cxx
   itkLBFGSBOptimizerv4.cxx
-  itkAmoebaOptimizerv4.cxx
-  itkRegistrationParameterScalesEstimator.cxx
+  itkLBFGSOptimizerv4.cxx
+  itkLBFGSOptimizerv4Base.cxx
   itkObjectToObjectMetricBase.cxx
+  itkObjectToObjectOptimizerBase.cxx
+  itkRegistrationParameterScalesEstimator.cxx
+  itkSingleValuedNonLinearVnlOptimizerv4.cxx
+  itkSingleValuedVnlCostFunctionAdaptorv4.cxx
 )
 
 itk_module_add_library(ITKOptimizersv4 ${ITKOptimizersv4_SRCS})

--- a/Modules/Numerics/Optimizersv4/test/CMakeLists.txt
+++ b/Modules/Numerics/Optimizersv4/test/CMakeLists.txt
@@ -1,32 +1,32 @@
 itk_module_test()
 set(
   ITKOptimizersv4Tests
-  itkObjectToObjectOptimizerBaseTest.cxx
+  itkAmoebaOptimizerv4Test.cxx
+  itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
+  itkAutoScaledGradientDescentRegistrationTest.cxx
+  itkConjugateGradientLineSearchOptimizerv4Test.cxx
+  itkExhaustiveOptimizerv4Test.cxx
+  itkGradientDescentLineSearchOptimizerv4Test.cxx
   itkGradientDescentOptimizerBasev4Test.cxx
   itkGradientDescentOptimizerv4Test.cxx
   itkGradientDescentOptimizerv4Test2.cxx
-  itkGradientDescentLineSearchOptimizerv4Test.cxx
-  itkConjugateGradientLineSearchOptimizerv4Test.cxx
-  itkMultiStartOptimizerv4Test.cxx
-  itkMultiGradientOptimizerv4Test.cxx
-  itkOptimizerParameterScalesEstimatorTest.cxx
-  itkRegistrationParameterScalesEstimatorTest.cxx
-  itkRegistrationParameterScalesFromPhysicalShiftTest.cxx
-  itkRegistrationParameterScalesFromPhysicalShiftPointSetTest.cxx
-  itkRegistrationParameterScalesFromIndexShiftTest.cxx
-  itkRegistrationParameterScalesFromJacobianTest.cxx
-  itkAutoScaledGradientDescentRegistrationTest.cxx
-  itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
-  itkQuasiNewtonOptimizerv4Test.cxx
-  itkObjectToObjectMetricBaseTest.cxx
-  itkLBFGSOptimizerv4Test.cxx
   itkLBFGS2Optimizerv4Test.cxx
   itkLBFGSBOptimizerv4Test.cxx
-  itkRegularStepGradientDescentOptimizerv4Test.cxx
-  itkAmoebaOptimizerv4Test.cxx
-  itkExhaustiveOptimizerv4Test.cxx
-  itkPowellOptimizerv4Test.cxx
+  itkLBFGSOptimizerv4Test.cxx
+  itkMultiGradientOptimizerv4Test.cxx
+  itkMultiStartOptimizerv4Test.cxx
+  itkObjectToObjectMetricBaseTest.cxx
+  itkObjectToObjectOptimizerBaseTest.cxx
   itkOnePlusOneEvolutionaryOptimizerv4Test.cxx
+  itkOptimizerParameterScalesEstimatorTest.cxx
+  itkPowellOptimizerv4Test.cxx
+  itkQuasiNewtonOptimizerv4Test.cxx
+  itkRegistrationParameterScalesEstimatorTest.cxx
+  itkRegistrationParameterScalesFromIndexShiftTest.cxx
+  itkRegistrationParameterScalesFromJacobianTest.cxx
+  itkRegistrationParameterScalesFromPhysicalShiftPointSetTest.cxx
+  itkRegistrationParameterScalesFromPhysicalShiftTest.cxx
+  itkRegularStepGradientDescentOptimizerv4Test.cxx
 )
 
 set(INPUTDATA ${ITK_DATA_ROOT}/Input)

--- a/Modules/Numerics/Statistics/src/CMakeLists.txt
+++ b/Modules/Numerics/Statistics/src/CMakeLists.txt
@@ -1,19 +1,19 @@
 set(
   ITKStatistics_SRCS
-  itkProbabilityDistribution.cxx
-  itkDenseFrequencyContainer2.cxx
-  itkSparseFrequencyContainer2.cxx
   itkChiSquareDistribution.cxx
-  itkGaussianDistribution.cxx
-  itkTDistribution.cxx
-  itkNormalVariateGenerator.cxx
   itkDecisionRule.cxx
+  itkDenseFrequencyContainer2.cxx
+  itkExpectationMaximizationMixtureModelEstimator.cxx
+  itkGaussianDistribution.cxx
+  itkHistogramToRunLengthFeaturesFilter.cxx
+  itkHistogramToTextureFeaturesFilter.cxx
   itkMaximumDecisionRule.cxx
   itkMaximumRatioDecisionRule.cxx
   itkMinimumDecisionRule.cxx
-  itkHistogramToRunLengthFeaturesFilter.cxx
-  itkExpectationMaximizationMixtureModelEstimator.cxx
-  itkHistogramToTextureFeaturesFilter.cxx
+  itkNormalVariateGenerator.cxx
+  itkProbabilityDistribution.cxx
+  itkSparseFrequencyContainer2.cxx
+  itkTDistribution.cxx
 )
 
 itk_module_add_library(ITKStatistics ${ITKStatistics_SRCS})

--- a/Modules/Numerics/Statistics/test/CMakeLists.txt
+++ b/Modules/Numerics/Statistics/test/CMakeLists.txt
@@ -1,13 +1,33 @@
 itk_module_test()
 set(
   ITKStatisticsTests
+  itkChiSquareDistributionTest.cxx
+  itkCovarianceSampleFilterTest.cxx
+  itkCovarianceSampleFilterTest2.cxx
+  itkCovarianceSampleFilterTest3.cxx
   itkDecisionRuleTest.cxx
   itkDenseFrequencyContainer2Test.cxx
+  itkDistanceMetricTest.cxx
+  itkDistanceMetricTest2.cxx
+  itkDistanceToCentroidMembershipFunctionTest.cxx
+  itkEuclideanDistanceMetricTest.cxx
+  itkEuclideanSquareDistanceMetricTest.cxx
   itkExpectationMaximizationMixtureModelEstimatorTest.cxx
   itkGaussianDistributionTest.cxx
   itkGaussianMembershipFunctionTest.cxx
   itkGaussianMixtureModelComponentTest.cxx
   itkGaussianRandomSpatialNeighborSubsamplerTest.cxx
+  itkHistogramTest.cxx
+  itkHistogramToTextureFeaturesFilterNaNTest.cxx
+  itkHistogramToTextureFeaturesFilterTest.cxx
+  itkImageToHistogramFilterTest.cxx
+  itkImageToHistogramFilterTest2.cxx
+  itkImageToListSampleAdaptorTest.cxx
+  itkImageToListSampleAdaptorTest2.cxx
+  itkImageToListSampleFilterTest.cxx
+  itkImageToListSampleFilterTest2.cxx
+  itkImageToListSampleFilterTest3.cxx
+  itkJointDomainImageToListSampleAdaptorTest.cxx
   itkKalmanLinearEstimatorTest.cxx
   itkKdTreeBasedKmeansEstimatorTest.cxx
   itkKdTreeGeneratorTest.cxx
@@ -15,50 +35,26 @@ set(
   itkKdTreeTest2.cxx
   itkKdTreeTest3.cxx
   itkKdTreeTestSamplePoints.cxx
+  itkListSampleTest.cxx
+  itkListSampleTest.cxx
+  itkMahalanobisDistanceMetricTest.cxx
+  itkManhattanDistanceMetricTest.cxx
   itkMaximumDecisionRuleTest.cxx
-  itkMinimumDecisionRuleTest.cxx
   itkMaximumRatioDecisionRuleTest.cxx
   itkMeanSampleFilterTest.cxx
   itkMeanSampleFilterTest2.cxx
   itkMeanSampleFilterTest3.cxx
-  itkHistogramTest.cxx
-  itkHistogramToTextureFeaturesFilterTest.cxx
-  itkHistogramToTextureFeaturesFilterNaNTest.cxx
-  itkChiSquareDistributionTest.cxx
-  itkCovarianceSampleFilterTest.cxx
-  itkCovarianceSampleFilterTest2.cxx
-  itkCovarianceSampleFilterTest3.cxx
-  itkWeightedCovarianceSampleFilterTest.cxx
-  itkWeightedCovarianceSampleFilterTest2.cxx
-  itkWeightedMeanSampleFilterTest.cxx
-  itkWeightedCentroidKdTreeGeneratorTest1.cxx
-  itkWeightedCentroidKdTreeGeneratorTest8.cxx
-  itkWeightedCentroidKdTreeGeneratorTest9.cxx
-  itkMahalanobisDistanceMetricTest.cxx
-  itkManhattanDistanceMetricTest.cxx
+  itkMeasurementVectorTraitsTest.cxx
   itkMembershipFunctionBaseTest.cxx
   itkMembershipFunctionBaseTest2.cxx
   itkMembershipSampleTest1.cxx
   itkMembershipSampleTest2.cxx
   itkMembershipSampleTest3.cxx
   itkMembershipSampleTest4.cxx
-  itkMeasurementVectorTraitsTest.cxx
-  itkNeighborhoodSamplerTest1.cxx
+  itkMinimumDecisionRuleTest.cxx
   itkMixtureModelComponentBaseTest.cxx
+  itkNeighborhoodSamplerTest1.cxx
   itkNormalVariateGeneratorTest1.cxx
-  itkDistanceMetricTest.cxx
-  itkDistanceMetricTest2.cxx
-  itkDistanceToCentroidMembershipFunctionTest.cxx
-  itkEuclideanDistanceMetricTest.cxx
-  itkEuclideanSquareDistanceMetricTest.cxx
-  itkListSampleTest.cxx
-  itkImageToListSampleAdaptorTest.cxx
-  itkImageToListSampleAdaptorTest2.cxx
-  itkImageToListSampleFilterTest.cxx
-  itkImageToListSampleFilterTest2.cxx
-  itkImageToListSampleFilterTest3.cxx
-  itkListSampleTest.cxx
-  itkJointDomainImageToListSampleAdaptorTest.cxx
   itkPointSetToListSampleAdaptorTest.cxx
   itkProbabilityDistributionTest.cxx
   itkRandomVariateGeneratorBaseTest.cxx
@@ -77,24 +73,28 @@ set(
   itkScalarImageToCooccurrenceListSampleFilterTest.cxx
   itkScalarImageToCooccurrenceMatrixFilterTest.cxx
   itkScalarImageToCooccurrenceMatrixFilterTest2.cxx
-  itkScalarImageToTextureFeaturesFilterTest.cxx
-  itkScalarImageToRunLengthMatrixFilterTest.cxx
+  itkScalarImageToHistogramGeneratorTest.cxx
   itkScalarImageToRunLengthFeaturesFilterTest.cxx
+  itkScalarImageToRunLengthMatrixFilterTest.cxx
+  itkScalarImageToTextureFeaturesFilterTest.cxx
   itkSparseFrequencyContainer2Test.cxx
   itkSpatialNeighborSubsamplerTest.cxx
   itkStandardDeviationPerComponentSampleFilterTest.cxx
+  itkStatisticsAlgorithmTest.cxx
+  itkStatisticsAlgorithmTest2.cxx
   itkStatisticsTypesTest.cxx
   itkSubsampleTest.cxx
   itkSubsampleTest2.cxx
   itkSubsampleTest3.cxx
   itkTDistributionTest.cxx
-  itkStatisticsAlgorithmTest.cxx
-  itkStatisticsAlgorithmTest2.cxx
   itkUniformRandomSpatialNeighborSubsamplerTest.cxx
   itkVectorContainerToListSampleAdaptorTest.cxx
-  itkImageToHistogramFilterTest.cxx
-  itkImageToHistogramFilterTest2.cxx
-  itkScalarImageToHistogramGeneratorTest.cxx
+  itkWeightedCentroidKdTreeGeneratorTest1.cxx
+  itkWeightedCentroidKdTreeGeneratorTest8.cxx
+  itkWeightedCentroidKdTreeGeneratorTest9.cxx
+  itkWeightedCovarianceSampleFilterTest.cxx
+  itkWeightedCovarianceSampleFilterTest2.cxx
+  itkWeightedMeanSampleFilterTest.cxx
 )
 
 createtestdriver(ITKStatistics "${ITKStatistics-Test_LIBRARIES}" "${ITKStatisticsTests}")

--- a/Modules/Registration/Common/test/CMakeLists.txt
+++ b/Modules/Registration/Common/test/CMakeLists.txt
@@ -1,16 +1,21 @@
 itk_module_test()
 set(
   ITKRegistrationCommonTests
-  itkBSplineTransformParametersAdaptorTest.cxx
-  itkDisplacementFieldTransformParametersAdaptorTest.cxx
-  itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
-  itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
+  itkBlockMatchingImageFilterTest.cxx
   itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
-  itkGaussianExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
+  itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
+  itkBSplineTransformParametersAdaptorTest.cxx
   itkCenteredTransformInitializerTest.cxx
   itkCenteredVersorTransformInitializerTest.cxx
-  itkMultiResolutionImageRegistrationMethodTest_1.cxx
-  itkMultiResolutionImageRegistrationMethodTest_2.cxx
+  itkCompareHistogramImageToImageMetricTest.cxx
+  itkCorrelationCoefficientHistogramImageToImageMetricTest.cxx
+  itkDisplacementFieldTransformParametersAdaptorTest.cxx
+  itkEuclideanDistancePointMetricTest.cxx
+  itkGaussianExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
+  itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
+  itkHistogramImageToImageMetricTest.cxx
+  itkImageRegistrationMethodTest.cxx
+  itkImageRegistrationMethodTest_1.cxx
   itkImageRegistrationMethodTest_10.cxx
   itkImageRegistrationMethodTest_11.cxx
   itkImageRegistrationMethodTest_12.cxx
@@ -18,26 +23,7 @@ set(
   itkImageRegistrationMethodTest_14.cxx
   itkImageRegistrationMethodTest_15.cxx
   itkImageRegistrationMethodTest_16.cxx
-  itkMeanSquaresPointSetToImageMetricTest.cxx
-  itkHistogramImageToImageMetricTest.cxx
-  itkMutualInformationHistogramImageToImageMetricTest.cxx
-  itkMeanReciprocalSquareDifferencePointSetToImageMetricTest.cxx
-  itkMultiResolutionImageRegistrationMethodTest.cxx
-  itkCompareHistogramImageToImageMetricTest.cxx
-  itkMeanSquaresHistogramImageToImageMetricTest.cxx
-  itkImageRegistrationMethodTest.cxx
-  itkCorrelationCoefficientHistogramImageToImageMetricTest.cxx
-  itkNormalizedCorrelationPointSetToImageMetricTest.cxx
-  itkKullbackLeiblerCompareHistogramImageToImageMetricTest.cxx
-  itkNormalizedMutualInformationHistogramImageToImageMetricTest.cxx
-  itkPointSetToSpatialObjectDemonsRegistrationTest.cxx
-  itkPointSetToImageRegistrationTest.cxx
-  itkPointsLocatorTest.cxx
-  itkKappaStatisticImageToImageMetricTest.cxx
-  itkMattesMutualInformationImageToImageMetricTest.cxx
-  itkMatchCardinalityImageToImageMetricTest.cxx
-  itkMultiResolutionPyramidImageFilterTest.cxx
-  itkImageRegistrationMethodTest_1.cxx
+  itkImageRegistrationMethodTest_17.cxx
   itkImageRegistrationMethodTest_2.cxx
   itkImageRegistrationMethodTest_3.cxx
   itkImageRegistrationMethodTest_4.cxx
@@ -46,17 +32,31 @@ set(
   itkImageRegistrationMethodTest_7.cxx
   itkImageRegistrationMethodTest_8.cxx
   itkImageRegistrationMethodTest_9.cxx
-  itkRecursiveMultiResolutionPyramidImageFilterTest.cxx
-  itkNormalizedCorrelationImageMetricTest.cxx
-  itkMeanReciprocalSquareDifferenceImageMetricTest.cxx
-  itkMeanSquaresImageMetricTest.cxx
-  itkMutualInformationMetricTest.cxx
-  itkPointSetToPointSetRegistrationTest.cxx
   itkImageToSpatialObjectRegistrationTest.cxx
-  itkBlockMatchingImageFilterTest.cxx
+  itkKappaStatisticImageToImageMetricTest.cxx
+  itkKullbackLeiblerCompareHistogramImageToImageMetricTest.cxx
   itkLandmarkBasedTransformInitializerTest.cxx
-  itkImageRegistrationMethodTest_17.cxx
-  itkEuclideanDistancePointMetricTest.cxx
+  itkMatchCardinalityImageToImageMetricTest.cxx
+  itkMattesMutualInformationImageToImageMetricTest.cxx
+  itkMeanReciprocalSquareDifferenceImageMetricTest.cxx
+  itkMeanReciprocalSquareDifferencePointSetToImageMetricTest.cxx
+  itkMeanSquaresHistogramImageToImageMetricTest.cxx
+  itkMeanSquaresImageMetricTest.cxx
+  itkMeanSquaresPointSetToImageMetricTest.cxx
+  itkMultiResolutionImageRegistrationMethodTest.cxx
+  itkMultiResolutionImageRegistrationMethodTest_1.cxx
+  itkMultiResolutionImageRegistrationMethodTest_2.cxx
+  itkMultiResolutionPyramidImageFilterTest.cxx
+  itkMutualInformationHistogramImageToImageMetricTest.cxx
+  itkMutualInformationMetricTest.cxx
+  itkNormalizedCorrelationImageMetricTest.cxx
+  itkNormalizedCorrelationPointSetToImageMetricTest.cxx
+  itkNormalizedMutualInformationHistogramImageToImageMetricTest.cxx
+  itkPointSetToImageRegistrationTest.cxx
+  itkPointSetToPointSetRegistrationTest.cxx
+  itkPointSetToSpatialObjectDemonsRegistrationTest.cxx
+  itkPointsLocatorTest.cxx
+  itkRecursiveMultiResolutionPyramidImageFilterTest.cxx
 )
 
 createtestdriver(ITKRegistrationCommon "${ITKRegistrationCommon-Test_LIBRARIES}" "${ITKRegistrationCommonTests}")

--- a/Modules/Registration/FEM/test/CMakeLists.txt
+++ b/Modules/Registration/FEM/test/CMakeLists.txt
@@ -2,10 +2,10 @@ itk_module_test()
 set(
   ITKFEMRegistrationTests
   itkFEMFiniteDifferenceFunctionLoadTest.cxx
-  itkFEMRegistrationFilterTest.cxx
   itkFEMRegistrationFilter2DTest.cxx
-  itkMIRegistrationFunctionTest.cxx
+  itkFEMRegistrationFilterTest.cxx
   itkFEMRegistrationFilterTest2.cxx
+  itkMIRegistrationFunctionTest.cxx
   itkPhysicsBasedNonRigidRegistrationMethodTest.cxx
 )
 

--- a/Modules/Registration/Metricsv4/test/CMakeLists.txt
+++ b/Modules/Registration/Metricsv4/test/CMakeLists.txt
@@ -1,39 +1,39 @@
 itk_module_test()
 set(
   ITKMetricsv4Tests
-  itkEuclideanDistancePointSetMetricTest.cxx
-  itkExpectationBasedPointSetMetricTest.cxx
-  itkJensenHavrdaCharvatTsallisPointSetMetricTest.cxx
-  itkJensenHavrdaCharvatTsallisPointSetMetricRegistrationTest.cxx
-  itkLabeledPointSetMetricTest.cxx
-  itkLabeledPointSetMetricRegistrationTest.cxx
-  itkImageToImageMetricv4Test.cxx
-  itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
-  itkJointHistogramMutualInformationImageToImageRegistrationTest.cxx
-  itkMeanSquaresImageToImageMetricv4Test.cxx
-  itkCorrelationImageToImageMetricv4Test.cxx
-  itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
-  itkMeanSquaresImageToImageMetricv4OnVectorTest2.cxx
   itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
   itkANTSNeighborhoodCorrelationImageToImageRegistrationTest.cxx
-  itkMattesMutualInformationImageToImageMetricv4Test.cxx
-  itkMattesMutualInformationImageToImageMetricv4RegistrationTest.cxx
-  itkMultiStartImageToImageMetricv4RegistrationTest.cxx
-  itkMultiGradientImageToImageMetricv4RegistrationTest.cxx
-  itkMetricImageGradientTest.cxx
-  itkMeanSquaresImageToImageMetricv4RegistrationTest.cxx
-  itkMeanSquaresImageToImageMetricv4RegistrationTest2.cxx
-  itkImageToImageMetricv4RegistrationTest.cxx
-  itkDemonsImageToImageMetricv4Test.cxx
+  itkCorrelationImageToImageMetricv4Test.cxx
   itkDemonsImageToImageMetricv4RegistrationTest.cxx
+  itkDemonsImageToImageMetricv4Test.cxx
   itkEuclideanDistancePointSetMetricRegistrationTest.cxx
-  itkExpectationBasedPointSetMetricRegistrationTest.cxx
+  itkEuclideanDistancePointSetMetricTest.cxx
   itkEuclideanDistancePointSetMetricTest2.cxx
   itkEuclideanDistancePointSetMetricTest3.cxx
-  itkObjectToObjectMultiMetricv4Test.cxx
-  itkObjectToObjectMultiMetricv4RegistrationTest.cxx
+  itkExpectationBasedPointSetMetricRegistrationTest.cxx
+  itkExpectationBasedPointSetMetricTest.cxx
+  itkImageToImageMetricv4RegistrationTest.cxx
+  itkImageToImageMetricv4Test.cxx
+  itkJensenHavrdaCharvatTsallisPointSetMetricRegistrationTest.cxx
+  itkJensenHavrdaCharvatTsallisPointSetMetricTest.cxx
+  itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
+  itkJointHistogramMutualInformationImageToImageRegistrationTest.cxx
+  itkLabeledPointSetMetricRegistrationTest.cxx
+  itkLabeledPointSetMetricTest.cxx
+  itkMattesMutualInformationImageToImageMetricv4RegistrationTest.cxx
+  itkMattesMutualInformationImageToImageMetricv4Test.cxx
+  itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
+  itkMeanSquaresImageToImageMetricv4OnVectorTest2.cxx
+  itkMeanSquaresImageToImageMetricv4RegistrationTest.cxx
+  itkMeanSquaresImageToImageMetricv4RegistrationTest2.cxx
   itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
+  itkMeanSquaresImageToImageMetricv4Test.cxx
   itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.cxx
+  itkMetricImageGradientTest.cxx
+  itkMultiGradientImageToImageMetricv4RegistrationTest.cxx
+  itkMultiStartImageToImageMetricv4RegistrationTest.cxx
+  itkObjectToObjectMultiMetricv4RegistrationTest.cxx
+  itkObjectToObjectMultiMetricv4Test.cxx
 )
 
 set(INPUTDATA ${ITK_DATA_ROOT}/Input)

--- a/Modules/Registration/PDEDeformable/test/CMakeLists.txt
+++ b/Modules/Registration/PDEDeformable/test/CMakeLists.txt
@@ -1,14 +1,14 @@
 itk_module_test()
 set(
   ITKPDEDeformableRegistrationTests
-  itkMultiResolutionPDEDeformableRegistrationTest.cxx
   itkDemonsRegistrationFilterTest.cxx
   itkDiffeomorphicDemonsRegistrationFilterTest.cxx
   itkDiffeomorphicDemonsRegistrationFilterTest2.cxx
+  itkESMDemonsRegistrationFunctionTest.cxx
   itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
   itkLevelSetMotionRegistrationFilterTest.cxx
+  itkMultiResolutionPDEDeformableRegistrationTest.cxx
   itkSymmetricForcesDemonsRegistrationFilterTest.cxx
-  itkESMDemonsRegistrationFunctionTest.cxx
 )
 # Define some convenient locations
 set(BASELINE ${ITK_DATA_ROOT}/Baseline/Algorithms)

--- a/Modules/Registration/RegistrationMethodsv4/test/CMakeLists.txt
+++ b/Modules/Registration/RegistrationMethodsv4/test/CMakeLists.txt
@@ -1,24 +1,24 @@
 itk_module_test()
 set(
   ITKRegistrationMethodsv4Tests
+  itkBSplineExponentialImageRegistrationTest.cxx
+  itkBSplineImageRegistrationTest.cxx
+  itkBSplineSyNImageRegistrationTest.cxx
+  itkBSplineSyNPointSetRegistrationTest.cxx
+  itkExponentialImageRegistrationTest.cxx
   itkImageRegistrationSamplingTest.cxx
+  itkQuasiNewtonOptimizerv4RegistrationTest.cxx
   itkSimpleImageRegistrationTest.cxx
   itkSimpleImageRegistrationTest2.cxx
   itkSimpleImageRegistrationTest3.cxx
   itkSimpleImageRegistrationTest4.cxx
   itkSimpleImageRegistrationTestWithMaskAndSampling.cxx
   itkSimplePointSetRegistrationTest.cxx
-  itkExponentialImageRegistrationTest.cxx
-  itkBSplineExponentialImageRegistrationTest.cxx
-  itkTimeVaryingBSplineVelocityFieldImageRegistrationTest.cxx
-  itkTimeVaryingVelocityFieldImageRegistrationTest.cxx
   itkSyNImageRegistrationTest.cxx
   itkSyNPointSetRegistrationTest.cxx
-  itkBSplineSyNImageRegistrationTest.cxx
-  itkBSplineSyNPointSetRegistrationTest.cxx
+  itkTimeVaryingBSplineVelocityFieldImageRegistrationTest.cxx
   itkTimeVaryingBSplineVelocityFieldPointSetRegistrationTest.cxx
-  itkQuasiNewtonOptimizerv4RegistrationTest.cxx
-  itkBSplineImageRegistrationTest.cxx
+  itkTimeVaryingVelocityFieldImageRegistrationTest.cxx
 )
 
 set(INPUTDATA ${ITK_DATA_ROOT}/Input)

--- a/Modules/Segmentation/Classifiers/test/CMakeLists.txt
+++ b/Modules/Segmentation/Classifiers/test/CMakeLists.txt
@@ -1,11 +1,9 @@
 itk_module_test()
 set(
   ITKClassifiersTests
-  itkScalarImageKmeansImageFilterTest.cxx
-  itkSupervisedImageClassifierTest.cxx
   itkBayesianClassifierImageFilterTest.cxx
-  itkKmeansModelEstimatorTest.cxx
   itkImageClassifierFilterTest.cxx
+  itkKmeansModelEstimatorTest.cxx
   itkSampleClassifierFilterTest1.cxx
   itkSampleClassifierFilterTest2.cxx
   itkSampleClassifierFilterTest3.cxx
@@ -13,8 +11,10 @@ set(
   itkSampleClassifierFilterTest5.cxx
   itkSampleClassifierFilterTest6.cxx
   itkSampleClassifierFilterTest7.cxx
-  itkScalarImageKmeansImageFilterTest.cxx
   itkScalarImageKmeansImageFilter3DTest.cxx
+  itkScalarImageKmeansImageFilterTest.cxx
+  itkScalarImageKmeansImageFilterTest.cxx
+  itkSupervisedImageClassifierTest.cxx
 )
 
 createtestdriver(ITKClassifiers "${ITKClassifiers-Test_LIBRARIES}" "${ITKClassifiersTests}")

--- a/Modules/Segmentation/ConnectedComponents/test/CMakeLists.txt
+++ b/Modules/Segmentation/ConnectedComponents/test/CMakeLists.txt
@@ -1,16 +1,16 @@
 itk_module_test()
 set(
   ITKConnectedComponentsTests
-  itkRelabelComponentImageFilterTest.cxx
-  itkHardConnectedComponentImageFilterTest.cxx
-  itkConnectedComponentImageFilterTestRGB.cxx
-  itkConnectedComponentImageFilterTest.cxx
   itkConnectedComponentImageFilterBackgroundTest.cxx
-  itkThresholdMaximumConnectedComponentsImageFilterTest.cxx
-  itkScalarConnectedComponentImageFilterTest.cxx
-  itkVectorConnectedComponentImageFilterTest.cxx
+  itkConnectedComponentImageFilterTest.cxx
+  itkConnectedComponentImageFilterTestRGB.cxx
   itkConnectedComponentImageFilterTooManyObjectsTest.cxx
+  itkHardConnectedComponentImageFilterTest.cxx
   itkMaskConnectedComponentImageFilterTest.cxx
+  itkRelabelComponentImageFilterTest.cxx
+  itkScalarConnectedComponentImageFilterTest.cxx
+  itkThresholdMaximumConnectedComponentsImageFilterTest.cxx
+  itkVectorConnectedComponentImageFilterTest.cxx
 )
 
 createtestdriver(ITKConnectedComponents "${ITKConnectedComponents-Test_LIBRARIES}" "${ITKConnectedComponentsTests}")
@@ -178,8 +178,8 @@ itk_add_test(
 
 set(
   ITKConnectedComponentsGTests
-  itkRelabelComponentImageFilterGTest.cxx
   itkConnectedComponentImageFilterGTest.cxx
+  itkRelabelComponentImageFilterGTest.cxx
 )
 creategoogletestdriver(ITKConnectedComponents "${ITKConnectedComponents-Test_LIBRARIES}"
                        "${ITKConnectedComponentsGTests}"

--- a/Modules/Segmentation/DeformableMesh/test/CMakeLists.txt
+++ b/Modules/Segmentation/DeformableMesh/test/CMakeLists.txt
@@ -1,8 +1,8 @@
 itk_module_test()
 set(
   ITKDeformableMeshTests
-  itkDeformableSimplexMesh3DFilterTest.cxx
   itkDeformableSimplexMesh3DBalloonForceFilterTest.cxx
+  itkDeformableSimplexMesh3DFilterTest.cxx
   itkDeformableSimplexMesh3DGradientConstraintForceFilterTest.cxx
 )
 

--- a/Modules/Segmentation/KLMRegionGrowing/src/CMakeLists.txt
+++ b/Modules/Segmentation/KLMRegionGrowing/src/CMakeLists.txt
@@ -1,9 +1,9 @@
 set(
   ITKKLMRegionGrowing_SRCS
-  itkSegmentationRegion.cxx
+  itkKLMSegmentationBorder.cxx
   itkKLMSegmentationRegion.cxx
   itkSegmentationBorder.cxx
-  itkKLMSegmentationBorder.cxx
+  itkSegmentationRegion.cxx
 )
 
 itk_module_add_library(ITKKLMRegionGrowing ${ITKKLMRegionGrowing_SRCS})

--- a/Modules/Segmentation/LabelVoting/test/CMakeLists.txt
+++ b/Modules/Segmentation/LabelVoting/test/CMakeLists.txt
@@ -1,12 +1,12 @@
 itk_module_test()
 set(
   ITKLabelVotingTests
-  itkVotingBinaryImageFilterTest.cxx
+  itkBinaryMedianImageFilterTest.cxx
   itkLabelVotingImageFilterTest.cxx
   itkMultiLabelSTAPLEImageFilterTest.cxx
-  itkVotingBinaryIterativeHoleFillingImageFilterTest.cxx
-  itkBinaryMedianImageFilterTest.cxx
   itkVotingBinaryHoleFillingImageFilterTest.cxx
+  itkVotingBinaryImageFilterTest.cxx
+  itkVotingBinaryIterativeHoleFillingImageFilterTest.cxx
 )
 
 createtestdriver(ITKLabelVoting "${ITKLabelVoting-Test_LIBRARIES}" "${ITKLabelVotingTests}")

--- a/Modules/Segmentation/LevelSets/test/CMakeLists.txt
+++ b/Modules/Segmentation/LevelSets/test/CMakeLists.txt
@@ -1,34 +1,34 @@
 itk_module_test()
 set(
   ITKLevelSetsTests
-  itkThresholdSegmentationLevelSetImageFilterTest.cxx
-  itkVectorThresholdSegmentationLevelSetImageFilterTest.cxx
   itkAnisotropicFourthOrderLevelSetImageFilterTest.cxx
-  itkReinitializeLevelSetImageFilterTest.cxx
-  itkLevelSetVelocityNeighborhoodExtractorTest.cxx
-  itkIsotropicFourthOrderLevelSetImageFilterTest.cxx
-  itkGeodesicActiveContourLevelSetImageFilterTest.cxx
-  itkGeodesicActiveContourShapePriorLevelSetImageFilterTest_2.cxx
-  itkParallelSparseFieldLevelSetImageFilterTest.cxx
-  itkShapeDetectionLevelSetImageFilterTest.cxx
-  itkNarrowBandThresholdSegmentationLevelSetImageFilterTest.cxx
-  itkNarrowBandCurvesLevelSetImageFilterTest.cxx
-  itkCollidingFrontsImageFilterTest.cxx
-  itkGeodesicActiveContourShapePriorLevelSetImageFilterTest.cxx
-  itkLevelSetFunctionTest.cxx
-  itkExtensionVelocitiesImageFilterTest.cxx
+  itkBinaryMaskToNarrowBandPointSetFilterTest.cxx
   itkCannySegmentationLevelSetImageFilterTest.cxx
-  itkLevelSetNeighborhoodExtractorTest.cxx
-  itkShapePriorMAPCostFunctionTest.cxx
-  itkImplicitManifoldNormalVectorFilterTest.cxx
-  itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
-  itkLaplacianSegmentationLevelSetImageFilterTest.cxx
-  itkShapePriorSegmentationLevelSetFunctionTest.cxx
-  itkGeodesicActiveContourLevelSetImageFilterZeroSigmaTest.cxx
-  itkUnsharpMaskLevelSetImageFilterTest.cxx
+  itkCollidingFrontsImageFilterTest.cxx
   itkCurvesLevelSetImageFilterTest.cxx
   itkCurvesLevelSetImageFilterZeroSigmaTest.cxx
-  itkBinaryMaskToNarrowBandPointSetFilterTest.cxx
+  itkExtensionVelocitiesImageFilterTest.cxx
+  itkGeodesicActiveContourLevelSetImageFilterTest.cxx
+  itkGeodesicActiveContourLevelSetImageFilterZeroSigmaTest.cxx
+  itkGeodesicActiveContourShapePriorLevelSetImageFilterTest.cxx
+  itkGeodesicActiveContourShapePriorLevelSetImageFilterTest_2.cxx
+  itkImplicitManifoldNormalVectorFilterTest.cxx
+  itkIsotropicFourthOrderLevelSetImageFilterTest.cxx
+  itkLaplacianSegmentationLevelSetImageFilterTest.cxx
+  itkLevelSetFunctionTest.cxx
+  itkLevelSetNeighborhoodExtractorTest.cxx
+  itkLevelSetVelocityNeighborhoodExtractorTest.cxx
+  itkNarrowBandCurvesLevelSetImageFilterTest.cxx
+  itkNarrowBandThresholdSegmentationLevelSetImageFilterTest.cxx
+  itkParallelSparseFieldLevelSetImageFilterTest.cxx
+  itkReinitializeLevelSetImageFilterTest.cxx
+  itkShapeDetectionLevelSetImageFilterTest.cxx
+  itkShapePriorMAPCostFunctionTest.cxx
+  itkShapePriorSegmentationLevelSetFunctionTest.cxx
+  itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
+  itkThresholdSegmentationLevelSetImageFilterTest.cxx
+  itkUnsharpMaskLevelSetImageFilterTest.cxx
+  itkVectorThresholdSegmentationLevelSetImageFilterTest.cxx
 )
 
 createtestdriver(ITKLevelSets "${ITKLevelSets-Test_LIBRARIES}" "${ITKLevelSetsTests}")

--- a/Modules/Segmentation/RegionGrowing/test/CMakeLists.txt
+++ b/Modules/Segmentation/RegionGrowing/test/CMakeLists.txt
@@ -1,11 +1,11 @@
 itk_module_test()
 set(
   ITKRegionGrowingTests
-  itkNeighborhoodConnectedImageFilterTest.cxx
-  itkIsolatedConnectedImageFilterTest.cxx
   itkConfidenceConnectedImageFilterTest.cxx
-  itkVectorConfidenceConnectedImageFilterTest.cxx
   itkConnectedThresholdImageFilterTest.cxx
+  itkIsolatedConnectedImageFilterTest.cxx
+  itkNeighborhoodConnectedImageFilterTest.cxx
+  itkVectorConfidenceConnectedImageFilterTest.cxx
 )
 
 createtestdriver(ITKRegionGrowing "${ITKRegionGrowing-Test_LIBRARIES}" "${ITKRegionGrowingTests}")

--- a/Modules/Segmentation/Voronoi/test/CMakeLists.txt
+++ b/Modules/Segmentation/Voronoi/test/CMakeLists.txt
@@ -1,11 +1,11 @@
 itk_module_test()
 set(
   ITKVoronoiTests
+  itkVoronoiDiagram2DInfiniteLoopTest.cxx
+  itkVoronoiDiagram2DTest.cxx
+  itkVoronoiPartitioningImageFilterTest.cxx
   itkVoronoiSegmentationImageFilterTest.cxx
   itkVoronoiSegmentationRGBImageFilterTest.cxx
-  itkVoronoiDiagram2DTest.cxx
-  itkVoronoiDiagram2DInfiniteLoopTest.cxx
-  itkVoronoiPartitioningImageFilterTest.cxx
 )
 
 createtestdriver(ITKVoronoi "${ITKVoronoi-Test_LIBRARIES}" "${ITKVoronoiTests}")

--- a/Modules/Segmentation/Watersheds/src/CMakeLists.txt
+++ b/Modules/Segmentation/Watersheds/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(
   ITKWatersheds_SRCS
-  itkWatershedMiniPipelineProgressCommand.cxx
   itkOneWayEquivalencyTable.cxx
+  itkWatershedMiniPipelineProgressCommand.cxx
 )
 
 itk_module_add_library(ITKWatersheds ${ITKWatersheds_SRCS})

--- a/Modules/Segmentation/Watersheds/test/CMakeLists.txt
+++ b/Modules/Segmentation/Watersheds/test/CMakeLists.txt
@@ -1,12 +1,12 @@
 itk_module_test()
 set(
   ITKWatershedsTests
-  itkTobogganImageFilterTest.cxx
   itkIsolatedWatershedImageFilterTest.cxx
-  itkWatershedImageFilterTest.cxx
   itkMorphologicalWatershedFromMarkersImageFilterTest.cxx
   itkMorphologicalWatershedImageFilterTest.cxx
+  itkTobogganImageFilterTest.cxx
   itkWatershedImageFilterBadValuesTest.cxx
+  itkWatershedImageFilterTest.cxx
 )
 
 createtestdriver(ITKWatersheds "${ITKWatersheds-Test_LIBRARIES}" "${ITKWatershedsTests}")

--- a/Modules/Video/BridgeOpenCV/test/CMakeLists.txt
+++ b/Modules/Video/BridgeOpenCV/test/CMakeLists.txt
@@ -1,12 +1,12 @@
 itk_module_test()
 set(
   ITKVideoBridgeOpenCVTests
-  itkOpenCVVideoCaptureTest.cxx
+  itkOpenCVBasicTypeBridgeTest.cxx
   itkOpenCVImageBridgeGrayScaleTest.cxx
   itkOpenCVImageBridgeRGBTest.cxx
-  itkOpenCVVideoIOTest.cxx
+  itkOpenCVVideoCaptureTest.cxx
   itkOpenCVVideoIOFactoryTest.cxx
-  itkOpenCVBasicTypeBridgeTest.cxx
+  itkOpenCVVideoIOTest.cxx
 )
 
 include_directories(${ITKVideoBridgeOpenCV_INCLUDE_DIRS})

--- a/Modules/Video/Core/src/CMakeLists.txt
+++ b/Modules/Video/Core/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 set(
   ITKVideoCore_SRCS
-  itkTemporalRegion.cxx
   itkTemporalDataObject.cxx
   itkTemporalProcessObject.cxx
+  itkTemporalRegion.cxx
 )
 
 itk_module_add_library(ITKVideoCore ${ITKVideoCore_SRCS})

--- a/Modules/Video/Core/test/CMakeLists.txt
+++ b/Modules/Video/Core/test/CMakeLists.txt
@@ -3,12 +3,12 @@ set(
   ITKVideoCoreTests
   itkImageToVideoFilterTest.cxx
   itkRingBufferTest.cxx
-  itkTemporalRegionTest.cxx
   itkTemporalDataObjectTest.cxx
   itkTemporalProcessObjectTest.cxx
+  itkTemporalRegionTest.cxx
   itkVectorImageToVideoTest.cxx
-  itkVideoStreamTest.cxx
   itkVideoSourceTest.cxx
+  itkVideoStreamTest.cxx
 )
 
 createtestdriver(ITKVideoCore "${ITKVideoCore-Test_LIBRARIES}" "${ITKVideoCoreTests}")

--- a/Modules/Video/Filtering/test/CMakeLists.txt
+++ b/Modules/Video/Filtering/test/CMakeLists.txt
@@ -1,10 +1,10 @@
 itk_module_test()
 set(
   ITKVideoFilteringTests
-  itkFrameAverageVideoFilterTest.cxx
   itkDecimateFramesVideoFilterTest.cxx
-  itkImageFilterToVideoFilterWrapperTest.cxx
+  itkFrameAverageVideoFilterTest.cxx
   itkFrameDifferenceVideoFilterTest.cxx
+  itkImageFilterToVideoFilterWrapperTest.cxx
 )
 
 createtestdriver(ITKVideoFiltering "${ITKVideoFiltering-Test_LIBRARIES}" "${ITKVideoFilteringTests}")

--- a/Modules/Video/IO/test/CMakeLists.txt
+++ b/Modules/Video/IO/test/CMakeLists.txt
@@ -1,9 +1,9 @@
 itk_module_test()
 set(
   ITKVideoIOTests
-  itkVideoFileReaderWriterTest.cxx
-  itkFileListVideoIOTest.cxx
   itkFileListVideoIOFactoryTest.cxx
+  itkFileListVideoIOTest.cxx
+  itkVideoFileReaderWriterTest.cxx
 )
 
 createtestdriver(ITKVideoIO "${ITKVideoIO-Test_LIBRARIES}" "${ITKVideoIOTests}")

--- a/Utilities/Maintenance/SortCMakeSourceLists.py
+++ b/Utilities/Maintenance/SortCMakeSourceLists.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================
+"""
+SortCMakeSourceLists.py — alphabetize source-file entries in CMake set() and
+list(APPEND) commands across the ITK source tree.
+
+This is a manually runnable maintenance script, not a pre-commit hook.
+
+What it does
+------------
+Scans every CMakeLists.txt and *.cmake file under the ITK source tree
+(excluding Modules/ThirdParty) and rewrites any ``set(VAR ...)`` or
+``list(APPEND VAR ...)`` command whose argument list looks like a C/C++
+source- or header-file list, sorting the entries alphabetically so that
+future diffs and merge conflicts are easier to interpret.
+
+Detection rules
+---------------
+A command is treated as a "source file list" if either:
+
+  1. The variable name ends with one of the conventional suffixes used
+     by ITK module CMakeLists files:
+
+         _SRCS, _SOURCES, _SRC,
+         _HDR, _HDRS, _HEADERS,
+         _SOURCE_FILES, _HEADER_FILES
+
+  2. At least 80% of the *plain-text* (non-substitution) entries have
+     an extension in this set:
+
+         .cxx .cpp .cc .c .h .hxx .hpp .hh
+
+The command body must be in ITK's canonical "one token per line" layout:
+
+     set(
+       VAR_NAME
+       file1.cxx
+       file2.cxx
+       ...
+     )
+
+or the equivalent
+
+     list(
+       APPEND
+       VAR_NAME
+       file1.cxx
+       ...
+     )
+
+Any command that is on a single line, or whose body contains comments,
+blank lines, or multi-token lines, is left untouched. This is a safety
+feature: the script only rewrites commands whose structure it fully
+understands.
+
+Sort rules
+----------
+* Entries containing a CMake variable substitution ``${...}`` stay at
+  the top of the list in their original relative order. This keeps
+  generated/binary-dir paths grouped at the top.
+* Remaining (plain-filename) entries are sorted case-insensitively, with
+  a case-sensitive tiebreaker for determinism.
+* If *every* entry contains ``${...}``, the list is skipped — its order
+  is likely semantic.
+* Lists with fewer than two plain entries are skipped.
+
+Self-verification
+-----------------
+Before writing a modified file, the script verifies that the multiset of
+whitespace-separated word tokens in the file is identical before and
+after transformation. If they differ, the file is left unchanged and a
+warning is printed. This guarantees that a sort cannot accidentally add,
+drop, or rename any token (including CMake keywords, variable names, or
+file entries).
+
+Usage
+-----
+    # Sort the whole tree (in place):
+    python3 Utilities/Maintenance/SortCMakeSourceLists.py
+
+    # Preview what would change without writing:
+    python3 Utilities/Maintenance/SortCMakeSourceLists.py --dry-run
+
+    # Target a different tree root:
+    python3 Utilities/Maintenance/SortCMakeSourceLists.py /path/to/ITK
+
+Exit status
+-----------
+  0  success (with or without changes)
+  1  self-verification failure on at least one file
+  2  usage / fatal error
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+SOURCE_EXTS = (
+    ".cxx",
+    ".cpp",
+    ".cc",
+    ".c",
+    ".h",
+    ".hxx",
+    ".hpp",
+    ".hh",
+)
+VAR_NAME_SUFFIXES = (
+    "_SRCS",
+    "_SOURCES",
+    "_SRC",
+    "_HDR",
+    "_HDRS",
+    "_HEADERS",
+    "_SOURCE_FILES",
+    "_HEADER_FILES",
+)
+
+# Canonical "one token per line" body pattern. Each body line must be:
+#   <one or more spaces/tabs>
+#   <first char: not whitespace, not paren, not #>
+#   <remaining non-whitespace chars>
+#   <optional trailing spaces>
+#   <newline>
+# A comment line, blank line, or multi-token line will cause the regex to
+# fail to match the surrounding command, which is intentional.
+_BODY_LINE = r"[ \t]+[^\s()#][^\s]*[ \t]*\n"
+_BODY = rf"(?:{_BODY_LINE})+"
+
+# set(VAR_NAME
+#   entry1
+#   entry2
+#   ...
+# )
+SET_RE = re.compile(
+    rf"""
+    (set)\s*\(\s*
+    ([A-Za-z_][A-Za-z0-9_]*)\s*\n
+    ({_BODY})
+    ([ \t]*)\)
+    """,
+    re.VERBOSE,
+)
+
+# list(
+#   APPEND
+#   VAR_NAME
+#   entry1
+#   ...
+# )
+# or the equivalent with APPEND on the opening line.
+LIST_APPEND_RE = re.compile(
+    rf"""
+    (list)\s*\(\s*
+    APPEND\s+
+    ([A-Za-z_][A-Za-z0-9_]*)\s*\n
+    ({_BODY})
+    ([ \t]*)\)
+    """,
+    re.VERBOSE,
+)
+
+
+def looks_like_source(tok: str) -> bool:
+    name = tok.rsplit("/", 1)[-1]
+    return name.lower().endswith(SOURCE_EXTS)
+
+
+def is_source_list(var_name: str, args: list[str]) -> bool:
+    if any(var_name.endswith(suf) for suf in VAR_NAME_SUFFIXES):
+        return True
+    plain = [a for a in args if "${" not in a]
+    if not plain:
+        return False
+    matches = sum(1 for a in plain if looks_like_source(a))
+    return (matches / len(plain)) >= 0.8
+
+
+def compute_sorted_args(args: list[str]) -> list[str] | None:
+    """Return sorted args, or None if the list should be skipped."""
+    sub_args = [a for a in args if "${" in a]
+    plain_args = [a for a in args if "${" not in a]
+    if len(plain_args) < 2:
+        return None  # nothing meaningful to sort
+    sorted_plain = sorted(plain_args, key=lambda s: (s.lower(), s))
+    return sub_args + sorted_plain
+
+
+def _rewrite_match(match: re.Match) -> str:
+    var = match.group(2)
+    body = match.group(3)
+
+    body_lines = body.splitlines(keepends=False)
+    if not body_lines:
+        return match.group(0)
+
+    entries: list[str] = []
+    indents: list[str] = []
+    for line in body_lines:
+        stripped = line.lstrip(" \t")
+        indent = line[: len(line) - len(stripped)]
+        token = stripped.rstrip(" \t")
+        entries.append(token)
+        indents.append(indent)
+
+    if len(set(indents)) != 1:
+        return match.group(0)
+    indent = indents[0]
+
+    if len(entries) < 2:
+        return match.group(0)
+
+    if not is_source_list(var, entries):
+        return match.group(0)
+
+    sorted_entries = compute_sorted_args(entries)
+    if sorted_entries is None:
+        return match.group(0)
+    if sorted_entries == entries:
+        return match.group(0)
+
+    new_body = "".join(f"{indent}{e}\n" for e in sorted_entries)
+    original = match.group(0)
+    body_start = match.start(3) - match.start(0)
+    body_end = match.end(3) - match.start(0)
+    return original[:body_start] + new_body + original[body_end:]
+
+
+def _token_multiset(text: str) -> Counter[str]:
+    """Return a multiset of whitespace-separated tokens for self-verification."""
+    return Counter(text.split())
+
+
+def process_file(path: Path, dry_run: bool) -> tuple[bool, bool]:
+    """Return (changed, verified_ok)."""
+    original = path.read_text(encoding="utf-8")
+
+    text = SET_RE.sub(_rewrite_match, original)
+    text = LIST_APPEND_RE.sub(_rewrite_match, text)
+
+    if text == original:
+        return False, True
+
+    if _token_multiset(text) != _token_multiset(original):
+        sys.stderr.write(
+            f"WARNING: token multiset mismatch after sort; "
+            f"leaving unchanged: {path}\n"
+        )
+        return False, False
+
+    if not dry_run:
+        path.write_text(text, encoding="utf-8")
+    return True, True
+
+
+def gather_targets(root: Path) -> list[Path]:
+    excluded = (root / "Modules" / "ThirdParty").resolve()
+    targets: list[Path] = []
+    # Single walk that filters by name/suffix.  Using one rglob avoids the
+    # potential for duplicate paths if a future filesystem entry could match
+    # multiple patterns (e.g. a hypothetical "CMakeLists.cmake").
+    for p in root.rglob("*"):
+        if not p.is_file():
+            continue
+        if p.name != "CMakeLists.txt" and p.suffix != ".cmake":
+            continue
+        if ".git" in p.parts:
+            continue
+        try:
+            p.resolve().relative_to(excluded)
+            continue  # inside ThirdParty — skip
+        except ValueError:
+            pass
+        targets.append(p)
+    return sorted(targets)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Alphabetically sort source file entries in CMake "
+            "set()/list(APPEND) commands across the ITK tree."
+        ),
+    )
+    ap.add_argument(
+        "root",
+        type=Path,
+        nargs="?",
+        default=Path.cwd(),
+        help="ITK source tree root (default: current directory)",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Do not modify files; only report which files would change",
+    )
+    args = ap.parse_args()
+
+    root = args.root.resolve()
+    if not (root / "CMakeLists.txt").exists():
+        sys.stderr.write(f"ERROR: no CMakeLists.txt at {root}\n")
+        return 2
+
+    targets = gather_targets(root)
+    changed = 0
+    failed = 0
+    for p in targets:
+        did_change, ok = process_file(p, args.dry_run)
+        if not ok:
+            failed += 1
+            continue
+        if did_change:
+            changed += 1
+            rel = p.relative_to(root)
+            prefix = "[DRY] " if args.dry_run else ""
+            print(f"{prefix}sorted: {rel}")
+
+    action = "would change" if args.dry_run else "changed"
+    print(f"\nTotal files {action}: {changed}")
+    if failed:
+        sys.stderr.write(f"Self-verification failures: {failed}\n")
+        return 1
+    if args.dry_run and changed:
+        # Non-zero exit lets CI gate on drift without actually rewriting files.
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Alphabetize source-file entries in every CMake `set()` and `list(APPEND)`
command across the ITK tree that holds a list of C/C++ source or header files,
**excluding `Modules/ThirdParty`**. The reordering is purely mechanical — no
files are added, removed, or renamed, and the multiset of whitespace-separated
tokens in each modified file is provably identical before and after the sort.

96 CMakeLists.txt files are modified (791 insertions / 791 deletions — a pure
reorder). Plus one new maintenance script:
`Utilities/Maintenance/SortCMakeSourceLists.py`, a manually runnable helper
(not a pre-commit hook) that can be re-run in the future to keep things tidy.

## Why — rationale for reviewers

Sorting source-file lists is one of the highest-leverage "no-op" changes a
large build system can adopt. It measurably improves every downstream diff,
review, and merge without changing any runtime behavior:

1. **Predictable insertion point for new files.** Today, when a contributor
   adds a new source file, there is no "right" place to put it — the list is
   unsorted, so people append to the end, insert near a visually similar
   filename, or drop it wherever the diff happens to put it. In a sorted
   list, there is exactly one correct line for the insertion, and it is
   obvious to both the author and the reviewer.

2. **Merge conflicts almost disappear.** Two branches that each add a file
   to the same list currently produce a textual conflict whenever both append
   to the end. In a sorted list, the two new entries land in different
   alphabetical regions unless their filenames sort adjacently — meaning the
   vast majority of "two branches added files" cases become conflict-free.

3. **When conflicts *do* occur, resolution is mechanical.** "Take both sides
   and re-sort" is a one-line operation with this PR's helper script. There's
   no longer any judgment call about which order is "correct".

4. **Duplicate and missing entries become visible.** A duplicate in an
   unsorted list can hide for years; in an alphabetized list a reviewer spots
   it immediately because the two copies sit on adjacent lines.

5. **Diffs shrink.** Adding a single source file to an unsorted 90-entry list
   today sometimes produces a multi-line diff (because of trailing-comma
   or whitespace drift); in a sorted list it produces *exactly* one added
   line. Reviewers can instantly distinguish "file added" from "file moved"
   from "file removed" at a glance.

6. **Tooling already emits sorted lists.** Most IDEs and codegen tools that
   auto-register build sources already produce sorted output. The repository
   state now matches what those tools produce, eliminating a class of manual
   resorting churn.

## Sort rules (applied by `SortCMakeSourceLists.py`)

* A command is treated as a "source file list" if either (i) the variable
  name ends with one of the conventional ITK suffixes (`_SRCS`, `_SOURCES`,
  `_SRC`, `_HDR`, `_HDRS`, `_HEADERS`, `_SOURCE_FILES`, `_HEADER_FILES`), or
  (ii) at least 80% of the plain-text entries have a C/C++ source/header
  extension (`.cxx .cpp .cc .c .h .hxx .hpp .hh`).
* CMake variable substitutions of the form `${VAR}/file.cxx` are preserved
  in their original relative order at the **top** of each list; plain
  filenames are sorted case-insensitively below them. Lists whose entries
  are *all* substitutions are skipped entirely (their order is likely
  semantic).
* Only the canonical "one token per line" ITK layout is touched. Any
  command whose body contains comments, blank lines, or multi-token lines
  is left strictly alone — the sorter only rewrites structures it fully
  understands.
* Before writing any file, the sorter verifies that the multiset of
  whitespace-separated tokens is identical before and after the
  transformation. Any mismatch aborts the write. This is a hard
  correctness gate, independent of the regex patterns.

## Verification

- [x] Script is idempotent — re-running produces zero further changes.
- [x] `cmake -S . -B <scratch> -G Ninja -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF`
      configures cleanly against the modified tree (71 s).
- [x] Full `ninja -j10` build completes successfully — 2301/2301 targets
      linked with zero errors or warnings introduced by this PR.
- [x] Every pre-commit hook in `.pre-commit-config.yaml` passes on the
      modified files (gersemi reports zero additional reformatting needed,
      black is clean, all hygiene checks pass). `pyupgrade` is known-broken
      on Python 3.14 with an upstream `tokenize.cookie_re` TypeError crash
      that is unrelated to this PR; the script already uses py310+ idioms.
- [x] Diff is symmetric: 791 insertions, 791 deletions across 96
      CMakeLists.txt files — a pure reorder.
- [x] Zero files under `Modules/ThirdParty` are touched.

## Running the script in the future

```bash
# Sort the whole tree in place:
python3 Utilities/Maintenance/SortCMakeSourceLists.py

# Preview without writing:
python3 Utilities/Maintenance/SortCMakeSourceLists.py --dry-run
```

## Test plan

- [x] CI passes on all platforms
- [x] Spot-check `Modules/Core/Common/src/CMakeLists.txt` ordering
- [x] Confirm no `Modules/ThirdParty` files appear in the diff
- [x] `python3 Utilities/Maintenance/SortCMakeSourceLists.py --dry-run`
      reports 0 files would change after merge