### PR TITLE
STYLE: Remove GoToBegin() from just constructed iterators "WithIndex"

### DIFF
--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
@@ -302,7 +302,6 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
     gradientImagePointer = itkDynamicCastInDebugMode<GradientImagesType *>(this->ProcessObject::GetInput(0));
 
     ImageRegionConstIteratorWithIndex git(gradientImagePointer, outputRegionForThread);
-    git.GoToBegin();
 
     // Compute the indices of the baseline images and gradient images
     std::vector<unsigned int> baselineind; // contains the indices of

--- a/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkBinomialBlurImageFilter.hxx
@@ -144,7 +144,6 @@ BinomialBlurImageFilter<TInputImage, TOutputImage>::GenerateData()
     for (unsigned int dim = 0; dim < NDimensions; ++dim)
     {
       ImageRegionIteratorWithIndex tempItDir(tempPtr, tempPtr->GetRequestedRegion());
-      tempItDir.GoToBegin();
       while (!tempItDir.IsAtEnd())
       {
         // determine the index of the output pixel

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.hxx
@@ -84,8 +84,7 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeHImage()
   ImageRegionConstIteratorWithIndex constIt(contourImage, contourImage->GetRequestedRegion());
 
   ImageRegionIteratorWithIndex It(hBuffer, hBuffer->GetRequestedRegion());
-
-  It.GoToBegin(), constIt.GoToBegin();
+  constIt.GoToBegin();
 
   while (!constIt.IsAtEnd())
   {

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -578,8 +578,6 @@ ImageToImageMetric<TFixedImage, TMovingImage>::SampleFullFixedImageRegion(FixedI
   // Set up a region iterator within the user specified fixed image region.
   ImageRegionConstIteratorWithIndex regionIter(m_FixedImage, GetFixedImageRegion());
 
-  regionIter.GoToBegin();
-
   typename FixedImageSampleContainer::iterator iter;
   const auto                                   end = samples.end();
 


### PR DESCRIPTION
Using Notepad++, Replace in Files, doing:

    Find what: ^([ ]+)(Image\w+IteratorWithIndex[ ]+)(\w+)(.+)[\r\n]+\1\3\.GoToBegin\(\).
    Replace with: $1$2$3$4
    Search Mode: Regular expression

- Follow-up to pull request #4830