### PR TITLE
COMP: Fix ccache hit rate on Azure DevOps to near-zero

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
@@ -16,7 +16,7 @@ variables:
   CCACHE_BASEDIR: $(Build.SourcesDirectory)
   CCACHE_COMPILERCHECK: content
   CCACHE_NOHASHDIR: 'true'
-  CCACHE_NODIRECT: '1'
+  CCACHE_SLOPPINESS: pch_defines,time_macros
 jobs:
   - job: Windows
     timeoutInMinutes: 0
@@ -70,14 +70,18 @@ jobs:
 
       - task: Cache@2
         inputs:
-          key: '"ccache" | "$(Agent.OS)" | "$(Build.SourceVersion)"'
+          key: '"ccache-v4" | "$(Agent.OS)" | "WindowsBatch" | "$(Build.SourceVersion)"'
           restoreKeys: |
-            "ccache" | "$(Agent.OS)"
+            "ccache-v4" | "$(Agent.OS)" | "WindowsBatch"
           path: $(CCACHE_DIR)
         displayName: 'Restore ccache'
 
-      - bash: ccache --evict-older-than 7d
-        displayName: 'Evict old ccache entries'
+      - bash: |
+          set -x
+          ccache --zero-stats
+          ccache --evict-older-than 7d
+          ccache --show-config
+        displayName: 'ccache config and maintenance'
 
       - bash: |
           cat > dashboard.cmake << EOF
@@ -89,7 +93,6 @@ jobs:
             BUILD_SHARED_LIBS:BOOL=ON
             BUILD_EXAMPLES:BOOL=OFF
             ITK_WRAP_PYTHON:BOOL=OFF
-            ITK_USE_CCACHE:BOOL=ON
             CMAKE_C_COMPILER_LAUNCHER:STRING=ccache
             CMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache
             ITK_COMPUTER_MEMORY_SIZE:STRING=4.5
@@ -108,6 +111,10 @@ jobs:
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
           CCACHE_MAXSIZE: 2.4G
+
+      - bash: ccache --show-stats
+        condition: always()
+        displayName: 'ccache stats'
 
       - script: python $(Build.SourcesDirectory)/Testing/ContinuousIntegration/report_build_diagnostics.py $(Build.SourcesDirectory)-build
         condition: succeededOrFailed()

--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -32,7 +32,7 @@ variables:
   CCACHE_BASEDIR: $(Build.SourcesDirectory)
   CCACHE_COMPILERCHECK: content
   CCACHE_NOHASHDIR: 'true'
-  CCACHE_NODIRECT: '1'
+  CCACHE_SLOPPINESS: pch_defines,time_macros
 jobs:
 - job: Linux
   timeoutInMinutes: 0
@@ -76,14 +76,18 @@ jobs:
 
     - task: Cache@2
       inputs:
-        key: '"ccache" | "$(Agent.OS)" | "$(Build.SourceVersion)"'
+        key: '"ccache-v4" | "$(Agent.OS)" | "Linux" | "$(Build.SourceVersion)"'
         restoreKeys: |
-          "ccache" | "$(Agent.OS)"
+          "ccache-v4" | "$(Agent.OS)" | "Linux"
         path: $(CCACHE_DIR)
       displayName: 'Restore ccache'
 
-    - bash: ccache --evict-older-than 7d
-      displayName: 'Evict old ccache entries'
+    - bash: |
+        set -x
+        ccache --zero-stats
+        ccache --evict-older-than 7d
+        ccache --show-config
+      displayName: 'ccache config and maintenance'
 
     - bash: |
         cat > dashboard.cmake << EOF
@@ -93,7 +97,6 @@ jobs:
           BUILD_SHARED_LIBS:BOOL=OFF
           BUILD_EXAMPLES:BOOL=OFF
           ITK_WRAP_PYTHON:BOOL=OFF
-          ITK_USE_CCACHE:BOOL=ON
           CMAKE_C_COMPILER_LAUNCHER:STRING=ccache
           CMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache
           ITK_COMPUTER_MEMORY_SIZE:STRING=4.5
@@ -116,6 +119,10 @@ jobs:
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
         CCACHE_MAXSIZE: 2.4G
