### PR TITLE
BUG: Backport zero-check guard in CumulativeGaussianCostFunction

### DIFF
--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianCostFunction.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianCostFunction.cxx
@@ -43,7 +43,7 @@ CumulativeGaussianCostFunction::CalculateFitError(MeasureType * setTestArray)
   // Use root mean square error as a measure of fit quality.
   unsigned int numberOfElements = m_OriginalDataArray.GetNumberOfElements();
 
-  if (numberOfElements != setTestArray->GetNumberOfElements())
+  if (numberOfElements == 0 || numberOfElements != setTestArray->GetNumberOfElements())
   {
     return 1;
   }


### PR DESCRIPTION
Adapted from d7845fee on main. Adds `numberOfElements == 0` check before the size-mismatch check in `CalculateFitError` to guard against division-by-zero.

On main this was a reorder of an existing compound condition; on release-5.4 the zero check was entirely absent.

Backport for #6051 (Tier 1).

<!--
provenance: claude-code session 2026-04-15
adapted-from: d7845feee7 on main
note: release-5.4 had no zero check at all, main had it in wrong order
-->