### PR TITLE
STYLE: Add SPDX license identifiers to all ITK source files

### DIFF
--- a/Examples/DataRepresentation/Image/Image1.cxx
+++ b/Examples/DataRepresentation/Image/Image1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Image/Image2.cxx
+++ b/Examples/DataRepresentation/Image/Image2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Image/Image3.cxx
+++ b/Examples/DataRepresentation/Image/Image3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Image/Image4.cxx
+++ b/Examples/DataRepresentation/Image/Image4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Image/Image5.cxx
+++ b/Examples/DataRepresentation/Image/Image5.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Image/ImageAdaptor1.cxx
+++ b/Examples/DataRepresentation/Image/ImageAdaptor1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Image/ImageAdaptor2.cxx
+++ b/Examples/DataRepresentation/Image/ImageAdaptor2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Image/ImageAdaptor3.cxx
+++ b/Examples/DataRepresentation/Image/ImageAdaptor3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Image/ImageAdaptor4.cxx
+++ b/Examples/DataRepresentation/Image/ImageAdaptor4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Image/ImageToArray.py
+++ b/Examples/DataRepresentation/Image/ImageToArray.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Examples/DataRepresentation/Image/RGBImage.cxx
+++ b/Examples/DataRepresentation/Image/RGBImage.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Image/VectorImage.cxx
+++ b/Examples/DataRepresentation/Image/VectorImage.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Mesh/AutomaticMesh.cxx
+++ b/Examples/DataRepresentation/Mesh/AutomaticMesh.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Mesh/ImageToPointSet.cxx
+++ b/Examples/DataRepresentation/Mesh/ImageToPointSet.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Mesh/Mesh1.cxx
+++ b/Examples/DataRepresentation/Mesh/Mesh1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Mesh/Mesh2.cxx
+++ b/Examples/DataRepresentation/Mesh/Mesh2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Mesh/Mesh3.cxx
+++ b/Examples/DataRepresentation/Mesh/Mesh3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Mesh/MeshCellVisitor.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshCellVisitor.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Mesh/MeshCellVisitor2.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshCellVisitor2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Mesh/MeshCellsIteration.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshCellsIteration.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Mesh/MeshKComplex.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshKComplex.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Mesh/MeshPolyLine.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshPolyLine.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Mesh/MeshTraits.cxx
+++ b/Examples/DataRepresentation/Mesh/MeshTraits.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Mesh/PointSet1.cxx
+++ b/Examples/DataRepresentation/Mesh/PointSet1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Mesh/PointSet2.cxx
+++ b/Examples/DataRepresentation/Mesh/PointSet2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Mesh/PointSet3.cxx
+++ b/Examples/DataRepresentation/Mesh/PointSet3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Mesh/PointSetWithCovariantVectors.cxx
+++ b/Examples/DataRepresentation/Mesh/PointSetWithCovariantVectors.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Mesh/PointSetWithVectors.cxx
+++ b/Examples/DataRepresentation/Mesh/PointSetWithVectors.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Mesh/RGBPointSet.cxx
+++ b/Examples/DataRepresentation/Mesh/RGBPointSet.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/DataRepresentation/Path/PolyLineParametricPath1.cxx
+++ b/Examples/DataRepresentation/Path/PolyLineParametricPath1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/AntiAliasBinaryImageFilter.cxx
+++ b/Examples/Filtering/AntiAliasBinaryImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/BilateralImageFilter.cxx
+++ b/Examples/Filtering/BilateralImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/BinaryMedianImageFilter.cxx
+++ b/Examples/Filtering/BinaryMedianImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/BinaryMinMaxCurvatureFlowImageFilter.cxx
+++ b/Examples/Filtering/BinaryMinMaxCurvatureFlowImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/BinaryThresholdImageFilter.cxx
+++ b/Examples/Filtering/BinaryThresholdImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/BinomialBlurImageFilter.cxx
+++ b/Examples/Filtering/BinomialBlurImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/CannyEdgeDetectionImageFilter.cxx
+++ b/Examples/Filtering/CannyEdgeDetectionImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/CastingImageFilters.cxx
+++ b/Examples/Filtering/CastingImageFilters.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/CompositeFilterExample.cxx
+++ b/Examples/Filtering/CompositeFilterExample.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/CurvatureAnisotropicDiffusionImageFilter.cxx
+++ b/Examples/Filtering/CurvatureAnisotropicDiffusionImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/CurvatureFlowImageFilter.cxx
+++ b/Examples/Filtering/CurvatureFlowImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/DanielssonDistanceMapImageFilter.cxx
+++ b/Examples/Filtering/DanielssonDistanceMapImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/DerivativeImageFilter.cxx
+++ b/Examples/Filtering/DerivativeImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/DiffusionTensor3DReconstructionImageFilter.cxx
+++ b/Examples/Filtering/DiffusionTensor3DReconstructionImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/DigitallyReconstructedRadiograph1.cxx
+++ b/Examples/Filtering/DigitallyReconstructedRadiograph1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/DiscreteGaussianImageFilter.cxx
+++ b/Examples/Filtering/DiscreteGaussianImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/FFTDirectInverse.cxx
+++ b/Examples/Filtering/FFTDirectInverse.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/FFTDirectInverse2.cxx
+++ b/Examples/Filtering/FFTDirectInverse2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/FFTImageFilter.cxx
+++ b/Examples/Filtering/FFTImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/FFTImageFilterFourierDomainFiltering.cxx
+++ b/Examples/Filtering/FFTImageFilterFourierDomainFiltering.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/FlipImageFilter.cxx
+++ b/Examples/Filtering/FlipImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/GaussianBlurImageFunction.cxx
+++ b/Examples/Filtering/GaussianBlurImageFunction.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/GradientAnisotropicDiffusionImageFilter.cxx
+++ b/Examples/Filtering/GradientAnisotropicDiffusionImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/GradientMagnitudeImageFilter.cxx
+++ b/Examples/Filtering/GradientMagnitudeImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/GradientMagnitudeRecursiveGaussianImageFilter.cxx
+++ b/Examples/Filtering/GradientMagnitudeRecursiveGaussianImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/GradientRecursiveGaussianImageFilter.cxx
+++ b/Examples/Filtering/GradientRecursiveGaussianImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/GradientVectorFlowImageFilter.cxx
+++ b/Examples/Filtering/GradientVectorFlowImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/GrayscaleFunctionDilateImageFilter.cxx
+++ b/Examples/Filtering/GrayscaleFunctionDilateImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/LaplacianImageFilter.cxx
+++ b/Examples/Filtering/LaplacianImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/LaplacianRecursiveGaussianImageFilter1.cxx
+++ b/Examples/Filtering/LaplacianRecursiveGaussianImageFilter1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/LaplacianRecursiveGaussianImageFilter2.cxx
+++ b/Examples/Filtering/LaplacianRecursiveGaussianImageFilter2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/LaplacianSharpeningImageFilter.cxx
+++ b/Examples/Filtering/LaplacianSharpeningImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/MathematicalMorphologyBinaryFilters.cxx
+++ b/Examples/Filtering/MathematicalMorphologyBinaryFilters.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/MathematicalMorphologyGrayscaleFilters.cxx
+++ b/Examples/Filtering/MathematicalMorphologyGrayscaleFilters.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/MeanImageFilter.cxx
+++ b/Examples/Filtering/MeanImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/MedianImageFilter.cxx
+++ b/Examples/Filtering/MedianImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/MinMaxCurvatureFlowImageFilter.cxx
+++ b/Examples/Filtering/MinMaxCurvatureFlowImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/MorphologicalImageEnhancement.cxx
+++ b/Examples/Filtering/MorphologicalImageEnhancement.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/OrientImageFilter.cxx
+++ b/Examples/Filtering/OrientImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/OtsuMultipleThresholdImageFilter.cxx
+++ b/Examples/Filtering/OtsuMultipleThresholdImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/OtsuThresholdImageFilter.cxx
+++ b/Examples/Filtering/OtsuThresholdImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/RGBCurvatureAnisotropicDiffusionImageFilter.cxx
+++ b/Examples/Filtering/RGBCurvatureAnisotropicDiffusionImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/RGBGradientAnisotropicDiffusionImageFilter.cxx
+++ b/Examples/Filtering/RGBGradientAnisotropicDiffusionImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/RGBToGrayscale.cxx
+++ b/Examples/Filtering/RGBToGrayscale.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/ResampleImageFilter.cxx
+++ b/Examples/Filtering/ResampleImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/ResampleImageFilter2.cxx
+++ b/Examples/Filtering/ResampleImageFilter2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/ResampleImageFilter3.cxx
+++ b/Examples/Filtering/ResampleImageFilter3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/ResampleImageFilter4.cxx
+++ b/Examples/Filtering/ResampleImageFilter4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/ResampleImageFilter5.cxx
+++ b/Examples/Filtering/ResampleImageFilter5.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/ResampleImageFilter6.cxx
+++ b/Examples/Filtering/ResampleImageFilter6.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/ResampleImageFilter7.cxx
+++ b/Examples/Filtering/ResampleImageFilter7.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/ResampleImageFilter8.cxx
+++ b/Examples/Filtering/ResampleImageFilter8.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/ResampleImageFilter9.cxx
+++ b/Examples/Filtering/ResampleImageFilter9.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/ResampleVolumesToBeIsotropic.cxx
+++ b/Examples/Filtering/ResampleVolumesToBeIsotropic.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/ScaleSpaceGenerator2D.cxx
+++ b/Examples/Filtering/ScaleSpaceGenerator2D.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/SecondDerivativeRecursiveGaussianImageFilter.cxx
+++ b/Examples/Filtering/SecondDerivativeRecursiveGaussianImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/SigmoidImageFilter.cxx
+++ b/Examples/Filtering/SigmoidImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/SignedDanielssonDistanceMapImageFilter.cxx
+++ b/Examples/Filtering/SignedDanielssonDistanceMapImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/SmoothingRecursiveGaussianImageFilter.cxx
+++ b/Examples/Filtering/SmoothingRecursiveGaussianImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/SmoothingRecursiveGaussianImageFilter2.cxx
+++ b/Examples/Filtering/SmoothingRecursiveGaussianImageFilter2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/SpatialObjectToImage1.cxx
+++ b/Examples/Filtering/SpatialObjectToImage1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/SpatialObjectToImage2.cxx
+++ b/Examples/Filtering/SpatialObjectToImage2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/SpatialObjectToImage3.cxx
+++ b/Examples/Filtering/SpatialObjectToImage3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/SubsampleVolume.cxx
+++ b/Examples/Filtering/SubsampleVolume.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/SurfaceExtraction.cxx
+++ b/Examples/Filtering/SurfaceExtraction.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/ThresholdImageFilter.cxx
+++ b/Examples/Filtering/ThresholdImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/VectorCurvatureAnisotropicDiffusionImageFilter.cxx
+++ b/Examples/Filtering/VectorCurvatureAnisotropicDiffusionImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/VectorGradientAnisotropicDiffusionImageFilter.cxx
+++ b/Examples/Filtering/VectorGradientAnisotropicDiffusionImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/VectorIndexSelection.cxx
+++ b/Examples/Filtering/VectorIndexSelection.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/VesselnessMeasureImageFilter.cxx
+++ b/Examples/Filtering/VesselnessMeasureImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/VotingBinaryHoleFillingImageFilter.cxx
+++ b/Examples/Filtering/VotingBinaryHoleFillingImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/VotingBinaryIterativeHoleFillingImageFilter.cxx
+++ b/Examples/Filtering/VotingBinaryIterativeHoleFillingImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/WarpImageFilter1.cxx
+++ b/Examples/Filtering/WarpImageFilter1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Filtering/ZeroCrossingBasedEdgeDetectionImageFilter.cxx
+++ b/Examples/Filtering/ZeroCrossingBasedEdgeDetectionImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/HelloFetchITK/FetchWorld.cxx
+++ b/Examples/HelloFetchITK/FetchWorld.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/ComplexImageReadWrite.cxx
+++ b/Examples/IO/ComplexImageReadWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/CovariantVectorImageExtractComponent.cxx
+++ b/Examples/IO/CovariantVectorImageExtractComponent.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/CovariantVectorImageRead.cxx
+++ b/Examples/IO/CovariantVectorImageRead.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/CovariantVectorImageWrite.cxx
+++ b/Examples/IO/CovariantVectorImageWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/DicomImageReadChangeHeaderWrite.cxx
+++ b/Examples/IO/DicomImageReadChangeHeaderWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/DicomImageReadPrintTags.cxx
+++ b/Examples/IO/DicomImageReadPrintTags.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/DicomImageReadWrite.cxx
+++ b/Examples/IO/DicomImageReadWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/DicomPrintPatientInformation.cxx
+++ b/Examples/IO/DicomPrintPatientInformation.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/DicomSeriesReadGaussianImageWrite.cxx
+++ b/Examples/IO/DicomSeriesReadGaussianImageWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/DicomSeriesReadImageWrite.cxx
+++ b/Examples/IO/DicomSeriesReadImageWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/DicomSeriesReadImageWrite2.cxx
+++ b/Examples/IO/DicomSeriesReadImageWrite2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/DicomSeriesReadPrintTags.cxx
+++ b/Examples/IO/DicomSeriesReadPrintTags.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/DicomSeriesReadSeriesWrite.cxx
+++ b/Examples/IO/DicomSeriesReadSeriesWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/DicomSliceRead.py
+++ b/Examples/IO/DicomSliceRead.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Examples/IO/IOFactoryRegistration.cxx
+++ b/Examples/IO/IOFactoryRegistration.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/IOPlugin.cxx
+++ b/Examples/IO/IOPlugin.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/ImageReadCastWrite.cxx
+++ b/Examples/IO/ImageReadCastWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/ImageReadDicomSeriesWrite.cxx
+++ b/Examples/IO/ImageReadDicomSeriesWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/ImageReadExportVTK.cxx
+++ b/Examples/IO/ImageReadExportVTK.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/ImageReadExtractFilterInsertWrite.cxx
+++ b/Examples/IO/ImageReadExtractFilterInsertWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/ImageReadExtractWrite.cxx
+++ b/Examples/IO/ImageReadExtractWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/ImageReadImageSeriesWrite.cxx
+++ b/Examples/IO/ImageReadImageSeriesWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/ImageReadRegionOfInterestWrite.cxx
+++ b/Examples/IO/ImageReadRegionOfInterestWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/ImageReadWrite.cxx
+++ b/Examples/IO/ImageReadWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/ImageSeriesReadWrite.cxx
+++ b/Examples/IO/ImageSeriesReadWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/ImageSeriesReadWrite2.cxx
+++ b/Examples/IO/ImageSeriesReadWrite2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/RGBImageReadWrite.cxx
+++ b/Examples/IO/RGBImageReadWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/RGBImageSeriesReadWrite.cxx
+++ b/Examples/IO/RGBImageSeriesReadWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/TransformReadWrite.cxx
+++ b/Examples/IO/TransformReadWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/VectorImageReadWrite.cxx
+++ b/Examples/IO/VectorImageReadWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/VisibleHumanPasteWrite.cxx
+++ b/Examples/IO/VisibleHumanPasteWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/VisibleHumanStreamReadWrite.cxx
+++ b/Examples/IO/VisibleHumanStreamReadWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/XML/DOMFindDemo.cxx
+++ b/Examples/IO/XML/DOMFindDemo.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/XML/ParticleSwarmOptimizerReadWrite.cxx
+++ b/Examples/IO/XML/ParticleSwarmOptimizerReadWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/XML/itkParticleSwarmOptimizerDOMReader.cxx
+++ b/Examples/IO/XML/itkParticleSwarmOptimizerDOMReader.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/XML/itkParticleSwarmOptimizerDOMReader.h
+++ b/Examples/IO/XML/itkParticleSwarmOptimizerDOMReader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/XML/itkParticleSwarmOptimizerDOMWriter.cxx
+++ b/Examples/IO/XML/itkParticleSwarmOptimizerDOMWriter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/XML/itkParticleSwarmOptimizerDOMWriter.h
+++ b/Examples/IO/XML/itkParticleSwarmOptimizerDOMWriter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/XML/itkParticleSwarmOptimizerSAXReader.cxx
+++ b/Examples/IO/XML/itkParticleSwarmOptimizerSAXReader.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/XML/itkParticleSwarmOptimizerSAXReader.h
+++ b/Examples/IO/XML/itkParticleSwarmOptimizerSAXReader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/XML/itkParticleSwarmOptimizerSAXWriter.cxx
+++ b/Examples/IO/XML/itkParticleSwarmOptimizerSAXWriter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/IO/XML/itkParticleSwarmOptimizerSAXWriter.h
+++ b/Examples/IO/XML/itkParticleSwarmOptimizerSAXWriter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Installation/HelloWorld.cxx
+++ b/Examples/Installation/HelloWorld.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Iterators/ImageLinearIteratorWithIndex.cxx
+++ b/Examples/Iterators/ImageLinearIteratorWithIndex.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Iterators/ImageLinearIteratorWithIndex2.cxx
+++ b/Examples/Iterators/ImageLinearIteratorWithIndex2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Iterators/ImageRandomConstIteratorWithIndex.cxx
+++ b/Examples/Iterators/ImageRandomConstIteratorWithIndex.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Iterators/ImageRegionIterator.cxx
+++ b/Examples/Iterators/ImageRegionIterator.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Iterators/ImageRegionIteratorWithIndex.cxx
+++ b/Examples/Iterators/ImageRegionIteratorWithIndex.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Iterators/ImageSliceIteratorWithIndex.cxx
+++ b/Examples/Iterators/ImageSliceIteratorWithIndex.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Iterators/NeighborhoodIterators1.cxx
+++ b/Examples/Iterators/NeighborhoodIterators1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Iterators/NeighborhoodIterators2.cxx
+++ b/Examples/Iterators/NeighborhoodIterators2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Iterators/NeighborhoodIterators3.cxx
+++ b/Examples/Iterators/NeighborhoodIterators3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Iterators/NeighborhoodIterators4.cxx
+++ b/Examples/Iterators/NeighborhoodIterators4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Iterators/NeighborhoodIterators5.cxx
+++ b/Examples/Iterators/NeighborhoodIterators5.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Iterators/NeighborhoodIterators6.cxx
+++ b/Examples/Iterators/NeighborhoodIterators6.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Iterators/ShapedNeighborhoodIterators1.cxx
+++ b/Examples/Iterators/ShapedNeighborhoodIterators1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Iterators/ShapedNeighborhoodIterators2.cxx
+++ b/Examples/Iterators/ShapedNeighborhoodIterators2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Numerics/FourierDescriptors1.cxx
+++ b/Examples/Numerics/FourierDescriptors1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/BSplineWarping1.cxx
+++ b/Examples/RegistrationITKv4/BSplineWarping1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/BSplineWarping2.cxx
+++ b/Examples/RegistrationITKv4/BSplineWarping2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ChangeInformationImageFilter.cxx
+++ b/Examples/RegistrationITKv4/ChangeInformationImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/DeformableRegistration1.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/DeformableRegistration10.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration10.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/DeformableRegistration11.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration11.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/DeformableRegistration12.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration12.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/DeformableRegistration13.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration13.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/DeformableRegistration14.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration14.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/DeformableRegistration15.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration15.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/DeformableRegistration16.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration16.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/DeformableRegistration17.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration17.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/DeformableRegistration2.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/DeformableRegistration3.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/DeformableRegistration4.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/DeformableRegistration5.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration5.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/DeformableRegistration6.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration6.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/DeformableRegistration7.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration7.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/DeformableRegistration8.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration8.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/DeformableRegistration9.cxx
+++ b/Examples/RegistrationITKv4/DeformableRegistration9.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/DisplacementFieldInitialization.cxx
+++ b/Examples/RegistrationITKv4/DisplacementFieldInitialization.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration1.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration10.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration10.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration11.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration11.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration12.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration12.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration13.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration13.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration14.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration14.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration15.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration15.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration16.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration16.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration17.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration17.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration18.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration18.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration19.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration19.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration2.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration20.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration20.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration3.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration3.py
+++ b/Examples/RegistrationITKv4/ImageRegistration3.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration4.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration4.py
+++ b/Examples/RegistrationITKv4/ImageRegistration4.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration5.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration5.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration5.py
+++ b/Examples/RegistrationITKv4/ImageRegistration5.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration6.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration6.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration7.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration7.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration8.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration8.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistration9.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration9.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ImageRegistrationHistogramPlotter.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistrationHistogramPlotter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/IterativeClosestPoint1.cxx
+++ b/Examples/RegistrationITKv4/IterativeClosestPoint1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/IterativeClosestPoint2.cxx
+++ b/Examples/RegistrationITKv4/IterativeClosestPoint2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/IterativeClosestPoint3.cxx
+++ b/Examples/RegistrationITKv4/IterativeClosestPoint3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/LandmarkWarping2.cxx
+++ b/Examples/RegistrationITKv4/LandmarkWarping2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/MeanSquaresImageMetric1.cxx
+++ b/Examples/RegistrationITKv4/MeanSquaresImageMetric1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ModelToImageRegistration1.cxx
+++ b/Examples/RegistrationITKv4/ModelToImageRegistration1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ModelToImageRegistration2.cxx
+++ b/Examples/RegistrationITKv4/ModelToImageRegistration2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/MultiResImageRegistration1.cxx
+++ b/Examples/RegistrationITKv4/MultiResImageRegistration1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/MultiResImageRegistration2.cxx
+++ b/Examples/RegistrationITKv4/MultiResImageRegistration2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/MultiResImageRegistration3.cxx
+++ b/Examples/RegistrationITKv4/MultiResImageRegistration3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/MultiStageImageRegistration1.cxx
+++ b/Examples/RegistrationITKv4/MultiStageImageRegistration1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/MultiStageImageRegistration2.cxx
+++ b/Examples/RegistrationITKv4/MultiStageImageRegistration2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/RegistrationITKv4/ThinPlateSplineWarp.cxx
+++ b/Examples/RegistrationITKv4/ThinPlateSplineWarp.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Segmentation/CannySegmentationLevelSetImageFilter.cxx
+++ b/Examples/Segmentation/CannySegmentationLevelSetImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Segmentation/ConfidenceConnected.cxx
+++ b/Examples/Segmentation/ConfidenceConnected.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Segmentation/ConfidenceConnected3D.cxx
+++ b/Examples/Segmentation/ConfidenceConnected3D.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Segmentation/ConnectedThresholdImageFilter.cxx
+++ b/Examples/Segmentation/ConnectedThresholdImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Segmentation/CurvesLevelSetImageFilter.cxx
+++ b/Examples/Segmentation/CurvesLevelSetImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Segmentation/FastMarchingImageFilter.cxx
+++ b/Examples/Segmentation/FastMarchingImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Segmentation/GeodesicActiveContourImageFilter.cxx
+++ b/Examples/Segmentation/GeodesicActiveContourImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Segmentation/GeodesicActiveContourShapePriorLevelSetImageFilter.cxx
+++ b/Examples/Segmentation/GeodesicActiveContourShapePriorLevelSetImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Segmentation/GibbsPriorImageFilter1.cxx
+++ b/Examples/Segmentation/GibbsPriorImageFilter1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Segmentation/HoughTransform2DCirclesImageFilter.cxx
+++ b/Examples/Segmentation/HoughTransform2DCirclesImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Segmentation/HoughTransform2DLinesImageFilter.cxx
+++ b/Examples/Segmentation/HoughTransform2DLinesImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Segmentation/IsolatedConnectedImageFilter.cxx
+++ b/Examples/Segmentation/IsolatedConnectedImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Segmentation/LaplacianSegmentationLevelSetImageFilter.cxx
+++ b/Examples/Segmentation/LaplacianSegmentationLevelSetImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Segmentation/NeighborhoodConnectedImageFilter.cxx
+++ b/Examples/Segmentation/NeighborhoodConnectedImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Segmentation/RelabelComponentImageFilter.cxx
+++ b/Examples/Segmentation/RelabelComponentImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Segmentation/ShapeDetectionLevelSetFilter.cxx
+++ b/Examples/Segmentation/ShapeDetectionLevelSetFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Segmentation/ThresholdSegmentationLevelSetImageFilter.cxx
+++ b/Examples/Segmentation/ThresholdSegmentationLevelSetImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Segmentation/VectorConfidenceConnected.cxx
+++ b/Examples/Segmentation/VectorConfidenceConnected.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Segmentation/VoronoiSegmentation.py
+++ b/Examples/Segmentation/VoronoiSegmentation.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Examples/Segmentation/WatershedSegmentation1.cxx
+++ b/Examples/Segmentation/WatershedSegmentation1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Segmentation/WatershedSegmentation1.py
+++ b/Examples/Segmentation/WatershedSegmentation1.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Examples/Segmentation/WatershedSegmentation2.cxx
+++ b/Examples/Segmentation/WatershedSegmentation2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/SpatialObjects/ArrowSpatialObject.cxx
+++ b/Examples/SpatialObjects/ArrowSpatialObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/SpatialObjects/BlobSpatialObject.cxx
+++ b/Examples/SpatialObjects/BlobSpatialObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/SpatialObjects/BoundingBoxFromImageMaskSpatialObject.cxx
+++ b/Examples/SpatialObjects/BoundingBoxFromImageMaskSpatialObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/SpatialObjects/DTITubeSpatialObject.cxx
+++ b/Examples/SpatialObjects/DTITubeSpatialObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/SpatialObjects/EllipseSpatialObject.cxx
+++ b/Examples/SpatialObjects/EllipseSpatialObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/SpatialObjects/GaussianSpatialObject.cxx
+++ b/Examples/SpatialObjects/GaussianSpatialObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/SpatialObjects/GroupSpatialObject.cxx
+++ b/Examples/SpatialObjects/GroupSpatialObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/SpatialObjects/ImageMaskSpatialObject.cxx
+++ b/Examples/SpatialObjects/ImageMaskSpatialObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/SpatialObjects/ImageSpatialObject.cxx
+++ b/Examples/SpatialObjects/ImageSpatialObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/SpatialObjects/LandmarkSpatialObject.cxx
+++ b/Examples/SpatialObjects/LandmarkSpatialObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/SpatialObjects/LineSpatialObject.cxx
+++ b/Examples/SpatialObjects/LineSpatialObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/SpatialObjects/MeshSpatialObject.cxx
+++ b/Examples/SpatialObjects/MeshSpatialObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/SpatialObjects/ReadWriteSpatialObject.cxx
+++ b/Examples/SpatialObjects/ReadWriteSpatialObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/SpatialObjects/SceneSpatialObject.cxx
+++ b/Examples/SpatialObjects/SceneSpatialObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/SpatialObjects/SpatialObjectHierarchy.cxx
+++ b/Examples/SpatialObjects/SpatialObjectHierarchy.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/SpatialObjects/SpatialObjectToImageStatisticsCalculator.cxx
+++ b/Examples/SpatialObjects/SpatialObjectToImageStatisticsCalculator.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/SpatialObjects/SpatialObjectTransforms.cxx
+++ b/Examples/SpatialObjects/SpatialObjectTransforms.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/SpatialObjects/SurfaceSpatialObject.cxx
+++ b/Examples/SpatialObjects/SurfaceSpatialObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/SpatialObjects/TubeSpatialObject.cxx
+++ b/Examples/SpatialObjects/TubeSpatialObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/SpatialObjects/VesselTubeSpatialObject.cxx
+++ b/Examples/SpatialObjects/VesselTubeSpatialObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/BayesianClassifier.cxx
+++ b/Examples/Statistics/BayesianClassifier.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/BayesianClassifierInitializer.cxx
+++ b/Examples/Statistics/BayesianClassifierInitializer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/BayesianPluginClassifier.cxx
+++ b/Examples/Statistics/BayesianPluginClassifier.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/EuclideanDistanceMetric.cxx
+++ b/Examples/Statistics/EuclideanDistanceMetric.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/ExpectationMaximizationMixtureModelEstimator.cxx
+++ b/Examples/Statistics/ExpectationMaximizationMixtureModelEstimator.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/GaussianMembershipFunction.cxx
+++ b/Examples/Statistics/GaussianMembershipFunction.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/Histogram.cxx
+++ b/Examples/Statistics/Histogram.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/ImageEntropy1.cxx
+++ b/Examples/Statistics/ImageEntropy1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/ImageHistogram1.cxx
+++ b/Examples/Statistics/ImageHistogram1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/ImageHistogram2.cxx
+++ b/Examples/Statistics/ImageHistogram2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/ImageHistogram3.cxx
+++ b/Examples/Statistics/ImageHistogram3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/ImageHistogram4.cxx
+++ b/Examples/Statistics/ImageHistogram4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/ImageMutualInformation1.cxx
+++ b/Examples/Statistics/ImageMutualInformation1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/ImageToListSampleAdaptor.cxx
+++ b/Examples/Statistics/ImageToListSampleAdaptor.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/KdTree.cxx
+++ b/Examples/Statistics/KdTree.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/KdTreeBasedKMeansClustering.cxx
+++ b/Examples/Statistics/KdTreeBasedKMeansClustering.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/ListSample.cxx
+++ b/Examples/Statistics/ListSample.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/MaximumDecisionRule.cxx
+++ b/Examples/Statistics/MaximumDecisionRule.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/MaximumRatioDecisionRule.cxx
+++ b/Examples/Statistics/MaximumRatioDecisionRule.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/MembershipSample.cxx
+++ b/Examples/Statistics/MembershipSample.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/MembershipSampleGenerator.cxx
+++ b/Examples/Statistics/MembershipSampleGenerator.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/MinimumDecisionRule.cxx
+++ b/Examples/Statistics/MinimumDecisionRule.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/NeighborhoodSampler.cxx
+++ b/Examples/Statistics/NeighborhoodSampler.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/NormalVariateGenerator.cxx
+++ b/Examples/Statistics/NormalVariateGenerator.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/PointSetToAdaptor.cxx
+++ b/Examples/Statistics/PointSetToAdaptor.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/PointSetToListSampleAdaptor.cxx
+++ b/Examples/Statistics/PointSetToListSampleAdaptor.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/SampleSorting.cxx
+++ b/Examples/Statistics/SampleSorting.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/SampleStatistics.cxx
+++ b/Examples/Statistics/SampleStatistics.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/SampleToHistogramFilter.cxx
+++ b/Examples/Statistics/SampleToHistogramFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/ScalarImageKmeansClassifier.cxx
+++ b/Examples/Statistics/ScalarImageKmeansClassifier.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/ScalarImageKmeansModelEstimator.cxx
+++ b/Examples/Statistics/ScalarImageKmeansModelEstimator.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/ScalarImageMarkovRandomField1.cxx
+++ b/Examples/Statistics/ScalarImageMarkovRandomField1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/SelectiveSubsampleGenerator.cxx
+++ b/Examples/Statistics/SelectiveSubsampleGenerator.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/Subsample.cxx
+++ b/Examples/Statistics/Subsample.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Statistics/WeightedSampleStatistics.cxx
+++ b/Examples/Statistics/WeightedSampleStatistics.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Examples/Visualization/CannyEdgeDetectionImageFilterConnectVTKITK.py
+++ b/Examples/Visualization/CannyEdgeDetectionImageFilterConnectVTKITK.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Bridge/NumPy/include/itkPyBuffer.h
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyBuffer.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.h
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVectorContainer.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/NumPy/include/itkPyVnl.h
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/NumPy/include/itkPyVnl.hxx
+++ b/Modules/Bridge/NumPy/include/itkPyVnl.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/NumPy/wrapping/test/itkImageMetaDataSetGetItem.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkImageMetaDataSetGetItem.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Bridge/NumPy/wrapping/test/itkPyBufferMemoryLeakTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyBufferMemoryLeakTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Bridge/NumPy/wrapping/test/itkPyBufferPipelineTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyBufferPipelineTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Bridge/NumPy/wrapping/test/itkPyBufferTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyBufferTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Bridge/NumPy/wrapping/test/itkPyVectorContainerTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyVectorContainerTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Bridge/NumPy/wrapping/test/itkPyVnlTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyVnlTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Bridge/VTK/include/itkVTKImageExport.h
+++ b/Modules/Bridge/VTK/include/itkVTKImageExport.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VTK/include/itkVTKImageExport.hxx
+++ b/Modules/Bridge/VTK/include/itkVTKImageExport.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VTK/include/itkVTKImageExportBase.h
+++ b/Modules/Bridge/VTK/include/itkVTKImageExportBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VTK/include/itkVTKImageImport.h
+++ b/Modules/Bridge/VTK/include/itkVTKImageImport.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
+++ b/Modules/Bridge/VTK/include/itkVTKImageImport.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VTK/src/itkVTKImageExportBase.cxx
+++ b/Modules/Bridge/VTK/src/itkVTKImageExportBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VtkGlue/include/QuickView.h
+++ b/Modules/Bridge/VtkGlue/include/QuickView.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.h
+++ b/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.hxx
+++ b/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.h
+++ b/Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.hxx
+++ b/Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VtkGlue/include/itkViewImage.h
+++ b/Modules/Bridge/VtkGlue/include/itkViewImage.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VtkGlue/include/itkViewImage.hxx
+++ b/Modules/Bridge/VtkGlue/include/itkViewImage.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VtkGlue/include/vtkCaptureScreen.h
+++ b/Modules/Bridge/VtkGlue/include/vtkCaptureScreen.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VtkGlue/src/QuickView.cxx
+++ b/Modules/Bridge/VtkGlue/src/QuickView.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VtkGlue/test/QuickViewTest.cxx
+++ b/Modules/Bridge/VtkGlue/test/QuickViewTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VtkGlue/test/itkImageToVTKImageFilterRGBTest.cxx
+++ b/Modules/Bridge/VtkGlue/test/itkImageToVTKImageFilterRGBTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VtkGlue/test/itkImageToVTKImageFilterTest.cxx
+++ b/Modules/Bridge/VtkGlue/test/itkImageToVTKImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VtkGlue/test/itkVTKImageToImageFilterTest.cxx
+++ b/Modules/Bridge/VtkGlue/test/itkVTKImageToImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VtkGlue/test/itkVtkConnectedComponentImageFilterTest.cxx
+++ b/Modules/Bridge/VtkGlue/test/itkVtkConnectedComponentImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VtkGlue/test/itkVtkMedianFilterTest.cxx
+++ b/Modules/Bridge/VtkGlue/test/itkVtkMedianFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Bridge/VtkGlue/test/runViewImage.cxx
+++ b/Modules/Bridge/VtkGlue/test/runViewImage.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Compatibility/Deprecated/include/itkDeprecatedPlaceholder.h
+++ b/Modules/Compatibility/Deprecated/include/itkDeprecatedPlaceholder.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Compatibility/Deprecated/src/itkDeprecatedPlaceholder.cxx
+++ b/Modules/Compatibility/Deprecated/src/itkDeprecatedPlaceholder.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/CMake/itkCheckHasConfigthreadlocale.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasConfigthreadlocale.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/CMake/itkCheckHasFeenableexcept.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasFeenableexcept.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/CMake/itkCheckHasFegetenv.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasFegetenv.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/CMake/itkCheckHasFenvtStructMember.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasFenvtStructMember.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/CMake/itkCheckHasFeraiseexcept.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasFeraiseexcept.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/CMake/itkCheckHasFesetenv.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasFesetenv.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/CMake/itkCheckHasGNUAttributeAligned.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasGNUAttributeAligned.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/CMake/itkCheckHasMallinfo.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasMallinfo.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/CMake/itkCheckHasMallinfo2.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasMallinfo2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/CMake/itkCheckHasNewlocale.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasNewlocale.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/CMake/itkCheckHasSchedGetAffinity.cxx
+++ b/Modules/Core/Common/CMake/itkCheckHasSchedGetAffinity.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/CMake/itkGetCXXCompilerVersion.cxx
+++ b/Modules/Core/Common/CMake/itkGetCXXCompilerVersion.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/VNLIterativeSparseSolverTraits.h
+++ b/Modules/Core/Common/include/VNLIterativeSparseSolverTraits.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/VNLSparseLUSolverTraits.h
+++ b/Modules/Core/Common/include/VNLSparseLUSolverTraits.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkAnatomicalOrientation.h
+++ b/Modules/Core/Common/include/itkAnatomicalOrientation.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkAnnulusOperator.h
+++ b/Modules/Core/Common/include/itkAnnulusOperator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkAnnulusOperator.hxx
+++ b/Modules/Core/Common/include/itkAnnulusOperator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkArray.h
+++ b/Modules/Core/Common/include/itkArray.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkArray.hxx
+++ b/Modules/Core/Common/include/itkArray.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkArray2D.h
+++ b/Modules/Core/Common/include/itkArray2D.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkArray2D.hxx
+++ b/Modules/Core/Common/include/itkArray2D.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkAtanRegularizedHeavisideStepFunction.h
+++ b/Modules/Core/Common/include/itkAtanRegularizedHeavisideStepFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkAtanRegularizedHeavisideStepFunction.hxx
+++ b/Modules/Core/Common/include/itkAtanRegularizedHeavisideStepFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkAutoPointer.h
+++ b/Modules/Core/Common/include/itkAutoPointer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkAutoPointerDataObjectDecorator.h
+++ b/Modules/Core/Common/include/itkAutoPointerDataObjectDecorator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkAutoPointerDataObjectDecorator.hxx
+++ b/Modules/Core/Common/include/itkAutoPointerDataObjectDecorator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkBSplineDerivativeKernelFunction.h
+++ b/Modules/Core/Common/include/itkBSplineDerivativeKernelFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
+++ b/Modules/Core/Common/include/itkBSplineInterpolationWeightFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkBSplineKernelFunction.h
+++ b/Modules/Core/Common/include/itkBSplineKernelFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkBackwardDifferenceOperator.h
+++ b/Modules/Core/Common/include/itkBackwardDifferenceOperator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkBackwardDifferenceOperator.hxx
+++ b/Modules/Core/Common/include/itkBackwardDifferenceOperator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkBinaryOperationConcept.h
+++ b/Modules/Core/Common/include/itkBinaryOperationConcept.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkBinaryThresholdSpatialFunction.h
+++ b/Modules/Core/Common/include/itkBinaryThresholdSpatialFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkBinaryThresholdSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkBinaryThresholdSpatialFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkBitCast.h
+++ b/Modules/Core/Common/include/itkBitCast.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkBoolean.h
+++ b/Modules/Core/Common/include/itkBoolean.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkBooleanStdVector.h
+++ b/Modules/Core/Common/include/itkBooleanStdVector.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkBoundingBox.h
+++ b/Modules/Core/Common/include/itkBoundingBox.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkBoundingBox.hxx
+++ b/Modules/Core/Common/include/itkBoundingBox.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkBresenhamLine.h
+++ b/Modules/Core/Common/include/itkBresenhamLine.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkBresenhamLine.hxx
+++ b/Modules/Core/Common/include/itkBresenhamLine.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkBufferedImageNeighborhoodPixelAccessPolicy.h
+++ b/Modules/Core/Common/include/itkBufferedImageNeighborhoodPixelAccessPolicy.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkBuildInformation.h
+++ b/Modules/Core/Common/include/itkBuildInformation.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkByteSwapper.h
+++ b/Modules/Core/Common/include/itkByteSwapper.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkByteSwapper.hxx
+++ b/Modules/Core/Common/include/itkByteSwapper.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkCellInterface.h
+++ b/Modules/Core/Common/include/itkCellInterface.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkCellInterface.hxx
+++ b/Modules/Core/Common/include/itkCellInterface.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkCellInterfaceVisitor.h
+++ b/Modules/Core/Common/include/itkCellInterfaceVisitor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkColorTable.h
+++ b/Modules/Core/Common/include/itkColorTable.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkColorTable.hxx
+++ b/Modules/Core/Common/include/itkColorTable.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkCommand.h
+++ b/Modules/Core/Common/include/itkCommand.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkCommonEnums.h
+++ b/Modules/Core/Common/include/itkCommonEnums.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkCompensatedSummation.h
+++ b/Modules/Core/Common/include/itkCompensatedSummation.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkCompensatedSummation.hxx
+++ b/Modules/Core/Common/include/itkCompensatedSummation.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkConceptChecking.h
+++ b/Modules/Core/Common/include/itkConceptChecking.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkConditionalConstIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkConicShellInteriorExteriorSpatialFunction.h
+++ b/Modules/Core/Common/include/itkConicShellInteriorExteriorSpatialFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkConicShellInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkConicShellInteriorExteriorSpatialFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkConnectedComponentAlgorithm.h
+++ b/Modules/Core/Common/include/itkConnectedComponentAlgorithm.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkConnectedImageNeighborhoodShape.h
+++ b/Modules/Core/Common/include/itkConnectedImageNeighborhoodShape.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkConstSliceIterator.h
+++ b/Modules/Core/Common/include/itkConstSliceIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkConstantBoundaryCondition.h
+++ b/Modules/Core/Common/include/itkConstantBoundaryCondition.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkConstantBoundaryCondition.hxx
+++ b/Modules/Core/Common/include/itkConstantBoundaryCondition.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkConstantBoundaryImageNeighborhoodPixelAccessPolicy.h
+++ b/Modules/Core/Common/include/itkConstantBoundaryImageNeighborhoodPixelAccessPolicy.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkContinuousIndex.h
+++ b/Modules/Core/Common/include/itkContinuousIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkCopy.h
+++ b/Modules/Core/Common/include/itkCopy.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkCorrespondenceDataStructureIterator.h
+++ b/Modules/Core/Common/include/itkCorrespondenceDataStructureIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkCorrespondenceDataStructureIterator.hxx
+++ b/Modules/Core/Common/include/itkCorrespondenceDataStructureIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkCovariantVector.h
+++ b/Modules/Core/Common/include/itkCovariantVector.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkCovariantVector.hxx
+++ b/Modules/Core/Common/include/itkCovariantVector.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkCreateObjectFunction.h
+++ b/Modules/Core/Common/include/itkCreateObjectFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkCrossHelper.h
+++ b/Modules/Core/Common/include/itkCrossHelper.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDataObject.h
+++ b/Modules/Core/Common/include/itkDataObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDataObjectConstIterator.h
+++ b/Modules/Core/Common/include/itkDataObjectConstIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDataObjectDecorator.h
+++ b/Modules/Core/Common/include/itkDataObjectDecorator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDataObjectDecorator.hxx
+++ b/Modules/Core/Common/include/itkDataObjectDecorator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDataObjectIterator.h
+++ b/Modules/Core/Common/include/itkDataObjectIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDefaultConvertPixelTraits.h
+++ b/Modules/Core/Common/include/itkDefaultConvertPixelTraits.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDefaultDynamicMeshTraits.h
+++ b/Modules/Core/Common/include/itkDefaultDynamicMeshTraits.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDefaultPixelAccessor.h
+++ b/Modules/Core/Common/include/itkDefaultPixelAccessor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDefaultPixelAccessorFunctor.h
+++ b/Modules/Core/Common/include/itkDefaultPixelAccessorFunctor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDefaultStaticMeshTraits.h
+++ b/Modules/Core/Common/include/itkDefaultStaticMeshTraits.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDefaultVectorPixelAccessor.h
+++ b/Modules/Core/Common/include/itkDefaultVectorPixelAccessor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDefaultVectorPixelAccessorFunctor.h
+++ b/Modules/Core/Common/include/itkDefaultVectorPixelAccessorFunctor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDeref.h
+++ b/Modules/Core/Common/include/itkDeref.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkDerivativeOperator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDerivativeOperator.hxx
+++ b/Modules/Core/Common/include/itkDerivativeOperator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDiffusionTensor3D.h
+++ b/Modules/Core/Common/include/itkDiffusionTensor3D.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDiffusionTensor3D.hxx
+++ b/Modules/Core/Common/include/itkDiffusionTensor3D.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDirectory.h
+++ b/Modules/Core/Common/include/itkDirectory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDomainThreader.h
+++ b/Modules/Core/Common/include/itkDomainThreader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDomainThreader.hxx
+++ b/Modules/Core/Common/include/itkDomainThreader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkDynamicLoader.h
+++ b/Modules/Core/Common/include/itkDynamicLoader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkEllipsoidInteriorExteriorSpatialFunction.h
+++ b/Modules/Core/Common/include/itkEllipsoidInteriorExteriorSpatialFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkEllipsoidInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkEllipsoidInteriorExteriorSpatialFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkEnableIf.h
+++ b/Modules/Core/Common/include/itkEnableIf.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkEquivalencyTable.h
+++ b/Modules/Core/Common/include/itkEquivalencyTable.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkEventObject.h
+++ b/Modules/Core/Common/include/itkEventObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkExceptionObject.h
+++ b/Modules/Core/Common/include/itkExceptionObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkExtractImageFilter.h
+++ b/Modules/Core/Common/include/itkExtractImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkExtractImageFilter.hxx
+++ b/Modules/Core/Common/include/itkExtractImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkExtractImageFilterRegionCopier.h
+++ b/Modules/Core/Common/include/itkExtractImageFilterRegionCopier.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkFactoryTestLib.h
+++ b/Modules/Core/Common/include/itkFactoryTestLib.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkFileOutputWindow.h
+++ b/Modules/Core/Common/include/itkFileOutputWindow.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.h
+++ b/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkFiniteCylinderSpatialFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkFixedArray.h
+++ b/Modules/Core/Common/include/itkFixedArray.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkFixedArray.hxx
+++ b/Modules/Core/Common/include/itkFixedArray.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkFloatTypes.h
+++ b/Modules/Core/Common/include/itkFloatTypes.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkFloatingPointExceptions.h
+++ b/Modules/Core/Common/include/itkFloatingPointExceptions.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkFloodFilledImageFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkFloodFilledImageFunctionConditionalConstIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkFloodFilledImageFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkFloodFilledImageFunctionConditionalConstIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkFloodFilledImageFunctionConditionalIterator.h
+++ b/Modules/Core/Common/include/itkFloodFilledImageFunctionConditionalIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkFloodFilledSpatialFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkFloodFilledSpatialFunctionConditionalConstIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkFloodFilledSpatialFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkFloodFilledSpatialFunctionConditionalConstIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkFloodFilledSpatialFunctionConditionalIterator.h
+++ b/Modules/Core/Common/include/itkFloodFilledSpatialFunctionConditionalIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkForwardDifferenceOperator.h
+++ b/Modules/Core/Common/include/itkForwardDifferenceOperator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkForwardDifferenceOperator.hxx
+++ b/Modules/Core/Common/include/itkForwardDifferenceOperator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkFrustumSpatialFunction.h
+++ b/Modules/Core/Common/include/itkFrustumSpatialFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkFrustumSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkFrustumSpatialFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkFunctionBase.h
+++ b/Modules/Core/Common/include/itkFunctionBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianDerivativeOperator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkGaussianDerivativeSpatialFunction.h
+++ b/Modules/Core/Common/include/itkGaussianDerivativeSpatialFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkGaussianDerivativeSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkGaussianDerivativeSpatialFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkGaussianKernelFunction.h
+++ b/Modules/Core/Common/include/itkGaussianKernelFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkGaussianOperator.h
+++ b/Modules/Core/Common/include/itkGaussianOperator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkGaussianOperator.hxx
+++ b/Modules/Core/Common/include/itkGaussianOperator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkGaussianSpatialFunction.h
+++ b/Modules/Core/Common/include/itkGaussianSpatialFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkGaussianSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkGaussianSpatialFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkHeavisideStepFunction.h
+++ b/Modules/Core/Common/include/itkHeavisideStepFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkHeavisideStepFunction.hxx
+++ b/Modules/Core/Common/include/itkHeavisideStepFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkHeavisideStepFunctionBase.h
+++ b/Modules/Core/Common/include/itkHeavisideStepFunctionBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkHexahedronCell.h
+++ b/Modules/Core/Common/include/itkHexahedronCell.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkHexahedronCell.hxx
+++ b/Modules/Core/Common/include/itkHexahedronCell.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkHexahedronCellTopology.h
+++ b/Modules/Core/Common/include/itkHexahedronCellTopology.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImage.h
+++ b/Modules/Core/Common/include/itkImage.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImage.hxx
+++ b/Modules/Core/Common/include/itkImage.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageAlgorithm.h
+++ b/Modules/Core/Common/include/itkImageAlgorithm.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkImageAlgorithm.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageBase.h
+++ b/Modules/Core/Common/include/itkImageBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageBase.hxx
+++ b/Modules/Core/Common/include/itkImageBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageBoundaryCondition.h
+++ b/Modules/Core/Common/include/itkImageBoundaryCondition.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageBufferRange.h
+++ b/Modules/Core/Common/include/itkImageBufferRange.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageConstIterator.h
+++ b/Modules/Core/Common/include/itkImageConstIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithIndex.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithOnlyIndex.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageContainerInterface.h
+++ b/Modules/Core/Common/include/itkImageContainerInterface.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageDuplicator.h
+++ b/Modules/Core/Common/include/itkImageDuplicator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageDuplicator.hxx
+++ b/Modules/Core/Common/include/itkImageDuplicator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageHelper.h
+++ b/Modules/Core/Common/include/itkImageHelper.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageIORegion.h
+++ b/Modules/Core/Common/include/itkImageIORegion.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageIterator.h
+++ b/Modules/Core/Common/include/itkImageIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageIterator.hxx
+++ b/Modules/Core/Common/include/itkImageIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageIteratorWithIndex.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageKernelOperator.h
+++ b/Modules/Core/Common/include/itkImageKernelOperator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageKernelOperator.hxx
+++ b/Modules/Core/Common/include/itkImageKernelOperator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageLinearConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageLinearConstIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageLinearConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageLinearConstIteratorWithIndex.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageLinearIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageLinearIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageLinearIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageLinearIteratorWithIndex.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageNeighborhoodOffsets.h
+++ b/Modules/Core/Common/include/itkImageNeighborhoodOffsets.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRandomIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRandomIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomIteratorWithIndex.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingIteratorWithIndex.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegion.h
+++ b/Modules/Core/Common/include/itkImageRegion.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegion.hxx
+++ b/Modules/Core/Common/include/itkImageRegion.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionConstIterator.h
+++ b/Modules/Core/Common/include/itkImageRegionConstIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionConstIterator.hxx
+++ b/Modules/Core/Common/include/itkImageRegionConstIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionConstIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionConstIteratorWithOnlyIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionConstIteratorWithOnlyIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRegionConstIteratorWithOnlyIndex.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionExclusionConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionExclusionConstIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionExclusionConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRegionExclusionConstIteratorWithIndex.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionExclusionIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionExclusionIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionExclusionIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRegionExclusionIteratorWithIndex.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionIterator.h
+++ b/Modules/Core/Common/include/itkImageRegionIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionIterator.hxx
+++ b/Modules/Core/Common/include/itkImageRegionIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRegionIteratorWithIndex.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionRange.h
+++ b/Modules/Core/Common/include/itkImageRegionRange.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionReverseConstIterator.h
+++ b/Modules/Core/Common/include/itkImageRegionReverseConstIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionReverseIterator.h
+++ b/Modules/Core/Common/include/itkImageRegionReverseIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionReverseIterator.hxx
+++ b/Modules/Core/Common/include/itkImageRegionReverseIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionSplitterBase.h
+++ b/Modules/Core/Common/include/itkImageRegionSplitterBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionSplitterDirection.h
+++ b/Modules/Core/Common/include/itkImageRegionSplitterDirection.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionSplitterMultidimensional.h
+++ b/Modules/Core/Common/include/itkImageRegionSplitterMultidimensional.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageRegionSplitterSlowDimension.h
+++ b/Modules/Core/Common/include/itkImageRegionSplitterSlowDimension.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageReverseConstIterator.h
+++ b/Modules/Core/Common/include/itkImageReverseConstIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageReverseIterator.h
+++ b/Modules/Core/Common/include/itkImageReverseIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageReverseIterator.hxx
+++ b/Modules/Core/Common/include/itkImageReverseIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageScanlineConstIterator.h
+++ b/Modules/Core/Common/include/itkImageScanlineConstIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageScanlineConstIterator.hxx
+++ b/Modules/Core/Common/include/itkImageScanlineConstIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageScanlineIterator.h
+++ b/Modules/Core/Common/include/itkImageScanlineIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageScanlineIterator.hxx
+++ b/Modules/Core/Common/include/itkImageScanlineIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageSink.h
+++ b/Modules/Core/Common/include/itkImageSink.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageSink.hxx
+++ b/Modules/Core/Common/include/itkImageSink.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageSliceConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageSliceConstIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageSliceConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageSliceConstIteratorWithIndex.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageSliceIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageSliceIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageSliceIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageSliceIteratorWithIndex.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageSource.h
+++ b/Modules/Core/Common/include/itkImageSource.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageSource.hxx
+++ b/Modules/Core/Common/include/itkImageSource.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageSourceCommon.h
+++ b/Modules/Core/Common/include/itkImageSourceCommon.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageToImageFilter.h
+++ b/Modules/Core/Common/include/itkImageToImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageToImageFilter.hxx
+++ b/Modules/Core/Common/include/itkImageToImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageToImageFilterCommon.h
+++ b/Modules/Core/Common/include/itkImageToImageFilterCommon.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageToImageFilterDetail.h
+++ b/Modules/Core/Common/include/itkImageToImageFilterDetail.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageVectorOptimizerParametersHelper.h
+++ b/Modules/Core/Common/include/itkImageVectorOptimizerParametersHelper.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImageVectorOptimizerParametersHelper.hxx
+++ b/Modules/Core/Common/include/itkImageVectorOptimizerParametersHelper.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImportImageContainer.h
+++ b/Modules/Core/Common/include/itkImportImageContainer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImportImageContainer.hxx
+++ b/Modules/Core/Common/include/itkImportImageContainer.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImportImageFilter.h
+++ b/Modules/Core/Common/include/itkImportImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkImportImageFilter.hxx
+++ b/Modules/Core/Common/include/itkImportImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkInPlaceImageFilter.h
+++ b/Modules/Core/Common/include/itkInPlaceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkInPlaceImageFilter.hxx
+++ b/Modules/Core/Common/include/itkInPlaceImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkIndent.h
+++ b/Modules/Core/Common/include/itkIndent.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkIndex.h
+++ b/Modules/Core/Common/include/itkIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkIndexRange.h
+++ b/Modules/Core/Common/include/itkIndexRange.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkIndexedContainerInterface.h
+++ b/Modules/Core/Common/include/itkIndexedContainerInterface.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkInputDataObjectConstIterator.h
+++ b/Modules/Core/Common/include/itkInputDataObjectConstIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkInputDataObjectIterator.h
+++ b/Modules/Core/Common/include/itkInputDataObjectIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkIntTypes.h
+++ b/Modules/Core/Common/include/itkIntTypes.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkInteriorExteriorSpatialFunction.h
+++ b/Modules/Core/Common/include/itkInteriorExteriorSpatialFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkInteriorExteriorSpatialFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkIsBaseOf.h
+++ b/Modules/Core/Common/include/itkIsBaseOf.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkIsConvertible.h
+++ b/Modules/Core/Common/include/itkIsConvertible.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkIsNumber.h
+++ b/Modules/Core/Common/include/itkIsNumber.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkIsSame.h
+++ b/Modules/Core/Common/include/itkIsSame.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkIterationReporter.h
+++ b/Modules/Core/Common/include/itkIterationReporter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkKernelFunctionBase.h
+++ b/Modules/Core/Common/include/itkKernelFunctionBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkLaplacianOperator.h
+++ b/Modules/Core/Common/include/itkLaplacianOperator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkLaplacianOperator.hxx
+++ b/Modules/Core/Common/include/itkLaplacianOperator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkLexicographicCompare.h
+++ b/Modules/Core/Common/include/itkLexicographicCompare.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkLightObject.h
+++ b/Modules/Core/Common/include/itkLightObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkLightProcessObject.h
+++ b/Modules/Core/Common/include/itkLightProcessObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkLineCell.h
+++ b/Modules/Core/Common/include/itkLineCell.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkLineCell.hxx
+++ b/Modules/Core/Common/include/itkLineCell.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkLineConstIterator.h
+++ b/Modules/Core/Common/include/itkLineConstIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkLineConstIterator.hxx
+++ b/Modules/Core/Common/include/itkLineConstIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkLineIterator.h
+++ b/Modules/Core/Common/include/itkLineIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkLineIterator.hxx
+++ b/Modules/Core/Common/include/itkLineIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkLogOutput.h
+++ b/Modules/Core/Common/include/itkLogOutput.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkLogger.h
+++ b/Modules/Core/Common/include/itkLogger.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkLoggerBase.h
+++ b/Modules/Core/Common/include/itkLoggerBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkLoggerManager.h
+++ b/Modules/Core/Common/include/itkLoggerManager.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkLoggerOutput.h
+++ b/Modules/Core/Common/include/itkLoggerOutput.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkLoggerThreadWrapper.h
+++ b/Modules/Core/Common/include/itkLoggerThreadWrapper.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkLoggerThreadWrapper.hxx
+++ b/Modules/Core/Common/include/itkLoggerThreadWrapper.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMakeFilled.h
+++ b/Modules/Core/Common/include/itkMakeFilled.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMakeUniqueForOverwrite.h
+++ b/Modules/Core/Common/include/itkMakeUniqueForOverwrite.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMapContainer.h
+++ b/Modules/Core/Common/include/itkMapContainer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMapContainer.hxx
+++ b/Modules/Core/Common/include/itkMapContainer.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMathDetail.h
+++ b/Modules/Core/Common/include/itkMathDetail.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMatrix.h
+++ b/Modules/Core/Common/include/itkMatrix.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMatrix.hxx
+++ b/Modules/Core/Common/include/itkMatrix.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMatrixResizeableDataObject.h
+++ b/Modules/Core/Common/include/itkMatrixResizeableDataObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMemoryProbe.h
+++ b/Modules/Core/Common/include/itkMemoryProbe.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMemoryProbesCollectorBase.h
+++ b/Modules/Core/Common/include/itkMemoryProbesCollectorBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMemoryUsageObserver.h
+++ b/Modules/Core/Common/include/itkMemoryUsageObserver.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
+++ b/Modules/Core/Common/include/itkMersenneTwisterRandomVariateGenerator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMetaDataDictionary.h
+++ b/Modules/Core/Common/include/itkMetaDataDictionary.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMetaDataObject.h
+++ b/Modules/Core/Common/include/itkMetaDataObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMetaDataObject.hxx
+++ b/Modules/Core/Common/include/itkMetaDataObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMetaDataObjectBase.h
+++ b/Modules/Core/Common/include/itkMetaDataObjectBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMetaDataObjectDetail.h
+++ b/Modules/Core/Common/include/itkMetaDataObjectDetail.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMetaProgrammingLibrary.h
+++ b/Modules/Core/Common/include/itkMetaProgrammingLibrary.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMinimumMaximumImageCalculator.h
+++ b/Modules/Core/Common/include/itkMinimumMaximumImageCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMinimumMaximumImageCalculator.hxx
+++ b/Modules/Core/Common/include/itkMinimumMaximumImageCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMultiThreaderBase.h
+++ b/Modules/Core/Common/include/itkMultiThreaderBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkMultipleLogOutput.h
+++ b/Modules/Core/Common/include/itkMultipleLogOutput.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNeighborhood.h
+++ b/Modules/Core/Common/include/itkNeighborhood.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNeighborhood.hxx
+++ b/Modules/Core/Common/include/itkNeighborhood.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNeighborhoodAccessorFunctor.h
+++ b/Modules/Core/Common/include/itkNeighborhoodAccessorFunctor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNeighborhoodAlgorithm.h
+++ b/Modules/Core/Common/include/itkNeighborhoodAlgorithm.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNeighborhoodAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodAlgorithm.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNeighborhoodAllocator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodAllocator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNeighborhoodInnerProduct.h
+++ b/Modules/Core/Common/include/itkNeighborhoodInnerProduct.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNeighborhoodInnerProduct.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodInnerProduct.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNeighborhoodIterator.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNeighborhoodIteratorTestCommon.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodIteratorTestCommon.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNeighborhoodOperator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodOperator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNeighborhoodOperator.hxx
+++ b/Modules/Core/Common/include/itkNeighborhoodOperator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNumberToString.h
+++ b/Modules/Core/Common/include/itkNumberToString.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNumberToString.hxx
+++ b/Modules/Core/Common/include/itkNumberToString.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNumericLocale.h
+++ b/Modules/Core/Common/include/itkNumericLocale.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNumericTraits.h
+++ b/Modules/Core/Common/include/itkNumericTraits.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNumericTraitsArrayPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsArrayPixel.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNumericTraitsCovariantVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsCovariantVectorPixel.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNumericTraitsDiffusionTensor3DPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsDiffusionTensor3DPixel.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsFixedArrayPixel.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNumericTraitsPointPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsPointPixel.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNumericTraitsRGBAPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsRGBAPixel.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNumericTraitsRGBPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsRGBPixel.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNumericTraitsStdVector.h
+++ b/Modules/Core/Common/include/itkNumericTraitsStdVector.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNumericTraitsTensorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsTensorPixel.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNumericTraitsVariableLengthVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsVariableLengthVectorPixel.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkNumericTraitsVectorPixel.h
+++ b/Modules/Core/Common/include/itkNumericTraitsVectorPixel.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkObject.h
+++ b/Modules/Core/Common/include/itkObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkObjectFactory.h
+++ b/Modules/Core/Common/include/itkObjectFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkObjectFactoryBase.h
+++ b/Modules/Core/Common/include/itkObjectFactoryBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkObjectStore.h
+++ b/Modules/Core/Common/include/itkObjectStore.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkObjectStore.hxx
+++ b/Modules/Core/Common/include/itkObjectStore.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkOctree.h
+++ b/Modules/Core/Common/include/itkOctree.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkOctree.hxx
+++ b/Modules/Core/Common/include/itkOctree.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkOctreeNode.h
+++ b/Modules/Core/Common/include/itkOctreeNode.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkOffset.h
+++ b/Modules/Core/Common/include/itkOffset.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkOptimizerParameters.h
+++ b/Modules/Core/Common/include/itkOptimizerParameters.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkOptimizerParametersHelper.h
+++ b/Modules/Core/Common/include/itkOptimizerParametersHelper.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkOrientationAdapterBase.h
+++ b/Modules/Core/Common/include/itkOrientationAdapterBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkOutputDataObjectConstIterator.h
+++ b/Modules/Core/Common/include/itkOutputDataObjectConstIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkOutputDataObjectIterator.h
+++ b/Modules/Core/Common/include/itkOutputDataObjectIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkOutputWindow.h
+++ b/Modules/Core/Common/include/itkOutputWindow.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPeriodicBoundaryCondition.h
+++ b/Modules/Core/Common/include/itkPeriodicBoundaryCondition.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPeriodicBoundaryCondition.hxx
+++ b/Modules/Core/Common/include/itkPeriodicBoundaryCondition.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPhasedArray3DSpecialCoordinatesImage.h
+++ b/Modules/Core/Common/include/itkPhasedArray3DSpecialCoordinatesImage.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPhasedArray3DSpecialCoordinatesImage.hxx
+++ b/Modules/Core/Common/include/itkPhasedArray3DSpecialCoordinatesImage.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPixelTraits.h
+++ b/Modules/Core/Common/include/itkPixelTraits.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPlatformMultiThreader.h
+++ b/Modules/Core/Common/include/itkPlatformMultiThreader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPoint.h
+++ b/Modules/Core/Common/include/itkPoint.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPoint.hxx
+++ b/Modules/Core/Common/include/itkPoint.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPointSet.h
+++ b/Modules/Core/Common/include/itkPointSet.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPointSet.hxx
+++ b/Modules/Core/Common/include/itkPointSet.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPointSetBase.h
+++ b/Modules/Core/Common/include/itkPointSetBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPointSetBase.hxx
+++ b/Modules/Core/Common/include/itkPointSetBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPointSetToImageFilter.h
+++ b/Modules/Core/Common/include/itkPointSetToImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPointSetToImageFilter.hxx
+++ b/Modules/Core/Common/include/itkPointSetToImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPolyLineCell.h
+++ b/Modules/Core/Common/include/itkPolyLineCell.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPolyLineCell.hxx
+++ b/Modules/Core/Common/include/itkPolyLineCell.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPolygonCell.h
+++ b/Modules/Core/Common/include/itkPolygonCell.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPolygonCell.hxx
+++ b/Modules/Core/Common/include/itkPolygonCell.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPoolMultiThreader.h
+++ b/Modules/Core/Common/include/itkPoolMultiThreader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPrintHelper.h
+++ b/Modules/Core/Common/include/itkPrintHelper.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPriorityQueueContainer.h
+++ b/Modules/Core/Common/include/itkPriorityQueueContainer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPriorityQueueContainer.hxx
+++ b/Modules/Core/Common/include/itkPriorityQueueContainer.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkProcessObject.h
+++ b/Modules/Core/Common/include/itkProcessObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkProgressAccumulator.h
+++ b/Modules/Core/Common/include/itkProgressAccumulator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkProgressReporter.h
+++ b/Modules/Core/Common/include/itkProgressReporter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkProgressTransformer.h
+++ b/Modules/Core/Common/include/itkProgressTransformer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPromoteType.h
+++ b/Modules/Core/Common/include/itkPromoteType.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPyCommand.h
+++ b/Modules/Core/Common/include/itkPyCommand.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPyImageFilter.h
+++ b/Modules/Core/Common/include/itkPyImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkPyImageFilter.hxx
+++ b/Modules/Core/Common/include/itkPyImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkQuadraticEdgeCell.h
+++ b/Modules/Core/Common/include/itkQuadraticEdgeCell.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkQuadraticEdgeCell.hxx
+++ b/Modules/Core/Common/include/itkQuadraticEdgeCell.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkQuadraticTriangleCell.h
+++ b/Modules/Core/Common/include/itkQuadraticTriangleCell.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkQuadraticTriangleCell.hxx
+++ b/Modules/Core/Common/include/itkQuadraticTriangleCell.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkQuadraticTriangleCellTopology.h
+++ b/Modules/Core/Common/include/itkQuadraticTriangleCellTopology.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkQuadrilateralCell.h
+++ b/Modules/Core/Common/include/itkQuadrilateralCell.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkQuadrilateralCell.hxx
+++ b/Modules/Core/Common/include/itkQuadrilateralCell.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkQuadrilateralCellTopology.h
+++ b/Modules/Core/Common/include/itkQuadrilateralCellTopology.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkRGBAPixel.h
+++ b/Modules/Core/Common/include/itkRGBAPixel.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkRGBAPixel.hxx
+++ b/Modules/Core/Common/include/itkRGBAPixel.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkRGBPixel.h
+++ b/Modules/Core/Common/include/itkRGBPixel.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkRGBPixel.hxx
+++ b/Modules/Core/Common/include/itkRGBPixel.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkRandomVariateGeneratorBase.h
+++ b/Modules/Core/Common/include/itkRandomVariateGeneratorBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkRealTimeClock.h
+++ b/Modules/Core/Common/include/itkRealTimeClock.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkRealTimeInterval.h
+++ b/Modules/Core/Common/include/itkRealTimeInterval.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkRealTimeStamp.h
+++ b/Modules/Core/Common/include/itkRealTimeStamp.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkRectangularImageNeighborhoodShape.h
+++ b/Modules/Core/Common/include/itkRectangularImageNeighborhoodShape.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkRegion.h
+++ b/Modules/Core/Common/include/itkRegion.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkRegularizedHeavisideStepFunction.h
+++ b/Modules/Core/Common/include/itkRegularizedHeavisideStepFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkRegularizedHeavisideStepFunction.hxx
+++ b/Modules/Core/Common/include/itkRegularizedHeavisideStepFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkResourceProbe.h
+++ b/Modules/Core/Common/include/itkResourceProbe.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkResourceProbe.hxx
+++ b/Modules/Core/Common/include/itkResourceProbe.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkResourceProbesCollectorBase.h
+++ b/Modules/Core/Common/include/itkResourceProbesCollectorBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkResourceProbesCollectorBase.hxx
+++ b/Modules/Core/Common/include/itkResourceProbesCollectorBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSTLConstContainerAdaptor.h
+++ b/Modules/Core/Common/include/itkSTLConstContainerAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSTLContainerAdaptor.h
+++ b/Modules/Core/Common/include/itkSTLContainerAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkShapedFloodFilledImageFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkShapedFloodFilledImageFunctionConditionalConstIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkShapedFloodFilledImageFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkShapedFloodFilledImageFunctionConditionalConstIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkShapedFloodFilledImageFunctionConditionalIterator.h
+++ b/Modules/Core/Common/include/itkShapedFloodFilledImageFunctionConditionalIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
+++ b/Modules/Core/Common/include/itkShapedImageNeighborhoodRange.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSimpleDataObjectDecorator.h
+++ b/Modules/Core/Common/include/itkSimpleDataObjectDecorator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSimpleDataObjectDecorator.hxx
+++ b/Modules/Core/Common/include/itkSimpleDataObjectDecorator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSimpleFilterWatcher.h
+++ b/Modules/Core/Common/include/itkSimpleFilterWatcher.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSinRegularizedHeavisideStepFunction.h
+++ b/Modules/Core/Common/include/itkSinRegularizedHeavisideStepFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSinRegularizedHeavisideStepFunction.hxx
+++ b/Modules/Core/Common/include/itkSinRegularizedHeavisideStepFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSingleton.h
+++ b/Modules/Core/Common/include/itkSingleton.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSingletonMacro.h
+++ b/Modules/Core/Common/include/itkSingletonMacro.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSize.h
+++ b/Modules/Core/Common/include/itkSize.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSliceIterator.h
+++ b/Modules/Core/Common/include/itkSliceIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSmapsFileParser.h
+++ b/Modules/Core/Common/include/itkSmapsFileParser.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSmapsFileParser.hxx
+++ b/Modules/Core/Common/include/itkSmapsFileParser.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSmartPointer.h
+++ b/Modules/Core/Common/include/itkSmartPointer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSmartPointerForwardReference.hxx
+++ b/Modules/Core/Common/include/itkSmartPointerForwardReference.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSobelOperator.h
+++ b/Modules/Core/Common/include/itkSobelOperator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSobelOperator.hxx
+++ b/Modules/Core/Common/include/itkSobelOperator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSparseFieldLayer.h
+++ b/Modules/Core/Common/include/itkSparseFieldLayer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSparseFieldLayer.hxx
+++ b/Modules/Core/Common/include/itkSparseFieldLayer.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSparseImage.h
+++ b/Modules/Core/Common/include/itkSparseImage.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSparseImage.hxx
+++ b/Modules/Core/Common/include/itkSparseImage.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSpatialFunction.h
+++ b/Modules/Core/Common/include/itkSpatialFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkSpatialFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSpatialOrientation.h
+++ b/Modules/Core/Common/include/itkSpatialOrientation.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSpatialOrientationAdapter.h
+++ b/Modules/Core/Common/include/itkSpatialOrientationAdapter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSpecialCoordinatesImage.h
+++ b/Modules/Core/Common/include/itkSpecialCoordinatesImage.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSpecialCoordinatesImage.hxx
+++ b/Modules/Core/Common/include/itkSpecialCoordinatesImage.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSphereSpatialFunction.h
+++ b/Modules/Core/Common/include/itkSphereSpatialFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSphereSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkSphereSpatialFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkStaticAssert.h
+++ b/Modules/Core/Common/include/itkStaticAssert.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkStdStreamLogOutput.h
+++ b/Modules/Core/Common/include/itkStdStreamLogOutput.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkStdStreamStateSave.h
+++ b/Modules/Core/Common/include/itkStdStreamStateSave.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkStoppingCriterionBase.h
+++ b/Modules/Core/Common/include/itkStoppingCriterionBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkStreamingImageFilter.h
+++ b/Modules/Core/Common/include/itkStreamingImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkStreamingImageFilter.hxx
+++ b/Modules/Core/Common/include/itkStreamingImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkStreamingProcessObject.h
+++ b/Modules/Core/Common/include/itkStreamingProcessObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkStringConvert.h
+++ b/Modules/Core/Common/include/itkStringConvert.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkStructHashFunction.h
+++ b/Modules/Core/Common/include/itkStructHashFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.hxx
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSymmetricEllipsoidInteriorExteriorSpatialFunction.h
+++ b/Modules/Core/Common/include/itkSymmetricEllipsoidInteriorExteriorSpatialFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSymmetricEllipsoidInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkSymmetricEllipsoidInteriorExteriorSpatialFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSymmetricSecondRankTensor.h
+++ b/Modules/Core/Common/include/itkSymmetricSecondRankTensor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkSymmetricSecondRankTensor.hxx
+++ b/Modules/Core/Common/include/itkSymmetricSecondRankTensor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkTBBMultiThreader.h
+++ b/Modules/Core/Common/include/itkTBBMultiThreader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkTetrahedronCell.h
+++ b/Modules/Core/Common/include/itkTetrahedronCell.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkTetrahedronCell.hxx
+++ b/Modules/Core/Common/include/itkTetrahedronCell.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkTetrahedronCellTopology.h
+++ b/Modules/Core/Common/include/itkTetrahedronCellTopology.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkTextOutput.h
+++ b/Modules/Core/Common/include/itkTextOutput.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkThreadLogger.h
+++ b/Modules/Core/Common/include/itkThreadLogger.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkThreadPool.h
+++ b/Modules/Core/Common/include/itkThreadPool.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkThreadSupport.h
+++ b/Modules/Core/Common/include/itkThreadSupport.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkThreadedDomainPartitioner.h
+++ b/Modules/Core/Common/include/itkThreadedDomainPartitioner.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkThreadedImageRegionPartitioner.h
+++ b/Modules/Core/Common/include/itkThreadedImageRegionPartitioner.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkThreadedImageRegionPartitioner.hxx
+++ b/Modules/Core/Common/include/itkThreadedImageRegionPartitioner.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkThreadedIndexedContainerPartitioner.h
+++ b/Modules/Core/Common/include/itkThreadedIndexedContainerPartitioner.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkThreadedIteratorRangePartitioner.h
+++ b/Modules/Core/Common/include/itkThreadedIteratorRangePartitioner.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkThreadedIteratorRangePartitioner.hxx
+++ b/Modules/Core/Common/include/itkThreadedIteratorRangePartitioner.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkTimeProbe.h
+++ b/Modules/Core/Common/include/itkTimeProbe.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkTimeProbesCollectorBase.h
+++ b/Modules/Core/Common/include/itkTimeProbesCollectorBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkTimeStamp.h
+++ b/Modules/Core/Common/include/itkTimeStamp.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkTorusInteriorExteriorSpatialFunction.h
+++ b/Modules/Core/Common/include/itkTorusInteriorExteriorSpatialFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkTorusInteriorExteriorSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkTorusInteriorExteriorSpatialFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkTotalProgressReporter.h
+++ b/Modules/Core/Common/include/itkTotalProgressReporter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkTriangleCell.h
+++ b/Modules/Core/Common/include/itkTriangleCell.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkTriangleCell.hxx
+++ b/Modules/Core/Common/include/itkTriangleCell.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkTriangleCellTopology.h
+++ b/Modules/Core/Common/include/itkTriangleCellTopology.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkTriangleHelper.h
+++ b/Modules/Core/Common/include/itkTriangleHelper.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkTriangleHelper.hxx
+++ b/Modules/Core/Common/include/itkTriangleHelper.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkUnaryCorrespondenceMatrix.h
+++ b/Modules/Core/Common/include/itkUnaryCorrespondenceMatrix.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkUnaryFunctorImageFilter.h
+++ b/Modules/Core/Common/include/itkUnaryFunctorImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkUnaryFunctorImageFilter.hxx
+++ b/Modules/Core/Common/include/itkUnaryFunctorImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkValarrayImageContainer.h
+++ b/Modules/Core/Common/include/itkValarrayImageContainer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkVariableLengthVector.h
+++ b/Modules/Core/Common/include/itkVariableLengthVector.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkVariableLengthVector.hxx
+++ b/Modules/Core/Common/include/itkVariableLengthVector.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkVariableSizeMatrix.h
+++ b/Modules/Core/Common/include/itkVariableSizeMatrix.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkVariableSizeMatrix.hxx
+++ b/Modules/Core/Common/include/itkVariableSizeMatrix.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkVector.h
+++ b/Modules/Core/Common/include/itkVector.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkVector.hxx
+++ b/Modules/Core/Common/include/itkVector.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkVectorContainer.h
+++ b/Modules/Core/Common/include/itkVectorContainer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkVectorContainer.hxx
+++ b/Modules/Core/Common/include/itkVectorContainer.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkVectorImage.h
+++ b/Modules/Core/Common/include/itkVectorImage.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkVectorImage.hxx
+++ b/Modules/Core/Common/include/itkVectorImage.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkVectorImageNeighborhoodAccessorFunctor.h
+++ b/Modules/Core/Common/include/itkVectorImageNeighborhoodAccessorFunctor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkVectorNeighborhoodInnerProduct.h
+++ b/Modules/Core/Common/include/itkVectorNeighborhoodInnerProduct.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkVectorNeighborhoodInnerProduct.hxx
+++ b/Modules/Core/Common/include/itkVectorNeighborhoodInnerProduct.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkVersion.h
+++ b/Modules/Core/Common/include/itkVersion.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkVersor.h
+++ b/Modules/Core/Common/include/itkVersor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkVersor.hxx
+++ b/Modules/Core/Common/include/itkVersor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkVertexCell.h
+++ b/Modules/Core/Common/include/itkVertexCell.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkVertexCell.hxx
+++ b/Modules/Core/Common/include/itkVertexCell.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkWeakPointer.h
+++ b/Modules/Core/Common/include/itkWeakPointer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkWin32Header.h
+++ b/Modules/Core/Common/include/itkWin32Header.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkWin32OutputWindow.h
+++ b/Modules/Core/Common/include/itkWin32OutputWindow.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkWindows.h
+++ b/Modules/Core/Common/include/itkWindows.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkXMLFileOutputWindow.h
+++ b/Modules/Core/Common/include/itkXMLFileOutputWindow.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkXMLFilterWatcher.h
+++ b/Modules/Core/Common/include/itkXMLFilterWatcher.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkZeroFluxNeumannBoundaryCondition.h
+++ b/Modules/Core/Common/include/itkZeroFluxNeumannBoundaryCondition.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkZeroFluxNeumannBoundaryCondition.hxx
+++ b/Modules/Core/Common/include/itkZeroFluxNeumannBoundaryCondition.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/include/itkZeroFluxNeumannImageNeighborhoodPixelAccessPolicy.h
+++ b/Modules/Core/Common/include/itkZeroFluxNeumannImageNeighborhoodPixelAccessPolicy.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkAnatomicalOrientation.cxx
+++ b/Modules/Core/Common/src/itkAnatomicalOrientation.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkArrayOutputSpecialization.cxx
+++ b/Modules/Core/Common/src/itkArrayOutputSpecialization.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkCommand.cxx
+++ b/Modules/Core/Common/src/itkCommand.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkCommonEnums.cxx
+++ b/Modules/Core/Common/src/itkCommonEnums.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkCompensatedSummation.cxx
+++ b/Modules/Core/Common/src/itkCompensatedSummation.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkCovariantVector.cxx
+++ b/Modules/Core/Common/src/itkCovariantVector.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkCreateObjectFunction.cxx
+++ b/Modules/Core/Common/src/itkCreateObjectFunction.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkDataObject.cxx
+++ b/Modules/Core/Common/src/itkDataObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkDirectory.cxx
+++ b/Modules/Core/Common/src/itkDirectory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkDynamicLoader.cxx
+++ b/Modules/Core/Common/src/itkDynamicLoader.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkEquivalencyTable.cxx
+++ b/Modules/Core/Common/src/itkEquivalencyTable.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkEventObject.cxx
+++ b/Modules/Core/Common/src/itkEventObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkExceptionObject.cxx
+++ b/Modules/Core/Common/src/itkExceptionObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkExtractImageFilter.cxx
+++ b/Modules/Core/Common/src/itkExtractImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkFileOutputWindow.cxx
+++ b/Modules/Core/Common/src/itkFileOutputWindow.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkFloatingPointExceptions.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkFloatingPointExceptions_unix_feenableexcept_using_fegetenv.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions_unix_feenableexcept_using_fegetenv.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkFloatingPointExceptions_unix_signalhandler.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions_unix_signalhandler.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkFloatingPointExceptions_win.cxx
+++ b/Modules/Core/Common/src/itkFloatingPointExceptions_win.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkFrustumSpatialFunction.cxx
+++ b/Modules/Core/Common/src/itkFrustumSpatialFunction.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkGaussianDerivativeOperator.cxx
+++ b/Modules/Core/Common/src/itkGaussianDerivativeOperator.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkHexahedronCellTopology.cxx
+++ b/Modules/Core/Common/src/itkHexahedronCellTopology.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkImageIORegion.cxx
+++ b/Modules/Core/Common/src/itkImageIORegion.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkImageRegionSplitterBase.cxx
+++ b/Modules/Core/Common/src/itkImageRegionSplitterBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkImageRegionSplitterDirection.cxx
+++ b/Modules/Core/Common/src/itkImageRegionSplitterDirection.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkImageRegionSplitterMultidimensional.cxx
+++ b/Modules/Core/Common/src/itkImageRegionSplitterMultidimensional.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkImageRegionSplitterSlowDimension.cxx
+++ b/Modules/Core/Common/src/itkImageRegionSplitterSlowDimension.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkImageSourceCommon.cxx
+++ b/Modules/Core/Common/src/itkImageSourceCommon.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkImageToImageFilterCommon.cxx
+++ b/Modules/Core/Common/src/itkImageToImageFilterCommon.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkIndent.cxx
+++ b/Modules/Core/Common/src/itkIndent.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkIterationReporter.cxx
+++ b/Modules/Core/Common/src/itkIterationReporter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkLightObject.cxx
+++ b/Modules/Core/Common/src/itkLightObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkLightProcessObject.cxx
+++ b/Modules/Core/Common/src/itkLightProcessObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkLogOutput.cxx
+++ b/Modules/Core/Common/src/itkLogOutput.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkLogger.cxx
+++ b/Modules/Core/Common/src/itkLogger.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkLoggerBase.cxx
+++ b/Modules/Core/Common/src/itkLoggerBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkLoggerManager.cxx
+++ b/Modules/Core/Common/src/itkLoggerManager.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkLoggerOutput.cxx
+++ b/Modules/Core/Common/src/itkLoggerOutput.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkLoggerThreadWrapper.cxx
+++ b/Modules/Core/Common/src/itkLoggerThreadWrapper.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkMemoryProbe.cxx
+++ b/Modules/Core/Common/src/itkMemoryProbe.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkMemoryProbesCollectorBase.cxx
+++ b/Modules/Core/Common/src/itkMemoryProbesCollectorBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkMemoryUsageObserver.cxx
+++ b/Modules/Core/Common/src/itkMemoryUsageObserver.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
+++ b/Modules/Core/Common/src/itkMersenneTwisterRandomVariateGenerator.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkMetaDataDictionary.cxx
+++ b/Modules/Core/Common/src/itkMetaDataDictionary.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkMetaDataObject.cxx
+++ b/Modules/Core/Common/src/itkMetaDataObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkMetaDataObjectBase.cxx
+++ b/Modules/Core/Common/src/itkMetaDataObjectBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkMultiThreaderBase.cxx
+++ b/Modules/Core/Common/src/itkMultiThreaderBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkMultipleLogOutput.cxx
+++ b/Modules/Core/Common/src/itkMultipleLogOutput.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkNumberToString.cxx
+++ b/Modules/Core/Common/src/itkNumberToString.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkNumericLocale.cxx
+++ b/Modules/Core/Common/src/itkNumericLocale.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkNumericTraits.cxx
+++ b/Modules/Core/Common/src/itkNumericTraits.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkNumericTraitsCovariantVectorPixel.cxx
+++ b/Modules/Core/Common/src/itkNumericTraitsCovariantVectorPixel.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkNumericTraitsDiffusionTensor3DPixel.cxx
+++ b/Modules/Core/Common/src/itkNumericTraitsDiffusionTensor3DPixel.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkNumericTraitsFixedArrayPixel.cxx
+++ b/Modules/Core/Common/src/itkNumericTraitsFixedArrayPixel.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkNumericTraitsFixedArrayPixel2.cxx
+++ b/Modules/Core/Common/src/itkNumericTraitsFixedArrayPixel2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkNumericTraitsPointPixel.cxx
+++ b/Modules/Core/Common/src/itkNumericTraitsPointPixel.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkNumericTraitsRGBAPixel.cxx
+++ b/Modules/Core/Common/src/itkNumericTraitsRGBAPixel.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkNumericTraitsRGBPixel.cxx
+++ b/Modules/Core/Common/src/itkNumericTraitsRGBPixel.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkNumericTraitsTensorPixel.cxx
+++ b/Modules/Core/Common/src/itkNumericTraitsTensorPixel.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkNumericTraitsTensorPixel2.cxx
+++ b/Modules/Core/Common/src/itkNumericTraitsTensorPixel2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkNumericTraitsVectorPixel.cxx
+++ b/Modules/Core/Common/src/itkNumericTraitsVectorPixel.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkObjectStore.cxx
+++ b/Modules/Core/Common/src/itkObjectStore.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkOctreeNode.cxx
+++ b/Modules/Core/Common/src/itkOctreeNode.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkOutputWindow.cxx
+++ b/Modules/Core/Common/src/itkOutputWindow.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkPlatformMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreader.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkPlatformMultiThreaderPosix.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreaderPosix.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkPlatformMultiThreaderSingle.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreaderSingle.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkPlatformMultiThreaderWindows.cxx
+++ b/Modules/Core/Common/src/itkPlatformMultiThreaderWindows.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkPoolMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkPoolMultiThreader.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkProcessObject.cxx
+++ b/Modules/Core/Common/src/itkProcessObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkProgressAccumulator.cxx
+++ b/Modules/Core/Common/src/itkProgressAccumulator.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkProgressReporter.cxx
+++ b/Modules/Core/Common/src/itkProgressReporter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkProgressTransformer.cxx
+++ b/Modules/Core/Common/src/itkProgressTransformer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkPyCommand.cxx
+++ b/Modules/Core/Common/src/itkPyCommand.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkQuadraticTriangleCellTopology.cxx
+++ b/Modules/Core/Common/src/itkQuadraticTriangleCellTopology.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkQuadrilateralCellTopology.cxx
+++ b/Modules/Core/Common/src/itkQuadrilateralCellTopology.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkRandomVariateGeneratorBase.cxx
+++ b/Modules/Core/Common/src/itkRandomVariateGeneratorBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkRealTimeClock.cxx
+++ b/Modules/Core/Common/src/itkRealTimeClock.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkRealTimeInterval.cxx
+++ b/Modules/Core/Common/src/itkRealTimeInterval.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkRealTimeStamp.cxx
+++ b/Modules/Core/Common/src/itkRealTimeStamp.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkRegion.cxx
+++ b/Modules/Core/Common/src/itkRegion.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkSimpleFilterWatcher.cxx
+++ b/Modules/Core/Common/src/itkSimpleFilterWatcher.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkSingleton.cxx
+++ b/Modules/Core/Common/src/itkSingleton.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkSmapsFileParser.cxx
+++ b/Modules/Core/Common/src/itkSmapsFileParser.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkSpatialOrientation.cxx
+++ b/Modules/Core/Common/src/itkSpatialOrientation.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkSpatialOrientationAdapter.cxx
+++ b/Modules/Core/Common/src/itkSpatialOrientationAdapter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkStdStreamLogOutput.cxx
+++ b/Modules/Core/Common/src/itkStdStreamLogOutput.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkStoppingCriterionBase.cxx
+++ b/Modules/Core/Common/src/itkStoppingCriterionBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkStreamingProcessObject.cxx
+++ b/Modules/Core/Common/src/itkStreamingProcessObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkStringConvert.cxx
+++ b/Modules/Core/Common/src/itkStringConvert.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkSymmetricEigenAnalysis.cxx
+++ b/Modules/Core/Common/src/itkSymmetricEigenAnalysis.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkTBBMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkTBBMultiThreader.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkTetrahedronCellTopology.cxx
+++ b/Modules/Core/Common/src/itkTetrahedronCellTopology.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkTextOutput.cxx
+++ b/Modules/Core/Common/src/itkTextOutput.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkThreadLogger.cxx
+++ b/Modules/Core/Common/src/itkThreadLogger.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkThreadPool.cxx
+++ b/Modules/Core/Common/src/itkThreadPool.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkThreadedIndexedContainerPartitioner.cxx
+++ b/Modules/Core/Common/src/itkThreadedIndexedContainerPartitioner.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkTimeProbe.cxx
+++ b/Modules/Core/Common/src/itkTimeProbe.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkTimeProbesCollectorBase.cxx
+++ b/Modules/Core/Common/src/itkTimeProbesCollectorBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkTimeStamp.cxx
+++ b/Modules/Core/Common/src/itkTimeStamp.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkTotalProgressReporter.cxx
+++ b/Modules/Core/Common/src/itkTotalProgressReporter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkTriangleCellTopology.cxx
+++ b/Modules/Core/Common/src/itkTriangleCellTopology.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkVector.cxx
+++ b/Modules/Core/Common/src/itkVector.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkVersion.cxx
+++ b/Modules/Core/Common/src/itkVersion.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkWin32OutputWindow.cxx
+++ b/Modules/Core/Common/src/itkWin32OutputWindow.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkXMLFileOutputWindow.cxx
+++ b/Modules/Core/Common/src/itkXMLFileOutputWindow.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/src/itkXMLFilterWatcher.cxx
+++ b/Modules/Core/Common/src/itkXMLFilterWatcher.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/ClientTestLibraryA.cxx
+++ b/Modules/Core/Common/test/ClientTestLibraryA.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/ClientTestLibraryA.h
+++ b/Modules/Core/Common/test/ClientTestLibraryA.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/ClientTestLibraryB.cxx
+++ b/Modules/Core/Common/test/ClientTestLibraryB.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/ClientTestLibraryB.h
+++ b/Modules/Core/Common/test/ClientTestLibraryB.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/ClientTestLibraryC.cxx
+++ b/Modules/Core/Common/test/ClientTestLibraryC.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/ClientTestLibraryC.h
+++ b/Modules/Core/Common/test/ClientTestLibraryC.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/SharedTestLibraryA.cxx
+++ b/Modules/Core/Common/test/SharedTestLibraryA.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/SharedTestLibraryA.h
+++ b/Modules/Core/Common/test/SharedTestLibraryA.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/SharedTestLibraryB.cxx
+++ b/Modules/Core/Common/test/SharedTestLibraryB.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/SharedTestLibraryB.h
+++ b/Modules/Core/Common/test/SharedTestLibraryB.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/VNLSparseLUSolverTraitsTest.cxx
+++ b/Modules/Core/Common/test/VNLSparseLUSolverTraitsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkAbortProcessObjectGTest.cxx
+++ b/Modules/Core/Common/test/itkAbortProcessObjectGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkAdaptorComparisonGTest.cxx
+++ b/Modules/Core/Common/test/itkAdaptorComparisonGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkAggregateTypesGTest.cxx
+++ b/Modules/Core/Common/test/itkAggregateTypesGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkAnatomicalOrientationGTest.cxx
+++ b/Modules/Core/Common/test/itkAnatomicalOrientationGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkAnnulusOperatorGTest.cxx
+++ b/Modules/Core/Common/test/itkAnnulusOperatorGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkArray2DGTest.cxx
+++ b/Modules/Core/Common/test/itkArray2DGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkArrayGTest.cxx
+++ b/Modules/Core/Common/test/itkArrayGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkAutoPointerGTest.cxx
+++ b/Modules/Core/Common/test/itkAutoPointerGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkBSplineKernelFunctionGTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineKernelFunctionGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkBitCastGTest.cxx
+++ b/Modules/Core/Common/test/itkBitCastGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkBooleanStdVectorGTest.cxx
+++ b/Modules/Core/Common/test/itkBooleanStdVectorGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkBoundaryConditionGTest.cxx
+++ b/Modules/Core/Common/test/itkBoundaryConditionGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkBoundingBoxGTest.cxx
+++ b/Modules/Core/Common/test/itkBoundingBoxGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkBresenhamLineGTest.cxx
+++ b/Modules/Core/Common/test/itkBresenhamLineGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkBuildInformationGTest.cxx
+++ b/Modules/Core/Common/test/itkBuildInformationGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkByteSwapGTest.cxx
+++ b/Modules/Core/Common/test/itkByteSwapGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkCMakeConfigurationTest.cxx
+++ b/Modules/Core/Common/test/itkCMakeConfigurationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkColorTableTest.cxx
+++ b/Modules/Core/Common/test/itkColorTableTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkCommandObserverObjectGTest.cxx
+++ b/Modules/Core/Common/test/itkCommandObserverObjectGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkCommonTypeTraitsGTest.cxx
+++ b/Modules/Core/Common/test/itkCommonTypeTraitsGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkCompensatedSummationGTest.cxx
+++ b/Modules/Core/Common/test/itkCompensatedSummationGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkCompensatedSummationTest2.cxx
+++ b/Modules/Core/Common/test/itkCompensatedSummationTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkConicShellInteriorExteriorSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkConicShellInteriorExteriorSpatialFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkConnectedImageNeighborhoodShapeGTest.cxx
+++ b/Modules/Core/Common/test/itkConnectedImageNeighborhoodShapeGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstNeighborhoodIteratorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkConstNeighborhoodIteratorWithOnlyIndexTest.cxx
+++ b/Modules/Core/Common/test/itkConstNeighborhoodIteratorWithOnlyIndexTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest2.cxx
+++ b/Modules/Core/Common/test/itkConstShapedNeighborhoodIteratorTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkConstantBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkConstantBoundaryConditionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkConstantBoundaryImageNeighborhoodPixelAccessPolicyGTest.cxx
+++ b/Modules/Core/Common/test/itkConstantBoundaryImageNeighborhoodPixelAccessPolicyGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkCopyGTest.cxx
+++ b/Modules/Core/Common/test/itkCopyGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkCovariantVectorGTest.cxx
+++ b/Modules/Core/Common/test/itkCovariantVectorGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkCrossHelperGTest.cxx
+++ b/Modules/Core/Common/test/itkCrossHelperGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkDataObjectAndProcessObjectTest.cxx
+++ b/Modules/Core/Common/test/itkDataObjectAndProcessObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkDataObjectTest.cxx
+++ b/Modules/Core/Common/test/itkDataObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkDataTypeGTest.cxx
+++ b/Modules/Core/Common/test/itkDataTypeGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkDecoratorGTest.cxx
+++ b/Modules/Core/Common/test/itkDecoratorGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkDerefGTest.cxx
+++ b/Modules/Core/Common/test/itkDerefGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkDerivativeOperatorGTest.cxx
+++ b/Modules/Core/Common/test/itkDerivativeOperatorGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkDiffusionTensor3DGTest.cxx
+++ b/Modules/Core/Common/test/itkDiffusionTensor3DGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkDirectoryTest.cxx
+++ b/Modules/Core/Common/test/itkDirectoryTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkDownCastTest.cxx
+++ b/Modules/Core/Common/test/itkDownCastTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkEllipsoidInteriorExteriorSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkEllipsoidInteriorExteriorSpatialFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkEventObjectGTest.cxx
+++ b/Modules/Core/Common/test/itkEventObjectGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkExceptionObjectGTest.cxx
+++ b/Modules/Core/Common/test/itkExceptionObjectGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkExceptionObjectTest.cxx
+++ b/Modules/Core/Common/test/itkExceptionObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkExtractImage3Dto2DTest.cxx
+++ b/Modules/Core/Common/test/itkExtractImage3Dto2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkExtractImageTest.cxx
+++ b/Modules/Core/Common/test/itkExtractImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkFactoryTestLib.cxx
+++ b/Modules/Core/Common/test/itkFactoryTestLib.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkFileOutputWindowTest.cxx
+++ b/Modules/Core/Common/test/itkFileOutputWindowTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkFilterDispatchGTest.cxx
+++ b/Modules/Core/Common/test/itkFilterDispatchGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkFiniteCylinderSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkFiniteCylinderSpatialFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkFixedArrayGTest.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkFixedArrayTest2.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkFloatingPointExceptionsExtern.cxx
+++ b/Modules/Core/Common/test/itkFloatingPointExceptionsExtern.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkFloatingPointExceptionsTest.cxx
+++ b/Modules/Core/Common/test/itkFloatingPointExceptionsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkFloodFillIteratorGTest.cxx
+++ b/Modules/Core/Common/test/itkFloodFillIteratorGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkFloodFilledSpatialFunctionGTest.cxx
+++ b/Modules/Core/Common/test/itkFloodFilledSpatialFunctionGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkFrustumSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkFrustumSpatialFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkGaussianDerivativeOperatorGTest.cxx
+++ b/Modules/Core/Common/test/itkGaussianDerivativeOperatorGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkGaussianSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkGaussianSpatialFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkHashTableGTest.cxx
+++ b/Modules/Core/Common/test/itkHashTableGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkHeavisideStepFunctionGTest.cxx
+++ b/Modules/Core/Common/test/itkHeavisideStepFunctionGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageAdaptorPipeLineTest.cxx
+++ b/Modules/Core/Common/test/itkImageAdaptorPipeLineTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageAlgorithmCopyTest.cxx
+++ b/Modules/Core/Common/test/itkImageAlgorithmCopyTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageAlgorithmCopyTest2.cxx
+++ b/Modules/Core/Common/test/itkImageAlgorithmCopyTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageBaseGTest.cxx
+++ b/Modules/Core/Common/test/itkImageBaseGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageComputeOffsetAndIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageComputeOffsetAndIndexTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageDuplicatorTest.cxx
+++ b/Modules/Core/Common/test/itkImageDuplicatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageDuplicatorTest2.cxx
+++ b/Modules/Core/Common/test/itkImageDuplicatorTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageFillBufferTest.cxx
+++ b/Modules/Core/Common/test/itkImageFillBufferTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageGTest.cxx
+++ b/Modules/Core/Common/test/itkImageGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageIORegionGTest.cxx
+++ b/Modules/Core/Common/test/itkImageIORegionGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageIteratorWithIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorWithIndexTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageIteratorsForwardBackwardTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorsForwardBackwardTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageIteratorsGTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorsGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageLinearIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageLinearIteratorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageNeighborhoodOffsetsGTest.cxx
+++ b/Modules/Core/Common/test/itkImageNeighborhoodOffsetsGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageRandomConstIteratorWithIndexGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomConstIteratorWithIndexGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageRandomConstIteratorWithOnlyIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomConstIteratorWithOnlyIndexTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageRandomIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomIteratorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
+++ b/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRandomNonRepeatingIteratorWithIndexGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageRegionConstIteratorWithOnlyIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionConstIteratorWithOnlyIndexTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageRegionExclusionIteratorWithIndexTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionExclusionIteratorWithIndexTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageRegionExplicitTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionExplicitTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageRegionGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageRegionIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionIteratorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageRegionSplitterDirectionTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionSplitterDirectionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageRegionSplitterMultidimensionalTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionSplitterMultidimensionalTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageRegionSplitterSlowDimensionTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionSplitterSlowDimensionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageRegionTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageReverseIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageReverseIteratorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageScanlineIteratorTest1.cxx
+++ b/Modules/Core/Common/test/itkImageScanlineIteratorTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageSliceIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageSliceIteratorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageTest.cxx
+++ b/Modules/Core/Common/test/itkImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageToImageToleranceTest.cxx
+++ b/Modules/Core/Common/test/itkImageToImageToleranceTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageTransformGTest.cxx
+++ b/Modules/Core/Common/test/itkImageTransformGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImageVectorOptimizerParametersHelperTest.cxx
+++ b/Modules/Core/Common/test/itkImageVectorOptimizerParametersHelperTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImportContainerGTest.cxx
+++ b/Modules/Core/Common/test/itkImportContainerGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkImportImageGTest.cxx
+++ b/Modules/Core/Common/test/itkImportImageGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkIndexGTest.cxx
+++ b/Modules/Core/Common/test/itkIndexGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkIndexRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkIndexRangeGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkIntTypesGTest.cxx
+++ b/Modules/Core/Common/test/itkIntTypesGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkIteratorTests.cxx
+++ b/Modules/Core/Common/test/itkIteratorTests.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkLightObjectGTest.cxx
+++ b/Modules/Core/Common/test/itkLightObjectGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkLightObjectTest.cxx
+++ b/Modules/Core/Common/test/itkLightObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkLineIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkLineIteratorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkLogTester.h
+++ b/Modules/Core/Common/test/itkLogTester.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkLoggerManagerTest.cxx
+++ b/Modules/Core/Common/test/itkLoggerManagerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkLoggerOutputTest.cxx
+++ b/Modules/Core/Common/test/itkLoggerOutputTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkLoggerTest.cxx
+++ b/Modules/Core/Common/test/itkLoggerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkLoggerThreadWrapperTest.cxx
+++ b/Modules/Core/Common/test/itkLoggerThreadWrapperTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMakeUniqueForOverwriteGTest.cxx
+++ b/Modules/Core/Common/test/itkMakeUniqueForOverwriteGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMapContainerTest.cxx
+++ b/Modules/Core/Common/test/itkMapContainerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMathCastWithRangeCheckGTest.cxx
+++ b/Modules/Core/Common/test/itkMathCastWithRangeCheckGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMathGTest.cxx
+++ b/Modules/Core/Common/test/itkMathGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMathRoundGTest.cxx
+++ b/Modules/Core/Common/test/itkMathRoundGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMatrixGTest.cxx
+++ b/Modules/Core/Common/test/itkMatrixGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMatrixTest.cxx
+++ b/Modules/Core/Common/test/itkMatrixTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMemoryLeakTest.cxx
+++ b/Modules/Core/Common/test/itkMemoryLeakTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMemoryProbesCollecterBaseTest.cxx
+++ b/Modules/Core/Common/test/itkMemoryProbesCollecterBaseTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMersenneTwisterRandomVariateGeneratorGTest.cxx
+++ b/Modules/Core/Common/test/itkMersenneTwisterRandomVariateGeneratorGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMetaDataDictionaryGTest.cxx
+++ b/Modules/Core/Common/test/itkMetaDataDictionaryGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMetaDataDictionaryTest.cxx
+++ b/Modules/Core/Common/test/itkMetaDataDictionaryTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMetaDataObjectTest.cxx
+++ b/Modules/Core/Common/test/itkMetaDataObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMetaProgrammingLibraryTest.cxx
+++ b/Modules/Core/Common/test/itkMetaProgrammingLibraryTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMinimumMaximumImageCalculatorTest.cxx
+++ b/Modules/Core/Common/test/itkMinimumMaximumImageCalculatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkModifiedTimeGTest.cxx
+++ b/Modules/Core/Common/test/itkModifiedTimeGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMultiThreaderBaseTest.cxx
+++ b/Modules/Core/Common/test/itkMultiThreaderBaseTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMultiThreaderExceptionsTest.cxx
+++ b/Modules/Core/Common/test/itkMultiThreaderExceptionsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMultiThreaderParallelizeArrayTest.cxx
+++ b/Modules/Core/Common/test/itkMultiThreaderParallelizeArrayTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMultiThreaderTypeFromEnvironmentTest.cxx
+++ b/Modules/Core/Common/test/itkMultiThreaderTypeFromEnvironmentTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMultiThreadingEnvironmentTest.cxx
+++ b/Modules/Core/Common/test/itkMultiThreadingEnvironmentTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMultipleLogOutputTest.cxx
+++ b/Modules/Core/Common/test/itkMultipleLogOutputTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkMultithreadingTest.cxx
+++ b/Modules/Core/Common/test/itkMultithreadingTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkNeighborhoodAlgorithmTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodAlgorithmTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkNeighborhoodAllocatorGTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodAllocatorGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodIteratorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkNeighborhoodOperatorTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodOperatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkNeighborhoodTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkNumberToStringGTest.cxx
+++ b/Modules/Core/Common/test/itkNumberToStringGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkNumberToStringTest.cxx
+++ b/Modules/Core/Common/test/itkNumberToStringTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkNumericLocaleGTest.cxx
+++ b/Modules/Core/Common/test/itkNumericLocaleGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkNumericTraitsTest.cxx
+++ b/Modules/Core/Common/test/itkNumericTraitsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkNumericsTest.cxx
+++ b/Modules/Core/Common/test/itkNumericsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkObjectFactoryBaseGTest.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryBaseGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkObjectFactoryBasePrivateDestructor.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryBasePrivateDestructor.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkObjectFactoryOnlyNewTest.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryOnlyNewTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkObjectFactoryTest.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkObjectFactoryTest2.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkObjectFactoryTest3.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkObjectStoreTest.cxx
+++ b/Modules/Core/Common/test/itkObjectStoreTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkOctreeTest.cxx
+++ b/Modules/Core/Common/test/itkOctreeTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkOffsetGTest.cxx
+++ b/Modules/Core/Common/test/itkOffsetGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkOptimizerParametersGTest.cxx
+++ b/Modules/Core/Common/test/itkOptimizerParametersGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkOptimizerParametersTest.cxx
+++ b/Modules/Core/Common/test/itkOptimizerParametersTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkPeriodicBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkPeriodicBoundaryConditionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkPhasedArray3DSpecialCoordinatesImageTest.cxx
+++ b/Modules/Core/Common/test/itkPhasedArray3DSpecialCoordinatesImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkPixelAccessGTest.cxx
+++ b/Modules/Core/Common/test/itkPixelAccessGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkPointGTest.cxx
+++ b/Modules/Core/Common/test/itkPointGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkPointGeometryTest.cxx
+++ b/Modules/Core/Common/test/itkPointGeometryTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkPointSetGTest.cxx
+++ b/Modules/Core/Common/test/itkPointSetGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkPointSetTest.cxx
+++ b/Modules/Core/Common/test/itkPointSetTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkPointSetToImageFilterTest1.cxx
+++ b/Modules/Core/Common/test/itkPointSetToImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkPointSetToImageFilterTest2.cxx
+++ b/Modules/Core/Common/test/itkPointSetToImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkPrintHelperGTest.cxx
+++ b/Modules/Core/Common/test/itkPrintHelperGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkPriorityQueueGTest.cxx
+++ b/Modules/Core/Common/test/itkPriorityQueueGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkPromoteType.cxx
+++ b/Modules/Core/Common/test/itkPromoteType.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkRGBAPixelGTest.cxx
+++ b/Modules/Core/Common/test/itkRGBAPixelGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkRGBPixelGTest.cxx
+++ b/Modules/Core/Common/test/itkRGBPixelGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkRGBPixelTest.cxx
+++ b/Modules/Core/Common/test/itkRGBPixelTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkRangeGTestUtilities.h
+++ b/Modules/Core/Common/test/itkRangeGTestUtilities.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkRealTimeClockTest.cxx
+++ b/Modules/Core/Common/test/itkRealTimeClockTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkRealTimeIntervalGTest.cxx
+++ b/Modules/Core/Common/test/itkRealTimeIntervalGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkRealTimeStampGTest.cxx
+++ b/Modules/Core/Common/test/itkRealTimeStampGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSTLContainerAdaptorTest.cxx
+++ b/Modules/Core/Common/test/itkSTLContainerAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSTLThreadTest.cxx
+++ b/Modules/Core/Common/test/itkSTLThreadTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkShapedNeighborhoodIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkShapedNeighborhoodIteratorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSimpleFilterWatcherTest.cxx
+++ b/Modules/Core/Common/test/itkSimpleFilterWatcherTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSizeGTest.cxx
+++ b/Modules/Core/Common/test/itkSizeGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSliceIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkSliceIteratorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSmartPointerGTest.cxx
+++ b/Modules/Core/Common/test/itkSmartPointerGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSmartPointerTest.cxx
+++ b/Modules/Core/Common/test/itkSmartPointerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSobelOperatorGTest.cxx
+++ b/Modules/Core/Common/test/itkSobelOperatorGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSobelOperatorImageConvolutionTest.cxx
+++ b/Modules/Core/Common/test/itkSobelOperatorImageConvolutionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSobelOperatorImageFilterTest.cxx
+++ b/Modules/Core/Common/test/itkSobelOperatorImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSparseFieldLayerTest.cxx
+++ b/Modules/Core/Common/test/itkSparseFieldLayerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSparseImageTest.cxx
+++ b/Modules/Core/Common/test/itkSparseImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkSpatialFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSpatialOrientationAdaptorGTest.cxx
+++ b/Modules/Core/Common/test/itkSpatialOrientationAdaptorGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSpatialOrientationTest.cxx
+++ b/Modules/Core/Common/test/itkSpatialOrientationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkStdStreamLogOutputTest.cxx
+++ b/Modules/Core/Common/test/itkStdStreamLogOutputTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkStdStreamStateSaveGTest.cxx
+++ b/Modules/Core/Common/test/itkStdStreamStateSaveGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkStreamingImageFilterTest.cxx
+++ b/Modules/Core/Common/test/itkStreamingImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkStreamingImageFilterTest2.cxx
+++ b/Modules/Core/Common/test/itkStreamingImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkStreamingImageFilterTest3.cxx
+++ b/Modules/Core/Common/test/itkStreamingImageFilterTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkStringConvertGTest.cxx
+++ b/Modules/Core/Common/test/itkStringConvertGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSymmetricEigenAnalysisTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricEigenAnalysisTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSymmetricEllipsoidInteriorExteriorSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricEllipsoidInteriorExteriorSpatialFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorGTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageReadTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorImageWriteReadTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSymmetricSecondRankTensorTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricSecondRankTensorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkSystemInformation.cxx
+++ b/Modules/Core/Common/test/itkSystemInformation.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkThreadDefsTest.cxx
+++ b/Modules/Core/Common/test/itkThreadDefsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkThreadLoggerTest.cxx
+++ b/Modules/Core/Common/test/itkThreadLoggerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkThreadedImageRegionPartitionerGTest.cxx
+++ b/Modules/Core/Common/test/itkThreadedImageRegionPartitionerGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkThreadedIndexedContainerPartitionerGTest.cxx
+++ b/Modules/Core/Common/test/itkThreadedIndexedContainerPartitionerGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerGTest.cxx
+++ b/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerGTest2.cxx
+++ b/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerGTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerGTest3.cxx
+++ b/Modules/Core/Common/test/itkThreadedIteratorRangePartitionerGTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkTimeProbeTest.cxx
+++ b/Modules/Core/Common/test/itkTimeProbeTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkTimeProbeTest2.cxx
+++ b/Modules/Core/Common/test/itkTimeProbeTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkTimeProbesTest.cxx
+++ b/Modules/Core/Common/test/itkTimeProbesTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkTimeStampGTest.cxx
+++ b/Modules/Core/Common/test/itkTimeStampGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkTorusInteriorExteriorSpatialFunctionTest.cxx
+++ b/Modules/Core/Common/test/itkTorusInteriorExteriorSpatialFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkVNLRoundProfileTest1.cxx
+++ b/Modules/Core/Common/test/itkVNLRoundProfileTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkVariableLengthVectorGTest.cxx
+++ b/Modules/Core/Common/test/itkVariableLengthVectorGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkVariableLengthVectorTest.cxx
+++ b/Modules/Core/Common/test/itkVariableLengthVectorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkVariableSizeMatrixTest.cxx
+++ b/Modules/Core/Common/test/itkVariableSizeMatrixTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkVectorContainerGTest.cxx
+++ b/Modules/Core/Common/test/itkVectorContainerGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkVectorContainerTest.cxx
+++ b/Modules/Core/Common/test/itkVectorContainerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkVectorGTest.cxx
+++ b/Modules/Core/Common/test/itkVectorGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkVectorGeometryTest.cxx
+++ b/Modules/Core/Common/test/itkVectorGeometryTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkVectorMultiplyTest.cxx
+++ b/Modules/Core/Common/test/itkVectorMultiplyTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkVectorTest.cxx
+++ b/Modules/Core/Common/test/itkVectorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkVersionGTest.cxx
+++ b/Modules/Core/Common/test/itkVersionGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkVersorTest.cxx
+++ b/Modules/Core/Common/test/itkVersorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkWeakPointerGTest.cxx
+++ b/Modules/Core/Common/test/itkWeakPointerGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkXMLFileOutputWindowTest.cxx
+++ b/Modules/Core/Common/test/itkXMLFileOutputWindowTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkXMLFilterWatcherTest.cxx
+++ b/Modules/Core/Common/test/itkXMLFilterWatcherTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/test/itkZeroFluxBoundaryConditionTest.cxx
+++ b/Modules/Core/Common/test/itkZeroFluxBoundaryConditionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Common/wrapping/test/itkDirectoryTest.py
+++ b/Modules/Core/Common/wrapping/test/itkDirectoryTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Core/Common/wrapping/test/itkImageDuplicatorTest.py
+++ b/Modules/Core/Common/wrapping/test/itkImageDuplicatorTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Core/Common/wrapping/test/itkImageInteropTest.py
+++ b/Modules/Core/Common/wrapping/test/itkImageInteropTest.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Core/Common/wrapping/test/itkImageLifetimeTest.py
+++ b/Modules/Core/Common/wrapping/test/itkImageLifetimeTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Core/Common/wrapping/test/itkImageTest.py
+++ b/Modules/Core/Common/wrapping/test/itkImageTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Core/Common/wrapping/test/itkIndexOffsetTest.py
+++ b/Modules/Core/Common/wrapping/test/itkIndexOffsetTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Core/Common/wrapping/test/itkMatrixTest.py
+++ b/Modules/Core/Common/wrapping/test/itkMatrixTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Core/Common/wrapping/test/itkMetaDataDictionaryTest.py
+++ b/Modules/Core/Common/wrapping/test/itkMetaDataDictionaryTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Core/Common/wrapping/test/itkPointSetSerializationTest.py
+++ b/Modules/Core/Common/wrapping/test/itkPointSetSerializationTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Core/Common/wrapping/test/itkPointSetTest.py
+++ b/Modules/Core/Common/wrapping/test/itkPointSetTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Core/Common/wrapping/test/itkSpatialOrientationAdapterTest.py
+++ b/Modules/Core/Common/wrapping/test/itkSpatialOrientationAdapterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Core/Common/wrapping/test/itkVariableLengthVectorTest.py
+++ b/Modules/Core/Common/wrapping/test/itkVariableLengthVectorTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.h
+++ b/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceFunction.h
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceFunction.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.h
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.h
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFunction.h
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFunction.hxx
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceSparseImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/CMake/itkCheckHasBlocks.cxx
+++ b/Modules/Core/GPUCommon/CMake/itkCheckHasBlocks.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/include/itkGPUContextManager.h
+++ b/Modules/Core/GPUCommon/include/itkGPUContextManager.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/include/itkGPUDataManager.h
+++ b/Modules/Core/GPUCommon/include/itkGPUDataManager.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/include/itkGPUFunctorBase.h
+++ b/Modules/Core/GPUCommon/include/itkGPUFunctorBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/include/itkGPUImage.h
+++ b/Modules/Core/GPUCommon/include/itkGPUImage.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/include/itkGPUImage.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUImage.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/include/itkGPUImageDataManager.h
+++ b/Modules/Core/GPUCommon/include/itkGPUImageDataManager.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/include/itkGPUImageDataManager.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUImageDataManager.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/include/itkGPUImageOps.h
+++ b/Modules/Core/GPUCommon/include/itkGPUImageOps.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/include/itkGPUImageToImageFilter.h
+++ b/Modules/Core/GPUCommon/include/itkGPUImageToImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/include/itkGPUImageToImageFilter.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUImageToImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/include/itkGPUInPlaceImageFilter.h
+++ b/Modules/Core/GPUCommon/include/itkGPUInPlaceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/include/itkGPUInPlaceImageFilter.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUInPlaceImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/include/itkGPUKernelManager.h
+++ b/Modules/Core/GPUCommon/include/itkGPUKernelManager.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/include/itkGPUReduction.h
+++ b/Modules/Core/GPUCommon/include/itkGPUReduction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/include/itkGPUReduction.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUReduction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/include/itkGPUUnaryFunctorImageFilter.h
+++ b/Modules/Core/GPUCommon/include/itkGPUUnaryFunctorImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/include/itkGPUUnaryFunctorImageFilter.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUUnaryFunctorImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/include/itkOpenCLUtil.h
+++ b/Modules/Core/GPUCommon/include/itkOpenCLUtil.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/src/itkGPUContextManager.cxx
+++ b/Modules/Core/GPUCommon/src/itkGPUContextManager.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/src/itkGPUDataManager.cxx
+++ b/Modules/Core/GPUCommon/src/itkGPUDataManager.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/src/itkGPUKernelManager.cxx
+++ b/Modules/Core/GPUCommon/src/itkGPUKernelManager.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/src/itkOpenCLUtil.cxx
+++ b/Modules/Core/GPUCommon/src/itkOpenCLUtil.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/test/itkGPUImageTest.cxx
+++ b/Modules/Core/GPUCommon/test/itkGPUImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/test/itkGPUReductionTest.cxx
+++ b/Modules/Core/GPUCommon/test/itkGPUReductionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/wrapping/test/itkGPUImageTest.py
+++ b/Modules/Core/GPUCommon/wrapping/test/itkGPUImageTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Core/GPUCommon/wrapping/test/itkGPUReductionTest.py
+++ b/Modules/Core/GPUCommon/wrapping/test/itkGPUReductionTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUDenseFiniteDifferenceImageFilter.h
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUDenseFiniteDifferenceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUDenseFiniteDifferenceImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceFilterEnum.h
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceFilterEnum.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceFunction.h
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.hxx
+++ b/Modules/Core/GPUFiniteDifference/include/itkGPUFiniteDifferenceImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/GPUFiniteDifference/src/itkGPUFiniteDifferenceFilterEnum.cxx
+++ b/Modules/Core/GPUFiniteDifference/src/itkGPUFiniteDifferenceFilterEnum.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkAbsImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkAbsImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkAcosImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkAcosImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkAddImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkAddImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkAddPixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkAddPixelAccessor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkAsinImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkAsinImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkAtanImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkAtanImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkBluePixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkBluePixelAccessor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkComplexConjugateImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkComplexConjugateImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkComplexToImaginaryImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkComplexToImaginaryImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkComplexToModulusImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkComplexToModulusImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkComplexToPhaseImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkComplexToPhaseImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkComplexToRealImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkComplexToRealImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkCosImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkCosImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkExpImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkExpImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkExpNegativeImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkExpNegativeImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkGreenPixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkGreenPixelAccessor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkImageAdaptor.hxx
+++ b/Modules/Core/ImageAdaptors/include/itkImageAdaptor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkLog10ImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkLog10ImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkLogImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkLogImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkNthElementImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkNthElementImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkNthElementPixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkNthElementPixelAccessor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkPixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkPixelAccessor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkRGBToLuminanceImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkRGBToLuminanceImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkRGBToVectorImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkRGBToVectorImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkRGBToVectorPixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkRGBToVectorPixelAccessor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkRedPixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkRedPixelAccessor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkSinImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkSinImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkSqrtImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkSqrtImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkTanImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkTanImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkVectorImageToImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkVectorImageToImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkVectorToRGBImageAdaptor.h
+++ b/Modules/Core/ImageAdaptors/include/itkVectorToRGBImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/include/itkVectorToRGBPixelAccessor.h
+++ b/Modules/Core/ImageAdaptors/include/itkVectorToRGBPixelAccessor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/test/itkComplexConjugateImageAdaptorTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkComplexConjugateImageAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/test/itkImageAdaptorGTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkImageAdaptorGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/test/itkImageAdaptorTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkImageAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/test/itkNthElementPixelAccessorGTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkNthElementPixelAccessorGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/test/itkRGBToVectorImageAdaptorTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkRGBToVectorImageAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkVectorImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageAdaptors/test/itkVectorImageToImageAdaptorTest.cxx
+++ b/Modules/Core/ImageAdaptors/test/itkVectorImageToImageAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkBSplineResampleImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkBSplineResampleImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkBinaryThresholdImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkBinaryThresholdImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkBinaryThresholdImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkBinaryThresholdImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkCentralDifferenceImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkCovarianceImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkCovarianceImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkCovarianceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkCovarianceImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkExtrapolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkExtrapolateImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianBlurImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianDerivativeImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkGaussianInterpolateImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkInterpolateImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkLabelImageGaussianInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkLabelImageGaussianInterpolateImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkLabelImageGaussianInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkLabelImageGaussianInterpolateImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkLinearInterpolateImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkMahalanobisDistanceThresholdImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkMahalanobisDistanceThresholdImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkMahalanobisDistanceThresholdImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMahalanobisDistanceThresholdImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkMeanImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkMeanImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkMeanImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMeanImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkMedianImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkMedianImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkMedianImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkMedianImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkNearestNeighborExtrapolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkNearestNeighborExtrapolateImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkNearestNeighborInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkNearestNeighborInterpolateImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkNeighborhoodBinaryThresholdImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkNeighborhoodBinaryThresholdImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkNeighborhoodBinaryThresholdImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkNeighborhoodBinaryThresholdImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkNeighborhoodOperatorImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkNeighborhoodOperatorImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkNeighborhoodOperatorImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkNeighborhoodOperatorImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkScatterMatrixImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkScatterMatrixImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkScatterMatrixImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkScatterMatrixImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkSumOfSquaresImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkSumOfSquaresImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkSumOfSquaresImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkSumOfSquaresImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkVarianceImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVarianceImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkVarianceImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVarianceImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkVectorInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorInterpolateImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkVectorMeanImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorMeanImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkVectorMeanImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkVectorMeanImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkVectorNearestNeighborInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkVectorNearestNeighborInterpolateImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkWindowedSincInterpolateImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkBSplineDecompositionImageFilterTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineDecompositionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkBSplineResampleImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineResampleImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkBinaryThresholdImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBinaryThresholdImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorSpeedTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorSpeedTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionSpeedTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionSpeedTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkCovarianceImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCovarianceImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkGaussianBlurImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianBlurImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkGaussianDerivativeImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianDerivativeImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianInterpolateImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkImageAdaptorInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkImageAdaptorInterpolateImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkInterpolateTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkInterpolateTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkLabelImageGaussianInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLabelImageGaussianInterpolateImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkMahalanobisDistanceThresholdImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkMahalanobisDistanceThresholdImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkMeanImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkMeanImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkMedianImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkMedianImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkNearestNeighborExtrapolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkNearestNeighborExtrapolateImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkNearestNeighborInterpolateImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkNeighborhoodOperatorImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkNeighborhoodOperatorImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkRGBInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkRGBInterpolateImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkRayCastInterpolateImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkScatterMatrixImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkScatterMatrixImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkVarianceImageFunctionGTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkVarianceImageFunctionGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkVectorInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkVectorInterpolateImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkVectorLinearInterpolateNearestNeighborExtrapolateImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkVectorMeanImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkVectorMeanImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/itkWindowedSincInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkWindowedSincInterpolateImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/ImageFunction/test/makeRandomImageBsplineInterpolator.h
+++ b/Modules/Core/ImageFunction/test/makeRandomImageBsplineInterpolator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkAutomaticTopologyMeshSource.h
+++ b/Modules/Core/Mesh/include/itkAutomaticTopologyMeshSource.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkAutomaticTopologyMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkAutomaticTopologyMeshSource.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.h
+++ b/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkImageToMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkImageToMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkImageToMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkImageToMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkImageToParametricSpaceFilter.h
+++ b/Modules/Core/Mesh/include/itkImageToParametricSpaceFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkImageToParametricSpaceFilter.hxx
+++ b/Modules/Core/Mesh/include/itkImageToParametricSpaceFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkInteriorExteriorMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkMesh.h
+++ b/Modules/Core/Mesh/include/itkMesh.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkMesh.hxx
+++ b/Modules/Core/Mesh/include/itkMesh.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkMeshRegion.h
+++ b/Modules/Core/Mesh/include/itkMeshRegion.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkMeshSource.h
+++ b/Modules/Core/Mesh/include/itkMeshSource.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkMeshSource.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkMeshToMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkMeshToMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkMeshToMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkMeshToMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkParametricSpaceToImageSpaceMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkParametricSpaceToImageSpaceMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkParametricSpaceToImageSpaceMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkParametricSpaceToImageSpaceMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkRegularSphereMeshSource.h
+++ b/Modules/Core/Mesh/include/itkRegularSphereMeshSource.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkRegularSphereMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkRegularSphereMeshSource.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkSimplexMesh.h
+++ b/Modules/Core/Mesh/include/itkSimplexMesh.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkSimplexMesh.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMesh.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.h
+++ b/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkSimplexMeshGeometry.h
+++ b/Modules/Core/Mesh/include/itkSimplexMeshGeometry.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshToTriangleMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.h
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkSphereMeshSource.h
+++ b/Modules/Core/Mesh/include/itkSphereMeshSource.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkSphereMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkSphereMeshSource.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkTransformMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkTransformMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkTransformMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTransformMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.h
+++ b/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.h
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkVTKPolyDataReader.h
+++ b/Modules/Core/Mesh/include/itkVTKPolyDataReader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkVTKPolyDataReader.hxx
+++ b/Modules/Core/Mesh/include/itkVTKPolyDataReader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkVTKPolyDataWriter.h
+++ b/Modules/Core/Mesh/include/itkVTKPolyDataWriter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkVTKPolyDataWriter.hxx
+++ b/Modules/Core/Mesh/include/itkVTKPolyDataWriter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkWarpMeshFilter.h
+++ b/Modules/Core/Mesh/include/itkWarpMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/include/itkWarpMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkWarpMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/src/itkMeshRegion.cxx
+++ b/Modules/Core/Mesh/src/itkMeshRegion.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/src/itkSimplexMeshGeometry.cxx
+++ b/Modules/Core/Mesh/src/itkSimplexMeshGeometry.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/src/itkTriangleMeshCurvatureCalculator.cxx
+++ b/Modules/Core/Mesh/src/itkTriangleMeshCurvatureCalculator.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkAutomaticTopologyMeshSourceTest.cxx
+++ b/Modules/Core/Mesh/test/itkAutomaticTopologyMeshSourceTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkBinaryMask3DMeshSourceTest.cxx
+++ b/Modules/Core/Mesh/test/itkBinaryMask3DMeshSourceTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkCellInterfaceTest.cxx
+++ b/Modules/Core/Mesh/test/itkCellInterfaceTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkConnectedRegionsMeshFilterTest1.cxx
+++ b/Modules/Core/Mesh/test/itkConnectedRegionsMeshFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkConnectedRegionsMeshFilterTest2.cxx
+++ b/Modules/Core/Mesh/test/itkConnectedRegionsMeshFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkDynamicMeshTest.cxx
+++ b/Modules/Core/Mesh/test/itkDynamicMeshTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkImageToParametricSpaceFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkImageToParametricSpaceFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkInteriorExteriorMeshFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkInteriorExteriorMeshFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkMeshCellDataTest.cxx
+++ b/Modules/Core/Mesh/test/itkMeshCellDataTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkMeshFstreamTest.cxx
+++ b/Modules/Core/Mesh/test/itkMeshFstreamTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkMeshRegionTest.cxx
+++ b/Modules/Core/Mesh/test/itkMeshRegionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkMeshSourceGraftOutputTest.cxx
+++ b/Modules/Core/Mesh/test/itkMeshSourceGraftOutputTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkMeshSpatialObjectIOTest.cxx
+++ b/Modules/Core/Mesh/test/itkMeshSpatialObjectIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkMeshTest.cxx
+++ b/Modules/Core/Mesh/test/itkMeshTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkNewTest.cxx
+++ b/Modules/Core/Mesh/test/itkNewTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkParametricSpaceToImageSpaceMeshFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkParametricSpaceToImageSpaceMeshFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkQuadrilateralCellTest.cxx
+++ b/Modules/Core/Mesh/test/itkQuadrilateralCellTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkRegularSphereMeshSourceTest.cxx
+++ b/Modules/Core/Mesh/test/itkRegularSphereMeshSourceTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkRegularSphereMeshSourceTest2.cxx
+++ b/Modules/Core/Mesh/test/itkRegularSphereMeshSourceTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkSimplexMeshAdaptTopologyFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkSimplexMeshAdaptTopologyFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkSimplexMeshTest.cxx
+++ b/Modules/Core/Mesh/test/itkSimplexMeshTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkSimplexMeshToTriangleMeshFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkSimplexMeshToTriangleMeshFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkSimplexMeshVolumeCalculatorTest.cxx
+++ b/Modules/Core/Mesh/test/itkSimplexMeshVolumeCalculatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkSphereMeshSourceTest.cxx
+++ b/Modules/Core/Mesh/test/itkSphereMeshSourceTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkTransformMeshFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkTransformMeshFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkTriangleCellTest.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleCellTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkTriangleMeshCurvatureCalculatorTest.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshCurvatureCalculatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest1.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest2.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest3.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest4.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToBinaryImageFilterTest4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkTriangleMeshToSimplexMeshFilter2Test.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToSimplexMeshFilter2Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkTriangleMeshToSimplexMeshFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkTriangleMeshToSimplexMeshFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkVTKPolyDataReaderTest.cxx
+++ b/Modules/Core/Mesh/test/itkVTKPolyDataReaderTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkVTKPolyDataWriterTest01.cxx
+++ b/Modules/Core/Mesh/test/itkVTKPolyDataWriterTest01.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkVTKPolyDataWriterTest02.cxx
+++ b/Modules/Core/Mesh/test/itkVTKPolyDataWriterTest02.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/test/itkWarpMeshFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkWarpMeshFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Mesh/wrapping/test/itkConnectedRegionsMeshFilterTest.py
+++ b/Modules/Core/Mesh/wrapping/test/itkConnectedRegionsMeshFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Core/Mesh/wrapping/test/itkMeshArrayPixelTypeTest.py
+++ b/Modules/Core/Mesh/wrapping/test/itkMeshArrayPixelTypeTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Core/Mesh/wrapping/test/itkMeshSerializationTest.py
+++ b/Modules/Core/Mesh/wrapping/test/itkMeshSerializationTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkGeometricalQuadEdge.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdge.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdge.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeCellTraitsInfo.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeCellTraitsInfo.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMesh.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBoundaryEdgesMeshFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBoundaryEdgesMeshFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBoundaryEdgesMeshFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBoundaryEdgesMeshFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorCreateCenterVertexFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorFlipEdgeFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorFlipEdgeFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorFlipEdgeFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorFlipEdgeFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinFacetFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinFacetFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinFacetFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinFacetFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitEdgeFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitEdgeFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitFacetFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitFacetFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitFacetFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitFacetFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitVertexFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitVertexFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorSplitVertexFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorsTestHelper.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorsTestHelper.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshExtendedTraits.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshExtendedTraits.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFrontIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFunctionBase.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFunctionBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshLineCell.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshLineCell.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshLineCell.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshLineCell.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshMacro.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshMacro.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPoint.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshPolygonCell.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshScalarDataVTKPolyDataWriter.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshScalarDataVTKPolyDataWriter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshScalarDataVTKPolyDataWriter.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshScalarDataVTKPolyDataWriter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshToQuadEdgeMeshFilter.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshToQuadEdgeMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshToQuadEdgeMeshFilter.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshToQuadEdgeMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTopologyChecker.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTopologyChecker.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTopologyChecker.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTopologyChecker.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTraits.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshTraits.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshZipMeshFunction.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshZipMeshFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshZipMeshFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshZipMeshFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/src/itkQuadEdge.cxx
+++ b/Modules/Core/QuadEdgeMesh/src/itkQuadEdge.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/src/itkQuadEdgeMeshEulerOperatorFlipEdgeFunction.cxx
+++ b/Modules/Core/QuadEdgeMesh/src/itkQuadEdgeMeshEulerOperatorFlipEdgeFunction.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkDynamicQuadEdgeMeshTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkDynamicQuadEdgeMeshTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkGeometricalQuadEdgeTest1.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkGeometricalQuadEdgeTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshAddFaceTest1.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshAddFaceTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshAddFaceTest2.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshAddFaceTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshBasicLayerTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshBasicLayerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshCellInterfaceTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshCellInterfaceTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshCountingCellsTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshCountingCellsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshDeleteEdgeTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshDeleteEdgeTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshDeletePointAndReorderIDsTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshDeletePointAndReorderIDsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorCreateCenterVertexTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorCreateCenterVertexTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorDeleteCenterVertexTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorFlipTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorFlipTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorJoinFacetTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorJoinFacetTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorJoinVertexTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorJoinVertexTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorSplitEdgeTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorSplitEdgeTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorSplitFaceTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorSplitFaceTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorSplitVertexTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshEulerOperatorSplitVertexTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshFrontIteratorTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshFrontIteratorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshIteratorTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshIteratorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshNoPointConstTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshNoPointConstTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshPointTest1.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshPointTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshPolygonCellTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshPolygonCellTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshScalarDataVTKPolyDataWriterTest1.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshScalarDataVTKPolyDataWriterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshTest1.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshTest2.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshTest3.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshTypeTraitsGTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshTypeTraitsGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeTest1.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkVTKPolyDataIOQuadEdgeMeshTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkVTKPolyDataIOQuadEdgeMeshTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/QuadEdgeMesh/test/itkVTKPolyDataReaderQuadEdgeMeshTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkVTKPolyDataReaderQuadEdgeMeshTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkBlobSpatialObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkCastSpatialObjectFilter.h
+++ b/Modules/Core/SpatialObjects/include/itkCastSpatialObjectFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkCastSpatialObjectFilter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkCastSpatialObjectFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkDTITubeSpatialObjectPoint.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkGroupSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkGroupSpatialObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkGroupSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkGroupSpatialObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkLandmarkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkLandmarkSpatialObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkLandmarkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLandmarkSpatialObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObjectPoint.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaArrowConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaArrowConverter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaArrowConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaArrowConverter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaBlobConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaBlobConverter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaBlobConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaBlobConverter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaContourConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaContourConverter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaContourConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaContourConverter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaConverterBase.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaConverterBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaConverterBase.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaConverterBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaDTITubeConverter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaEllipseConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaEllipseConverter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaEllipseConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaEllipseConverter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaEvent.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaEvent.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaGaussianConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaGaussianConverter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaGaussianConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaGaussianConverter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaGroupConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaGroupConverter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaGroupConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaGroupConverter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaImageConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaImageConverter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaImageConverter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaImageMaskConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaImageMaskConverter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaLandmarkConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaLandmarkConverter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaLandmarkConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaLandmarkConverter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaLineConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaLineConverter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaLineConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaLineConverter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaMeshConverter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaSurfaceConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaSurfaceConverter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaSurfaceConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSurfaceConverter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaTubeConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaTubeConverter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaTubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaTubeConverter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaVesselTubeConverter.h
+++ b/Modules/Core/SpatialObjects/include/itkMetaVesselTubeConverter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkMetaVesselTubeConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaVesselTubeConverter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectDuplicator.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectDuplicator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectDuplicator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectDuplicator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectExport.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectExport.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectFactory.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectFactoryBase.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectFactoryBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectProperty.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectProperty.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToPointSetFilter.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToPointSetFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToPointSetFilter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToPointSetFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSurfaceSpatialObjectPoint.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/src/itkContourSpatialObject.cxx
+++ b/Modules/Core/SpatialObjects/src/itkContourSpatialObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/src/itkDTITubeSpatialObjectPoint.cxx
+++ b/Modules/Core/SpatialObjects/src/itkDTITubeSpatialObjectPoint.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/src/itkMetaEvent.cxx
+++ b/Modules/Core/SpatialObjects/src/itkMetaEvent.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/src/itkSpatialObjectFactoryBase.cxx
+++ b/Modules/Core/SpatialObjects/src/itkSpatialObjectFactoryBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/src/itkSpatialObjectProperty.cxx
+++ b/Modules/Core/SpatialObjects/src/itkSpatialObjectProperty.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkArrowSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkArrowSpatialObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkBlobSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkBlobSpatialObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkBoxSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkBoxSpatialObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkCastSpatialObjectFilterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkCastSpatialObjectFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkContourSpatialObjectPointTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkContourSpatialObjectPointTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkContourSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkContourSpatialObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkDTITubeSpatialObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkEllipseSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkEllipseSpatialObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkGaussianSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkGaussianSpatialObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest4.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest5.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest5.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkLandmarkSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkLandmarkSpatialObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkLineSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkLineSpatialObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkMeshSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkMeshSpatialObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkMetaArrowConverterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkMetaArrowConverterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkMetaGaussianConverterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkMetaGaussianConverterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkNewMetaObjectTypeTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkNewMetaObjectTypeTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkPolygonSpatialObjectIsInsideInObjectSpaceTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkPolygonSpatialObjectIsInsideInObjectSpaceTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkPolygonSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkPolygonSpatialObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectDuplicatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectDuplicatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectPointGTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectPointGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageFilterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectToPointSetFilterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectToPointSetFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSurfaceSpatialObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/SpatialObjects/wrapping/test/SpatialObjectTest.py
+++ b/Modules/Core/SpatialObjects/wrapping/test/SpatialObjectTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Core/TestKernel/include/itkGTest.h
+++ b/Modules/Core/TestKernel/include/itkGTest.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/include/itkGTestPredicate.h
+++ b/Modules/Core/TestKernel/include/itkGTestPredicate.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/include/itkGTestTypedefsAndConstructors.h
+++ b/Modules/Core/TestKernel/include/itkGTestTypedefsAndConstructors.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/include/itkRandomImageSource.h
+++ b/Modules/Core/TestKernel/include/itkRandomImageSource.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
+++ b/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/include/itkTestDriverInclude.h
+++ b/Modules/Core/TestKernel/include/itkTestDriverInclude.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/include/itkTestDriverIncludeRequiredFactories.h
+++ b/Modules/Core/TestKernel/include/itkTestDriverIncludeRequiredFactories.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/include/itkTestDriverIncludeRequiredIOFactories.h
+++ b/Modules/Core/TestKernel/include/itkTestDriverIncludeRequiredIOFactories.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/include/itkTestVerifyMetaData.h
+++ b/Modules/Core/TestKernel/include/itkTestVerifyMetaData.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingComparisonImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/include/itkTestingHashImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkTestingHashImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/include/itkTestingHashImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingHashImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/include/itkTestingMacros.h
+++ b/Modules/Core/TestKernel/include/itkTestingMacros.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.h
+++ b/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/src/itkTestDriver.cxx
+++ b/Modules/Core/TestKernel/src/itkTestDriver.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
+++ b/Modules/Core/TestKernel/src/itkTestDriverInclude.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/src/itkTestDriverIncludeRequiredFactories.cxx
+++ b/Modules/Core/TestKernel/src/itkTestDriverIncludeRequiredFactories.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/src/itkTestingExtractSliceImageFilter.cxx
+++ b/Modules/Core/TestKernel/src/itkTestingExtractSliceImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/src/itkTestingHashImageFilter.cxx
+++ b/Modules/Core/TestKernel/src/itkTestingHashImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/test/itkGoogleTest.cxx
+++ b/Modules/Core/TestKernel/test/itkGoogleTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/test/itkGoogleTestFixture.cxx
+++ b/Modules/Core/TestKernel/test/itkGoogleTestFixture.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/test/itkRandomImageSourceAttributesTest.cxx
+++ b/Modules/Core/TestKernel/test/itkRandomImageSourceAttributesTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/test/itkRandomImageSourceValuesTest.cxx
+++ b/Modules/Core/TestKernel/test/itkRandomImageSourceValuesTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/test/itkTestingComparisonImageFilterGTest.cxx
+++ b/Modules/Core/TestKernel/test/itkTestingComparisonImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/test/itkTestingExtractSliceImageFilterTest.cxx
+++ b/Modules/Core/TestKernel/test/itkTestingExtractSliceImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/TestKernel/test/itkTestingStretchIntensityImageFilterTest.cxx
+++ b/Modules/Core/TestKernel/test/itkTestingStretchIntensityImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkAffineTransform.h
+++ b/Modules/Core/Transform/include/itkAffineTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkAffineTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.h
+++ b/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.hxx
+++ b/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkBSplineTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkBSplineTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkBSplineTransformInitializer.h
+++ b/Modules/Core/Transform/include/itkBSplineTransformInitializer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkBSplineTransformInitializer.hxx
+++ b/Modules/Core/Transform/include/itkBSplineTransformInitializer.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkCenteredAffineTransform.h
+++ b/Modules/Core/Transform/include/itkCenteredAffineTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkCenteredAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkCenteredAffineTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkCenteredEuler3DTransform.h
+++ b/Modules/Core/Transform/include/itkCenteredEuler3DTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkCenteredEuler3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkCenteredEuler3DTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkCenteredRigid2DTransform.h
+++ b/Modules/Core/Transform/include/itkCenteredRigid2DTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkCenteredRigid2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkCenteredRigid2DTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkCenteredSimilarity2DTransform.h
+++ b/Modules/Core/Transform/include/itkCenteredSimilarity2DTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkCenteredSimilarity2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkCenteredSimilarity2DTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.h
+++ b/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkCompositeTransform.h
+++ b/Modules/Core/Transform/include/itkCompositeTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkElasticBodyReciprocalSplineKernelTransform.h
+++ b/Modules/Core/Transform/include/itkElasticBodyReciprocalSplineKernelTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkElasticBodyReciprocalSplineKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkElasticBodyReciprocalSplineKernelTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkElasticBodySplineKernelTransform.h
+++ b/Modules/Core/Transform/include/itkElasticBodySplineKernelTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkElasticBodySplineKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkElasticBodySplineKernelTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkEuler2DTransform.h
+++ b/Modules/Core/Transform/include/itkEuler2DTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkEuler2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkEuler2DTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkEuler3DTransform.h
+++ b/Modules/Core/Transform/include/itkEuler3DTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkEuler3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkEuler3DTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkFixedCenterOfRotationAffineTransform.h
+++ b/Modules/Core/Transform/include/itkFixedCenterOfRotationAffineTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkFixedCenterOfRotationAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkFixedCenterOfRotationAffineTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkIdentityTransform.h
+++ b/Modules/Core/Transform/include/itkIdentityTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkKernelTransform.h
+++ b/Modules/Core/Transform/include/itkKernelTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkKernelTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
+++ b/Modules/Core/Transform/include/itkMatrixOffsetTransformBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkMultiTransform.h
+++ b/Modules/Core/Transform/include/itkMultiTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkMultiTransform.hxx
+++ b/Modules/Core/Transform/include/itkMultiTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkQuaternionRigidTransform.h
+++ b/Modules/Core/Transform/include/itkQuaternionRigidTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkQuaternionRigidTransform.hxx
+++ b/Modules/Core/Transform/include/itkQuaternionRigidTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkRigid2DTransform.h
+++ b/Modules/Core/Transform/include/itkRigid2DTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkRigid2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkRigid2DTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkRigid3DPerspectiveTransform.h
+++ b/Modules/Core/Transform/include/itkRigid3DPerspectiveTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkRigid3DPerspectiveTransform.hxx
+++ b/Modules/Core/Transform/include/itkRigid3DPerspectiveTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkRigid3DTransform.h
+++ b/Modules/Core/Transform/include/itkRigid3DTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkRigid3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkRigid3DTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkScalableAffineTransform.h
+++ b/Modules/Core/Transform/include/itkScalableAffineTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkScalableAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkScalableAffineTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkScaleLogarithmicTransform.h
+++ b/Modules/Core/Transform/include/itkScaleLogarithmicTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkScaleLogarithmicTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleLogarithmicTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkScaleSkewVersor3DTransform.h
+++ b/Modules/Core/Transform/include/itkScaleSkewVersor3DTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkScaleSkewVersor3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleSkewVersor3DTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkScaleTransform.h
+++ b/Modules/Core/Transform/include/itkScaleTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkScaleTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkScaleVersor3DTransform.h
+++ b/Modules/Core/Transform/include/itkScaleVersor3DTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkScaleVersor3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleVersor3DTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkSimilarity2DTransform.h
+++ b/Modules/Core/Transform/include/itkSimilarity2DTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkSimilarity2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkSimilarity2DTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkSimilarity3DTransform.h
+++ b/Modules/Core/Transform/include/itkSimilarity3DTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkSimilarity3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkSimilarity3DTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkThinPlateR2LogRSplineKernelTransform.h
+++ b/Modules/Core/Transform/include/itkThinPlateR2LogRSplineKernelTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkThinPlateR2LogRSplineKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkThinPlateR2LogRSplineKernelTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkThinPlateSplineKernelTransform.h
+++ b/Modules/Core/Transform/include/itkThinPlateSplineKernelTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkThinPlateSplineKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkThinPlateSplineKernelTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkTransform.h
+++ b/Modules/Core/Transform/include/itkTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkTransform.hxx
+++ b/Modules/Core/Transform/include/itkTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkTransformBase.h
+++ b/Modules/Core/Transform/include/itkTransformBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkTransformGeometryImageFilter.h
+++ b/Modules/Core/Transform/include/itkTransformGeometryImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkTransformGeometryImageFilter.hxx
+++ b/Modules/Core/Transform/include/itkTransformGeometryImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkTranslationTransform.h
+++ b/Modules/Core/Transform/include/itkTranslationTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkTranslationTransform.hxx
+++ b/Modules/Core/Transform/include/itkTranslationTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkVersorRigid3DTransform.h
+++ b/Modules/Core/Transform/include/itkVersorRigid3DTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkVersorRigid3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkVersorRigid3DTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkVersorTransform.h
+++ b/Modules/Core/Transform/include/itkVersorTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkVersorTransform.hxx
+++ b/Modules/Core/Transform/include/itkVersorTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkVolumeSplineKernelTransform.h
+++ b/Modules/Core/Transform/include/itkVolumeSplineKernelTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkVolumeSplineKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkVolumeSplineKernelTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/include/itkv3Rigid3DTransform.h
+++ b/Modules/Core/Transform/include/itkv3Rigid3DTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/src/itkTransformBase.cxx
+++ b/Modules/Core/Transform/src/itkTransformBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkAffineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkAffineTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkAzimuthElevationToCartesianTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkAzimuthElevationToCartesianTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest2.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest3.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkBSplineTransformGTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkBSplineTransformInitializerTest1.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformInitializerTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkBSplineTransformInitializerTest2.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformInitializerTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkBSplineTransformTest2.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkBSplineTransformTest3.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkCenteredAffineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkCenteredAffineTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkCenteredEuler3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkCenteredEuler3DTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkCenteredRigid2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkCenteredRigid2DTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkComposeScaleSkewVersor3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkComposeScaleSkewVersor3DTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkCompositeTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkCompositeTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkEuler2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkEuler2DTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkEuler3DTransformGTest.cxx
+++ b/Modules/Core/Transform/test/itkEuler3DTransformGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkEuler3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkEuler3DTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkFixedCenterOfRotationAffineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkFixedCenterOfRotationAffineTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkIdentityTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkIdentityTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkMatrixOffsetTransformBaseGTest.cxx
+++ b/Modules/Core/Transform/test/itkMatrixOffsetTransformBaseGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkMultiTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkMultiTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkQuaternionRigidTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkQuaternionRigidTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkRigid2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkRigid2DTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkRigid3DPerspectiveTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkRigid3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkRigid3DTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkScaleLogarithmicTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkScaleLogarithmicTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkScaleSkewVersor3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkScaleSkewVersor3DTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkScaleTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkScaleTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkScaleVersor3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkScaleVersor3DTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkSimilarity2DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkSimilarity2DTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkSimilarity3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkSimilarity3DTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkSimilarityTransformGTest.cxx
+++ b/Modules/Core/Transform/test/itkSimilarityTransformGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkSplineKernelTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkSplineKernelTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkTestTransformGetInverse.cxx
+++ b/Modules/Core/Transform/test/itkTestTransformGetInverse.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkTransformCloneTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformCloneTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkTransformGTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkTransformGeometryImageFilterTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformGeometryImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkTransformsSetParametersTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformsSetParametersTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkTranslationTransformGTest.cxx
+++ b/Modules/Core/Transform/test/itkTranslationTransformGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkTranslationTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkTranslationTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkVersorRigid3DTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkVersorRigid3DTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/test/itkVersorTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkVersorTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Core/Transform/wrapping/test/itkTransformSerializationTest.py
+++ b/Modules/Core/Transform/wrapping/test/itkTransformSerializationTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionImageFilter.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkCurvatureAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkCurvatureAnisotropicDiffusionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkCurvatureNDAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkCurvatureNDAnisotropicDiffusionFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkCurvatureNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkCurvatureNDAnisotropicDiffusionFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkGradientAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkGradientAnisotropicDiffusionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkGradientNDAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkGradientNDAnisotropicDiffusionFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkGradientNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkGradientNDAnisotropicDiffusionFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkScalarAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkScalarAnisotropicDiffusionFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkScalarAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkScalarAnisotropicDiffusionFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorAnisotropicDiffusionFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorAnisotropicDiffusionFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureAnisotropicDiffusionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureNDAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureNDAnisotropicDiffusionFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureNDAnisotropicDiffusionFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientAnisotropicDiffusionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientNDAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientNDAnisotropicDiffusionFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorGradientNDAnisotropicDiffusionFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/test/itkCurvatureAnisotropicDiffusionImageFilterTest.cxx
+++ b/Modules/Filtering/AnisotropicSmoothing/test/itkCurvatureAnisotropicDiffusionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/test/itkGradientAnisotropicDiffusionImageFilterTest.cxx
+++ b/Modules/Filtering/AnisotropicSmoothing/test/itkGradientAnisotropicDiffusionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/test/itkGradientAnisotropicDiffusionImageFilterTest2.cxx
+++ b/Modules/Filtering/AnisotropicSmoothing/test/itkGradientAnisotropicDiffusionImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/test/itkMinMaxCurvatureFlowImageFilterTest.cxx
+++ b/Modules/Filtering/AnisotropicSmoothing/test/itkMinMaxCurvatureFlowImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/test/itkVectorAnisotropicDiffusionImageFilterTest.cxx
+++ b/Modules/Filtering/AnisotropicSmoothing/test/itkVectorAnisotropicDiffusionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/wrapping/test/CurvatureAnisotropicDiffusionImageFilterTest.py
+++ b/Modules/Filtering/AnisotropicSmoothing/wrapping/test/CurvatureAnisotropicDiffusionImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/wrapping/test/GradientAnisotropicDiffusionImageFilterTest.py
+++ b/Modules/Filtering/AnisotropicSmoothing/wrapping/test/GradientAnisotropicDiffusionImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/AnisotropicSmoothing/wrapping/test/SmoothingRecursiveGaussianImageFilterTest.py
+++ b/Modules/Filtering/AnisotropicSmoothing/wrapping/test/SmoothingRecursiveGaussianImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.h
+++ b/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.hxx
+++ b/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AntiAlias/test/itkAntiAliasBinaryImageFilterTest.cxx
+++ b/Modules/Filtering/AntiAlias/test/itkAntiAliasBinaryImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/AntiAlias/wrapping/test/AntiAliasBinaryImageFilterTest.py
+++ b/Modules/Filtering/AntiAlias/wrapping/test/AntiAliasBinaryImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/BiasCorrection/include/itkCacheableScalarFunction.h
+++ b/Modules/Filtering/BiasCorrection/include/itkCacheableScalarFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BiasCorrection/include/itkCompositeValleyFunction.h
+++ b/Modules/Filtering/BiasCorrection/include/itkCompositeValleyFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.h
+++ b/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.h
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.h
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BiasCorrection/src/itkCacheableScalarFunction.cxx
+++ b/Modules/Filtering/BiasCorrection/src/itkCacheableScalarFunction.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BiasCorrection/src/itkCompositeValleyFunction.cxx
+++ b/Modules/Filtering/BiasCorrection/src/itkCompositeValleyFunction.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BiasCorrection/test/itkCompositeValleyFunctionGTest.cxx
+++ b/Modules/Filtering/BiasCorrection/test/itkCompositeValleyFunctionGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BiasCorrection/test/itkMRIBiasFieldCorrectionFilterTest.cxx
+++ b/Modules/Filtering/BiasCorrection/test/itkMRIBiasFieldCorrectionFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BiasCorrection/test/itkN4BiasFieldCorrectionImageFilterTest.cxx
+++ b/Modules/Filtering/BiasCorrection/test/itkN4BiasFieldCorrectionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryThinningImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkDilateObjectMorphologyImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkDilateObjectMorphologyImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkDilateObjectMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkDilateObjectMorphologyImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkErodeObjectMorphologyImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkErodeObjectMorphologyImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkErodeObjectMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkErodeObjectMorphologyImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkFastIncrementalBinaryDilateImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkFastIncrementalBinaryDilateImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryClosingByReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryClosingByReconstructionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryDilateImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryDilateImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryDilateImageFilterTest3.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryDilateImageFilterTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryErodeImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryErodeImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryErodeImageFilterTest3.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryErodeImageFilterTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryMorphologicalClosingImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryMorphologicalClosingImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryMorphologicalOpeningImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryMorphologicalOpeningImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryOpeningByReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryOpeningByReconstructionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryThinningImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkBinaryThinningImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkErodeObjectMorphologyImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkErodeObjectMorphologyImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/itkFastIncrementalBinaryDilateImageFilterTest.cxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/itkFastIncrementalBinaryDilateImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/BinaryMathematicalMorphology/wrapping/test/BinaryDilateImageFilterTest.py
+++ b/Modules/Filtering/BinaryMathematicalMorphology/wrapping/test/BinaryDilateImageFilterTest.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 
 # ==========================================================================
 #

--- a/Modules/Filtering/BinaryMathematicalMorphology/wrapping/test/BinaryErodeImageFilterTest.py
+++ b/Modules/Filtering/BinaryMathematicalMorphology/wrapping/test/BinaryErodeImageFilterTest.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 
 # ==========================================================================
 #

--- a/Modules/Filtering/Colormap/include/itkAutumnColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkAutumnColormapFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkAutumnColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkAutumnColormapFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkBlueColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkBlueColormapFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkBlueColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkBlueColormapFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkColormapFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkCoolColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkCoolColormapFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkCoolColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkCoolColormapFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkCopperColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkCopperColormapFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkCopperColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkCopperColormapFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkCustomColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkCustomColormapFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkCustomColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkCustomColormapFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkGreenColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkGreenColormapFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkGreenColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkGreenColormapFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkGreyColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkGreyColormapFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkGreyColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkGreyColormapFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkHSVColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkHSVColormapFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkHSVColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkHSVColormapFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkHotColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkHotColormapFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkHotColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkHotColormapFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkJetColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkJetColormapFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkJetColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkJetColormapFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkOverUnderColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkOverUnderColormapFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkOverUnderColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkOverUnderColormapFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkRedColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkRedColormapFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkRedColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkRedColormapFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.h
+++ b/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.hxx
+++ b/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkSpringColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkSpringColormapFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkSpringColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkSpringColormapFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkSummerColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkSummerColormapFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkSummerColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkSummerColormapFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkWinterColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkWinterColormapFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/include/itkWinterColormapFunction.hxx
+++ b/Modules/Filtering/Colormap/include/itkWinterColormapFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/src/itkScalarToRGBColormapImageFilter.cxx
+++ b/Modules/Filtering/Colormap/src/itkScalarToRGBColormapImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/test/itkCustomColormapFunctionTest.cxx
+++ b/Modules/Filtering/Colormap/test/itkCustomColormapFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Colormap/test/itkScalarToRGBColormapImageFilterTest.cxx
+++ b/Modules/Filtering/Colormap/test/itkScalarToRGBColormapImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.hxx
+++ b/Modules/Filtering/Convolution/include/itkConvolutionImageFilterBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/include/itkFFTNormalizedCorrelationImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkFFTNormalizedCorrelationImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/include/itkFFTNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkFFTNormalizedCorrelationImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/src/itkConvolutionImageFilterBase.cxx
+++ b/Modules/Filtering/Convolution/src/itkConvolutionImageFilterBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterDeltaFunctionTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterDeltaFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterStreamingTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterStreamingTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterSubregionTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterSubregionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterTestInt.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterTestInt.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterDeltaFunctionTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterDeltaFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterTestInt.cxx
+++ b/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterTestInt.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/test/itkFFTNormalizedCorrelationImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkFFTNormalizedCorrelationImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/test/itkMaskedFFTNormalizedCorrelationImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkMaskedFFTNormalizedCorrelationImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/test/itkNormalizedCorrelationImageFilterTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkNormalizedCorrelationImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Convolution/wrapping/test/FFTConvolutionImageFilterTest.py
+++ b/Modules/Filtering/Convolution/wrapping/test/FFTConvolutionImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowFunction.h
+++ b/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowImageFilter.h
+++ b/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowImageFilter.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.h
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.h
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.h
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowImageFilter.h
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowImageFilter.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/CurvatureFlow/test/itkBinaryMinMaxCurvatureFlowImageFilterTest.cxx
+++ b/Modules/Filtering/CurvatureFlow/test/itkBinaryMinMaxCurvatureFlowImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/CurvatureFlow/test/itkCurvatureFlowTest.cxx
+++ b/Modules/Filtering/CurvatureFlow/test/itkCurvatureFlowTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/CurvatureFlow/wrapping/test/CurvatureFlowImageFilterTest.py
+++ b/Modules/Filtering/CurvatureFlow/wrapping/test/CurvatureFlowImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/include/itkInverseDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkInverseDeconvolutionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/include/itkInverseDeconvolutionImageFilter.hxx
+++ b/Modules/Filtering/Deconvolution/include/itkInverseDeconvolutionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/include/itkIterativeDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkIterativeDeconvolutionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/include/itkIterativeDeconvolutionImageFilter.hxx
+++ b/Modules/Filtering/Deconvolution/include/itkIterativeDeconvolutionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/include/itkLandweberDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkLandweberDeconvolutionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/include/itkLandweberDeconvolutionImageFilter.hxx
+++ b/Modules/Filtering/Deconvolution/include/itkLandweberDeconvolutionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/include/itkParametricBlindLeastSquaresDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkParametricBlindLeastSquaresDeconvolutionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/include/itkParametricBlindLeastSquaresDeconvolutionImageFilter.hxx
+++ b/Modules/Filtering/Deconvolution/include/itkParametricBlindLeastSquaresDeconvolutionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/include/itkProjectedIterativeDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkProjectedIterativeDeconvolutionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/include/itkProjectedIterativeDeconvolutionImageFilter.hxx
+++ b/Modules/Filtering/Deconvolution/include/itkProjectedIterativeDeconvolutionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/include/itkProjectedLandweberDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkProjectedLandweberDeconvolutionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/include/itkProjectedLandweberDeconvolutionImageFilter.hxx
+++ b/Modules/Filtering/Deconvolution/include/itkProjectedLandweberDeconvolutionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/include/itkRichardsonLucyDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkRichardsonLucyDeconvolutionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/include/itkRichardsonLucyDeconvolutionImageFilter.hxx
+++ b/Modules/Filtering/Deconvolution/include/itkRichardsonLucyDeconvolutionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/include/itkTikhonovDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkTikhonovDeconvolutionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/include/itkTikhonovDeconvolutionImageFilter.hxx
+++ b/Modules/Filtering/Deconvolution/include/itkTikhonovDeconvolutionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/include/itkWienerDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkWienerDeconvolutionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/include/itkWienerDeconvolutionImageFilter.hxx
+++ b/Modules/Filtering/Deconvolution/include/itkWienerDeconvolutionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/test/itkDeconvolutionIterationCommand.h
+++ b/Modules/Filtering/Deconvolution/test/itkDeconvolutionIterationCommand.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/test/itkInverseDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkInverseDeconvolutionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/test/itkLandweberDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkLandweberDeconvolutionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/test/itkParametricBlindLeastSquaresDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkParametricBlindLeastSquaresDeconvolutionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/test/itkProjectedIterativeDeconvolutionImageFilterGTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkProjectedIterativeDeconvolutionImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/test/itkProjectedLandweberDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkProjectedLandweberDeconvolutionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/test/itkRichardsonLucyDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkRichardsonLucyDeconvolutionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/test/itkTikhonovDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkTikhonovDeconvolutionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Deconvolution/test/itkWienerDeconvolutionImageFilterTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkWienerDeconvolutionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.h
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingBaseImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.h
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Denoising/src/itkPatchBasedDenoisingBaseImageFilter.cxx
+++ b/Modules/Filtering/Denoising/src/itkPatchBasedDenoisingBaseImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterDefaultTest.cxx
+++ b/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterDefaultTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterTest.cxx
+++ b/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.h
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DiffusionTensorImage/include/itkTensorFractionalAnisotropyImageFilter.h
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkTensorFractionalAnisotropyImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DiffusionTensorImage/include/itkTensorRelativeAnisotropyImageFilter.h
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkTensorRelativeAnisotropyImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DiffusionTensorImage/src/itkDiffusionTensor3DReconstructionImageFilter.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/src/itkDiffusionTensor3DReconstructionImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DReconstructionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DiffusionTensorImage/test/itkTensorFractionalAnisotropyImageFilterTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkTensorFractionalAnisotropyImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DiffusionTensorImage/test/itkTensorRelativeAnisotropyImageFilterGTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkTensorRelativeAnisotropyImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkComposeDisplacementFieldsImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkComposeDisplacementFieldsImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkComposeDisplacementFieldsImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkComposeDisplacementFieldsImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkExponentialDisplacementFieldImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkExponentialDisplacementFieldImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkExponentialDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkExponentialDisplacementFieldImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkLandmarkDisplacementFieldSource.h
+++ b/Modules/Filtering/DisplacementField/include/itkLandmarkDisplacementFieldSource.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkLandmarkDisplacementFieldSource.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkLandmarkDisplacementFieldSource.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingBSplineVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingBSplineVelocityFieldTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingBSplineVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingBSplineVelocityFieldTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.h
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/test/itkBSplineExponentialDiffeomorphicTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkBSplineExponentialDiffeomorphicTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/test/itkComposeDisplacementFieldsImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkComposeDisplacementFieldsImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldJacobianDeterminantFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldJacobianDeterminantFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldToBSplineImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldToBSplineImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformCloneTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformCloneTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/test/itkExponentialDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkExponentialDisplacementFieldImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/test/itkGaussianExponentialDiffeomorphicTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkGaussianExponentialDiffeomorphicTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/test/itkInverseDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkInverseDisplacementFieldImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/test/itkInvertDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkInvertDisplacementFieldImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/test/itkIterativeInverseDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkIterativeInverseDisplacementFieldImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/test/itkLandmarkDisplacementFieldSourceTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkLandmarkDisplacementFieldSourceTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingBSplineVelocityFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingBSplineVelocityFieldTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldIntegrationImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldTransformTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTimeVaryingVelocityFieldTransformTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest1.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkTransformToDisplacementFieldFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/wrapping/test/itkDisplacementFieldTransformTest.py
+++ b/Modules/Filtering/DisplacementField/wrapping/test/itkDisplacementFieldTransformTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/DisplacementField/wrapping/test/itkTransformToDisplacementFieldTest.py
+++ b/Modules/Filtering/DisplacementField/wrapping/test/itkTransformToDisplacementFieldTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkApproximateSignedDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkApproximateSignedDistanceMapImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkApproximateSignedDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkApproximateSignedDistanceMapImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkContourDirectedMeanDistanceImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkContourMeanDistanceImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkFastChamferDistanceImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkHausdorffDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkHausdorffDistanceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkHausdorffDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkHausdorffDistanceImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkReflectiveImageRegionConstIterator.h
+++ b/Modules/Filtering/DistanceMap/include/itkReflectiveImageRegionConstIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkReflectiveImageRegionConstIterator.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkReflectiveImageRegionConstIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkReflectiveImageRegionIterator.h
+++ b/Modules/Filtering/DistanceMap/include/itkReflectiveImageRegionIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkReflectiveImageRegionIterator.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkReflectiveImageRegionIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.h
+++ b/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkSignedMaurerDistanceMapImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/test/itkApproximateSignedDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkApproximateSignedDistanceMapImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/test/itkContourDirectedMeanDistanceImageFilterGTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkContourDirectedMeanDistanceImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/test/itkContourMeanDistanceImageFilterGTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkContourMeanDistanceImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/test/itkDanielssonDistanceMapImageFilterGTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkDanielssonDistanceMapImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/test/itkDanielssonDistanceMapImageFilterTest1.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkDanielssonDistanceMapImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/test/itkDanielssonDistanceMapImageFilterTest2.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkDanielssonDistanceMapImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/test/itkDirectedHausdorffDistanceImageFilterGTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkDirectedHausdorffDistanceImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/test/itkDirectedHausdorffDistanceImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkDirectedHausdorffDistanceImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/test/itkFastChamferDistanceImageFilterGTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkFastChamferDistanceImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/test/itkHausdorffDistanceImageFilterGTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkHausdorffDistanceImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/test/itkIsoContourDistanceImageFilterGTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkIsoContourDistanceImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/test/itkReflectiveImageRegionIteratorGTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkReflectiveImageRegionIteratorGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/test/itkShowDistanceMap.h
+++ b/Modules/Filtering/DistanceMap/test/itkShowDistanceMap.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterGTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest1.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest2.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/test/itkSignedMaurerDistanceMapImageFilterGTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedMaurerDistanceMapImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/DistanceMap/test/itkSignedMaurerDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedMaurerDistanceMapImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkComplexToComplex1DFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkComplexToComplexFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkComplexToComplexFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkComplexToComplexFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkComplexToComplexFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTImageFilterFactory.h
+++ b/Modules/Filtering/FFT/include/itkFFTImageFilterFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTPadImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTPadImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTPadImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTPadImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTShiftImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTShiftImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTShiftImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTShiftImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTWCommon.h
+++ b/Modules/Filtering/FFT/include/itkFFTWCommon.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTWCommonExtended.h
+++ b/Modules/Filtering/FFT/include/itkFFTWCommonExtended.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTWComplexToComplexFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWComplexToComplexFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTWComplexToComplexFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWComplexToComplexFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTWFFTImageFilterInitFactory.h
+++ b/Modules/Filtering/FFT/include/itkFFTWFFTImageFilterInitFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTWForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWForwardFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTWForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWForwardFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTWGlobalConfiguration.h
+++ b/Modules/Filtering/FFT/include/itkFFTWGlobalConfiguration.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTWHalfHermitianToRealInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWHalfHermitianToRealInverseFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTWHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTWInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWInverseFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTWInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWInverseFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTWRealToHalfHermitianForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFFTWRealToHalfHermitianForwardFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFFTWRealToHalfHermitianForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWRealToHalfHermitianForwardFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkForward1DFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkForwardFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFullToHalfHermitianImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkFullToHalfHermitianImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkFullToHalfHermitianImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFullToHalfHermitianImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkHalfToFullHermitianImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkHalfToFullHermitianImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkHalfToFullHermitianImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkHalfToFullHermitianImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkInverse1DFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkInverseFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkInverseFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkRealToHalfHermitianForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkRealToHalfHermitianForwardFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkRealToHalfHermitianForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkRealToHalfHermitianForwardFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkVnlComplexToComplex1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlComplexToComplex1DFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkVnlComplexToComplex1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlComplexToComplex1DFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkVnlComplexToComplexFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlComplexToComplexFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkVnlComplexToComplexFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlComplexToComplexFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkVnlFFTCommon.h
+++ b/Modules/Filtering/FFT/include/itkVnlFFTCommon.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkVnlFFTCommon.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlFFTCommon.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkVnlFFTImageFilterInitFactory.h
+++ b/Modules/Filtering/FFT/include/itkVnlFFTImageFilterInitFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkVnlForward1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlForward1DFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkVnlForward1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlForward1DFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkVnlForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlForwardFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkVnlForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlForwardFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkVnlHalfHermitianToRealInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlHalfHermitianToRealInverseFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkVnlHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkVnlInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlInverse1DFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkVnlInverse1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlInverse1DFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkVnlInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlInverseFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkVnlInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlInverseFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkVnlRealToHalfHermitianForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlRealToHalfHermitianForwardFFTImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/include/itkVnlRealToHalfHermitianForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkVnlRealToHalfHermitianForwardFFTImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/src/itkComplexToComplexFFTImageFilter.cxx
+++ b/Modules/Filtering/FFT/src/itkComplexToComplexFFTImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/src/itkFFTWFFTImageFilterInitFactory.cxx
+++ b/Modules/Filtering/FFT/src/itkFFTWFFTImageFilterInitFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
+++ b/Modules/Filtering/FFT/src/itkFFTWGlobalConfiguration.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/src/itkVnlFFTImageFilterInitFactory.cxx
+++ b/Modules/Filtering/FFT/src/itkVnlFFTImageFilterInitFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkComplexToComplex1DFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkComplexToComplex1DFFTImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkComplexToComplexFFTImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkFFT1DImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFT1DImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkFFTPadImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTPadImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkFFTShiftImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTShiftImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkFFTTest.h
+++ b/Modules/Filtering/FFT/test/itkFFTTest.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkFFTWComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTWComplexToComplexFFTImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkFFTWD_FFTTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTWD_FFTTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkFFTWD_RealFFTTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTWD_RealFFTTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkFFTWF_FFTTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTWF_FFTTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkFFTWF_RealFFTTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTWF_RealFFTTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkFFTWFactoryRegistrationGTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTWFactoryRegistrationGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkForward1DFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkForward1DFFTImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkForwardInverseFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkForwardInverseFFTImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkForwardInverseFFTTest.h
+++ b/Modules/Filtering/FFT/test/itkForwardInverseFFTTest.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkFullToHalfHermitianImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFullToHalfHermitianImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkHalfToFullHermitianImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkHalfToFullHermitianImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkInverse1DFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkInverse1DFFTImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkRealFFTTest.h
+++ b/Modules/Filtering/FFT/test/itkRealFFTTest.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkTestCircularDependency.cxx
+++ b/Modules/Filtering/FFT/test/itkTestCircularDependency.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkVnlComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkVnlComplexToComplexFFTImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkVnlFFTTest.cxx
+++ b/Modules/Filtering/FFT/test/itkVnlFFTTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkVnlFFTWD_FFTTest.cxx
+++ b/Modules/Filtering/FFT/test/itkVnlFFTWD_FFTTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkVnlFFTWD_RealFFTTest.cxx
+++ b/Modules/Filtering/FFT/test/itkVnlFFTWD_RealFFTTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkVnlFFTWF_FFTTest.cxx
+++ b/Modules/Filtering/FFT/test/itkVnlFFTWF_FFTTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkVnlFFTWF_RealFFTTest.cxx
+++ b/Modules/Filtering/FFT/test/itkVnlFFTWF_RealFFTTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/test/itkVnlRealFFTTest.cxx
+++ b/Modules/Filtering/FFT/test/itkVnlRealFFTTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FFT/wrapping/test/FFTImageFilterTest.py
+++ b/Modules/Filtering/FFT/wrapping/test/FFTImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/FFT/wrapping/test/FFTObjectFactoryTest.py
+++ b/Modules/Filtering/FFT/wrapping/test/FFTObjectFactoryTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingBase.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilterBase.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilterBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingExtensionImageFilterBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageToNodePairContainerAdaptor.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageToNodePairContainerAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageToNodePairContainerAdaptor.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageToNodePairContainerAdaptor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingNumberOfElementsStoppingCriterion.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingNumberOfElementsStoppingCriterion.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingQuadEdgeMeshFilterBase.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingQuadEdgeMeshFilterBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingQuadEdgeMeshFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingQuadEdgeMeshFilterBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingReachedTargetNodesStoppingCriterion.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingReachedTargetNodesStoppingCriterion.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingStoppingCriterionBase.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingStoppingCriterionBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingThresholdStoppingCriterion.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingThresholdStoppingCriterion.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingTraits.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingTraits.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilterBase.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilterBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilterBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkLevelSet.h
+++ b/Modules/Filtering/FastMarching/include/itkLevelSet.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkLevelSetNode.h
+++ b/Modules/Filtering/FastMarching/include/itkLevelSetNode.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/include/itkNodePair.h
+++ b/Modules/Filtering/FastMarching/include/itkNodePair.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/src/itkFastMarchingBase.cxx
+++ b/Modules/Filtering/FastMarching/src/itkFastMarchingBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/src/itkFastMarchingImageFilter.cxx
+++ b/Modules/Filtering/FastMarching/src/itkFastMarchingImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/src/itkFastMarchingReachedTargetNodesStoppingCriterion.cxx
+++ b/Modules/Filtering/FastMarching/src/itkFastMarchingReachedTargetNodesStoppingCriterion.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/src/itkFastMarchingUpwindGradientImageFilter.cxx
+++ b/Modules/Filtering/FastMarching/src/itkFastMarchingUpwindGradientImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingBaseTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingExtensionImageFilterTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingExtensionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest1.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest2.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealWithNumberOfElementsTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterRealWithNumberOfElementsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageTopologicalTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageTopologicalTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingNumberOfElementsStoppingCriterionTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingNumberOfElementsStoppingCriterionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingQuadEdgeMeshFilterBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingQuadEdgeMeshFilterBaseTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingQuadEdgeMeshFilterBaseTest2.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingQuadEdgeMeshFilterBaseTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingQuadEdgeMeshFilterBaseTest3.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingQuadEdgeMeshFilterBaseTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingQuadEdgeMeshFilterBaseTest4.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingQuadEdgeMeshFilterBaseTest4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingQuadEdgeMeshFilterWithNumberOfElementsTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingQuadEdgeMeshFilterWithNumberOfElementsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingStoppingCriterionBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingStoppingCriterionBaseTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingTest2.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingThresholdStoppingCriterionTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingThresholdStoppingCriterionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientBaseTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientBaseTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/FastMarching/wrapping/test/FastMarchingImageFilterTest.py
+++ b/Modules/Filtering/FastMarching/wrapping/test/FastMarchingImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionImageFilter.hxx
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUAnisotropicDiffusionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientAnisotropicDiffusionImageFilter.h
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientAnisotropicDiffusionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientAnisotropicDiffusionImageFilterFactory.h
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientAnisotropicDiffusionImageFilterFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientNDAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientNDAnisotropicDiffusionFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUGradientNDAnisotropicDiffusionFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUScalarAnisotropicDiffusionFunction.h
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUScalarAnisotropicDiffusionFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUScalarAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/include/itkGPUScalarAnisotropicDiffusionFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUAnisotropicSmoothing/test/itkGPUGradientAnisotropicDiffusionImageFilterTest.cxx
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/test/itkGPUGradientAnisotropicDiffusionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUAnisotropicSmoothing/wrapping/test/itkGPUGradientAnisotropicDiffusionImageFilterTest.py
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/wrapping/test/itkGPUGradientAnisotropicDiffusionImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/GPUImageFilterBase/include/itkGPUBoxImageFilter.h
+++ b/Modules/Filtering/GPUImageFilterBase/include/itkGPUBoxImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUImageFilterBase/include/itkGPUCastImageFilter.h
+++ b/Modules/Filtering/GPUImageFilterBase/include/itkGPUCastImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUImageFilterBase/include/itkGPUCastImageFilter.hxx
+++ b/Modules/Filtering/GPUImageFilterBase/include/itkGPUCastImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUImageFilterBase/include/itkGPUNeighborhoodOperatorImageFilter.h
+++ b/Modules/Filtering/GPUImageFilterBase/include/itkGPUNeighborhoodOperatorImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUImageFilterBase/include/itkGPUNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/GPUImageFilterBase/include/itkGPUNeighborhoodOperatorImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUImageFilterBase/test/itkGPUNeighborhoodOperatorImageFilterTest.cxx
+++ b/Modules/Filtering/GPUImageFilterBase/test/itkGPUNeighborhoodOperatorImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUImageFilterBase/wrapping/test/itkGPUNeighborhoodOperatorImageFilterTest.py
+++ b/Modules/Filtering/GPUImageFilterBase/wrapping/test/itkGPUNeighborhoodOperatorImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/GPUSmoothing/include/itkGPUDiscreteGaussianImageFilter.h
+++ b/Modules/Filtering/GPUSmoothing/include/itkGPUDiscreteGaussianImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUSmoothing/include/itkGPUDiscreteGaussianImageFilter.hxx
+++ b/Modules/Filtering/GPUSmoothing/include/itkGPUDiscreteGaussianImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUSmoothing/include/itkGPUMeanImageFilter.h
+++ b/Modules/Filtering/GPUSmoothing/include/itkGPUMeanImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUSmoothing/include/itkGPUMeanImageFilter.hxx
+++ b/Modules/Filtering/GPUSmoothing/include/itkGPUMeanImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUSmoothing/test/itkGPUDiscreteGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/GPUSmoothing/test/itkGPUDiscreteGaussianImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUSmoothing/test/itkGPUMeanImageFilterTest.cxx
+++ b/Modules/Filtering/GPUSmoothing/test/itkGPUMeanImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUSmoothing/wrapping/test/itkGPUMeanImageFilterTest.py
+++ b/Modules/Filtering/GPUSmoothing/wrapping/test/itkGPUMeanImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.h
+++ b/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.hxx
+++ b/Modules/Filtering/GPUThresholding/include/itkGPUBinaryThresholdImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUThresholding/test/itkGPUBinaryThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/GPUThresholding/test/itkGPUBinaryThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/GPUThresholding/test/itkGPUImageFilterTest.cxx
+++ b/Modules/Filtering/GPUThresholding/test/itkGPUImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompare/include/itkAbsoluteValueDifferenceImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkAbsoluteValueDifferenceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompare/include/itkCheckerBoardImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkCheckerBoardImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompare/include/itkCheckerBoardImageFilter.hxx
+++ b/Modules/Filtering/ImageCompare/include/itkCheckerBoardImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx
+++ b/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompare/include/itkSimilarityIndexImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkSimilarityIndexImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompare/include/itkSimilarityIndexImageFilter.hxx
+++ b/Modules/Filtering/ImageCompare/include/itkSimilarityIndexImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompare/include/itkSquaredDifferenceImageFilter.h
+++ b/Modules/Filtering/ImageCompare/include/itkSquaredDifferenceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompare/test/itkAbsoluteValueDifferenceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkAbsoluteValueDifferenceImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompare/test/itkCheckerBoardImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkCheckerBoardImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompare/test/itkConstrainedValueDifferenceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkConstrainedValueDifferenceImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompare/test/itkImageFileReaderIOToRequestedRegionMismatchTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkImageFileReaderIOToRequestedRegionMismatchTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompare/test/itkSTAPLEImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkSTAPLEImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompare/test/itkSimilarityIndexImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkSimilarityIndexImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompare/test/itkSquaredDifferenceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkSquaredDifferenceImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompare/test/itkTestingComparisonImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkTestingComparisonImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompose/include/itkComposeImageFilter.h
+++ b/Modules/Filtering/ImageCompose/include/itkComposeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompose/include/itkComposeImageFilter.hxx
+++ b/Modules/Filtering/ImageCompose/include/itkComposeImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompose/include/itkJoinImageFilter.h
+++ b/Modules/Filtering/ImageCompose/include/itkJoinImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.h
+++ b/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
+++ b/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompose/test/itkCompose2DCovariantVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkCompose2DCovariantVectorImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompose/test/itkCompose2DVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkCompose2DVectorImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompose/test/itkCompose3DCovariantVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkCompose3DCovariantVectorImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompose/test/itkCompose3DVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkCompose3DVectorImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompose/test/itkComposeBigVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkComposeBigVectorImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompose/test/itkComposeRGBAImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkComposeRGBAImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompose/test/itkComposeRGBImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkComposeRGBImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompose/test/itkImageReadRealAndImaginaryWriteComplexTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkImageReadRealAndImaginaryWriteComplexTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompose/test/itkImageToVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkImageToVectorImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompose/test/itkJoinImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkJoinImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompose/test/itkJoinSeriesImageFilterStreamingTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkJoinSeriesImageFilterStreamingTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageCompose/test/itkJoinSeriesImageFilterTest.cxx
+++ b/Modules/Filtering/ImageCompose/test/itkJoinSeriesImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkDerivativeImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkDiscreteGaussianDerivativeImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkGradientVectorFlowImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkGradientVectorFlowImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkGradientVectorFlowImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkGradientVectorFlowImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessian3DToVesselnessMeasureImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DCirclesImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHoughTransform2DLinesImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianSharpeningImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkSobelEdgeDetectionImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkSobelEdgeDetectionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkSobelEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkSobelEdgeDetectionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkUnsharpMaskImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingBasedEdgeDetectionImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingBasedEdgeDetectionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingBasedEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingBasedEdgeDetectionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.h
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/src/itkMultiScaleHessianBasedMeasureImageFilter.cxx
+++ b/Modules/Filtering/ImageFeature/src/itkMultiScaleHessianBasedMeasureImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkBilateralImageFilterTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkCannyEdgeDetectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkCannyEdgeDetectionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkCannyEdgeDetectionImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkCannyEdgeDetectionImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkDerivativeImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkDerivativeImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkDiscreteGaussianDerivativeImageFilterScaleSpaceTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkDiscreteGaussianDerivativeImageFilterScaleSpaceTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkDiscreteGaussianDerivativeImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkDiscreteGaussianDerivativeImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkGradientVectorFlowImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkGradientVectorFlowImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkHessian3DToVesselnessMeasureImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessian3DToVesselnessMeasureImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterScaleSpaceTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterScaleSpaceTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessianRecursiveGaussianFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkHessianToObjectnessMeasureImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHessianToObjectnessMeasureImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DLinesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DLinesImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkLaplacianImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkLaplacianImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkLaplacianRecursiveGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkLaplacianRecursiveGaussianImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkLaplacianSharpeningImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkLaplacianSharpeningImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkMaskFeaturePointSelectionFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkMaskFeaturePointSelectionFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkMultiScaleHessianBasedMeasureImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkMultiScaleHessianBasedMeasureImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkSimpleContourExtractorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkSimpleContourExtractorImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkSobelEdgeDetectionImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkSobelEdgeDetectionImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkSobelEdgeDetectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkSobelEdgeDetectionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkUnsharpMaskImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkUnsharpMaskImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkUnsharpMaskImageFilterTestSimple.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkUnsharpMaskImageFilterTestSimple.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkZeroCrossingBasedEdgeDetectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkZeroCrossingBasedEdgeDetectionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/test/itkZeroCrossingImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkZeroCrossingImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/wrapping/test/CannyEdgeDetectionImageFilterTest.py
+++ b/Modules/Filtering/ImageFeature/wrapping/test/CannyEdgeDetectionImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/wrapping/test/HoughTransform2DLinesImageFilterTest.py
+++ b/Modules/Filtering/ImageFeature/wrapping/test/HoughTransform2DLinesImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/wrapping/test/LaplacianImageFilterTest.py
+++ b/Modules/Filtering/ImageFeature/wrapping/test/LaplacianImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/ImageFeature/wrapping/test/itkGradientVectorFlowImageFilterTest.py
+++ b/Modules/Filtering/ImageFeature/wrapping/test/itkGradientVectorFlowImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkBinaryFunctorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkBinaryFunctorImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkBinaryFunctorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkBinaryFunctorImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkBinaryGeneratorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkBinaryGeneratorImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkBinaryGeneratorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkBinaryGeneratorImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkBoxImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkBoxImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkBoxImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkBoxImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkCastImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkKernelImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkKernelImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkKernelImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkKernelImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilterBase.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilterBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilterBase.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilterBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkNeighborhoodOperatorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkNeighborhoodOperatorImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNeighborhoodOperatorImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNoiseImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkNullImageToImageFilterDriver.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkNullImageToImageFilterDriver.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkRecursiveSeparableImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkTernaryFunctorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkTernaryFunctorImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkTernaryFunctorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkTernaryFunctorImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkTernaryGeneratorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkTernaryGeneratorImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkTernaryGeneratorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkTernaryGeneratorImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkUnaryGeneratorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkUnaryGeneratorImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkUnaryGeneratorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkUnaryGeneratorImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkVectorNeighborhoodOperatorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkVectorNeighborhoodOperatorImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/include/itkVectorNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkVectorNeighborhoodOperatorImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkCastImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/test/itkGeneratorImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkGeneratorImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/test/itkImageToImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkImageToImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/test/itkMaskNeighborhoodOperatorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkMaskNeighborhoodOperatorImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/test/itkNeighborhoodOperatorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkNeighborhoodOperatorImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/test/itkVectorNeighborhoodOperatorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkVectorNeighborhoodOperatorImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFilterBase/wrapping/test/CastImageFilterTest.py
+++ b/Modules/Filtering/ImageFilterBase/wrapping/test/CastImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.hxx
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyFFTLayoutImageRegionIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyFFTLayoutImageRegionIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyHalfHermitianFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyHalfHermitianFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyHalfHermitianFFTLayoutImageRegionIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyHalfHermitianFFTLayoutImageRegionIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyImageRegionConstIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyImageRegionIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyImageRegionIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionIteratorWithIndex.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.h
+++ b/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.hxx
+++ b/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyBandImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyBandImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFrequency/test/itkFrequencyIteratorsGTest.cxx
+++ b/Modules/Filtering/ImageFrequency/test/itkFrequencyIteratorsGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/include/itkLabelMapContourOverlayImageFilter.h
+++ b/Modules/Filtering/ImageFusion/include/itkLabelMapContourOverlayImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/include/itkLabelMapContourOverlayImageFilter.hxx
+++ b/Modules/Filtering/ImageFusion/include/itkLabelMapContourOverlayImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/include/itkLabelMapOverlayImageFilter.h
+++ b/Modules/Filtering/ImageFusion/include/itkLabelMapOverlayImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/include/itkLabelMapOverlayImageFilter.hxx
+++ b/Modules/Filtering/ImageFusion/include/itkLabelMapOverlayImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/include/itkLabelMapToRGBImageFilter.h
+++ b/Modules/Filtering/ImageFusion/include/itkLabelMapToRGBImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/include/itkLabelMapToRGBImageFilter.hxx
+++ b/Modules/Filtering/ImageFusion/include/itkLabelMapToRGBImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/include/itkLabelOverlayFunctor.h
+++ b/Modules/Filtering/ImageFusion/include/itkLabelOverlayFunctor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/include/itkLabelOverlayImageFilter.h
+++ b/Modules/Filtering/ImageFusion/include/itkLabelOverlayImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/include/itkLabelOverlayImageFilter.hxx
+++ b/Modules/Filtering/ImageFusion/include/itkLabelOverlayImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/include/itkLabelToRGBFunctor.h
+++ b/Modules/Filtering/ImageFusion/include/itkLabelToRGBFunctor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/include/itkLabelToRGBImageFilter.h
+++ b/Modules/Filtering/ImageFusion/include/itkLabelToRGBImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/include/itkLabelToRGBImageFilter.hxx
+++ b/Modules/Filtering/ImageFusion/include/itkLabelToRGBImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/include/itkScalarToRGBPixelFunctor.h
+++ b/Modules/Filtering/ImageFusion/include/itkScalarToRGBPixelFunctor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/include/itkScalarToRGBPixelFunctor.hxx
+++ b/Modules/Filtering/ImageFusion/include/itkScalarToRGBPixelFunctor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/test/itkLabelMapContourOverlayImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelMapContourOverlayImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/test/itkLabelMapContourOverlayImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelMapContourOverlayImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/test/itkLabelMapContourOverlayImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelMapContourOverlayImageFilterTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/test/itkLabelMapOverlayImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelMapOverlayImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/test/itkLabelMapOverlayImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelMapOverlayImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/test/itkLabelMapOverlayImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelMapOverlayImageFilterTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/test/itkLabelMapToRGBImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelMapToRGBImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/test/itkLabelMapToRGBImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelMapToRGBImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/test/itkLabelOverlayImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelOverlayImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/test/itkLabelToRGBImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkLabelToRGBImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageFusion/test/itkScalarToRGBPixelFunctorGTest.cxx
+++ b/Modules/Filtering/ImageFusion/test/itkScalarToRGBPixelFunctorGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/include/itkDifferenceOfGaussiansGradientImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkDifferenceOfGaussiansGradientImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/include/itkDifferenceOfGaussiansGradientImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkDifferenceOfGaussiansGradientImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/test/itkDifferenceOfGaussiansGradientTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkDifferenceOfGaussiansGradientTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/test/itkGradientImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeRecursiveGaussianFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterSpeedTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterSpeedTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest2.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest4.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkVectorGradientMagnitudeImageFilterTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGradient/wrapping/test/GradientMagnitudeRecursiveGaussianImageFilterTest.py
+++ b/Modules/Filtering/ImageGradient/wrapping/test/GradientMagnitudeRecursiveGaussianImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkBSplineCenteredL2ResampleImageFilterBase.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineCenteredL2ResampleImageFilterBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkBSplineCenteredL2ResampleImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineCenteredL2ResampleImageFilterBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkBSplineCenteredResampleImageFilterBase.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineCenteredResampleImageFilterBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkBSplineCenteredResampleImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineCenteredResampleImageFilterBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineDownsampleImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkBSplineL2ResampleImageFilterBase.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineL2ResampleImageFilterBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkBSplineL2ResampleImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineL2ResampleImageFilterBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineResampleImageFilterBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineUpsampleImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBinShrinkImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkConstantPadImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkConstantPadImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkConstantPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkConstantPadImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkCoxDeBoorBSplineKernelFunction.h
+++ b/Modules/Filtering/ImageGrid/include/itkCoxDeBoorBSplineKernelFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkCoxDeBoorBSplineKernelFunction.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkCoxDeBoorBSplineKernelFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkCropImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkCropImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkCropImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkCropImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkCyclicShiftImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkCyclicShiftImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkCyclicShiftImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkCyclicShiftImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkExpandImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkFlipImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkFlipImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkFlipImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkFlipImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkInterpolateImagePointsFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkMirrorPadImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkOrientImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkPadImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkPadImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPadImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkPadImageFilterBase.h
+++ b/Modules/Filtering/ImageGrid/include/itkPadImageFilterBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkPadImageFilterBase.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPadImageFilterBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPermuteAxesImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkRegionOfInterestImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkRegionOfInterestImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkRegionOfInterestImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkRegionOfInterestImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkShrinkImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceBySliceImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkSliceImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkWrapPadImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWrapPadImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkWrapPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWrapPadImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkZeroFluxNeumannPadImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkZeroFluxNeumannPadImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/include/itkZeroFluxNeumannPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkZeroFluxNeumannPadImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFunctionTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkBSplineDownsampleImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineDownsampleImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkBSplineResampleImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineResampleImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest4.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest5.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineScatteredDataPointSetToImageFilterTest5.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkBSplineUpsampleImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineUpsampleImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkBasicArchitectureTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBasicArchitectureTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkBinShrinkImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBinShrinkImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkBinShrinkImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBinShrinkImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkChangeInformationImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkChangeInformationImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkChangeInformationImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkChangeInformationImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkConstantPadImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkConstantPadImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkCoxDeBoorBSplineKernelFunctionTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkCoxDeBoorBSplineKernelFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkCoxDeBoorBSplineKernelFunctionTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkCoxDeBoorBSplineKernelFunctionTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkCropImageFilter3DTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkCropImageFilter3DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkCropImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkCropImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkCyclicReferences.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkCyclicReferences.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkCyclicShiftImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkCyclicShiftImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkExpandImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkExpandImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkExpandImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkExpandImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkFlipImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkFlipImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkInterpolateImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkInterpolateImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkInterpolateImagePointsFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkInterpolateImagePointsFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkMirrorPadImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkMirrorPadImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkMirrorPadImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkMirrorPadImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkOrientImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkPadImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkPadImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkPasteImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkPasteImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkPasteImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkPasteImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkPermuteAxesImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkPermuteAxesImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkPushPopTileImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkPushPopTileImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkRegionOfInterestImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkRegionOfInterestImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest2Streaming.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest2Streaming.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest3.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest4.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest5.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest5.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest6.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest6.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest7.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResampleImageTest8.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkResamplePhasedArray3DSpecialCoordinatesImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkResamplePhasedArray3DSpecialCoordinatesImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkShrinkImageStreamingTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkShrinkImageStreamingTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkShrinkImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkShrinkImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkSliceBySliceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkSliceBySliceImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkSliceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkSliceImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkTileImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkTileImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkTileImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkTileImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpVectorImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkWrapPadImageTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWrapPadImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/test/itkZeroFluxNeumannPadImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkZeroFluxNeumannPadImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/wrapping/test/OrientImageFilterTest.py
+++ b/Modules/Filtering/ImageGrid/wrapping/test/OrientImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/wrapping/test/PhasedArray3DResampleTest.py
+++ b/Modules/Filtering/ImageGrid/wrapping/test/PhasedArray3DResampleTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/ImageGrid/wrapping/test/ResampleImageFilterTest.py
+++ b/Modules/Filtering/ImageGrid/wrapping/test/ResampleImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkAbsImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAbsImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkAcosImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAcosImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkAdaptImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAdaptImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkAddImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAddImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkAndImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAndImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkArithmeticOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkArithmeticOpsFunctors.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkAsinImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAsinImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkAtan2ImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAtan2ImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkAtanImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkAtanImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkBinaryMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkBinaryMagnitudeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkBitwiseOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkBitwiseOpsFunctors.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkBoundedReciprocalImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkBoundedReciprocalImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkClampImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkClampImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkClampImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkClampImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkComplexToImaginaryImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkComplexToImaginaryImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkComplexToModulusImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkComplexToModulusImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkComplexToPhaseImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkComplexToPhaseImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkComplexToRealImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkComplexToRealImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkConstrainedValueAdditionImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkConstrainedValueAdditionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkConstrainedValueDifferenceImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkConstrainedValueDifferenceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkCosImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkCosImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkDiscreteGaussianDerivativeImageFunction.h
+++ b/Modules/Filtering/ImageIntensity/include/itkDiscreteGaussianDerivativeImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkDiscreteGaussianDerivativeImageFunction.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkDiscreteGaussianDerivativeImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkDiscreteGradientMagnitudeGaussianImageFunction.h
+++ b/Modules/Filtering/ImageIntensity/include/itkDiscreteGradientMagnitudeGaussianImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkDiscreteGradientMagnitudeGaussianImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkDiscreteHessianGaussianImageFunction.h
+++ b/Modules/Filtering/ImageIntensity/include/itkDiscreteHessianGaussianImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkDiscreteHessianGaussianImageFunction.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkDiscreteHessianGaussianImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkDivideImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkDivideImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkDivideOrZeroOutImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkDivideOrZeroOutImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkEdgePotentialImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkEdgePotentialImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkExpImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkExpImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkExpNegativeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkExpNegativeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkIntensityWindowingImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkIntensityWindowingImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkIntensityWindowingImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkIntensityWindowingImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkInvertIntensityImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkInvertIntensityImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkInvertIntensityImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkInvertIntensityImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkLog10ImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkLog10ImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkLogImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkLogImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkLogicOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkLogicOpsFunctors.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkMagnitudeAndPhaseToComplexImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMagnitudeAndPhaseToComplexImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkMaskImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkMaskNegatedImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskNegatedImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkMatrixIndexSelectionImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMatrixIndexSelectionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkMaximumImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaximumImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkMinimumImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMinimumImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkModulusImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkModulusImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkModulusImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkModulusImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkMultiplyImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMultiplyImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkNaryAddImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNaryAddImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkNaryFunctorImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNaryFunctorImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkNaryFunctorImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkNaryFunctorImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkNaryMaximumImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNaryMaximumImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkNormalizeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNormalizeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkNormalizeImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkNormalizeImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkNormalizeToConstantImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNormalizeToConstantImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkNormalizeToConstantImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkNormalizeToConstantImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkNotImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNotImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkOrImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkOrImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkPowImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkPowImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkRGBToLuminanceImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkRGBToLuminanceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkRescaleIntensityImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkRescaleIntensityImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkRescaleIntensityImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkRescaleIntensityImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkRoundImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkRoundImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkShiftScaleImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkShiftScaleImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkShiftScaleImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkShiftScaleImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkSigmoidImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSigmoidImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkSinImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSinImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkSqrtImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSqrtImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkSquareImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSquareImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkSubtractImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSubtractImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkSymmetricEigenAnalysisImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkSymmetricEigenAnalysisImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkTanImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkTanImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkTernaryAddImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkTernaryAddImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkTernaryMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkTernaryMagnitudeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkTernaryMagnitudeSquaredImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkTernaryMagnitudeSquaredImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkTernaryOperatorImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkTernaryOperatorImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorExpandImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkVectorIndexSelectionCastImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorIndexSelectionCastImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkVectorMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorMagnitudeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkWeightedAddImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkWeightedAddImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/include/itkXorImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkXorImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/src/itkSymmetricEigenAnalysisImageFilter.cxx
+++ b/Modules/Filtering/ImageIntensity/src/itkSymmetricEigenAnalysisImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkAbsImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAbsImageFilterAndAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkAcosImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAcosImageFilterAndAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkAddImageAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAddImageAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkAddImageFilterFrameTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAddImageFilterFrameTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkAddImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAddImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkAddImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAddImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkAndImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAndImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkArithmeticOpsFunctorsTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkArithmeticOpsFunctorsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkAsinImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAsinImageFilterAndAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkAtan2ImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAtan2ImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkAtanImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAtanImageFilterAndAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkBinaryMagnitudeImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkBinaryMagnitudeImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkBitwiseOpsFunctorsTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkBitwiseOpsFunctorsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkBoundedReciprocalImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkBoundedReciprocalImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkClampImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkClampImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkComplexToImaginaryFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkComplexToImaginaryFilterAndAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkComplexToModulusFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkComplexToModulusFilterAndAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkComplexToPhaseFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkComplexToPhaseFilterAndAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkComplexToRealFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkComplexToRealFilterAndAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkConstrainedValueAdditionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkConstrainedValueAdditionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkCosImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkCosImageFilterAndAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkDiscreteGaussianDerivativeImageFunctionTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkDiscreteGaussianDerivativeImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkDivideImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkDivideImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkDivideImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkDivideImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkDivideOrZeroOutImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkDivideOrZeroOutImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkEdgePotentialImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkEdgePotentialImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkEqualTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkExpImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkExpImageFilterAndAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkExpNegativeImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkExpNegativeImageFilterAndAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkGreaterEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkGreaterEqualTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkGreaterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkGreaterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkHistogramMatchingImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkHistogramMatchingImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkImageAdaptorNthElementTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkImageAdaptorNthElementTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkIntensityWindowingImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkIntensityWindowingImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkInvertIntensityImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkInvertIntensityImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkLessEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkLessEqualTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkLessTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkLessTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkLog10ImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkLog10ImageFilterAndAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkLogImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkLogImageFilterAndAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkLogicTestSupport.h
+++ b/Modules/Filtering/ImageIntensity/test/itkLogicTestSupport.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkMagnitudeAndPhaseToComplexImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMagnitudeAndPhaseToComplexImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkMaskImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMaskImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkMaskNegatedImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMaskNegatedImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkMatrixIndexSelectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMatrixIndexSelectionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkMaximumImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMaximumImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkMinimumImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMinimumImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkModulusImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkModulusImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkMultiplyImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMultiplyImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkNaryAddImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNaryAddImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkNaryMaximumImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNaryMaximumImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkNormalizeImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNormalizeImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkNormalizeToConstantImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNormalizeToConstantImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkNotEqualTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNotEqualTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkNotImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNotImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkNthElementPixelAccessorTest2.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNthElementPixelAccessorTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkOrImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkOrImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkPolylineMask2DImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkPolylineMask2DImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkPolylineMaskImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkPolylineMaskImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkPowImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkPowImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkPromoteDimensionImageTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkPromoteDimensionImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkRGBToLuminanceImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkRGBToLuminanceImageFilterAndAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkRGBToVectorAdaptImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkRGBToVectorAdaptImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkRescaleIntensityImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkRescaleIntensityImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkRoundImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkRoundImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkShiftScaleImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkShiftScaleImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkSigmoidImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSigmoidImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkSinImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSinImageFilterAndAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkSqrtImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSqrtImageFilterAndAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkSquareImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSquareImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkSubtractImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSubtractImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkSymmetricEigenAnalysisImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSymmetricEigenAnalysisImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkTanImageFilterAndAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkTanImageFilterAndAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkTernaryMagnitudeImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkTernaryMagnitudeImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkTernaryMagnitudeSquaredImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkTernaryMagnitudeSquaredImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkTernaryOperatorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkTernaryOperatorImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkVectorExpandImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkVectorExpandImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkVectorIndexSelectionCastImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkVectorIndexSelectionCastImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkVectorMagnitudeImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkVectorMagnitudeImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkVectorRescaleIntensityImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkVectorRescaleIntensityImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkVectorToRGBImageAdaptorTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkVectorToRGBImageAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkWeightedAddImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkWeightedAddImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/test/itkXorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkXorImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/wrapping/test/SigmoidImageFilterTest.py
+++ b/Modules/Filtering/ImageIntensity/wrapping/test/SigmoidImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/wrapping/test/itkImageFilterNumPyInputsTest.py
+++ b/Modules/Filtering/ImageIntensity/wrapping/test/itkImageFilterNumPyInputsTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/ImageIntensity/wrapping/test/itkIntensityWindowingImageFilterTest.py
+++ b/Modules/Filtering/ImageIntensity/wrapping/test/itkIntensityWindowingImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.h
+++ b/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.hxx
+++ b/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageLabel/include/itkChangeLabelImageFilter.h
+++ b/Modules/Filtering/ImageLabel/include/itkChangeLabelImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageLabel/include/itkChangeLabelImageFilter.hxx
+++ b/Modules/Filtering/ImageLabel/include/itkChangeLabelImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageLabel/include/itkLabelContourImageFilter.h
+++ b/Modules/Filtering/ImageLabel/include/itkLabelContourImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageLabel/include/itkLabelContourImageFilter.hxx
+++ b/Modules/Filtering/ImageLabel/include/itkLabelContourImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
+++ b/Modules/Filtering/ImageLabel/include/itkScanlineFilterCommon.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageLabel/test/itkBinaryContourImageFilterTest.cxx
+++ b/Modules/Filtering/ImageLabel/test/itkBinaryContourImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageLabel/test/itkChangeLabelImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageLabel/test/itkChangeLabelImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageLabel/test/itkLabelContourImageFilterTest.cxx
+++ b/Modules/Filtering/ImageLabel/test/itkLabelContourImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.h
+++ b/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.h
+++ b/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.h
+++ b/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.h
+++ b/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.h
+++ b/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageNoise/test/itkAdditiveGaussianNoiseImageFilterTest.cxx
+++ b/Modules/Filtering/ImageNoise/test/itkAdditiveGaussianNoiseImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageNoise/test/itkPeakSignalToNoiseRatioCalculator.h
+++ b/Modules/Filtering/ImageNoise/test/itkPeakSignalToNoiseRatioCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageNoise/test/itkPeakSignalToNoiseRatioCalculator.hxx
+++ b/Modules/Filtering/ImageNoise/test/itkPeakSignalToNoiseRatioCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageNoise/test/itkPeakSignalToNoiseRatioCalculatorTest.cxx
+++ b/Modules/Filtering/ImageNoise/test/itkPeakSignalToNoiseRatioCalculatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageNoise/test/itkSaltAndPepperNoiseImageFilterTest.cxx
+++ b/Modules/Filtering/ImageNoise/test/itkSaltAndPepperNoiseImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageNoise/test/itkShotNoiseImageFilterTest.cxx
+++ b/Modules/Filtering/ImageNoise/test/itkShotNoiseImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageNoise/test/itkSpeckleNoiseImageFilterTest.cxx
+++ b/Modules/Filtering/ImageNoise/test/itkSpeckleNoiseImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageSources/include/itkGaborImageSource.h
+++ b/Modules/Filtering/ImageSources/include/itkGaborImageSource.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageSources/include/itkGaborImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGaborImageSource.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageSources/include/itkGaborKernelFunction.h
+++ b/Modules/Filtering/ImageSources/include/itkGaborKernelFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageSources/include/itkGaussianImageSource.h
+++ b/Modules/Filtering/ImageSources/include/itkGaussianImageSource.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageSources/include/itkGaussianImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGaussianImageSource.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageSources/include/itkGenerateImageSource.h
+++ b/Modules/Filtering/ImageSources/include/itkGenerateImageSource.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageSources/include/itkGenerateImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGenerateImageSource.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageSources/include/itkGridImageSource.h
+++ b/Modules/Filtering/ImageSources/include/itkGridImageSource.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageSources/include/itkGridImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGridImageSource.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageSources/include/itkParametricImageSource.h
+++ b/Modules/Filtering/ImageSources/include/itkParametricImageSource.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageSources/include/itkParametricImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkParametricImageSource.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageSources/include/itkPhysicalPointImageSource.h
+++ b/Modules/Filtering/ImageSources/include/itkPhysicalPointImageSource.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageSources/include/itkPhysicalPointImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkPhysicalPointImageSource.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageSources/test/itkGaborImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGaborImageSourceTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageSources/test/itkGaborKernelFunctionGTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGaborKernelFunctionGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageSources/test/itkGaussianImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGaussianImageSourceTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageSources/test/itkGridImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGridImageSourceTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageSources/test/itkGridImageSourceTest2.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGridImageSourceTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageSources/test/itkPhysicalPointImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkPhysicalPointImageSourceTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkAccumulateImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkAdaptiveEqualizationHistogram.h
+++ b/Modules/Filtering/ImageStatistics/include/itkAdaptiveEqualizationHistogram.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkAdaptiveHistogramEqualizationImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkAdaptiveHistogramEqualizationImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkAdaptiveHistogramEqualizationImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkAdaptiveHistogramEqualizationImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkBinaryProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkBinaryProjectionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkGetAverageSliceImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkGetAverageSliceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkGetAverageSliceImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkGetAverageSliceImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkHistogramAlgorithmBase.h
+++ b/Modules/Filtering/ImageStatistics/include/itkHistogramAlgorithmBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkHistogramAlgorithmBase.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkHistogramAlgorithmBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.h
+++ b/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.h
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.h
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkImageShapeModelEstimatorBase.h
+++ b/Modules/Filtering/ImageStatistics/include/itkImageShapeModelEstimatorBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkImageShapeModelEstimatorBase.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImageShapeModelEstimatorBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkMaximumProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkMaximumProjectionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkMeanProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkMeanProjectionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkMedianProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkMedianProjectionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkMinimumMaximumImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkMinimumMaximumImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkMinimumMaximumImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkMinimumMaximumImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkMinimumProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkMinimumProjectionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkProjectionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkStandardDeviationProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkStandardDeviationProjectionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/include/itkSumProjectionImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkSumProjectionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkAccumulateImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkAccumulateImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkAdaptiveHistogramEqualizationImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkAdaptiveHistogramEqualizationImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkBinaryProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkBinaryProjectionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkGetAverageSliceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkGetAverageSliceImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkHistogramToEntropyImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkHistogramToEntropyImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkHistogramToEntropyImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkHistogramToEntropyImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkHistogramToIntensityImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkHistogramToIntensityImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkHistogramToIntensityImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkHistogramToIntensityImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkHistogramToLogProbabilityImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkHistogramToLogProbabilityImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkHistogramToLogProbabilityImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkHistogramToLogProbabilityImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkHistogramToProbabilityImageFilterTest1.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkHistogramToProbabilityImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkHistogramToProbabilityImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkHistogramToProbabilityImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkImageMomentsTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImageMomentsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkImagePCADecompositionCalculatorTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImagePCADecompositionCalculatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkImagePCAShapeModelEstimatorTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkImagePCAShapeModelEstimatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkLabelOverlapMeasuresImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkLabelOverlapMeasuresImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkLabelOverlapMeasuresImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkLabelOverlapMeasuresImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkLabelStatisticsImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkLabelStatisticsImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkMaximumProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkMaximumProjectionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkMaximumProjectionImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkMaximumProjectionImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkMaximumProjectionImageFilterTest3.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkMaximumProjectionImageFilterTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkMaximumProjectionImageFilterTest4.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkMaximumProjectionImageFilterTest4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkMeanProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkMeanProjectionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkMedianProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkMedianProjectionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkMinimumMaximumImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkMinimumMaximumImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkMinimumMaximumImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkMinimumMaximumImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkMinimumProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkMinimumProjectionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkProjectionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkStandardDeviationProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkStandardDeviationProjectionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkStatisticsImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkStatisticsImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/ImageStatistics/test/itkSumProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkSumProjectionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkAggregateLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAggregateLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkAggregateLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAggregateLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkAttributeKeepNObjectsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeKeepNObjectsLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkAttributeKeepNObjectsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAttributeKeepNObjectsLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkAttributeLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeLabelObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkAttributeOpeningLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeOpeningLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkAttributeOpeningLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAttributeOpeningLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkAttributePositionLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributePositionLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkAttributePositionLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAttributePositionLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkAttributeRelabelLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeRelabelLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkAttributeRelabelLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAttributeRelabelLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkAttributeSelectionLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeSelectionLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkAttributeSelectionLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAttributeSelectionLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkAttributeUniqueLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAttributeUniqueLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkAttributeUniqueLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAttributeUniqueLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkAutoCropLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkAutoCropLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkAutoCropLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAutoCropLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryFillholeImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryFillholeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryFillholeImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryFillholeImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToShapeLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToShapeLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToShapeLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToStatisticsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToStatisticsLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToStatisticsLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryNotImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryNotImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByDilationImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByDilationImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByDilationImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByDilationImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByErosionImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByErosionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByErosionImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByErosionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryReconstructionLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryReconstructionLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryReconstructionLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryReconstructionLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryShapeKeepNObjectsImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryShapeKeepNObjectsImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryShapeKeepNObjectsImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryShapeKeepNObjectsImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryShapeOpeningImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryShapeOpeningImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryShapeOpeningImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryShapeOpeningImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryStatisticsKeepNObjectsImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryStatisticsKeepNObjectsImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryStatisticsKeepNObjectsImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryStatisticsKeepNObjectsImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryStatisticsOpeningImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkBinaryStatisticsOpeningImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkBinaryStatisticsOpeningImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryStatisticsOpeningImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkChangeLabelLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkChangeLabelLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkChangeLabelLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkChangeLabelLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkChangeRegionLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkChangeRegionLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkChangeRegionLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkChangeRegionLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkConvertLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkConvertLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkConvertLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkConvertLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkCropLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkCropLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkCropLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkCropLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkGeometryUtilities.h
+++ b/Modules/Filtering/LabelMap/include/itkGeometryUtilities.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkInPlaceLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkInPlaceLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkInPlaceLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkInPlaceLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToShapeLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToShapeLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToShapeLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToStatisticsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToStatisticsLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToStatisticsLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelMap.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMap.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelMap.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMap.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelMapToAttributeImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapToAttributeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelMapToAttributeImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapToAttributeImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelMapToBinaryImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapToBinaryImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelMapToBinaryImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapToBinaryImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelMapToLabelImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapToLabelImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelMapToLabelImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapToLabelImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelMapUtilities.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapUtilities.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelObjectAccessors.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelObjectAccessors.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelObjectLine.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelObjectLine.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelObjectLine.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelObjectLine.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelObjectLineComparator.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelObjectLineComparator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelSelectionLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelSelectionLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelShapeKeepNObjectsImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelShapeKeepNObjectsImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelShapeKeepNObjectsImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelShapeKeepNObjectsImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelShapeOpeningImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelShapeOpeningImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelShapeOpeningImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelShapeOpeningImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelStatisticsKeepNObjectsImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelStatisticsKeepNObjectsImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelStatisticsKeepNObjectsImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelStatisticsKeepNObjectsImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelStatisticsOpeningImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelStatisticsOpeningImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelStatisticsOpeningImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelStatisticsOpeningImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkLabelUniqueLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkLabelUniqueLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkMergeLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkMergeLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkMergeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkMergeLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkObjectByObjectLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkObjectByObjectLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkObjectByObjectLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkObjectByObjectLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkPadLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkPadLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkPadLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkPadLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkRegionFromReferenceLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkRegionFromReferenceLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkRegionFromReferenceLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkRegionFromReferenceLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkRelabelLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkRelabelLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkShapeKeepNObjectsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeKeepNObjectsLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkShapeKeepNObjectsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeKeepNObjectsLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelObjectAccessors.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelObjectAccessors.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkShapeOpeningLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeOpeningLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkShapeOpeningLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeOpeningLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkShapePositionLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapePositionLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkShapePositionLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapePositionLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkShapeRelabelImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeRelabelImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkShapeRelabelImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeRelabelImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkShapeRelabelLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeRelabelLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkShapeRelabelLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeRelabelLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkShapeUniqueLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeUniqueLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkShapeUniqueLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeUniqueLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkShiftScaleLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkShiftScaleLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkShiftScaleLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShiftScaleLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkStatisticsKeepNObjectsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsKeepNObjectsLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkStatisticsKeepNObjectsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsKeepNObjectsLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelObjectAccessors.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelObjectAccessors.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkStatisticsOpeningLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsOpeningLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkStatisticsOpeningLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsOpeningLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkStatisticsPositionLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsPositionLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkStatisticsPositionLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsPositionLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkStatisticsRelabelImageFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsRelabelImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkStatisticsRelabelImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsRelabelImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkStatisticsRelabelLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsRelabelLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkStatisticsRelabelLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsRelabelLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkStatisticsUniqueLabelMapFilter.h
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsUniqueLabelMapFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/include/itkStatisticsUniqueLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsUniqueLabelMapFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/src/itkGeometryUtilities.cxx
+++ b/Modules/Filtering/LabelMap/src/itkGeometryUtilities.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/src/itkMergeLabelMapFilter.cxx
+++ b/Modules/Filtering/LabelMap/src/itkMergeLabelMapFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkAggregateLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkAggregateLabelMapFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkAttributeKeepNObjectsLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkAttributeKeepNObjectsLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkAttributeLabelObjectAccessorsTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkAttributeLabelObjectAccessorsTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkAttributeOpeningLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkAttributeOpeningLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkAttributePositionLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkAttributePositionLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkAttributeRelabelLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkAttributeRelabelLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkAttributeUniqueLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkAttributeUniqueLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkAutoCropLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkAutoCropLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkAutoCropLabelMapFilterTest2.cxx
+++ b/Modules/Filtering/LabelMap/test/itkAutoCropLabelMapFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkBinaryFillholeImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryFillholeImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkBinaryGrindPeakImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryGrindPeakImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkBinaryImageToLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryImageToLabelMapFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkBinaryImageToLabelMapFilterTest2.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryImageToLabelMapFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkBinaryImageToShapeLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryImageToShapeLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkBinaryImageToStatisticsLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryImageToStatisticsLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkBinaryNotImageFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryNotImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkBinaryReconstructionByDilationImageFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryReconstructionByDilationImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkBinaryReconstructionByErosionImageFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryReconstructionByErosionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkBinaryReconstructionLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryReconstructionLabelMapFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkBinaryShapeKeepNObjectsImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryShapeKeepNObjectsImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkBinaryShapeOpeningImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryShapeOpeningImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkBinaryStatisticsKeepNObjectsImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryStatisticsKeepNObjectsImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkBinaryStatisticsOpeningImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryStatisticsOpeningImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkChangeLabelLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkChangeLabelLabelMapFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkChangeRegionLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkChangeRegionLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkConvertLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkConvertLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkConvertLabelMapFilterTest2.cxx
+++ b/Modules/Filtering/LabelMap/test/itkConvertLabelMapFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkCropLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkCropLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkLabelImageToLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelImageToLabelMapFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkLabelImageToShapeLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelImageToShapeLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkLabelImageToStatisticsLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelImageToStatisticsLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelMapFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkLabelMapMaskImageFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelMapMaskImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkLabelMapTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelMapTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkLabelMapTest2.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelMapTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkLabelMapToAttributeImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelMapToAttributeImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkLabelMapToBinaryImageFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelMapToBinaryImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkLabelMapToLabelImageFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelMapToLabelImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkLabelObjectLineComparatorTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelObjectLineComparatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkLabelObjectLineTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelObjectLineTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkLabelObjectTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkLabelSelectionLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelSelectionLabelMapFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkLabelShapeKeepNObjectsImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelShapeKeepNObjectsImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkLabelShapeOpeningImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelShapeOpeningImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkLabelStatisticsKeepNObjectsImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelStatisticsKeepNObjectsImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkLabelStatisticsOpeningImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelStatisticsOpeningImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkLabelUniqueLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelUniqueLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkMergeLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkMergeLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkObjectByObjectLabelMapFilterTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkObjectByObjectLabelMapFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkPadLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkPadLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkRegionFromReferenceLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkRegionFromReferenceLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkRelabelLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkRelabelLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkShapeKeepNObjectsLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeKeepNObjectsLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkShapeLabelMapFilterGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeLabelMapFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkShapeLabelObjectAccessorsTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeLabelObjectAccessorsTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkShapeOpeningLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeOpeningLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkShapePositionLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapePositionLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkShapeRelabelImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeRelabelImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkShapeRelabelLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeRelabelLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkShapeUniqueLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeUniqueLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkShiftLabelObjectTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShiftLabelObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkShiftScaleLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShiftScaleLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkStatisticsKeepNObjectsLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsKeepNObjectsLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkStatisticsLabelMapFilterGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsLabelMapFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkStatisticsOpeningLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsOpeningLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkStatisticsPositionLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsPositionLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkStatisticsRelabelImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsRelabelImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkStatisticsRelabelLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsRelabelLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkStatisticsUniqueLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsUniqueLabelMapFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/test/itkUniqueLabelMapFiltersGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkUniqueLabelMapFiltersGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/LabelMap/wrapping/test/BinaryFillholeImageFilterTest.py
+++ b/Modules/Filtering/LabelMap/wrapping/test/BinaryFillholeImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorCloseImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorCloseImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorDilateImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateLine.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateLine.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateLine.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeDilateLine.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseLine.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseLine.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseLine.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseLine.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorUtilities.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorUtilities.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorUtilities.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkBasicDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBasicDilateImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkBasicDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBasicDilateImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkBasicErodeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBasicErodeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkBasicErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBasicErodeImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkBinaryBallStructuringElement.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBinaryBallStructuringElement.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkBinaryBallStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBinaryBallStructuringElement.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkBinaryCrossStructuringElement.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBinaryCrossStructuringElement.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkBinaryCrossStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBinaryCrossStructuringElement.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkBlackTopHatImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBlackTopHatImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkBlackTopHatImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkBlackTopHatImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkClosingByReconstructionImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkClosingByReconstructionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkClosingByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkClosingByReconstructionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleDilateImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleDilateImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleErodeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleErodeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleErodeImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFillholeImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionDilateImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionDilateImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionErodeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionErodeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleFunctionErodeImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGrindPeakImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalClosingImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalClosingImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalClosingImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalClosingImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkMaskedRankImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMaskedRankImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkMaskedRankImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMaskedRankImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkMathematicalMorphologyEnums.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMathematicalMorphologyEnums.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkMorphologicalGradientImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMorphologicalGradientImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkMorphologicalGradientImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMorphologicalGradientImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkMorphologyHistogram.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMorphologyHistogram.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkMorphologyImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMorphologyImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkMorphologyImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMorphologyImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramDilateImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramErodeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramErodeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramMorphologicalGradientImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramMorphologicalGradientImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramMorphologyImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramMorphologyImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramMorphologyImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMovingHistogramMorphologyImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkOpeningByReconstructionImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkOpeningByReconstructionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkOpeningByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkOpeningByReconstructionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkRankHistogram.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRankHistogram.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkRankImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRankImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkRankImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRankImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkReconstructionByDilationImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkReconstructionByDilationImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkReconstructionByErosionImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkReconstructionByErosionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkSharedMorphologyUtilities.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkSharedMorphologyUtilities.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkSharedMorphologyUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkSharedMorphologyUtilities.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalExtremaImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalMaximaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalMaximaImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalMinimaImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkValuedRegionalMinimaImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanDilateImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanErodeDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanErodeDilateImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanErodeDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanErodeDilateImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanErodeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanErodeImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanUtilities.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanUtilities.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanUtilities.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanUtilities.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkWhiteTopHatImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkWhiteTopHatImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/include/itkWhiteTopHatImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkWhiteTopHatImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/src/itkMathematicalMorphologyEnums.cxx
+++ b/Modules/Filtering/MathematicalMorphology/src/itkMathematicalMorphologyEnums.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkAnchorErodeDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkAnchorErodeDilateImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkAnchorOpenCloseImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkAnchorOpenCloseImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkClosingByReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkClosingByReconstructionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkDoubleThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkDoubleThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest3.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkFlatStructuringElementTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleConnectedClosingImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleConnectedClosingImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleConnectedOpeningImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleConnectedOpeningImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleDilateImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleErodeImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleErodeImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFillholeImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFillholeImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionDilateImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionErodeImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleFunctionErodeImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleGeodesicErodeDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleGeodesicErodeDilateImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleGrindPeakImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleGrindPeakImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalClosingImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalClosingImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalClosingImageFilterTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalClosingImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalOpeningImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalOpeningImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalOpeningImageFilterTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkGrayscaleMorphologicalOpeningImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkHConcaveImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkHConcaveImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkHConvexConcaveImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkHConvexConcaveImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkHConvexImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkHConvexImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkHMaximaImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkHMaximaImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkHMaximaMinimaImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkHMaximaMinimaImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkHMinimaImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkHMinimaImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleDilateImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleErodeImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleErodeImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalClosingImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalClosingImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalOpeningImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapGrayscaleMorphologicalOpeningImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapMaskedRankImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapMaskedRankImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkMapRankImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMapRankImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkMaskedRankImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMaskedRankImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkMathematicalMorphologyEnumsGTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMathematicalMorphologyEnumsGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkMorphologicalGradientImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMorphologicalGradientImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkMorphologicalGradientImageFilterTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMorphologicalGradientImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkMovingHistogramMorphologyImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkMovingHistogramMorphologyImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkObjectMorphologyImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkObjectMorphologyImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkOpeningByReconstructionImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkOpeningByReconstructionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkOpeningByReconstructionImageFilterTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkOpeningByReconstructionImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkRankImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkRankImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkRegionalMaximaImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkRegionalMaximaImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkRegionalMinimaImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkRegionalMinimaImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkRemoveBoundaryObjectsTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkRemoveBoundaryObjectsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkRemoveBoundaryObjectsTest2.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkRemoveBoundaryObjectsTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkShapedIteratorFromStructuringElementTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkShapedIteratorFromStructuringElementTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkTopHatImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkTopHatImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkValuedRegionalMaximaImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkValuedRegionalMaximaImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkValuedRegionalMinimaImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkValuedRegionalMinimaImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/test/itkVanHerkGilWermanErodeDilateImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkVanHerkGilWermanErodeDilateImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/wrapping/test/BoxGrayscaleDilateImageFilterTest.py
+++ b/Modules/Filtering/MathematicalMorphology/wrapping/test/BoxGrayscaleDilateImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/wrapping/test/FlatStructuringElementTest.py
+++ b/Modules/Filtering/MathematicalMorphology/wrapping/test/FlatStructuringElementTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/MathematicalMorphology/wrapping/test/GrayscaleDilateImageFilterTest.py
+++ b/Modules/Filtering/MathematicalMorphology/wrapping/test/GrayscaleDilateImageFilterTest.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 
 # ==========================================================================
 #

--- a/Modules/Filtering/MathematicalMorphology/wrapping/test/GrayscaleErodeImageFilterTest.py
+++ b/Modules/Filtering/MathematicalMorphology/wrapping/test/GrayscaleErodeImageFilterTest.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 
 # ==========================================================================
 #

--- a/Modules/Filtering/Path/include/itkChainCodePath.h
+++ b/Modules/Filtering/Path/include/itkChainCodePath.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkChainCodePath.hxx
+++ b/Modules/Filtering/Path/include/itkChainCodePath.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkChainCodePath2D.h
+++ b/Modules/Filtering/Path/include/itkChainCodePath2D.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkChainCodeToFourierSeriesPathFilter.h
+++ b/Modules/Filtering/Path/include/itkChainCodeToFourierSeriesPathFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkChainCodeToFourierSeriesPathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkChainCodeToFourierSeriesPathFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.h
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.h
+++ b/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkFourierSeriesPath.h
+++ b/Modules/Filtering/Path/include/itkFourierSeriesPath.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkFourierSeriesPath.hxx
+++ b/Modules/Filtering/Path/include/itkFourierSeriesPath.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkHilbertPath.h
+++ b/Modules/Filtering/Path/include/itkHilbertPath.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkHilbertPath.hxx
+++ b/Modules/Filtering/Path/include/itkHilbertPath.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkImageAndPathToImageFilter.h
+++ b/Modules/Filtering/Path/include/itkImageAndPathToImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkImageAndPathToImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkImageAndPathToImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkImageToPathFilter.h
+++ b/Modules/Filtering/Path/include/itkImageToPathFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkImageToPathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkImageToPathFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.h
+++ b/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkOrthogonallyCorrected2DParametricPath.h
+++ b/Modules/Filtering/Path/include/itkOrthogonallyCorrected2DParametricPath.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkParametricPath.h
+++ b/Modules/Filtering/Path/include/itkParametricPath.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkParametricPath.hxx
+++ b/Modules/Filtering/Path/include/itkParametricPath.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkPath.h
+++ b/Modules/Filtering/Path/include/itkPath.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkPathAndImageToPathFilter.h
+++ b/Modules/Filtering/Path/include/itkPathAndImageToPathFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkPathAndImageToPathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathAndImageToPathFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkPathConstIterator.h
+++ b/Modules/Filtering/Path/include/itkPathConstIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkPathConstIterator.hxx
+++ b/Modules/Filtering/Path/include/itkPathConstIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkPathFunctions.h
+++ b/Modules/Filtering/Path/include/itkPathFunctions.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkPathIterator.h
+++ b/Modules/Filtering/Path/include/itkPathIterator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkPathIterator.hxx
+++ b/Modules/Filtering/Path/include/itkPathIterator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkPathSource.h
+++ b/Modules/Filtering/Path/include/itkPathSource.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkPathSource.hxx
+++ b/Modules/Filtering/Path/include/itkPathSource.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkPathToChainCodePathFilter.h
+++ b/Modules/Filtering/Path/include/itkPathToChainCodePathFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkPathToChainCodePathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathToChainCodePathFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkPathToImageFilter.h
+++ b/Modules/Filtering/Path/include/itkPathToImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkPathToPathFilter.h
+++ b/Modules/Filtering/Path/include/itkPathToPathFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkPathToPathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathToPathFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkPolyLineParametricPath.h
+++ b/Modules/Filtering/Path/include/itkPolyLineParametricPath.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/include/itkPolyLineParametricPath.hxx
+++ b/Modules/Filtering/Path/include/itkPolyLineParametricPath.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/src/itkChainCodePath2D.cxx
+++ b/Modules/Filtering/Path/src/itkChainCodePath2D.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/src/itkOrthogonallyCorrected2DParametricPath.cxx
+++ b/Modules/Filtering/Path/src/itkOrthogonallyCorrected2DParametricPath.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/test/itkChainCodePath2DTest.cxx
+++ b/Modules/Filtering/Path/test/itkChainCodePath2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/test/itkChainCodePathTest.cxx
+++ b/Modules/Filtering/Path/test/itkChainCodePathTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/test/itkChainCodeToFourierSeriesPathFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkChainCodeToFourierSeriesPathFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/test/itkContourExtractor2DImageFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkContourExtractor2DImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/test/itkExtractOrthogonalSwath2DImageFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkExtractOrthogonalSwath2DImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/test/itkFourierSeriesPathTest.cxx
+++ b/Modules/Filtering/Path/test/itkFourierSeriesPathTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/test/itkHilbertPathTest.cxx
+++ b/Modules/Filtering/Path/test/itkHilbertPathTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/test/itkOrthogonalSwath2DPathFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkOrthogonalSwath2DPathFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/test/itkOrthogonallyCorrected2DParametricPathTest.cxx
+++ b/Modules/Filtering/Path/test/itkOrthogonallyCorrected2DParametricPathTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/test/itkPathFunctionsTest.cxx
+++ b/Modules/Filtering/Path/test/itkPathFunctionsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/test/itkPathIteratorTest.cxx
+++ b/Modules/Filtering/Path/test/itkPathIteratorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/test/itkPathToChainCodePathFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkPathToChainCodePathFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/test/itkPathToImageFilterTest.cxx
+++ b/Modules/Filtering/Path/test/itkPathToImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Path/test/itkPolyLineParametricPathTest.cxx
+++ b/Modules/Filtering/Path/test/itkPolyLineParametricPathTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkBorderQuadEdgeMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkCleanQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkCleanQuadEdgeMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkCleanQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkCleanQuadEdgeMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDecimationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDecimationQuadEdgeMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDelaunayConformingQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDelaunayConformingQuadEdgeMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDelaunayConformingQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDelaunayConformingQuadEdgeMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteCurvatureQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteCurvatureQuadEdgeMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteCurvatureTensorQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteCurvatureTensorQuadEdgeMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteGaussianCurvatureQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteGaussianCurvatureQuadEdgeMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteMaximumCurvatureQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteMaximumCurvatureQuadEdgeMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteMeanCurvatureQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteMeanCurvatureQuadEdgeMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteMinimumCurvatureQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscreteMinimumCurvatureQuadEdgeMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscretePrincipalCurvaturesQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkDiscretePrincipalCurvaturesQuadEdgeMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkEdgeDecimationQuadEdgeMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraints.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraints.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraints.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraints.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraints.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraints.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraints.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraints.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkNormalQuadEdgeMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkParameterizationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkParameterizationQuadEdgeMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkParameterizationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkParameterizationQuadEdgeMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationCriteria.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationCriteria.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshParamMatrixCoefficients.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshParamMatrixCoefficients.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadricDecimationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadricDecimationQuadEdgeMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadricDecimationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadricDecimationQuadEdgeMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSmoothingQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSmoothingQuadEdgeMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSmoothingQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSmoothingQuadEdgeMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSquaredEdgeLengthDecimationQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSquaredEdgeLengthDecimationQuadEdgeMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSquaredEdgeLengthDecimationQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkSquaredEdgeLengthDecimationQuadEdgeMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/src/itkBorderQuadEdgeMeshFilter.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/src/itkBorderQuadEdgeMeshFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/src/itkLaplacianDeformationQuadEdgeMeshFilter.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/src/itkLaplacianDeformationQuadEdgeMeshFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/src/itkNormalQuadEdgeMeshFilter.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/src/itkNormalQuadEdgeMeshFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkAutomaticTopologyQuadEdgeMeshSourceTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkAutomaticTopologyQuadEdgeMeshSourceTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkBinaryMask3DQuadEdgeMeshSourceTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkBinaryMask3DQuadEdgeMeshSourceTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkBorderQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkBorderQuadEdgeMeshFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkBorderQuadEdgeMeshFilterTest2.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkBorderQuadEdgeMeshFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkCleanQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkCleanQuadEdgeMeshFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDelaunayConformingQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDelaunayConformingQuadEdgeMeshFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDiscreteGaussianCurvatureQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDiscreteGaussianCurvatureQuadEdgeMeshFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDiscreteMaximumCurvatureQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDiscreteMaximumCurvatureQuadEdgeMeshFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDiscreteMeanCurvatureQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDiscreteMeanCurvatureQuadEdgeMeshFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDiscreteMinimumCurvatureQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDiscreteMinimumCurvatureQuadEdgeMeshFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithHardConstraintsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkLaplacianDeformationQuadEdgeMeshFilterWithSoftConstraintsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkNormalQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkNormalQuadEdgeMeshFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkParameterizationQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkParameterizationQuadEdgeMeshFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkQuadricDecimationQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkQuadricDecimationQuadEdgeMeshFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkRegularSphereQuadEdgeMeshSourceTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkRegularSphereQuadEdgeMeshSourceTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkSmoothingQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkSmoothingQuadEdgeMeshFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkSquaredEdgeLengthDecimationQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkSquaredEdgeLengthDecimationQuadEdgeMeshFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/include/itkBoxMeanImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkBoxMeanImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/include/itkBoxMeanImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkBoxMeanImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/include/itkBoxSigmaImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkBoxSigmaImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/include/itkBoxSigmaImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkBoxSigmaImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/include/itkBoxUtilities.h
+++ b/Modules/Filtering/Smoothing/include/itkBoxUtilities.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilterFactory.h
+++ b/Modules/Filtering/Smoothing/include/itkFFTDiscreteGaussianImageFilterFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/include/itkMeanImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkMeanImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/include/itkMeanImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkMeanImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/include/itkMedianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkMedianImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/include/itkMedianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkMedianImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkRecursiveGaussianImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/src/itkFFTDiscreteGaussianImageFilter.cxx
+++ b/Modules/Filtering/Smoothing/src/itkFFTDiscreteGaussianImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/src/itkRecursiveGaussianImageFilter.cxx
+++ b/Modules/Filtering/Smoothing/src/itkRecursiveGaussianImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/test/itkBoxMeanImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkBoxMeanImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/test/itkBoxSigmaImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkBoxSigmaImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/test/itkDiscreteGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkDiscreteGaussianImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/test/itkDiscreteGaussianImageFilterTest2.cxx
+++ b/Modules/Filtering/Smoothing/test/itkDiscreteGaussianImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/test/itkFFTDiscreteGaussianImageFilterFactoryTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkFFTDiscreteGaussianImageFilterFactoryTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/test/itkFFTDiscreteGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkFFTDiscreteGaussianImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/test/itkMeanImageFilterGTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkMeanImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/test/itkMeanImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkMeanImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/test/itkMedianImageFilterGTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkMedianImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/test/itkMedianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkMedianImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterOnTensorsTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterOnTensorsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterOnVectorImageTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterOnVectorImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/test/itkRecursiveGaussianScaleSpaceTest1.cxx
+++ b/Modules/Filtering/Smoothing/test/itkRecursiveGaussianScaleSpaceTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnImageAdaptorTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnImageAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnImageOfVectorTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnImageOfVectorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnVectorImageTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterOnVectorImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/wrapping/test/MeanImageFilterFunctionCallTest.py
+++ b/Modules/Filtering/Smoothing/wrapping/test/MeanImageFilterFunctionCallTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/wrapping/test/MeanImageFilterTest.py
+++ b/Modules/Filtering/Smoothing/wrapping/test/MeanImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/wrapping/test/MedianImageFilterFunctionalDocumentationTest.py
+++ b/Modules/Filtering/Smoothing/wrapping/test/MedianImageFilterFunctionalDocumentationTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/wrapping/test/MedianImageFilterTest.py
+++ b/Modules/Filtering/Smoothing/wrapping/test/MedianImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/Smoothing/wrapping/test/PythonAutoPipelineTest.py
+++ b/Modules/Filtering/Smoothing/wrapping/test/PythonAutoPipelineTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/SpatialFunction/include/itkSpatialFunctionImageEvaluatorFilter.h
+++ b/Modules/Filtering/SpatialFunction/include/itkSpatialFunctionImageEvaluatorFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/SpatialFunction/include/itkSpatialFunctionImageEvaluatorFilter.hxx
+++ b/Modules/Filtering/SpatialFunction/include/itkSpatialFunctionImageEvaluatorFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/SpatialFunction/test/itkSpatialFunctionImageEvaluatorFilterTest.cxx
+++ b/Modules/Filtering/SpatialFunction/test/itkSpatialFunctionImageEvaluatorFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkBinaryThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkBinaryThresholdImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkBinaryThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkBinaryThresholdImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkBinaryThresholdProjectionImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkBinaryThresholdProjectionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkHistogramThresholdCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkHistogramThresholdCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkHuangThresholdCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkHuangThresholdCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkHuangThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkHuangThresholdCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkHuangThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkHuangThresholdImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkIntermodesThresholdCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkIntermodesThresholdCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkIntermodesThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkIntermodesThresholdCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkIntermodesThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkIntermodesThresholdImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkIsoDataThresholdCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkIsoDataThresholdCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkIsoDataThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkIsoDataThresholdCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkIsoDataThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkIsoDataThresholdImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkKittlerIllingworthThresholdCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkKittlerIllingworthThresholdCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkKittlerIllingworthThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkKittlerIllingworthThresholdCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkKittlerIllingworthThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkKittlerIllingworthThresholdImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkLiThresholdCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkLiThresholdCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkLiThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkLiThresholdCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkLiThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkLiThresholdImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkMaximumEntropyThresholdCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkMaximumEntropyThresholdCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkMaximumEntropyThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkMaximumEntropyThresholdCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkMaximumEntropyThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkMaximumEntropyThresholdImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkMomentsThresholdCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkMomentsThresholdCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkMomentsThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkMomentsThresholdCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkMomentsThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkMomentsThresholdImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkOtsuThresholdCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuThresholdCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkOtsuThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkOtsuThresholdCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkOtsuThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkOtsuThresholdImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkRenyiEntropyThresholdCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkRenyiEntropyThresholdCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkRenyiEntropyThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkRenyiEntropyThresholdCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkRenyiEntropyThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkRenyiEntropyThresholdImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkShanbhagThresholdCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkShanbhagThresholdCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkShanbhagThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkShanbhagThresholdCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkShanbhagThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkShanbhagThresholdImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkThresholdImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkThresholdImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkThresholdLabelerImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkThresholdLabelerImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkThresholdLabelerImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkThresholdLabelerImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkTriangleThresholdCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkTriangleThresholdCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkTriangleThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkTriangleThresholdCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkTriangleThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkTriangleThresholdImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkYenThresholdCalculator.h
+++ b/Modules/Filtering/Thresholding/include/itkYenThresholdCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkYenThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkYenThresholdCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/include/itkYenThresholdImageFilter.h
+++ b/Modules/Filtering/Thresholding/include/itkYenThresholdImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkBinaryThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkBinaryThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkBinaryThresholdImageFilterTest2.cxx
+++ b/Modules/Filtering/Thresholding/test/itkBinaryThresholdImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkBinaryThresholdProjectionImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkBinaryThresholdProjectionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkBinaryThresholdSpatialFunctionTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkBinaryThresholdSpatialFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkHuangMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkHuangMaskedThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkHuangThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkHuangThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkIntermodesMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkIntermodesMaskedThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkIntermodesThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkIntermodesThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkIsoDataMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkIsoDataMaskedThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkIsoDataThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkIsoDataThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkKappaSigmaThresholdImageCalculatorTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkKappaSigmaThresholdImageCalculatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkKappaSigmaThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkKappaSigmaThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkKittlerIllingworthMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkKittlerIllingworthMaskedThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkKittlerIllingworthThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkKittlerIllingworthThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkLiMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkLiMaskedThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkLiThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkLiThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkMaximumEntropyMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkMaximumEntropyMaskedThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkMaximumEntropyThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkMaximumEntropyThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkMomentsMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkMomentsMaskedThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkMomentsThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkMomentsThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkOtsuMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuMaskedThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsCalculatorTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsCalculatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsCalculatorTest2.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsCalculatorTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuMultipleThresholdsImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkOtsuThresholdCalculatorTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuThresholdCalculatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkOtsuThresholdCalculatorVersusOtsuMultipleThresholdsCalculatorTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuThresholdCalculatorVersusOtsuMultipleThresholdsCalculatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkOtsuThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkOtsuThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkRenyiEntropyMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkRenyiEntropyMaskedThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkRenyiEntropyThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkRenyiEntropyThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkShanbhagMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkShanbhagMaskedThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkShanbhagThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkShanbhagThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkThresholdLabelerImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkThresholdLabelerImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkTriangleMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkTriangleMaskedThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkTriangleThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkTriangleThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkYenMaskedThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkYenMaskedThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/test/itkYenThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkYenThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/wrapping/test/BinaryThresholdImageFilterTest.py
+++ b/Modules/Filtering/Thresholding/wrapping/test/BinaryThresholdImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Filtering/Thresholding/wrapping/test/ThresholdImageFilterTest.py
+++ b/Modules/Filtering/Thresholding/wrapping/test/ThresholdImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/IO/BMP/include/itkBMPImageIO.h
+++ b/Modules/IO/BMP/include/itkBMPImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/BMP/include/itkBMPImageIOFactory.h
+++ b/Modules/IO/BMP/include/itkBMPImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/BMP/src/itkBMPImageIO.cxx
+++ b/Modules/IO/BMP/src/itkBMPImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/BMP/src/itkBMPImageIOFactory.cxx
+++ b/Modules/IO/BMP/src/itkBMPImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/BMP/test/itkBMPImageIOTest.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/BMP/test/itkBMPImageIOTest2.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/BMP/test/itkBMPImageIOTest3.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/BMP/test/itkBMPImageIOTest4.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTest4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/BMP/test/itkBMPImageIOTest5.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTest5.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/BMP/test/itkBMPImageIOTestExtension.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTestExtension.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/BMP/test/itkBMPImageIOTestPalette.cxx
+++ b/Modules/IO/BMP/test/itkBMPImageIOTestPalette.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/BioRad/include/itkBioRadImageIO.h
+++ b/Modules/IO/BioRad/include/itkBioRadImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/BioRad/include/itkBioRadImageIOFactory.h
+++ b/Modules/IO/BioRad/include/itkBioRadImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
+++ b/Modules/IO/BioRad/src/itkBioRadImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/BioRad/src/itkBioRadImageIOFactory.cxx
+++ b/Modules/IO/BioRad/src/itkBioRadImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/BioRad/test/itkBioRadImageIOTest.cxx
+++ b/Modules/IO/BioRad/test/itkBioRadImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Bruker/include/itkBruker2dseqImageIO.h
+++ b/Modules/IO/Bruker/include/itkBruker2dseqImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Bruker/include/itkBruker2dseqImageIOFactory.h
+++ b/Modules/IO/Bruker/include/itkBruker2dseqImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIOFactory.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Bruker/test/itkBrukerImageTest.cxx
+++ b/Modules/IO/Bruker/test/itkBrukerImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/CSV/include/itkCSVArray2DDataObject.h
+++ b/Modules/IO/CSV/include/itkCSVArray2DDataObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/CSV/include/itkCSVArray2DDataObject.hxx
+++ b/Modules/IO/CSV/include/itkCSVArray2DDataObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/CSV/include/itkCSVArray2DFileReader.h
+++ b/Modules/IO/CSV/include/itkCSVArray2DFileReader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/CSV/include/itkCSVArray2DFileReader.hxx
+++ b/Modules/IO/CSV/include/itkCSVArray2DFileReader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/CSV/include/itkCSVFileReaderBase.h
+++ b/Modules/IO/CSV/include/itkCSVFileReaderBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/CSV/include/itkCSVNumericObjectFileWriter.h
+++ b/Modules/IO/CSV/include/itkCSVNumericObjectFileWriter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/CSV/include/itkCSVNumericObjectFileWriter.hxx
+++ b/Modules/IO/CSV/include/itkCSVNumericObjectFileWriter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/CSV/src/itkCSVFileReaderBase.cxx
+++ b/Modules/IO/CSV/src/itkCSVFileReaderBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/CSV/test/itkCSVArray2DFileReaderTest.cxx
+++ b/Modules/IO/CSV/test/itkCSVArray2DFileReaderTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/CSV/test/itkCSVArray2DFileReaderWriterTest.cxx
+++ b/Modules/IO/CSV/test/itkCSVArray2DFileReaderWriterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/CSV/test/itkCSVNumericObjectFileWriterTest.cxx
+++ b/Modules/IO/CSV/test/itkCSVNumericObjectFileWriterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/DCMTK/include/itkDCMTKFileReader.h
+++ b/Modules/IO/DCMTK/include/itkDCMTKFileReader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/DCMTK/include/itkDCMTKImageIO.h
+++ b/Modules/IO/DCMTK/include/itkDCMTKImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/DCMTK/include/itkDCMTKImageIOFactory.h
+++ b/Modules/IO/DCMTK/include/itkDCMTKImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/DCMTK/include/itkDCMTKSeriesFileNames.h
+++ b/Modules/IO/DCMTK/include/itkDCMTKSeriesFileNames.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/DCMTK/src/itkDCMTKImageIOFactory.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/DCMTK/test/itkDCMTKImageIOMultiFrameImageTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKImageIOMultiFrameImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/DCMTK/test/itkDCMTKImageIONoPreambleTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKImageIONoPreambleTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/DCMTK/test/itkDCMTKImageIOOrthoDirTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKImageIOOrthoDirTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/DCMTK/test/itkDCMTKImageIOSlopeInterceptTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKImageIOSlopeInterceptTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/DCMTK/test/itkDCMTKImageIOSpacingTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKImageIOSpacingTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/DCMTK/test/itkDCMTKImageIOTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/DCMTK/test/itkDCMTKLoggerTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKLoggerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/DCMTK/test/itkDCMTKMultiFrame4DTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKMultiFrame4DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/DCMTK/test/itkDCMTKRGBImageIOTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKRGBImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/DCMTK/test/itkDCMTKSeriesReadImageWrite.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKSeriesReadImageWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/DCMTK/test/itkDCMTKSeriesStreamReadImageWrite.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKSeriesStreamReadImageWrite.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GDCM/include/itkGDCMImageIO.h
+++ b/Modules/IO/GDCM/include/itkGDCMImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GDCM/include/itkGDCMImageIOFactory.h
+++ b/Modules/IO/GDCM/include/itkGDCMImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GDCM/include/itkGDCMSeriesFileNames.h
+++ b/Modules/IO/GDCM/include/itkGDCMSeriesFileNames.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GDCM/src/itkGDCMImageIOFactory.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GDCM/test/itkGDCMImageIO32bitsStoredTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIO32bitsStoredTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GDCM/test/itkGDCMImageIONoCrashTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIONoCrashTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GDCM/test/itkGDCMImageIONoPreambleTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIONoPreambleTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GDCM/test/itkGDCMImageIOOrthoDirTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIOOrthoDirTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GDCM/test/itkGDCMImageIOTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GDCM/test/itkGDCMImageIOTest2.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIOTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GDCM/test/itkGDCMImageOrientationPatientTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageOrientationPatientTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GDCM/test/itkGDCMImagePositionPatientTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImagePositionPatientTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GDCM/test/itkGDCMImageReadSeriesWriteTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageReadSeriesWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GDCM/test/itkGDCMImageReadWriteTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageReadWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GDCM/test/itkGDCMLegacyMultiFrameTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMLegacyMultiFrameTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GDCM/test/itkGDCMLoadImageSpacingTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMLoadImageSpacingTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GDCM/test/itkGDCMSeriesStreamReadImageWriteTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMSeriesStreamReadImageWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GDCM/wrapping/test/ReadDicomAndReadTagTest.py
+++ b/Modules/IO/GDCM/wrapping/test/ReadDicomAndReadTagTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/IO/GE/include/itkGE4ImageIO.h
+++ b/Modules/IO/GE/include/itkGE4ImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GE/include/itkGE4ImageIOFactory.h
+++ b/Modules/IO/GE/include/itkGE4ImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GE/include/itkGE5ImageIO.h
+++ b/Modules/IO/GE/include/itkGE5ImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GE/include/itkGE5ImageIOFactory.h
+++ b/Modules/IO/GE/include/itkGE5ImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GE/include/itkGEAdwImageIO.h
+++ b/Modules/IO/GE/include/itkGEAdwImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GE/include/itkGEAdwImageIOFactory.h
+++ b/Modules/IO/GE/include/itkGEAdwImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GE/include/itkMvtSunf.h
+++ b/Modules/IO/GE/include/itkMvtSunf.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GE/src/Ge4xHdr.h
+++ b/Modules/IO/GE/src/Ge4xHdr.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GE/src/Ge5xHdr.h
+++ b/Modules/IO/GE/src/Ge5xHdr.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GE/src/itkGE4ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE4ImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GE/src/itkGE4ImageIOFactory.cxx
+++ b/Modules/IO/GE/src/itkGE4ImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GE/src/itkGE5ImageIO.cxx
+++ b/Modules/IO/GE/src/itkGE5ImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GE/src/itkGE5ImageIOFactory.cxx
+++ b/Modules/IO/GE/src/itkGE5ImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GE/src/itkGEAdwImageIO.cxx
+++ b/Modules/IO/GE/src/itkGEAdwImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GE/src/itkGEAdwImageIOFactory.cxx
+++ b/Modules/IO/GE/src/itkGEAdwImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GE/test/itkGEImageIOTest.cxx
+++ b/Modules/IO/GE/test/itkGEImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GIPL/include/itkGiplImageIO.h
+++ b/Modules/IO/GIPL/include/itkGiplImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GIPL/include/itkGiplImageIOFactory.h
+++ b/Modules/IO/GIPL/include/itkGiplImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GIPL/src/itkGiplImageIOFactory.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/GIPL/test/itkGiplImageIOTest.cxx
+++ b/Modules/IO/GIPL/test/itkGiplImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/HDF5/include/itkHDF5ImageIO.h
+++ b/Modules/IO/HDF5/include/itkHDF5ImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/HDF5/include/itkHDF5ImageIOFactory.h
+++ b/Modules/IO/HDF5/include/itkHDF5ImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/HDF5/src/itkHDF5ImageIOFactory.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOStreamingReadWriteTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOStreamingReadWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/IPL/include/itkGEImageHeader.h
+++ b/Modules/IO/IPL/include/itkGEImageHeader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/IPL/include/itkIPLCommonImageIO.h
+++ b/Modules/IO/IPL/include/itkIPLCommonImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/IPL/include/itkIPLFileNameList.h
+++ b/Modules/IO/IPL/include/itkIPLFileNameList.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
+++ b/Modules/IO/IPL/src/itkIPLCommonImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/IPL/src/itkIPLFileNameList.cxx
+++ b/Modules/IO/IPL/src/itkIPLFileNameList.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/CMake/itkTestCStyleIOWCharFilename.cxx
+++ b/Modules/IO/ImageBase/CMake/itkTestCStyleIOWCharFilename.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/CMake/itkTestFDStream.cxx
+++ b/Modules/IO/ImageBase/CMake/itkTestFDStream.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/CMake/itkTestIOStreamsWCharFilenameConstructors.cxx
+++ b/Modules/IO/ImageBase/CMake/itkTestIOStreamsWCharFilenameConstructors.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/include/itkArchetypeSeriesFileNames.h
+++ b/Modules/IO/ImageBase/include/itkArchetypeSeriesFileNames.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/include/itkConvertPixelBuffer.h
+++ b/Modules/IO/ImageBase/include/itkConvertPixelBuffer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/include/itkConvertPixelBuffer.hxx
+++ b/Modules/IO/ImageBase/include/itkConvertPixelBuffer.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/include/itkIOCommon.h
+++ b/Modules/IO/ImageBase/include/itkIOCommon.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/include/itkIOTestHelper.h
+++ b/Modules/IO/ImageBase/include/itkIOTestHelper.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/include/itkImageFileReader.h
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/include/itkImageFileReaderException.h
+++ b/Modules/IO/ImageBase/include/itkImageFileReaderException.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.h
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/include/itkImageIOBase.h
+++ b/Modules/IO/ImageBase/include/itkImageIOBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/include/itkImageIOFactory.h
+++ b/Modules/IO/ImageBase/include/itkImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.h
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesReader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.h
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/include/itkInternationalizationIOHelpers.h
+++ b/Modules/IO/ImageBase/include/itkInternationalizationIOHelpers.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/include/itkNumericSeriesFileNames.h
+++ b/Modules/IO/ImageBase/include/itkNumericSeriesFileNames.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/include/itkRegularExpressionSeriesFileNames.h
+++ b/Modules/IO/ImageBase/include/itkRegularExpressionSeriesFileNames.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/include/itkStreamingImageIOBase.h
+++ b/Modules/IO/ImageBase/include/itkStreamingImageIOBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/src/itkArchetypeSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkArchetypeSeriesFileNames.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/src/itkIOCommon.cxx
+++ b/Modules/IO/ImageBase/src/itkIOCommon.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/src/itkImageFileReaderException.cxx
+++ b/Modules/IO/ImageBase/src/itkImageFileReaderException.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/src/itkImageFileWriter.cxx
+++ b/Modules/IO/ImageBase/src/itkImageFileWriter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/src/itkImageIOFactory.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/src/itkImageSeriesWriter.cxx
+++ b/Modules/IO/ImageBase/src/itkImageSeriesWriter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/src/itkNumericSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkNumericSeriesFileNames.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/src/itkRawImageIOUtilities.cxx
+++ b/Modules/IO/ImageBase/src/itkRawImageIOUtilities.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/src/itkRegularExpressionSeriesFileNames.cxx
+++ b/Modules/IO/ImageBase/src/itkRegularExpressionSeriesFileNames.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/src/itkStreamingImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkStreamingImageIOBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itk64bitTest.cxx
+++ b/Modules/IO/ImageBase/test/itk64bitTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkArchetypeSeriesFileNamesTest.cxx
+++ b/Modules/IO/ImageBase/test/itkArchetypeSeriesFileNamesTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkConvertBufferTest.cxx
+++ b/Modules/IO/ImageBase/test/itkConvertBufferTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkConvertBufferTest2.cxx
+++ b/Modules/IO/ImageBase/test/itkConvertBufferTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkFileFreeImageIO.cxx
+++ b/Modules/IO/ImageBase/test/itkFileFreeImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkFileFreeImageIO.h
+++ b/Modules/IO/ImageBase/test/itkFileFreeImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkFileFreeImageIOFactory.cxx
+++ b/Modules/IO/ImageBase/test/itkFileFreeImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkFileFreeImageIOFactory.h
+++ b/Modules/IO/ImageBase/test/itkFileFreeImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkIOCommonTest.cxx
+++ b/Modules/IO/ImageBase/test/itkIOCommonTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkIOCommonTest2.cxx
+++ b/Modules/IO/ImageBase/test/itkIOCommonTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkIOPluginTest.cxx
+++ b/Modules/IO/ImageBase/test/itkIOPluginTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageFileReaderDimensionsTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileReaderDimensionsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageFileReaderManyComponentVectorTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileReaderManyComponentVectorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageFileReaderPositiveSpacingTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileReaderPositiveSpacingTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageFileReaderStreamingTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileReaderStreamingTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageFileReaderStreamingTest2.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileReaderStreamingTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageFileReaderTest1.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileReaderTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageFileWriterPastingTest1.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterPastingTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageFileWriterPastingTest2.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterPastingTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageFileWriterPastingTest3.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterPastingTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageFileWriterStreamingPastingCompressingTest1.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterStreamingPastingCompressingTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageFileWriterStreamingTest1.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterStreamingTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageFileWriterStreamingTest2.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterStreamingTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageFileWriterTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageFileWriterTest2.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageFileWriterUpdateLargestPossibleRegionTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterUpdateLargestPossibleRegionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageIOBaseTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageIOBaseTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageIODirection2DTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageIODirection2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageIODirection3DTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageIODirection3DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageIOFileNameExtensionsTests.cxx
+++ b/Modules/IO/ImageBase/test/itkImageIOFileNameExtensionsTests.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageSeriesReaderDimensionsTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageSeriesReaderDimensionsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageSeriesReaderSamplingTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageSeriesReaderSamplingTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageSeriesReaderVectorTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageSeriesReaderVectorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkImageSeriesWriterTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageSeriesWriterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkLargeImageWriteConvertReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkLargeImageWriteConvertReadTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkLargeImageWriteReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkLargeImageWriteReadTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkMatrixImageWriteReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkMatrixImageWriteReadTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkNoiseImageFilterTest.cxx
+++ b/Modules/IO/ImageBase/test/itkNoiseImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkNumericSeriesFileNamesTest.cxx
+++ b/Modules/IO/ImageBase/test/itkNumericSeriesFileNamesTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkReadWriteImageWithDictionaryTest.cxx
+++ b/Modules/IO/ImageBase/test/itkReadWriteImageWithDictionaryTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkRegularExpressionSeriesFileNamesTest.cxx
+++ b/Modules/IO/ImageBase/test/itkRegularExpressionSeriesFileNamesTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkUnicodeIOTest.cxx
+++ b/Modules/IO/ImageBase/test/itkUnicodeIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkVectorImageReadWriteTest.cxx
+++ b/Modules/IO/ImageBase/test/itkVectorImageReadWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/ImageBase/test/itkWriteImageFunctionGTest.cxx
+++ b/Modules/IO/ImageBase/test/itkWriteImageFunctionGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG/include/itkJPEGImageIO.h
+++ b/Modules/IO/JPEG/include/itkJPEGImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG/include/itkJPEGImageIOFactory.h
+++ b/Modules/IO/JPEG/include/itkJPEGImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
+++ b/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG/src/itkJPEGImageIOFactory.cxx
+++ b/Modules/IO/JPEG/src/itkJPEGImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG/test/itkJPEGImageIOBrokenCasesTest.cxx
+++ b/Modules/IO/JPEG/test/itkJPEGImageIOBrokenCasesTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG/test/itkJPEGImageIOCMYKTest.cxx
+++ b/Modules/IO/JPEG/test/itkJPEGImageIOCMYKTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG/test/itkJPEGImageIODegenerateCasesTest.cxx
+++ b/Modules/IO/JPEG/test/itkJPEGImageIODegenerateCasesTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG/test/itkJPEGImageIOTest.cxx
+++ b/Modules/IO/JPEG/test/itkJPEGImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG/test/itkJPEGImageIOTest2.cxx
+++ b/Modules/IO/JPEG/test/itkJPEGImageIOTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG2000/include/itkJPEG2000ImageIO.h
+++ b/Modules/IO/JPEG2000/include/itkJPEG2000ImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG2000/include/itkJPEG2000ImageIOFactory.h
+++ b/Modules/IO/JPEG2000/include/itkJPEG2000ImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
+++ b/Modules/IO/JPEG2000/src/itkJPEG2000ImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG2000/src/itkJPEG2000ImageIOFactory.cxx
+++ b/Modules/IO/JPEG2000/src/itkJPEG2000ImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOFactoryTest01.cxx
+++ b/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOFactoryTest01.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG2000/test/itkJPEG2000ImageIORegionOfInterest.cxx
+++ b/Modules/IO/JPEG2000/test/itkJPEG2000ImageIORegionOfInterest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest00.cxx
+++ b/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest00.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest01.cxx
+++ b/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest01.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest02.cxx
+++ b/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest02.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest03.cxx
+++ b/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest03.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest04.cxx
+++ b/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest04.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest05.cxx
+++ b/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest05.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest06.cxx
+++ b/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOTest06.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/LSM/include/itkLSMImageIO.h
+++ b/Modules/IO/LSM/include/itkLSMImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/LSM/include/itkLSMImageIOFactory.h
+++ b/Modules/IO/LSM/include/itkLSMImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/LSM/src/itkLSMImageIO.cxx
+++ b/Modules/IO/LSM/src/itkLSMImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/LSM/src/itkLSMImageIOFactory.cxx
+++ b/Modules/IO/LSM/src/itkLSMImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/LSM/test/itkLSMImageIOTest.cxx
+++ b/Modules/IO/LSM/test/itkLSMImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MINC/include/itkMINCImageIO.h
+++ b/Modules/IO/MINC/include/itkMINCImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MINC/include/itkMINCImageIOFactory.h
+++ b/Modules/IO/MINC/include/itkMINCImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MINC/src/itkMINCImageIOFactory.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MINC/test/itkMINCImageIOTest2.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MINC/test/itkMINCImageIOTest4.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MINC/test/itkMINCImageIOTest_2D.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest_2D.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MINC/test/itkMINCImageIOTest_4D.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest_4D.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MINC/test/itkMINCImageIOTest_Labels.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest_Labels.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MRC/include/itkMRCHeaderObject.h
+++ b/Modules/IO/MRC/include/itkMRCHeaderObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MRC/include/itkMRCImageIO.h
+++ b/Modules/IO/MRC/include/itkMRCImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MRC/include/itkMRCImageIOFactory.h
+++ b/Modules/IO/MRC/include/itkMRCImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MRC/src/itkMRCHeaderObject.cxx
+++ b/Modules/IO/MRC/src/itkMRCHeaderObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MRC/src/itkMRCImageIO.cxx
+++ b/Modules/IO/MRC/src/itkMRCImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MRC/src/itkMRCImageIOFactory.cxx
+++ b/Modules/IO/MRC/src/itkMRCImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MRC/src/itkMRCImageIOPrivate.h
+++ b/Modules/IO/MRC/src/itkMRCImageIOPrivate.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MRC/test/itkMRCImageIOTest.cxx
+++ b/Modules/IO/MRC/test/itkMRCImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MRC/test/itkMRCImageIOTest2.cxx
+++ b/Modules/IO/MRC/test/itkMRCImageIOTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Mesh/test/itkMeshFileReadWriteTest.cxx
+++ b/Modules/IO/Mesh/test/itkMeshFileReadWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBYU/include/itkBYUMeshIO.h
+++ b/Modules/IO/MeshBYU/include/itkBYUMeshIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBYU/include/itkBYUMeshIOFactory.h
+++ b/Modules/IO/MeshBYU/include/itkBYUMeshIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
+++ b/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBYU/src/itkBYUMeshIOFactory.cxx
+++ b/Modules/IO/MeshBYU/src/itkBYUMeshIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBYU/test/itkBYUMeshIOTest.cxx
+++ b/Modules/IO/MeshBYU/test/itkBYUMeshIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBYU/test/itkMeshFileReadWriteTest.cxx
+++ b/Modules/IO/MeshBYU/test/itkMeshFileReadWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBase/include/itkConvertArrayPixelBuffer.h
+++ b/Modules/IO/MeshBase/include/itkConvertArrayPixelBuffer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBase/include/itkConvertArrayPixelBuffer.hxx
+++ b/Modules/IO/MeshBase/include/itkConvertArrayPixelBuffer.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBase/include/itkConvertVariableLengthVectorPixelBuffer.h
+++ b/Modules/IO/MeshBase/include/itkConvertVariableLengthVectorPixelBuffer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBase/include/itkConvertVariableLengthVectorPixelBuffer.hxx
+++ b/Modules/IO/MeshBase/include/itkConvertVariableLengthVectorPixelBuffer.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBase/include/itkMeshConvertPixelTraits.h
+++ b/Modules/IO/MeshBase/include/itkMeshConvertPixelTraits.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileReader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBase/include/itkMeshFileReaderException.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileReaderException.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBase/include/itkMeshFileTestHelper.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileTestHelper.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBase/include/itkMeshFileWriter.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBase/include/itkMeshFileWriterException.h
+++ b/Modules/IO/MeshBase/include/itkMeshFileWriterException.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBase/include/itkMeshIOBase.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBase/include/itkMeshIOFactory.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBase/include/itkMeshIOTestHelper.h
+++ b/Modules/IO/MeshBase/include/itkMeshIOTestHelper.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBase/src/itkMeshFileReaderException.cxx
+++ b/Modules/IO/MeshBase/src/itkMeshFileReaderException.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBase/src/itkMeshFileWriterException.cxx
+++ b/Modules/IO/MeshBase/src/itkMeshFileWriterException.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBase/src/itkMeshIOBase.cxx
+++ b/Modules/IO/MeshBase/src/itkMeshIOBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBase/src/itkMeshIOFactory.cxx
+++ b/Modules/IO/MeshBase/src/itkMeshIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshBase/test/itkMeshFileReaderWriterTest.cxx
+++ b/Modules/IO/MeshBase/test/itkMeshFileReaderWriterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshFreeSurfer/include/itkFreeSurferAsciiMeshIO.h
+++ b/Modules/IO/MeshFreeSurfer/include/itkFreeSurferAsciiMeshIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshFreeSurfer/include/itkFreeSurferAsciiMeshIOFactory.h
+++ b/Modules/IO/MeshFreeSurfer/include/itkFreeSurferAsciiMeshIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshFreeSurfer/include/itkFreeSurferBinaryMeshIO.h
+++ b/Modules/IO/MeshFreeSurfer/include/itkFreeSurferBinaryMeshIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshFreeSurfer/include/itkFreeSurferBinaryMeshIOFactory.h
+++ b/Modules/IO/MeshFreeSurfer/include/itkFreeSurferBinaryMeshIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIOFactory.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferAsciiMeshIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIOFactory.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshFreeSurfer/test/itkFreeSurferMeshIOTest.cxx
+++ b/Modules/IO/MeshFreeSurfer/test/itkFreeSurferMeshIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshFreeSurfer/test/itkMeshFileReadWriteTest.cxx
+++ b/Modules/IO/MeshFreeSurfer/test/itkMeshFileReadWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshGifti/include/itkGiftiMeshIO.h
+++ b/Modules/IO/MeshGifti/include/itkGiftiMeshIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshGifti/include/itkGiftiMeshIOFactory.h
+++ b/Modules/IO/MeshGifti/include/itkGiftiMeshIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshGifti/src/itkGiftiMeshIO.cxx
+++ b/Modules/IO/MeshGifti/src/itkGiftiMeshIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshGifti/src/itkGiftiMeshIOFactory.cxx
+++ b/Modules/IO/MeshGifti/src/itkGiftiMeshIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshGifti/test/itkGiftiMeshIOTest.cxx
+++ b/Modules/IO/MeshGifti/test/itkGiftiMeshIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshGifti/test/itkMeshFileReadWriteTest.cxx
+++ b/Modules/IO/MeshGifti/test/itkMeshFileReadWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshOBJ/include/itkOBJMeshIO.h
+++ b/Modules/IO/MeshOBJ/include/itkOBJMeshIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshOBJ/include/itkOBJMeshIOFactory.h
+++ b/Modules/IO/MeshOBJ/include/itkOBJMeshIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
+++ b/Modules/IO/MeshOBJ/src/itkOBJMeshIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshOBJ/src/itkOBJMeshIOFactory.cxx
+++ b/Modules/IO/MeshOBJ/src/itkOBJMeshIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshOBJ/test/itkMeshFileReadWriteTest.cxx
+++ b/Modules/IO/MeshOBJ/test/itkMeshFileReadWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshOBJ/test/itkOBJMeshIOTest.cxx
+++ b/Modules/IO/MeshOBJ/test/itkOBJMeshIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshOFF/include/itkOFFMeshIO.h
+++ b/Modules/IO/MeshOFF/include/itkOFFMeshIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshOFF/include/itkOFFMeshIOFactory.h
+++ b/Modules/IO/MeshOFF/include/itkOFFMeshIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
+++ b/Modules/IO/MeshOFF/src/itkOFFMeshIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshOFF/src/itkOFFMeshIOFactory.cxx
+++ b/Modules/IO/MeshOFF/src/itkOFFMeshIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshOFF/test/itkMeshFileReadWriteTest.cxx
+++ b/Modules/IO/MeshOFF/test/itkMeshFileReadWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshOFF/test/itkOFFMeshIOTest.cxx
+++ b/Modules/IO/MeshOFF/test/itkOFFMeshIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIO.h
+++ b/Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIOFactory.h
+++ b/Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
+++ b/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIOFactory.cxx
+++ b/Modules/IO/MeshVTK/src/itkVTKPolyDataMeshIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshVTK/test/itkMeshFileReadWriteTest.cxx
+++ b/Modules/IO/MeshVTK/test/itkMeshFileReadWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshVTK/test/itkMeshFileReadWriteVectorAttributeTest.cxx
+++ b/Modules/IO/MeshVTK/test/itkMeshFileReadWriteVectorAttributeTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshVTK/test/itkMeshFileWriteReadTensorTest.cxx
+++ b/Modules/IO/MeshVTK/test/itkMeshFileWriteReadTensorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshVTK/test/itkPolylineReadWriteTest.cxx
+++ b/Modules/IO/MeshVTK/test/itkPolylineReadWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshVTK/test/itkVTKPolyDataMeshCanReadImageTest.cxx
+++ b/Modules/IO/MeshVTK/test/itkVTKPolyDataMeshCanReadImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshVTK/test/itkVTKPolyDataMeshIOGTest.cxx
+++ b/Modules/IO/MeshVTK/test/itkVTKPolyDataMeshIOGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/MeshVTK/test/itkVTKPolyDataMeshIOTest.cxx
+++ b/Modules/IO/MeshVTK/test/itkVTKPolyDataMeshIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/include/itkMetaArrayReader.h
+++ b/Modules/IO/Meta/include/itkMetaArrayReader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/include/itkMetaArrayWriter.h
+++ b/Modules/IO/Meta/include/itkMetaArrayWriter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/include/itkMetaImageIO.h
+++ b/Modules/IO/Meta/include/itkMetaImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/include/itkMetaImageIOFactory.h
+++ b/Modules/IO/Meta/include/itkMetaImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/src/itkMetaArrayReader.cxx
+++ b/Modules/IO/Meta/src/itkMetaArrayReader.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/src/itkMetaArrayWriter.cxx
+++ b/Modules/IO/Meta/src/itkMetaArrayWriter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/src/itkMetaImageIO.cxx
+++ b/Modules/IO/Meta/src/itkMetaImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/src/itkMetaImageIOFactory.cxx
+++ b/Modules/IO/Meta/src/itkMetaImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/test/itkLargeMetaImageWriteReadTest.cxx
+++ b/Modules/IO/Meta/test/itkLargeMetaImageWriteReadTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/test/itkMetaImageIOGzTest.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageIOGzTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/test/itkMetaImageIOMetaDataTest.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageIOMetaDataTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/test/itkMetaImageIOTest.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/test/itkMetaImageIOTest2.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageIOTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/test/itkMetaImageStreamingIOTest.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageStreamingIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/test/itkMetaImageStreamingWriterIOTest.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageStreamingWriterIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/test/itkMetaTestLongFilename.cxx
+++ b/Modules/IO/Meta/test/itkMetaTestLongFilename.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/test/testMetaArray.cxx
+++ b/Modules/IO/Meta/test/testMetaArray.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/test/testMetaCommand.cxx
+++ b/Modules/IO/Meta/test/testMetaCommand.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/test/testMetaGroup.cxx
+++ b/Modules/IO/Meta/test/testMetaGroup.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/test/testMetaImage.cxx
+++ b/Modules/IO/Meta/test/testMetaImage.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Meta/test/testMetaMesh.cxx
+++ b/Modules/IO/Meta/test/testMetaMesh.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/include/itkNiftiImageIO.h
+++ b/Modules/IO/NIFTI/include/itkNiftiImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/include/itkNiftiImageIOFactory.h
+++ b/Modules/IO/NIFTI/include/itkNiftiImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/src/itkNiftiImageIOFactory.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/BigEndian_hdr.h
+++ b/Modules/IO/NIFTI/test/BigEndian_hdr.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/BigEndian_img.h
+++ b/Modules/IO/NIFTI/test/BigEndian_img.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/LittleEndian_hdr.h
+++ b/Modules/IO/NIFTI/test/LittleEndian_hdr.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/LittleEndian_img.h
+++ b/Modules/IO/NIFTI/test/LittleEndian_img.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkExtractSlice.cxx
+++ b/Modules/IO/NIFTI/test/itkExtractSlice.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest10.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest10.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest11.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest11.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest12.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest12.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest13.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest13.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest14.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest14.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest2.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest4.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest5.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest5.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest6.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest6.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest7.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest7.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest8.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest8.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest9.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest9.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTestHelper.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTestHelper.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkNiftiLargeImageRegionReadTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiLargeImageRegionReadTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkNiftiReadAnalyzeTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiReadAnalyzeTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkNiftiReadWriteDirectionTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiReadWriteDirectionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NIFTI/test/itkNiftiWriteCoerceOrthogonalDirectionTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiWriteCoerceOrthogonalDirectionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/include/itkNrrdImageIO.h
+++ b/Modules/IO/NRRD/include/itkNrrdImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/include/itkNrrdImageIOFactory.h
+++ b/Modules/IO/NRRD/include/itkNrrdImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
+++ b/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/src/itkNrrdImageIOFactory.cxx
+++ b/Modules/IO/NRRD/src/itkNrrdImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/test/itkNrrd5dVectorImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrd5dVectorImageReadWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/test/itkNrrdComplexImageReadTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdComplexImageReadTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/test/itkNrrdComplexImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdComplexImageReadWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/test/itkNrrdCovariantVectorImageReadTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdCovariantVectorImageReadTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/test/itkNrrdCovariantVectorImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdCovariantVectorImageReadWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/test/itkNrrdDiffusionTensor3DImageReadTensorDoubleWriteTensorDoubleTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdDiffusionTensor3DImageReadTensorDoubleWriteTensorDoubleTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/test/itkNrrdDiffusionTensor3DImageReadTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdDiffusionTensor3DImageReadTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/test/itkNrrdDiffusionTensor3DImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdDiffusionTensor3DImageReadWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/test/itkNrrdImageIOTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/test/itkNrrdImageIOTest.h
+++ b/Modules/IO/NRRD/test/itkNrrdImageIOTest.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/test/itkNrrdImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdImageReadWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/test/itkNrrdLocaleTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdLocaleTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/test/itkNrrdMetaDataTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdMetaDataTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/test/itkNrrdRGBAImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdRGBAImageReadWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/test/itkNrrdRGBImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdRGBImageReadWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/test/itkNrrdVectorImageReadTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdVectorImageReadTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/test/itkNrrdVectorImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdVectorImageReadWriteTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/NRRD/test/itkNrrdVectorImageUnitLabelReadTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdVectorImageUnitLabelReadTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/PNG/include/itkPNGImageIO.h
+++ b/Modules/IO/PNG/include/itkPNGImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/PNG/include/itkPNGImageIOFactory.h
+++ b/Modules/IO/PNG/include/itkPNGImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/PNG/src/itkPNGImageIOFactory.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/PNG/test/itkPNGImageIOTest.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/PNG/test/itkPNGImageIOTest2.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/PNG/test/itkPNGImageIOTest3.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/PNG/test/itkPNGImageIOTestPalette.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTestPalette.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/PhilipsREC/include/itkPhilipsPAR.h
+++ b/Modules/IO/PhilipsREC/include/itkPhilipsPAR.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/PhilipsREC/include/itkPhilipsRECImageIO.h
+++ b/Modules/IO/PhilipsREC/include/itkPhilipsRECImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/PhilipsREC/include/itkPhilipsRECImageIOFactory.h
+++ b/Modules/IO/PhilipsREC/include/itkPhilipsRECImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/PhilipsREC/src/itkPhilipsPAR.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsPAR.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIOFactory.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsRECImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOOrientationTest.cxx
+++ b/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOOrientationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOPrintTest.cxx
+++ b/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOPrintTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOTest.cxx
+++ b/Modules/IO/PhilipsREC/test/itkPhilipsRECImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/RAW/include/itkRawImageIO.h
+++ b/Modules/IO/RAW/include/itkRawImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/RAW/include/itkRawImageIO.hxx
+++ b/Modules/IO/RAW/include/itkRawImageIO.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/RAW/test/itkRawImageIOTest.cxx
+++ b/Modules/IO/RAW/test/itkRawImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/RAW/test/itkRawImageIOTest2.cxx
+++ b/Modules/IO/RAW/test/itkRawImageIOTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/RAW/test/itkRawImageIOTest3.cxx
+++ b/Modules/IO/RAW/test/itkRawImageIOTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/RAW/test/itkRawImageIOTest4.cxx
+++ b/Modules/IO/RAW/test/itkRawImageIOTest4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/RAW/test/itkRawImageIOTest5.cxx
+++ b/Modules/IO/RAW/test/itkRawImageIOTest5.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Siemens/include/itkSiemensVisionImageIO.h
+++ b/Modules/IO/Siemens/include/itkSiemensVisionImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Siemens/include/itkSiemensVisionImageIOFactory.h
+++ b/Modules/IO/Siemens/include/itkSiemensVisionImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Siemens/src/itkSiemensVisionImageIO.cxx
+++ b/Modules/IO/Siemens/src/itkSiemensVisionImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Siemens/src/itkSiemensVisionImageIOFactory.cxx
+++ b/Modules/IO/Siemens/src/itkSiemensVisionImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/SpatialObjects/include/itkPolygonGroupSpatialObjectXMLFile.h
+++ b/Modules/IO/SpatialObjects/include/itkPolygonGroupSpatialObjectXMLFile.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/SpatialObjects/include/itkSpatialObjectReader.h
+++ b/Modules/IO/SpatialObjects/include/itkSpatialObjectReader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/SpatialObjects/include/itkSpatialObjectReader.hxx
+++ b/Modules/IO/SpatialObjects/include/itkSpatialObjectReader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.h
+++ b/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.hxx
+++ b/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
+++ b/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/SpatialObjects/test/itkPolygonGroupSpatialObjectXMLFileTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkPolygonGroupSpatialObjectXMLFileTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/SpatialObjects/test/itkPolygonGroupXMLMalformedTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkPolygonGroupXMLMalformedTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/SpatialObjects/test/itkReadVesselTubeSpatialObjectTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkReadVesselTubeSpatialObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Stimulate/include/itkStimulateImageIO.h
+++ b/Modules/IO/Stimulate/include/itkStimulateImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Stimulate/include/itkStimulateImageIOFactory.h
+++ b/Modules/IO/Stimulate/include/itkStimulateImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
+++ b/Modules/IO/Stimulate/src/itkStimulateImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Stimulate/src/itkStimulateImageIOFactory.cxx
+++ b/Modules/IO/Stimulate/src/itkStimulateImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Stimulate/test/itkStimulateImageIOTest.cxx
+++ b/Modules/IO/Stimulate/test/itkStimulateImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/Stimulate/test/itkStimulateImageIOTest2.cxx
+++ b/Modules/IO/Stimulate/test/itkStimulateImageIOTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TIFF/include/itkTIFFImageIO.h
+++ b/Modules/IO/TIFF/include/itkTIFFImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TIFF/include/itkTIFFImageIOFactory.h
+++ b/Modules/IO/TIFF/include/itkTIFFImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TIFF/src/itkTIFFImageIOFactory.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TIFF/src/itkTIFFReaderInternal.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFReaderInternal.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TIFF/src/itkTIFFReaderInternal.h
+++ b/Modules/IO/TIFF/src/itkTIFFReaderInternal.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TIFF/test/itkImageSeriesReaderReverse.cxx
+++ b/Modules/IO/TIFF/test/itkImageSeriesReaderReverse.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TIFF/test/itkLargeTIFFImageWriteReadTest.cxx
+++ b/Modules/IO/TIFF/test/itkLargeTIFFImageWriteReadTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TIFF/test/itkTIFFImageIOCompressionTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOCompressionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TIFF/test/itkTIFFImageIOInfoTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOInfoTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TIFF/test/itkTIFFImageIOIntPixelTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOIntPixelTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TIFF/test/itkTIFFImageIOTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TIFF/test/itkTIFFImageIOTest2.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TIFF/test/itkTIFFImageIOTestPalette.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOTestPalette.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformBase/include/itkCompositeTransformIOHelper.h
+++ b/Modules/IO/TransformBase/include/itkCompositeTransformIOHelper.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformBase/include/itkTransformFileReader.h
+++ b/Modules/IO/TransformBase/include/itkTransformFileReader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformBase/include/itkTransformFileWriter.h
+++ b/Modules/IO/TransformBase/include/itkTransformFileWriter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformBase/include/itkTransformIOBase.h
+++ b/Modules/IO/TransformBase/include/itkTransformIOBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformBase/include/itkTransformIOFactory.h
+++ b/Modules/IO/TransformBase/include/itkTransformIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformBase/src/itkCompositeTransformIOHelper.cxx
+++ b/Modules/IO/TransformBase/src/itkCompositeTransformIOHelper.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformBase/src/itkTransformFileReader.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformFileReader.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformBase/src/itkTransformFileWriterSpecializations.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformFileWriterSpecializations.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformBase/src/itkTransformIOBase.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformIOBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformBase/src/itkTransformIOFactory.cxx
+++ b/Modules/IO/TransformBase/src/itkTransformIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformBase/test/itkTransformFileReaderTemplateTest.cxx
+++ b/Modules/IO/TransformBase/test/itkTransformFileReaderTemplateTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformBase/test/itkTransformFileReaderTest.cxx
+++ b/Modules/IO/TransformBase/test/itkTransformFileReaderTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformBase/test/itkTransformFileWriterTemplateTest.cxx
+++ b/Modules/IO/TransformBase/test/itkTransformFileWriterTemplateTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformBase/test/itkTransformFileWriterTest.cxx
+++ b/Modules/IO/TransformBase/test/itkTransformFileWriterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformFactory/include/itkTransformFactory.h
+++ b/Modules/IO/TransformFactory/include/itkTransformFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformFactory/include/itkTransformFactoryBase.h
+++ b/Modules/IO/TransformFactory/include/itkTransformFactoryBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformFactory/src/itkTransformFactoryBase.cxx
+++ b/Modules/IO/TransformFactory/src/itkTransformFactoryBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformFactory/src/itkTransformFactoryBaseRegister.hxx
+++ b/Modules/IO/TransformFactory/src/itkTransformFactoryBaseRegister.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformFactory/src/itkTransformFactoryBaseRegisterDoubleParameters.cxx
+++ b/Modules/IO/TransformFactory/src/itkTransformFactoryBaseRegisterDoubleParameters.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformFactory/src/itkTransformFactoryBaseRegisterFloatParameters.cxx
+++ b/Modules/IO/TransformFactory/src/itkTransformFactoryBaseRegisterFloatParameters.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformFactory/test/itkTransformFactoryBaseTest.cxx
+++ b/Modules/IO/TransformFactory/test/itkTransformFactoryBaseTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformHDF5/include/itkHDF5TransformIO.h
+++ b/Modules/IO/TransformHDF5/include/itkHDF5TransformIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformHDF5/include/itkHDF5TransformIOFactory.h
+++ b/Modules/IO/TransformHDF5/include/itkHDF5TransformIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
+++ b/Modules/IO/TransformHDF5/src/itkHDF5TransformIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformHDF5/src/itkHDF5TransformIOFactory.cxx
+++ b/Modules/IO/TransformHDF5/src/itkHDF5TransformIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformHDF5/test/itkIOTransformHDF5Test.cxx
+++ b/Modules/IO/TransformHDF5/test/itkIOTransformHDF5Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformHDF5/test/itkThinPlateTransformWriteReadTest.cxx
+++ b/Modules/IO/TransformHDF5/test/itkThinPlateTransformWriteReadTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformInsightLegacy/include/itkTxtTransformIO.h
+++ b/Modules/IO/TransformInsightLegacy/include/itkTxtTransformIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformInsightLegacy/include/itkTxtTransformIOFactory.h
+++ b/Modules/IO/TransformInsightLegacy/include/itkTxtTransformIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformInsightLegacy/src/itkTxtTransformIO.cxx
+++ b/Modules/IO/TransformInsightLegacy/src/itkTxtTransformIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformInsightLegacy/src/itkTxtTransformIOFactory.cxx
+++ b/Modules/IO/TransformInsightLegacy/src/itkTxtTransformIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformInsightLegacy/test/itkIOEuler3DTransformTxtTest.cxx
+++ b/Modules/IO/TransformInsightLegacy/test/itkIOEuler3DTransformTxtTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformInsightLegacy/test/itkIOTransformTxtTest.cxx
+++ b/Modules/IO/TransformInsightLegacy/test/itkIOTransformTxtTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformMINC/include/itkMINCTransformAdapter.h
+++ b/Modules/IO/TransformMINC/include/itkMINCTransformAdapter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformMINC/include/itkMINCTransformIO.h
+++ b/Modules/IO/TransformMINC/include/itkMINCTransformIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformMINC/include/itkMINCTransformIOFactory.h
+++ b/Modules/IO/TransformMINC/include/itkMINCTransformIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx
+++ b/Modules/IO/TransformMINC/src/itkMINCTransformIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformMINC/src/itkMINCTransformIOFactory.cxx
+++ b/Modules/IO/TransformMINC/src/itkMINCTransformIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformMINC/test/itkMINCTransformAdapterTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkMINCTransformAdapterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformMatlab/include/itkMatlabTransformIO.h
+++ b/Modules/IO/TransformMatlab/include/itkMatlabTransformIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformMatlab/include/itkMatlabTransformIOFactory.h
+++ b/Modules/IO/TransformMatlab/include/itkMatlabTransformIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformMatlab/src/itkMatlabTransformIO.cxx
+++ b/Modules/IO/TransformMatlab/src/itkMatlabTransformIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformMatlab/src/itkMatlabTransformIOFactory.cxx
+++ b/Modules/IO/TransformMatlab/src/itkMatlabTransformIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/TransformMatlab/test/itkIOTransformMatlabGTest.cxx
+++ b/Modules/IO/TransformMatlab/test/itkIOTransformMatlabGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/VTK/include/itkVTKImageIO.h
+++ b/Modules/IO/VTK/include/itkVTKImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/VTK/include/itkVTKImageIOFactory.h
+++ b/Modules/IO/VTK/include/itkVTKImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/VTK/src/itkVTKImageIOFactory.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/VTK/test/itkVTKImageIO2Test.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIO2Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/VTK/test/itkVTKImageIO2Test2.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIO2Test2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/VTK/test/itkVTKImageIOFileReadTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOFileReadTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/VTK/test/itkVTKImageIOStreamTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOStreamTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/VTK/test/itkVTKImageIOTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/VTK/test/itkVTKImageIOTest2.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/VTK/test/itkVTKImageIOTest3.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/include/itkDOMNode.h
+++ b/Modules/IO/XML/include/itkDOMNode.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/include/itkDOMNodeXMLReader.h
+++ b/Modules/IO/XML/include/itkDOMNodeXMLReader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/include/itkDOMNodeXMLWriter.h
+++ b/Modules/IO/XML/include/itkDOMNodeXMLWriter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/include/itkDOMReader.h
+++ b/Modules/IO/XML/include/itkDOMReader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/include/itkDOMReader.hxx
+++ b/Modules/IO/XML/include/itkDOMReader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/include/itkDOMTextNode.h
+++ b/Modules/IO/XML/include/itkDOMTextNode.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/include/itkDOMWriter.h
+++ b/Modules/IO/XML/include/itkDOMWriter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/include/itkDOMWriter.hxx
+++ b/Modules/IO/XML/include/itkDOMWriter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/include/itkFancyString.h
+++ b/Modules/IO/XML/include/itkFancyString.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/include/itkFancyString.hxx
+++ b/Modules/IO/XML/include/itkFancyString.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/include/itkFileTools.h
+++ b/Modules/IO/XML/include/itkFileTools.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/include/itkStringTools.h
+++ b/Modules/IO/XML/include/itkStringTools.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/include/itkStringTools.hxx
+++ b/Modules/IO/XML/include/itkStringTools.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/include/itkXMLFile.h
+++ b/Modules/IO/XML/include/itkXMLFile.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/src/itkDOMNode.cxx
+++ b/Modules/IO/XML/src/itkDOMNode.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/src/itkDOMNodeXMLReader.cxx
+++ b/Modules/IO/XML/src/itkDOMNodeXMLReader.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/src/itkDOMNodeXMLWriter.cxx
+++ b/Modules/IO/XML/src/itkDOMNodeXMLWriter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/src/itkFancyString.cxx
+++ b/Modules/IO/XML/src/itkFancyString.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/src/itkStringTools.cxx
+++ b/Modules/IO/XML/src/itkStringTools.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/src/itkXMLFile.cxx
+++ b/Modules/IO/XML/src/itkXMLFile.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/test/itkDOMTest1.cxx
+++ b/Modules/IO/XML/test/itkDOMTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/test/itkDOMTest2.cxx
+++ b/Modules/IO/XML/test/itkDOMTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/test/itkDOMTest3.cxx
+++ b/Modules/IO/XML/test/itkDOMTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/test/itkDOMTest4.cxx
+++ b/Modules/IO/XML/test/itkDOMTest4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/test/itkDOMTest5.cxx
+++ b/Modules/IO/XML/test/itkDOMTest5.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/test/itkDOMTest6.cxx
+++ b/Modules/IO/XML/test/itkDOMTest6.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/test/itkDOMTest8.cxx
+++ b/Modules/IO/XML/test/itkDOMTest8.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/test/itkDOMTestObject.h
+++ b/Modules/IO/XML/test/itkDOMTestObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/test/itkDOMTestObjectDOMReader.h
+++ b/Modules/IO/XML/test/itkDOMTestObjectDOMReader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/test/itkDOMTestObjectDOMWriter.h
+++ b/Modules/IO/XML/test/itkDOMTestObjectDOMWriter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/test/itkFancyStringTest.cxx
+++ b/Modules/IO/XML/test/itkFancyStringTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/IO/XML/test/itkFileToolsTest.cxx
+++ b/Modules/IO/XML/test/itkFileToolsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkAlgorithmsPrintTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkAlgorithmsPrintTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkAlgorithmsPrintTest2.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkAlgorithmsPrintTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkAlgorithmsPrintTest3.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkAlgorithmsPrintTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkAlgorithmsPrintTest4.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkAlgorithmsPrintTest4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkBasicFiltersPrintTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkBasicFiltersPrintTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkBasicFiltersPrintTest2.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkBasicFiltersPrintTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkBioRadImageIOTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkBioRadImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkCommonPrintTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkCommonPrintTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkFilterImageAddTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkFilterImageAddTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkIOPrintTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkIOPrintTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkImageToHistogramFilterTest4.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkImageToHistogramFilterTest4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkMaskedImageToHistogramFilterTest1.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkMaskedImageToHistogramFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkMaximumDecisionRuleTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkMaximumDecisionRuleTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkMaximumRatioDecisionRuleTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkMaximumRatioDecisionRuleTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkMinimumDecisionRuleTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkMinimumDecisionRuleTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkNumericsPrintTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkNumericsPrintTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkPolygonCellTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkPolygonCellTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkReleaseDataFilterTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkReleaseDataFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkShrinkImagePreserveObjectPhysicalLocations.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkShrinkImagePreserveObjectPhysicalLocations.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkSpatialObjectPrintTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkSpatialObjectPrintTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkStatisticsPrintTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkStatisticsPrintTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/test/itkTriangleHelperTest.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkTriangleHelperTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/IntegratedTest/wrapping/test/itkCurvatureFlowTestPython2.py
+++ b/Modules/Nonunit/IntegratedTest/wrapping/test/itkCurvatureFlowTestPython2.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkAreaClosingImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAreaClosingImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkAreaOpeningImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAreaOpeningImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkComplexBSplineInterpolateImageFunction.h
+++ b/Modules/Nonunit/Review/include/itkComplexBSplineInterpolateImageFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkComplexBSplineInterpolateImageFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkComplexBSplineInterpolateImageFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.h
+++ b/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkConformalFlatteningMeshFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkConstrainedRegionBasedLevelSetFunctionSharedData.h
+++ b/Modules/Nonunit/Review/include/itkConstrainedRegionBasedLevelSetFunctionSharedData.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkDirectFourierReconstructionImageToImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkDirectFourierReconstructionImageToImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkDirectFourierReconstructionImageToImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkDirectFourierReconstructionImageToImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkFastApproximateRankImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkFastApproximateRankImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkGridForwardWarpImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkGridForwardWarpImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkGridForwardWarpImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkGridForwardWarpImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkMiniPipelineSeparableImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkMiniPipelineSeparableImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkMiniPipelineSeparableImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMiniPipelineSeparableImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseDenseFiniteDifferenceImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseFiniteDifferenceImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.h
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionData.h
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionData.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionData.hxx
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionData.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionSharedData.h
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunctionSharedData.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdCalculator.h
+++ b/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdCalculator.hxx
+++ b/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseDenseLevelSetImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseDenseLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseDenseLevelSetImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseDenseLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseLevelSetFunction.h
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseLevelSetFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseLevelSetFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseLevelSetFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseLevelSetFunctionData.h
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseLevelSetFunctionData.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseSparseLevelSetImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseSparseLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkScalarChanAndVeseSparseLevelSetImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkScalarChanAndVeseSparseLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkScalarRegionBasedLevelSetFunction.h
+++ b/Modules/Nonunit/Review/include/itkScalarRegionBasedLevelSetFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkScalarRegionBasedLevelSetFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkScalarRegionBasedLevelSetFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkStochasticFractalDimensionImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkStochasticFractalDimensionImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkStochasticFractalDimensionImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkStochasticFractalDimensionImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkUnconstrainedRegionBasedLevelSetFunctionSharedData.h
+++ b/Modules/Nonunit/Review/include/itkUnconstrainedRegionBasedLevelSetFunctionSharedData.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkVoxBoCUBImageIO.h
+++ b/Modules/Nonunit/Review/include/itkVoxBoCUBImageIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkVoxBoCUBImageIOFactory.h
+++ b/Modules/Nonunit/Review/include/itkVoxBoCUBImageIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkWarpHarmonicEnergyCalculator.h
+++ b/Modules/Nonunit/Review/include/itkWarpHarmonicEnergyCalculator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/include/itkWarpHarmonicEnergyCalculator.hxx
+++ b/Modules/Nonunit/Review/include/itkWarpHarmonicEnergyCalculator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/src/itkVoxBoCUBImageIO.cxx
+++ b/Modules/Nonunit/Review/src/itkVoxBoCUBImageIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/src/itkVoxBoCUBImageIOFactory.cxx
+++ b/Modules/Nonunit/Review/src/itkVoxBoCUBImageIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkAreaClosingImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkAreaClosingImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkAreaOpeningImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkAreaOpeningImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkConformalFlatteningMeshFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkConformalFlatteningMeshFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkConformalFlatteningQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkConformalFlatteningQuadEdgeMeshFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkDirectFourierReconstructionImageToImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkDirectFourierReconstructionImageToImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkFastApproximateRankImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkFastApproximateRankImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkGridForwardWarpImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkGridForwardWarpImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkImageFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkLabelGeometryImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkLabelGeometryImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkMultiphaseDenseFiniteDifferenceImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkMultiphaseDenseFiniteDifferenceImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkMultiphaseFiniteDifferenceImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkMultiphaseFiniteDifferenceImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkMultiphaseSparseFiniteDifferenceImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkMultiphaseSparseFiniteDifferenceImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkOptImageToImageMetricsTest.cxx
+++ b/Modules/Nonunit/Review/test/itkOptImageToImageMetricsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkOptImageToImageMetricsTest.h
+++ b/Modules/Nonunit/Review/test/itkOptImageToImageMetricsTest.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkOptImageToImageMetricsTest2.cxx
+++ b/Modules/Nonunit/Review/test/itkOptImageToImageMetricsTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkOptImageToImageMetricsTest2.h
+++ b/Modules/Nonunit/Review/test/itkOptImageToImageMetricsTest2.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkOptMattesMutualInformationImageToImageMetricThreadsTest1.cxx
+++ b/Modules/Nonunit/Review/test/itkOptMattesMutualInformationImageToImageMetricThreadsTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkRegionBasedLevelSetFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkRegionBasedLevelSetFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkReviewPrintTest.cxx
+++ b/Modules/Nonunit/Review/test/itkReviewPrintTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkRobustAutomaticThresholdCalculatorTest.cxx
+++ b/Modules/Nonunit/Review/test/itkRobustAutomaticThresholdCalculatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkRobustAutomaticThresholdImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkRobustAutomaticThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkScalarChanAndVeseDenseLevelSetImageFilterTest1.cxx
+++ b/Modules/Nonunit/Review/test/itkScalarChanAndVeseDenseLevelSetImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkScalarChanAndVeseDenseLevelSetImageFilterTest2.cxx
+++ b/Modules/Nonunit/Review/test/itkScalarChanAndVeseDenseLevelSetImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkScalarChanAndVeseDenseLevelSetImageFilterTest3.cxx
+++ b/Modules/Nonunit/Review/test/itkScalarChanAndVeseDenseLevelSetImageFilterTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkScalarChanAndVeseDenseLevelSetImageFilterTest4.cxx
+++ b/Modules/Nonunit/Review/test/itkScalarChanAndVeseDenseLevelSetImageFilterTest4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkScalarChanAndVeseLevelSetFunctionTest1.cxx
+++ b/Modules/Nonunit/Review/test/itkScalarChanAndVeseLevelSetFunctionTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkScalarChanAndVeseLevelSetFunctionTest2.cxx
+++ b/Modules/Nonunit/Review/test/itkScalarChanAndVeseLevelSetFunctionTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkScalarChanAndVeseSparseLevelSetImageFilterTest1.cxx
+++ b/Modules/Nonunit/Review/test/itkScalarChanAndVeseSparseLevelSetImageFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkScalarChanAndVeseSparseLevelSetImageFilterTest2.cxx
+++ b/Modules/Nonunit/Review/test/itkScalarChanAndVeseSparseLevelSetImageFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkScalarRegionBasedLevelSetFunctionTest.cxx
+++ b/Modules/Nonunit/Review/test/itkScalarRegionBasedLevelSetFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest1.cxx
+++ b/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest2.cxx
+++ b/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest3.cxx
+++ b/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkStochasticFractalDimensionImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkStochasticFractalDimensionImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkTimeAndMemoryProbeTest.cxx
+++ b/Modules/Nonunit/Review/test/itkTimeAndMemoryProbeTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkVoxBoCUBImageIOTest.cxx
+++ b/Modules/Nonunit/Review/test/itkVoxBoCUBImageIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkWarpHarmonicEnergyCalculatorTest.cxx
+++ b/Modules/Nonunit/Review/test/itkWarpHarmonicEnergyCalculatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Nonunit/Review/test/itkWarpJacobianDeterminantFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkWarpJacobianDeterminantFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.h
+++ b/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.hxx
+++ b/Modules/Numerics/Eigen/include/itkEigenAnalysis2DImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Eigen/test/itkEigenAnalysis2DImageFilterTest.cxx
+++ b/Modules/Numerics/Eigen/test/itkEigenAnalysis2DImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement1DStress.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement1DStress.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement1DStress.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMElement1DStress.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearLine.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearLine.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearLineStress.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearLineStress.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateral.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateral.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateralMembrane.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateralMembrane.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateralStrain.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateralStrain.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateralStress.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearQuadrilateralStress.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangular.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangular.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangularMembrane.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangularMembrane.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangularStrain.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangularStrain.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangularStress.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0LinearTriangularStress.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0QuadraticTriangular.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0QuadraticTriangular.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0QuadraticTriangularStrain.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0QuadraticTriangularStrain.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC0QuadraticTriangularStress.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC0QuadraticTriangularStress.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement2DC1Beam.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DC1Beam.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement2DMembrane.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DMembrane.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement2DMembrane.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DMembrane.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement2DStrain.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DStrain.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement2DStrain.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DStrain.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement2DStress.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DStress.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement2DStress.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMElement2DStress.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearHexahedron.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearHexahedron.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearHexahedronMembrane.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearHexahedronMembrane.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearHexahedronStrain.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearHexahedronStrain.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTetrahedron.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTetrahedron.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTetrahedronMembrane.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTetrahedronMembrane.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTetrahedronStrain.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTetrahedronStrain.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTriangular.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTriangular.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  * Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTriangularLaplaceBeltrami.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTriangularLaplaceBeltrami.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  * Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTriangularMembrane.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DC0LinearTriangularMembrane.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  * Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement3DMembrane.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DMembrane.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement3DMembrane.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DMembrane.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement3DMembrane1DOF.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DMembrane1DOF.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  * Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement3DMembrane1DOF.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DMembrane1DOF.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  * Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement3DStrain.h
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DStrain.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElement3DStrain.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMElement3DStrain.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElementBase.h
+++ b/Modules/Numerics/FEM/include/itkFEMElementBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElementStd.h
+++ b/Modules/Numerics/FEM/include/itkFEMElementStd.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElementStd.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMElementStd.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMElements.h
+++ b/Modules/Numerics/FEM/include/itkFEMElements.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMException.h
+++ b/Modules/Numerics/FEM/include/itkFEMException.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMFactory.h
+++ b/Modules/Numerics/FEM/include/itkFEMFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMFactoryBase.h
+++ b/Modules/Numerics/FEM/include/itkFEMFactoryBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.h
+++ b/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMImageMetricLoad.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMItpackSparseMatrix.h
+++ b/Modules/Numerics/FEM/include/itkFEMItpackSparseMatrix.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMLightObject.h
+++ b/Modules/Numerics/FEM/include/itkFEMLightObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapper.h
+++ b/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapper.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapperDenseVNL.h
+++ b/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapperDenseVNL.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapperItpack.h
+++ b/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapperItpack.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapperVNL.h
+++ b/Modules/Numerics/FEM/include/itkFEMLinearSystemWrapperVNL.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMLinearSystemWrappers.h
+++ b/Modules/Numerics/FEM/include/itkFEMLinearSystemWrappers.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMLoadBC.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadBC.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMLoadBCMFC.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadBCMFC.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMLoadBase.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMLoadEdge.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadEdge.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMLoadElementBase.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadElementBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMLoadGrav.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadGrav.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMLoadLandmark.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadLandmark.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMLoadNode.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadNode.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMLoadNoisyLandmark.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadNoisyLandmark.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMLoadPoint.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadPoint.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMLoadTest.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoadTest.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMLoads.h
+++ b/Modules/Numerics/FEM/include/itkFEMLoads.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMMaterialBase.h
+++ b/Modules/Numerics/FEM/include/itkFEMMaterialBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMMaterialLinearElasticity.h
+++ b/Modules/Numerics/FEM/include/itkFEMMaterialLinearElasticity.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMMaterials.h
+++ b/Modules/Numerics/FEM/include/itkFEMMaterials.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMObject.h
+++ b/Modules/Numerics/FEM/include/itkFEMObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMObject.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMObjectSpatialObject.h
+++ b/Modules/Numerics/FEM/include/itkFEMObjectSpatialObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMObjectSpatialObject.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMObjectSpatialObject.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMP.h
+++ b/Modules/Numerics/FEM/include/itkFEMP.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMPArray.h
+++ b/Modules/Numerics/FEM/include/itkFEMPArray.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMRobustSolver.h
+++ b/Modules/Numerics/FEM/include/itkFEMRobustSolver.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMRobustSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMRobustSolver.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMScatteredDataPointSetToImageFilter.h
+++ b/Modules/Numerics/FEM/include/itkFEMScatteredDataPointSetToImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMScatteredDataPointSetToImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMSolution.h
+++ b/Modules/Numerics/FEM/include/itkFEMSolution.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMSolver.h
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMSolver.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMSolver.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMSolverCrankNicolson.h
+++ b/Modules/Numerics/FEM/include/itkFEMSolverCrankNicolson.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMSolverCrankNicolson.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMSolverCrankNicolson.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMSolverHyperbolic.h
+++ b/Modules/Numerics/FEM/include/itkFEMSolverHyperbolic.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMSolverHyperbolic.hxx
+++ b/Modules/Numerics/FEM/include/itkFEMSolverHyperbolic.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMSpatialObjectReader.h
+++ b/Modules/Numerics/FEM/include/itkFEMSpatialObjectReader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMSpatialObjectWriter.h
+++ b/Modules/Numerics/FEM/include/itkFEMSpatialObjectWriter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkFEMUtility.h
+++ b/Modules/Numerics/FEM/include/itkFEMUtility.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.h
+++ b/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.hxx
+++ b/Modules/Numerics/FEM/include/itkImageToRectilinearFEMObjectFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.h
+++ b/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.hxx
+++ b/Modules/Numerics/FEM/include/itkMetaFEMObjectConverter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/include/itpack.h
+++ b/Modules/Numerics/FEM/include/itpack.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearLine.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearLine.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearLineStress.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearLineStress.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateral.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateral.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralMembrane.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralMembrane.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralStrain.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralStrain.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralStress.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearQuadrilateralStress.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangular.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangular.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularMembrane.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularMembrane.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularStrain.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularStrain.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularStress.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0LinearTriangularStress.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangular.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangular.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangularStrain.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangularStrain.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangularStress.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC0QuadraticTriangularStress.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement2DC1Beam.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement2DC1Beam.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedron.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedron.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedronMembrane.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedronMembrane.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedronStrain.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearHexahedronStrain.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedron.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedron.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedronMembrane.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedronMembrane.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedronStrain.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTetrahedronStrain.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangular.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangular.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  * Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangularLaplaceBeltrami.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangularLaplaceBeltrami.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  * Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangularMembrane.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangularMembrane.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  * Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMElementBase.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElementBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMException.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMException.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMFactoryBase.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMFactoryBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMItpackSparseMatrix.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMItpackSparseMatrix.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMLightObject.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLightObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapper.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapper.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperDenseVNL.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperDenseVNL.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperItpack.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperItpack.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperVNL.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperVNL.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMLoadBC.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadBC.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMLoadBCMFC.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadBCMFC.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMLoadBase.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMLoadEdge.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadEdge.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMLoadElementBase.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadElementBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMLoadGrav.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadGrav.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMLoadLandmark.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadLandmark.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMLoadNode.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadNode.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMLoadNoisyLandmark.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadNoisyLandmark.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMLoadPoint.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLoadPoint.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMMaterialBase.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMMaterialBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMMaterialLinearElasticity.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMMaterialLinearElasticity.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMSolution.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMSolution.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/src/itkFEMUtility.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMUtility.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearLineStressItpackTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearLineStressItpackTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearLineStressTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearLineStressTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearQuadrilateralMembraneTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearQuadrilateralMembraneTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearQuadrilateralStrainItpackTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearQuadrilateralStrainItpackTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearQuadrilateralStrainTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearQuadrilateralStrainTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearQuadrilateralStressTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearQuadrilateralStressTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearQuadrilateralStressTestFEMObjectReader.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearQuadrilateralStressTestFEMObjectReader.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearTriangleMembraneTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearTriangleMembraneTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearTriangleStrainTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearTriangleStrainTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearTriangleStressTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearTriangleStressTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0QuadraticTriangleStrainTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0QuadraticTriangleStrainTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0QuadraticTriangleStressTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0QuadraticTriangleStressTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement2DC1BeamTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC1BeamTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement2DMembraneTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DMembraneTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement2DQuadraticTriangularTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DQuadraticTriangularTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement2DStrainTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DStrainTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement2DTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement3DC0LinearHexahedronMembraneTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement3DC0LinearHexahedronMembraneTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement3DC0LinearHexahedronStrainTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement3DC0LinearHexahedronStrainTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement3DC0LinearTetrahedronMembraneTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement3DC0LinearTetrahedronMembraneTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement3DC0LinearTetrahedronStrainTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement3DC0LinearTetrahedronStrainTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement3DMembraneTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement3DMembraneTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElement3DTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement3DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElementTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElementTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMElementTest.h
+++ b/Modules/Numerics/FEM/test/itkFEMElementTest.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMExceptionTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMExceptionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMFactoryTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMFactoryTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMGenerateMeshTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMGenerateMeshTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMLandmarkLoadImplementationTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMLandmarkLoadImplementationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMLinearSystemWrapperDenseVNLTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMLinearSystemWrapperDenseVNLTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMLinearSystemWrapperItpackTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMLinearSystemWrapperItpackTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMLinearSystemWrapperItpackTest2.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMLinearSystemWrapperItpackTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMLinearSystemWrapperVNLTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMLinearSystemWrapperVNLTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMLoadBCMFCTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMLoadBCMFCTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMLoadBCMFCTestUser.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMLoadBCMFCTestUser.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMLoadEdgeTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMLoadEdgeTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMLoadGravConstTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMLoadGravConstTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMLoadPointTestUser.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMLoadPointTestUser.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMObjectTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMObjectTest2.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMObjectTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMPArrayTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMPArrayTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMRobustSolverTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMRobustSolverTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMScatteredDataPointSetToImageFilterTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMScatteredDataPointSetToImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMSolverHyperbolicTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMSolverHyperbolicTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMSolverTest2D.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMSolverTest2D.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMSolverTest3D.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMSolverTest3D.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkFEMSpatialObjectTest.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMSpatialObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkImageToRectilinearFEMObjectFilter2DTest.cxx
+++ b/Modules/Numerics/FEM/test/itkImageToRectilinearFEMObjectFilter2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/FEM/test/itkImageToRectilinearFEMObjectFilter3DTest.cxx
+++ b/Modules/Numerics/FEM/test/itkImageToRectilinearFEMObjectFilter3DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/NarrowBand/include/itkNarrowBand.h
+++ b/Modules/Numerics/NarrowBand/include/itkNarrowBand.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/NarrowBand/include/itkNarrowBand.hxx
+++ b/Modules/Numerics/NarrowBand/include/itkNarrowBand.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.h
+++ b/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.hxx
+++ b/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/NarrowBand/test/itkNarrowBandImageFilterBaseTest.cxx
+++ b/Modules/Numerics/NarrowBand/test/itkNarrowBandImageFilterBaseTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/NarrowBand/test/itkNarrowBandTest.cxx
+++ b/Modules/Numerics/NarrowBand/test/itkNarrowBandTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkAmoebaOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkAmoebaOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkConjugateGradientOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkConjugateGradientOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkCostFunction.h
+++ b/Modules/Numerics/Optimizers/include/itkCostFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkCostFunction.hxx
+++ b/Modules/Numerics/Optimizers/include/itkCostFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkCumulativeGaussianCostFunction.h
+++ b/Modules/Numerics/Optimizers/include/itkCumulativeGaussianCostFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkCumulativeGaussianOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkCumulativeGaussianOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkExhaustiveOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkExhaustiveOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkFRPROptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkFRPROptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkGradientDescentOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkGradientDescentOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkInitializationBiasedParticleSwarmOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkInitializationBiasedParticleSwarmOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkLBFGSBOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkLBFGSBOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkLBFGSOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkLBFGSOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkLevenbergMarquardtOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkLevenbergMarquardtOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkMultipleValuedCostFunction.h
+++ b/Modules/Numerics/Optimizers/include/itkMultipleValuedCostFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkMultipleValuedNonLinearOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkMultipleValuedNonLinearOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkMultipleValuedNonLinearVnlOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkMultipleValuedNonLinearVnlOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkMultipleValuedVnlCostFunctionAdaptor.h
+++ b/Modules/Numerics/Optimizers/include/itkMultipleValuedVnlCostFunctionAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkNonLinearOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkNonLinearOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkOnePlusOneEvolutionaryOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkOnePlusOneEvolutionaryOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkParticleSwarmOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkParticleSwarmOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkParticleSwarmOptimizerBase.h
+++ b/Modules/Numerics/Optimizers/include/itkParticleSwarmOptimizerBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkPowellOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkPowellOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkQuaternionRigidTransformGradientDescentOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkQuaternionRigidTransformGradientDescentOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkRegularStepGradientDescentBaseOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkRegularStepGradientDescentBaseOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkRegularStepGradientDescentOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkRegularStepGradientDescentOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkSPSAOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkSPSAOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkSingleValuedCostFunction.h
+++ b/Modules/Numerics/Optimizers/include/itkSingleValuedCostFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkSingleValuedNonLinearOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkSingleValuedNonLinearOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkSingleValuedNonLinearVnlOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkSingleValuedNonLinearVnlOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkSingleValuedVnlCostFunctionAdaptor.h
+++ b/Modules/Numerics/Optimizers/include/itkSingleValuedVnlCostFunctionAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkVersorRigid3DTransformOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkVersorRigid3DTransformOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/include/itkVersorTransformOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkVersorTransformOptimizer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkAmoebaOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkAmoebaOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkConjugateGradientOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkConjugateGradientOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianCostFunction.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianCostFunction.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkFRPROptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkGradientDescentOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkInitializationBiasedParticleSwarmOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkInitializationBiasedParticleSwarmOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkLBFGSBOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLBFGSBOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkLBFGSOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLBFGSOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkLevenbergMarquardtOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLevenbergMarquardtOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkMultipleValuedCostFunction.cxx
+++ b/Modules/Numerics/Optimizers/src/itkMultipleValuedCostFunction.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearVnlOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkMultipleValuedNonLinearVnlOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkMultipleValuedVnlCostFunctionAdaptor.cxx
+++ b/Modules/Numerics/Optimizers/src/itkMultipleValuedVnlCostFunctionAdaptor.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkNonLinearOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkNonLinearOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkOnePlusOneEvolutionaryOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkOnePlusOneEvolutionaryOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkQuaternionRigidTransformGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkQuaternionRigidTransformGradientDescentOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkSingleValuedCostFunction.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSingleValuedCostFunction.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearVnlOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearVnlOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkSingleValuedVnlCostFunctionAdaptor.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSingleValuedVnlCostFunctionAdaptor.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/src/itkVersorTransformOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkVersorTransformOptimizer.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/test/itkAmoebaOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkAmoebaOptimizerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/test/itkConjugateGradientOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkConjugateGradientOptimizerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/test/itkCumulativeGaussianOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkCumulativeGaussianOptimizerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/test/itkExhaustiveOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkExhaustiveOptimizerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/test/itkFRPROptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkFRPROptimizerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/test/itkGradientDescentOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkGradientDescentOptimizerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/test/itkInitializationBiasedParticleSwarmOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkInitializationBiasedParticleSwarmOptimizerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/test/itkLBFGSBOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkLBFGSBOptimizerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/test/itkLBFGSOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkLBFGSOptimizerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/test/itkLevenbergMarquardtOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkLevenbergMarquardtOptimizerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/test/itkOnePlusOneEvolutionaryOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkOnePlusOneEvolutionaryOptimizerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/test/itkOptimizersHierarchyTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkOptimizersHierarchyTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/test/itkParticleSwarmOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkParticleSwarmOptimizerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/test/itkParticleSwarmOptimizerTestFunctions.h
+++ b/Modules/Numerics/Optimizers/test/itkParticleSwarmOptimizerTestFunctions.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/test/itkPowellOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkPowellOptimizerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/test/itkRegularStepGradientDescentOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkRegularStepGradientDescentOptimizerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/test/itkSPSAOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkSPSAOptimizerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/test/itkVersorRigid3DTransformOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkVersorRigid3DTransformOptimizerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizers/test/itkVersorTransformOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkVersorTransformOptimizerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkAmoebaOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkAmoebaOptimizerv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkCommandIterationUpdatev4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkCommandIterationUpdatev4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkConjugateGradientLineSearchOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkConjugateGradientLineSearchOptimizerv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkConjugateGradientLineSearchOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkConjugateGradientLineSearchOptimizerv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkConvergenceMonitoringFunction.h
+++ b/Modules/Numerics/Optimizersv4/include/itkConvergenceMonitoringFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4ModifyGradientByLearningRateThreader.h
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4ModifyGradientByLearningRateThreader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4ModifyGradientByLearningRateThreader.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4ModifyGradientByLearningRateThreader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4ModifyGradientByScalesThreader.h
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4ModifyGradientByScalesThreader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4ModifyGradientByScalesThreader.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4ModifyGradientByScalesThreader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGS2Optimizerv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGSBOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGSBOptimizerv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerBasev4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerBasev4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerBasev4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerBasev4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkLBFGSOptimizerv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.h
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetricBase.h
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetricBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetricBase.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetricBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectOptimizerBase.h
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectOptimizerBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkOptimizerParameterScalesEstimator.h
+++ b/Modules/Numerics/Optimizersv4/include/itkOptimizerParameterScalesEstimator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4EstimateNewtonStepThreader.h
+++ b/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4EstimateNewtonStepThreader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4EstimateNewtonStepThreader.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4EstimateNewtonStepThreader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.h
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromIndexShift.h
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromIndexShift.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromIndexShift.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromIndexShift.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromJacobian.h
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromJacobian.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromJacobian.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromJacobian.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromPhysicalShift.h
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromPhysicalShift.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromPhysicalShift.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromPhysicalShift.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.h
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesFromShiftBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkRegularStepGradientDescentOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkRegularStepGradientDescentOptimizerv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkRegularStepGradientDescentOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegularStepGradientDescentOptimizerv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkSingleValuedCostFunctionv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkSingleValuedCostFunctionv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkSingleValuedNonLinearVnlOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkSingleValuedNonLinearVnlOptimizerv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkSingleValuedVnlCostFunctionAdaptorv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkSingleValuedVnlCostFunctionAdaptorv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkWindowConvergenceMonitoringFunction.h
+++ b/Modules/Numerics/Optimizersv4/include/itkWindowConvergenceMonitoringFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/include/itkWindowConvergenceMonitoringFunction.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkWindowConvergenceMonitoringFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/src/itkAmoebaOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkAmoebaOptimizerv4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGS2Optimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGS2Optimizerv4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSBOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSBOptimizerv4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4Base.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4Base.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/src/itkObjectToObjectMetricBase.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkObjectToObjectMetricBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/src/itkObjectToObjectOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkObjectToObjectOptimizerBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/src/itkRegistrationParameterScalesEstimator.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkRegistrationParameterScalesEstimator.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/src/itkSingleValuedNonLinearVnlOptimizerv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkSingleValuedNonLinearVnlOptimizerv4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/src/itkSingleValuedVnlCostFunctionAdaptorv4.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkSingleValuedVnlCostFunctionAdaptorv4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkAmoebaOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAmoebaOptimizerv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkConjugateGradientLineSearchOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkConjugateGradientLineSearchOptimizerv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkExhaustiveOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkExhaustiveOptimizerv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentLineSearchOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentLineSearchOptimizerv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerBasev4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerBasev4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test2.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkLBFGS2Optimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkLBFGS2Optimizerv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkLBFGSBOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkLBFGSBOptimizerv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkLBFGSOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkLBFGSOptimizerv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkMultiGradientOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkMultiGradientOptimizerv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkMultiStartOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkMultiStartOptimizerv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkObjectToObjectMetricBaseTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkObjectToObjectMetricBaseTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkObjectToObjectOptimizerBaseTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkObjectToObjectOptimizerBaseTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkOnePlusOneEvolutionaryOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkOnePlusOneEvolutionaryOptimizerv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkOptimizerParameterScalesEstimatorTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkOptimizerParameterScalesEstimatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkPowellOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkPowellOptimizerv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkQuasiNewtonOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkQuasiNewtonOptimizerv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesEstimatorTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesEstimatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromIndexShiftTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromIndexShiftTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromJacobianTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromJacobianTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftPointSetTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftPointSetTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegistrationParameterScalesFromPhysicalShiftTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkRegularStepGradientDescentOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegularStepGradientDescentOptimizerv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Optimizersv4/test/itkWindowConvergenceMonitoringFunctionGTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkWindowConvergenceMonitoringFunctionGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Polynomials/include/itkMultivariateLegendrePolynomial.h
+++ b/Modules/Numerics/Polynomials/include/itkMultivariateLegendrePolynomial.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Polynomials/src/itkMultivariateLegendrePolynomial.cxx
+++ b/Modules/Numerics/Polynomials/src/itkMultivariateLegendrePolynomial.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Polynomials/test/itkMultivariateLegendrePolynomialTest.cxx
+++ b/Modules/Numerics/Polynomials/test/itkMultivariateLegendrePolynomialTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkChiSquareDistribution.h
+++ b/Modules/Numerics/Statistics/include/itkChiSquareDistribution.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkCovarianceSampleFilter.h
+++ b/Modules/Numerics/Statistics/include/itkCovarianceSampleFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkCovarianceSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkCovarianceSampleFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkDecisionRule.h
+++ b/Modules/Numerics/Statistics/include/itkDecisionRule.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkDenseFrequencyContainer2.h
+++ b/Modules/Numerics/Statistics/include/itkDenseFrequencyContainer2.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkDistanceMetric.h
+++ b/Modules/Numerics/Statistics/include/itkDistanceMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkDistanceMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkDistanceToCentroidMembershipFunction.h
+++ b/Modules/Numerics/Statistics/include/itkDistanceToCentroidMembershipFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkDistanceToCentroidMembershipFunction.hxx
+++ b/Modules/Numerics/Statistics/include/itkDistanceToCentroidMembershipFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkEuclideanDistanceMetric.h
+++ b/Modules/Numerics/Statistics/include/itkEuclideanDistanceMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkEuclideanDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkEuclideanDistanceMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkEuclideanSquareDistanceMetric.h
+++ b/Modules/Numerics/Statistics/include/itkEuclideanSquareDistanceMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkEuclideanSquareDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkEuclideanSquareDistanceMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.h
+++ b/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.hxx
+++ b/Modules/Numerics/Statistics/include/itkExpectationMaximizationMixtureModelEstimator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkGaussianDistribution.h
+++ b/Modules/Numerics/Statistics/include/itkGaussianDistribution.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkGaussianMembershipFunction.h
+++ b/Modules/Numerics/Statistics/include/itkGaussianMembershipFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkGaussianMembershipFunction.hxx
+++ b/Modules/Numerics/Statistics/include/itkGaussianMembershipFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkGaussianMixtureModelComponent.h
+++ b/Modules/Numerics/Statistics/include/itkGaussianMixtureModelComponent.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkGaussianMixtureModelComponent.hxx
+++ b/Modules/Numerics/Statistics/include/itkGaussianMixtureModelComponent.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkHistogram.h
+++ b/Modules/Numerics/Statistics/include/itkHistogram.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkHistogramToEntropyImageFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToEntropyImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkHistogramToImageFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkHistogramToImageFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogramToImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkHistogramToIntensityImageFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToIntensityImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkHistogramToLogProbabilityImageFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToLogProbabilityImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkHistogramToProbabilityImageFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToProbabilityImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkHistogramToRunLengthFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToRunLengthFeaturesFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkHistogramToRunLengthFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogramToRunLengthFeaturesFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogramToTextureFeaturesFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkImageClassifierFilter.h
+++ b/Modules/Numerics/Statistics/include/itkImageClassifierFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkImageClassifierFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageClassifierFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.h
+++ b/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToHistogramFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleAdaptor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleFilter.h
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkJointDomainImageToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkJointDomainImageToListSampleAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkJointDomainImageToListSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkJointDomainImageToListSampleAdaptor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkKalmanLinearEstimator.h
+++ b/Modules/Numerics/Statistics/include/itkKalmanLinearEstimator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkKdTree.h
+++ b/Modules/Numerics/Statistics/include/itkKdTree.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkKdTree.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTree.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.h
+++ b/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTreeBasedKmeansEstimator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkKdTreeGenerator.h
+++ b/Modules/Numerics/Statistics/include/itkKdTreeGenerator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkKdTreeGenerator.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTreeGenerator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkListSample.h
+++ b/Modules/Numerics/Statistics/include/itkListSample.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkListSample.hxx
+++ b/Modules/Numerics/Statistics/include/itkListSample.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.h
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.hxx
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.h
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkManhattanDistanceMetric.h
+++ b/Modules/Numerics/Statistics/include/itkManhattanDistanceMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkManhattanDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkManhattanDistanceMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkMaskedImageToHistogramFilter.h
+++ b/Modules/Numerics/Statistics/include/itkMaskedImageToHistogramFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkMaskedImageToHistogramFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkMaskedImageToHistogramFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkMaximumDecisionRule.h
+++ b/Modules/Numerics/Statistics/include/itkMaximumDecisionRule.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkMaximumRatioDecisionRule.h
+++ b/Modules/Numerics/Statistics/include/itkMaximumRatioDecisionRule.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkMeanSampleFilter.h
+++ b/Modules/Numerics/Statistics/include/itkMeanSampleFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkMeanSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkMeanSampleFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h
+++ b/Modules/Numerics/Statistics/include/itkMeasurementVectorTraits.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkMembershipFunctionBase.h
+++ b/Modules/Numerics/Statistics/include/itkMembershipFunctionBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkMembershipSample.h
+++ b/Modules/Numerics/Statistics/include/itkMembershipSample.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkMembershipSample.hxx
+++ b/Modules/Numerics/Statistics/include/itkMembershipSample.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkMinimumDecisionRule.h
+++ b/Modules/Numerics/Statistics/include/itkMinimumDecisionRule.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkMixtureModelComponentBase.h
+++ b/Modules/Numerics/Statistics/include/itkMixtureModelComponentBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkMixtureModelComponentBase.hxx
+++ b/Modules/Numerics/Statistics/include/itkMixtureModelComponentBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkNeighborhoodSampler.h
+++ b/Modules/Numerics/Statistics/include/itkNeighborhoodSampler.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkNeighborhoodSampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkNeighborhoodSampler.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkNormalVariateGenerator.h
+++ b/Modules/Numerics/Statistics/include/itkNormalVariateGenerator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkPointSetToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkPointSetToListSampleAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkPointSetToListSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkPointSetToListSampleAdaptor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkProbabilityDistribution.h
+++ b/Modules/Numerics/Statistics/include/itkProbabilityDistribution.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkRegionConstrainedSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkRegionConstrainedSubsampler.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkRegionConstrainedSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkRegionConstrainedSubsampler.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkSample.h
+++ b/Modules/Numerics/Statistics/include/itkSample.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkSampleClassifierFilter.h
+++ b/Modules/Numerics/Statistics/include/itkSampleClassifierFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkSampleClassifierFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkSampleClassifierFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkSampleToHistogramFilter.h
+++ b/Modules/Numerics/Statistics/include/itkSampleToHistogramFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkSampleToHistogramFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkSampleToHistogramFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkSampleToSubsampleFilter.h
+++ b/Modules/Numerics/Statistics/include/itkSampleToSubsampleFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkSampleToSubsampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkSampleToSubsampleFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceMatrixFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkScalarImageToHistogramGenerator.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToHistogramGenerator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkScalarImageToHistogramGenerator.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToHistogramGenerator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthFeaturesFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToTextureFeaturesFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkSparseFrequencyContainer2.h
+++ b/Modules/Numerics/Statistics/include/itkSparseFrequencyContainer2.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkStandardDeviationPerComponentSampleFilter.h
+++ b/Modules/Numerics/Statistics/include/itkStandardDeviationPerComponentSampleFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkStandardDeviationPerComponentSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkStandardDeviationPerComponentSampleFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkStatisticsAlgorithm.h
+++ b/Modules/Numerics/Statistics/include/itkStatisticsAlgorithm.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkStatisticsAlgorithm.hxx
+++ b/Modules/Numerics/Statistics/include/itkStatisticsAlgorithm.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkSubsample.h
+++ b/Modules/Numerics/Statistics/include/itkSubsample.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkSubsample.hxx
+++ b/Modules/Numerics/Statistics/include/itkSubsample.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkSubsamplerBase.h
+++ b/Modules/Numerics/Statistics/include/itkSubsamplerBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkSubsamplerBase.hxx
+++ b/Modules/Numerics/Statistics/include/itkSubsamplerBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkTDistribution.h
+++ b/Modules/Numerics/Statistics/include/itkTDistribution.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.h
+++ b/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.h
+++ b/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkVectorContainerToListSampleAdaptor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkWeightedCentroidKdTreeGenerator.h
+++ b/Modules/Numerics/Statistics/include/itkWeightedCentroidKdTreeGenerator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkWeightedCentroidKdTreeGenerator.hxx
+++ b/Modules/Numerics/Statistics/include/itkWeightedCentroidKdTreeGenerator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkWeightedCovarianceSampleFilter.h
+++ b/Modules/Numerics/Statistics/include/itkWeightedCovarianceSampleFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkWeightedCovarianceSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkWeightedCovarianceSampleFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkWeightedMeanSampleFilter.h
+++ b/Modules/Numerics/Statistics/include/itkWeightedMeanSampleFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/include/itkWeightedMeanSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkWeightedMeanSampleFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/src/itkChiSquareDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkChiSquareDistribution.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/src/itkDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkDecisionRule.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/src/itkDenseFrequencyContainer2.cxx
+++ b/Modules/Numerics/Statistics/src/itkDenseFrequencyContainer2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/src/itkExpectationMaximizationMixtureModelEstimator.cxx
+++ b/Modules/Numerics/Statistics/src/itkExpectationMaximizationMixtureModelEstimator.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/src/itkGaussianDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkGaussianDistribution.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/src/itkHistogramToRunLengthFeaturesFilter.cxx
+++ b/Modules/Numerics/Statistics/src/itkHistogramToRunLengthFeaturesFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/src/itkHistogramToTextureFeaturesFilter.cxx
+++ b/Modules/Numerics/Statistics/src/itkHistogramToTextureFeaturesFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/src/itkMaximumDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkMaximumDecisionRule.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/src/itkMaximumRatioDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkMaximumRatioDecisionRule.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/src/itkMinimumDecisionRule.cxx
+++ b/Modules/Numerics/Statistics/src/itkMinimumDecisionRule.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/src/itkNormalVariateGenerator.cxx
+++ b/Modules/Numerics/Statistics/src/itkNormalVariateGenerator.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/src/itkProbabilityDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkProbabilityDistribution.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/src/itkSparseFrequencyContainer2.cxx
+++ b/Modules/Numerics/Statistics/src/itkSparseFrequencyContainer2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/src/itkTDistribution.cxx
+++ b/Modules/Numerics/Statistics/src/itkTDistribution.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkChiSquareDistributionGTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkChiSquareDistributionGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkCovarianceSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkCovarianceSampleFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkCovarianceSampleFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkCovarianceSampleFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkCovarianceSampleFilterTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkCovarianceSampleFilterTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkDecisionRuleBackwardCompatibility.cxx
+++ b/Modules/Numerics/Statistics/test/itkDecisionRuleBackwardCompatibility.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkDecisionRuleTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkDecisionRuleTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkDenseFrequencyContainer2Test.cxx
+++ b/Modules/Numerics/Statistics/test/itkDenseFrequencyContainer2Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkDistanceMetricTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkDistanceMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkDistanceMetricTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkDistanceMetricTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkDistanceToCentroidMembershipFunctionTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkDistanceToCentroidMembershipFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkEuclideanDistanceMetricTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkEuclideanDistanceMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkEuclideanSquareDistanceMetricTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkEuclideanSquareDistanceMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkExpectationMaximizationMixtureModelEstimatorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkExpectationMaximizationMixtureModelEstimatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkGaussianDistributionTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkGaussianDistributionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkGaussianMembershipFunctionTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkGaussianMembershipFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkGaussianMixtureModelComponentTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkGaussianMixtureModelComponentTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkGaussianRandomSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkGaussianRandomSpatialNeighborSubsamplerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkHistogramTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkHistogramTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkHistogramToTextureFeaturesFilterNaNTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkHistogramToTextureFeaturesFilterNaNTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkHistogramToTextureFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkHistogramToTextureFeaturesFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkImageToHistogramFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToHistogramFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkImageToHistogramFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToHistogramFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleAdaptorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleAdaptorTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleAdaptorTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkJointDomainImageToListSampleAdaptorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkJointDomainImageToListSampleAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkKalmanLinearEstimatorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkKalmanLinearEstimatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkKdTreeBasedKmeansEstimatorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkKdTreeBasedKmeansEstimatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkKdTreeGeneratorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkKdTreeGeneratorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkKdTreeTest1.cxx
+++ b/Modules/Numerics/Statistics/test/itkKdTreeTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkKdTreeTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkKdTreeTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkKdTreeTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkKdTreeTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkKdTreeTestSamplePoints.cxx
+++ b/Modules/Numerics/Statistics/test/itkKdTreeTestSamplePoints.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkListSampleTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkListSampleTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkMahalanobisDistanceMetricTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMahalanobisDistanceMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkManhattanDistanceMetricTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkManhattanDistanceMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkMaximumDecisionRuleTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMaximumDecisionRuleTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkMaximumRatioDecisionRuleTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMaximumRatioDecisionRuleTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkMeanSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMeanSampleFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkMeanSampleFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkMeanSampleFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkMeanSampleFilterTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkMeanSampleFilterTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkMeasurementVectorTraitsTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMeasurementVectorTraitsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkMembershipFunctionBaseTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMembershipFunctionBaseTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkMembershipFunctionBaseTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkMembershipFunctionBaseTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkMembershipSampleTest1.cxx
+++ b/Modules/Numerics/Statistics/test/itkMembershipSampleTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkMembershipSampleTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkMembershipSampleTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkMembershipSampleTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkMembershipSampleTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkMembershipSampleTest4.cxx
+++ b/Modules/Numerics/Statistics/test/itkMembershipSampleTest4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkMinimumDecisionRuleTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMinimumDecisionRuleTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkMixtureModelComponentBaseTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMixtureModelComponentBaseTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkNeighborhoodSamplerTest1.cxx
+++ b/Modules/Numerics/Statistics/test/itkNeighborhoodSamplerTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkNormalVariateGeneratorTest1.cxx
+++ b/Modules/Numerics/Statistics/test/itkNormalVariateGeneratorTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkPointSetToListSampleAdaptorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkPointSetToListSampleAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkProbabilityDistributionTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkProbabilityDistributionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkRandomVariateGeneratorBaseTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkRandomVariateGeneratorBaseTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkSampleTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkSampleTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkSampleTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkSampleTest4.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleTest4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest4.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest5.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest5.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest6.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest6.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest7.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleToHistogramFilterTest7.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkSampleToSubsampleFilterTest1.cxx
+++ b/Modules/Numerics/Statistics/test/itkSampleToSubsampleFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceListSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceListSampleFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToCooccurrenceMatrixFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkScalarImageToHistogramGeneratorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToHistogramGeneratorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthFeaturesFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthMatrixFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToRunLengthMatrixFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkScalarImageToTextureFeaturesFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkScalarImageToTextureFeaturesFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkSparseFrequencyContainer2Test.cxx
+++ b/Modules/Numerics/Statistics/test/itkSparseFrequencyContainer2Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkSpatialNeighborSubsamplerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkStandardDeviationPerComponentSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkStandardDeviationPerComponentSampleFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkStatisticsAlgorithmTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkStatisticsAlgorithmTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkStatisticsAlgorithmTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkStatisticsAlgorithmTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkStatisticsTypesTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkStatisticsTypesTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkSubsampleTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkSubsampleTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkSubsampleTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkSubsampleTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkSubsampleTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkSubsampleTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkTDistributionTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkTDistributionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkUniformRandomSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkUniformRandomSpatialNeighborSubsamplerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkVectorContainerToListSampleAdaptorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkVectorContainerToListSampleAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest1.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest8.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest8.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest9.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCentroidKdTreeGeneratorTest9.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkWeightedCovarianceSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCovarianceSampleFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkWeightedCovarianceSampleFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedCovarianceSampleFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Numerics/Statistics/test/itkWeightedMeanSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkWeightedMeanSampleFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkBSplineExponentialDiffeomorphicTransformParametersAdaptor.h
+++ b/Modules/Registration/Common/include/itkBSplineExponentialDiffeomorphicTransformParametersAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkBSplineExponentialDiffeomorphicTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkBSplineExponentialDiffeomorphicTransformParametersAdaptor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.h
+++ b/Modules/Registration/Common/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkBSplineTransformParametersAdaptor.h
+++ b/Modules/Registration/Common/include/itkBSplineTransformParametersAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkBSplineTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkBSplineTransformParametersAdaptor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkBlockMatchingImageFilter.h
+++ b/Modules/Registration/Common/include/itkBlockMatchingImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkCenteredTransformInitializer.h
+++ b/Modules/Registration/Common/include/itkCenteredTransformInitializer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkCenteredTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkCenteredTransformInitializer.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkCenteredVersorTransformInitializer.h
+++ b/Modules/Registration/Common/include/itkCenteredVersorTransformInitializer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkCenteredVersorTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkCenteredVersorTransformInitializer.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkCommandIterationUpdate.h
+++ b/Modules/Registration/Common/include/itkCommandIterationUpdate.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkCommandVnlIterationUpdate.h
+++ b/Modules/Registration/Common/include/itkCommandVnlIterationUpdate.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkCompareHistogramImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkCompareHistogramImageToImageMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkCompareHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkCompareHistogramImageToImageMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkConstantVelocityFieldTransformParametersAdaptor.h
+++ b/Modules/Registration/Common/include/itkConstantVelocityFieldTransformParametersAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkConstantVelocityFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkConstantVelocityFieldTransformParametersAdaptor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkCorrelationCoefficientHistogramImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkCorrelationCoefficientHistogramImageToImageMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkCorrelationCoefficientHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkCorrelationCoefficientHistogramImageToImageMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkDisplacementFieldTransformParametersAdaptor.h
+++ b/Modules/Registration/Common/include/itkDisplacementFieldTransformParametersAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkDisplacementFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkDisplacementFieldTransformParametersAdaptor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.h
+++ b/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.hxx
+++ b/Modules/Registration/Common/include/itkEuclideanDistancePointMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkGaussianExponentialDiffeomorphicTransformParametersAdaptor.h
+++ b/Modules/Registration/Common/include/itkGaussianExponentialDiffeomorphicTransformParametersAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkGaussianExponentialDiffeomorphicTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkGaussianExponentialDiffeomorphicTransformParametersAdaptor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.h
+++ b/Modules/Registration/Common/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkGradientDifferenceImageToImageMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkHistogramImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkHistogramImageToImageMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkHistogramImageToImageMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkImageRegistrationMethod.h
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethod.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethod.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkImageRegistrationMethodImageSource.h
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethodImageSource.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.h
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectRegistrationMethod.h
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectRegistrationMethod.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectRegistrationMethod.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkKullbackLeiblerCompareHistogramImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkKullbackLeiblerCompareHistogramImageToImageMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkKullbackLeiblerCompareHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkKullbackLeiblerCompareHistogramImageToImageMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.h
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferenceImageToImageMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanReciprocalSquareDifferencePointSetToImageMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.h
+++ b/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMeanSquaresHistogramImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMeanSquaresHistogramImageToImageMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMeanSquaresHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquaresHistogramImageToImageMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquaresImageToImageMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMeanSquaresPointSetToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMeanSquaresPointSetToImageMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMeanSquaresPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquaresPointSetToImageMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.h
+++ b/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.h
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMutualInformationHistogramImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMutualInformationHistogramImageToImageMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMutualInformationHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMutualInformationHistogramImageToImageMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMutualInformationImageToImageMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationImageToImageMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.h
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedCorrelationPointSetToImageMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkNormalizedMutualInformationHistogramImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkNormalizedMutualInformationHistogramImageToImageMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkNormalizedMutualInformationHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkNormalizedMutualInformationHistogramImageToImageMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkPDEDeformableRegistrationFunction.h
+++ b/Modules/Registration/Common/include/itkPDEDeformableRegistrationFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkPointSetToImageMetric.h
+++ b/Modules/Registration/Common/include/itkPointSetToImageMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToImageMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkPointSetToImageRegistrationMethod.h
+++ b/Modules/Registration/Common/include/itkPointSetToImageRegistrationMethod.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkPointSetToImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToImageRegistrationMethod.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkPointSetToPointSetMetric.h
+++ b/Modules/Registration/Common/include/itkPointSetToPointSetMetric.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkPointSetToPointSetMetric.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToPointSetMetric.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkPointSetToPointSetRegistrationMethod.h
+++ b/Modules/Registration/Common/include/itkPointSetToPointSetRegistrationMethod.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkPointSetToPointSetRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToPointSetRegistrationMethod.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkPointSetToSpatialObjectDemonsRegistration.h
+++ b/Modules/Registration/Common/include/itkPointSetToSpatialObjectDemonsRegistration.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkPointSetToSpatialObjectDemonsRegistration.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToSpatialObjectDemonsRegistration.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkPointsLocator.h
+++ b/Modules/Registration/Common/include/itkPointsLocator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkPointsLocator.hxx
+++ b/Modules/Registration/Common/include/itkPointsLocator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.h
+++ b/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkRecursiveMultiResolutionPyramidImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkSimpleMultiResolutionImageRegistrationUI.h
+++ b/Modules/Registration/Common/include/itkSimpleMultiResolutionImageRegistrationUI.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkTimeVaryingBSplineVelocityFieldTransformParametersAdaptor.h
+++ b/Modules/Registration/Common/include/itkTimeVaryingBSplineVelocityFieldTransformParametersAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkTimeVaryingBSplineVelocityFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkTimeVaryingBSplineVelocityFieldTransformParametersAdaptor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkTimeVaryingVelocityFieldTransformParametersAdaptor.h
+++ b/Modules/Registration/Common/include/itkTimeVaryingVelocityFieldTransformParametersAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkTimeVaryingVelocityFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkTimeVaryingVelocityFieldTransformParametersAdaptor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkTransformParametersAdaptor.h
+++ b/Modules/Registration/Common/include/itkTransformParametersAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/include/itkTransformParametersAdaptorBase.h
+++ b/Modules/Registration/Common/include/itkTransformParametersAdaptorBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration10.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration10.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration12.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration12.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration4.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration6.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration6.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration7.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration7.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration8.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/DeformableRegistration8.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/DeformationFieldJacobian.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/DeformationFieldJacobian.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration1.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration11.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration11.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration12.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration12.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration13.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration13.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration14.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration14.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration3.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration4.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration5.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration5.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration6.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration6.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration7.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration7.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration8.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration8.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration9.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration9.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/MeanSquaresImageMetric1.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/MeanSquaresImageMetric1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/RegistrationITKv3/MultiResImageRegistration1.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/MultiResImageRegistration1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkBSplineExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkBSplineTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkBSplineTransformParametersAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkBlockMatchingImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkBlockMatchingImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkCenteredTransformInitializerTest.cxx
+++ b/Modules/Registration/Common/test/itkCenteredTransformInitializerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkCenteredVersorTransformInitializerTest.cxx
+++ b/Modules/Registration/Common/test/itkCenteredVersorTransformInitializerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkCompareHistogramImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkCompareHistogramImageToImageMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkCorrelationCoefficientHistogramImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkCorrelationCoefficientHistogramImageToImageMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkDisplacementFieldTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkDisplacementFieldTransformParametersAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkEuclideanDistancePointMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkEuclideanDistancePointMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkGaussianExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkGaussianExponentialDiffeomorphicTransformParametersAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
+++ b/Modules/Registration/Common/test/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkGradientDifferenceImageToImageMetricGTest.cxx
+++ b/Modules/Registration/Common/test/itkGradientDifferenceImageToImageMetricGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkHistogramImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkHistogramImageToImageMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_1.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_10.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_10.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_11.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_11.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_12.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_12.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_13.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_13.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_14.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_14.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_15.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_15.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_16.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_16.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_17.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_17.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_2.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_3.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_4.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_5.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_5.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_6.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_6.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_7.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_7.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_8.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_8.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_9.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_9.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkImageToSpatialObjectRegistrationTest.cxx
+++ b/Modules/Registration/Common/test/itkImageToSpatialObjectRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkKappaStatisticImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkKappaStatisticImageToImageMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkKullbackLeiblerCompareHistogramImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkKullbackLeiblerCompareHistogramImageToImageMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkLandmarkBasedTransformInitializerTest.cxx
+++ b/Modules/Registration/Common/test/itkLandmarkBasedTransformInitializerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkMatchCardinalityImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMatchCardinalityImageToImageMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkMeanReciprocalSquareDifferenceImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMeanReciprocalSquareDifferenceImageMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkMeanReciprocalSquareDifferencePointSetToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMeanReciprocalSquareDifferencePointSetToImageMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkMeanSquaresHistogramImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMeanSquaresHistogramImageToImageMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkMeanSquaresImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMeanSquaresImageMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkMeanSquaresPointSetToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMeanSquaresPointSetToImageMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_1.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_2.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionImageRegistrationMethodTest_2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkMultiResolutionPyramidImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkMutualInformationHistogramImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMutualInformationHistogramImageToImageMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkMutualInformationMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMutualInformationMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkNormalizedCorrelationImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkNormalizedCorrelationImageMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkNormalizedCorrelationPointSetToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkNormalizedCorrelationPointSetToImageMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkNormalizedMutualInformationHistogramImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkNormalizedMutualInformationHistogramImageToImageMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkPointSetToImageRegistrationTest.cxx
+++ b/Modules/Registration/Common/test/itkPointSetToImageRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkPointSetToPointSetRegistrationTest.cxx
+++ b/Modules/Registration/Common/test/itkPointSetToPointSetRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkPointSetToSpatialObjectDemonsRegistrationTest.cxx
+++ b/Modules/Registration/Common/test/itkPointSetToSpatialObjectDemonsRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkPointsLocatorTest.cxx
+++ b/Modules/Registration/Common/test/itkPointsLocatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkRecursiveMultiResolutionPyramidImageFilterTest.cxx
+++ b/Modules/Registration/Common/test/itkRecursiveMultiResolutionPyramidImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/test/itkTransformInitializersGTest.cxx
+++ b/Modules/Registration/Common/test/itkTransformInitializersGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Common/wrapping/test/itkPointsLocatorTest.py
+++ b/Modules/Registration/Common/wrapping/test/itkPointsLocatorTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.h
+++ b/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.hxx
+++ b/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/FEM/include/itkMIRegistrationFunction.h
+++ b/Modules/Registration/FEM/include/itkMIRegistrationFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/FEM/include/itkMIRegistrationFunction.hxx
+++ b/Modules/Registration/FEM/include/itkMIRegistrationFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/FEM/include/itkNCCRegistrationFunction.h
+++ b/Modules/Registration/FEM/include/itkNCCRegistrationFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/FEM/include/itkNCCRegistrationFunction.hxx
+++ b/Modules/Registration/FEM/include/itkNCCRegistrationFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/FEM/include/itkPhysicsBasedNonRigidRegistrationMethod.h
+++ b/Modules/Registration/FEM/include/itkPhysicsBasedNonRigidRegistrationMethod.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/FEM/include/itkPhysicsBasedNonRigidRegistrationMethod.hxx
+++ b/Modules/Registration/FEM/include/itkPhysicsBasedNonRigidRegistrationMethod.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/FEM/src/itkFEMRegistrationFilter.cxx
+++ b/Modules/Registration/FEM/src/itkFEMRegistrationFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/FEM/test/itkFEMFiniteDifferenceFunctionLoadTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMFiniteDifferenceFunctionLoadTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilter2DTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilter2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest2.cxx
+++ b/Modules/Registration/FEM/test/itkFEMRegistrationFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/FEM/test/itkMIRegistrationFunctionTest.cxx
+++ b/Modules/Registration/FEM/test/itkMIRegistrationFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/FEM/test/itkPhysicsBasedNonRigidRegistrationMethodTest.cxx
+++ b/Modules/Registration/FEM/test/itkPhysicsBasedNonRigidRegistrationMethodTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/GPUCommon/include/itkGPUPDEDeformableRegistrationFunction.h
+++ b/Modules/Registration/GPUCommon/include/itkGPUPDEDeformableRegistrationFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFilter.h
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.h
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUPDEDeformableRegistrationFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
+++ b/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkANTSNeighborhoodCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4HelperThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4HelperThreader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4HelperThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkCorrelationImageToImageMetricv4HelperThreader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkDefaultImageToImageMetricTraitsv4.h
+++ b/Modules/Registration/Metricsv4/include/itkDefaultImageToImageMetricTraitsv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4GetValueAndDerivativeThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4GetValueAndDerivativeThreader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkDemonsImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkEuclideanDistancePointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkEuclideanDistancePointSetToPointSetMetricv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkEuclideanDistancePointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkEuclideanDistancePointSetToPointSetMetricv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkExpectationBasedPointSetToPointSetMetricv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.h
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.hxx
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4GetValueAndDerivativeThreaderBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.h
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationComputeJointPDFThreaderBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationGetValueAndDerivativeThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationGetValueAndDerivativeThreader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationGetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationGetValueAndDerivativeThreader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJointHistogramMutualInformationImageToImageMetricv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkLabeledPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkLabeledPointSetToPointSetMetricv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkLabeledPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkLabeledPointSetToPointSetMetricv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.hxx
+++ b/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMattesMutualInformationImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkMeanSquaresImageToImageMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkMeanSquaresImageToImageMetricv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkMeanSquaresImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMeanSquaresImageToImageMetricv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkMeanSquaresImageToImageMetricv4GetValueAndDerivativeThreader.h
+++ b/Modules/Registration/Metricsv4/include/itkMeanSquaresImageToImageMetricv4GetValueAndDerivativeThreader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkMeanSquaresImageToImageMetricv4GetValueAndDerivativeThreader.hxx
+++ b/Modules/Registration/Metricsv4/include/itkMeanSquaresImageToImageMetricv4GetValueAndDerivativeThreader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkObjectToObjectMultiMetricv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkPointSetFunction.hxx
+++ b/Modules/Registration/Metricsv4/include/itkPointSetFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/include/itkVectorImageToImageMetricTraitsv4.h
+++ b/Modules/Registration/Metricsv4/include/itkVectorImageToImageMetricTraitsv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageMetricv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkANTSNeighborhoodCorrelationImageToImageRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4RegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkDemonsImageToImageMetricv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest3.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkExpectationBasedPointSetMetricRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkExpectationBasedPointSetMetricRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkExpectationBasedPointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkExpectationBasedPointSetMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4RegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkJensenHavrdaCharvatTsallisPointSetMetricRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJensenHavrdaCharvatTsallisPointSetMetricRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkJensenHavrdaCharvatTsallisPointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJensenHavrdaCharvatTsallisPointSetMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkLabeledPointSetMetricRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkLabeledPointSetMetricRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkLabeledPointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkLabeledPointSetMetricTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkMattesMutualInformationImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMattesMutualInformationImageToImageMetricv4RegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkMattesMutualInformationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMattesMutualInformationImageToImageMetricv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4RegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4RegistrationTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4RegistrationTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4SpeedTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkMetricImageGradientTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMetricImageGradientTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkMultiGradientImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMultiGradientImageToImageMetricv4RegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkMultiStartImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMultiStartImageToImageMetricv4RegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4RegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4Test.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkCurvatureRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkCurvatureRegistrationFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkCurvatureRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkCurvatureRegistrationFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.h
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkMultiResolutionPDEDeformableRegistration.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/src/itkESMDemonsRegistrationFunction.cxx
+++ b/Modules/Registration/PDEDeformable/src/itkESMDemonsRegistrationFunction.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/test/itkCurvatureRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkCurvatureRegistrationFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/test/itkDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDemonsRegistrationFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest2.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkDiffeomorphicDemonsRegistrationFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/test/itkESMDemonsRegistrationFunctionTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkESMDemonsRegistrationFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkFastSymmetricForcesDemonsRegistrationFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/test/itkLevelSetMotionRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkLevelSetMotionRegistrationFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkMultiResolutionPDEDeformableRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/PDEDeformable/test/itkSymmetricForcesDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/PDEDeformable/test/itkSymmetricForcesDemonsRegistrationFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/include/itkBSplineSyNImageRegistrationMethod.h
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkBSplineSyNImageRegistrationMethod.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/include/itkBSplineSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkBSplineSyNImageRegistrationMethod.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.h
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.h
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.h
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.h
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/src/itkImageRegistrationMethodv4.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/src/itkImageRegistrationMethodv4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineExponentialImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineExponentialImageRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineImageRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNImageRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNPointSetRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNPointSetRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/test/itkExponentialImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkExponentialImageRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/test/itkImageRegistrationSamplingTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkImageRegistrationSamplingTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/test/itkQuasiNewtonOptimizerv4RegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkQuasiNewtonOptimizerv4RegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest2.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest3.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest4.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTestWithMaskAndSampling.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTestWithMaskAndSampling.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimplePointSetRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimplePointSetRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSyNImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSyNImageRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSyNPointSetRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSyNPointSetRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldImageRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldPointSetRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldPointSetRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingVelocityFieldImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingVelocityFieldImageRegistrationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.h
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.h
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/include/itkClassifierBase.h
+++ b/Modules/Segmentation/Classifiers/include/itkClassifierBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/include/itkClassifierBase.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkClassifierBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/include/itkImageClassifierBase.h
+++ b/Modules/Segmentation/Classifiers/include/itkImageClassifierBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/include/itkImageClassifierBase.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageClassifierBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/include/itkImageGaussianModelEstimator.h
+++ b/Modules/Segmentation/Classifiers/include/itkImageGaussianModelEstimator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/include/itkImageGaussianModelEstimator.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageGaussianModelEstimator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.h
+++ b/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/include/itkImageModelEstimatorBase.h
+++ b/Modules/Segmentation/Classifiers/include/itkImageModelEstimatorBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/include/itkImageModelEstimatorBase.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageModelEstimatorBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.h
+++ b/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/test/itkBayesianClassifierImageFilterTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkBayesianClassifierImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/test/itkImageClassifierFilterTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkImageClassifierFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/test/itkKmeansModelEstimatorTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkKmeansModelEstimatorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest1.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest1.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest2.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest3.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest3.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest4.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest4.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest5.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest5.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest6.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest6.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest7.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSampleClassifierFilterTest7.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilter3DTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilter3DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilterTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Classifiers/test/itkSupervisedImageClassifierTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkSupervisedImageClassifierTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentFunctorImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkConnectedComponentImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkHardConnectedComponentImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkRelabelComponentImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/include/itkScalarConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkScalarConnectedComponentImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/include/itkVectorConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkVectorConnectedComponentImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterBackgroundTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterBackgroundTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterGTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTestRGB.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTestRGB.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTooManyObjectsTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTooManyObjectsTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/test/itkHardConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkHardConnectedComponentImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/test/itkMaskConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkMaskConnectedComponentImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterGTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/test/itkScalarConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkScalarConnectedComponentImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/test/itkThresholdMaximumConnectedComponentsImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkThresholdMaximumConnectedComponentsImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/ConnectedComponents/test/itkVectorConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkVectorConnectedComponentImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DBalloonForceFilter.h
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DBalloonForceFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DBalloonForceFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DBalloonForceFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.h
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.h
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
+++ b/Modules/Segmentation/DeformableMesh/include/itkDeformableSimplexMesh3DGradientConstraintForceFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/DeformableMesh/src/itkDeformableSimplexMesh3DGradientConstraintForceFilter.cxx
+++ b/Modules/Segmentation/DeformableMesh/src/itkDeformableSimplexMesh3DGradientConstraintForceFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DBalloonForceFilterTest.cxx
+++ b/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DBalloonForceFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DFilterTest.cxx
+++ b/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DGradientConstraintForceFilterTest.cxx
+++ b/Modules/Segmentation/DeformableMesh/test/itkDeformableSimplexMesh3DGradientConstraintForceFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/DeformableMesh/test/itkSimplexMeshWithFloatCoordRepGTest.cxx
+++ b/Modules/Segmentation/DeformableMesh/test/itkSimplexMeshWithFloatCoordRepGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.h
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMSegmentationBorder.h
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMSegmentationBorder.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMSegmentationRegion.h
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMSegmentationRegion.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkRegionGrowImageFilter.h
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkRegionGrowImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkRegionGrowImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkSegmentationBorder.h
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkSegmentationBorder.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkSegmentationRegion.h
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkSegmentationRegion.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationBorder.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationBorder.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationRegion.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkKLMSegmentationRegion.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkSegmentationBorder.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkSegmentationBorder.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/KLMRegionGrowing/src/itkSegmentationRegion.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/src/itkSegmentationRegion.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
+++ b/Modules/Segmentation/KLMRegionGrowing/test/itkRegionGrow2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LabelVoting/include/itkBinaryMedianImageFilter.h
+++ b/Modules/Segmentation/LabelVoting/include/itkBinaryMedianImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LabelVoting/include/itkBinaryMedianImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkBinaryMedianImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.h
+++ b/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.h
+++ b/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryHoleFillingImageFilter.h
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryHoleFillingImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryHoleFillingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryHoleFillingImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.h
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryIterativeHoleFillingImageFilter.h
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryIterativeHoleFillingImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryIterativeHoleFillingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryIterativeHoleFillingImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LabelVoting/test/itkBinaryMedianImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkBinaryMedianImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LabelVoting/test/itkLabelVotingImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkLabelVotingImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LabelVoting/test/itkVotingBinaryHoleFillingImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkVotingBinaryHoleFillingImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LabelVoting/test/itkVotingBinaryImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkVotingBinaryImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LabelVoting/test/itkVotingBinaryIterativeHoleFillingImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkVotingBinaryIterativeHoleFillingImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkAnisotropicFourthOrderLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkAnisotropicFourthOrderLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkAnisotropicFourthOrderLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkAnisotropicFourthOrderLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkBinaryMaskToNarrowBandPointSetFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkBinaryMaskToNarrowBandPointSetFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkBinaryMaskToNarrowBandPointSetFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkBinaryMaskToNarrowBandPointSetFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkCannySegmentationLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkCannySegmentationLevelSetFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkCannySegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkCannySegmentationLevelSetFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkCannySegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkCannySegmentationLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkCannySegmentationLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkCannySegmentationLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkCollidingFrontsImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkCollidingFrontsImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkCollidingFrontsImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkCollidingFrontsImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkCurvesLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkExtensionVelocitiesImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkExtensionVelocitiesImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkExtensionVelocitiesImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkExtensionVelocitiesImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourLevelSetFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourLevelSetFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourShapePriorLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourShapePriorLevelSetFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourShapePriorLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourShapePriorLevelSetFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourShapePriorLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourShapePriorLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourShapePriorLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkGeodesicActiveContourShapePriorLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkImplicitManifoldNormalVectorFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkImplicitManifoldNormalVectorFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkImplicitManifoldNormalVectorFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkImplicitManifoldNormalVectorFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkIsotropicFourthOrderLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkIsotropicFourthOrderLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkIsotropicFourthOrderLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkIsotropicFourthOrderLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkLaplacianSegmentationLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkLaplacianSegmentationLevelSetFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkLaplacianSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLaplacianSegmentationLevelSetFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkLaplacianSegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkLaplacianSegmentationLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkLaplacianSegmentationLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLaplacianSegmentationLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunctionWithRefitTerm.h
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunctionWithRefitTerm.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunctionWithRefitTerm.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunctionWithRefitTerm.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.h
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetVelocityNeighborhoodExtractor.h
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetVelocityNeighborhoodExtractor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetVelocityNeighborhoodExtractor.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetVelocityNeighborhoodExtractor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkNarrowBandCurvesLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkNarrowBandCurvesLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkNarrowBandCurvesLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkNarrowBandCurvesLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkNarrowBandLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkNarrowBandLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkNarrowBandLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkNarrowBandLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkNarrowBandThresholdSegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkNarrowBandThresholdSegmentationLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkNarrowBandThresholdSegmentationLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkNarrowBandThresholdSegmentationLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkNormalVectorDiffusionFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkNormalVectorDiffusionFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkNormalVectorDiffusionFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkNormalVectorDiffusionFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkNormalVectorFunctionBase.h
+++ b/Modules/Segmentation/LevelSets/include/itkNormalVectorFunctionBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkNormalVectorFunctionBase.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkNormalVectorFunctionBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkReinitializeLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSegmentationLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkShapeDetectionLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkShapeDetectionLevelSetFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkShapeDetectionLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkShapeDetectionLevelSetFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkShapeDetectionLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkShapeDetectionLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkShapeDetectionLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkShapeDetectionLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunctionBase.h
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunctionBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunctionBase.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorMAPCostFunctionBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldFourthOrderLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkThresholdSegmentationLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkUnsharpMaskLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkUnsharpMaskLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkUnsharpMaskLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkUnsharpMaskLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetFunction.h
+++ b/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkVectorThresholdSegmentationLevelSetImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkAnisotropicFourthOrderLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkAnisotropicFourthOrderLevelSetImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkBinaryMaskToNarrowBandPointSetFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkBinaryMaskToNarrowBandPointSetFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkCannySegmentationLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkCannySegmentationLevelSetImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkCollidingFrontsImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkCollidingFrontsImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkCurvesLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkCurvesLevelSetImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkCurvesLevelSetImageFilterZeroSigmaTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkCurvesLevelSetImageFilterZeroSigmaTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkExtensionVelocitiesImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkExtensionVelocitiesImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourLevelSetImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourLevelSetImageFilterZeroSigmaTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourLevelSetImageFilterZeroSigmaTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest_2.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest_2.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkImplicitManifoldNormalVectorFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkImplicitManifoldNormalVectorFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkIsotropicFourthOrderLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkIsotropicFourthOrderLevelSetImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkLaplacianSegmentationLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLaplacianSegmentationLevelSetImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkLevelSetNeighborhoodExtractorTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLevelSetNeighborhoodExtractorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkLevelSetVelocityNeighborhoodExtractorTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLevelSetVelocityNeighborhoodExtractorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkNarrowBandCurvesLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkNarrowBandCurvesLevelSetImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkNarrowBandThresholdSegmentationLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkNarrowBandThresholdSegmentationLevelSetImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkReinitializeLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkReinitializeLevelSetImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkShapeDetectionLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkShapeDetectionLevelSetImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkShapePriorMAPCostFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkShapePriorMAPCostFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkShapePriorSegmentationLevelSetFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkShapePriorSegmentationLevelSetFunctionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkThresholdSegmentationLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkThresholdSegmentationLevelSetImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkUnsharpMaskLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkUnsharpMaskLevelSetImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/test/itkVectorThresholdSegmentationLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkVectorThresholdSegmentationLevelSetImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/wrapping/test/GeodesicActiveContourImageFilterTest.py
+++ b/Modules/Segmentation/LevelSets/wrapping/test/GeodesicActiveContourImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/wrapping/test/LazyLoadingImageTest.py
+++ b/Modules/Segmentation/LevelSets/wrapping/test/LazyLoadingImageTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSets/wrapping/test/ThresholdSegmentationLevelSetImageFilterTest.py
+++ b/Modules/Segmentation/LevelSets/wrapping/test/ThresholdSegmentationLevelSetImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptor.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptorBase.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkBinaryImageToLevelSetImageAdaptorBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkDiscreteLevelSetImage.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkDiscreteLevelSetImage.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkDiscreteLevelSetImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkDiscreteLevelSetImage.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetBase.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainer.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainerBase.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainerBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainerBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetContainerBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDenseImage.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDenseImage.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDenseImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDenseImage.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainMapImageFilter.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainMapImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainMapImageFilter.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainMapImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartition.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartition.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartition.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartition.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionBase.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImage.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImage.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImage.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImageWithKdTree.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImageWithKdTree.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImageWithKdTree.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionImageWithKdTree.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionMesh.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionMesh.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionMesh.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetDomainPartitionMesh.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationAdvectionTerm.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationBinaryMaskTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationBinaryMaskTerm.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationBinaryMaskTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationBinaryMaskTerm.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationChanAndVeseExternalTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationChanAndVeseExternalTerm.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationChanAndVeseExternalTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationChanAndVeseExternalTerm.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationChanAndVeseInternalTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationChanAndVeseInternalTerm.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationChanAndVeseInternalTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationChanAndVeseInternalTerm.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationContainer.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationContainer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationContainer.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationContainer.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationCurvatureTerm.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationLaplacianTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationLaplacianTerm.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationLaplacianTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationLaplacianTerm.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationOverlapPenaltyTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationOverlapPenaltyTerm.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationOverlapPenaltyTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationOverlapPenaltyTerm.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationPropagationTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationPropagationTerm.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationPropagationTerm.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationPropagationTerm.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationRegionTerm.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationRegionTerm.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermBase.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermContainer.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermContainer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermContainer.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEquationTermContainer.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolution.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolution.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolution.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolution.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionBase.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionBase.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionComputeIterationThreader.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionComputeIterationThreader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionComputeIterationThreader.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionComputeIterationThreader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionNumberOfIterationsStoppingCriterion.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionNumberOfIterationsStoppingCriterion.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionNumberOfIterationsStoppingCriterion.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionNumberOfIterationsStoppingCriterion.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionStoppingCriterion.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionStoppingCriterion.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionStoppingCriterion.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionStoppingCriterion.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionUpdateLevelSetsThreader.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionUpdateLevelSetsThreader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionUpdateLevelSetsThreader.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetEvolutionUpdateLevelSetsThreader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetImage.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetImage.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetImage.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetQuadEdgeMesh.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetQuadEdgeMesh.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetQuadEdgeMesh.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetQuadEdgeMesh.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetSparseImage.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetSparseImage.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkLevelSetSparseImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkLevelSetSparseImage.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkMalcolmSparseLevelSetImage.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkMalcolmSparseLevelSetImage.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkMalcolmSparseLevelSetImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkMalcolmSparseLevelSetImage.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkShiSparseLevelSetImage.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkShiSparseLevelSetImage.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkShiSparseLevelSetImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkShiSparseLevelSetImage.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateMalcolmSparseLevelSet.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateShiSparseLevelSet.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateShiSparseLevelSet.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateShiSparseLevelSet.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateShiSparseLevelSet.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateWhitakerSparseLevelSet.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateWhitakerSparseLevelSet.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkUpdateWhitakerSparseLevelSet.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkUpdateWhitakerSparseLevelSet.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkWhitakerSparseLevelSetImage.h
+++ b/Modules/Segmentation/LevelSetsv4/include/itkWhitakerSparseLevelSetImage.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/include/itkWhitakerSparseLevelSetImage.hxx
+++ b/Modules/Segmentation/LevelSetsv4/include/itkWhitakerSparseLevelSetImage.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkBinaryImageToMalcolmSparseLevelSetAdaptorTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkBinaryImageToMalcolmSparseLevelSetAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkBinaryImageToShiSparseLevelSetAdaptorTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkBinaryImageToShiSparseLevelSetAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkBinaryImageToWhitakerSparseLevelSetAdaptorTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkBinaryImageToWhitakerSparseLevelSetAdaptorTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkDenseLevelSetContainerTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkDenseLevelSetContainerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDenseImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDenseImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainMapImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainMapImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionBaseTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionBaseTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageWithKdTreeTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetDomainPartitionImageWithKdTreeTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationBinaryMaskTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationBinaryMaskTermTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseExternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseExternalTermTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseInternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseInternalTermTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationCurvatureTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationCurvatureTermTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationLaplacianTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationLaplacianTermTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationOverlapPenaltyTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationOverlapPenaltyTermTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationPropagationTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationPropagationTermTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationRegionTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationRegionTermTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermBaseTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermBaseTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermContainerTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermContainerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEvolutionNumberOfIterationsStoppingCriterionTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEvolutionNumberOfIterationsStoppingCriterionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetTestFunction.h
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetTestFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetTestFunction.hxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetTestFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkMalcolmSparseLevelSetImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMalcolmSparseLevelSetImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetChanAndVeseInternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetChanAndVeseInternalTermTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageSubset2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetDenseImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetEvolutionTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetEvolutionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetMalcolmImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetMalcolmImageSubset2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetShiImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetShiImageSubset2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetWhitakerImageSubset2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkMultiLevelSetWhitakerImageSubset2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkShiSparseLevelSetImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkShiSparseLevelSetImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetDenseAdvectionImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetDenseAdvectionImage2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetDenseImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetDenseImage2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetMalcolmImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetMalcolmImage2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetShiImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetShiImage2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DWithCurvatureTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DWithCurvatureTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DWithLaplacianTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DWithLaplacianTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DWithPropagationTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSingleLevelSetWhitakerImage2DWithPropagationTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkSparseLevelSetContainerTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkSparseLevelSetContainerTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetDenseImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetDenseImage2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetMalcolmImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetMalcolmImage2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetShiImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetShiImage2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetWhitakerImage2DTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkTwoLevelSetWhitakerImage2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/LevelSetsv4/test/itkWhitakerSparseLevelSetImageTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkWhitakerSparseLevelSetImageTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.h
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.h
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/src/itkMRFImageFilter.cxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/src/itkMRFImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkMRFImageFilterTest.cxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkMRFImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkRGBGibbsPriorFilterTest.cxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkRGBGibbsPriorFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.h
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/RegionGrowing/include/itkConnectedThresholdImageFilter.h
+++ b/Modules/Segmentation/RegionGrowing/include/itkConnectedThresholdImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/RegionGrowing/include/itkConnectedThresholdImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConnectedThresholdImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.h
+++ b/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/RegionGrowing/include/itkNeighborhoodConnectedImageFilter.h
+++ b/Modules/Segmentation/RegionGrowing/include/itkNeighborhoodConnectedImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/RegionGrowing/include/itkNeighborhoodConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkNeighborhoodConnectedImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.h
+++ b/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/RegionGrowing/src/itkConnectedThresholdImageFilter.cxx
+++ b/Modules/Segmentation/RegionGrowing/src/itkConnectedThresholdImageFilter.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/RegionGrowing/test/itkConfidenceConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkConfidenceConnectedImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/RegionGrowing/test/itkConnectedThresholdImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkConnectedThresholdImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/RegionGrowing/test/itkIsolatedConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkIsolatedConnectedImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/RegionGrowing/test/itkNeighborhoodConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkNeighborhoodConnectedImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/RegionGrowing/test/itkVectorConfidenceConnectedImageFilterTest.cxx
+++ b/Modules/Segmentation/RegionGrowing/test/itkVectorConfidenceConnectedImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkPCAShapeSignedDistanceFunction.h
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkPCAShapeSignedDistanceFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkPCAShapeSignedDistanceFunction.hxx
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkPCAShapeSignedDistanceFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkShapeSignedDistanceFunction.h
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkShapeSignedDistanceFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkSphereSignedDistanceFunction.h
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkSphereSignedDistanceFunction.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/SignedDistanceFunction/include/itkSphereSignedDistanceFunction.hxx
+++ b/Modules/Segmentation/SignedDistanceFunction/include/itkSphereSignedDistanceFunction.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/SignedDistanceFunction/test/itkPCAShapeSignedDistanceFunctionGTest.cxx
+++ b/Modules/Segmentation/SignedDistanceFunction/test/itkPCAShapeSignedDistanceFunctionGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/SignedDistanceFunction/test/itkSphereSignedDistanceFunctionGTest.cxx
+++ b/Modules/Segmentation/SignedDistanceFunction/test/itkSphereSignedDistanceFunctionGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/SignedDistanceFunction/wrapping/test/itkPCAShapeSignedDistanceFunction.py
+++ b/Modules/Segmentation/SignedDistanceFunction/wrapping/test/itkPCAShapeSignedDistanceFunction.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.h
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterGTest.cxx
+++ b/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterTest.cxx
+++ b/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2D.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiPartitioningImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.h
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationRGBImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Voronoi/test/itkVoronoiDiagram2DInfiniteLoopTest.cxx
+++ b/Modules/Segmentation/Voronoi/test/itkVoronoiDiagram2DInfiniteLoopTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Voronoi/test/itkVoronoiDiagram2DTest.cxx
+++ b/Modules/Segmentation/Voronoi/test/itkVoronoiDiagram2DTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Voronoi/test/itkVoronoiPartitioningImageFilterTest.cxx
+++ b/Modules/Segmentation/Voronoi/test/itkVoronoiPartitioningImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationImageFilterTest.cxx
+++ b/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationRGBImageFilterTest.cxx
+++ b/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationRGBImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkIsolatedWatershedImageFilter.h
+++ b/Modules/Segmentation/Watersheds/include/itkIsolatedWatershedImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkIsolatedWatershedImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkIsolatedWatershedImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.h
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.h
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkOneWayEquivalencyTable.h
+++ b/Modules/Segmentation/Watersheds/include/itkOneWayEquivalencyTable.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.h
+++ b/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkTobogganImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkWatershedBoundary.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedBoundary.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkWatershedBoundary.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedBoundary.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedBoundaryResolver.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkWatershedEquivalenceRelabeler.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedEquivalenceRelabeler.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkWatershedEquivalenceRelabeler.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedEquivalenceRelabeler.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkWatershedImageFilter.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedImageFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkWatershedImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedImageFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkWatershedMiniPipelineProgressCommand.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedMiniPipelineProgressCommand.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedRelabeler.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTable.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTree.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTree.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTree.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTree.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmentTreeGenerator.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.h
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkWatershedSegmenter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/src/itkOneWayEquivalencyTable.cxx
+++ b/Modules/Segmentation/Watersheds/src/itkOneWayEquivalencyTable.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/src/itkWatershedMiniPipelineProgressCommand.cxx
+++ b/Modules/Segmentation/Watersheds/src/itkWatershedMiniPipelineProgressCommand.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/test/itkIsolatedWatershedImageFilterTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkIsolatedWatershedImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/test/itkMorphologicalWatershedFromMarkersImageFilterTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkMorphologicalWatershedFromMarkersImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/test/itkMorphologicalWatershedImageFilterTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkMorphologicalWatershedImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/test/itkTobogganImageFilterTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkTobogganImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/test/itkWatershedImageFilterBadValuesTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkWatershedImageFilterBadValuesTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/test/itkWatershedImageFilterTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkWatershedImageFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Segmentation/Watersheds/wrapping/test/WatershedSegmentation1Test.py
+++ b/Modules/Segmentation/Watersheds/wrapping/test/WatershedSegmentation1Test.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVBasicTypeBridge.h
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVBasicTypeBridge.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVImageBridge.h
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVImageBridge.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVImageBridge.hxx
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVImageBridge.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoCapture.h
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoCapture.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoCapture.hxx
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoCapture.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoIO.h
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoIOFactory.h
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeOpenCV/src/itkOpenCVVideoIO.cxx
+++ b/Modules/Video/BridgeOpenCV/src/itkOpenCVVideoIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeOpenCV/src/itkOpenCVVideoIOFactory.cxx
+++ b/Modules/Video/BridgeOpenCV/src/itkOpenCVVideoIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVBasicTypeBridgeTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVBasicTypeBridgeTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeGrayScaleTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeGrayScaleTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVTestHelper.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVTestHelper.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVTestHelper.h
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVTestHelper.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoCaptureTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoCaptureTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoIOFactoryTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoIOFactoryTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoIOTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeVXL/include/itkVXLVideoIO.h
+++ b/Modules/Video/BridgeVXL/include/itkVXLVideoIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeVXL/include/itkVXLVideoIOFactory.h
+++ b/Modules/Video/BridgeVXL/include/itkVXLVideoIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeVXL/include/vidl_itk_istream.h
+++ b/Modules/Video/BridgeVXL/include/vidl_itk_istream.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeVXL/include/vidl_itk_istream.hxx
+++ b/Modules/Video/BridgeVXL/include/vidl_itk_istream.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeVXL/src/itkVXLVideoIO.cxx
+++ b/Modules/Video/BridgeVXL/src/itkVXLVideoIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeVXL/src/itkVXLVideoIOFactory.cxx
+++ b/Modules/Video/BridgeVXL/src/itkVXLVideoIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeVXL/test/itkVXLVideoIOFactoryTest.cxx
+++ b/Modules/Video/BridgeVXL/test/itkVXLVideoIOFactoryTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeVXL/test/itkVXLVideoIOTest.cxx
+++ b/Modules/Video/BridgeVXL/test/itkVXLVideoIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/BridgeVXL/test/vidl_itk_istreamTest.cxx
+++ b/Modules/Video/BridgeVXL/test/vidl_itk_istreamTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/include/itkImageToVideoFilter.h
+++ b/Modules/Video/Core/include/itkImageToVideoFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/include/itkImageToVideoFilter.hxx
+++ b/Modules/Video/Core/include/itkImageToVideoFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/include/itkRingBuffer.h
+++ b/Modules/Video/Core/include/itkRingBuffer.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/include/itkRingBuffer.hxx
+++ b/Modules/Video/Core/include/itkRingBuffer.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/include/itkTemporalDataObject.h
+++ b/Modules/Video/Core/include/itkTemporalDataObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/include/itkTemporalProcessObject.h
+++ b/Modules/Video/Core/include/itkTemporalProcessObject.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/include/itkTemporalRegion.h
+++ b/Modules/Video/Core/include/itkTemporalRegion.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/include/itkVideoSource.h
+++ b/Modules/Video/Core/include/itkVideoSource.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/include/itkVideoSource.hxx
+++ b/Modules/Video/Core/include/itkVideoSource.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/include/itkVideoStream.h
+++ b/Modules/Video/Core/include/itkVideoStream.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/include/itkVideoStream.hxx
+++ b/Modules/Video/Core/include/itkVideoStream.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/include/itkVideoToVideoFilter.h
+++ b/Modules/Video/Core/include/itkVideoToVideoFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/include/itkVideoToVideoFilter.hxx
+++ b/Modules/Video/Core/include/itkVideoToVideoFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/src/itkTemporalDataObject.cxx
+++ b/Modules/Video/Core/src/itkTemporalDataObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/src/itkTemporalProcessObject.cxx
+++ b/Modules/Video/Core/src/itkTemporalProcessObject.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/src/itkTemporalRegion.cxx
+++ b/Modules/Video/Core/src/itkTemporalRegion.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/test/itkImageToVideoFilterTest.cxx
+++ b/Modules/Video/Core/test/itkImageToVideoFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/test/itkRingBufferTest.cxx
+++ b/Modules/Video/Core/test/itkRingBufferTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/test/itkTemporalDataObjectTest.cxx
+++ b/Modules/Video/Core/test/itkTemporalDataObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
+++ b/Modules/Video/Core/test/itkTemporalProcessObjectTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/test/itkTemporalRegionTest.cxx
+++ b/Modules/Video/Core/test/itkTemporalRegionTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/test/itkVectorImageToVideoTest.cxx
+++ b/Modules/Video/Core/test/itkVectorImageToVideoTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/test/itkVideoSourceTest.cxx
+++ b/Modules/Video/Core/test/itkVideoSourceTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/test/itkVideoStreamTest.cxx
+++ b/Modules/Video/Core/test/itkVideoStreamTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Core/test/itkVideoToVideoFilterGTest.cxx
+++ b/Modules/Video/Core/test/itkVideoToVideoFilterGTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Filtering/include/itkDecimateFramesVideoFilter.h
+++ b/Modules/Video/Filtering/include/itkDecimateFramesVideoFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Filtering/include/itkDecimateFramesVideoFilter.hxx
+++ b/Modules/Video/Filtering/include/itkDecimateFramesVideoFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Filtering/include/itkFrameAverageVideoFilter.h
+++ b/Modules/Video/Filtering/include/itkFrameAverageVideoFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Filtering/include/itkFrameAverageVideoFilter.hxx
+++ b/Modules/Video/Filtering/include/itkFrameAverageVideoFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Filtering/include/itkFrameDifferenceVideoFilter.h
+++ b/Modules/Video/Filtering/include/itkFrameDifferenceVideoFilter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Filtering/include/itkFrameDifferenceVideoFilter.hxx
+++ b/Modules/Video/Filtering/include/itkFrameDifferenceVideoFilter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Filtering/include/itkImageFilterToVideoFilterWrapper.h
+++ b/Modules/Video/Filtering/include/itkImageFilterToVideoFilterWrapper.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Filtering/include/itkImageFilterToVideoFilterWrapper.hxx
+++ b/Modules/Video/Filtering/include/itkImageFilterToVideoFilterWrapper.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Filtering/test/itkDecimateFramesVideoFilterTest.cxx
+++ b/Modules/Video/Filtering/test/itkDecimateFramesVideoFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Filtering/test/itkFrameAverageVideoFilterTest.cxx
+++ b/Modules/Video/Filtering/test/itkFrameAverageVideoFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Filtering/test/itkFrameDifferenceVideoFilterTest.cxx
+++ b/Modules/Video/Filtering/test/itkFrameDifferenceVideoFilterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/Filtering/test/itkImageFilterToVideoFilterWrapperTest.cxx
+++ b/Modules/Video/Filtering/test/itkImageFilterToVideoFilterWrapperTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/IO/include/itkFileListVideoIO.h
+++ b/Modules/Video/IO/include/itkFileListVideoIO.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/IO/include/itkFileListVideoIOFactory.h
+++ b/Modules/Video/IO/include/itkFileListVideoIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/IO/include/itkVideoFileReader.h
+++ b/Modules/Video/IO/include/itkVideoFileReader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/IO/include/itkVideoFileReader.hxx
+++ b/Modules/Video/IO/include/itkVideoFileReader.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/IO/include/itkVideoFileWriter.h
+++ b/Modules/Video/IO/include/itkVideoFileWriter.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/IO/include/itkVideoFileWriter.hxx
+++ b/Modules/Video/IO/include/itkVideoFileWriter.hxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/IO/include/itkVideoIOBase.h
+++ b/Modules/Video/IO/include/itkVideoIOBase.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/IO/include/itkVideoIOFactory.h
+++ b/Modules/Video/IO/include/itkVideoIOFactory.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/IO/src/itkFileListVideoIO.cxx
+++ b/Modules/Video/IO/src/itkFileListVideoIO.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/IO/src/itkFileListVideoIOFactory.cxx
+++ b/Modules/Video/IO/src/itkFileListVideoIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/IO/src/itkVideoIOBase.cxx
+++ b/Modules/Video/IO/src/itkVideoIOBase.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/IO/src/itkVideoIOFactory.cxx
+++ b/Modules/Video/IO/src/itkVideoIOFactory.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/IO/test/itkFileListVideoIOFactoryTest.cxx
+++ b/Modules/Video/IO/test/itkFileListVideoIOFactoryTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/IO/test/itkFileListVideoIOTest.cxx
+++ b/Modules/Video/IO/test/itkFileListVideoIOTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Modules/Video/IO/test/itkVideoFileReaderWriterTest.cxx
+++ b/Modules/Video/IO/test/itkVideoFileReaderWriterTest.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Utilities/Hooks/kw-commit-msg.py
+++ b/Utilities/Hooks/kw-commit-msg.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Utilities/KWStyle/ITKHeader.h
+++ b/Utilities/KWStyle/ITKHeader.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Utilities/Maintenance/AddEmptyDefaultMemberInitializers.cxx
+++ b/Utilities/Maintenance/AddEmptyDefaultMemberInitializers.cxx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS

--- a/Utilities/Maintenance/BuildHeaderTest.py
+++ b/Utilities/Maintenance/BuildHeaderTest.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 
 # ==========================================================================
 #

--- a/Utilities/Maintenance/FindRedundantHeaderIncludes.py
+++ b/Utilities/Maintenance/FindRedundantHeaderIncludes.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Utilities/Maintenance/ParallelStripIncludes.py
+++ b/Utilities/Maintenance/ParallelStripIncludes.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Utilities/Maintenance/SortCMakeSourceLists.py
+++ b/Utilities/Maintenance/SortCMakeSourceLists.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Utilities/Maintenance/StripIncludes.py
+++ b/Utilities/Maintenance/StripIncludes.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Utilities/Maintenance/UpdateCopyrightStatementsInITK.py
+++ b/Utilities/Maintenance/UpdateCopyrightStatementsInITK.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Utilities/Maintenance/fix-redundant-namespace-qualifiers.py
+++ b/Utilities/Maintenance/fix-redundant-namespace-qualifiers.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/CMakeLists.txt
+++ b/Wrapping/CMakeLists.txt
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 #==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/ModifiedTime.py
+++ b/Wrapping/Generators/Python/Tests/ModifiedTime.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/PyImageFilterTest.py
+++ b/Wrapping/Generators/Python/Tests/PyImageFilterTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/PythonTemplateTest.py
+++ b/Wrapping/Generators/Python/Tests/PythonTemplateTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/PythonTypeTest.py
+++ b/Wrapping/Generators/Python/Tests/PythonTypeTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/PythonTypemapsTest.py
+++ b/Wrapping/Generators/Python/Tests/PythonTypemapsTest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/complex.py
+++ b/Wrapping/Generators/Python/Tests/complex.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/dicomSeries.py
+++ b/Wrapping/Generators/Python/Tests/dicomSeries.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/findEmptyClasses.py
+++ b/Wrapping/Generators/Python/Tests/findEmptyClasses.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/findSegfaults.py
+++ b/Wrapping/Generators/Python/Tests/findSegfaults.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/getNameOfClass.py
+++ b/Wrapping/Generators/Python/Tests/getNameOfClass.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/helpers.py
+++ b/Wrapping/Generators/Python/Tests/helpers.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/lazy.py
+++ b/Wrapping/Generators/Python/Tests/lazy.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/module2module.py
+++ b/Wrapping/Generators/Python/Tests/module2module.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/nodefaultfactories.py
+++ b/Wrapping/Generators/Python/Tests/nodefaultfactories.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/nolazy.py
+++ b/Wrapping/Generators/Python/Tests/nolazy.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/readWriteVLV.py
+++ b/Wrapping/Generators/Python/Tests/readWriteVLV.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/returnedTypeCoverage.py
+++ b/Wrapping/Generators/Python/Tests/returnedTypeCoverage.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/simple_pipeline.py
+++ b/Wrapping/Generators/Python/Tests/simple_pipeline.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/templated_pipeline.py
+++ b/Wrapping/Generators/Python/Tests/templated_pipeline.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/test_imread_single_file_list.py
+++ b/Wrapping/Generators/Python/Tests/test_imread_single_file_list.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/test_metadata.py
+++ b/Wrapping/Generators/Python/Tests/test_metadata.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/test_xarray.py
+++ b/Wrapping/Generators/Python/Tests/test_xarray.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/timing.py
+++ b/Wrapping/Generators/Python/Tests/timing.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/verifyGetOutputAPIConsistency.py
+++ b/Wrapping/Generators/Python/Tests/verifyGetOutputAPIConsistency.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/verifyTTypeAPIConsistency.py
+++ b/Wrapping/Generators/Python/Tests/verifyTTypeAPIConsistency.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/Tests/wrappingCoverage.py
+++ b/Wrapping/Generators/Python/Tests/wrappingCoverage.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/itk/__init__.py
+++ b/Wrapping/Generators/Python/itk/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/itk/support/base.py
+++ b/Wrapping/Generators/Python/itk/support/base.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/itk/support/extras.py
+++ b/Wrapping/Generators/Python/itk/support/extras.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/itk/support/helpers.py
+++ b/Wrapping/Generators/Python/itk/support/helpers.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/itk/support/lazy.py
+++ b/Wrapping/Generators/Python/itk/support/lazy.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/itk/support/template_class.py
+++ b/Wrapping/Generators/Python/itk/support/template_class.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/itk/support/types.py
+++ b/Wrapping/Generators/Python/itk/support/types.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/itk/support/xarray.py
+++ b/Wrapping/Generators/Python/itk/support/xarray.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/itkConfig.template.in.py
+++ b/Wrapping/Generators/Python/itkConfig.template.in.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright NumFOCUS
+# SPDX-License-Identifier: Apache-2.0
 # ==========================================================================
 #
 #   Copyright NumFOCUS

--- a/Wrapping/Generators/Python/itkPyITKCommonCAPI.h
+++ b/Wrapping/Generators/Python/itkPyITKCommonCAPI.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright NumFOCUS
+// SPDX-License-Identifier: Apache-2.0
 /*=========================================================================
  *
  *  Copyright NumFOCUS


### PR DESCRIPTION
Prepends two machine-readable SPDX lines to each of 5,698 ITK-owned source files following VTK's convention, and updates the KWStyle header template so new files are enforced to carry SPDX going forward. Pairs with [#5817](https://github.com/InsightSoftwareConsortium/ITK/pull/5817) (SBOM infrastructure, targets this branch); **the two PRs are bound and must merge together or in strict order (this PR first, then #5817 rebased onto main)**.

Single commit, mechanical diff — copy-paste review.

> **Note:** this PR replaces the phantom-merged [#6063](https://github.com/InsightSoftwareConsortium/ITK/pull/6063), which was auto-closed by GitHub as "merged" when a force-push to its source branch made its head an ancestor of the (changed) base. No content landed in `main` from that closure; this PR carries the same content with correct base/head.

<details>
<summary>Format (matching VTK convention)</summary>

C/C++ files (`.h`, `.hxx`, `.cxx`, `.txx`):
```cpp
// SPDX-FileCopyrightText: Copyright NumFOCUS
// SPDX-License-Identifier: Apache-2.0
/*=========================================================================
 *  Copyright NumFOCUS
 *  ...existing Apache-2.0 block, unchanged...
 *=========================================================================*/
```

Python / CMake / shell files use `#`-prefix equivalents. The existing 17-line Apache-2.0 notice block is unchanged.

The two SPDX lines are machine-readable equivalents of the existing Apache-2.0 notice and are parseable by REUSE, scancode-toolkit, fossology, Trivy, Grype, and OSV-Scanner.

</details>

<details>
<summary>Scope — what changes in this PR</summary>

- **5,698 ITK-owned files modified**: .h, .hxx, .cxx, .txx, .py, .cmake, CMakeLists.txt
- **1 KWStyle template updated**: `Utilities/KWStyle/ITKHeader.h` gains the two SPDX lines so new files going forward are enforced
- Only files containing `Copyright NumFOCUS` are touched (ITK-owned criterion)
- `Modules/ThirdParty/` excluded — vendored projects keep upstream notices and are tracked per-module in the SBOM ([#5817](https://github.com/InsightSoftwareConsortium/ITK/pull/5817))
- Total: 5,699 files, +11,398 lines, -0 lines; no non-tagging changes

**Not in this PR (in #5817 instead):**
- The migration script (`Utilities/Maintenance/AddSPDXHeaders.py`) used to produce this diff
- The pre-commit hook (`check-spdx-headers`)
- The SBOM generator and four validation CTests
- REUSE.toml and LICENSES/

</details>

<details>
<summary>Why these two PRs are bound</summary>

Neither PR is functional without the other:

- **This PR alone** tags 5,698 files with SPDX headers but ships no tooling that consumes them. No SBOM generator reads the metadata. The tags are dead weight without the infrastructure.
- **#5817 alone** ships the SBOM generator, validators, migration script, REUSE metadata, and pre-commit hook — but the 5,698 source files still carry the old header shape. `reuse lint` would flag thousands of files. CI breaks.

Merge order: **this PR merges first** (onto `main`), then **#5817 rebases onto the new main and merges**. Or both merge together via a merge queue.

</details>

<details>
<summary>Why — regulatory drivers (medical imaging + commercial use)</summary>

ITK's 2019 community survey documented **32% commercial users, 74% medical imaging focus**. The combination makes SPDX-tagged source files and the companion SBOM a hard regulatory requirement for ITK's core audience:

- **21 USC 360n-2 / FD&C Act §524B(b)(3)** (effective 2023-03-29) — federal statute requiring an SBOM for every "cyber device" premarket submission, listing commercial, open-source, and off-the-shelf software components. ITK is explicitly OTS per [docs.itk.org](https://docs.itk.org/en/latest/learn/fda_sw_development_guidelines.html).
- **IEC 81001-5-1:2021** — EU-harmonized cybersecurity standard with explicit SBOM reference in Annex E.2.4; harmonized under MDR since May 2024.
- **EU Cyber Resilience Act** (Regulation 2024/2847) — machine-readable SBOM obligations from 2027-12-11.

Discourse evidence of real commercial-audit incidents:
[#7452](https://discourse.itk.org/t/itk-license-compatibility-concern-with-vnl/7452) (ACM-licensed `rpoly.f` discovery), [#7632](https://discourse.itk.org/t/would-like-to-compile-the-itk-without-external-third-party-libraries/7632) (manual license audits), [#7748](https://discourse.itk.org/t/is-itk-vulnerable-to-gdcm-cve-2026-3650-memory-consumption-issue/7748) (active CVE tracking).

See #5817 for the full justification discussion.

</details>

<details>
<summary>Test plan — verified locally on the combined stack</summary>

- [x] CMake configure: 49.2s, no errors
- [x] Full build: 5,968/5,968 targets, 0 warnings, 0 errors
- [x] Full CTest suite: 3,218/3,218 tests pass (1 unrelated NumericLocale skip)
- [x] `pre-commit run --all-files` passes every hook
- [x] `reuse lint` reports 0 non-ThirdParty compliance gaps
- [x] Generated SBOM validates against `spdx-tools`
- [x] `cmake --install` places SBOM at `share/spdx/sbom.spdx.json`
- [x] Sample files across each extension spot-checked byte-perfect against the KWStyle template

</details>

<!--
provenance: claude-code session 2026-04-17 / 2026-04-18
scope: bulk SPDX tagging only (5,698 files + KWStyle template, one commit)
companion_pr: #5817 (SBOM infrastructure)
binding: atomic pair with #5817; must merge together or in strict order
target_branch: main
replaces: #6063 (auto-closed during reorganization)
support_docs: .claude/worktrees/pr-6063-spdx-support/{CLEANUP-PHASE-1-PLAN,justification-expanded,validation-report}.md
-->
