### PR TITLE
BUG: Detect non-positive-definite covariance in GaussianMembershipFunction

### DIFF
--- a/Modules/Numerics/Statistics/include/itkGaussianMembershipFunction.hxx
+++ b/Modules/Numerics/Statistics/include/itkGaussianMembershipFunction.hxx
@@ -18,6 +18,8 @@
 #ifndef itkGaussianMembershipFunction_hxx
 #define itkGaussianMembershipFunction_hxx
 
+#include "vnl/algo/vnl_determinant.h"
+
 namespace itk::Statistics
 {
 template <typename TMeasurementVector>
@@ -99,18 +101,28 @@ GaussianMembershipFunction<TMeasurementVector>::SetCovariance(const CovarianceMa
     return;
   }
 
-  m_Covariance = cov;
-
   // the inverse of the covariance matrix is first computed by SVD
-  const vnl_matrix_inverse<double> inv_cov(m_Covariance.GetVnlMatrix());
+  const vnl_matrix_inverse<double> inv_cov(cov.GetVnlMatrix());
 
-  // the determinant is then costless this way
-  const double det = inv_cov.determinant_magnitude();
+  // Compute the *signed* determinant of the covariance matrix.
+  // vnl_matrix_inverse::determinant_magnitude() (which used to be used
+  // here) returns the product of singular values and is always
+  // non-negative, so it cannot detect a non-positive-definite matrix.
+  // Use vnl_determinant on the original covariance instead; this is
+  // O(n^3) but n is the measurement-vector dimension (typically very
+  // small) so the cost is negligible compared to the SVD already
+  // computed for the inverse.
+  const double det = vnl_determinant(cov.GetVnlMatrix());
 
-  if (det < 0.)
+  if (det <= 0.0)
   {
-    itkExceptionStringMacro("det( m_Covariance ) < 0");
+    itkExceptionMacro("Covariance matrix must be positive definite (det = " << det << ").");
   }
+
+  // Assign only after validation passes so the object is never left in
+  // an inconsistent state (m_Covariance updated but m_InverseCovariance
+  // and m_PreFactor still reflecting the previous matrix).
+  m_Covariance = cov;
 
   // 1e-6 is an arbitrary value!!!
   constexpr double singularThreshold{ 1.0e-6 };

--- a/Modules/Numerics/Statistics/test/itkGaussianMembershipFunctionTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkGaussianMembershipFunctionTest.cxx
@@ -89,6 +89,46 @@ itkGaussianMembershipFunctionTest(int, char *[])
     return EXIT_FAILURE;
   }
 
+  // -----------------------------------------------------------------
+  // Reject non-positive-definite covariance matrices.
+  //
+  // The previous implementation tested `inv_cov.determinant_magnitude()
+  // < 0` which can never trigger because determinant_magnitude() returns
+  // the product of singular values (always non-negative).  The fix uses
+  // vnl_determinant on the original covariance and rejects det <= 0,
+  // which catches both singular and non-positive-definite cases.
+  // -----------------------------------------------------------------
+  using NPDMVType = itk::FixedArray<float, 2>;
+  using NPDMembershipFunctionType = itk::Statistics::GaussianMembershipFunction<NPDMVType>;
+  auto npdFunction = NPDMembershipFunctionType::New();
+  npdFunction->SetMeasurementVectorSize(2);
+
+  // Singular: rank 1, det = 0
+  NPDMembershipFunctionType::CovarianceMatrixType singular;
+  singular.SetSize(2, 2);
+  singular(0, 0) = 1.0;
+  singular(0, 1) = 1.0;
+  singular(1, 0) = 1.0;
+  singular(1, 1) = 1.0;
+  ITK_TRY_EXPECT_EXCEPTION(npdFunction->SetCovariance(singular));
+
+  // Indefinite (not symmetric positive-definite): det = -3
+  NPDMembershipFunctionType::CovarianceMatrixType nonPosDef;
+  nonPosDef.SetSize(2, 2);
+  nonPosDef(0, 0) = 1.0;
+  nonPosDef(0, 1) = 2.0;
+  nonPosDef(1, 0) = 2.0;
+  nonPosDef(1, 1) = 1.0;
+  ITK_TRY_EXPECT_EXCEPTION(npdFunction->SetCovariance(nonPosDef));
+
+  // Well-formed: det = 3.75 (positive definite)
+  NPDMembershipFunctionType::CovarianceMatrixType posDef;
+  posDef.SetSize(2, 2);
+  posDef(0, 0) = 2.0;
+  posDef(0, 1) = 0.5;
+  posDef(1, 0) = 0.5;
+  posDef(1, 1) = 2.0;
+  ITK_TRY_EXPECT_NO_EXCEPTION(npdFunction->SetCovariance(posDef));
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;


### PR DESCRIPTION
## Summary

Fixes #3589.

`GaussianMembershipFunction::SetCovariance()` previously checked

```cpp
const vnl_matrix_inverse<double> inv_cov(m_Covariance.GetVnlMatrix());
const double det = inv_cov.determinant_magnitude();
if (det < 0.) { itkExceptionStringMacro(\"det( m_Covariance ) < 0\"); }
```

`vnl_matrix_inverse::determinant_magnitude()` returns the product of singular values, which is **always non-negative**, so the `det < 0.` check is unreachable dead code. A singular or negative-definite covariance matrix would silently slip through and propagate NaNs into the multivariate Gaussian normalization constant downstream (`m_PreFactor = 1.0 / (std::sqrt(det) * ...)`).

This PR replaces the check with `vnl_determinant()` on the *original* (non-inverted) covariance and rejects `det <= 0`, which catches both singular (`det == 0`) and non-positive-definite (`det < 0`) cases. The cost is `O(n^3)` but `n` is the measurement-vector dimension (typically 1..16), negligible compared to the SVD already computed for the inverse on the next line.

## Diff

```diff
+#include \"vnl/algo/vnl_determinant.h\"
 ...
-  // the determinant is then costless this way
-  const double det = inv_cov.determinant_magnitude();
-
-  if (det < 0.)
-  {
-    itkExceptionStringMacro(\"det( m_Covariance ) < 0\");
-  }
+  // Compute the *signed* determinant of the covariance matrix.  See
+  // commit message for the rationale (determinant_magnitude is the
+  // product of singular values and is never negative).
+  const double det = vnl_determinant(m_Covariance.GetVnlMatrix());
+
+  if (det <= 0.0)
+  {
+    itkExceptionMacro(\"Covariance matrix must be positive definite (det = \" << det << \").\");
+  }
```

## Tests

Three new regression cases added to `itkGaussianMembershipFunctionTest.cxx`:

1. **Singular covariance** `[[1,1],[1,1]]` (det = 0) — must throw.
2. **Negative-definite (indefinite) covariance** `[[1,2],[2,1]]` (det = −3) — must throw.
3. **Well-formed covariance** `[[2,0.5],[0.5,2]]` (det = 3.75, symmetric positive-definite) — must succeed.

## AI Assistance

Generated by [Claude Code](https://claude.com/claude-code) as part of the 2026-04-10 open-issue triage cleanup.

## Test plan

- [x] Local build (`ITKStatisticsTestDriver`) compiles cleanly
- [x] `itkGaussianMembershipFunctionTest` passes locally with the new singular / negative-definite / positive-definite assertions
- [x] `pre-commit run` clean (clang-format, kw-pre-commit)
- [ ] CI: Linux, Windows, macOS, Python, ARM