### PR TITLE
DOC: Remove "Needed since we provide a cast constructor."

### DIFF
--- a/Modules/Core/Common/include/itkImageLinearConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageLinearConstIteratorWithIndex.h
@@ -130,7 +130,7 @@ public:
   using PixelContainer = typename TImage::PixelContainer;
   using PixelContainerPointer = typename PixelContainer::Pointer;
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageLinearConstIteratorWithIndex()
     : ImageConstIteratorWithIndex<TImage>()
 

--- a/Modules/Core/Common/include/itkImageLinearIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageLinearIteratorWithIndex.h
@@ -83,7 +83,7 @@ public:
   using typename Superclass::PixelType;
   using typename Superclass::AccessorType;
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageLinearIteratorWithIndex() = default;
 
   /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.h
@@ -136,7 +136,7 @@ public:
   using typename Superclass::OffsetValueType;
   using typename Superclass::SizeValueType;
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageRandomConstIteratorWithIndex() = default;
 
   ~ImageRandomConstIteratorWithIndex() override = default;

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithOnlyIndex.h
@@ -138,7 +138,7 @@ public:
   using typename Superclass::OffsetValueType;
   using typename Superclass::SizeValueType;
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageRandomConstIteratorWithOnlyIndex() = default;
 
   ~ImageRandomConstIteratorWithOnlyIndex() override = default;

--- a/Modules/Core/Common/include/itkImageRandomIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomIteratorWithIndex.h
@@ -83,7 +83,7 @@ public:
   using typename Superclass::PixelType;
   using typename Superclass::AccessorType;
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageRandomIteratorWithIndex() = default;
 
   /** Constructor establishes an iterator to walk a particular image and a

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.h
@@ -229,7 +229,7 @@ public:
   using typename Superclass::OffsetValueType;
   using typename Superclass::SizeValueType;
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageRandomNonRepeatingConstIteratorWithIndex() = default;
 
   ~ImageRandomNonRepeatingConstIteratorWithIndex() override { delete m_Permutation; }

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingIteratorWithIndex.h
@@ -95,7 +95,7 @@ public:
   using typename Superclass::PixelType;
   using typename Superclass::AccessorType;
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageRandomNonRepeatingIteratorWithIndex() = default;
 
   /** Constructor establishes an iterator to walk a particular image and a

--- a/Modules/Core/Common/include/itkImageRegionConstIterator.h
+++ b/Modules/Core/Common/include/itkImageRegionConstIterator.h
@@ -140,7 +140,7 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ImageRegionConstIterator);
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageRegionConstIterator()
     : ImageConstIterator<TImage>()
   {}

--- a/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.h
@@ -152,7 +152,7 @@ public:
   using typename Superclass::PixelType;
   using typename Superclass::AccessorType;
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageRegionConstIteratorWithIndex()
     : ImageConstIteratorWithIndex<TImage>()
   {}

--- a/Modules/Core/Common/include/itkImageRegionConstIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionConstIteratorWithOnlyIndex.h
@@ -148,7 +148,7 @@ public:
   using typename Superclass::RegionType;
   using typename Superclass::ImageType;
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageRegionConstIteratorWithOnlyIndex()
     : ImageConstIteratorWithOnlyIndex<TImage>()
   {}

--- a/Modules/Core/Common/include/itkImageRegionExclusionConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionExclusionConstIteratorWithIndex.h
@@ -148,7 +148,7 @@ public:
   using typename Superclass::PixelType;
   using typename Superclass::AccessorType;
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageRegionExclusionConstIteratorWithIndex() = default;
 
   /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes

--- a/Modules/Core/Common/include/itkImageRegionExclusionIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionExclusionIteratorWithIndex.h
@@ -84,7 +84,7 @@ public:
   using typename Superclass::PixelType;
   using typename Superclass::AccessorType;
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageRegionExclusionIteratorWithIndex() = default;
 
   /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes

--- a/Modules/Core/Common/include/itkImageRegionIterator.h
+++ b/Modules/Core/Common/include/itkImageRegionIterator.h
@@ -96,7 +96,7 @@ public:
   using typename Superclass::PixelType;
   using typename Superclass::AccessorType;
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageRegionIterator() = default;
 
   /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes

--- a/Modules/Core/Common/include/itkImageRegionIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionIteratorWithIndex.h
@@ -89,7 +89,7 @@ public:
   using typename Superclass::PixelType;
   using typename Superclass::AccessorType;
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageRegionIteratorWithIndex() = default;
 
   /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes

--- a/Modules/Core/Common/include/itkImageRegionReverseConstIterator.h
+++ b/Modules/Core/Common/include/itkImageRegionReverseConstIterator.h
@@ -146,7 +146,7 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ImageRegionReverseConstIterator);
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageRegionReverseConstIterator()
     : Superclass()
   {}

--- a/Modules/Core/Common/include/itkImageRegionReverseIterator.h
+++ b/Modules/Core/Common/include/itkImageRegionReverseIterator.h
@@ -85,7 +85,7 @@ public:
   using typename Superclass::PixelType;
   using typename Superclass::AccessorType;
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageRegionReverseIterator() = default;
 
   /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes

--- a/Modules/Core/Common/include/itkImageReverseIterator.h
+++ b/Modules/Core/Common/include/itkImageReverseIterator.h
@@ -81,7 +81,7 @@ public:
   using typename Superclass::PixelType;
   using typename Superclass::AccessorType;
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageReverseIterator() = default;
 
   /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes

--- a/Modules/Core/Common/include/itkImageScanlineConstIterator.h
+++ b/Modules/Core/Common/include/itkImageScanlineConstIterator.h
@@ -94,7 +94,7 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ImageScanlineConstIterator);
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageScanlineConstIterator()
     : ImageConstIterator<TImage>()
   {}

--- a/Modules/Core/Common/include/itkImageScanlineIterator.h
+++ b/Modules/Core/Common/include/itkImageScanlineIterator.h
@@ -58,7 +58,7 @@ public:
   using typename Superclass::PixelType;
   using typename Superclass::AccessorType;
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageScanlineIterator() = default;
 
   /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes

--- a/Modules/Core/Common/include/itkImageSliceConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageSliceConstIteratorWithIndex.h
@@ -130,7 +130,7 @@ public:
   using typename Superclass::PixelType;
   using typename Superclass::AccessorType;
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageSliceConstIteratorWithIndex()
     : ImageConstIteratorWithIndex<TImage>()
   {}

--- a/Modules/Core/Common/include/itkImageSliceIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageSliceIteratorWithIndex.h
@@ -85,7 +85,7 @@ public:
   using typename Superclass::PixelType;
   using typename Superclass::AccessorType;
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ImageSliceIteratorWithIndex() = default;
 
   /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes

--- a/Modules/Filtering/DistanceMap/include/itkReflectiveImageRegionConstIterator.h
+++ b/Modules/Filtering/DistanceMap/include/itkReflectiveImageRegionConstIterator.h
@@ -91,7 +91,7 @@ public:
   using OffsetType = typename TImage::OffsetType;
   using OffsetValueType = typename OffsetType::OffsetValueType;
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ReflectiveImageRegionConstIterator();
 
   /** Default destructor.  */

