### PR TITLE
BUG: Backport null checks after ReadHeader in IPLCommonImageIO

### DIFF
--- a/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
+++ b/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
@@ -133,9 +133,10 @@ IPLCommonImageIO::ReadImageInformation()
   FileNameToRead = _imagePath;
 
   this->m_ImageHeader = this->ReadHeader(FileNameToRead.c_str());
-  //
-  // if anything fails in the header read, just let
-  // exceptions propagate up.
+  if (m_ImageHeader == nullptr)
+  {
+    itkExceptionMacro("ReadHeader failed for " << FileNameToRead);
+  }
 
   bool        isCT = false;
   std::string modality = m_ImageHeader->modality;
@@ -223,6 +224,10 @@ IPLCommonImageIO::ReadImageInformation()
       // So if, for example we run into a subdirectory, it would
       // throw an exception, and we'd just want to skip it.
       continue;
+    }
+    if (curImageHeader == nullptr)
+    {
+      itkExceptionMacro("ReadHeader failed for " << fullPath);
     }
     if ((((isCT) ? curImageHeader->examNumber : curImageHeader->echoNumber) == m_FilenameList->GetKey2()) &&
         (curImageHeader->seriesNumber == m_FilenameList->GetKey1()))


### PR DESCRIPTION
Cherry-pick of 0eb1c42d from main. Adds null checks after `ReadHeader` calls in `IPLCommonImageIO` to prevent null pointer dereference.

Backport for #6051 (Tier 1).

<!--
provenance: claude-code session 2026-04-15
cherry-pick: 0eb1c42d0e from main
-->