### PR TITLE
BUG: Prevent SIGSEGV in VectorImage SetPixel with shorter source VLV

### DIFF
--- a/Modules/Core/Common/include/itkDefaultVectorPixelAccessor.h
+++ b/Modules/Core/Common/include/itkDefaultVectorPixelAccessor.h
@@ -21,6 +21,7 @@
 #include "itkMacro.h"
 #include "itkVariableLengthVector.h"
 #include "itkIntTypes.h"
+#include <algorithm> // for std::min
 
 namespace itk
 {
@@ -61,13 +62,30 @@ public:
   /** Internal type alias. It defines the internal real representation of data. */
   using InternalType = TType;
 
-  /** Set output using the value in input */
+  /** Set output using the value in input.
+   *
+   * Copies up to `m_VectorLength` components from `input` into the pixel
+   * slot at `output` + offset. When `input` is shorter than
+   * `m_VectorLength`, only the available components are copied; the
+   * remaining destination components are left unchanged. This guards
+   * against callers that construct an under-sized source vector — in
+   * particular, `VariableLengthVector<T>(0)` whose internal data
+   * pointer is null (see ITK commit 1d87efa5), which previously caused
+   * a SIGSEGV when the implicit copy dereferenced the null buffer. */
   inline void
   Set(InternalType & output, const ExternalType & input, const SizeValueType offset) const
   {
     InternalType * truePixel = (&output) + offset * m_OffsetMultiplier;
 
-    for (VectorLengthType i = 0; i < m_VectorLength; ++i)
+    // A well-formed caller passes a source of length 0 (sentinel / no-op)
+    // or exactly m_VectorLength. Anything else is a caller bug that was
+    // silently masked by the pre-1d87efa5 allocation behavior; catch it
+    // in debug builds.
+    itkAssertInDebugAndIgnoreInReleaseMacro(input.GetSize() == 0 || input.GetSize() == m_VectorLength);
+
+    const VectorLengthType copyLength = std::min<VectorLengthType>(m_VectorLength, input.GetSize());
+
+    for (VectorLengthType i = 0; i < copyLength; ++i)
     {
       truePixel[i] = input[i];
     }

--- a/Modules/Core/Common/test/itkVariableLengthVectorGTest.cxx
+++ b/Modules/Core/Common/test/itkVariableLengthVectorGTest.cxx
@@ -19,6 +19,8 @@
 // First include the header file to be tested:
 #include "itkVariableLengthVector.h"
 #include "itkRangeGTestUtilities.h"
+#include "itkVectorImage.h"
+#include "itkImageRegionIterator.h"
 #include <gtest/gtest.h>
 #include <numeric> // For iota.
 #include <random>  // For mt19937.
@@ -161,4 +163,95 @@ TEST(VariableLengthVector, ConstructWithSpecifiedLengthAndValue)
       EXPECT_EQ(std::count(variableLengthVector.cbegin(), variableLengthVector.cend(), value), length);
     }
   }
+}
+
+
+// Regression test: ensure that setting a VectorImage pixel from a
+// VariableLengthVector that is shorter than the image's
+// NumberOfComponentsPerPixel does not crash. Before commit
+// 1d87efa529, `VariableLengthVector(length)` with length=0 allocated a
+// valid (zero-size) heap block whose address was non-null. That commit
+// changed the ctor to store `nullptr` for length=0 and caused
+// DefaultVectorPixelAccessor::Set — which copies m_VectorLength
+// elements from the source VLV regardless of the source's own size —
+// to dereference the source's null data pointer, producing SIGSEGV.
+// This test documents that a length-mismatched source VLV is safe to
+// pass; it is permitted for the target pixel to receive
+// implementation-defined values, but the call must not crash.
+TEST(VariableLengthVector, VectorImageSetPixelFromShorterSourceIsSafe)
+{
+  using ValueType = float;
+  using ImageType = itk::VectorImage<ValueType, 3>;
+  using PixelType = ImageType::PixelType;
+
+  constexpr unsigned int      componentsPerPixel = 3;
+  auto                        image = ImageType::New();
+  const ImageType::SizeType   size = { { 2, 2, 2 } };
+  const ImageType::RegionType region{ size };
+  image->SetRegions(region);
+  image->SetNumberOfComponentsPerPixel(componentsPerPixel);
+  image->Allocate();
+
+  // Seed every pixel with a known sentinel value so we can assert the
+  // fix's "trailing components left unchanged" guarantee.
+  constexpr ValueType sentinelValue = 42.0f;
+  PixelType           sentinel(componentsPerPixel);
+  sentinel.Fill(sentinelValue);
+  for (itk::ImageRegionIterator<ImageType> seedIt(image, region); !seedIt.IsAtEnd(); ++seedIt)
+  {
+    seedIt.Set(sentinel);
+  }
+
+  // Pre-regression, VLV(0) had m_Data = new ValueType[0] (non-null).
+  // Post-regression, m_Data is nullptr. The iterator-based Set()
+  // path must tolerate that without dereferencing the null buffer.
+  PixelType shorter(0);
+  EXPECT_EQ(shorter.GetSize(), 0u);
+
+  itk::ImageRegionIterator<ImageType> it(image, region);
+  it.GoToBegin();
+  ASSERT_FALSE(it.IsAtEnd());
+  // The regression manifests here: before the fix, this produces
+  // a SIGSEGV due to memcpy/load from a null source buffer.
+  ASSERT_NO_FATAL_FAILURE(it.Set(shorter));
+
+  // Verify the fix's guarantee: a length-0 source is a no-op; the
+  // destination pixel retains its prior (sentinel) value.
+  const auto unchanged = it.Get();
+  ASSERT_EQ(unchanged.GetSize(), componentsPerPixel);
+  EXPECT_FLOAT_EQ(unchanged[0], sentinelValue);
+  EXPECT_FLOAT_EQ(unchanged[1], sentinelValue);
+  EXPECT_FLOAT_EQ(unchanged[2], sentinelValue);
+}
+
+
+// Companion: verify the normal, length-matched path still works.
+TEST(VariableLengthVector, VectorImageSetPixelFromMatchedSourceWorks)
+{
+  using ValueType = float;
+  using ImageType = itk::VectorImage<ValueType, 3>;
+  using PixelType = ImageType::PixelType;
+
+  constexpr unsigned int      componentsPerPixel = 3;
+  auto                        image = ImageType::New();
+  const ImageType::SizeType   size = { { 2, 2, 2 } };
+  const ImageType::RegionType region{ size };
+  image->SetRegions(region);
+  image->SetNumberOfComponentsPerPixel(componentsPerPixel);
+  image->Allocate();
+
+  PixelType matched(componentsPerPixel);
+  matched[0] = 1.0f;
+  matched[1] = 2.0f;
+  matched[2] = 3.0f;
+
+  itk::ImageRegionIterator<ImageType> it(image, region);
+  it.GoToBegin();
+  it.Set(matched);
+
+  const auto roundTrip = it.Get();
+  ASSERT_EQ(roundTrip.GetSize(), componentsPerPixel);
+  EXPECT_FLOAT_EQ(roundTrip[0], 1.0f);
+  EXPECT_FLOAT_EQ(roundTrip[1], 2.0f);
+  EXPECT_FLOAT_EQ(roundTrip[2], 3.0f);
 }