--- a/Modules/Filtering/DistanceMap/include/itkReflectiveImageRegionIterator.h
+++ b/Modules/Filtering/DistanceMap/include/itkReflectiveImageRegionIterator.h
@@ -64,7 +64,7 @@ public:
   using typename Superclass::PixelType;
   using typename Superclass::AccessorType;
 
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   ReflectiveImageRegionIterator();
 
   /** Constructor establishes an iterator to walk a particular image and a

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -134,7 +134,7 @@ public:
 
   using FrequencyType = typename ImageType::SpacingType;
   using FrequencyValueType = typename ImageType::SpacingValueType;
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   FrequencyFFTLayoutImageRegionConstIteratorWithIndex()
     : ImageRegionConstIteratorWithIndex<TImage>()
   {

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyFFTLayoutImageRegionIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyFFTLayoutImageRegionIteratorWithIndex.h
@@ -83,7 +83,7 @@ public:
 
   using FrequencyType = typename ImageType::SpacingType;
   using FrequencyValueType = typename ImageType::SpacingValueType;
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   FrequencyFFTLayoutImageRegionIteratorWithIndex()
     : FrequencyFFTLayoutImageRegionConstIteratorWithIndex<TImage>()
   {}

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyHalfHermitianFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyHalfHermitianFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -139,7 +139,7 @@ public:
 
   using FrequencyType = typename ImageType::SpacingType;
   using FrequencyValueType = typename ImageType::SpacingValueType;
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   FrequencyHalfHermitianFFTLayoutImageRegionConstIteratorWithIndex()
     : ImageRegionConstIteratorWithIndex<TImage>()
 

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyHalfHermitianFFTLayoutImageRegionIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyHalfHermitianFFTLayoutImageRegionIteratorWithIndex.h
@@ -83,7 +83,7 @@ public:
 
   using FrequencyType = typename ImageType::SpacingType;
   using FrequencyValueType = typename ImageType::SpacingValueType;
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   FrequencyHalfHermitianFFTLayoutImageRegionIteratorWithIndex()
     : FrequencyHalfHermitianFFTLayoutImageRegionConstIteratorWithIndex<TImage>()
   {}

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyImageRegionConstIteratorWithIndex.h
@@ -96,7 +96,7 @@ public:
 
   using FrequencyType = typename ImageType::SpacingType;
   using FrequencyValueType = typename ImageType::SpacingValueType;
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   FrequencyImageRegionConstIteratorWithIndex()
     : ImageRegionConstIteratorWithIndex<TImage>()
   {

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyImageRegionIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyImageRegionIteratorWithIndex.h
@@ -83,7 +83,7 @@ public:
 
   using FrequencyType = typename ImageType::SpacingType;
   using FrequencyValueType = typename ImageType::SpacingValueType;
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   FrequencyImageRegionIteratorWithIndex()
     : FrequencyImageRegionConstIteratorWithIndex<TImage>()
   {}

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -134,7 +134,7 @@ public:
 
   using FrequencyType = typename ImageType::SpacingType;
   using FrequencyValueType = typename ImageType::SpacingValueType;
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   FrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex()
     : ImageRegionConstIteratorWithIndex<TImage>()
   {

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionIteratorWithIndex.h
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyShiftedFFTLayoutImageRegionIteratorWithIndex.h
@@ -83,7 +83,7 @@ public:
 
   using FrequencyType = typename ImageType::SpacingType;
   using FrequencyValueType = typename ImageType::SpacingValueType;
-  /** Default constructor. Needed since we provide a cast constructor. */
+  /** Default constructor. */
   FrequencyShiftedFFTLayoutImageRegionIteratorWithIndex()
     : FrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex<TImage>()
   {}


### PR DESCRIPTION
This sentence was previously added to the documentation of many default-constructors of iterators, but does not seem very helpful. It may be obsolete. The sentence already appeared in 2000: https://github.com/InsightSoftwareConsortium/ITK/blob/16e02706143953caa5fa8172237e6bef4b829702/Code/Common/itkImageBufferIterator.h#L75