### PR TITLE
BUG: Fix float-precision division in BresenhamLine::BuildLine

### DIFF
--- a/Modules/Core/Common/include/itkBresenhamLine.hxx
+++ b/Modules/Core/Common/include/itkBresenhamLine.hxx
@@ -41,7 +41,8 @@ BresenhamLine<VDimension>::BuildLine(LType Direction, IdentifierType length) -> 
   // compute actual line length because the shorter distance
   // the larger deviation due to rounding to integers
   const IdentifierType mainDirectionLen = length - 1;
-  const double         euclideanLineLen = mainDirectionLen / itk::Math::Absolute(Direction[maxDistanceDimension]);
+  const double         euclideanLineLen =
+    static_cast<double>(mainDirectionLen) / static_cast<double>(itk::Math::Absolute(Direction[maxDistanceDimension]));
 
   // we are going to start at 0
   constexpr IndexType StartIndex{ 0 };


### PR DESCRIPTION
Fix float-precision division in `BuildLine(Direction, length)`. The expression `IdentifierType / float` was evaluating in float precision despite storing the result in a `double`. Adds explicit `static_cast<double>()` on both operands.

Companion to the release-5.4 backport in #6054 where this was caught by Greptile review.

<!--
provenance: claude-code session 2026-04-14
key_facts: LType = Vector<float>; division was float-precision; companion to backport #6054
related_files: Modules/Core/Common/include/itkBresenhamLine.hxx:44
-->