### PR TITLE
BUG: Fix NRRD measurement-frame corruption; refactor reserved-field dispatch

### DIFF
--- a/Modules/IO/NRRD/include/itkNrrdImageIO.h
+++ b/Modules/IO/NRRD/include/itkNrrdImageIO.h
@@ -78,6 +78,13 @@ using AxesReorderEnum = NrrdImageIOEnums::AxesReorder;
  * to the dictionary with keys: "NRRD_thicknesses[0]",
  * "NRRD_thicknesses[1]" and "NRRD_thicknesses[2]".
  *
+ * The NRRD file version (NRRD0001 through NRRD0006) is selected
+ * automatically by teem based on the fields present on the Nrrd
+ * struct: setting a measurement frame promotes the magic to NRRD0005;
+ * setting thicknesses / space / space dimension / sample units
+ * requires NRRD0004; and so on.  No explicit version switch is
+ * required on the ITK side.
+ *
  *  \ingroup IOFilters
  * \ingroup ITKIONRRD
  */

--- a/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
+++ b/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
@@ -233,24 +233,38 @@ void
 WriteMeasurementFrame(NrrdWriteReservedFieldCtx & ctx)
 {
   std::vector<std::vector<double>> msrFrame;
-  itk::ExposeMetaData<std::vector<std::vector<double>>>(ctx.dict, ctx.metaKey, msrFrame);
+  if (!itk::ExposeMetaData<std::vector<std::vector<double>>>(ctx.dict, ctx.metaKey, msrFrame))
+  {
+    return;
+  }
+  // teem requires the measurement frame to be either fully specified or
+  // absent; any finite coefficient causes the frame to be written to the
+  // header.  A user-supplied frame whose dimensions do not match
+  // nrrd->spaceDim is therefore rejected with an exception rather than
+  // silently corrupted.  (The prior behavior padded missing entries with
+  // the sentinel value 666666, which teem faithfully wrote as real matrix
+  // coefficients -- an orientation data corruption bug.)
+  bool dimensionsOk = (msrFrame.size() >= ctx.nrrd->spaceDim);
+  for (unsigned int saxi = 0; dimensionsOk && saxi < ctx.nrrd->spaceDim; ++saxi)
+  {
+    if (msrFrame[saxi].size() < ctx.nrrd->spaceDim)
+    {
+      dimensionsOk = false;
+    }
+  }
+  if (!dimensionsOk)
+  {
+    itkGenericExceptionMacro(
+      "NRRD '" << ctx.metaKey << "': supplied measurement frame (" << msrFrame.size() << " rows"
+               << (msrFrame.empty() ? std::string{} : " x up to " + std::to_string(msrFrame.front().size()) + " cols")
+               << ") does not match image space dimension " << ctx.nrrd->spaceDim
+               << ".  The measurement frame must be fully specified for every space axis.");
+  }
   for (unsigned int saxi = 0; saxi < ctx.nrrd->spaceDim; ++saxi)
   {
     for (unsigned int saxj = 0; saxj < ctx.nrrd->spaceDim; ++saxj)
     {
-      if (saxi < msrFrame.size() && saxj < msrFrame[saxi].size())
-      {
-        ctx.nrrd->measurementFrame[saxi][saxj] = msrFrame[saxi][saxj];
-      }
-      else
-      {
-        // The dimension of the recorded measurement frame differs from the
-        // actual dimension of the ITK image (which, for now, determines
-        // nrrd->spaceDim).  AIR_NAN is invalid because the coefficients must
-        // all be equally existent; 0 would be indistinguishable from valid
-        // data; use a large sentinel instead.
-        ctx.nrrd->measurementFrame[saxi][saxj] = 666666;
-      }
+      ctx.nrrd->measurementFrame[saxi][saxj] = msrFrame[saxi][saxj];
     }
   }
 }

--- a/Modules/IO/NRRD/test/itkNrrdMetaDataTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdMetaDataTest.cxx
@@ -256,5 +256,57 @@ itkNrrdMetaDataTest(int argc, char * argv[])
     itksys::SystemTools::RemoveFile(v5Fname);
   }
 
