### PR TITLE
STYLE: Remove "Const" from `markerImageP` in ReconstructionImageFilter

### DIFF
--- a/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkReconstructionImageFilter.hxx
@@ -90,8 +90,8 @@ ReconstructionImageFilter<TInputImage, TOutputImage, TCompare>::GenerateData()
   // create padded versions of the marker image and the mask image
   using PadType = typename itk::ConstantPadImageFilter<InputImageType, InputImageType>;
 
-  MarkerImageConstPointer markerImageP;
-  MaskImageConstPointer   maskImageP;
+  MarkerImagePointer    markerImageP;
+  MaskImageConstPointer maskImageP;
 
   ISizeType padSize;
 


### PR DESCRIPTION
Declared `markerImageP` as MarkerImagePointer instead of MarkerImageConstPointer.

It appeared confusing to have `markerImageP` declared as pointer-to-const, in `ReconstructionImageFilter::GenerateData()`, because the member function _does_ modify its pixel data, by calling SetCenterPixel on a neighborhood iterator (`outNIt`) that iterates over its pixels.

----

- Aims to supersede pull request #6100, which accidentally mentioned  `maskImageP`, instead of `markerImageP`, in its commit message.