### PR TITLE
COMP: Bump pyupgrade v3.19.0 to v3.21.2 for Python 3.14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@ repos:
      args: ['--target-version', 'py310' ] # Allow black to fail and provide auto-formatting to files that need it for compliance
      exclude: ".*build.*|\\/ThirdParty\\/|\\/Data\\/"
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.0
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
         exclude: ".*build.*|\\/ThirdParty\\/|\\/Data\\/"


### PR DESCRIPTION
Fix `pre-commit run -a` failure when pixi provides Python 3.14. pyupgrade v3.19.0 crashes with `TypeError: cannot use a bytes pattern on a string-like object` because Python 3.14 changed `tokenize.cookie_re` from bytes to str.

<details>
<summary>Error trace</summary>

```
File "pyupgrade/_main.py", line 297, in _fix_tokens
    tokenize.cookie_re.match(token.src)
TypeError: cannot use a bytes pattern on a string-like object
```

Fixed upstream in asottile/pyupgrade. v3.21.2 handles both bytes and str `cookie_re` variants.

</details>

<!--
provenance: claude-code session 2026-04-13
key_facts:
  - pyupgrade v3.19.0 incompatible with Python 3.14 tokenize.cookie_re change
  - pixi pre-commit env provides Python 3.14
  - v3.21.2 is latest, fixes the issue
related_files:
  - .pre-commit-config.yaml:81
-->