### PR TITLE
DOC: Fix WIP: guidance to match kw-commit-msg.py reality

### DIFF
--- a/Documentation/AI/enforced-code-style.md
+++ b/Documentation/AI/enforced-code-style.md
@@ -28,9 +28,11 @@ Do not use `--no-verify` to bypass — the format check exists to keep CI green.
 
 The `kw-commit-msg.py` hook enforces:
 - Subject line ≤78 characters
-- Standard prefix required (`ENH:` `BUG:` `COMP:` `DOC:` `STYLE:` `PERF:`)
-- `WIP:` is **not** allowed by `ghostflow-check-main` — use `[WIP]` in the
-  PR title instead (see [git-commits.md](./git-commits.md))
+- Standard prefix required (`ENH:` `BUG:` `COMP:` `DOC:` `STYLE:` `PERF:` `WIP:`)
+- `WIP:` is accepted by the local hook for iterative commits, but
+  `ghostflow-check-main` rejects it at PR-merge time — rebase or rename
+  WIP commits before marking the PR ready (see
+  [git-commits.md](./git-commits.md))
 
 KWStyle also checks that every header has the doxygen `\class` tag. See
 [compiler-cautions.md](./compiler-cautions.md) section 12a for the

--- a/Documentation/AI/enforced-code-style.md
+++ b/Documentation/AI/enforced-code-style.md
@@ -28,7 +28,7 @@ Do not use `--no-verify` to bypass — the format check exists to keep CI green.
 
 The `kw-commit-msg.py` hook enforces:
 - Subject line ≤78 characters
-- Standard prefix required (`ENH:` `BUG:` `COMP:` `DOC:` `STYLE:` `PERF:` `BUILD:`)
+- Standard prefix required (`ENH:` `BUG:` `COMP:` `DOC:` `STYLE:` `PERF:`)
 - `WIP:` is **not** allowed by `ghostflow-check-main` — use `[WIP]` in the
   PR title instead (see [git-commits.md](./git-commits.md))
 

--- a/Documentation/AI/git-commits.md
+++ b/Documentation/AI/git-commits.md
@@ -29,7 +29,6 @@ subject should be scannable in `git log --oneline`.
 | `DOC:` | Documentation only |
 | `STYLE:` | Formatting, naming, no logic change |
 | `PERF:` | Performance improvement |
-| `BUILD:` | Build-system / CMake changes |
 
 > **Do not use `WIP:` as a commit-subject prefix.** It is not in the
 > `ghostflow-check-main` allowed list and will reject the PR. To mark a PR

--- a/Documentation/AI/git-commits.md
+++ b/Documentation/AI/git-commits.md
@@ -30,12 +30,14 @@ subject should be scannable in `git log --oneline`.
 | `STYLE:` | Formatting, naming, no logic change |
 | `PERF:` | Performance improvement |
 
-> **Do not use `WIP:` as a commit-subject prefix.** It is not in the
-> `ghostflow-check-main` allowed list and will reject the PR. To mark a PR
-> as work-in-progress, use a `[WIP]` prefix in the **PR title** (the GitHub
-> "WIP" app gates merging on it) but keep individual commit subjects on a
-> standard prefix like `ENH:` or `BUG:`. When the PR is ready, remove
-> `[WIP]` from the title.
+> **Using `WIP:` on commit subjects.** The local `kw-commit-msg.py` hook
+> accepts `WIP:` so it can be used for iterative local commits, but
+> `ghostflow-check-main` (the GitHub App gating PR merge) rejects any
+> commit whose subject starts with `WIP:`. Either rebase/squash WIP
+> commits into standard-prefix commits before making the PR ready, or
+> avoid `WIP:` on commit subjects altogether. To mark a whole PR as
+> work-in-progress, add `[WIP]` to the **PR title** — the GitHub "WIP"
+> app gates merging on that; remove it when the PR is ready.
 
 ## Commit Message Length
 


### PR DESCRIPTION
Symmetric follow-up to #6080. The AI docs forbid `WIP:` as a commit-subject prefix, but the local `kw-commit-msg.py` hook actually accepts it — only the `ghostflow-check-main` GitHub App (kwrobot) rejects it at PR-merge time. Updates both `Documentation/AI/enforced-code-style.md` and `Documentation/AI/git-commits.md` to describe real behaviour.

**Merge order: land #6080 first.** This branch is rebased on top of `doc-remove-build-prefix` to avoid a merge conflict on `enforced-code-style.md:31`. After #6080 merges, the stacked commit here still applies cleanly; if this merges first, #6080 will need a rebase.

<details>
<summary>Ground truth from the hook</summary>

`Utilities/Hooks/kw-commit-msg.py:115` lists these acceptable subject prefixes: `Merge` / `Revert` / `BUG:` / `COMP:` / `DOC:` / `ENH:` / `PERF:` / `STYLE:` / `WIP:`.

`WIP:` is in the allowed list; `BUILD:` is not (hence #6080).

</details>

<details>
<summary>What changes</summary>

| File | Change |
|------|--------|
| `Documentation/AI/enforced-code-style.md` | `WIP:` added to the listed hook prefixes; ghostflow caveat reworded to "accepted locally; rejected at merge" |
| `Documentation/AI/git-commits.md` | WIP: section rewritten: rebase or squash before merge; or use `[WIP]` in PR title for draft gating |

</details>

<!--
provenance: claude-code session 2026-04-17
key_facts:
  hook_line: Utilities/Hooks/kw-commit-msg.py:115 (regex)
  hook_allowed_list: Merge | Revert | BUG: | COMP: | DOC: | ENH: | PERF: | STYLE: | WIP:
  hook_rejects: BUILD:
  external_blocker: ghostflow-check-main (kwrobot GitHub App) rejects WIP: at PR-merge time
related_prs: #6080 (converse BUILD: cleanup; this PR is rebased on top of that branch)
related_files:
  - Documentation/AI/enforced-code-style.md:31-34
  - Documentation/AI/git-commits.md:33-40
post_merge_action: none
-->
