### PR TITLE
Use ConstShapedNeighborhoodIterator in ShapedFloodFilledFunctionConditionalConstIterator

### DIFF
--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.h
@@ -76,8 +76,12 @@ public:
   /** External Pixel Type */
   using PixelType = typename TImage::PixelType;
 
-  /** Internal Neighborhood Iterator Type */
-  using NeighborhoodIteratorType = typename itk::ShapedNeighborhoodIterator<ImageType>;
+#ifndef ITK_LEGACY_REMOVE
+  /** \deprecated Internal type alias; use \c ShapedNeighborhoodIterator<TImage> directly. */
+  using NeighborhoodIteratorType
+    [[deprecated("This nested type alias was only for internal use, and is now obsolete!")]] =
+      ShapedNeighborhoodIterator<TImage>;
+#endif
 
   /** Dimension of the image the iterator walks.  This constant is needed so
    * that functions that are templated over image iterator type (as opposed to

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.h
@@ -270,7 +270,7 @@ protected: // made protected so other iterators can access
   typename ImageType::SpacingType m_ImageSpacing{};
 
   /** The neighborhood iterator */
-  NeighborhoodIteratorType m_NeighborhoodIterator{};
+  ConstShapedNeighborhoodIterator<TImage> m_NeighborhoodIterator{};
 
   /** Region of the source image */
   RegionType m_ImageRegion{};

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
@@ -77,7 +77,7 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::Initialize
   m_ImageRegion = this->m_Image->GetBufferedRegion();
 
   // Build and setup the neighborhood iterator
-  constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<SizeType>(1);
 
   const ConstShapedNeighborhoodIterator<TImage> tmp_iter(radius, this->m_Image, m_ImageRegion);
   m_NeighborhoodIterator = tmp_iter;
@@ -169,8 +169,8 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::DoFloodSte
 
   // We are explicitly not calling set location since only offsets of
   // the neighborhood iterator are accessed.
-  typename NeighborhoodIteratorType::ConstIterator       neighborIt = m_NeighborhoodIterator.Begin();
-  const typename NeighborhoodIteratorType::ConstIterator neighborEnd = m_NeighborhoodIterator.End();
+  auto       neighborIt = m_NeighborhoodIterator.Begin();
+  const auto neighborEnd = m_NeighborhoodIterator.End();
 
   for (; neighborIt != neighborEnd; ++neighborIt)
   {

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
@@ -79,7 +79,7 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::Initialize
   // Build and setup the neighborhood iterator
   constexpr auto radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
 
-  const NeighborhoodIteratorType tmp_iter(radius, this->m_Image, m_ImageRegion);
+  const ConstShapedNeighborhoodIterator<TImage> tmp_iter(radius, this->m_Image, m_ImageRegion);
   m_NeighborhoodIterator = tmp_iter;
 
   setConnectivity(&m_NeighborhoodIterator, m_FullyConnected);


### PR DESCRIPTION
Improved const-correctness of ShapedFloodFilledFunctionConditionalConstIterator by using ConstShapedNeighborhoodIterator, instead of its non-const NeighborhoodIteratorType, which is an internal alias of the non-const ShapedNeighborhoodIterator.

Deprecated (ITK_FUTURE_LEGACY_REMOVE) the internal NeighborhoodIteratorType alias.