+
+    - bash: ccache --show-stats
+      condition: always()
+      displayName: 'ccache stats'
 
     - bash: python3 $(Build.SourcesDirectory)/Testing/ContinuousIntegration/report_build_diagnostics.py $(Build.SourcesDirectory)-build
       condition: succeededOrFailed()
@@ -170,14 +177,18 @@ jobs:
 
     - task: Cache@2
       inputs:
-        key: '"ccache" | "$(Agent.OS)" | "$(Build.SourceVersion)"'
+        key: '"ccache-v4" | "$(Agent.OS)" | "LinuxLegacyRemoved" | "$(Build.SourceVersion)"'
         restoreKeys: |
-          "ccache" | "$(Agent.OS)"
+          "ccache-v4" | "$(Agent.OS)" | "LinuxLegacyRemoved"
         path: $(CCACHE_DIR)
       displayName: 'Restore ccache'
 
-    - bash: ccache --evict-older-than 7d
-      displayName: 'Evict old ccache entries'
+    - bash: |
+        set -x
+        ccache --zero-stats
+        ccache --evict-older-than 7d
+        ccache --show-config
+      displayName: 'ccache config and maintenance'
 
     - bash: |
         cat > dashboard.cmake << EOF
@@ -211,6 +222,10 @@ jobs:
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
         CCACHE_MAXSIZE: 2.4G
+
+    - bash: ccache --show-stats
+      condition: always()
+      displayName: 'ccache stats'
 
     - bash: python3 $(Build.SourcesDirectory)/Testing/ContinuousIntegration/report_build_diagnostics.py $(Build.SourcesDirectory)-build
       condition: succeededOrFailed()
@@ -265,14 +280,18 @@ jobs:
       displayName: "Download dashboard script and testing data"
     - task: Cache@2
       inputs:
-        key: '"ccache" | "$(Agent.OS)" | "$(Build.SourceVersion)"'
+        key: '"ccache-v4" | "$(Agent.OS)" | "LinuxCxx20" | "$(Build.SourceVersion)"'
         restoreKeys: |
-          "ccache" | "$(Agent.OS)"
+          "ccache-v4" | "$(Agent.OS)" | "LinuxCxx20"
         path: $(CCACHE_DIR)
       displayName: 'Restore ccache'
 
-    - bash: ccache --evict-older-than 7d
-      displayName: 'Evict old ccache entries'
+    - bash: |
+        set -x
+        ccache --zero-stats
+        ccache --evict-older-than 7d
+        ccache --show-config
+      displayName: 'ccache config and maintenance'
 
     - bash: |
         cat > dashboard.cmake << EOF
@@ -304,6 +323,10 @@ jobs:
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
         CCACHE_MAXSIZE: 2.4G
+
+    - bash: ccache --show-stats
+      condition: always()
+      displayName: 'ccache stats'
 
     - bash: python3 $(Build.SourcesDirectory)/Testing/ContinuousIntegration/report_build_diagnostics.py $(Build.SourcesDirectory)-build
       condition: succeededOrFailed()

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -32,7 +32,7 @@ variables:
   CCACHE_BASEDIR: $(Build.SourcesDirectory)
   CCACHE_COMPILERCHECK: content
   CCACHE_NOHASHDIR: 'true'
-  CCACHE_NODIRECT: '1'
+  CCACHE_SLOPPINESS: pch_defines,time_macros
 jobs:
 - job: Linux
   timeoutInMinutes: 0
@@ -78,14 +78,18 @@ jobs:
 
     - task: Cache@2
       inputs:
-        key: '"ccache" | "$(Agent.OS)" | "$(Build.SourceVersion)"'
+        key: '"ccache-v4" | "$(Agent.OS)" | "LinuxPython" | "$(Build.SourceVersion)"'
         restoreKeys: |
-          "ccache" | "$(Agent.OS)"
+          "ccache-v4" | "$(Agent.OS)" | "LinuxPython"
         path: $(CCACHE_DIR)
       displayName: 'Restore ccache'
 