+  // Regression test for the pre-existing 666666 sentinel in
+  // WriteMeasurementFrame:
+  //   When the user supplies a measurement frame whose dimensions do not
+  //   match the image's space dimension, the writer must throw rather
+  //   than silently write a frame populated with the sentinel value
+  //   666666 (which teem faithfully emits to the on-disk header,
+  //   corrupting the orientation matrix).
+  {
+    auto badImage = ImageType::New(); // 3-D image, spaceDim = 3
+    badImage->SetRegions(size);
+    badImage->Allocate();
+    badImage->FillBuffer(0);
+    itk::MetaDataDictionary & badDict = badImage->GetMetaDataDictionary();
+    // 2x2 frame provided for a 3-D image -- malformed.
+    std::vector<std::vector<double>> badFrame = { { 1.0, 0.0 }, { 0.0, 1.0 } };
+    itk::EncapsulateMetaData<std::vector<std::vector<double>>>(badDict, "NRRD_measurement frame", badFrame);
+
+    std::string badFname = argv[1];
+    badFname += "/metadatatest_badframe.nrrd";
+
+    auto badWriter = ImageWriterType::New();
+    badWriter->SetImageIO(itk::NrrdImageIO::New());
+    badWriter->SetFileName(badFname.c_str());
+    badWriter->SetInput(badImage);
+    bool threw = false;
+    try
+    {
+      badWriter->Update();
+    }
+    catch (const itk::ExceptionObject &)
+    {
+      threw = true;
+    }
+    if (!threw)
+    {
+      std::cerr << "Writing a malformed measurement frame must throw; it did not.\n";
+      return EXIT_FAILURE;
+    }
+    // If a partial file was produced before the throw, verify the
+    // 666666 sentinel is not present.
+    if (itksys::SystemTools::FileExists(badFname.c_str()))
+    {
+      const std::string header = readNrrdHeader(badFname);
+      if (header.find("666666") != std::string::npos)
+      {
+        std::cerr << "666666 sentinel leaked into the header (regression). Header:\n" << header;
+        return EXIT_FAILURE;
+      }
+      itksys::SystemTools::RemoveFile(badFname);
+    }
+  }
+
   return EXIT_SUCCESS;
 }

--- a/Modules/IO/NRRD/test/itkNrrdMetaDataTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdMetaDataTest.cxx
@@ -22,6 +22,9 @@
 #include "itksys/SystemTools.hxx"
 #include "itkNrrdImageIO.h"
 
