### PR TITLE
BoxUtilities const-correctness fixes regarding the use of ShapedNeighborhoodIterator

### DIFF
--- a/Modules/Filtering/Smoothing/include/itkBoxUtilities.h
+++ b/Modules/Filtering/Smoothing/include/itkBoxUtilities.h
@@ -97,7 +97,7 @@ namespace itk
 template <typename TInputImage, typename TOutputImage>
 void
 BoxAccumulateFunction(const TInputImage *               inputImage,
-                      const TOutputImage *              outputImage,
+                      TOutputImage *                    outputImage,
                       typename TInputImage::RegionType  inputRegion,
                       typename TOutputImage::RegionType outputRegion)
 {

--- a/Modules/Filtering/Smoothing/include/itkBoxUtilities.h
+++ b/Modules/Filtering/Smoothing/include/itkBoxUtilities.h
@@ -164,7 +164,7 @@ template <typename TImage>
 std::vector<typename TImage::OffsetType>
 CornerOffsets(const TImage * im)
 {
-  using NIterator = ShapedNeighborhoodIterator<TImage>;
+  using NIterator = ConstShapedNeighborhoodIterator<TImage>;
   auto                                     unitradius = TImage::SizeType::Filled(1);
   const NIterator                          n1(unitradius, im, im->GetRequestedRegion());
   const unsigned int                       centerIndex = n1.GetCenterNeighborhoodIndex();


### PR DESCRIPTION
Two little const-correctness fixes:
- Remove const from outputImage parameter of `BoxAccumulateFunction(inputImage, outputImage, inputRegion, outputRegion)`
- Use ConstShapedNeighborhoodIterator, instead of the non-const ShapedNeighborhoodIterator, in CornerOffsets