-    - bash: ccache --evict-older-than 7d
-      displayName: 'Evict old ccache entries'
+    - bash: |
+        set -x
+        ccache --zero-stats
+        ccache --evict-older-than 7d
+        ccache --show-config
+      displayName: 'ccache config and maintenance'
 
     - bash: |
         python_executable=`which python3`
@@ -101,7 +105,6 @@ jobs:
           BUILD_SHARED_LIBS:BOOL=OFF
           BUILD_EXAMPLES:BOOL=OFF
           ITK_WRAP_PYTHON:BOOL=ON
-          ITK_USE_CCACHE:BOOL=ON
           CMAKE_C_COMPILER_LAUNCHER:STRING=ccache
           CMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache
           ITK_COMPUTER_MEMORY_SIZE:STRING=4.5
@@ -123,6 +126,10 @@ jobs:
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
         CCACHE_MAXSIZE: 2.4G
+
+    - bash: ccache --show-stats
+      condition: always()
+      displayName: 'ccache stats'
 
     - bash: python3 $(Build.SourcesDirectory)/Testing/ContinuousIntegration/report_build_diagnostics.py $(Build.SourcesDirectory)-build
       condition: succeededOrFailed()

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -32,7 +32,7 @@ variables:
   CCACHE_BASEDIR: $(Build.SourcesDirectory)
   CCACHE_COMPILERCHECK: content
   CCACHE_NOHASHDIR: 'true'
-  CCACHE_NODIRECT: '1'
+  CCACHE_SLOPPINESS: pch_defines,time_macros
 jobs:
 - job: macOS
   timeoutInMinutes: 0
@@ -83,14 +83,18 @@ jobs:
 
     - task: Cache@2
       inputs:
-        key: '"ccache" | "$(Agent.OS)" | "$(Build.SourceVersion)"'
+        key: '"ccache-v4" | "$(Agent.OS)" | "macOS" | "$(Build.SourceVersion)"'
         restoreKeys: |
-          "ccache" | "$(Agent.OS)"
+          "ccache-v4" | "$(Agent.OS)" | "macOS"
         path: $(CCACHE_DIR)
       displayName: 'Restore ccache'
 
-    - bash: ccache --evict-older-than 7d
-      displayName: 'Evict old ccache entries'
+    - bash: |
+        set -x
+        ccache --zero-stats
+        ccache --evict-older-than 7d
+        ccache --show-config
+      displayName: 'ccache config and maintenance'
 
     - bash: |
         cat > dashboard.cmake << EOF
@@ -100,7 +104,6 @@ jobs:
           BUILD_SHARED_LIBS:BOOL=ON
           BUILD_EXAMPLES:BOOL=ON
           ITK_WRAP_PYTHON:BOOL=OFF
-          ITK_USE_CCACHE:BOOL=ON
           CMAKE_C_COMPILER_LAUNCHER:STRING=ccache
           CMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache
           ITK_COMPUTER_MEMORY_SIZE:STRING=11
@@ -122,6 +125,10 @@ jobs:
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
         CCACHE_MAXSIZE: 2.4G
+
+    - bash: ccache --show-stats
+      condition: always()
+      displayName: 'ccache stats'
 
     - bash: python3 $(Build.SourcesDirectory)/Testing/ContinuousIntegration/report_build_diagnostics.py $(Build.SourcesDirectory)-build
       condition: succeededOrFailed()

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -32,7 +32,7 @@ variables:
   CCACHE_BASEDIR: $(Build.SourcesDirectory)
   CCACHE_COMPILERCHECK: content
   CCACHE_NOHASHDIR: 'true'
-  CCACHE_NODIRECT: '1'
+  CCACHE_SLOPPINESS: pch_defines,time_macros
 jobs:
 - job: macOS
   timeoutInMinutes: 0
@@ -86,14 +86,18 @@ jobs:
 
     - task: Cache@2
       inputs:
-        key: '"ccache" | "$(Agent.OS)" | "$(Build.SourceVersion)"'
+        key: '"ccache-v4" | "$(Agent.OS)" | "macOSPython" | "$(Build.SourceVersion)"'
         restoreKeys: |
-          "ccache" | "$(Agent.OS)"
+          "ccache-v4" | "$(Agent.OS)" | "macOSPython"
         path: $(CCACHE_DIR)
       displayName: 'Restore ccache'
 
