### PR TITLE
COMP: Replace legacy itk::Math::abs with itk::Math::Absolute in tests

### DIFF
--- a/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearQuadrilateralStressTestFEMObjectReader.cxx
+++ b/Modules/Numerics/FEM/test/itkFEMElement2DC0LinearQuadrilateralStressTestFEMObjectReader.cxx
@@ -124,14 +124,14 @@ itkFEMElement2DC0LinearQuadrilateralStressTestFEMObjectReader(int argc, char * a
   const unsigned int constrainedDofs[] = { 0, 1, 6, 7 };
   for (const auto dof : constrainedDofs)
   {
-    ITK_TEST_EXPECT_TRUE(itk::Math::abs(solver->GetSolution(dof)) < tolerance);
+    ITK_TEST_EXPECT_TRUE(itk::Math::Absolute(solver->GetSolution(dof)) < tolerance);
   }
 
   // Unconstrained DOFs must have non-zero displacement (forces applied).
   const unsigned int unconstrainedDofs[] = { 2, 3, 4, 5 };
   for (const auto dof : unconstrainedDofs)
   {
-    ITK_TEST_EXPECT_TRUE(itk::Math::abs(solver->GetSolution(dof)) > tolerance);
+    ITK_TEST_EXPECT_TRUE(itk::Math::Absolute(solver->GetSolution(dof)) > tolerance);
   }
 
   std::cout << "Test PASSED!" << std::endl;

--- a/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterTest.cxx
@@ -233,7 +233,7 @@ itkMultiLabelSTAPLEImageFilterTest(int, char *[])
   }
   for (unsigned int i = 0; i < priors.GetSize(); ++i)
   {
-    if (itk::Math::abs(priors[i] - expectedPriors[i]) > tolerance)
+    if (itk::Math::Absolute(priors[i] - expectedPriors[i]) > tolerance)
     {
       std::cerr << "PriorProbabilities[" << i << "] = " << priors[i] << ", expected " << expectedPriors[i] << std::endl;
       return EXIT_FAILURE;
@@ -257,7 +257,7 @@ itkMultiLabelSTAPLEImageFilterTest(int, char *[])
     {
       for (unsigned int c = 0; c < cm.cols(); ++c)
       {
-        if (itk::Math::abs(cm(r, c) - expected(r, c)) > tolerance)
+        if (itk::Math::Absolute(cm(r, c) - expected(r, c)) > tolerance)
         {
           std::cerr << "Confusion matrix " << rater << " (" << r << ',' << c << ") = " << cm(r, c) << ", expected "
                     << expected(r, c) << std::endl;


### PR DESCRIPTION
Fixes `ITK_FUTURE_LEGACY_REMOVE=ON` builds by migrating three `itk::Math::abs` call sites in two recently-added tests to the canonical `itk::Math::Absolute`.

<details>
<summary>Root cause</summary>

`itk::Math::abs` is an `ITK_FUTURE_LEGACY_REMOVE`-gated backward-compat alias at `Modules/Core/Common/include/itkMath.h:930`:

```cpp
#if !defined(ITK_FUTURE_LEGACY_REMOVE)
// itk::Math::Absolute has different behavior than std::abs.  The use of
// abs() in the ITK context without namespace resolution can be confusing
// The abs() version is provided for backwards compatibility.
template <typename T>
auto
abs(T x) noexcept
{
  return Absolute(x);
}
#endif
```

When ITK is configured with `ITK_FUTURE_LEGACY_REMOVE=ON`, the alias is compiled out, producing:

```
error: no member named 'abs' in namespace 'itk::Math'; did you mean simply 'abs'?
```

The canonical replacement is `itk::Math::Absolute` (`itkMath.h:882`). For floating-point inputs — which is what all three call sites pass — `Absolute` behaves identically to `std::abs`, so the semantic is unchanged.

</details>

<details>
<summary>Call sites fixed</summary>

| File | Line | Context |
|---|---|---|
| `Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterTest.cxx` | 236 | Assertions on MultiLabelSTAPLE priors (introduced by `7c2ad58b1a`, 2026-04-10) |
| `Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterTest.cxx` | 260 | Assertions on confusion-matrix entries (same commit) |
| `Modules/Numerics/FEM/test/itkFEMElement2DC0LinearQuadrilateralStressTestFEMObjectReader.cxx` | 127, 134 | Solver DOF displacement checks |

All other `itk::Math::abs` matches in the tree are in `Documentation/docs/releases/*.md` historical changelog entries and `output/` build artifacts — not source.

</details>

<!--
provenance: claude-code session 2026-04-23
trigger: user reported compile error on main with ITK_FUTURE_LEGACY_REMOVE=ON at itkMultiLabelSTAPLEImageFilterTest.cxx:260
key_facts:
  - legacy_alias_location: Modules/Core/Common/include/itkMath.h:930 (gated by !ITK_FUTURE_LEGACY_REMOVE)
  - canonical_replacement: itk::Math::Absolute at Modules/Core/Common/include/itkMath.h:882
  - sites_fixed: 3 call sites in 2 test files
  - introducing_commit_STAPLE: 7c2ad58b1a (2026-04-10, "BUG: Assert MultiLabelSTAPLE confusion matrices and priors")
-->