### PR TITLE
COMP: Move inline = default destructors to .cxx for 30 exported classes

### DIFF
--- a/Modules/Core/Common/include/itkEquivalencyTable.h
+++ b/Modules/Core/Common/include/itkEquivalencyTable.h
@@ -175,7 +175,7 @@ public:
 
 protected:
   EquivalencyTable() = default;
-  ~EquivalencyTable() override = default;
+  ~EquivalencyTable() override;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Core/Common/include/itkLoggerManager.h
+++ b/Modules/Core/Common/include/itkLoggerManager.h
@@ -101,7 +101,7 @@ protected:
   LoggerManager() = default;
 
   /** Destructor */
-  ~LoggerManager() override = default;
+  ~LoggerManager() override;
 
   /** Print contents of a LoggerManager */
   void

--- a/Modules/Core/Common/include/itkLoggerOutput.h
+++ b/Modules/Core/Common/include/itkLoggerOutput.h
@@ -103,7 +103,7 @@ public:
 
 protected:
   LoggerOutput() = default;
-  ~LoggerOutput() override = default;
+  ~LoggerOutput() override;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Core/Common/src/itkEquivalencyTable.cxx
+++ b/Modules/Core/Common/src/itkEquivalencyTable.cxx
@@ -19,6 +19,8 @@
 
 namespace itk
 {
+EquivalencyTable::~EquivalencyTable() = default;
+
 bool
 EquivalencyTable::Add(unsigned long a, unsigned long b)
 {

--- a/Modules/Core/Common/src/itkLoggerManager.cxx
+++ b/Modules/Core/Common/src/itkLoggerManager.cxx
@@ -19,6 +19,8 @@
 
 namespace itk
 {
+LoggerManager::~LoggerManager() = default;
+
 /** create a logger and add it into LoggerManager */
 LoggerManager::LoggerPointer
 LoggerManager::CreateLogger(const NameType & name, PriorityLevelEnum level, PriorityLevelEnum levelForFlushing)

--- a/Modules/Core/Common/src/itkLoggerOutput.cxx
+++ b/Modules/Core/Common/src/itkLoggerOutput.cxx
@@ -29,6 +29,8 @@
 
 namespace itk
 {
+LoggerOutput::~LoggerOutput() = default;
+
 /** Send a string to display. */
 void
 LoggerOutput::DisplayText(const char * t)

--- a/Modules/IO/ImageBase/include/itkArchetypeSeriesFileNames.h
+++ b/Modules/IO/ImageBase/include/itkArchetypeSeriesFileNames.h
@@ -108,7 +108,7 @@ public:
 
 protected:
   ArchetypeSeriesFileNames();
-  ~ArchetypeSeriesFileNames() override = default;
+  ~ArchetypeSeriesFileNames() override;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/IO/ImageBase/include/itkNumericSeriesFileNames.h
+++ b/Modules/IO/ImageBase/include/itkNumericSeriesFileNames.h
@@ -98,7 +98,7 @@ public:
 
 protected:
   NumericSeriesFileNames();
-  ~NumericSeriesFileNames() override = default;
+  ~NumericSeriesFileNames() override;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/IO/ImageBase/include/itkRegularExpressionSeriesFileNames.h
+++ b/Modules/IO/ImageBase/include/itkRegularExpressionSeriesFileNames.h
@@ -115,7 +115,7 @@ protected:
     : m_Directory(".")
     , m_RegularExpression(".*\\.([0-9]+)")
   {}
-  ~RegularExpressionSeriesFileNames() override = default;
+  ~RegularExpressionSeriesFileNames() override;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/IO/ImageBase/src/itkArchetypeSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkArchetypeSeriesFileNames.cxx
@@ -23,6 +23,8 @@
 
 namespace itk
 {
+ArchetypeSeriesFileNames::~ArchetypeSeriesFileNames() = default;
+
 ArchetypeSeriesFileNames::ArchetypeSeriesFileNames()
   : m_Archetype("")
 {}

--- a/Modules/IO/ImageBase/src/itkNumericSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkNumericSeriesFileNames.cxx
@@ -22,6 +22,8 @@
 
 namespace itk
 {
+NumericSeriesFileNames::~NumericSeriesFileNames() = default;
+
 NumericSeriesFileNames::NumericSeriesFileNames()
   : m_SeriesFormat("%d")
 {}

--- a/Modules/IO/ImageBase/src/itkRegularExpressionSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkRegularExpressionSeriesFileNames.cxx
@@ -43,6 +43,8 @@ struct lt_pair_alphabetic_string_string
 
 namespace itk
 {
+RegularExpressionSeriesFileNames::~RegularExpressionSeriesFileNames() = default;
+
 const std::vector<std::string> &
 RegularExpressionSeriesFileNames::GetFileNames()
 {

--- a/Modules/Numerics/FEM/include/itkFEMLightObject.h
+++ b/Modules/Numerics/FEM/include/itkFEMLightObject.h
@@ -77,7 +77,7 @@ protected:
   /**
    * Virtual destructor
    */
-  ~FEMLightObject() override = default;
+  ~FEMLightObject() override;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Numerics/FEM/src/itkFEMLightObject.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLightObject.cxx
@@ -22,6 +22,8 @@ namespace itk
 {
 namespace fem
 {
+FEMLightObject::~FEMLightObject() = default;
+
 /**
  * Here we just read the global number from the stream.
  * This should be the first function called when reading object data.

--- a/Modules/Numerics/Optimizers/include/itkExhaustiveOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkExhaustiveOptimizer.h
@@ -136,7 +136,7 @@ public:
 
 protected:
   ExhaustiveOptimizer();
-  ~ExhaustiveOptimizer() override = default;
+  ~ExhaustiveOptimizer() override;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Numerics/Optimizers/include/itkGradientDescentOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkGradientDescentOptimizer.h
@@ -168,7 +168,7 @@ public:
 
 protected:
   GradientDescentOptimizer();
-  ~GradientDescentOptimizer() override = default;
+  ~GradientDescentOptimizer() override;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Numerics/Optimizers/include/itkInitializationBiasedParticleSwarmOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkInitializationBiasedParticleSwarmOptimizer.h
@@ -116,7 +116,7 @@ public:
 
 protected:
   InitializationBiasedParticleSwarmOptimizer();
-  ~InitializationBiasedParticleSwarmOptimizer() override = default;
+  ~InitializationBiasedParticleSwarmOptimizer() override;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
   void

--- a/Modules/Numerics/Optimizers/include/itkMultipleValuedNonLinearOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkMultipleValuedNonLinearOptimizer.h
@@ -72,7 +72,7 @@ public:
 
 protected:
   MultipleValuedNonLinearOptimizer();
-  ~MultipleValuedNonLinearOptimizer() override = default;
+  ~MultipleValuedNonLinearOptimizer() override;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Numerics/Optimizers/include/itkOnePlusOneEvolutionaryOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkOnePlusOneEvolutionaryOptimizer.h
@@ -193,7 +193,7 @@ public:
 protected:
   OnePlusOneEvolutionaryOptimizer();
   OnePlusOneEvolutionaryOptimizer(const OnePlusOneEvolutionaryOptimizer &);
-  ~OnePlusOneEvolutionaryOptimizer() override = default;
+  ~OnePlusOneEvolutionaryOptimizer() override;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Numerics/Optimizers/include/itkOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkOptimizer.h
@@ -93,7 +93,7 @@ public:
 
 protected:
   Optimizer();
-  ~Optimizer() override = default;
+  ~Optimizer() override;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Numerics/Optimizers/include/itkQuaternionRigidTransformGradientDescentOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkQuaternionRigidTransformGradientDescentOptimizer.h
@@ -76,7 +76,7 @@ public:
 
 protected:
   QuaternionRigidTransformGradientDescentOptimizer() = default;
-  ~QuaternionRigidTransformGradientDescentOptimizer() override = default;
+  ~QuaternionRigidTransformGradientDescentOptimizer() override;
 };
 } // end namespace itk
 

--- a/Modules/Numerics/Optimizers/include/itkRegularStepGradientDescentBaseOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkRegularStepGradientDescentBaseOptimizer.h
@@ -145,7 +145,7 @@ public:
 
 protected:
   RegularStepGradientDescentBaseOptimizer();
-  ~RegularStepGradientDescentBaseOptimizer() override = default;
+  ~RegularStepGradientDescentBaseOptimizer() override;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Numerics/Optimizers/include/itkRegularStepGradientDescentOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkRegularStepGradientDescentOptimizer.h
@@ -53,7 +53,7 @@ public:
 
 protected:
   RegularStepGradientDescentOptimizer() = default;
-  ~RegularStepGradientDescentOptimizer() override = default;
+  ~RegularStepGradientDescentOptimizer() override;
 
   /** Advance one step along the corrected gradient taking into
    * account the steplength represented by factor.

--- a/Modules/Numerics/Optimizers/include/itkSPSAOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkSPSAOptimizer.h
@@ -256,7 +256,7 @@ public:
 
 protected:
   SPSAOptimizer();
-  ~SPSAOptimizer() override = default;
+  ~SPSAOptimizer() override;
 
   /** PrintSelf method. */
   void

--- a/Modules/Numerics/Optimizers/include/itkSingleValuedNonLinearOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkSingleValuedNonLinearOptimizer.h
@@ -78,7 +78,7 @@ public:
 
 protected:
   SingleValuedNonLinearOptimizer();
-  ~SingleValuedNonLinearOptimizer() override = default;
+  ~SingleValuedNonLinearOptimizer() override;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Numerics/Optimizers/include/itkVersorTransformOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkVersorTransformOptimizer.h
@@ -76,7 +76,7 @@ public:
 
 protected:
   VersorTransformOptimizer() = default;
-  ~VersorTransformOptimizer() override = default;
+  ~VersorTransformOptimizer() override;
 };
 } // end namespace itk
 

--- a/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
@@ -19,6 +19,7 @@
 
 namespace itk
 {
+ExhaustiveOptimizer::~ExhaustiveOptimizer() = default;
 
 ExhaustiveOptimizer::ExhaustiveOptimizer() = default;
 

--- a/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
@@ -20,6 +20,8 @@
 
 namespace itk
 {
+GradientDescentOptimizer::~GradientDescentOptimizer() = default;
+
 /**
  * Constructor
  */

--- a/Modules/Numerics/Optimizers/src/itkInitializationBiasedParticleSwarmOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkInitializationBiasedParticleSwarmOptimizer.cxx
@@ -19,6 +19,7 @@
 
 namespace itk
 {
+InitializationBiasedParticleSwarmOptimizer::~InitializationBiasedParticleSwarmOptimizer() = default;
 
 InitializationBiasedParticleSwarmOptimizer::InitializationBiasedParticleSwarmOptimizer()
 {

--- a/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearOptimizer.cxx
@@ -20,6 +20,8 @@
 
 namespace itk
 {
+MultipleValuedNonLinearOptimizer::~MultipleValuedNonLinearOptimizer() = default;
+
 MultipleValuedNonLinearOptimizer::MultipleValuedNonLinearOptimizer()
 {
   m_CostFunction = nullptr;

--- a/Modules/Numerics/Optimizers/src/itkOnePlusOneEvolutionaryOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkOnePlusOneEvolutionaryOptimizer.cxx
@@ -21,6 +21,8 @@
 #include "itkMath.h"
 namespace itk
 {
+OnePlusOneEvolutionaryOptimizer::~OnePlusOneEvolutionaryOptimizer() = default;
+
 OnePlusOneEvolutionaryOptimizer::OnePlusOneEvolutionaryOptimizer()
 {
   m_CatchGetValueException = false;

--- a/Modules/Numerics/Optimizers/src/itkOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkOptimizer.cxx
@@ -20,6 +20,8 @@
 
 namespace itk
 {
+Optimizer::~Optimizer() = default;
+
 /**
  * Constructor
  */

--- a/Modules/Numerics/Optimizers/src/itkQuaternionRigidTransformGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkQuaternionRigidTransformGradientDescentOptimizer.cxx
@@ -21,6 +21,8 @@
 
 namespace itk
 {
+QuaternionRigidTransformGradientDescentOptimizer::~QuaternionRigidTransformGradientDescentOptimizer() = default;
+
 /**
  * Advance one Step following the gradient direction
  */

--- a/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
@@ -20,6 +20,8 @@
 
 namespace itk
 {
+RegularStepGradientDescentBaseOptimizer::~RegularStepGradientDescentBaseOptimizer() = default;
+
 /**
  * Constructor
  */

--- a/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentOptimizer.cxx
@@ -20,6 +20,8 @@
 
 namespace itk
 {
+RegularStepGradientDescentOptimizer::~RegularStepGradientDescentOptimizer() = default;
+
 /**
  * Advance one Step following the gradient direction
  * This method will be overridden in non-vector spaces

--- a/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
@@ -21,6 +21,7 @@
 
 namespace itk
 {
+SPSAOptimizer::~SPSAOptimizer() = default;
 
 SPSAOptimizer::SPSAOptimizer()
 

--- a/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearOptimizer.cxx
@@ -20,6 +20,8 @@
 
 namespace itk
 {
+SingleValuedNonLinearOptimizer::~SingleValuedNonLinearOptimizer() = default;
+
 SingleValuedNonLinearOptimizer::SingleValuedNonLinearOptimizer()
 {
   m_CostFunction = nullptr;

--- a/Modules/Numerics/Optimizers/src/itkVersorTransformOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkVersorTransformOptimizer.cxx
@@ -20,6 +20,8 @@
 
 namespace itk
 {
+VersorTransformOptimizer::~VersorTransformOptimizer() = default;
+
 /**
  * Advance one Step following the gradient direction
  * This method will be overridden in non-vector spaces

--- a/Modules/Numerics/Statistics/include/itkChiSquareDistribution.h
+++ b/Modules/Numerics/Statistics/include/itkChiSquareDistribution.h
@@ -228,7 +228,7 @@ public:
 
 protected:
   ChiSquareDistribution();
-  ~ChiSquareDistribution() override = default;
+  ~ChiSquareDistribution() override;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Numerics/Statistics/include/itkDenseFrequencyContainer2.h
+++ b/Modules/Numerics/Statistics/include/itkDenseFrequencyContainer2.h
@@ -112,7 +112,7 @@ public:
 
 protected:
   DenseFrequencyContainer2();
-  ~DenseFrequencyContainer2() override = default;
+  ~DenseFrequencyContainer2() override;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Numerics/Statistics/include/itkGaussianDistribution.h
+++ b/Modules/Numerics/Statistics/include/itkGaussianDistribution.h
@@ -265,7 +265,7 @@ public:
 
 protected:
   GaussianDistribution();
-  ~GaussianDistribution() override = default;
+  ~GaussianDistribution() override;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Numerics/Statistics/include/itkMaximumDecisionRule.h
+++ b/Modules/Numerics/Statistics/include/itkMaximumDecisionRule.h
@@ -69,7 +69,7 @@ public:
 
 protected:
   MaximumDecisionRule() = default;
-  ~MaximumDecisionRule() override = default;
+  ~MaximumDecisionRule() override;
 
 }; // end of class
 } // end of namespace Statistics

--- a/Modules/Numerics/Statistics/include/itkMaximumRatioDecisionRule.h
+++ b/Modules/Numerics/Statistics/include/itkMaximumRatioDecisionRule.h
@@ -106,7 +106,7 @@ public:
 
 protected:
   MaximumRatioDecisionRule();
-  ~MaximumRatioDecisionRule() override = default;
+  ~MaximumRatioDecisionRule() override;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Numerics/Statistics/include/itkMinimumDecisionRule.h
+++ b/Modules/Numerics/Statistics/include/itkMinimumDecisionRule.h
@@ -66,7 +66,7 @@ public:
 
 protected:
   MinimumDecisionRule() = default;
-  ~MinimumDecisionRule() override = default;
+  ~MinimumDecisionRule() override;
 
 }; // end of class
 } // end of namespace Statistics

--- a/Modules/Numerics/Statistics/include/itkSparseFrequencyContainer2.h
+++ b/Modules/Numerics/Statistics/include/itkSparseFrequencyContainer2.h
@@ -105,7 +105,7 @@ public:
 
 protected:
   SparseFrequencyContainer2();
-  ~SparseFrequencyContainer2() override = default;
+  ~SparseFrequencyContainer2() override;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Numerics/Statistics/include/itkTDistribution.h
+++ b/Modules/Numerics/Statistics/include/itkTDistribution.h
@@ -228,7 +228,7 @@ public:
 
 protected:
   TDistribution();
-  ~TDistribution() override = default;
+  ~TDistribution() override;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Numerics/Statistics/src/itkChiSquareDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkChiSquareDistribution.cxx
@@ -29,6 +29,8 @@ namespace itk
 {
 namespace Statistics
 {
+ChiSquareDistribution::~ChiSquareDistribution() = default;
+
 ChiSquareDistribution::ChiSquareDistribution()
 {
   m_Parameters = ParametersType(1);

--- a/Modules/Numerics/Statistics/src/itkDenseFrequencyContainer2.cxx
+++ b/Modules/Numerics/Statistics/src/itkDenseFrequencyContainer2.cxx
@@ -21,6 +21,8 @@ namespace itk
 {
 namespace Statistics
 {
+DenseFrequencyContainer2::~DenseFrequencyContainer2() = default;
+
 DenseFrequencyContainer2::DenseFrequencyContainer2()
 {
   m_FrequencyContainer = FrequencyContainerType::New();

--- a/Modules/Numerics/Statistics/src/itkGaussianDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkGaussianDistribution.cxx
@@ -23,6 +23,8 @@ namespace itk
 {
 namespace Statistics
 {
+GaussianDistribution::~GaussianDistribution() = default;
+
 GaussianDistribution::GaussianDistribution()
 {
   m_Parameters = ParametersType(2);

--- a/Modules/Numerics/Statistics/src/itkMaximumDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkMaximumDecisionRule.cxx
@@ -21,6 +21,8 @@ namespace itk
 {
 namespace Statistics
 {
+MaximumDecisionRule::~MaximumDecisionRule() = default;
+
 MaximumDecisionRule::ClassIdentifierType
 MaximumDecisionRule::Evaluate(const MembershipVectorType & discriminantScores) const
 {

--- a/Modules/Numerics/Statistics/src/itkMaximumRatioDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkMaximumRatioDecisionRule.cxx
@@ -22,6 +22,8 @@ namespace itk
 {
 namespace Statistics
 {
+MaximumRatioDecisionRule::~MaximumRatioDecisionRule() = default;
+
 MaximumRatioDecisionRule::MaximumRatioDecisionRule() = default;
 
 void

--- a/Modules/Numerics/Statistics/src/itkMinimumDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkMinimumDecisionRule.cxx
@@ -21,6 +21,8 @@ namespace itk
 {
 namespace Statistics
 {
+MinimumDecisionRule::~MinimumDecisionRule() = default;
+
 MinimumDecisionRule::ClassIdentifierType
 MinimumDecisionRule::Evaluate(const MembershipVectorType & discriminantScores) const
 {

--- a/Modules/Numerics/Statistics/src/itkSparseFrequencyContainer2.cxx
+++ b/Modules/Numerics/Statistics/src/itkSparseFrequencyContainer2.cxx
@@ -21,6 +21,8 @@ namespace itk
 {
 namespace Statistics
 {
+SparseFrequencyContainer2::~SparseFrequencyContainer2() = default;
+
 SparseFrequencyContainer2::SparseFrequencyContainer2()
 {
   m_TotalFrequency = TotalAbsoluteFrequencyType{};

--- a/Modules/Numerics/Statistics/src/itkTDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkTDistribution.cxx
@@ -30,6 +30,8 @@ namespace itk
 {
 namespace Statistics
 {
+TDistribution::~TDistribution() = default;
+
 TDistribution::TDistribution()
 {
   m_Parameters = ParametersType(1);

--- a/Modules/Segmentation/Watersheds/include/itkOneWayEquivalencyTable.h
+++ b/Modules/Segmentation/Watersheds/include/itkOneWayEquivalencyTable.h
@@ -162,7 +162,7 @@ public:
 
 protected:
   OneWayEquivalencyTable() = default;
-  ~OneWayEquivalencyTable() override = default;
+  ~OneWayEquivalencyTable() override;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Segmentation/Watersheds/include/itkWatershedMiniPipelineProgressCommand.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedMiniPipelineProgressCommand.h
@@ -73,7 +73,7 @@ public:
 
 protected:
   WatershedMiniPipelineProgressCommand() = default;
-  ~WatershedMiniPipelineProgressCommand() override = default;
+  ~WatershedMiniPipelineProgressCommand() override;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Segmentation/Watersheds/src/itkOneWayEquivalencyTable.cxx
+++ b/Modules/Segmentation/Watersheds/src/itkOneWayEquivalencyTable.cxx
@@ -19,6 +19,8 @@
 
 namespace itk
 {
+OneWayEquivalencyTable::~OneWayEquivalencyTable() = default;
+
 bool
 OneWayEquivalencyTable::Add(unsigned long a, unsigned long b)
 {

--- a/Modules/Segmentation/Watersheds/src/itkWatershedMiniPipelineProgressCommand.cxx
+++ b/Modules/Segmentation/Watersheds/src/itkWatershedMiniPipelineProgressCommand.cxx
@@ -19,6 +19,8 @@
 
 namespace itk
 {
+WatershedMiniPipelineProgressCommand::~WatershedMiniPipelineProgressCommand() = default;
+
 void
 WatershedMiniPipelineProgressCommand::Execute(Object * caller, const EventObject & event)
 {

--- a/Modules/Video/Core/include/itkTemporalProcessObject.h
+++ b/Modules/Video/Core/include/itkTemporalProcessObject.h
@@ -153,7 +153,7 @@ protected:
   TemporalProcessObject();
 
   /** Empty Destructor */
-  ~TemporalProcessObject() override = default;
+  ~TemporalProcessObject() override;
 
   /** ITK print mechanism */
   void

--- a/Modules/Video/Core/src/itkTemporalProcessObject.cxx
+++ b/Modules/Video/Core/src/itkTemporalProcessObject.cxx
@@ -22,6 +22,8 @@
 
 namespace itk
 {
+TemporalProcessObject::~TemporalProcessObject() = default;
+
 
 //-CONSTRUCTOR PRINT-----------------------------------------------------------
 


### PR DESCRIPTION
Non-template exported classes with `~ClassName() override = default;` inline in the header have hidden D1Ev/D0Ev destructor thunks under -fvisibility-inlines-hidden, even when the class vtable and typeinfo remain exported.  This breaks dynamic_cast across DSO boundaries in shared library builds.

Moving the destructor definition out of line to the .cxx file ensures it is compiled in exactly one translation unit, giving it default (exported) visibility and correctly anchoring all destructor thunks.

Affected modules: ITKCommon (3), ITKIOImageBase (3), ITKFEM (1), ITKOptimizers (11), ITKStatistics (8), ITKWatersheds (2), ITKVideoCore (1).

See: https://github.com/InsightSoftwareConsortium/ITK/issues/6000

This is a backport to @hjmjohnson 's patch to ITK 5.