### PR TITLE
COMP: IO modules publicly depend on ImageIOBase

### DIFF
--- a/Modules/IO/DCMTK/itk-module.cmake
+++ b/Modules/IO/DCMTK/itk-module.cmake
@@ -7,9 +7,10 @@ href=\"https://dicom.offis.de/dcmtk/\">DCMTK</a> DCMTK is a collection of librar
 itk_module(
   ITKIODCMTK
   ENABLE_SHARED
+  DEPENDS
+    ITKIOImageBase
   PRIVATE_DEPENDS
     ITKDCMTK
-    ITKIOImageBase
   TEST_DEPENDS
     ITKTestKernel
     ITKImageIntensity

--- a/Modules/IO/GE/itk-module.cmake
+++ b/Modules/IO/GE/itk-module.cmake
@@ -10,7 +10,6 @@ itk_module(
   ENABLE_SHARED
   DEPENDS
     ITKIOIPL
-  PRIVATE_DEPENDS
     ITKIOImageBase
   TEST_DEPENDS
     ITKTestKernel

--- a/Modules/IO/LSM/itk-module.cmake
+++ b/Modules/IO/LSM/itk-module.cmake
@@ -10,9 +10,9 @@ itk_module(
   ITKIOLSM
   DEPENDS
     ITKIOTIFF
+    ITKIOImageBase
   ENABLE_SHARED
   PRIVATE_DEPENDS
-    ITKIOImageBase
     ITKTIFF
   TEST_DEPENDS
     ITKTestKernel

--- a/Modules/IO/PhilipsREC/itk-module.cmake
+++ b/Modules/IO/PhilipsREC/itk-module.cmake
@@ -7,8 +7,9 @@ REC/PAR image files."
 itk_module(
   ITKIOPhilipsREC
   ENABLE_SHARED
-  PRIVATE_DEPENDS
+  DEPENDS
     ITKIOImageBase
+  PRIVATE_DEPENDS
     ITKZLIB
   TEST_DEPENDS
     ITKTestKernel


### PR DESCRIPTION
Move `ITKIOImageBase` from `PRIVATE_DEPENDS` to `DEPENDS` for 4 IO modules whose public headers `#include "itkImageIOBase.h"` or inherit from `ImageIOBase`: DCMTK, GE, LSM, and the Philips REC module.

Follows the same fix applied to VTK in #5850. With `PRIVATE_DEPENDS`, downstream projects that consume these modules' public headers may not receive the transitive include paths and link targets for `ITKIOImageBase`.

<details>
<summary>Header analysis confirming public dependency</summary>

Each module was verified to have public headers that directly reference ITKIOImageBase types:

- **DCMTK**: `itkDCMTKImageIO.h` includes `itkImageIOBase.h`, `DCMTKImageIO` inherits from `ImageIOBase`
- **GE**: `itkGE4ImageIOFactory.h`, `itkGE5ImageIOFactory.h`, `itkGEAdwImageIOFactory.h` include `itkImageIOBase.h`
- **LSM**: `itkLSMImageIOFactory.h` includes `itkImageIOBase.h`
- **Philips REC**: `itkPhilipsRECImageIO.h` includes `itkImageIOBase.h`, inherits from `ImageIOBase`

**Not included:** ITKIOCSV — its public headers do not reference any IOImageBase types. Its `PRIVATE_DEPENDS ITKIOImageBase` may be vestigial or only needed for module infrastructure, and warrants separate investigation.

</details>

<details>
<summary>Local build verification</summary>

- Configure: passed (ITK 6.0.0, CMake 3.26.6, Ninja, macOS)
- Build: 1145 incremental targets, 0 errors
- Tests: 4/4 IO module tests passed (GE, LSM; DCMTK and Philips REC are `EXCLUDE_FROM_DEFAULT`)
- Generated module configs verified: `ITKIOImageBase` appears in `PUBLIC_DEPENDS` and `TRANSITIVE_DEPENDS`
- gersemi pre-commit check: passed

</details>

<!--
provenance: claude-code session 2026-04-15
related: #5850 (VTK fix by blowekamp), #5842 (CMake interfaces refactor)
csv_note: ITKIOCSV excluded - no public header references to IOImageBase
local_build: ITK/build (main, ITK 6.0.0), 4/4 tests passed
-->
