### PR TITLE
WIP: Test ccache fix hypothesis on ITK.Linux Azure DevOps

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -1,29 +1,7 @@
 name: ITK.Arm64
 
 on:
-    push:
-        branches:
-            - main
-            - 'release*'
-        paths-ignore:
-            - '*.md'
-            - LICENSE
-            - NOTICE
-            - 'Documentation/**'
-            - 'Utilities/Debugger/**'
-            - 'Utilities/ITKv5Preparation/**'
-            - 'Utilities/Maintenance/**'
-            - 'Modules/Remote/*.remote.cmake'
-    pull_request:
-        paths-ignore:
-            - '*.md'
-            - LICENSE
-            - NOTICE
-            - 'Documentation/**'
-            - 'Utilities/Debugger/**'
-            - 'Utilities/ITKv5Preparation/**'
-            - 'Utilities/Maintenance/**'
-            - 'Modules/Remote/*.remote.cmake'
+    workflow_dispatch: {}  # WIP: disabled for ccache hypothesis testing
 
 concurrency:
   group: '${{ github.workflow }}@${{ github.head_ref || github.ref }}'

--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -1,29 +1,7 @@
 name: ITK.Pixi
 
 on:
-    push:
-        branches:
-            - main
-            - 'release*'
-        paths-ignore:
-            - '*.md'
-            - LICENSE
-            - NOTICE
-            - 'Documentation/**'
-            - 'Utilities/Debugger/**'
-            - 'Utilities/ITKv5Preparation/**'
-            - 'Utilities/Maintenance/**'
-            - 'Modules/Remote/*.remote.cmake'
-    pull_request:
-        paths-ignore:
-            - '*.md'
-            - LICENSE
-            - NOTICE
-            - 'Documentation/**'
-            - 'Utilities/Debugger/**'
-            - 'Utilities/ITKv5Preparation/**'
-            - 'Utilities/Maintenance/**'
-            - 'Modules/Remote/*.remote.cmake'
+    workflow_dispatch: {}  # WIP: disabled for ccache hypothesis testing
 
 concurrency:
   group: '${{ github.workflow }}@${{ github.head_ref || github.ref }}'

--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -36,6 +36,7 @@ variables:
   # NOTE: CCACHE_NODIRECT intentionally removed — direct mode is the
   # fast path (97%+ hit rate on ARM CI). NODIRECT forced preprocessor
   # mode on every file, killing cache efficiency.
+  # Run 2: This comment triggers a rebuild to measure warm-cache hit rate.
 jobs:
 - job: Linux
   timeoutInMinutes: 0

--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -32,7 +32,10 @@ variables:
   CCACHE_BASEDIR: $(Build.SourcesDirectory)
   CCACHE_COMPILERCHECK: content
   CCACHE_NOHASHDIR: 'true'
-  CCACHE_NODIRECT: '1'
+  CCACHE_SLOPPINESS: pch_defines,time_macros
+  # NOTE: CCACHE_NODIRECT intentionally removed — direct mode is the
+  # fast path (97%+ hit rate on ARM CI). NODIRECT forced preprocessor
+  # mode on every file, killing cache efficiency.
 jobs:
 - job: Linux
   timeoutInMinutes: 0
@@ -76,14 +79,18 @@ jobs:
 
     - task: Cache@2
       inputs:
-        key: '"ccache" | "$(Agent.OS)" | "$(Build.SourceVersion)"'
+        key: '"ccache-v5" | "$(Agent.OS)" | "Linux" | "$(Build.SourceVersion)"'
         restoreKeys: |
-          "ccache" | "$(Agent.OS)"
+          "ccache-v5" | "$(Agent.OS)" | "Linux"
         path: $(CCACHE_DIR)
       displayName: 'Restore ccache'
 
-    - bash: ccache --evict-older-than 7d
-      displayName: 'Evict old ccache entries'
+    - bash: |
+        set -x
+        ccache --zero-stats
+        ccache --evict-older-than 7d
+        ccache --show-config
+      displayName: 'ccache config and maintenance'
 
     - bash: |
         cat > dashboard.cmake << EOF