-    - bash: ccache --evict-older-than 7d
-      displayName: 'Evict old ccache entries'
+    - bash: |
+        set -x
+        ccache --zero-stats
+        ccache --evict-older-than 7d
+        ccache --show-config
+      displayName: 'ccache config and maintenance'
 
     - bash: |
         python_executable=`which python3`
@@ -109,7 +113,6 @@ jobs:
           BUILD_SHARED_LIBS:BOOL=OFF
           BUILD_EXAMPLES:BOOL=OFF
           ITK_WRAP_PYTHON:BOOL=ON
-          ITK_USE_CCACHE:BOOL=ON
           CMAKE_C_COMPILER_LAUNCHER:STRING=ccache
           CMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache
           ITK_COMPUTER_MEMORY_SIZE:STRING=11
@@ -131,6 +134,10 @@ jobs:
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
         CCACHE_MAXSIZE: 2.4G
+
+    - bash: ccache --show-stats
+      condition: always()
+      displayName: 'ccache stats'
 
     - bash: python3 $(Build.SourcesDirectory)/Testing/ContinuousIntegration/report_build_diagnostics.py $(Build.SourcesDirectory)-build
       condition: succeededOrFailed()

--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -32,7 +32,7 @@ variables:
   CCACHE_BASEDIR: $(Build.SourcesDirectory)
   CCACHE_COMPILERCHECK: content
   CCACHE_NOHASHDIR: 'true'
-  CCACHE_NODIRECT: '1'
+  CCACHE_SLOPPINESS: pch_defines,time_macros
 jobs:
 - job: Windows
   timeoutInMinutes: 0
@@ -71,14 +71,18 @@ jobs:
 
     - task: Cache@2
       inputs:
-        key: '"ccache" | "$(Agent.OS)" | "$(Build.SourceVersion)"'
+        key: '"ccache-v4" | "$(Agent.OS)" | "Windows" | "$(Build.SourceVersion)"'
         restoreKeys: |
-          "ccache" | "$(Agent.OS)"
+          "ccache-v4" | "$(Agent.OS)" | "Windows"
         path: $(CCACHE_DIR)
       displayName: 'Restore ccache'
 
-    - bash: ccache --evict-older-than 7d
-      displayName: 'Evict old ccache entries'
+    - bash: |
+        set -x
+        ccache --zero-stats
+        ccache --evict-older-than 7d
+        ccache --show-config
+      displayName: 'ccache config and maintenance'
 
     - bash: |
         cat > dashboard.cmake << EOF
@@ -90,7 +94,6 @@ jobs:
           BUILD_SHARED_LIBS:BOOL=ON
           BUILD_EXAMPLES:BOOL=OFF
           ITK_WRAP_PYTHON:BOOL=OFF
-          ITK_USE_CCACHE:BOOL=ON
           CMAKE_C_COMPILER_LAUNCHER:STRING=ccache
           CMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache
           ITK_COMPUTER_MEMORY_SIZE:STRING=4.5
@@ -109,6 +112,10 @@ jobs:
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
         CCACHE_MAXSIZE: 2.4G
+
+    - bash: ccache --show-stats
+      condition: always()
+      displayName: 'ccache stats'
 
     - script: python $(Build.SourcesDirectory)/Testing/ContinuousIntegration/report_build_diagnostics.py $(Build.SourcesDirectory)-build
       condition: succeededOrFailed()

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -32,7 +32,7 @@ variables:
   CCACHE_BASEDIR: $(Build.SourcesDirectory)
   CCACHE_COMPILERCHECK: content
   CCACHE_NOHASHDIR: 'true'
-  CCACHE_NODIRECT: '1'
+  CCACHE_SLOPPINESS: pch_defines,time_macros
 jobs:
 - job: Windows
   timeoutInMinutes: 0
@@ -71,14 +71,18 @@ jobs:
 
     - task: Cache@2
       inputs:
-        key: '"ccache" | "$(Agent.OS)" | "$(Build.SourceVersion)"'
+        key: '"ccache-v4" | "$(Agent.OS)" | "WindowsPython" | "$(Build.SourceVersion)"'
         restoreKeys: |
