### PR TITLE
DOC: Clarify WIP: prefix workflow; align AI docs with hook

### DIFF
--- a/Documentation/AI/enforced-code-style.md
+++ b/Documentation/AI/enforced-code-style.md
@@ -28,9 +28,8 @@ Do not use `--no-verify` to bypass — the format check exists to keep CI green.
 
 The `kw-commit-msg.py` hook enforces:
 - Subject line ≤78 characters
-- Standard prefix required (`ENH:` `BUG:` `COMP:` `DOC:` `STYLE:` `PERF:` `BUILD:`)
-- `WIP:` is **not** allowed by `ghostflow-check-main` — use `[WIP]` in the
-  PR title instead (see [git-commits.md](./git-commits.md))
+- Approved commit-subject prefix — see
+  [git-commits.md § Prefixes](./git-commits.md#prefixes) for the list
 
 KWStyle also checks that every header has the doxygen `\class` tag. See
 [compiler-cautions.md](./compiler-cautions.md) section 12a for the

--- a/Documentation/AI/git-commits.md
+++ b/Documentation/AI/git-commits.md
@@ -29,14 +29,21 @@ subject should be scannable in `git log --oneline`.
 | `DOC:` | Documentation only |
 | `STYLE:` | Formatting, naming, no logic change |
 | `PERF:` | Performance improvement |
-| `BUILD:` | Build-system / CMake changes |
+| `WIP:` | Transient commits for development testing only |
 
-> **Do not use `WIP:` as a commit-subject prefix.** It is not in the
-> `ghostflow-check-main` allowed list and will reject the PR. To mark a PR
-> as work-in-progress, use a `[WIP]` prefix in the **PR title** (the GitHub
-> "WIP" app gates merging on it) but keep individual commit subjects on a
-> standard prefix like `ENH:` or `BUG:`. When the PR is ready, remove
-> `[WIP]` from the title.
+> **`WIP:` on commit subjects is a two-layer opt-in — use it deliberately.**
+> The local `kw-commit-msg.py` hook **intentionally** accepts `WIP:` so
+> developers can commit probe tests, A/B experiments, and other work they
+> know is not suitable for `main` — without renaming the prefix on every
+> iteration. `ghostflow-check-main` (the GitHub App gating PR merge) then
+> rejects any commit whose subject begins with `WIP:`, which is the
+> intended safety net: `WIP:` commits cannot accidentally land on `main`.
+> Before marking the PR ready for review, remove, reword, fixup, or squash
+> `WIP:` commits into standard-prefix commits.
+>
+> To mark an entire PR (rather than individual commits) as
+> work-in-progress, add `[WIP]` to the **PR title** — the GitHub "WIP" app
+> gates merging on that string; remove it when the PR is ready.
 
 ## Commit Message Length
 


### PR DESCRIPTION
Clarify that `WIP:` is intentionally accepted by the local `kw-commit-msg.py` hook — so developers can stage probe tests and A/B experiments without renaming the prefix — and rejected at merge time by `ghostflow-check-main`. Also drops `BUILD:` from the prefix table (the hook never accepted it) and consolidates the authoritative prefix list into `git-commits.md`.

<details>
<summary>Background: three inconsistencies between the AI docs and kw-commit-msg.py</summary>

1. **`WIP:` was documented as "do not use"**, but the hook regex at `Utilities/Hooks/kw-commit-msg.py:115` *does* accept it — by design. The local accept + merge-time reject is the intended two-layer workflow: commit in-progress work without prefix churn on every iteration; remove, reword, fixup, or squash before marking the PR ready. `git-commits.md` now describes this gating explicitly.

2. **`BUILD:` was aspirational, not real.** Listed in both `git-commits.md`'s prefix table and `enforced-code-style.md`'s kw-commit-msg.py allow-list, but the hook regex rejects it. Any `BUILD:` commit would fail the local hook.

3. **The prefix list was triplicated** — hook regex, `git-commits.md`, and `enforced-code-style.md` each had to stay in sync. `enforced-code-style.md`'s KWStyle section now delegates to `git-commits.md § Prefixes`; the hook has exactly one authoritative doc reflection.

</details>

<details>
<summary>Files changed (+17 / −11)</summary>

- `Documentation/AI/git-commits.md` — new `WIP:` table row; rewritten blockquote describing the two-layer gating; `BUILD:` row removed
- `Documentation/AI/enforced-code-style.md` — KWStyle section now delegates to `git-commits.md § Prefixes`

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code — identified the three-way inconsistency, drafted the WIP: blockquote rewrite and the prefix-list consolidation, applied the mechanical edits
- Human reviewed the diff in a local difit session before push

</details>

<!--
provenance: claude-code session 2026-04-17
hook_reference: Utilities/Hooks/kw-commit-msg.py:115 (prefix allow-list regex)
authoritative_doc: Documentation/AI/git-commits.md § Prefixes
related_commit: 7637510088 (amended from 3cd7c7bc37 after local difit review)
post_merge_action: none — doc-only, no code or CI impact
-->