@@ -93,10 +100,15 @@ jobs:
           BUILD_SHARED_LIBS:BOOL=OFF
           BUILD_EXAMPLES:BOOL=OFF
           ITK_WRAP_PYTHON:BOOL=OFF
-          ITK_USE_CCACHE:BOOL=ON
           CMAKE_C_COMPILER_LAUNCHER:STRING=ccache
           CMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache
           ITK_COMPUTER_MEMORY_SIZE:STRING=4.5
+          ITK_BUILD_DEFAULT_MODULES:BOOL=OFF
+          Module_ITKCommon:BOOL=ON
+          Module_ITKIOImageBase:BOOL=ON
+          Module_ITKIONIFTI:BOOL=ON
+          Module_ITKIOPNG:BOOL=ON
+          Module_ITKTestKernel:BOOL=ON
         ")
         set(CTEST_TEST_ARGS EXCLUDE_LABEL BigIO) # Disabled to conserve disk space
         include(\$ENV{AGENT_BUILDDIRECTORY}/ITK-dashboard/azure_dashboard.cmake)
@@ -116,6 +128,10 @@ jobs:
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
         CCACHE_MAXSIZE: 2.4G
+
+    - bash: ccache --show-stats --verbose
+      condition: always()
+      displayName: 'ccache stats'
 
     - bash: python3 $(Build.SourcesDirectory)/Testing/ContinuousIntegration/report_build_diagnostics.py $(Build.SourcesDirectory)-build
       condition: succeededOrFailed()
@@ -132,190 +148,3 @@ jobs:
         testRunTitle: 'CTest $(Agent.OS)'
       condition: succeededOrFailed()
       displayName: 'Publish test results'
