### PR TITLE
WIP: REMOTE_MODULE_TEST BUG: Fix DCMTK external module compatibility (ijg include paths + MSVC __cplusplus)

### DIFF
--- a/CMake/itkCompilerChecks.cmake
+++ b/CMake/itkCompilerChecks.cmake
@@ -38,3 +38,12 @@ if(NOT ITK_IGNORE_CMAKE_CXX17_CHECKS)
     set(CMAKE_CXX_EXTENSIONS OFF)
   endif()
 endif()
+
+# MSVC does not set __cplusplus correctly by default (returns 199711L
+# regardless of the actual standard). /Zc:__cplusplus makes it report
+# the true value. Required for third-party headers (e.g. DCMTK
+# osconfig.h) that check __cplusplus >= 201103L at compile time.
+# Available since VS2017 15.7 (MSVC 19.14); we require 19.20+.
+if(MSVC AND NOT CMAKE_CXX_FLAGS MATCHES "/Zc:__cplusplus")
+  string(APPEND CMAKE_CXX_FLAGS " /Zc:__cplusplus")
+endif()

--- a/Modules/ThirdParty/DCMTK/CMakeLists.txt
+++ b/Modules/ThirdParty/DCMTK/CMakeLists.txt
@@ -130,7 +130,13 @@ else(ITK_USE_SYSTEM_DCMTK)
   set(ITKDCMTK_LIBRARIES "${_ITKDCMTK_LIB_NAMES}")
   #
   # add all the embedded include directories to include dirs
+  # Skip internal JPEG codec libraries (ijg8, ijg12, ijg16) — they have
+  # no public headers and exporting non-existent paths in
+  # INTERFACE_INCLUDE_DIRECTORIES causes CMake errors in external modules.
   foreach(lib ${_ITKDCMTK_LIB_NAMES})
+    if(lib MATCHES "^ijg")
+      continue()
+    endif()
     # add to include list
     list(APPEND ITKDCMTK_INCLUDE_DIRS
       ${ITKDCMTK_INCLUDE}/${lib}/include)


### PR DESCRIPTION
Fix two DCMTK issues that break external module builds (e.g., ITKIOTransformDCMTK). Backport candidate for v5.4.6 per #6051.

**Issue 1 (Linux):** DCMTK internal JPEG codec libraries (ijg8, ijg12, ijg16) are included in the INTERFACE_INCLUDE_DIRECTORIES loop, but these libraries have no public headers. The exported paths don't exist, causing CMake configure errors in external modules.

**Issue 2 (Windows):** MSVC reports `__cplusplus == 199711L` regardless of the actual C++ standard. DCMTK's `osconfig.h` checks `__cplusplus >= 201103L` and raises `#error` on MSVC even with C++17 enabled. Adding `/Zc:__cplusplus` makes MSVC report the true value.

<details>
<summary>Downstream impact</summary>

- InsightSoftwareConsortium/ITKIOTransformDCMTK#17 — both issues confirmed
- Any external module that depends on ITKDCMTKModule and builds with the shared CI action

</details>

<details>
<summary>Commits</summary>

1. **BUG: Exclude DCMTK ijg* libs from INTERFACE_INCLUDE_DIRECTORIES** — skip `ijg8/ijg12/ijg16` in the include path loop
2. **COMP: Add /Zc:__cplusplus for MSVC** — in `itkCompilerChecks.cmake`, append `/Zc:__cplusplus` when building with MSVC (available since 19.14, we require 19.20+)

</details>

<!--
provenance: claude-code session 2026-04-15
fixes: ITKIOTransformDCMTK#17
backport_tracking: #6051
files: Modules/ThirdParty/DCMTK/CMakeLists.txt, CMake/itkCompilerChecks.cmake
-->