### PR TITLE
Use ConstShapedNeighborhoodIterator in ScalarImageToCooccurrenceListSampleFilter

### DIFF
--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.h
@@ -68,7 +68,7 @@ public:
   using ShapedNeighborhoodIteratorType = itk::ShapedNeighborhoodIterator<TImage, ConstantBoundaryCondition<TImage>>;
 
   /** Offset type used for Neighborhoods */
-  using OffsetType = typename ShapedNeighborhoodIteratorType::OffsetType;
+  using OffsetType = typename TImage::OffsetType;
   using OffsetTable = std::vector<OffsetType>;
 
   void

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.h
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.h
@@ -64,8 +64,12 @@ public:
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
-  /** Neighborhood iterator type. */
-  using ShapedNeighborhoodIteratorType = itk::ShapedNeighborhoodIterator<TImage, ConstantBoundaryCondition<TImage>>;
+#ifndef ITK_LEGACY_REMOVE
+  /** \deprecated Neighborhood iterator type; please use \c ShapedNeighborhoodIterator directly. */
+  using ShapedNeighborhoodIteratorType
+    [[deprecated("This nested type alias is obsolete; please use ShapedNeighborhoodIterator directly!")]] =
+      ShapedNeighborhoodIterator<TImage, ConstantBoundaryCondition<TImage>>;
+#endif
 
   /** Offset type used for Neighborhoods */
   using OffsetType = typename TImage::OffsetType;

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.hxx
@@ -71,13 +71,11 @@ template <typename TImage>
 void
 ScalarImageToCooccurrenceListSampleFilter<TImage>::GenerateData()
 {
-  constexpr auto radius = MakeFilled<typename ShapedNeighborhoodIteratorType::RadiusType>(1);
+  constexpr auto radius = MakeFilled<typename TImage::SizeType>(1);
 
   using FaceCalculatorType = itk::NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<ImageType>;
 
   FaceCalculatorType faceCalculator;
-
-  using ShapeNeighborhoodIterator = typename ShapedNeighborhoodIteratorType::ConstIterator;
 
   using PixelType = typename ImageType::PixelType;
 
@@ -111,7 +109,7 @@ ScalarImageToCooccurrenceListSampleFilter<TImage>::GenerateData()
     {
       const PixelType center_pixel_intensity = it.GetPixel(center_offset);
 
-      ShapeNeighborhoodIterator ci = it.Begin();
+      auto ci = it.Begin();
       while (ci != it.End())
       {
 

--- a/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToCooccurrenceListSampleFilter.hxx
@@ -98,7 +98,7 @@ ScalarImageToCooccurrenceListSampleFilter<TImage>::GenerateData()
 
   for (const auto & face : faceList)
   {
-    ShapedNeighborhoodIteratorType it(radius, input, face);
+    ConstShapedNeighborhoodIterator<TImage, ConstantBoundaryCondition<TImage>> it(radius, input, face);
 
     auto iter = m_OffsetTable.begin();
     while (iter != m_OffsetTable.end())


### PR DESCRIPTION
Improved const-correctness of ScalarImageToCooccurrenceListSampleFilter by using ConstShapedNeighborhoodIterator, instead of its non-const ShapedNeighborhoodIteratorType

- Similar to pull request #6099 