+#include <fstream>
+#include <sstream>
+
 /** This test was written in response to ITK task 2549
  * https://itk.icts.uiowa.edu/jira/browse/ITK-2549
  *
@@ -170,6 +173,87 @@ itkNrrdMetaDataTest(int argc, char * argv[])
     }
 
     itksys::SystemTools::RemoveFile(precFname);
+  }
+
+  // Helper: read the ASCII header of a NRRD file (lines up to but not
+  // including the first blank line, which separates header from data).
+  // Open in binary mode so that trailing CR characters on Windows-written
+  // files are visible to us (text mode would strip them) and always strip
+  // them explicitly, giving consistent cross-platform behavior.
+  const auto readNrrdHeader = [](const std::string & path) {
+    std::ifstream      in(path, std::ios::binary);
+    std::ostringstream out;
+    std::string        line;
+    while (std::getline(in, line))
+    {
+      if (!line.empty() && line.back() == '\r')
+      {
+        line.pop_back();
+      }
+      if (line.empty())
+      {
+        break;
+      }
+      out << line << '\n';
+    }
+    return out.str();
+  };
+
+  // Test for https://discourse.itk.org/t/6666 (NrrdImageIO and NRRD version 5):
+  //   When the user sets a v5-only field (measurement frame) via the
+  //   documented "NRRD_<field>" dictionary convention, the on-disk magic
+  //   must be bumped from NRRD0004 to NRRD0005.  teem's nrrdSave auto-
+  //   selects the minimum-version magic based on the interesting fields
+  //   set on the Nrrd struct (see nrrd__FormatNRRD_whichVersion in
+  //   NrrdIO's formatNRRD.c), so the correctness guarantee here is that
+  //   the writer actually transfers the measurement frame onto the Nrrd
+  //   struct when the metadata is supplied in the documented form.
+  {
+    auto v5Image = ImageType::New();
+    v5Image->SetRegions(size);
+    v5Image->Allocate();
+    v5Image->FillBuffer(0);
+    itk::MetaDataDictionary &        v5Dict = v5Image->GetMetaDataDictionary();
+    std::vector<std::vector<double>> mframe = { { 1.0, 0.0, 0.0 }, { 0.0, 1.0, 0.0 }, { 0.0, 0.0, 1.0 } };
+    itk::EncapsulateMetaData<std::vector<std::vector<double>>>(v5Dict, "NRRD_measurement frame", mframe);
+
+    std::string v5Fname = argv[1];
+    v5Fname += "/metadatatest_nrrd5.nrrd";
+
+    auto v5Writer = ImageWriterType::New();
+    v5Writer->SetImageIO(itk::NrrdImageIO::New());
+    v5Writer->SetFileName(v5Fname.c_str());
+    v5Writer->SetInput(v5Image);
+    try
+    {
+      v5Writer->Update();
+    }
+    catch (const itk::ExceptionObject & ex)
+    {
+      std::cerr << "V5 auto-bump write failed: " << ex << '\n';
+      return EXIT_FAILURE;
+    }
+
+    std::string magic;
+    {
+      std::ifstream in(v5Fname, std::ios::binary);
+      std::getline(in, magic);
+    } // close the handle before RemoveFile below (matters on Windows)
+    if (magic.rfind("NRRD0005", 0) != 0)
+    {
+      std::cerr << "Expected file to begin with NRRD0005 (measurement frame is a "
+                << "v5-only field); got '" << magic << "'\n";
+      return EXIT_FAILURE;
+    }
+    const std::string header = readNrrdHeader(v5Fname);
+    if (header.find("\nmeasurement frame:") == std::string::npos ||
+        header.find("measurement frame:=") != std::string::npos)
+    {
+      std::cerr << "Expected standard 'measurement frame:' field. Header:\n" << header;
+      return EXIT_FAILURE;
+    }
+
+    itksys::SystemTools::RemoveFile(v5Fname);
   }
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
Fixes a silent on-disk corruption in `NrrdImageIO::WriteMeasurementFrame` and documents the teem-driven NRRD version auto-bump that users on [Discourse #6666](https://discourse.itk.org/t/6666) and in #5461 did not realize was already available.  **Stacked on #6101** — the two STYLE commits that were originally here (range-based-for + dispatch-table refactor) now live in that PR so the structural review goes to a broad audience; once #6101 merges, this PR's diff narrows to the `ENH` + `BUG` commits that actually address the reported issue.

Does **not** attempt to paper over user-supplied metadata in non-documented forms.  Use `NRRD_<field>` per the (now-extended) class doxygen; non-conforming metadata either throws or falls through to NRRD's documented `:=` custom-pair escape hatch.

<details>
<summary>Commit sequence (after #6101 merges and this PR rebases)</summary>

1. **`ENH:`** document the teem-driven NRRD magic auto-bump (NRRD0001..NRRD0006) in the class doxygen and add an `itkNrrdMetaDataTest` subtest that writes a measurement frame via the documented `NRRD_measurement frame` key and asserts the on-disk magic is `NRRD0005`.  Addresses the confusion behind Discourse #6666.
2. **`BUG:`** `WriteMeasurementFrame` now throws `itk::ExceptionObject` when the user-supplied frame's dimensions do not match `nrrd->spaceDim`, instead of padding missing entries with the magic sentinel `666666` (which teem faithfully wrote to the header, silently corrupting orientation data).  Regression test added.

The two STYLE commits (range-based-for rename; reserved-field if-ladder → dispatch table) that used to be at the base of this PR are in #6101.

</details>

<details>
<summary>Relation to #5461 and SimpleITK/SimpleITK#2395</summary>

Neither is fixed here, by design:

- **#5461** — reporter used bare metadata keys like `content` and `thicknesses` instead of the documented `NRRD_content` / `NRRD_thicknesses[N]` form.  The docs were corrected in #5472; with those docs in place, the bare-key round-trip is user error.  Non-`NRRD_*` keys go through NRRD's documented `:=` custom-pair escape hatch, which is the standard's own answer for "anything not a reserved field."  No code change in this PR is required for that contract to hold.

- **SimpleITK/SimpleITK#2395** — the Python binding stores numeric metadata as strings, which the ITK `ExposeMetaData<double>` then fails to coerce, leaving a zero.  That is a Python-binding encoding bug in SimpleITK, not a NRRD writer bug.  Fixing it inside the C++ writer would require type-coercion machinery that accommodates a specific wrapper's encoding choice — maintenance burden for the core codebase in service of a third-party workaround.  The upstream SimpleITK issue is the correct venue.

</details>

<details>
<summary>Test plan</summary>

- [x] `ctest -R Nrrd` — 33/33 pass locally (Linux, clang 19 via conda-forge).
- [x] `itkNrrdMetaDataTest` extended with two new subtests: NRRD0005 auto-bump from `NRRD_measurement frame`; throw-on-malformed-measurement-frame regression.
- [ ] Verify on Windows/macOS runners once CI picks up the branch.

</details>

<details>
<summary>Review ordering</summary>

- Merge #6101 first (STYLE refactor, broad reviewer pool — mechanical).
- Rebase this branch onto the new `main`; the diff becomes just the `ENH` + `BUG` commits.
- Re-run CI; get the narrow specialist set to sign off on the BUG + regression test and the documentation extension.

</details>

<!--
provenance: claude-code session 2026-04-19 (Opus 4.7), stacked on 2026-04-22
stacked_on: #6101
related_files:
  Modules/IO/NRRD/src/itkNrrdImageIO.cxx (BUG: WriteMeasurementFrame throws; ENH: dispatch entry)
  Modules/IO/NRRD/include/itkNrrdImageIO.h (ENH doxygen: NRRD auto-bump)
  Modules/IO/NRRD/test/itkNrrdMetaDataTest.cxx (+2 subtests)
architecture_principle: do not paper over user-supplied non-documented metadata; either throw or fall through to NRRD's ":=" custom-pair form.  Bare-key promotion, bulk per-axis syntax, string-to-double coercion, and NRRD_type validation were implemented in an earlier revision of this PR and then removed because they each accommodated a user error in a way that imposed maintenance burden on the core codebase.
post_merge_action_on_merge_of_6101:
  - rebase this branch onto new main; commits 1-2 (STYLE) drop out as already-merged; commits 3-4 (ENH + BUG) remain as this PR's scope
-->
