### PR TITLE
BUG: Backport value-initialize singleton instances

### DIFF
--- a/Modules/Core/Common/include/itkSingleton.h
+++ b/Modules/Core/Common/include/itkSingleton.h
@@ -138,7 +138,7 @@ Singleton(const char * globalName, std::function<void()> deleteFunc)
   T *                                      instance = SingletonIndex::GetInstance()->GetGlobalInstance<T>(globalName);
   if (instance == nullptr)
   {
-    instance = new T;
+    instance = new T{};
     SingletonIndex::GetInstance()->SetGlobalInstance<T>(globalName, instance, std::move(deleteFunc));
   }
   return instance;


### PR DESCRIPTION
Cherry-pick of 2f37d7a3 from main. Value-initializes singleton instances to avoid indeterminate values from default-initialization.

Backport for #6051 (Tier 1).

<!--
provenance: claude-code session 2026-04-15
cherry-pick: 2f37d7a33e from main
-->