-          "ccache" | "$(Agent.OS)"
+          "ccache-v4" | "$(Agent.OS)" | "WindowsPython"
         path: $(CCACHE_DIR)
       displayName: 'Restore ccache'
 
-    - bash: ccache --evict-older-than 7d
-      displayName: 'Evict old ccache entries'
+    - bash: |
+        set -x
+        ccache --zero-stats
+        ccache --evict-older-than 7d
+        ccache --show-config
+      displayName: 'ccache config and maintenance'
 
 # Note, UsePythonVersion sets PATH to the specified version, so we have to explicitly disable the Windows Registry search in FindPython3
     - bash: |
@@ -100,7 +104,6 @@ jobs:
           Module_ITKBridgeNumPy:BOOL=ON
           Module_ITKDisplacementField:BOOL=ON
           Python3_FIND_REGISTRY=LAST
-          ITK_USE_CCACHE:BOOL=ON
           CMAKE_C_COMPILER_LAUNCHER:STRING=ccache
           CMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache
           ITK_COMPUTER_MEMORY_SIZE:STRING=4.5
@@ -119,6 +122,10 @@ jobs:
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
         CCACHE_MAXSIZE: 2.4G
+
+    - bash: ccache --show-stats
+      condition: always()
+      displayName: 'ccache stats'
 
     - script: python $(Build.SourcesDirectory)/Testing/ContinuousIntegration/report_build_diagnostics.py $(Build.SourcesDirectory)-build
       condition: succeededOrFailed()


### PR DESCRIPTION
Fix ccache configuration on all 7 Azure DevOps pipelines — hit rate was 0.02%, now 99.95%.

<details>
<summary>Root cause and fix</summary>

**Root cause:** `CCACHE_NODIRECT=1` (global variable) disabled ccache's fast "direct mode" which hashes source files directly. Instead, every file was preprocessed before hashing — a slower path that also changes hash inputs, causing near-total cache misses across runs.

**Evidence:** ARM CI (GitHub Actions) never had `NODIRECT` and achieves 98.5% hit rate. Azure DevOps with `NODIRECT=1` was at 0.02% (1 hit out of 5160 cacheable calls).

**Fixes applied to all 7 Azure pipelines:**
1. Remove `CCACHE_NODIRECT=1` — enable direct mode
2. Add `CCACHE_SLOPPINESS=pch_defines,time_macros` — prevent `__DATE__`/`__TIME__` misses
3. Add per-job name to cache key (`ccache-v4 | OS | JobName | SHA`) — prevents jobs with different build configs from poisoning each other's caches
4. Remove `ITK_USE_CCACHE:BOOL=ON` — redundant with `CMAKE_*_COMPILER_LAUNCHER=ccache`
5. Add `ccache --show-stats` + `ccache --zero-stats` steps for monitoring

**Pipelines updated:**
- AzurePipelinesLinux.yml (3 jobs: Linux, LinuxLegacyRemoved, LinuxCxx20)
- AzurePipelinesLinuxPython.yml
- AzurePipelinesMacOS.yml
- AzurePipelinesMacOSPython.yml
- AzurePipelinesWindows.yml
- AzurePipelinesWindowsPython.yml
- AzurePipelinesBatch.yml

</details>

<details>
<summary>Test results from PR #6047</summary>

| Metric | Before fix | Run 1 (cold) | Run 2 (warm) |
|--------|-----------|-------------|-------------|
| Hit rate | 0.02% | 0% (seeding) | **99.95%** |
| Direct hits | 1 | 0 | 2166/2167 |
| Misses | 5159 | ~2167 | 1 |

</details>

<!--
provenance: claude-code session 2026-04-13
key_facts: CCACHE_NODIRECT=1 was the sole root cause of near-zero hit rate; per-job cache keys prevent cross-config poisoning; CCACHE_SLOPPINESS needed for time macros
related_files: Testing/ContinuousIntegration/AzurePipelines*.yml
post_merge_action: monitor ccache stats on next few main-branch builds to confirm sustained 95%+ hit rate across all platforms
-->