### PR TITLE
DOC: Add factory meta-module guidance for external project test drivers

### DIFF
--- a/Documentation/docs/migration_guides/itk_6_migration_guide.md
+++ b/Documentation/docs/migration_guides/itk_6_migration_guide.md
@@ -396,6 +396,36 @@ target_link_libraries(MyTarget ${ITK_INTERFACE_LIBRARIES} ITK::ITKImageIO)
 In this example, the GDCM and NRRD ImageIO modules are explicitly loaded. Only the ImageIO factory type is registered and generated.
 
 
+**Factory Registration in External Project Test Drivers:**
+
+External projects (like RTK, BRAINSTools, or ITK remote modules) that need FFT, IO, or other
+factory-registered backends in their test drivers should **link against the meta-module target**
+rather than manually calling `RegisterFactory()`. This ensures the correct backends are
+registered automatically and stays in sync with the ITK build configuration.
+
+```cmake
+# In your external project's test CMakeLists.txt:
+find_package(ITK REQUIRED COMPONENTS ITKFFT)
+itk_generate_factory_registration()
+
+add_executable(MyTestDriver myTestDriver.cxx)
+target_link_libraries(MyTestDriver
+  PRIVATE
+    ITK::ITKFFTImageFilterInit   # Registers FFTW (if available) + VNL FFT backends
+    ITK::ITKImageIO              # Registers all image IO formats
+    ITK::ITKMeshIO               # Registers all mesh IO formats
+    ITK::ITKTransformIO          # Registers all transform IO formats
+)
+```
+
+This replaces the legacy pattern of manually including factory headers and calling
+`itk::ObjectFactoryBase::RegisterFactory()` for each backend. The meta-module approach is
+preferred because:
+
+- New backends are picked up automatically when ITK is reconfigured
+- Factory priority ordering is handled by the module system
+- No `#if defined(ITK_USE_FFTWF)` guards needed in application code
+
 **Determining Required Modules:**
 
 To identify which ITK modules your code depends on, use the `WhatModulesITK.py` utility:

--- a/Modules/Core/TestKernel/include/itkTestDriverIncludeRequiredFactories.h
+++ b/Modules/Core/TestKernel/include/itkTestDriverIncludeRequiredFactories.h
@@ -18,6 +18,14 @@
 #ifndef itkTestDriverIncludeRequiredFactories_h
 #define itkTestDriverIncludeRequiredFactories_h
 
+// WARNING: This header is part of ITK's internal test infrastructure.
+// External projects should NOT include this header or copy its registration
+// pattern. Instead, link against the factory meta-module targets:
+//
+//   target_link_libraries(MyTestDriver PRIVATE ITK::ITKFFTImageFilterInit)
+//
+// See the ITK 6 Migration Guide section "Factory Registration in External
+// Project Test Drivers" for the recommended approach.
 
 #include "itkTestDriverInclude.h"
 

--- a/Modules/Core/TestKernel/src/itkTestDriverIncludeRequiredFactories.cxx
+++ b/Modules/Core/TestKernel/src/itkTestDriverIncludeRequiredFactories.cxx
@@ -18,6 +18,20 @@
 
 #include "itkTestDriverIncludeRequiredFactories.h"
 
+// WARNING: The explicit factory registration pattern in this file is an
+// internal ITK test infrastructure mechanism. External projects should NOT
+// copy this pattern. Instead, link against the factory meta-module targets:
+//
+//   target_link_libraries(MyTestDriver PRIVATE
+//     ITK::ITKFFTImageFilterInit   # FFT backends
+//     ITK::ITKImageIO              # Image IO formats
+//     ITK::ITKMeshIO               # Mesh IO formats
+//     ITK::ITKTransformIO          # Transform IO formats
+//   )
+//
+// See the ITK 6 Migration Guide section "Factory Registration in External
+// Project Test Drivers" for details.
+
 // ImageIO
 #include "itkGDCMImageIOFactory.h"
 #include "itkMetaImageIOFactory.h"


### PR DESCRIPTION
Document the preferred pattern for external projects to register factory backends in test drivers: link against `ITK::ITKFFTImageFilterInit` (and `ITK::ITKImageIO`, etc.) instead of manually calling `RegisterFactory()`.

Motivated by @blowekamp's review of #6073 — the meta-module approach is more maintainable and consistent with how IO factories already work.

<details>
<summary>What the documentation adds</summary>

A new section "Factory Registration in External Project Test Drivers" in the ITK 6 migration guide, placed between the existing "Factory Registration with Meta-Modules" section and "Determining Required Modules". Shows the CMake pattern:

```cmake
target_link_libraries(MyTestDriver
  PRIVATE
    ITK::ITKFFTImageFilterInit
    ITK::ITKImageIO
    ITK::ITKMeshIO
    ITK::ITKTransformIO
)
```

Explains why this replaces manual `RegisterFactory()` calls.

</details>

<details>
<summary>Places in ITK that still use explicit registration</summary>

| Location | Pattern | Notes |
|---|---|---|
| `Modules/Core/TestKernel/src/itkTestDriverIncludeRequiredFactories.cxx` | Manual `RegisterFactory()` for all IO + FFT | Legacy pattern for ITK's own test drivers; kept as belt-and-suspenders (#6073) |
| `Modules/Filtering/FFT/test/itkFFT1DImageFilterTest.cxx:133-134` | Manual `RegisterInternalFactoryOnce<FFTWForward1DFFT>` | Test-specific — registers only the backends needed for that test |

These are internal to ITK and intentional. The documentation targets **external projects** that copy the manual pattern when they should use meta-modules instead.

</details>

<!--
provenance: claude-code session 2026-04-16
trigger: blowekamp review on #6073
related: #6073 (FFTW factory registration)
-->