### PR TITLE
COMP: Update retired windows-2019 CI runner to windows-2022

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
@@ -29,8 +29,8 @@ jobs:
           CTEST_CMAKE_GENERATOR_TOOLSET: v142
           CTEST_CMAKE_GENERATOR_PLATFORM: x64
           CTEST_CONFIGURATION_TYPE: Release
-          CTEST_CMAKE_GENERATOR: "Visual Studio 16 2019"
-          imageName: 'windows-2019'
+          CTEST_CMAKE_GENERATOR: "Visual Studio 17 2022"
+          imageName: 'windows-2022'
     pool:
       vmImage: $(imageName)
     steps:


### PR DESCRIPTION
Migrate the v142 (VS2019 toolset) batch job from the retired windows-2019 runner to windows-2022. Preserves v142 compiler compatibility testing on a supported runner image.

<details>
<summary>Changes</summary>

- Updated `imageName` from `windows-2019` to `windows-2022`
- Updated `CTEST_CMAKE_GENERATOR` from `"Visual Studio 16 2019"` to `"Visual Studio 17 2022"` (v142 toolset works within VS2022)
- `windows-2019` was [retired 2025-03-24](https://github.com/actions/runner-images/issues/5816)

</details>

<!--
provenance: claude-code session 2026-04-13
key_facts: v142 toolset preserved per dzenanz review; runs on windows-2022 with VS2022 generator
related_files: Testing/ContinuousIntegration/AzurePipelinesBatch.yml
-->