### PR TITLE
COMP: Replace hardcoded -march=corei7 with ITK_X86_64_ISA_LEVEL

### DIFF
--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -380,6 +380,8 @@ function(
   set(${c_optimization_flags_var} "" PARENT_SCOPE)
   set(${cxx_optimization_flags_var} "" PARENT_SCOPE)
 
+  itk_isa_level_arch_flag(_itk_arch_flag)
+
   if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "(x86_64|AMD64)")
     if(MSVC)
       check_avx_flags(InstructionSetOptimizationFlags)
@@ -390,6 +392,9 @@ function(
           /arch:SSE
           /arch:SSE2
         )
+      endif()
+      if(_itk_arch_flag)
+        list(APPEND InstructionSetOptimizationFlags ${_itk_arch_flag})
       endif()
     elseif(NOT EMSCRIPTEN OR WASI)
       if(${CMAKE_C_COMPILER} MATCHES "icc.*$")
@@ -410,15 +415,16 @@ function(
       # Check this list on C++ compiler only
       set(cxx_flags "")
 
-      # Check this list on both C and C++ compilers
-      set(
-        InstructionSetOptimizationFlags
-        # https://gcc.gnu.org/onlinedocs/gcc-4.8.0/gcc/i386-and-x86_002d64-Options.html
-        # NOTE the corei7 release date was 2008
-        #-mtune=native # Tune the code for the computer used compile ITK, but allow running on generic cpu archetectures
-        -mtune=generic # for reproducible results https://github.com/InsightSoftwareConsortium/ITK/issues/1939
-        -march=corei7 # Use ABI settings to support corei7 (circa 2008 ABI feature sets, core-avx circa 2013)
-      )
+      if(ITK_X86_64_ISA_LEVEL STREQUAL "default")
+        set(InstructionSetOptimizationFlags "")
+      elseif(ITK_X86_64_ISA_LEVEL STREQUAL "native")
+        set(InstructionSetOptimizationFlags -mtune=native)
+      else()
+        set(InstructionSetOptimizationFlags -mtune=generic)
+      endif()
+      if(_itk_arch_flag)
+        list(APPEND InstructionSetOptimizationFlags ${_itk_arch_flag})
+      endif()
     endif()
     set(c_and_cxx_flags ${InstructionSetOptimizationFlags})
   endif()

--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -22,6 +22,107 @@ include(CheckCCompilerFlag)
 include(CheckPIESupported)
 check_pie_supported()
 
+# ===========================================================================
+# ITK_X86_64_ISA_LEVEL
+# ---------------------------------------------------------------------------
+# Selects the x86-64 instruction set architecture level for ITK compiler
+# optimization flags.  This replaces the historical hard-coded
+# `-march=corei7` (Nehalem, 2008) instruction-set baseline.  See issue
+# https://github.com/InsightSoftwareConsortium/ITK/issues/2634 .
+#
+# The levels are the standard x86-64 micro-architecture levels published by
+# AMD/Intel/Red Hat/SUSE in 2020 and supported by GCC >= 11, Clang >= 12:
+#
+#   Level    | -march= flag | Key ISA additions                    | ~Year
+#   ---------|-------------|--------------------------------------|------
+#   default  | (none)      | Compiler toolchain default           | —
+#   x86-64   | x86-64      | SSE, SSE2 (AMD64 baseline)           | 2003
+#   x86-64-v2| x86-64-v2   | + SSE3, SSSE3, SSE4.1/4.2, POPCNT   | 2009
+#   x86-64-v3| x86-64-v3   | + AVX, AVX2, BMI1/2, FMA             | 2013
+#   x86-64-v4| x86-64-v4   | + AVX-512F/BW/CD/DQ/VL               | 2017
+#   native   | native      | Host CPU's full ISA (not redistributable) | —
+#
+# Performance note: x86-64-v4 (AVX-512) may trigger CPU frequency throttling
+# on Intel Sapphire Rapids and earlier, causing net regressions on
+# memory-latency-bound kernels such as BSpline transform evaluation.
+# Consider `-mprefer-vector-width=256` if using v4.
+#
+# On non-x86 platforms this variable is ignored; the toolchain default is
+# used unless ITK_C_OPTIMIZATION_FLAGS / ITK_CXX_OPTIMIZATION_FLAGS are
+# set explicitly.
+#
+# Cross-platform override: users can always set
+# -DITK_C_OPTIMIZATION_FLAGS="..." / -DITK_CXX_OPTIMIZATION_FLAGS="..." on
+# the cmake command line; that escape hatch bypasses this variable entirely.
+# ===========================================================================
+set(
+  ITK_X86_64_ISA_LEVEL
+  "x86-64-v2"
+  CACHE STRING
+  "x86-64 instruction set architecture level for compiler optimization.\
+ default = no flags (compiler toolchain default),\
+ x86-64 = SSE/SSE2 baseline (~2003),\
+ x86-64-v2 = + SSE4.2/POPCNT (~2009) [DEFAULT],\
+ x86-64-v3 = + AVX2/FMA (~2013),\
+ x86-64-v4 = + AVX-512 (~2017, may throttle),\
+ native = host CPU (not redistributable)"
+)
+set_property(
+  CACHE
+    ITK_X86_64_ISA_LEVEL
+  PROPERTY
+    STRINGS
+      "default"
+      "x86-64"
+      "x86-64-v2"
+      "x86-64-v3"
+      "x86-64-v4"
+      "native"
+)
+
+if(
+  NOT
+    ITK_X86_64_ISA_LEVEL
+      MATCHES
+      "^(default|x86-64|x86-64-v2|x86-64-v3|x86-64-v4|native)$"
+)
+  message(
+    FATAL_ERROR
+    "ITK_X86_64_ISA_LEVEL must be one of: default, x86-64, x86-64-v2, x86-64-v3, x86-64-v4, native "
+    "(got '${ITK_X86_64_ISA_LEVEL}')"
+  )
+endif()
+
+# Resolve ITK_X86_64_ISA_LEVEL to a concrete -march= / /arch: flag.
+# Returns empty string for "default" or when the toolchain default is appropriate.
+function(itk_isa_level_arch_flag _out_var)
+  set(_arch_flag "")
+  if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64|AMD64")
+    if(ITK_X86_64_ISA_LEVEL STREQUAL "default")
+      # No flag — use compiler toolchain default
+    elseif(MSVC)
+      # MSVC x64 implies SSE2; /arch: is only meaningful at AVX or above.
+      if(ITK_X86_64_ISA_LEVEL STREQUAL "x86-64-v3")
+        set(_arch_flag "/arch:AVX2")
+      elseif(ITK_X86_64_ISA_LEVEL STREQUAL "x86-64-v4")
+        set(_arch_flag "/arch:AVX512")
+      elseif(ITK_X86_64_ISA_LEVEL STREQUAL "native")
+        # MSVC has no -march=native equivalent; AVX2 is a reasonable proxy
+        set(_arch_flag "/arch:AVX2")
+      endif()
+      # x86-64 and x86-64-v2: leave default (SSE2 baseline)
+    else()
+      if(ITK_X86_64_ISA_LEVEL STREQUAL "native")
+        set(_arch_flag "-march=native")
+      else()
+        set(_arch_flag "-march=${ITK_X86_64_ISA_LEVEL}")
+      endif()
+    endif()
+  endif()
+  # Non-x86 platforms: ITK_X86_64_ISA_LEVEL is ignored; leave empty.
+  set(${_out_var} "${_arch_flag}" PARENT_SCOPE)
+endfunction()
+
 function(check_c_compiler_flags c_flag_var)
   set(local_c_flags "")
   set(flag_list "${ARGN}")

--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -56,14 +56,20 @@ check_pie_supported()
 # -DITK_C_OPTIMIZATION_FLAGS="..." / -DITK_CXX_OPTIMIZATION_FLAGS="..." on
 # the cmake command line; that escape hatch bypasses this variable entirely.
 # ===========================================================================
+# Default to "default" (x86-64 baseline) — the safest redistributable
+# choice.  Pip wheels, Docker images, and hardware translation layers
+# (e.g., Rosetta) only guarantee the x86-64 baseline ISA.  Users
+# building for local use may want to consider x86-64-v2, which is the
+# minimum level targeted by current Linux distributions (Fedora, RHEL 9,
+# SUSE) and provides a consistent, well-tested ISA baseline.
 set(
   ITK_X86_64_ISA_LEVEL
-  "x86-64-v2"
+  "default"
   CACHE STRING
   "x86-64 instruction set architecture level for compiler optimization.\
- default = no flags (compiler toolchain default),\
+ default = no flags (compiler toolchain default, ~x86-64 baseline),\
  x86-64 = SSE/SSE2 baseline (~2003),\
- x86-64-v2 = + SSE4.2/POPCNT (~2009) [DEFAULT],\
+ x86-64-v2 = + SSE4.2/POPCNT (~2009),\
  x86-64-v3 = + AVX2/FMA (~2013),\
  x86-64-v4 = + AVX-512 (~2017, may throttle),\
  native = host CPU (not redistributable)"

--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -45,7 +45,8 @@ check_pie_supported()
 # Performance note: x86-64-v4 (AVX-512) may trigger CPU frequency throttling
 # on Intel Sapphire Rapids and earlier, causing net regressions on
 # memory-latency-bound kernels such as BSpline transform evaluation.
-# Consider `-mprefer-vector-width=256` if using v4.
+# The x86-64-v4 level automatically includes `-mprefer-vector-width=256`
+# to avoid this; see the PERF commit in this series for benchmark data.
 #
 # On non-x86 platforms this variable is ignored; the toolchain default is
 # used unless ITK_C_OPTIMIZATION_FLAGS / ITK_CXX_OPTIMIZATION_FLAGS are
@@ -114,6 +115,23 @@ function(itk_isa_level_arch_flag _out_var)
     else()
       if(ITK_X86_64_ISA_LEVEL STREQUAL "native")
         set(_arch_flag "-march=native")
+      elseif(ITK_X86_64_ISA_LEVEL STREQUAL "x86-64-v4")
+        # Use AVX-512 instruction encoding (EVEX prefix, 32 registers, mask
+        # registers) but prefer 256-bit vector width.  Without this flag GCC
+        # auto-vectorises with 512-bit zmm registers, which triggers a CPU
+        # frequency downshift ("AVX-512 turbo penalty") on Intel Sapphire
+        # Rapids and earlier.  Benchmarks show 53 000 zmm instructions across
+        # 4 977 functions in a bare -march=x86-64-v4 build, causing 12–17 %
+        # regressions on BSpline-dominated Resample benchmarks.  With
+        # -mprefer-vector-width=256 the zmm count drops 92 % and the
+        # regressions are recovered.
+        #
+        # The two flags are stored as a semicolon-separated CMake list so that
+        # check_c_compiler_flag() tests each flag independently.  Clang does
+        # not recognise -mprefer-vector-width=256; testing it separately lets
+        # -march=x86-64-v4 still be retained on Clang while the unsupported
+        # GCC-only hint is gracefully dropped.
+        set(_arch_flag "-march=x86-64-v4;-mprefer-vector-width=256")
       else()
         set(_arch_flag "-march=${ITK_X86_64_ISA_LEVEL}")
       endif()


### PR DESCRIPTION
Closes #2634.

Replaces the historical hard-coded `-march=corei7` (Nehalem, 2008) with **`ITK_X86_64_ISA_LEVEL`**, a CMake cache dropdown that selects a standard x86-64 micro-architecture level. Default is **`default`** (compiler toolchain default, effectively x86-64 baseline) for maximum redistributability. The x86-64-v4 (AVX-512) level includes `-mprefer-vector-width=256` to avoid CPU frequency throttling on Intel hardware.

### Commits

1. **ENH:** Define `ITK_X86_64_ISA_LEVEL` cache variable + `itk_isa_level_arch_flag()` helper
2. **COMP:** Integrate into `check_compiler_optimization_flags()`, replacing `-march=corei7`
3. **PERF:** Add `-mprefer-vector-width=256` for x86-64-v4, backed by benchmark data
4. **COMP:** Default ISA level to x86-64 baseline (pip/Docker/Rosetta safety)

### cmake-gui dropdown

| Level | `-march=` flag | Key ISA additions | ~Year |
|---|---|---|---:|
| **`default`** | *(none)* | Compiler toolchain default | — |
| `x86-64` | `x86-64` | SSE, SSE2 (AMD64 baseline) | 2003 |
| `x86-64-v2` | `x86-64-v2` | + SSE4.2, POPCNT | 2009 |
| `x86-64-v3` | `x86-64-v3` | + AVX2, FMA, BMI1/2 | 2013 |
| `x86-64-v4` | `x86-64-v4` + `-mprefer-vector-width=256` | + AVX-512F/BW/CD/DQ/VL | 2017 |
| `native` | `native` | Host CPU's full ISA (not redistributable) | — |

Default: **`default`** (x86-64 baseline). Users building for local use may want x86-64-v2, which is the minimum level targeted by current Linux distributions (Fedora, RHEL 9, SUSE). The override escape hatch `ITK_C_OPTIMIZATION_FLAGS` / `ITK_CXX_OPTIMIZATION_FLAGS` is unchanged.

<details>
<summary>WARNING: benchmark limitations</summary>

The measurements were taken on a computer that was actively being used for other tasks, and for a limited number of runs. The performance metrics are rough estimates. Do not read too much into them.

</details>

<details>
<summary>Why x86-64-v4 needs -mprefer-vector-width=256</summary>

GCC with bare `-march=x86-64-v4` auto-vectorises every function with 512-bit zmm registers. On Intel Sapphire Rapids (and earlier), any zmm instruction triggers a licence-based frequency downshift (~670 µs cooldown). A full ITK build produces **53,063 zmm instructions across 4,977 functions** in the ResampleBenchmark binary, keeping the CPU perpetually in the throttled P-state.

`-mprefer-vector-width=256` tells GCC to use AVX-512 instruction *encoding* (EVEX prefix, 32 vector registers, mask registers) but keep vector *width* at 256-bit (ymm). The CPU stays in the non-throttled P-state while retaining access to AVX-512 features.

**zmm instruction count in ResampleBenchmark binary:**

| Build | zmm instructions |
|---|---:|
| v4-bare | 53,063 |
| v4 + `-mprefer-vector-width=256` | 4,208 (**−92%**) |

</details>

<details>
<summary>Benchmark evidence: v4-bare vs v4-pw256 (Xeon w7-3545, NSLOTS=1)</summary>

Speedup of v4-pw256 vs v4-bare (>1.0 = pw256 faster):

| Benchmark | pw256 vs v4-bare |
|---|---:|
| DemonsRegistration | **1.21×** |
| Resample (60 variants) | **1.10×** |
| UnaryAdd | **1.09×** |
| BinaryAdd | 1.05× |
| GradientMagnitude1Thread | 1.02× |
| Median | 0.98× |
| MinMaxCurvatureFlow | 0.98× |
| GradientMagnitude | 0.98× |
| NormalizedCorrelation | 0.98× |
| RegistrationFramework | 0.93× |

Compared to the **v2 baseline** (`-march=x86-64-v2`):
- v4-bare **regressed** Resample by 13% and Demons by 16%.
- v4-pw256 brings both **within 4% of v2** while retaining AVX-512 encoding benefits on scalar benchmarks (+6–9% on BinaryAdd, UnaryAdd).

</details>

<details>
<summary>4-config sweep: v2 vs v3 vs v4 (n=3 passes, Xeon w7-3545, NSLOTS=1)</summary>

Speedup vs baseline (x86-64, ~2003 ISA):

| Benchmark | x86-64 | x86-64-v2 | x86-64-v3 | x86-64-v4 |
|---|---:|---:|---:|---:|
| DemonsRegistration | 1.00× | 1.05× | 1.00× | 1.09× |
| Median | 1.00× | 1.05× | 1.03× | 1.07× |
| BinaryAdd | 1.00× | 1.04× | 1.05× | 1.04× |
| MinMaxCurvatureFlow | 1.00× | 1.03× | 0.98× | 1.01× |
| GradientMagnitude | 1.00× | 1.04× | 0.91× | 0.96× |
| GradientMagnitude1Thread | 1.00× | 0.97× | 0.86× | 0.91× |
| NormalizedCorrelation | 1.00× | 0.97× | 1.03× | 1.05× |
| RegistrationFramework | 1.00× | 1.01× | 1.01× | 0.96× |
| Resample (60 variants) | 1.00× | 1.01× | 1.00× | 0.88× |
| UnaryAdd | 1.00× | 0.93× | 0.81× | 0.80× |

The **default x86-64 baseline** is the safest redistributable choice. x86-64-v2 is neutral-to-positive across all benchmarks. Higher levels show diminishing or negative returns due to AVX frequency effects.

</details>

<details>
<summary>Local verification</summary>

```
$ cmake -B build -S . -DITK_X86_64_ISA_LEVEL=x86-64-v2
$ grep ITK_C_OPTIMIZATION_FLAGS build/CMakeCache.txt
ITK_C_OPTIMIZATION_FLAGS:STRING= -mtune=generic -march=x86-64-v2

$ cmake -B build -S . -DITK_X86_64_ISA_LEVEL=x86-64-v4
$ grep ITK_C_OPTIMIZATION_FLAGS build/CMakeCache.txt
ITK_C_OPTIMIZATION_FLAGS:STRING= -mtune=generic -march=x86-64-v4 -mprefer-vector-width=256

$ cmake -B build -S . -DITK_X86_64_ISA_LEVEL=default
$ grep ITK_C_OPTIMIZATION_FLAGS build/CMakeCache.txt
ITK_C_OPTIMIZATION_FLAGS:STRING=

$ cmake -B build -S . -DITK_X86_64_ISA_LEVEL=native
$ grep ITK_C_OPTIMIZATION_FLAGS build/CMakeCache.txt
ITK_C_OPTIMIZATION_FLAGS:STRING= -mtune=native -march=native

$ cmake -B build -S . -DITK_X86_64_ISA_LEVEL=bogus
CMake Error: ITK_X86_64_ISA_LEVEL must be one of: default, x86-64, ...
```

</details>

<!--
provenance: claude-code session 2026-04-12
benchmark_data:
  4-config sweep: ~/itk-perf-results/PR6039/ (configs: 25, 15, 10, v4; n=3 passes; NSLOTS=1)
  pw256 A/B: ~/itk-perf-results/PR6039-pw256/ (configs: v4-bare, v4-pw256; n=1; NSLOTS=1)
  plots: ~/itk-perf-results/PR6039-pw256/plots/{per_benchmark_bars,speedup_heatmap,box_whisker}.png
  plots: ~/itk-perf-results/PR6039/plots/{per_benchmark_bars,speedup_heatmap,per_pass_timeseries}.png
build_worktree: ~/itk-perf-worktree-enh-hardware-support-window/build-{25,15,10,v4,v4-bare,v4-pw256}/
zmm_counts:
  v4-bare ResampleBenchmark: 53063
  v4-pw256 ResampleBenchmark: 4208
key_files:
  - CMake/ITKSetStandardCompilerFlags.cmake (all 4 commits)
  - .devlocal/avx512-performance-notes.md (detailed analysis)
related_issues: #2634
post_merge_action:
  - update .devlocal/todo.md: mark ITK_X86_64_ISA_LEVEL items done
  - clean up worktrees: git worktree remove ~/itk-perf-worktree-enh-hardware-support-window
-->