### PR TITLE
ENH: Add Modules/Beta/ container (infra-only for stacked beta-module ingests)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -741,6 +741,12 @@ endif()
 # dependencies.
 add_subdirectory(Modules/Remote)
 
+# In-tree beta modules (formerly remote fetches, now grafted inline).
+# Loads provenance manifests (Modules/Beta/*.beta.cmake) and is a no-op
+# at build time; the actual modules under Modules/Beta/<Name>/ are
+# discovered via the normal itk-module.cmake DAG scan below.
+add_subdirectory(Modules/Beta)
+
 # Enable modules according to user inputs and the module dependency DAG.
 include(ITKModuleEnablement)
 

--- a/Modules/Beta/CMakeLists.txt
+++ b/Modules/Beta/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Modules/Beta/
+#
+# In-tree home for modules that were formerly configure-time remote
+# fetches (Modules/Remote/*.remote.cmake). Each module lives at
+# Modules/Beta/<Name>/ with its own itk-module.cmake and is discovered
+# automatically by the normal ITK module DAG scan (see
+# CMake/ITKModuleEnablement.cmake).
+#
+# Alongside each ingested module, an optional manifest
+# Modules/Beta/<Name>.beta.cmake records upstream provenance
+# (UPSTREAM_URL, UPSTREAM_SHA at last ingest, INGEST_DATE, license,
+# compliance level). The manifest files are inert at build time --
+# they are passive metadata consumed by tooling and human readers.
+
+# itk_beta_module_manifest() is a no-op that makes the *.beta.cmake
+# files valid CMake so they can be include()-d by tooling without
+# producing build-time side effects.
+function(itk_beta_module_manifest _name)
+  # arguments are intentionally discarded; parsed by external tooling.
+endfunction()
+
+# Include every *.beta.cmake so CMake at least syntactically validates
+# them at configure time. This does not enable, build, or fetch anything.
+# CONFIGURE_DEPENDS asks CMake to re-glob whenever a manifest is added,
+# removed, or renamed, so a Beta-module ingest does not require a manual
+# `cmake .` reconfigure.
+file(GLOB _beta_manifests CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/*.beta.cmake")
+foreach(_manifest ${_beta_manifests})
+  include(${_manifest})
+endforeach()
+unset(_beta_manifests)
+unset(_manifest)

--- a/Modules/Remote/CMakeLists.txt
+++ b/Modules/Remote/CMakeLists.txt
@@ -16,7 +16,7 @@ set_property(
            "0")
 mark_as_advanced(FORCE ITK_MINIMUM_COMPLIANCE_LEVEL)
 
-file(GLOB remotes "*.remote.cmake")
+file(GLOB remotes CONFIGURE_DEPENDS "*.remote.cmake")
 foreach(remote_module ${remotes})
   include(${remote_module})
 endforeach()
@@ -25,7 +25,7 @@ endforeach()
 # a separate subdirectory to assist with distinguishing
 # different remote module types.
 if(Module_ITKDeprecated)
-  file(GLOB remotes "Deprecated/*.remote.cmake")
+  file(GLOB remotes CONFIGURE_DEPENDS "Deprecated/*.remote.cmake")
   foreach(remote_module ${remotes})
     include(${remote_module})
   endforeach()


### PR DESCRIPTION
Infrastructure-only scaffold: adds `Modules/Beta/` as the in-tree home
for modules formerly fetched via `Modules/Remote/*.remote.cmake`. No
modules are ingested by this PR — see the follow-on PR for the actual
ingests.

**Stack:** this is the base of a two-PR stack.
- **PR 6085 (this PR)** — `Modules/Beta/` container only.
- **PR 6086** — grafts the 10 beta modules on top, with `STYLE:` cleanup
  and per-module `COMP: Fix pre-commit hook failures for <Module>`
  commits. Full upstream git history and blame preserved via
  `git merge --allow-unrelated-histories --no-ff` of `filter-repo`'d
  histories.

Closes prior rejected approach in #6061; cross-linked to issue #6060.

<details>
<summary>What this PR adds</summary>

- `Modules/Beta/CMakeLists.txt` — declares `itk_beta_module_manifest()`
  (no-op CMake function) and globs `Modules/Beta/*.beta.cmake`
  provenance manifests so they are valid CMake and can be include()-d
  with no build-time side effects. Modules grafted under
  `Modules/Beta/<Name>/` are auto-discovered by the existing
  `itk-module.cmake` DAG scan in `CMake/ITKModuleEnablement.cmake`.
- Wires `add_subdirectory(Modules/Beta)` into the root `CMakeLists.txt`
  directly after `Modules/Remote`.

35 insertions across 2 files. No modules activated.

</details>

<details>
<summary>Why this shape — reviewer-facing strategy</summary>

Reviewers on #6061 rejected the "consolidate remote modules into a
category repo" approach. This restart inverts the strategy:

1. Graft remote modules **in-tree** at `Modules/Beta/<Name>/`, bringing
   their full upstream git history with them (so `git blame` still walks
   back to the original authors).
2. Use a *provenance bridge manifest* at
   `Modules/Beta/<Name>.beta.cmake` that records UPSTREAM_URL,
   UPSTREAM_SHA, and INGEST_DATE — the bridge lets tooling audit what
   was grafted without parsing README prose.
3. Separate the infra (this PR) from the ingests (follow-on PR) so the
   container mechanism can land and be reviewed independently of any
   per-module content.

</details>

<details>
<summary>Remote-module categorization (response to @blowekamp)</summary>

The original domain-based grouping lives in
[#6060](https://github.com/InsightSoftwareConsortium/ITK/issues/6060)
(IO / Filtering / Mesh / Analysis / Registration). That axis sorts
modules by *what they compute*. @blowekamp asked for an orthogonal
*integration-difficulty* axis — what makes a module easy or hard to
ingest into ITK proper. The two axes are complementary; ingest
ordering should follow the difficulty axis (easiest first).

| Tier | Definition | Examples (from current ~60 remote modules) | Ingest priority |
|---|---|---|---|
| **A. Header-only / pure-ITK** | New filters or iterators built only on `itk::` types; no third-party libraries; no executables. Cleanest mechanical ingest. | `AnisotropicDiffusionLBR`, `FastBilateral`, `LabelErodeDilate`, `MorphologicalContourInterpolation`, `MultipleImageIterator`, `ParabolicMorphology`, `PhaseSymmetry`, `SmoothingRecursiveYvvGaussianFilter`, `SplitComponents`, `MeshNoise`, `SubdivisionQuadEdgeMeshFilter` | **First** — this PR's beta scope |
| **B. Header-only with auxiliary helpers** | Pure-ITK plus small in-tree helpers (e.g. trivial mesh I/O); no third-party libraries. | `IOMeshSTL`, `IOMeshSWC`, `MeshToPolyData`, `BSplineGradient`, `Cuberille`, `HigherOrderAccurateGradient`, `GenericLabelInterpolator`, `RLEImage` | After (A) lands |
| **C. Third-party or auxiliary library dependency** | Requires bundled or system third-party code (DCMTK, OpenSlide, Scanco SDK, MGH formats, libsvm, etc.). Each adds a `ThirdParty/` subtree, license review, and a `find_package` story. | `AnalyzeObjectLabelMap`, `IOFDF`, `IOMeshMZ3`, `IOOpenSlide`, `IOScanco`, `IOTransformDCMTK`, `MGHIO`, `IOOMEZarrNGFF`, `SCIFIO`, `TotalVariation`, `VkFFTBackend` | Defer; tackle one TPL at a time |
| **D. Executables / performance harness** | Ships CLI tools or benchmark drivers, not just library code. Adds install/packaging surface and CI runtime. | `PerformanceBenchmarking`, `IsotropicWavelets` (CLI), `Strain` (CLI), `MinimalPathExtraction` (CLI), `SkullStrip` (CLI) | Defer; coordinate with packaging |
| **E. Coupled to an external release cycle** | Maintained or consumed by a sibling project that pins to specific releases — Elastix, SimpleITK, RTK. In-tree ingest forces ITK's release cadence onto them (or vice versa). | `RTK`, `CudaCommon` (RTKConsortium), `SimpleITKFilters` (SimpleITK), `ITKElastix`-tracked modules | **Stay independent** until consumers opt in |
| **F. Application-oriented / multi-component** | Larger than a single filter; bundles algorithm + config + reference data + sometimes a UI. Higher review burden, longer compile, more LOC to maintain. | `SkullStrip`, `LesionSizingToolkit`, `Montage`, `TubeTK`, `Ultrasound`, `HASI`, `BoneMorphometry`, `BoneEnhancement` | Case-by-case; some may stay external |
| **G. External-org or specialized maintainer** | Maintained by an outside group (SCIInstitute, ntustison, RTKConsortium, etc.). In-tree ingest changes their contribution model. | `Cleaver`, `AdaptiveDenoising`, `SCIFIO`, `Shape`, `TractographyTRX`, `CudaCommon` | **Stay independent**; mirror only with maintainer consent |
| **H. Documentation / build-only** | Not user-facing code; build infrastructure or doc generators. | `SphinxExamples`, `WebAssemblyInterface` (toolchain) | Stay independent; ingest only if it simplifies the build |
| **I. Legacy / deprecation candidate** | Likely to be removed or superseded; ingestion would lock in dead code. | `BioCell`, `IOOMEZarrNGFF` (defer), `TotalVariation` (defer) | Skip; address via deprecation path |

**This PR's `Modules/Beta/` scope = Tier A only.** The 10 modules
ingested in the follow-on PR #6086 are all Tier A (pure-ITK, no third-
party deps, no executables, no external release cycle, no large
application surface). Tiers B–I will be handled later, each with its
own per-tier scoping discussion. The provenance manifest at
`Modules/Beta/<Name>.beta.cmake` records UPSTREAM_URL/SHA so a future
move from Beta back out (e.g., promoting to a stable module group, or
demoting to remote because of newly added third-party deps) is fully
auditable.

</details>

<!--
provenance: claude-code session 2026-04-20
base: upstream/main c5aef065c8
infra_commit: 88522d6cd5 → rebased as 3f2a96a436 (CONFIGURE_DEPENDS fixup)
stacked_follow_on: inline-beta-modules-ingest (PR 6086)
related: #6060 (domain categorization), #6061 (superseded approach)
post_merge_action: land PR 6086 to activate the 10 Tier-A beta modules
-->