### PR DESCRIPTION
## Summary

Restore the ability to pass an under-sized `itk::VariableLengthVector` (including a length-0 one) as the source of a `VectorImage` pixel `Set` without crashing. Regression introduced by commit [`1d87efa52`](https://github.com/InsightSoftwareConsortium/ITK/commit/1d87efa52922638065c557f02ce0c91abe8a5b43) ("BUG: Make `VariableLengthVector::m_Data` null when its length is zero").

<details>
<summary>Root cause</summary>

Before `1d87efa52`, `VariableLengthVector<T>(length)` always allocated via `new T[length]`, so even a length-0 vector held a non-null (though zero-size) data pointer. `DefaultVectorPixelAccessor::Set` copies exactly `m_VectorLength` components from that source pointer:

```cpp
for (VectorLengthType i = 0; i < m_VectorLength; ++i)
{
  truePixel[i] = input[i];
}
```

A source shorter than `m_VectorLength` was a latent caller bug, but "happened to work" because the non-null (out-of-spec) read did not crash. After `1d87efa52`, a length-0 VLV has `m_Data == nullptr`, and the compiler-vectorized fixed-count copy becomes a `memcpy(dst, nullptr, N*sizeof(T))` — SIGSEGV.

Reproducer (register state captured at crash):
```
#0  __memcpy_avx512_unaligned_erms
#1  <inlined in CreateAndInitializeImage<VectorImage<float,3>>>
rdi (dst) = 0x555555aa8be0     valid heap buffer
rsi (src) = 0x0                null
rdx (len) = 0xc (12 bytes)
```

</details>

<details>
<summary>Fix</summary>

Guard the copy loop in `DefaultVectorPixelAccessor::Set` so that at most `min(m_VectorLength, input.GetSize())` components are copied. When the source is shorter, the trailing destination components are left unchanged. A length-0 source is now a safe no-op.

This preserves `1d87efa52`'s null-data intent for zero-length VLVs without requiring every internal copy path to check for null before dereferencing.

</details>

<details>
<summary>Regression test</summary>

Two new cases in `itkVariableLengthVectorGTest.cxx`:

- `VectorImageSetPixelFromShorterSourceIsSafe` — constructs a `VLV<float>(0)`, sets it into a 3-component `VectorImage<float,3>` pixel via the iterator. **Fails with SIGSEGV on current main**, passes with this change.
- `VectorImageSetPixelFromMatchedSourceWorks` — the normal length-matched path; verifies the copy still works and round-trips.

</details>

<details>
<summary>How it was discovered</summary>

Hunting a SIGSEGV in `InsightSoftwareConsortium/ITKPerformanceBenchmarking`'s `CopyIterationBenchmark` across the v5.4.5 → current main bisect range. The benchmark passes `static_cast<PixelType>(count)` to seed pixel values — for `VectorImage`, this calls the VLV length constructor, so the very first iteration produces a length-0 source. Before `1d87efa52` the benchmark silently worked (reading uninitialized bytes); after, it crashes.

The benchmark itself is independently being hardened in [InsightSoftwareConsortium/ITKPerformanceBenchmarking#111](https://github.com/InsightSoftwareConsortium/ITKPerformanceBenchmarking/pull/111) so it constructs correctly-sized VLV pixels and works across the full bisect range regardless of this ITK-side fix.

</details>

## Test plan

- [x] Added `VectorImageSetPixelFromShorterSourceIsSafe` reproducer; fails on `main` without the fix, passes with it
- [x] Added `VectorImageSetPixelFromMatchedSourceWorks` for the happy path
- [x] Locally rebuilt `ITKCommon` and re-ran `CopyIterationBenchmark` — 15/15 probes captured, rc=0
- [ ] CI

<!--
provenance: claude-code session 2026-04-19
regression_commit: 1d87efa52922638065c557f02ce0c91abe8a5b43 (N-Dekker, 2026-01-01)
companion_pr: InsightSoftwareConsortium/ITKPerformanceBenchmarking#111
reproducer_backtrace: memcpy(rdi=valid, rsi=NULL, rdx=12) inside DefaultVectorPixelAccessor::Set
-->