-
-- job: LinuxLegacyRemoved
-  timeoutInMinutes: 0
-  cancelTimeoutInMinutes: 300
-  pool:
-    vmImage: ubuntu-22.04
-  steps:
-    - checkout: self
-      clean: true
-      fetchDepth: 5
-    - bash: |
-        set -x
-        if [ -n "$(System.PullRequest.SourceCommitId)" ]; then
-          git checkout $(System.PullRequest.SourceCommitId)
-        fi
-      displayName: 'Checkout pull request HEAD'
-
-    - bash: |
-        set -x
-        sudo pip3 install ninja
-        sudo apt-get update
-        sudo apt-get install -y python3-venv ccache locales
-        sudo locale-gen de_DE.UTF-8
-        sudo python3 -m pip install lxml scikit-ci-addons
-      displayName: 'Install dependencies'
-
-    - bash: |
-        set -x
-        git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
-
-        curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
-        cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
-        cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/CID $(Build.SourcesDirectory)/.ExternalData/CID
-      workingDirectory: $(Agent.BuildDirectory)
-      displayName: 'Download dashboard script and testing data'
-
-    - task: Cache@2
-      inputs:
-        key: '"ccache" | "$(Agent.OS)" | "$(Build.SourceVersion)"'
-        restoreKeys: |
-          "ccache" | "$(Agent.OS)"
-        path: $(CCACHE_DIR)
-      displayName: 'Restore ccache'
-
-    - bash: ccache --evict-older-than 7d
-      displayName: 'Evict old ccache entries'
-
-    - bash: |
-        cat > dashboard.cmake << EOF
-        set(CTEST_BUILD_CONFIGURATION "MinSizeRel")
-        set(CTEST_CMAKE_GENERATOR "Ninja")
-        set(BUILD_NAME_SUFFIX "LegacyRemoved")
-        set(dashboard_cache "
-          ITK_LEGACY_REMOVE:BOOL=ON
-          BUILD_SHARED_LIBS:BOOL=OFF
-          BUILD_EXAMPLES:BOOL=OFF
-          ITK_WRAP_PYTHON:BOOL=OFF
-          CMAKE_C_COMPILER_LAUNCHER:STRING=ccache
-          CMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache
-          ITK_COMPUTER_MEMORY_SIZE:STRING=4.5
-        ")
-        set(CTEST_TEST_ARGS EXCLUDE_LABEL BigIO) # Disabled to conserve disk space
-        include(\$ENV{AGENT_BUILDDIRECTORY}/ITK-dashboard/azure_dashboard.cmake)
-        EOF
-        cat dashboard.cmake
-      workingDirectory: $(Agent.BuildDirectory)/ITK-dashboard
-      displayName: 'Configure CTest script'
-
-    - bash: |
-        set -x
-
-        c++ --version
-        cmake --version
-
-        ctest -S $(Agent.BuildDirectory)/ITK-dashboard/dashboard.cmake -V -j 2
-      displayName: 'Build and test'
-      env:
-        CTEST_OUTPUT_ON_FAILURE: 1
-        CCACHE_MAXSIZE: 2.4G
-
-    - bash: python3 $(Build.SourcesDirectory)/Testing/ContinuousIntegration/report_build_diagnostics.py $(Build.SourcesDirectory)-build
-      condition: succeededOrFailed()
-      displayName: 'Report build warnings and errors'
-
-    - script: |
-        ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml
-      condition: succeededOrFailed()
-      displayName: 'Format CTest output in JUnit format'
-
-    - task: PublishTestResults@2
-      inputs:
-        testResultsFiles: "$(Agent.BuildDirectory)/JUnitTestResults.xml"
-        testRunTitle: 'CTest $(Agent.OS) LegacyRemoved'
-      condition: succeededOrFailed()
-      displayName: 'Publish test results'
-
-- job: LinuxCxx20
-  timeoutInMinutes: 0
-  cancelTimeoutInMinutes: 300
-  pool:
-    vmImage: ubuntu-24.04
-  steps:
-    - checkout: self
-      clean: true
-      fetchDepth: 5
-    - bash: |
-        set -x
-        if [ -n "$(System.PullRequest.SourceCommitId)" ]; then
-          git checkout $(System.PullRequest.SourceCommitId)
-        fi
-      displayName: "Checkout pull request HEAD"
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: "3.10"
-        architecture: "x64"
-    - bash: |
-        set -x
-        sudo pip3 install ninja
-        sudo apt-get update
-        sudo apt-get install -y python3-venv ccache locales
-        sudo locale-gen de_DE.UTF-8
-        sudo python3 -m pip install lxml scikit-ci-addons
-      displayName: "Install dependencies"
-    - bash: |
-        set -x
-        git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
-        curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
-        cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
-        cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/CID $(Build.SourcesDirectory)/.ExternalData/CID
-      workingDirectory: $(Agent.BuildDirectory)
-      displayName: "Download dashboard script and testing data"
-    - task: Cache@2
-      inputs:
-        key: '"ccache" | "$(Agent.OS)" | "$(Build.SourceVersion)"'
-        restoreKeys: |
-          "ccache" | "$(Agent.OS)"
-        path: $(CCACHE_DIR)
-      displayName: 'Restore ccache'
-
-    - bash: ccache --evict-older-than 7d
-      displayName: 'Evict old ccache entries'
-
-    - bash: |
-        cat > dashboard.cmake << EOF
-        set(CTEST_BUILD_CONFIGURATION "MinSizeRel")
-        set(CTEST_CMAKE_GENERATOR "Ninja")
-        set(BUILD_NAME_SUFFIX "Cxx20")
-        set(dashboard_cache "
-          CMAKE_CXX_STANDARD:STRING=20
-          CMAKE_CXX_STANDARD_REQUIRED:BOOL=ON
-          BUILD_SHARED_LIBS:BOOL=OFF
-          BUILD_EXAMPLES:BOOL=OFF
-          ITK_WRAP_PYTHON:BOOL=OFF
-          CMAKE_C_COMPILER_LAUNCHER:STRING=ccache
-          CMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache
-          ITK_COMPUTER_MEMORY_SIZE:STRING=4.5
-        ")
-        set(CTEST_TEST_ARGS EXCLUDE_LABEL BigIO) # Disabled to conserve disk space
-        include(\$ENV{AGENT_BUILDDIRECTORY}/ITK-dashboard/azure_dashboard.cmake)
-        EOF
-        cat dashboard.cmake
-      workingDirectory: $(Agent.BuildDirectory)/ITK-dashboard
-      displayName: "Configure CTest script"
-    - bash: |
-        set -x
-        c++ --version
-        cmake --version
-        ctest -S $(Agent.BuildDirectory)/ITK-dashboard/dashboard.cmake -V -j 2
-      displayName: "Build and test"
-      env:
-        CTEST_OUTPUT_ON_FAILURE: 1
-        CCACHE_MAXSIZE: 2.4G
-
-    - bash: python3 $(Build.SourcesDirectory)/Testing/ContinuousIntegration/report_build_diagnostics.py $(Build.SourcesDirectory)-build
-      condition: succeededOrFailed()
-      displayName: 'Report build warnings and errors'
-
-    - script: |
-        ci_addons ctest_junit_formatter $(Build.SourcesDirectory)-build > $(Agent.BuildDirectory)/JUnitTestResults.xml
-      condition: succeededOrFailed()
-      displayName: "Format CTest output in JUnit format"
-    - task: PublishTestResults@2
-      inputs:
-        testResultsFiles: "$(Agent.BuildDirectory)/JUnitTestResults.xml"
-        testRunTitle: "CTest $(Agent.OS) Cxx20"
-      condition: succeededOrFailed()
-      displayName: "Publish test results"

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -1,31 +1,7 @@
 name: ITK.Linux.Python
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
 variables:
   ExternalDataVersion: 5.4.5
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -1,31 +1,7 @@
 name: ITK.macOS
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
 variables:
   ExternalDataVersion: 5.4.5
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -1,31 +1,7 @@
 name: ITK.macOS.Python
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
 variables:
   ExternalDataVersion: 5.4.5
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache

--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -1,31 +1,7 @@
 name: ITK.Windows
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
 variables:
   ExternalDataVersion: 5.4.5
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -1,31 +1,7 @@
 name: ITK.Windows.Python
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
 variables:
   ExternalDataVersion: 5.4.5
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache


### PR DESCRIPTION
Test whether fixing ccache configuration on Azure DevOps ITK.Linux improves hit rate from ~0% to 95%+.

<details>
<summary>Hypothesis and changes</summary>

**Root cause analysis:** ITK.Linux Azure DevOps ccache had near-0% hit rate due to:
1. `CCACHE_NODIRECT=1` — disabled fast direct mode (ARM CI without this gets 98.5%)
2. Missing `CCACHE_SLOPPINESS=pch_defines,time_macros` — `__DATE__`/`__TIME__` macros cause misses
3. Three jobs (`Linux`, `LinuxLegacyRemoved`, `LinuxCxx20`) shared one cache key but built different configs
4. `ITK_USE_CCACHE=ON` + `CMAKE_*_COMPILER_LAUNCHER=ccache` — potential double-wrapping

**Changes to `AzurePipelinesLinux.yml`:**
- Remove `CCACHE_NODIRECT` (enable direct mode)
- Add `CCACHE_SLOPPINESS=pch_defines,time_macros`
- Add job name to cache key (`ccache-v5`)
- Remove `ITK_USE_CCACHE` (launcher is sufficient)
- Minimize build to ITKCommon+IO modules (fast iteration)
- Single job only to avoid cache collision
- Add `ccache --show-stats --verbose` step

**All other CI disabled** (trigger: none / workflow_dispatch) to isolate the test.

</details>

<details>
<summary>Expected result</summary>

- First run: 0% hit rate (cold cache with new key `ccache-v5`)
- Second run (push a trivial change): 95%+ hit rate with fast direct hits
- Build time on second run should be ~2-3 min vs ~30 min full rebuild

</details>

**DO NOT MERGE** — this PR disables all CI except ITK.Linux. Will be closed after hypothesis is confirmed.

<!--
provenance: claude-code session 2026-04-13
key_facts: CCACHE_NODIRECT was the primary culprit; ARM CI without it gets 98.5%
related_files: Testing/ContinuousIntegration/AzurePipelinesLinux.yml
post_merge_action: close this PR, open a clean PR with only the ccache fixes (no disabled CI)
-->