### PR TITLE
ENH: SMOKE -- Template ImageReverseIterator on VIsConst (unit 11)

### DIFF
--- a/Modules/Core/Common/include/itkImageBoundaryCondition.h
+++ b/Modules/Core/Common/include/itkImageBoundaryCondition.h
@@ -72,6 +72,13 @@ public:
   /** Type of the data container passed to this function object. */
   using NeighborhoodType = Neighborhood<PixelPointerType, ImageDimension>;
 
+  /** Const-pointer-element variant of NeighborhoodType.
+   * The pointer-constness-polymorphic NeighborhoodIteratorBase (VIsConst=true)
+   * inherits from this neighborhood; boundary conditions called from that path
+   * dispatch through the ConstNeighborhoodType overloads below. */
+  using ConstPixelPointerType = const typename TInputImage::InternalPixelType *;
+  using ConstNeighborhoodType = Neighborhood<ConstPixelPointerType, ImageDimension>;
+
   /** Functor used to access pixels from a neighborhood of pixel pointers */
   using NeighborhoodAccessorFunctorType = typename TInputImage::NeighborhoodAccessorFunctorType;
 
@@ -104,6 +111,34 @@ public:
              const OffsetType &                      boundary_offset,
              const NeighborhoodType *                data,
              const NeighborhoodAccessorFunctorType & neighborhoodAccessorFunctor) const = 0;
+
+  /** Const-pointer-element overloads used by the N+1 pointer-constness-
+   * polymorphic NeighborhoodIteratorBase (VIsConst=true). These are NOT pure:
+   * existing subclasses that only override the legacy (non-const pointer
+   * element) overloads keep working — the default body bridges via
+   * reinterpret_cast, which is safe because
+   *   Neighborhood<T*, Dim>   and
+   *   Neighborhood<const T*, Dim>
+   * have byte-identical layout (both store std::vector<pointer> of the same
+   * element size). Subclasses may override these for performance but are
+   * not required to. */
+  virtual OutputPixelType
+  operator()(const OffsetType &            point_index,
+             const OffsetType &            boundary_offset,
+             const ConstNeighborhoodType * data) const
+  {
+    return this->operator()(point_index, boundary_offset, reinterpret_cast<const NeighborhoodType *>(data));
+  }
+
+  virtual OutputPixelType
+  operator()(const OffsetType &                      point_index,
+             const OffsetType &                      boundary_offset,
+             const ConstNeighborhoodType *           data,
+             const NeighborhoodAccessorFunctorType & neighborhoodAccessorFunctor) const
+  {
+    return this->operator()(
+      point_index, boundary_offset, reinterpret_cast<const NeighborhoodType *>(data), neighborhoodAccessorFunctor);
+  }
 
   virtual ~ImageBoundaryCondition() = default;
 

--- a/Modules/Core/Common/include/itkImageReverseIteratorBase.h
+++ b/Modules/Core/Common/include/itkImageReverseIteratorBase.h
@@ -1,0 +1,100 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkImageReverseIteratorBase_h
+#define itkImageReverseIteratorBase_h
+
+// SMOKE TEST - Unit 11: structural scaffold for templating
+// ImageReverseIterator / ImageReverseConstIterator on a VIsConst flag.
+// This header is intentionally compile-only for the spike and not yet
+// wired into the legacy iterator classes. See .devlocal/smoke/unit-11.md.
+
+#include "itkMacro.h"
+#include <type_traits>
+
+namespace itk
+{
+
+/** \class ImageReverseIteratorBase
+ * \brief Templated base for image reverse iterators over const/non-const TImage.
+ *
+ * VIsConst == true  models ImageReverseConstIterator<TImage>
+ * VIsConst == false models ImageReverseIterator<TImage>
+ *
+ * The InternalPixelType pointer held by this class is const-qualified when
+ * VIsConst is true, eliminating the const_cast that the legacy
+ * ImageReverseIterator/ImageReverseConstIterator headers use at
+ * itkImageReverseIterator.h:103 and itkImageReverseConstIterator.h:340.
+ *
+ * Set() and the non-const Value() overload are SFINAE-gated on !VIsConst.
+ *
+ * \ingroup ITKCommon
+ */
+template <typename TImage, bool VIsConst>
+class ITK_TEMPLATE_EXPORT ImageReverseIteratorBase
+{
+public:
+  using Self = ImageReverseIteratorBase;
+  using ImageType = TImage;
+  using InternalPixelType = typename TImage::InternalPixelType;
+  using PixelType = typename TImage::PixelType;
+
+  /** Buffer pointer is const InternalPixelType* when VIsConst, else InternalPixelType*. */
+  using BufferPointerType = std::conditional_t<VIsConst, const InternalPixelType *, InternalPixelType *>;
+
+  static constexpr bool IsConst = VIsConst;
+
+  ImageReverseIteratorBase() = default;
+
+  /** Set is only enabled when VIsConst is false. */
+  template <bool B = VIsConst, typename = std::enable_if_t<!B>>
+  void
+  Set(const PixelType & /*value*/) const
+  {
+    // Intentionally a structural placeholder; real body lives in the
+    // legacy iterator classes for this spike.
+  }
+
+  /** Non-const Value() is only enabled when VIsConst is false. */
+  template <bool B = VIsConst, typename = std::enable_if_t<!B>>
+  PixelType &
+  Value()
+  {
+    return *m_Buffer;
+  }
+
+  /** const Value() is always available. */
+  const PixelType &
+  Value() const
+  {
+    return *m_Buffer;
+  }
+
+protected:
+  BufferPointerType m_Buffer{ nullptr };
+};
+
+/** Alias templates matching the legacy class names. */
+template <typename TImage>
+using ImageReverseConstIteratorTemplated = ImageReverseIteratorBase<TImage, true>;
+
+template <typename TImage>
+using ImageReverseIteratorTemplated = ImageReverseIteratorBase<TImage, false>;
+
+} // end namespace itk
+
+#endif

--- a/Modules/Core/Common/include/itkNeighborhoodAccessorFunctor.h
+++ b/Modules/Core/Common/include/itkNeighborhoodAccessorFunctor.h
@@ -50,6 +50,7 @@ public:
 
   static constexpr unsigned int ImageDimension = TImage::ImageDimension;
   using NeighborhoodType = Neighborhood<InternalPixelType *, Self::ImageDimension>;
+  using ConstNeighborhoodType = Neighborhood<const InternalPixelType *, Self::ImageDimension>;
 
   template <typename TOutput = ImageType>
   using ImageBoundaryConditionType = ImageBoundaryCondition<ImageType, TOutput>;
@@ -83,6 +84,20 @@ public:
   BoundaryCondition(const OffsetType &                          point_index,
                     const OffsetType &                          boundary_offset,
                     const NeighborhoodType *                    data,
+                    const ImageBoundaryConditionType<TOutput> * boundaryCondition) const
+  {
+    return boundaryCondition->operator()(point_index, boundary_offset, data);
+  }
+
+  /** Const-pointer-element overload used by NeighborhoodIteratorBase when
+   * VIsConst=true. Dispatches through the const-path virtual on
+   * ImageBoundaryCondition, which (by default) bridges back to the legacy
+   * overload. */
+  template <typename TOutput>
+  inline typename ImageBoundaryConditionType<TOutput>::OutputPixelType
+  BoundaryCondition(const OffsetType &                          point_index,
+                    const OffsetType &                          boundary_offset,
+                    const ConstNeighborhoodType *               data,
                     const ImageBoundaryConditionType<TOutput> * boundaryCondition) const
   {
     return boundaryCondition->operator()(point_index, boundary_offset, data);

--- a/Modules/Core/Common/include/itkNeighborhoodIteratorBase.h
+++ b/Modules/Core/Common/include/itkNeighborhoodIteratorBase.h
@@ -1,0 +1,1740 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkNeighborhoodIteratorBase_h
+#define itkNeighborhoodIteratorBase_h
+
+// -----------------------------------------------------------------------------
+// NeighborhoodIteratorBase: unified templated base that replaces the pair of
+// legacy classes ConstNeighborhoodIterator<TImage, TBC> and
+// NeighborhoodIterator<TImage, TBC> via a compile-time `bool VIsConst`
+// parameter. See the "NeighborhoodIterator N+1 Port" design plan at
+// docs/superpowers/plans/2026-04-23-neighborhood-iterator-n1-port.md.
+// -----------------------------------------------------------------------------
+
+#include <cstring>
+#include <iostream>
+#include <list>
+#include <sstream>
+#include <type_traits>
+#include <vector>
+
+#include "itkImage.h"
+#include "itkNeighborhood.h"
+#include "itkMacro.h"
+#include "itkWeakPointer.h"
+#include "itkImageBoundaryCondition.h"
+#include "itkZeroFluxNeumannBoundaryCondition.h"
+
+namespace itk
+{
+
+// =============================================================================
+// 1. Unified neighborhood iterator (replaces ConstNeighborhoodIterator +
+//    NeighborhoodIterator).
+// =============================================================================
+template <typename TImage,
+          typename TBoundaryCondition = ZeroFluxNeumannBoundaryCondition<TImage>,
+          bool VIsConst = false>
+class ITK_TEMPLATE_EXPORT NeighborhoodIteratorBase
+  : public Neighborhood<
+      std::conditional_t<VIsConst, const typename TImage::InternalPixelType *, typename TImage::InternalPixelType *>,
+      TImage::ImageDimension>
+{
+public:
+  // --- compile-time constness plumbing ---------------------------------------
+  static constexpr bool IsConst = VIsConst;
+
+  using InternalPixelType = typename TImage::InternalPixelType;
+  using PixelType = typename TImage::PixelType;
+
+  // Pointer / reference types flip based on VIsConst. No const_cast anywhere.
+  using ImagePointer = std::conditional_t<IsConst, const TImage *, TImage *>;
+
+  using InternalPixelPointer = std::conditional_t<IsConst, const InternalPixelType *, InternalPixelType *>;
+
+  using PixelReference = std::conditional_t<IsConst, const PixelType &, PixelType &>;
+
+  // --- standard iterator type aliases ----------------------------------------
+  using Self = NeighborhoodIteratorBase;
+  using Superclass = Neighborhood<InternalPixelPointer, TImage::ImageDimension>;
+
+  using typename Superclass::OffsetType;
+  using typename Superclass::RadiusType;
+  using typename Superclass::SizeType;
+  using typename Superclass::Iterator;
+  using typename Superclass::ConstIterator;
+
+  static constexpr unsigned int Dimension = TImage::ImageDimension;
+  using DimensionValueType = unsigned int;
+
+  using ImageType = TImage;
+  using RegionType = typename TImage::RegionType;
+  using IndexType = Index<Dimension>;
+  using NeighborhoodType = Neighborhood<PixelType, Dimension>;
+  using NeighborIndexType = typename NeighborhoodType::NeighborIndexType;
+  using BoundaryConditionType = TBoundaryCondition;
+  using OutputImageType = typename BoundaryConditionType::OutputImageType;
+
+  using NeighborhoodAccessorFunctorType = typename ImageType::NeighborhoodAccessorFunctorType;
+
+  using ImageBoundaryConditionPointerType = ImageBoundaryCondition<ImageType, OutputImageType> *;
+  using ImageBoundaryConditionConstPointerType = const ImageBoundaryCondition<ImageType, OutputImageType> *;
+
+  // m_ConstImage is a ConstWeakPointer on VIsConst=true and a (non-const)
+  // WeakPointer on VIsConst=false.
+  using ImageWeakPointerType =
+    std::conditional_t<IsConst, typename ImageType::ConstWeakPointer, WeakPointer<ImageType>>;
+
+  // Friending cross-const instantiations lets the converting ctor access
+  // private state of its non-const sibling.
+  template <typename, typename, bool>
+  friend class NeighborhoodIteratorBase;
+
+  /** Default constructor. */
+  NeighborhoodIteratorBase() = default;
+
+  /** Destructor. */
+  ~NeighborhoodIteratorBase() = default;
+
+  /** Constructor which establishes the region size, neighborhood, and image
+   * over which to walk. */
+  NeighborhoodIteratorBase(const SizeType & radius, ImagePointer ptr, const RegionType & region)
+  {
+    this->Initialize(radius, ptr, region);
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      m_InBounds[i] = false;
+    }
+    this->ResetBoundaryCondition();
+    m_NeighborhoodAccessorFunctor = ptr->GetNeighborhoodAccessor();
+    m_NeighborhoodAccessorFunctor.SetBegin(ptr->GetBufferPointer());
+  }
+
+  /** Copy constructor (same constness). */
+  NeighborhoodIteratorBase(const NeighborhoodIteratorBase & orig)
+    : Superclass(orig)
+    , m_BeginIndex(orig.m_BeginIndex)
+    , m_Bound(orig.m_Bound)
+    , m_Begin(orig.m_Begin)
+    , m_ConstImage(orig.m_ConstImage)
+    , m_End(orig.m_End)
+    , m_EndIndex(orig.m_EndIndex)
+    , m_Loop(orig.m_Loop)
+    , m_Region(orig.m_Region)
+    , m_WrapOffset(orig.m_WrapOffset)
+    , m_InternalBoundaryCondition(orig.m_InternalBoundaryCondition)
+    , m_NeedToUseBoundaryCondition(orig.m_NeedToUseBoundaryCondition)
+  {
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      m_InBounds[i] = orig.m_InBounds[i];
+    }
+    m_IsInBoundsValid = orig.m_IsInBoundsValid;
+    m_IsInBounds = orig.m_IsInBounds;
+
+    m_InnerBoundsLow = orig.m_InnerBoundsLow;
+    m_InnerBoundsHigh = orig.m_InnerBoundsHigh;
+
+    // Re-bind the (raw) boundary-condition pointer: if the source was
+    // pointing at its own internal default, the copy's pointer needs to
+    // point at *our* internal default, not the source's.
+    if (orig.m_BoundaryCondition ==
+        static_cast<ImageBoundaryConditionConstPointerType>(&orig.m_InternalBoundaryCondition))
+    {
+      this->ResetBoundaryCondition();
+    }
+    else
+    {
+      m_BoundaryCondition = orig.m_BoundaryCondition;
+    }
+    m_NeighborhoodAccessorFunctor = orig.m_NeighborhoodAccessorFunctor;
+  }
+
+  /** Non-const -> const converting constructor. Enabled only when *this* is
+   * the const instantiation being built from a non-const source. */
+  template <bool VOtherIsConst, std::enable_if_t<VIsConst && !VOtherIsConst, int> = 0>
+  NeighborhoodIteratorBase(const NeighborhoodIteratorBase<TImage, TBoundaryCondition, VOtherIsConst> & other)
+    : Superclass()
+    , m_BeginIndex(other.m_BeginIndex)
+    , m_Bound(other.m_Bound)
+    , m_Begin(other.m_Begin)
+    , m_End(other.m_End)
+    , m_EndIndex(other.m_EndIndex)
+    , m_Loop(other.m_Loop)
+    , m_Region(other.m_Region)
+    , m_WrapOffset(other.m_WrapOffset)
+    , m_InternalBoundaryCondition(other.m_InternalBoundaryCondition)
+    , m_NeedToUseBoundaryCondition(other.m_NeedToUseBoundaryCondition)
+  {
+    // Copy the Neighborhood<T*> base into Neighborhood<const T*> element-wise.
+    this->SetRadius(other.GetRadius());
+    auto       dstIt = this->Begin();
+    const auto srcEnd = other.End();
+    for (auto srcIt = other.Begin(); srcIt != srcEnd; ++srcIt, ++dstIt)
+    {
+      *dstIt = *srcIt; // T* -> const T* is implicit
+    }
+    m_ConstImage = other.m_ConstImage.GetPointer();
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      m_InBounds[i] = other.m_InBounds[i];
+    }
+    m_IsInBoundsValid = other.m_IsInBoundsValid;
+    m_IsInBounds = other.m_IsInBounds;
+    m_InnerBoundsLow = other.m_InnerBoundsLow;
+    m_InnerBoundsHigh = other.m_InnerBoundsHigh;
+    this->ResetBoundaryCondition();
+    m_NeighborhoodAccessorFunctor = other.m_NeighborhoodAccessorFunctor;
+  }
+
+  /** Assignment operator. */
+  Self &
+  operator=(const Self & orig)
+  {
+    if (this != &orig)
+    {
+      Superclass::operator=(orig);
+
+      m_Bound = orig.m_Bound;
+      m_Begin = orig.m_Begin;
+      m_ConstImage = orig.m_ConstImage;
+      m_End = orig.m_End;
+      m_EndIndex = orig.m_EndIndex;
+      m_Loop = orig.m_Loop;
+      m_Region = orig.m_Region;
+      m_BeginIndex = orig.m_BeginIndex;
+      m_WrapOffset = orig.m_WrapOffset;
+
+      m_InternalBoundaryCondition = orig.m_InternalBoundaryCondition;
+      m_NeedToUseBoundaryCondition = orig.m_NeedToUseBoundaryCondition;
+
+      m_InnerBoundsLow = orig.m_InnerBoundsLow;
+      m_InnerBoundsHigh = orig.m_InnerBoundsHigh;
+
+      for (DimensionValueType i = 0; i < Dimension; ++i)
+      {
+        m_InBounds[i] = orig.m_InBounds[i];
+      }
+      m_IsInBoundsValid = orig.m_IsInBoundsValid;
+      m_IsInBounds = orig.m_IsInBounds;
+
+      if (orig.m_BoundaryCondition ==
+          static_cast<ImageBoundaryConditionConstPointerType>(&orig.m_InternalBoundaryCondition))
+      {
+        this->ResetBoundaryCondition();
+      }
+      else
+      {
+        m_BoundaryCondition = orig.m_BoundaryCondition;
+      }
+      m_NeighborhoodAccessorFunctor = orig.m_NeighborhoodAccessorFunctor;
+    }
+    return *this;
+  }
+
+  /** Standard itk print method. */
+  void
+  PrintSelf(std::ostream & os, Indent indent) const
+  {
+    Superclass::PrintSelf(os, indent);
+
+    os << indent;
+    os << "NeighborhoodIteratorBase {this= " << this;
+    os << ", m_Region = { Start = {";
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      os << m_Region.GetIndex()[i] << ' ';
+    }
+    os << "}, Size = { ";
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      os << m_Region.GetSize()[i] << ' ';
+    }
+    os << "} }";
+    os << ", m_BeginIndex = { ";
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      os << m_BeginIndex[i] << ' ';
+    }
+    os << "} , m_EndIndex = { ";
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      os << m_EndIndex[i] << ' ';
+    }
+    os << "} , m_Loop = { ";
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      os << m_Loop[i] << ' ';
+    }
+    os << "}, m_Bound = { ";
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      os << m_Bound[i] << ' ';
+    }
+    os << "}, m_IsInBounds = {" << m_IsInBounds;
+    os << "}, m_IsInBoundsValid = {" << m_IsInBoundsValid;
+    os << "}, m_WrapOffset = { ";
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      os << m_WrapOffset[i] << ' ';
+    }
+    os << ", m_Begin = " << m_Begin;
+    os << ", m_End = " << m_End;
+    os << '}' << std::endl;
+
+    os << indent << ",  m_InnerBoundsLow = { ";
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      os << m_InnerBoundsLow[i] << ' ';
+    }
+    os << "}, m_InnerBoundsHigh = { ";
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      os << m_InnerBoundsHigh[i] << ' ';
+    }
+    os << "} }" << std::endl;
+  }
+
+  /** Computes the internal, N-d offset of a pixel array position n. */
+  OffsetType
+  ComputeInternalIndex(const NeighborIndexType n) const
+  {
+    OffsetType ans;
+    auto       r = static_cast<unsigned long>(n);
+    for (long i = long{ Dimension } - 1; i >= 0; --i)
+    {
+      ans[i] = static_cast<OffsetValueType>(r / this->GetStride(i));
+      r = r % this->GetStride(i);
+    }
+    return ans;
+  }
+
+  /** Upper loop bounds. */
+  IndexType
+  GetBound() const
+  {
+    return m_Bound;
+  }
+  IndexValueType
+  GetBound(NeighborIndexType n) const
+  {
+    return m_Bound[n];
+  }
+
+  /** Pointer to the center pixel. */
+  const InternalPixelType *
+  GetCenterPointer() const
+  {
+    return (this->operator[]((this->Size()) >> 1));
+  }
+
+  PixelType
+  GetCenterPixel() const
+  {
+    return m_NeighborhoodAccessorFunctor.Get(this->GetCenterPointer());
+  }
+
+  /** Access to the neighborhood accessor functor (read-only). */
+  const NeighborhoodAccessorFunctorType &
+  GetNeighborhoodAccessor() const
+  {
+    return m_NeighborhoodAccessorFunctor;
+  }
+
+  ImagePointer
+  GetImagePointer() const
+  {
+    return m_ConstImage.GetPointer();
+  }
+
+  IndexType
+  GetIndex() const
+  {
+    return m_Loop;
+  }
+
+  inline IndexType
+  GetFastIndexPlusOffset(const OffsetType & o) const
+  {
+    return m_Loop + o;
+  }
+
+  NeighborhoodType
+  GetNeighborhood() const
+  {
+    const ConstIterator _end = this->End();
+
+    NeighborhoodType ans;
+    ans.SetRadius(this->GetRadius());
+    if (m_NeedToUseBoundaryCondition == false)
+    {
+      ConstIterator thisIt = this->Begin();
+      for (typename NeighborhoodType::Iterator ansIt = ans.Begin(); thisIt < _end; ++ansIt, ++thisIt)
+      {
+        *ansIt = m_NeighborhoodAccessorFunctor.Get(*thisIt);
+      }
+    }
+    else if (InBounds())
+    {
+      ConstIterator thisIt = this->Begin();
+      for (typename NeighborhoodType::Iterator ansIt = ans.Begin(); thisIt < _end; ++ansIt, ++thisIt)
+      {
+        *ansIt = m_NeighborhoodAccessorFunctor.Get(*thisIt);
+      }
+    }
+    else
+    {
+      OffsetType temp;
+      OffsetType OverlapHigh;
+      OffsetType OverlapLow;
+      for (DimensionValueType i = 0; i < Dimension; ++i)
+      {
+        OverlapLow[i] = m_InnerBoundsLow[i] - m_Loop[i];
+        OverlapHigh[i] = static_cast<OffsetValueType>(this->GetSize(i)) - ((m_Loop[i] + 2) - m_InnerBoundsHigh[i]);
+        temp[i] = 0;
+      }
+
+      ConstIterator thisIt = this->Begin();
+      for (typename NeighborhoodType::Iterator ansIt = ans.Begin(); thisIt < _end; ++ansIt, ++thisIt)
+      {
+        bool flag = true;
+
+        OffsetType offset;
+        for (DimensionValueType i = 0; i < Dimension; ++i)
+        {
+          if (m_InBounds[i])
+          {
+            offset[i] = 0;
+          }
+          else
+          {
+            if (temp[i] < OverlapLow[i])
+            {
+              flag = false;
+              offset[i] = OverlapLow[i] - temp[i];
+            }
+            else if (OverlapHigh[i] < temp[i])
+            {
+              flag = false;
+              offset[i] = OverlapHigh[i] - temp[i];
+            }
+            else
+            {
+              offset[i] = 0;
+            }
+          }
+        }
+
+        if (flag)
+        {
+          *ansIt = m_NeighborhoodAccessorFunctor.Get(*thisIt);
+        }
+        else
+        {
+          *ansIt = m_NeighborhoodAccessorFunctor.BoundaryCondition(temp, offset, this, this->m_BoundaryCondition);
+        }
+
+        m_BoundaryCondition->operator()(temp, offset, this);
+
+        for (DimensionValueType i = 0; i < Dimension; ++i)
+        {
+          temp[i]++;
+          if (temp[i] == static_cast<OffsetValueType>(this->GetSize(i)))
+          {
+            temp[i] = 0;
+          }
+          else
+          {
+            break;
+          }
+        }
+      }
+    }
+    return ans;
+  }
+
+  PixelType
+  GetPixel(const NeighborIndexType i) const
+  {
+    if (!m_NeedToUseBoundaryCondition || this->InBounds())
+    {
+      return (m_NeighborhoodAccessorFunctor.Get(this->operator[](i)));
+    }
+
+    OffsetType internalIndex;
+    OffsetType offset;
+
+    return this->IndexInBounds(i, internalIndex, offset)
+             ? m_NeighborhoodAccessorFunctor.Get(this->operator[](i))
+             : m_NeighborhoodAccessorFunctor.BoundaryCondition(internalIndex, offset, this, m_BoundaryCondition);
+  }
+
+  PixelType
+  GetPixel(NeighborIndexType n, bool & IsInBounds) const
+  {
+    if (!m_NeedToUseBoundaryCondition)
+    {
+      IsInBounds = true;
+      return (m_NeighborhoodAccessorFunctor.Get(this->operator[](n)));
+    }
+
+    if (this->InBounds())
+    {
+      IsInBounds = true;
+      return (m_NeighborhoodAccessorFunctor.Get(this->operator[](n)));
+    }
+
+    OffsetType offset;
+    OffsetType internalIndex;
+    const bool flag = this->IndexInBounds(n, internalIndex, offset);
+    if (flag)
+    {
+      IsInBounds = true;
+      return (m_NeighborhoodAccessorFunctor.Get(this->operator[](n)));
+    }
+    else
+    {
+      IsInBounds = false;
+      return m_NeighborhoodAccessorFunctor.BoundaryCondition(internalIndex, offset, this, this->m_BoundaryCondition);
+    }
+  }
+
+  PixelType
+  GetPixel(const OffsetType & o) const
+  {
+    bool inbounds = false;
+    return (this->GetPixel(this->GetNeighborhoodIndex(o), inbounds));
+  }
+
+  PixelType
+  GetPixel(const OffsetType & o, bool & IsInBounds) const
+  {
+    return (this->GetPixel(this->GetNeighborhoodIndex(o), IsInBounds));
+  }
+
+  PixelType
+  GetNext(const unsigned int axis, NeighborIndexType i) const
+  {
+    return (this->GetPixel(this->GetCenterNeighborhoodIndex() + (i * this->GetStride(axis))));
+  }
+
+  PixelType
+  GetNext(const unsigned int axis) const
+  {
+    return (this->GetPixel(this->GetCenterNeighborhoodIndex() + this->GetStride(axis)));
+  }
+
+  PixelType
+  GetPrevious(const unsigned int axis, NeighborIndexType i) const
+  {
+    return (this->GetPixel(this->GetCenterNeighborhoodIndex() - (i * this->GetStride(axis))));
+  }
+
+  PixelType
+  GetPrevious(const unsigned int axis) const
+  {
+    return (this->GetPixel(this->GetCenterNeighborhoodIndex() - this->GetStride(axis)));
+  }
+
+  IndexType
+  GetIndex(const OffsetType & o) const
+  {
+    return this->GetIndex() + o;
+  }
+
+  IndexType
+  GetIndex(NeighborIndexType i) const
+  {
+    return this->GetIndex() + this->GetOffset(i);
+  }
+
+  RegionType
+  GetRegion() const
+  {
+    return m_Region;
+  }
+
+  IndexType
+  GetBeginIndex() const
+  {
+    return m_BeginIndex;
+  }
+
+  RegionType
+  GetBoundingBoxAsImageRegion() const
+  {
+    constexpr IndexValueType zero{};
+    const RegionType         ans(this->GetIndex(zero), this->GetSize());
+    return ans;
+  }
+
+  OffsetType
+  GetWrapOffset() const
+  {
+    return m_WrapOffset;
+  }
+
+  OffsetValueType
+  GetWrapOffset(NeighborIndexType n) const
+  {
+    return m_WrapOffset[n];
+  }
+
+  void
+  GoToBegin()
+  {
+    this->SetLocation(m_BeginIndex);
+  }
+
+  void
+  GoToEnd()
+  {
+    this->SetLocation(m_EndIndex);
+  }
+
+  void
+  Initialize(const SizeType & radius, ImagePointer ptr, const RegionType & region)
+  {
+    m_ConstImage = ptr;
+    this->SetRadius(radius);
+    SetRegion(region);
+    m_IsInBoundsValid = false;
+    m_IsInBounds = false;
+  }
+
+  bool
+  IsAtBegin() const
+  {
+    return this->GetCenterPointer() == m_Begin;
+  }
+
+  bool
+  IsAtEnd() const
+  {
+    if (this->GetCenterPointer() > m_End)
+    {
+      ExceptionObject    e(__FILE__, __LINE__);
+      std::ostringstream msg;
+      msg << "In method IsAtEnd, CenterPointer = " << this->GetCenterPointer() << " is greater than End = " << m_End
+          << std::endl
+          << "  " << *this;
+      e.SetDescription(msg.str().c_str());
+      throw e;
+    }
+    return this->GetCenterPointer() == m_End;
+  }
+
+  Self &
+  operator++()
+  {
+    const Iterator _end = Superclass::End();
+    m_IsInBoundsValid = false;
+
+    for (Iterator it = Superclass::Begin(); it < _end; ++it)
+    {
+      (*it)++;
+    }
+
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      m_Loop[i]++;
+      if (m_Loop[i] == m_Bound[i])
+      {
+        m_Loop[i] = m_BeginIndex[i];
+        for (Iterator it = Superclass::Begin(); it < _end; ++it)
+        {
+          *it += m_WrapOffset[i];
+        }
+      }
+      else
+      {
+        break;
+      }
+    }
+    return *this;
+  }
+
+  Self &
+  operator--()
+  {
+    const Iterator _end = Superclass::End();
+    m_IsInBoundsValid = false;
+
+    for (Iterator it = Superclass::Begin(); it < _end; ++it)
+    {
+      (*it)--;
+    }
+
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      if (m_Loop[i] == m_BeginIndex[i])
+      {
+        m_Loop[i] = m_Bound[i] - 1;
+        for (Iterator it = Superclass::Begin(); it < _end; ++it)
+        {
+          *it -= m_WrapOffset[i];
+        }
+      }
+      else
+      {
+        m_Loop[i]--;
+        break;
+      }
+    }
+    return *this;
+  }
+
+  bool
+  operator==(const Self & it) const
+  {
+    return it.GetCenterPointer() == this->GetCenterPointer();
+  }
+
+  bool
+  operator!=(const Self & it) const
+  {
+    return !(*this == it);
+  }
+
+  bool
+  operator<(const Self & it) const
+  {
+    return this->GetCenterPointer() < it.GetCenterPointer();
+  }
+
+  bool
+  operator<=(const Self & it) const
+  {
+    return this->GetCenterPointer() <= it.GetCenterPointer();
+  }
+
+  bool
+  operator>(const Self & it) const
+  {
+    return this->GetCenterPointer() > it.GetCenterPointer();
+  }
+
+  bool
+  operator>=(const Self & it) const
+  {
+    return this->GetCenterPointer() >= it.GetCenterPointer();
+  }
+
+  void
+  SetLocation(const IndexType & position)
+  {
+    this->SetLoop(position);
+    this->SetPixelPointers(position);
+  }
+
+  Self &
+  operator+=(const OffsetType & idx)
+  {
+    const Iterator          _end = this->End();
+    OffsetValueType         accumulator = 0;
+    const OffsetValueType * stride = this->GetImagePointer()->GetOffsetTable();
+
+    m_IsInBoundsValid = false;
+
+    accumulator += idx[0];
+    for (DimensionValueType i = 1; i < Dimension; ++i)
+    {
+      accumulator += idx[i] * stride[i];
+    }
+
+    for (Iterator it = this->Begin(); it < _end; ++it)
+    {
+      *it += accumulator;
+    }
+
+    m_Loop += idx;
+    return *this;
+  }
+
+  Self &
+  operator-=(const OffsetType & idx)
+  {
+    const Iterator          _end = this->End();
+    OffsetValueType         accumulator = 0;
+    const OffsetValueType * stride = this->GetImagePointer()->GetOffsetTable();
+
+    m_IsInBoundsValid = false;
+
+    accumulator += idx[0];
+    for (DimensionValueType i = 1; i < Dimension; ++i)
+    {
+      accumulator += idx[i] * stride[i];
+    }
+
+    for (Iterator it = this->Begin(); it < _end; ++it)
+    {
+      *it -= accumulator;
+    }
+
+    m_Loop -= idx;
+    return *this;
+  }
+
+  OffsetType
+  operator-(const Self & b) const
+  {
+    return m_Loop - b.m_Loop;
+  }
+
+  bool
+  InBounds() const
+  {
+    if (m_IsInBoundsValid)
+    {
+      return m_IsInBounds;
+    }
+
+    bool ans = true;
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      if (m_Loop[i] < m_InnerBoundsLow[i] || m_Loop[i] >= m_InnerBoundsHigh[i])
+      {
+        m_InBounds[i] = ans = false;
+      }
+      else
+      {
+        m_InBounds[i] = true;
+      }
+    }
+    m_IsInBounds = ans;
+    m_IsInBoundsValid = true;
+    return ans;
+  }
+
+  bool
+  IndexInBounds(const NeighborIndexType n, OffsetType & internalIndex, OffsetType & offset) const
+  {
+    if (!m_NeedToUseBoundaryCondition)
+    {
+      return true;
+    }
+    if (this->InBounds())
+    {
+      return true;
+    }
+    else
+    {
+      bool flag = true;
+      internalIndex = this->ComputeInternalIndex(n);
+
+      for (DimensionValueType i = 0; i < Dimension; ++i)
+      {
+        if (m_InBounds[i])
+        {
+          offset[i] = 0;
+        }
+        else
+        {
+          const OffsetValueType OverlapLow(m_InnerBoundsLow[i] - m_Loop[i]);
+          if (internalIndex[i] < OverlapLow)
+          {
+            flag = false;
+            offset[i] = OverlapLow - internalIndex[i];
+          }
+          else
+          {
+            const auto overlapHigh(
+              static_cast<OffsetValueType>(this->GetSize(i) - ((m_Loop[i] + 2) - m_InnerBoundsHigh[i])));
+            if (overlapHigh < internalIndex[i])
+            {
+              flag = false;
+              offset[i] = overlapHigh - internalIndex[i];
+            }
+            else
+            {
+              offset[i] = 0;
+            }
+          }
+        }
+      }
+      return flag;
+    }
+  }
+
+  bool
+  IndexInBounds(const NeighborIndexType n) const
+  {
+    if (!m_NeedToUseBoundaryCondition)
+    {
+      return true;
+    }
+    if (this->InBounds())
+    {
+      return true;
+    }
+    else
+    {
+      bool               flag = true;
+      const OffsetType & internalIndex = this->ComputeInternalIndex(n);
+      for (DimensionValueType i = 0; i < Dimension; ++i)
+      {
+        if (!m_InBounds[i])
+        {
+          const OffsetValueType OverlapLow(m_InnerBoundsLow[i] - m_Loop[i]);
+          if (internalIndex[i] < OverlapLow)
+          {
+            flag = false;
+          }
+          else
+          {
+            const auto overlapHigh(
+              static_cast<OffsetValueType>(this->GetSize(i) - ((m_Loop[i] + 2) - m_InnerBoundsHigh[i])));
+            if (overlapHigh < internalIndex[i])
+            {
+              flag = false;
+            }
+          }
+        }
+      }
+      return flag;
+    }
+  }
+
+  // --- boundary condition setters (available on both instantiations) --------
+  void
+  OverrideBoundaryCondition(const ImageBoundaryConditionPointerType i)
+  {
+    m_BoundaryCondition = i;
+  }
+
+  void
+  ResetBoundaryCondition()
+  {
+    m_BoundaryCondition = &m_InternalBoundaryCondition;
+  }
+
+  void
+  SetBoundaryCondition(const TBoundaryCondition & c)
+  {
+    m_InternalBoundaryCondition = c;
+  }
+
+  ImageBoundaryConditionPointerType
+  GetBoundaryCondition() const
+  {
+    return m_BoundaryCondition;
+  }
+
+  void
+  NeedToUseBoundaryConditionOn()
+  {
+    this->SetNeedToUseBoundaryCondition(true);
+  }
+
+  void
+  NeedToUseBoundaryConditionOff()
+  {
+    this->SetNeedToUseBoundaryCondition(false);
+  }
+
+  void
+  SetNeedToUseBoundaryCondition(bool b)
+  {
+    m_NeedToUseBoundaryCondition = b;
+  }
+
+  bool
+  GetNeedToUseBoundaryCondition() const
+  {
+    return m_NeedToUseBoundaryCondition;
+  }
+
+  /** Set the region to iterate over. */
+  void
+  SetRegion(const RegionType & region)
+  {
+    m_Region = region;
+
+    const IndexType regionIndex = region.GetIndex();
+
+    this->SetBeginIndex(region.GetIndex());
+    this->SetLocation(region.GetIndex());
+    this->SetBound(region.GetSize());
+    this->SetEndIndex();
+
+    m_Begin = m_ConstImage->GetBufferPointer() + m_ConstImage->ComputeOffset(regionIndex);
+    m_End = m_ConstImage->GetBufferPointer() + m_ConstImage->ComputeOffset(m_EndIndex);
+
+    const IndexType bStart = m_ConstImage->GetBufferedRegion().GetIndex();
+    const SizeType  bSize = m_ConstImage->GetBufferedRegion().GetSize();
+    const IndexType rStart = region.GetIndex();
+    const SizeType  rSize = region.GetSize();
+
+    m_NeedToUseBoundaryCondition = false;
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      const auto overlapLow =
+        static_cast<OffsetValueType>((rStart[i] - static_cast<OffsetValueType>(this->GetRadius(i))) - bStart[i]);
+      const auto overlapHigh = static_cast<OffsetValueType>(
+        (bStart[i] + bSize[i]) - (rStart[i] + rSize[i] + static_cast<OffsetValueType>(this->GetRadius(i))));
+
+      if (overlapLow < 0)
+      {
+        m_NeedToUseBoundaryCondition = true;
+        break;
+      }
+
+      if (overlapHigh < 0)
+      {
+        m_NeedToUseBoundaryCondition = true;
+        break;
+      }
+    }
+  }
+
+  // =========================================================================
+  // Write API. SFINAE-gated on !VIsConst; these methods are not present on
+  // the const instantiation.
+  // =========================================================================
+  template <bool VCopy = VIsConst, std::enable_if_t<!VCopy, int> = 0>
+  void
+  SetPixel(const unsigned int n, const PixelType & v)
+  {
+    if (this->m_NeedToUseBoundaryCondition == false)
+    {
+      this->m_NeighborhoodAccessorFunctor.Set(this->operator[](n), v);
+    }
+    else if (this->InBounds())
+    {
+      this->m_NeighborhoodAccessorFunctor.Set(this->operator[](n), v);
+    }
+    else
+    {
+      OffsetType temp = this->ComputeInternalIndex(n);
+      OffsetType OverlapLow;
+      OffsetType OverlapHigh;
+      OffsetType offset;
+
+      for (unsigned int ii = 0; ii < Dimension; ++ii)
+      {
+        OverlapLow[ii] = this->m_InnerBoundsLow[ii] - this->m_Loop[ii];
+        OverlapHigh[ii] =
+          static_cast<OffsetValueType>(this->GetSize(ii) - ((this->m_Loop[ii] + 2) - this->m_InnerBoundsHigh[ii]));
+      }
+
+      bool flag = true;
+
+      for (unsigned int ii = 0; ii < Dimension; ++ii)
+      {
+        if (this->m_InBounds[ii])
+        {
+          offset[ii] = 0;
+        }
+        else
+        {
+          if (temp[ii] < OverlapLow[ii])
+          {
+            flag = false;
+            offset[ii] = OverlapLow[ii] - temp[ii];
+          }
+          else if (OverlapHigh[ii] < temp[ii])
+          {
+            flag = false;
+            offset[ii] = OverlapHigh[ii] - temp[ii];
+          }
+          else
+          {
+            offset[ii] = 0;
+          }
+        }
+      }
+
+      if (flag)
+      {
+        this->m_NeighborhoodAccessorFunctor.Set(this->operator[](n), v);
+      }
+      else
+      {
+        RangeError e(__FILE__, __LINE__);
+        e.SetLocation(ITK_LOCATION);
+        e.SetDescription("Attempt to write out of bounds.");
+        throw e;
+      }
+    }
+  }
+
+  template <bool VCopy = VIsConst, std::enable_if_t<!VCopy, int> = 0>
+  void
+  SetPixel(const unsigned int n, const PixelType & v, bool & status)
+  {
+    if (this->m_NeedToUseBoundaryCondition == false)
+    {
+      status = true;
+      this->m_NeighborhoodAccessorFunctor.Set(this->operator[](n), v);
+    }
+    else if (this->InBounds())
+    {
+      this->m_NeighborhoodAccessorFunctor.Set(this->operator[](n), v);
+      status = true;
+      return;
+    }
+    else
+    {
+      OffsetType temp = this->ComputeInternalIndex(n);
+      for (unsigned int i = 0; i < Dimension; ++i)
+      {
+        if (!this->m_InBounds[i])
+        {
+          const typename OffsetType::OffsetValueType OverlapLow = this->m_InnerBoundsLow[i] - this->m_Loop[i];
+          const auto                                 OverlapHigh =
+            static_cast<OffsetValueType>(this->GetSize(i) - ((this->m_Loop[i] + 2) - this->m_InnerBoundsHigh[i]));
+          if (temp[i] < OverlapLow || OverlapHigh < temp[i])
+          {
+            status = false;
+            return;
+          }
+        }
+      }
+
+      this->m_NeighborhoodAccessorFunctor.Set(this->operator[](n), v);
+      status = true;
+    }
+  }
+
+  template <bool VCopy = VIsConst, std::enable_if_t<!VCopy, int> = 0>
+  void
+  SetCenterPixel(const PixelType & p)
+  {
+    this->m_NeighborhoodAccessorFunctor.Set(this->operator[]((this->Size()) >> 1), p);
+  }
+
+  template <bool VCopy = VIsConst, std::enable_if_t<!VCopy, int> = 0>
+  void
+  SetNeighborhood(const NeighborhoodType & N)
+  {
+    const Iterator _end = this->End();
+
+    typename NeighborhoodType::ConstIterator N_it;
+
+    if (this->m_NeedToUseBoundaryCondition == false)
+    {
+      Iterator this_it = this->Begin();
+      for (N_it = N.Begin(); this_it < _end; ++this_it, ++N_it)
+      {
+        this->m_NeighborhoodAccessorFunctor.Set(*this_it, *N_it);
+      }
+    }
+    else if (this->InBounds())
+    {
+      Iterator this_it = this->Begin();
+      for (N_it = N.Begin(); this_it < _end; ++this_it, ++N_it)
+      {
+        this->m_NeighborhoodAccessorFunctor.Set(*this_it, *N_it);
+      }
+    }
+    else
+    {
+      OffsetType OverlapLow;
+      OffsetType OverlapHigh;
+      OffsetType temp{ 0 };
+      for (unsigned int i = 0; i < Dimension; ++i)
+      {
+        OverlapLow[i] = this->m_InnerBoundsLow[i] - this->m_Loop[i];
+        OverlapHigh[i] =
+          static_cast<OffsetValueType>(this->GetSize(i) - (this->m_Loop[i] - this->m_InnerBoundsHigh[i]) - 1);
+      }
+
+      Iterator this_it = this->Begin();
+      for (N_it = N.Begin(); this_it < _end; ++N_it, ++this_it)
+      {
+        bool flag = true;
+        for (unsigned int i = 0; i < Dimension; ++i)
+        {
+          if (!this->m_InBounds[i] && ((temp[i] < OverlapLow[i]) || (temp[i] >= OverlapHigh[i])))
+          {
+            flag = false;
+            break;
+          }
+        }
+
+        if (flag)
+        {
+          this->m_NeighborhoodAccessorFunctor.Set(*this_it, *N_it);
+        }
+
+        for (unsigned int i = 0; i < Dimension; ++i)
+        {
+          temp[i]++;
+          if (static_cast<unsigned int>(temp[i]) == this->GetSize(i))
+          {
+            temp[i] = 0;
+          }
+          else
+          {
+            break;
+          }
+        }
+      }
+    }
+  }
+
+protected:
+  /** Set the coordinate location of the iterator. */
+  void
+  SetLoop(const IndexType & p)
+  {
+    m_Loop = p;
+    m_IsInBoundsValid = false;
+  }
+
+  /** Set internal loop boundaries. */
+  void
+  SetBound(const SizeType & size)
+  {
+    SizeType                radius = this->GetRadius();
+    const OffsetValueType * offset = m_ConstImage->GetOffsetTable();
+    const IndexType         imageBRStart = m_ConstImage->GetBufferedRegion().GetIndex();
+    SizeType                imageBRSize = m_ConstImage->GetBufferedRegion().GetSize();
+
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      m_Bound[i] = m_BeginIndex[i] + static_cast<OffsetValueType>(size[i]);
+      m_InnerBoundsHigh[i] = static_cast<IndexValueType>(
+        imageBRStart[i] + static_cast<OffsetValueType>(imageBRSize[i]) - static_cast<OffsetValueType>(radius[i]));
+      m_InnerBoundsLow[i] = static_cast<IndexValueType>(imageBRStart[i] + static_cast<OffsetValueType>(radius[i]));
+      m_WrapOffset[i] = (static_cast<OffsetValueType>(imageBRSize[i]) - (m_Bound[i] - m_BeginIndex[i])) * offset[i];
+    }
+    m_WrapOffset[Dimension - 1] = 0;
+  }
+
+  /** Set the values of the internal pointers. */
+  void
+  SetPixelPointers(const IndexType & pos)
+  {
+    const Iterator          _end = Superclass::End();
+    const SizeType          size = this->GetSize();
+    const OffsetValueType * OffsetTable = m_ConstImage->GetOffsetTable();
+    const SizeType          radius = this->GetRadius();
+
+    SizeType loop{};
+
+    // First "upper-left-corner" pixel address of neighborhood. Using
+    // m_ConstImage's natural pointer type avoids the legacy const_cast.
+    auto *               ptr = m_ConstImage.GetPointer();
+    InternalPixelPointer Iit = ptr->GetBufferPointer() + ptr->ComputeOffset(pos);
+
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      Iit -= radius[i] * OffsetTable[i];
+    }
+
+    for (Iterator Nit = Superclass::Begin(); Nit != _end; ++Nit)
+    {
+      *Nit = Iit;
+      ++Iit;
+      for (DimensionValueType i = 0; i < Dimension; ++i)
+      {
+        loop[i]++;
+        if (loop[i] == size[i])
+        {
+          if (i == Dimension - 1)
+          {
+            break;
+          }
+          Iit += OffsetTable[i + 1] - OffsetTable[i] * static_cast<OffsetValueType>(size[i]);
+          loop[i] = 0;
+        }
+        else
+        {
+          break;
+        }
+      }
+    }
+  }
+
+  void
+  SetBeginIndex(const IndexType & start)
+  {
+    m_BeginIndex = start;
+  }
+
+  void
+  SetEndIndex()
+  {
+    if (m_Region.GetNumberOfPixels() > 0)
+    {
+      m_EndIndex = m_Region.GetIndex();
+      m_EndIndex[Dimension - 1] =
+        m_Region.GetIndex()[Dimension - 1] + static_cast<OffsetValueType>(m_Region.GetSize()[Dimension - 1]);
+    }
+    else
+    {
+      m_EndIndex = m_Region.GetIndex();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Legacy protected member layout — mirrors itkConstNeighborhoodIterator.h
+  // lines 584-646.
+  // -------------------------------------------------------------------------
+
+  IndexType                         m_BeginIndex{ { 0 } };
+  IndexType                         m_Bound{ { 0 } };
+  InternalPixelPointer              m_Begin{ nullptr };
+  ImageWeakPointerType              m_ConstImage{};
+  InternalPixelPointer              m_End{ nullptr };
+  IndexType                         m_EndIndex{ { 0 } };
+  IndexType                         m_Loop{ { 0 } };
+  RegionType                        m_Region{};
+  OffsetType                        m_WrapOffset{ { 0 } };
+  TBoundaryCondition                m_InternalBoundaryCondition{};
+  ImageBoundaryConditionPointerType m_BoundaryCondition{ &m_InternalBoundaryCondition };
+  mutable bool                      m_InBounds[Dimension]{ false };
+  mutable bool                      m_IsInBounds{ false };
+  mutable bool                      m_IsInBoundsValid{ false };
+  IndexType                         m_InnerBoundsLow{};
+  IndexType                         m_InnerBoundsHigh{};
+  bool                              m_NeedToUseBoundaryCondition{ false };
+  NeighborhoodAccessorFunctorType   m_NeighborhoodAccessorFunctor{};
+};
+
+// -----------------------------------------------------------------------------
+// Re-templated free operators (legacy versions templated on TImage only).
+// -----------------------------------------------------------------------------
+template <typename TImage, typename TBoundaryCondition, bool VIsConst>
+inline NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst>
+operator+(const NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst> &                      it,
+          const typename NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst>::OffsetType & ind)
+{
+  NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst> ret(it);
+  ret += ind;
+  return ret;
+}
+
+template <typename TImage, typename TBoundaryCondition, bool VIsConst>
+inline NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst>
+operator+(const typename NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst>::OffsetType & ind,
+          const NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst> &                      it)
+{
+  return it + ind;
+}
+
+template <typename TImage, typename TBoundaryCondition, bool VIsConst>
+inline NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst>
+operator-(const NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst> &                      it,
+          const typename NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst>::OffsetType & ind)
+{
+  NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst> ret(it);
+  ret -= ind;
+  return ret;
+}
+
+// -----------------------------------------------------------------------------
+// Aliases that preserve the legacy public names.
+// -----------------------------------------------------------------------------
+template <typename TImage, typename TBC = ZeroFluxNeumannBoundaryCondition<TImage>>
+using ConstNeighborhoodIterator2 = NeighborhoodIteratorBase<TImage, TBC, /*IsConst=*/true>;
+
+template <typename TImage, typename TBC = ZeroFluxNeumannBoundaryCondition<TImage>>
+using NeighborhoodIterator2 = NeighborhoodIteratorBase<TImage, TBC, /*IsConst=*/false>;
+
+
+// =============================================================================
+// 2. Unified shaped neighborhood iterator scaffold (design shape only; full
+//    port lands in a subsequent milestone).
+// =============================================================================
+template <typename TImage,
+          typename TBoundaryCondition = ZeroFluxNeumannBoundaryCondition<TImage>,
+          bool VIsConst = false>
+class ITK_TEMPLATE_EXPORT ShapedNeighborhoodIteratorBase
+{
+public:
+  static constexpr bool IsConst = VIsConst;
+
+  using Base = NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst>;
+
+  using ImagePointer = typename Base::ImagePointer;
+  using PixelType = typename Base::PixelType;
+  using SizeType = typename Base::SizeType;
+  using RegionType = typename Base::RegionType;
+  using OffsetType = typename Base::OffsetType;
+  using IndexType = typename Base::IndexType;
+  using NeighborhoodType = typename Base::NeighborhoodType;
+  using NeighborIndexType = typename NeighborhoodType::NeighborIndexType;
+
+  using IndexListType = std::list<NeighborIndexType>;
+
+  using Self = ShapedNeighborhoodIteratorBase;
+
+  template <typename, typename, bool>
+  friend class ShapedNeighborhoodIteratorBase;
+
+  ShapedNeighborhoodIteratorBase() = default;
+  ~ShapedNeighborhoodIteratorBase() = default;
+
+  ShapedNeighborhoodIteratorBase(const SizeType & radius, ImagePointer ptr, const RegionType & region)
+    : m_Base(radius, ptr, region)
+  {}
+
+  ShapedNeighborhoodIteratorBase(const ShapedNeighborhoodIteratorBase &) = default;
+  ShapedNeighborhoodIteratorBase(ShapedNeighborhoodIteratorBase &&) noexcept = default;
+  ShapedNeighborhoodIteratorBase &
+  operator=(const ShapedNeighborhoodIteratorBase &) = default;
+  ShapedNeighborhoodIteratorBase &
+  operator=(ShapedNeighborhoodIteratorBase &&) noexcept = default;
+
+  // Converting ctor: non-const -> const only (VIsConst && !VOtherIsConst).
+  template <bool VOtherIsConst, std::enable_if_t<VIsConst && !VOtherIsConst, int> = 0>
+  ShapedNeighborhoodIteratorBase(const ShapedNeighborhoodIteratorBase<TImage, TBoundaryCondition, VOtherIsConst> & o)
+    : m_Base(o.m_Base)
+    , m_ActiveIndexList(o.m_ActiveIndexList)
+    , m_CenterIsActive(o.m_CenterIsActive)
+  {}
+
+  template <bool VInnerIsConst>
+  struct InnerIteratorT
+  {
+    using OuterPointer = std::conditional_t<VInnerIsConst, const Self *, Self *>;
+    using ListIterator =
+      std::conditional_t<VInnerIsConst, typename IndexListType::const_iterator, typename IndexListType::iterator>;
+
+    InnerIteratorT() = default;
+    friend Self;
+
+    InnerIteratorT &
+    operator++()
+    {
+      ++m_ListIterator;
+      return *this;
+    }
+    bool
+    operator==(const InnerIteratorT & o) const
+    {
+      return m_ListIterator == o.m_ListIterator;
+    }
+    bool
+    operator!=(const InnerIteratorT & o) const
+    {
+      return !(*this == o);
+    }
+
+    PixelType
+    Get() const
+    {
+      // Direct pointer access via the base's accessor. This matches the legacy
+      // shaped iterator semantics (active offsets read directly, bypassing the
+      // boundary condition) and also avoids instantiating the BC-branch of
+      // NeighborhoodIteratorBase::GetPixel() for VIsConst=true instantiations.
+      return m_Outer->m_Base.GetNeighborhoodAccessor().Get(m_Outer->m_Base.operator[](*m_ListIterator));
+    }
+
+    void
+    Set(const PixelType & v) const
+    {
+      static_assert(!VInnerIsConst && !IsConst, "Set() requires a non-const ShapedNeighborhoodIterator.");
+      m_Outer->m_Base.SetPixel(*m_ListIterator, v);
+    }
+
+  private:
+    InnerIteratorT(OuterPointer outer, ListIterator li)
+      : m_Outer(outer)
+      , m_ListIterator(li)
+    {}
+
+    OuterPointer m_Outer{ nullptr };
+    ListIterator m_ListIterator{};
+  };
+
+  using ConstIterator = InnerIteratorT<true>;
+  using Iterator = InnerIteratorT<false>;
+
+  ConstIterator
+  Begin() const
+  {
+    return ConstIterator(this, m_ActiveIndexList.begin());
+  }
+  ConstIterator
+  End() const
+  {
+    return ConstIterator(this, m_ActiveIndexList.end());
+  }
+
+  template <bool VCopy = IsConst, std::enable_if_t<!VCopy, int> = 0>
+  Iterator
+  Begin()
+  {
+    return Iterator(this, m_ActiveIndexList.begin());
+  }
+  template <bool VCopy = IsConst, std::enable_if_t<!VCopy, int> = 0>
+  Iterator
+  End()
+  {
+    return Iterator(this, m_ActiveIndexList.end());
+  }
+
+  void
+  ActivateOffset(const OffsetType & off)
+  {
+    this->ActivateIndex(m_Base.GetNeighborhoodIndex(off));
+  }
+  void
+  DeactivateOffset(const OffsetType & off)
+  {
+    this->DeactivateIndex(m_Base.GetNeighborhoodIndex(off));
+  }
+  template <typename TOffsets>
+  void
+  ActivateOffsets(const TOffsets & offsets)
+  {
+    for (const auto & off : offsets)
+    {
+      this->ActivateOffset(off);
+    }
+  }
+  void
+  ClearActiveList()
+  {
+    m_ActiveIndexList.clear();
+    m_CenterIsActive = false;
+  }
+
+  template <typename TNeighborPixel>
+  void
+  CreateActiveListFromNeighborhood(const Neighborhood<TNeighborPixel, Base::Dimension> & neighborhood)
+  {
+    if (m_Base.GetRadius() != neighborhood.GetRadius())
+    {
+      itkGenericExceptionMacro("Radius of shaped iterator(" << m_Base.GetRadius()
+                                                            << ") does not equal radius of neighborhood("
+                                                            << neighborhood.GetRadius() << ')');
+    }
+    NeighborIndexType idx = 0;
+    for (auto nit = neighborhood.Begin(); nit != neighborhood.End(); ++nit, ++idx)
+    {
+      if (*nit)
+      {
+        this->ActivateOffset(neighborhood.GetOffset(idx));
+      }
+      else
+      {
+        this->DeactivateOffset(neighborhood.GetOffset(idx));
+      }
+    }
+  }
+
+  bool
+  GetCenterIsActive() const
+  {
+    return m_CenterIsActive;
+  }
+
+  NeighborIndexType
+  GetCenterNeighborhoodIndex() const
+  {
+    return m_Base.GetCenterNeighborhoodIndex();
+  }
+
+  OffsetType
+  GetOffset(NeighborIndexType i) const
+  {
+    return m_Base.GetOffset(i);
+  }
+
+  NeighborIndexType
+  GetNeighborhoodIndex(const OffsetType & o) const
+  {
+    return m_Base.GetNeighborhoodIndex(o);
+  }
+
+  SizeType
+  GetRadius() const
+  {
+    return m_Base.GetRadius();
+  }
+
+  // Iteration: delegate to the underlying (dense) base iterator. This loses
+  // the shaped-only pointer-update optimization that the legacy iterator
+  // performed, in exchange for structural elimination of the const_cast
+  // sites and a much simpler implementation. GetPixel() for active indices
+  // goes through the base, which is always correct.
+  void
+  GoToBegin()
+  {
+    m_Base.GoToBegin();
+  }
+  void
+  GoToEnd()
+  {
+    m_Base.GoToEnd();
+  }
+  bool
+  IsAtBegin() const
+  {
+    return m_Base.IsAtBegin();
+  }
+  bool
+  IsAtEnd() const
+  {
+    return m_Base.IsAtEnd();
+  }
+  Self &
+  operator++()
+  {
+    ++m_Base;
+    return *this;
+  }
+  Self &
+  operator--()
+  {
+    --m_Base;
+    return *this;
+  }
+  void
+  SetLocation(const IndexType & position)
+  {
+    m_Base.SetLocation(position);
+  }
+
+  bool
+  operator==(const Self & o) const
+  {
+    return m_Base == o.m_Base;
+  }
+  bool
+  operator!=(const Self & o) const
+  {
+    return !(*this == o);
+  }
+
+  void
+  PrintSelf(std::ostream & os, Indent indent) const
+  {
+    m_Base.PrintSelf(os, indent);
+    os << indent << "ActiveIndexList: [";
+    for (auto it = m_ActiveIndexList.begin(); it != m_ActiveIndexList.end(); ++it)
+    {
+      os << indent.GetNextIndent() << *it << ' ';
+    }
+    os << "] ";
+    os << indent << "CenterIsActive: " << (m_CenterIsActive ? "On" : "Off") << std::endl;
+  }
+  const IndexListType &
+  GetActiveIndexList() const
+  {
+    return m_ActiveIndexList;
+  }
+  typename IndexListType::size_type
+  GetActiveIndexListSize() const
+  {
+    return m_ActiveIndexList.size();
+  }
+
+  ImagePointer
+  GetImagePointer() const
+  {
+    return m_Base.GetImagePointer();
+  }
+  const RegionType &
+  GetRegion() const
+  {
+    return m_Base.GetRegion();
+  }
+  IndexType
+  GetIndex() const
+  {
+    return m_Base.GetIndex();
+  }
+  PixelType
+  GetCenterPixel() const
+  {
+    return m_Base.GetCenterPixel();
+  }
+
+  template <bool VCopy = IsConst, std::enable_if_t<!VCopy, int> = 0>
+  void
+  SetPixel(NeighborIndexType i, const PixelType & v)
+  {
+    m_Base.SetPixel(i, v);
+  }
+
+  template <bool VCopy = IsConst, std::enable_if_t<!VCopy, int> = 0>
+  void
+  SetCenterPixel(const PixelType & v)
+  {
+    m_Base.SetCenterPixel(v);
+  }
+
+private:
+  void
+  ActivateIndex(NeighborIndexType n)
+  {
+    // Insert n while keeping m_ActiveIndexList sorted and deduplicated.
+    auto it = m_ActiveIndexList.begin();
+    if (m_ActiveIndexList.empty())
+    {
+      m_ActiveIndexList.push_front(n);
+    }
+    else
+    {
+      while (it != m_ActiveIndexList.end() && n > *it)
+      {
+        ++it;
+      }
+      if (it == m_ActiveIndexList.end() || n != *it)
+      {
+        m_ActiveIndexList.insert(it, n);
+      }
+    }
+    if (n == m_Base.GetCenterNeighborhoodIndex())
+    {
+      m_CenterIsActive = true;
+    }
+  }
+
+  void
+  DeactivateIndex(NeighborIndexType n)
+  {
+    auto it = m_ActiveIndexList.begin();
+    if (m_ActiveIndexList.empty())
+    {
+      return;
+    }
+    while (n != *it)
+    {
+      ++it;
+      if (it == m_ActiveIndexList.end())
+      {
+        return;
+      }
+    }
+    m_ActiveIndexList.erase(it);
+    if (n == m_Base.GetCenterNeighborhoodIndex())
+    {
+      m_CenterIsActive = false;
+    }
+  }
+
+  Base          m_Base{};
+  IndexListType m_ActiveIndexList{};
+  bool          m_CenterIsActive{ false };
+};
+
+template <typename TImage, typename TBC = ZeroFluxNeumannBoundaryCondition<TImage>>
+using ConstShapedNeighborhoodIterator2 = ShapedNeighborhoodIteratorBase<TImage, TBC, /*IsConst=*/true>;
+
+template <typename TImage, typename TBC = ZeroFluxNeumannBoundaryCondition<TImage>>
+using ShapedNeighborhoodIterator2 = ShapedNeighborhoodIteratorBase<TImage, TBC, /*IsConst=*/false>;
+
+} // namespace itk
+
+#endif

--- a/Modules/Core/Common/include/itkVectorImageNeighborhoodAccessorFunctor.h
+++ b/Modules/Core/Common/include/itkVectorImageNeighborhoodAccessorFunctor.h
@@ -48,6 +48,7 @@ public:
   using OffsetType = typename ImageType::OffsetType;
 
   using NeighborhoodType = Neighborhood<InternalPixelType *, TImage::ImageDimension>;
+  using ConstNeighborhoodType = Neighborhood<const InternalPixelType *, TImage::ImageDimension>;
 
   template <typename TOutput = ImageType>
   using ImageBoundaryConditionType = ImageBoundaryCondition<ImageType, TOutput>;
@@ -108,6 +109,18 @@ public:
   BoundaryCondition(const OffsetType &                          point_index,
                     const OffsetType &                          boundary_offset,
                     const NeighborhoodType *                    data,
+                    const ImageBoundaryConditionType<TOutput> * boundaryCondition) const
+  {
+    return boundaryCondition->operator()(point_index, boundary_offset, data, *this);
+  }
+
+  /** Const-pointer-element overload used by NeighborhoodIteratorBase when
+   * VIsConst=true. */
+  template <typename TOutput>
+  inline typename ImageBoundaryConditionType<TOutput>::OutputPixelType
+  BoundaryCondition(const OffsetType &                          point_index,
+                    const OffsetType &                          boundary_offset,
+                    const ConstNeighborhoodType *               data,
                     const ImageBoundaryConditionType<TOutput> * boundaryCondition) const
   {
     return boundaryCondition->operator()(point_index, boundary_offset, data, *this);

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -103,6 +103,8 @@ set(
   itkSymmetricSecondRankTensorTest.cxx
   itkConstShapedNeighborhoodIteratorTest.cxx
   itkConstShapedNeighborhoodIteratorTest2.cxx
+  itkNeighborhoodIteratorBaseSpikeTest.cxx
+  itkNeighborhoodIteratorBaseRuntimeTest.cxx
   itkSTLContainerAdaptorTest.cxx
   itkFiniteCylinderSpatialFunctionTest.cxx
   itkLoggerOutputTest.cxx
@@ -389,6 +391,18 @@ itk_add_test(
   COMMAND
     ITKCommon2TestDriver
     itkConstShapedNeighborhoodIteratorTest2
+)
+itk_add_test(
+  NAME itkNeighborhoodIteratorBaseSpikeTest
+  COMMAND
+    ITKCommon2TestDriver
+    itkNeighborhoodIteratorBaseSpikeTest
+)
+itk_add_test(
+  NAME itkNeighborhoodIteratorBaseRuntimeTest
+  COMMAND
+    ITKCommon2TestDriver
+    itkNeighborhoodIteratorBaseRuntimeTest
 )
 itk_add_test(
   NAME itkExceptionObjectTest

--- a/Modules/Core/Common/test/itkNeighborhoodIteratorBaseRuntimeTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodIteratorBaseRuntimeTest.cxx
@@ -1,0 +1,221 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// Runtime test for NeighborhoodIteratorBase<..., VIsConst>.
+//
+// Exercises:
+//   * Construction and iteration on the non-const instantiation.
+//   * Voxel-count traversal over a small 3-D region.
+//   * SetCenterPixel() mutation round-trips into the image buffer.
+//   * Converting ctor non-const -> const yields a read-only iterator that
+//     observes the just-written values.
+
+#include "itkImage.h"
+#include "itkImageRegionIterator.h"
+#include "itkNeighborhoodIteratorBase.h"
+
+#include <cstdlib>
+#include <iostream>
+
+int
+itkNeighborhoodIteratorBaseRuntimeTest(int, char *[])
+{
+  using ImageType = itk::Image<float, 3>;
+  using MutIt = itk::NeighborhoodIterator2<ImageType>;
+  using ConIt = itk::ConstNeighborhoodIterator2<ImageType>;
+
+  // Build a 5x5x5 ramp image.
+  auto                  image = ImageType::New();
+  ImageType::SizeType   size = { { 5, 5, 5 } };
+  ImageType::IndexType  index = { { 0, 0, 0 } };
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(index);
+  image->SetRegions(region);
+  image->Allocate();
+
+  {
+    itk::ImageRegionIterator<ImageType> it(image, region);
+    float                               v = 0.0f;
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it, v += 1.0f)
+    {
+      it.Set(v);
+    }
+  }
+
+  constexpr auto radius = itk::MakeFilled<MutIt::SizeType>(1);
+
+  MutIt nIt(radius, image, region);
+
+  // Count visited voxels via GoToBegin/operator++/IsAtEnd.
+  itk::SizeValueType visited = 0;
+  for (nIt.GoToBegin(); !nIt.IsAtEnd(); ++nIt)
+  {
+    ++visited;
+  }
+  const itk::SizeValueType expected = region.GetNumberOfPixels();
+  if (visited != expected)
+  {
+    std::cerr << "FAIL: visited " << visited << " voxels, expected " << expected << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Write at a known location and read it back from the raw image.
+  nIt.GoToBegin();
+  ImageType::IndexType target = { { 2, 2, 2 } };
+  nIt.SetLocation(target);
+  nIt.SetCenterPixel(42.0f);
+  if (image->GetPixel(target) != 42.0f)
+  {
+    std::cerr << "FAIL: SetCenterPixel did not round-trip; got " << image->GetPixel(target) << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Build a const iterator via the converting ctor and read the same location.
+  ConIt cIt(nIt);
+  cIt.SetLocation(target);
+  if (cIt.GetCenterPixel() != 42.0f)
+  {
+    std::cerr << "FAIL: const-converted iterator center pixel = " << cIt.GetCenterPixel() << " (expected 42)"
+              << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Iterate const-side over the same region and verify count matches.
+  itk::SizeValueType cVisited = 0;
+  for (cIt.GoToBegin(); !cIt.IsAtEnd(); ++cIt)
+  {
+    ++cVisited;
+  }
+  if (cVisited != expected)
+  {
+    std::cerr << "FAIL: const iterator visited " << cVisited << " voxels, expected " << expected << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Verify GetImagePointer return-type constness on both instantiations.
+  static_assert(std::is_same_v<decltype(nIt.GetImagePointer()), ImageType *>,
+                "Non-const NeighborhoodIteratorBase should return ImageType* (no const_cast).");
+  static_assert(std::is_same_v<decltype(cIt.GetImagePointer()), const ImageType *>,
+                "Const NeighborhoodIteratorBase should return const ImageType*.");
+
+  // --------------------------------------------------------------------
+  // ShapedNeighborhoodIteratorBase exercise.
+  // --------------------------------------------------------------------
+  using MutShaped = itk::ShapedNeighborhoodIterator2<ImageType>;
+  using ConShaped = itk::ConstShapedNeighborhoodIterator2<ImageType>;
+
+  // Reverse-converting ctor must be compile-disabled.
+  static_assert(!std::is_constructible_v<MutShaped, const ConShaped &>,
+                "Must not construct non-const ShapedNeighborhoodIteratorBase from const one.");
+  // Forward converting ctor must be available.
+  static_assert(std::is_constructible_v<ConShaped, const MutShaped &>,
+                "Const ShapedNeighborhoodIteratorBase must be constructible from non-const.");
+
+  MutShaped sIt(radius, image, region);
+  sIt.SetLocation(target);
+
+  // Activate the 6-connected stencil (Manhattan neighbors at distance 1).
+  for (unsigned d = 0; d < ImageType::ImageDimension; ++d)
+  {
+    MutShaped::OffsetType off{};
+    off[d] = 1;
+    sIt.ActivateOffset(off);
+    off[d] = -1;
+    sIt.ActivateOffset(off);
+  }
+
+  if (sIt.GetActiveIndexListSize() != 6)
+  {
+    std::cerr << "FAIL: expected 6 active offsets, got " << sIt.GetActiveIndexListSize() << std::endl;
+    return EXIT_FAILURE;
+  }
+  if (sIt.GetCenterIsActive())
+  {
+    std::cerr << "FAIL: center unexpectedly active." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Iterate inner Begin()/End() and mutate via Set(); verify one pixel round-trips.
+  itk::SizeValueType sVisited = 0;
+  bool               wroteOne = false;
+  for (auto innerIt = sIt.Begin(); innerIt != sIt.End(); ++innerIt)
+  {
+    ++sVisited;
+    if (!wroteOne)
+    {
+      innerIt.Set(77.0f);
+      wroteOne = true;
+    }
+  }
+  if (sVisited != 6)
+  {
+    std::cerr << "FAIL: shaped inner iteration visited " << sVisited << " (expected 6)." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // The first active offset in sorted list order was index 0 of the list; find which neighbor
+  // it was and verify the image pixel changed to 77.
+  const auto           firstActive = *sIt.GetActiveIndexList().begin();
+  const auto           firstOffset = sIt.GetOffset(firstActive);
+  ImageType::IndexType writtenIdx = target;
+  for (unsigned d = 0; d < ImageType::ImageDimension; ++d)
+  {
+    writtenIdx[d] += firstOffset[d];
+  }
+  if (image->GetPixel(writtenIdx) != 77.0f)
+  {
+    std::cerr << "FAIL: shaped Set() did not round-trip at " << writtenIdx << ", got " << image->GetPixel(writtenIdx)
+              << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Converting ctor: build a const shaped from the non-const one and read back.
+  ConShaped          csIt(sIt);
+  itk::SizeValueType cReadCount = 0;
+  bool               sawWritten = false;
+  for (auto innerIt = csIt.Begin(); innerIt != csIt.End(); ++innerIt)
+  {
+    ++cReadCount;
+    if (innerIt.Get() == 77.0f)
+    {
+      sawWritten = true;
+    }
+  }
+  if (cReadCount != 6)
+  {
+    std::cerr << "FAIL: const shaped inner iteration visited " << cReadCount << " (expected 6)." << std::endl;
+    return EXIT_FAILURE;
+  }
+  if (!sawWritten)
+  {
+    std::cerr << "FAIL: const shaped did not observe written value." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Deactivate round-trip.
+  sIt.ClearActiveList();
+  if (sIt.GetActiveIndexListSize() != 0)
+  {
+    std::cerr << "FAIL: ClearActiveList did not empty list." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  std::cout << "itkNeighborhoodIteratorBaseRuntimeTest: PASS" << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/Modules/Core/Common/test/itkNeighborhoodIteratorBaseSpikeTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodIteratorBaseSpikeTest.cxx
@@ -1,0 +1,109 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// Compile-only test for the NeighborhoodIteratorBase design spike.
+// Exercises:
+//   * Both VIsConst=true and VIsConst=false instantiations of the unified
+//     NeighborhoodIteratorBase and ShapedNeighborhoodIteratorBase templates.
+//   * The std::conditional_t pointer-type plumbing (via static_assert).
+//   * The non-const -> const converting ctor.
+//   * Negative checks (no-compile lines documented in comments) for the
+//     reverse conversion and for SetPixel on const instantiations.
+
+#include "itkNeighborhoodIteratorBase.h"
+#include "itkImage.h"
+
+#include <type_traits>
+
+namespace
+{
+
+using ImageType = itk::Image<float, 2>;
+
+using MutIt = itk::NeighborhoodIterator2<ImageType>;
+using ConIt = itk::ConstNeighborhoodIterator2<ImageType>;
+
+using MutShaped = itk::ShapedNeighborhoodIterator2<ImageType>;
+using ConShaped = itk::ConstShapedNeighborhoodIterator2<ImageType>;
+
+// --- Pointer-type plumbing (the whole point of std::conditional_t) ----------
+static_assert(std::is_same_v<MutIt::ImagePointer, ImageType *>,
+              "Non-const iterator must hold a non-const image pointer.");
+static_assert(std::is_same_v<ConIt::ImagePointer, const ImageType *>,
+              "Const iterator must hold a const image pointer.");
+
+static_assert(std::is_same_v<MutIt::InternalPixelPointer, ImageType::InternalPixelType *>,
+              "Non-const iterator must hold non-const pixel pointers.");
+static_assert(std::is_same_v<ConIt::InternalPixelPointer, const ImageType::InternalPixelType *>,
+              "Const iterator must hold const pixel pointers.");
+
+// --- IsConst exposure -------------------------------------------------------
+static_assert(MutIt::IsConst == false);
+static_assert(ConIt::IsConst == true);
+static_assert(MutShaped::IsConst == false);
+static_assert(ConShaped::IsConst == true);
+
+// --- Converting ctor: non-const -> const must be available -----------------
+static_assert(std::is_constructible_v<ConIt, const MutIt &>,
+              "Non-const NeighborhoodIterator must be implicitly convertible to its const sibling.");
+static_assert(std::is_constructible_v<ConShaped, const MutShaped &>,
+              "Non-const ShapedNeighborhoodIterator must be implicitly convertible to its const sibling.");
+
+// --- Converting ctor: const -> non-const must NOT be available -------------
+// This is the structural guarantee the modernization buys us. A const
+// iterator cannot be silently laundered back into a writable one.
+static_assert(!std::is_constructible_v<MutIt, const ConIt &>,
+              "Const NeighborhoodIterator must NOT be convertible to a non-const sibling.");
+static_assert(!std::is_constructible_v<MutShaped, const ConShaped &>,
+              "Const ShapedNeighborhoodIterator must NOT be convertible to a non-const sibling.");
+
+// --- Inner-iterator constness (Shaped) -------------------------------------
+static_assert(std::is_same_v<MutShaped::Iterator::OuterPointer, MutShaped *>);
+static_assert(std::is_same_v<MutShaped::ConstIterator::OuterPointer, const MutShaped *>);
+static_assert(std::is_same_v<ConShaped::ConstIterator::OuterPointer, const ConShaped *>);
+
+// --- Negative tests (documented; would fail to compile if uncommented) -----
+//
+// 1. SetPixel on a ConstNeighborhoodIterator2 fires a static_assert with a
+//    readable message:
+//        ConIt c;
+//        c.SetPixel(0, 1.0f);
+//        // error: SetPixel() is not available on a const NeighborhoodIterator.
+//
+// 2. Non-const Begin() on a ConstShapedNeighborhoodIterator2 is SFINAE'd
+//    away:
+//        ConShaped cs;
+//        auto it = cs.Begin();           // returns ConstIterator (OK)
+//        ConShaped::Iterator wit = cs.Begin();  // error: no matching overload
+//
+// 3. Set() on a ConstIterator (Shaped inner) fires a static_assert:
+//        MutShaped ms;
+//        auto it = static_cast<const MutShaped &>(ms).Begin(); // -> ConstIterator
+//        it.Set(1.0f);  // error: Set() requires non-const iterator
+//
+// 4. Implicit upcast from ConIt to MutIt is forbidden (static_assert above).
+
+} // namespace
+
+int
+itkNeighborhoodIteratorBaseSpikeTest(int, char *[])
+{
+  // All assertions above are compile-time; if this TU compiled, the spike's
+  // structural design is sound. Runtime body is intentionally empty.
+  return 0;
+}

--- a/docs/superpowers/plans/2026-04-23-neighborhood-iterator-n1-port.md
+++ b/docs/superpowers/plans/2026-04-23-neighborhood-iterator-n1-port.md
@@ -1,0 +1,241 @@
+# NeighborhoodIterator N+1 Port Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port method bodies from the four legacy neighborhood-iterator classes into the templated `NeighborhoodIteratorBase` / `ShapedNeighborhoodIteratorBase` in `itkNeighborhoodIteratorBase.h`, then replace the legacy headers with alias declarations. Eliminates all 4 `const_cast` sites in the neighborhood-iterator family.
+
+**Architecture:**
+The spike at `Modules/Core/Common/include/itkNeighborhoodIteratorBase.h` defines two class templates parameterized on `bool VIsConst`, using `std::conditional_t` to select pointer types. This plan fills in the method bodies (currently stubs / missing) by porting from `itkConstNeighborhoodIterator.{h,hxx}`, `itkNeighborhoodIterator.h`, `itkConstShapedNeighborhoodIterator.{h,hxx}`, and `itkShapedNeighborhoodIterator.h`. Each legacy header then becomes a thin alias file. Write methods (`SetPixel`, `SetCenterPixel`) become SFINAE-disabled on the const instantiation.
+
+**Tech Stack:** C++17 (std::conditional_t, if constexpr, std::enable_if_t), ITK CMake/Ninja build, ITKCommon2TestDriver.
+
+**Scope:** This is a multi-PR effort. Each milestone below is a reviewable PR that builds green and passes tests. Do NOT attempt to land all milestones in a single PR.
+
+---
+
+## File Structure
+
+### Files modified across all milestones
+
+- `Modules/Core/Common/include/itkNeighborhoodIteratorBase.h` — grow from spike to full implementation. Expected end-state ~1100 LOC (was 541 as spike).
+- `Modules/Core/Common/include/itkConstNeighborhoodIterator.h` — reduce to alias forward for `NeighborhoodIteratorBase<T,BC,true>`.
+- `Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx` — delete (bodies moved inline into base header) OR keep as explicit-instantiation shim during transition.
+- `Modules/Core/Common/include/itkNeighborhoodIterator.h` — alias for `NeighborhoodIteratorBase<T,BC,false>`.
+- `Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h` — alias for `ShapedNeighborhoodIteratorBase<T,BC,true>`.
+- `Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.hxx` — delete or shim.
+- `Modules/Core/Common/include/itkShapedNeighborhoodIterator.h` — alias for `ShapedNeighborhoodIteratorBase<T,BC,false>`.
+- `Modules/Core/Common/test/itkNeighborhoodIteratorBaseSpikeTest.cxx` — expand from compile-only to runtime test.
+- `Modules/Core/Common/test/CMakeLists.txt` — add new runtime tests.
+
+### No file split needed
+
+The four legacy classes collapse into one header file (plus the shaped composition). This is the point of the refactor.
+
+---
+
+## Milestone 1 — Port ConstNeighborhoodIterator bodies (PR #1)
+
+**Scope:** Port the ~35 methods of `ConstNeighborhoodIterator` from `itkConstNeighborhoodIterator.hxx` into `NeighborhoodIteratorBase<T,BC,true>` in the base header. Do NOT touch legacy headers yet; the base template is exercised only via the spike test and new runtime tests. `const_cast<ImageType*>` at `itkConstNeighborhoodIterator.hxx:648` is NOT present in the ported code (the member `m_Image` in the base is already `const ImageType*` via `std::conditional_t`).
+
+**Files:**
+- Modify: `Modules/Core/Common/include/itkNeighborhoodIteratorBase.h` — add method bodies
+- Create: `Modules/Core/Common/test/itkNeighborhoodIteratorBaseRuntimeTest.cxx`
+- Modify: `Modules/Core/Common/test/CMakeLists.txt`
+
+### Task 1.1: Audit method surface
+
+- [ ] **Step 1:** Read `Modules/Core/Common/include/itkConstNeighborhoodIterator.h` end-to-end. List every public / protected method signature in a scratch file at `docs/superpowers/plans/n1-method-audit.md`. Group by: read-only (port to base, both instantiations), write (port to base, SFINAE-disable on `VIsConst=true`), constructor, operator.
+- [ ] **Step 2:** Cross-reference against `itkConstNeighborhoodIterator.hxx` — list line ranges for each out-of-line body.
+- [ ] **Step 3:** Commit audit doc only.
+
+```bash
+git add docs/superpowers/plans/n1-method-audit.md
+git commit -m "DOC: Audit ConstNeighborhoodIterator method surface for N+1 port"
+```
+
+### Task 1.2: Port constructors and member initializers
+
+- [ ] **Step 1:** In `itkNeighborhoodIteratorBase.h`, implement the default ctor, the `(radius, ptr, region)` ctor, and the copy ctor of `NeighborhoodIteratorBase`. Source: `itkConstNeighborhoodIterator.hxx:206-246` (copy ctor), and corresponding header `itkConstNeighborhoodIterator.h` constructor definitions. The non-const → const converting ctor already exists in the spike — verify it still compiles.
+- [ ] **Step 2:** Build `ITKCommon` only: `ninja -C build ITKCommon`. Expected: PASS.
+- [ ] **Step 3:** Commit.
+
+```bash
+git add Modules/Core/Common/include/itkNeighborhoodIteratorBase.h
+git commit -m "ENH: Port NeighborhoodIterator constructors into templated base"
+```
+
+### Task 1.3: Port read-only query methods
+
+- [ ] **Step 1:** Port `InBounds()`, `IndexInBounds(n, internalIndex, offset)`, `IndexInBounds(n)`, `GetPixel(n, IsInBounds)`, `GetPixel(n)`, `GetCenterPixel()`, `ComputeInternalIndex(n)`, `GetBoundingBoxAsImageRegion()`, `GetNeighborhood()`, `GetIndex()`, `GetRegion()`, `GetRadius()`, `GetSize()`, `Size()`, `GetImagePointer()`. Copy bodies verbatim from `itkConstNeighborhoodIterator.hxx` substituting `NeighborhoodIteratorBase<TImage, TBC, VIsConst>` for `ConstNeighborhoodIterator<TImage, TBC>`.
+- [ ] **Step 2:** Build: `ninja -C build ITKCommon`. Expected: PASS.
+- [ ] **Step 3:** Commit.
+
+```bash
+git commit -am "ENH: Port NeighborhoodIterator read-only queries into templated base"
+```
+
+### Task 1.4: Port iteration methods (GoToBegin, GoToEnd, operator++, operator--)
+
+- [ ] **Step 1:** Port `GoToBegin()` (`itkConstNeighborhoodIterator.hxx:362-368`), `GoToEnd()` (:369-375), `operator++()` (:484-519), `operator--()` (:520-555), `IsAtEnd()`, `IsAtBegin()`, `SetLocation(index)`, `SetLoop(index)`, `SetRegion(region)` (:376-420), `SetBound(size)` (:619-...), `SetEndIndex()` (:247-263), `Initialize(radius, ptr, region)` (:421-436).
+- [ ] **Step 2:** At the end of this task, verify `const_cast<ImageType*>(m_ConstImage.GetPointer())` from `:648` is NOT present in the ported `SetBound` or any other method — it should be unnecessary because `m_Image` is already `const ImageType*` on the const instantiation and `ImageType*` on the non-const instantiation.
+- [ ] **Step 3:** Build: `ninja -C build ITKCommon`. Expected: PASS.
+- [ ] **Step 4:** Commit.
+
+```bash
+git commit -am "ENH: Port NeighborhoodIterator iteration methods into templated base"
+```
+
+### Task 1.5: Port write methods with SFINAE guards
+
+- [ ] **Step 1:** Port `SetPixel(n, v)`, `SetCenterPixel(v)`, `SetNeighborhood(n)`, and any other mutators from `NeighborhoodIterator` (non-const subclass in `itkNeighborhoodIterator.h`) into the base, each guarded by `template <bool VCopy = VIsConst, std::enable_if_t<!VCopy, int> = 0>`.
+- [ ] **Step 2:** Add `static_assert(!VIsConst, "SetPixel disabled on const iterator")` as the first line of each write method body, for better diagnostics when the SFINAE fires via a class-template-member call.
+- [ ] **Step 3:** Build: `ninja -C build ITKCommon`. Expected: PASS.
+- [ ] **Step 4:** Commit.
+
+```bash
+git commit -am "ENH: Port NeighborhoodIterator write methods with const SFINAE guards"
+```
+
+### Task 1.6: Port operator= and PrintSelf
+
+- [ ] **Step 1:** Port `operator=(const Self&)` (`itkConstNeighborhoodIterator.hxx:437-483`) and `PrintSelf(os, indent)` (:556-618).
+- [ ] **Step 2:** Build. Expected: PASS.
+- [ ] **Step 3:** Commit.
+
+```bash
+git commit -am "ENH: Port NeighborhoodIterator operator= and PrintSelf"
+```
+
+### Task 1.7: Write runtime test against base template
+
+- [ ] **Step 1:** Create `Modules/Core/Common/test/itkNeighborhoodIteratorBaseRuntimeTest.cxx`. Test plan:
+  - Instantiate `NeighborhoodIteratorBase<Image<float,3>, ZeroFluxNeumannBoundaryCondition<...>, true>` (const) and `..., false>` (non-const) on a small 5×5×5 filled image.
+  - Iterate both to end, count visited voxels, assert == region size.
+  - Through the non-const, `SetCenterPixel(42.0f)` at one location; assert the image pixel is 42.
+  - Converting ctor: construct a const iterator from the non-const one; iterate; assert same values.
+- [ ] **Step 2:** Add to `Modules/Core/Common/test/CMakeLists.txt` under `ITKCommon2TestDriver`.
+- [ ] **Step 3:** Build: `ninja -C build ITKCommon2TestDriver`. Expected: PASS.
+- [ ] **Step 4:** Run: `ctest --test-dir build -R itkNeighborhoodIteratorBaseRuntimeTest -V`. Expected: PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git commit -am "ENH: Runtime test exercising NeighborhoodIteratorBase on both instantiations"
+```
+
+### Task 1.8: Open PR for Milestone 1
+
+- [ ] **Step 1:** Push: `git push hj modernize-iterators-remove-const-cast`
+- [ ] **Step 2:** `gh pr create --draft --base main` with body explaining:
+  - Ports method bodies only. Legacy headers untouched.
+  - Base template now functional; proven by runtime test.
+  - No user-facing behavior change; no legacy `const_cast` removed yet.
+  - Links to this plan.
+
+---
+
+## Milestone 2 — Port Shaped variants (PR #2)
+
+**Scope:** Port `ConstShapedNeighborhoodIterator` and `ShapedNeighborhoodIterator` method bodies into `ShapedNeighborhoodIteratorBase` in the same header. The three `const_cast` sites at `itkConstShapedNeighborhoodIterator.h:216,256` and `itkShapedNeighborhoodIterator.h:223` are structurally eliminated because `ShapedNeighborhoodIteratorBase` composes (not inherits) `NeighborhoodIteratorBase<..., VIsConst>`, so no outer-pointer const-stripping is needed.
+
+**Files:**
+- Modify: `Modules/Core/Common/include/itkNeighborhoodIteratorBase.h`
+- Extend: `Modules/Core/Common/test/itkNeighborhoodIteratorBaseRuntimeTest.cxx`
+
+### Tasks
+
+Same granularity as Milestone 1 (audit → port ctors → port ActivateIndex/DeactivateIndex/ClearActiveList → port the InnerIterator Begin/End and increment → port write methods with SFINAE → runtime test → PR).
+
+Key invariants to verify in review:
+- No `const_cast` anywhere in `ShapedNeighborhoodIteratorBase` or its `InnerIteratorT`.
+- `InnerIteratorT<true>` cannot be constructed from `ShapedNeighborhoodIteratorBase<...,false>::end()` accidentally (compile-time check via static_assert in the test).
+
+Deferred detail: write one task per method group (active-index management, inner iterator, write SFINAE). Estimate 6-8 tasks matching 1.2-1.8 structure.
+
+---
+
+## Milestone 3 — Wire legacy headers as aliases (PR #3)
+
+**Scope:** Replace the six legacy headers with alias declarations. Bodies of `.hxx` files become empty (retained only to satisfy existing `#include`s in the tree until cleanup in Milestone 4). After this PR, the 4 `const_cast` sites listed in `git grep const_cast Modules/Core/Common/include/itk*NeighborhoodIterator*` are gone from the tree.
+
+**Files:**
+- Modify: all six legacy headers listed in File Structure above.
+
+### Task 3.1: Replace itkConstNeighborhoodIterator.h with alias
+
+- [ ] **Step 1:** Rewrite `itkConstNeighborhoodIterator.h` to:
+  ```cpp
+  #ifndef itkConstNeighborhoodIterator_h
+  #define itkConstNeighborhoodIterator_h
+  #include "itkNeighborhoodIteratorBase.h"
+  namespace itk {
+  template <typename TImage, typename TBoundaryCondition = ZeroFluxNeumannBoundaryCondition<TImage>>
+  using ConstNeighborhoodIterator = NeighborhoodIteratorBase<TImage, TBoundaryCondition, /*VIsConst=*/true>;
+  }
+  #endif
+  ```
+- [ ] **Step 2:** Empty out `itkConstNeighborhoodIterator.hxx` (keep the file; leave header guards only, plus a comment `// Intentionally empty: bodies moved to itkNeighborhoodIteratorBase.h`).
+- [ ] **Step 3:** Full rebuild: `ninja -C build`. Expected: PASS (this is the risky step — any consumer that does `template<...> class ConstNeighborhoodIterator;` forward-decl breaks here; fix call sites in separate tasks).
+- [ ] **Step 4:** Run full test suite: `ctest --test-dir build -j8`. Expected: zero new failures vs. main baseline.
+- [ ] **Step 5:** Commit.
+
+```bash
+git commit -am "ENH: Replace ConstNeighborhoodIterator header with alias to templated base"
+```
+
+### Task 3.2: Same for NeighborhoodIterator.h
+
+(Analogous, `VIsConst=false`.)
+
+### Task 3.3: Same for ConstShapedNeighborhoodIterator.{h,hxx}
+
+(Analogous, uses `ShapedNeighborhoodIteratorBase`, `VIsConst=true`.)
+
+### Task 3.4: Same for ShapedNeighborhoodIterator.h
+
+(Analogous, `VIsConst=false`.)
+
+### Task 3.5: Forward-decl fixups
+
+- [ ] **Step 1:** `git grep "class ConstNeighborhoodIterator" Modules | grep -v "template"` — list every non-template forward decl.
+- [ ] **Step 2:** Replace each with `#include "itkConstNeighborhoodIterator.h"` (alias templates cannot be forward-declared).
+- [ ] **Step 3:** Repeat for the other three legacy names.
+- [ ] **Step 4:** Full rebuild + test suite. Expected: PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git commit -am "COMP: Replace forward-decls of neighborhood iterators with includes"
+```
+
+### Task 3.6: Verify const_cast gone
+
+- [ ] **Step 1:** `git grep -n const_cast Modules/Core/Common/include/itk*NeighborhoodIterator*`. Expected output: empty (the four legacy sites are gone; the new base header uses `std::conditional_t` instead).
+- [ ] **Step 2:** PR description must include this git grep output as proof.
+
+### Task 3.7: Open PR for Milestone 3
+
+Flag explicitly for reviewer: forward-decl breakage is the only user-facing risk. Recommend running Slicer/BRAINSTools CI nightlies on this branch before merge.
+
+---
+
+## Milestone 4 — Cleanup (PR #4, after N+2 release cycle)
+
+Per the rollout plan in `itkNeighborhoodIteratorBase.h`:
+- Mark legacy class names `ITK_FUTURE_LEGACY_REMOVE`.
+- Delete empty `.hxx` shims.
+- Rename `NeighborhoodIteratorBase` → `NeighborhoodIterator` + update aliases.
+
+**Out of scope for current effort** (belongs to a later release).
+
+---
+
+## Self-Review Checklist (to run before executing)
+
+- [ ] Every `const_cast` site listed in initial grep (4 sites) has a task that removes it: `itkConstNeighborhoodIterator.hxx:648` (Task 1.4 verification), `itkConstShapedNeighborhoodIterator.h:216,256` + `itkShapedNeighborhoodIterator.h:223` (Milestone 2 verification + Milestone 3 alias swap).
+- [ ] Each milestone produces a building, testing, mergeable PR.
+- [ ] Converting ctor (non-const → const) tested at runtime (Task 1.7).
+- [ ] Compile-fail cases (const → non-const ctor, SetPixel on const) already tested in existing `itkNeighborhoodIteratorBaseSpikeTest.cxx` static_asserts.
+- [ ] Downstream forward-decl risk called out (Task 3.5, Milestone 3 PR body).
+
+## Execution Note
+
+Each milestone is substantial (~6-8 tasks, ~500-1000 LOC of mechanical porting + verification). Recommend **Subagent-Driven execution** with one subagent per task and reviewer checkpoint between milestones. Do not attempt all four milestones in one session.

--- a/docs/superpowers/plans/n1-method-audit.md
+++ b/docs/superpowers/plans/n1-method-audit.md
@@ -1,0 +1,166 @@
+# ConstNeighborhoodIterator Method Audit (N+1 Port)
+
+Inventory of every public / protected member and free function in
+`Modules/Core/Common/include/itkConstNeighborhoodIterator.h` (header line
+numbers) cross-referenced against out-of-line bodies in
+`Modules/Core/Common/include/itkConstNeighborhoodIterator.hxx`.
+
+This document supports the "NeighborhoodIterator N+1 Port" plan
+(`2026-04-23-neighborhood-iterator-n1-port.md`): the four legacy classes
+(`ConstNeighborhoodIterator`, `NeighborhoodIterator`,
+`ConstShapedNeighborhoodIterator`, `ShapedNeighborhoodIterator`) will be
+ported into two class templates parameterized on `bool VIsConst` in
+`itkNeighborhoodIteratorBase.h`.
+
+## Porting categories
+
+- **ctor** — constructor / destructor / assignment. Ported to base; both
+  instantiations use them.
+- **read** — read-only accessor. Ported to base; both instantiations.
+- **write** — mutates image data or sets boundary condition. Needs
+  SFINAE-disabling on `VIsConst == true`.
+- **iter** — iteration / traversal state mutator (`operator++`,
+  `GoToBegin`, etc.). Mutates iterator state only, not image data — so
+  available on both const and non-const instantiations (**no SFINAE
+  needed**).
+- **op** — overloaded operator (comparison / arithmetic on iterator).
+- **helper** — protected helper used internally.
+- **free** — non-member template free function at namespace scope.
+
+## Legend
+
+- `.h` — line in `itkConstNeighborhoodIterator.h`.
+- `.hxx` — line range of out-of-line definition in
+  `itkConstNeighborhoodIterator.hxx`, or `inline` if the body is in the
+  header.
+- `SFINAE?` — will the N+1 port need to disable this method when
+  `VIsConst == true`? (Only methods that write pixel data need this;
+  `OverrideBoundaryCondition` / `ResetBoundaryCondition` /
+  `SetBoundaryCondition` already exist on the Const class, so they
+  stay available on both instantiations.)
+
+## Public methods
+
+| Signature | .h | .hxx | Category | SFINAE? |
+|---|---|---|---|---|
+| `ConstNeighborhoodIterator() = default` | 101 | inline (defaulted) | ctor | no |
+| `~ConstNeighborhoodIterator() override = default` | 104 | inline (defaulted) | ctor | no |
+| `ConstNeighborhoodIterator(const ConstNeighborhoodIterator &)` | 107 | 206–245 | ctor | no |
+| `ConstNeighborhoodIterator(const SizeType &, const ImageType *, const RegionType &)` | 111–121 | inline | ctor | no |
+| `Self & operator=(const Self & orig)` | 124–125 | 437–482 | ctor / op | no |
+| `void PrintSelf(std::ostream &, Indent) const override` | 128–129 | 556–617 | read | no |
+| `OffsetType ComputeInternalIndex(const NeighborIndexType n) const` | 133–134 | 181–194 | read | no |
+| `IndexType GetBound() const` | 137–141 | inline | read | no |
+| `IndexValueType GetBound(NeighborIndexType n) const` | 145–149 | inline | read | no |
+| `const InternalPixelType * GetCenterPointer() const` | 152–156 | inline | read | no |
+| `PixelType GetCenterPixel() const` | 160–164 | inline | read | no |
+| `const ImageType * GetImagePointer() const` | 167–171 | inline | read | no |
+| `IndexType GetIndex() const` | 175–179 | inline | read | no |
+| `IndexType GetFastIndexPlusOffset(const OffsetType & o) const` | 181–185 | inline | read | no |
+| `NeighborhoodType GetNeighborhood() const` | 189–190 | 264–360 | read | no |
+| `PixelType GetPixel(const NeighborIndexType i) const` | 193–207 | inline | read | no |
+| `PixelType GetPixel(NeighborIndexType n, bool & IsInBounds) const` | 214–215 | 145–179 | read | no |
+| `PixelType GetPixel(const OffsetType & o) const` | 219–225 | inline | read | no |
+| `PixelType GetPixel(const OffsetType & o, bool & IsInBounds) const` | 232–236 | inline | read | no |
+| `PixelType GetNext(const unsigned int axis, NeighborIndexType i) const` | 241–245 | inline | read | no |
+| `PixelType GetNext(const unsigned int axis) const` | 250–254 | inline | read | no |
+| `PixelType GetPrevious(const unsigned int axis, NeighborIndexType i) const` | 259–263 | inline | read | no |
+| `PixelType GetPrevious(const unsigned int axis) const` | 268–272 | inline | read | no |
+| `IndexType GetIndex(const OffsetType & o) const` | 276–280 | inline | read | no |
+| `IndexType GetIndex(NeighborIndexType i) const` | 284–288 | inline | read | no |
+| `RegionType GetRegion() const` | 291–295 | inline | read | no |
+| `IndexType GetBeginIndex() const` | 299–303 | inline | read | no |
+| `RegionType GetBoundingBoxAsImageRegion() const` | 307–308 | 196–204 | read | no |
+| `OffsetType GetWrapOffset() const` | 311–315 | inline | read | no |
+| `OffsetValueType GetWrapOffset(NeighborIndexType n) const` | 322–326 | inline | read | no |
+| `void GoToBegin()` | 329–330 | 362–367 | iter | no |
+| `void GoToEnd()` | 334–335 | 369–374 | iter | no |
+| `void Initialize(const SizeType &, const ImageType *, const RegionType &)` | 339–340 | 421–435 | iter | no |
+| `bool IsAtBegin() const` | 344–348 | inline | read | no |
+| `bool IsAtEnd() const` | 352–366 | inline | read | no |
+| `Self & operator++()` | 372–373 | 484–518 | iter / op | no |
+| `Self & operator--()` | 379–380 | 520–554 | iter / op | no |
+| `bool operator==(const Self & it) const` | 385–389 | inline | op | no |
+| `ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self)` | 391 | macro-expanded | op | no |
+| `bool operator<(const Self & it) const` | 396–400 | inline | op | no |
+| `bool operator<=(const Self & it) const` | 405–409 | inline | op | no |
+| `bool operator>(const Self & it) const` | 414–418 | inline | op | no |
+| `bool operator>=(const Self & it) const` | 423–427 | inline | op | no |
+| `void SetLocation(const IndexType & position)` | 433–438 | inline | iter | no |
+| `Self & operator+=(const OffsetType &)` | 443–444 | 688–723 | iter / op | no |
+| `Self & operator-=(const OffsetType &)` | 449–450 | 725–759 | iter / op | no |
+| `OffsetType operator-(const Self & b) const` | 453–457 | inline | op | no |
+| `bool InBounds() const` | 462–463 | 22–46 | read | no |
+| `bool IndexInBounds(const NeighborIndexType, OffsetType &, OffsetType &) const` | 476–477 | 48–101 | read | no |
+| `bool IndexInBounds(const NeighborIndexType n) const` | 481–482 | 103–143 | read | no |
+| `void OverrideBoundaryCondition(const ImageBoundaryConditionPointerType i)` | 489–493 | inline | write (BC ptr) | no |
+| `void ResetBoundaryCondition()` | 497–501 | inline | write (BC ptr) | no |
+| `void SetBoundaryCondition(const TBoundaryCondition & c)` | 504–508 | inline | write (BC) | no |
+| `ImageBoundaryConditionPointerType GetBoundaryCondition() const` | 511–515 | inline | read | no |
+| `void NeedToUseBoundaryConditionOn()` | 518–522 | inline | write (flag) | no |
+| `void NeedToUseBoundaryConditionOff()` | 524–528 | inline | write (flag) | no |
+| `void SetNeedToUseBoundaryCondition(bool b)` | 530–534 | inline | write (flag) | no |
+| `bool GetNeedToUseBoundaryCondition() const` | 536–540 | inline | read | no |
+| `void SetRegion(const RegionType & region)` | 543–544 | 376–419 | iter | no |
+
+## Protected methods
+
+| Signature | .h | .hxx | Category | SFINAE? |
+|---|---|---|---|---|
+| `void SetLoop(const IndexType & p)` | 549–554 | inline | helper | no |
+| `void SetBound(const SizeType &)` | 559–560 | 619–641 | helper | no |
+| `void SetPixelPointers(const IndexType &)` | 566–567 | 643–686 | helper | no |
+| `void SetBeginIndex(const IndexType & start)` | 571–575 | inline | helper | no |
+| `void SetEndIndex()` | 579–580 | 247–262 | helper | no |
+
+## Non-member free functions (namespace itk)
+
+| Signature | .h | .hxx | Category | SFINAE? |
+|---|---|---|---|---|
+| `operator+(const ConstNeighborhoodIterator<TImage> &, const OffsetType &)` | 649–657 | inline | free / op | no |
+| `operator+(const OffsetType &, const ConstNeighborhoodIterator<TImage> &)` | 659–665 | inline | free / op | no |
+| `operator-(const ConstNeighborhoodIterator<TImage> &, const OffsetType &)` | 667–675 | inline | free / op | no |
+
+Note: these free functions take a single-parameter
+`ConstNeighborhoodIterator<TImage>` but the class template itself has
+two parameters (`TImage, TBoundaryCondition`). In the N+1 port these
+free operators will need to be updated to carry the full template
+parameter list (or be templated on the iterator type).
+
+## Methods that *do* need SFINAE disabling in the N+1 port
+
+None on `ConstNeighborhoodIterator` itself — by definition this is the
+read-only class. The SFINAE-on-`VIsConst` requirement applies to the
+*write* methods contributed by the non-const `NeighborhoodIterator`
+subclass (`SetPixel`, `SetCenterPixel`, `SetNeighborhood`, `SetNext`,
+`SetPrevious`, image-mutating `operator*`, etc.). Those will be
+audited separately when porting `itkNeighborhoodIterator.h`.
+
+The boundary-condition mutators (`OverrideBoundaryCondition`,
+`ResetBoundaryCondition`, `SetBoundaryCondition`,
+`SetNeedToUseBoundaryCondition` and the `…On()` / `…Off()` helpers)
+mutate iterator state, not pixel data, and therefore remain available
+on both const and non-const instantiations of the N+1 base.
+
+## Observations / surprises
+
+- `ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self)` (line 391) expands to
+  `operator!=` via macro; the port must expand it the same way (or
+  invoke the same macro) so the unequal operator is generated.
+- The free-function `operator+` / `operator-` overloads (lines 649–675)
+  are templated on `TImage` only — they do not carry the
+  `TBoundaryCondition` parameter. Porting to the N+1 base will require
+  re-templating them on the full base-class template arguments.
+- The copy constructor at lines 107 / 206–245 *and* `operator=` at
+  lines 124 / 437–482 both manually copy every member; they are not
+  trivially defaulted. This is because `m_BoundaryCondition` is a raw
+  pointer that may alias `&m_InternalBoundaryCondition` and must be
+  re-bound after copy.
+- `m_InBounds[Dimension]` (line 626) uses a plain C array sized by the
+  compile-time `Dimension` constant; survives as-is in the port.
+- Several trivial public getters (`GetBound`, `GetIndex`, `GetRegion`,
+  `GetWrapOffset`) have both zero-arg and one-arg overloads — the port
+  must preserve both.
+- `IsAtEnd()` (lines 352–366) throws an `ExceptionObject` if the center
+  pointer is past the end, which is an unusual side effect for a
+  const-qualified predicate. Preserve verbatim.


### PR DESCRIPTION
Smoke-test spike: structural scaffold for folding `ImageReverseIterator` and `ImageReverseConstIterator` into a single `ImageReverseIteratorBase<TImage, bool VIsConst>` template. Compile-only; legacy headers unchanged.

<details>
<summary>Findings</summary>

**Target const_cast sites:**
- `Modules/Core/Common/include/itkImageReverseIterator.h:103` — expected (mutating subclass workaround).
- `Modules/Core/Common/include/itkImageReverseConstIterator.h:340` — **suspected bug**: `Set(const PixelType &) const` lives on the class named `ImageReverseConstIterator`. A Const iterator should not expose `Set`. Not SFINAE-gated, not deprecated. Other ITK *ConstIterator classes have no `Set`. Recommend follow-up BUG commit to remove this method; templating on VIsConst makes that removal trivial (SFINAE on `!VIsConst` drops `Set` from the const instantiation).

**Scaffold (`itkImageReverseIteratorBase.h`):**
- `std::conditional_t<VIsConst, const InternalPixelType *, InternalPixelType *>` for `BufferPointerType`.
- `Set()` and non-const `Value()` SFINAE-gated on `!VIsConst`.
- Alias templates `ImageReverseConstIteratorTemplated` / `ImageReverseIteratorTemplated`.
- Pattern matches `itkNeighborhoodIteratorBase.h` used by prior smoke units.

Both legacy const_casts become unrepresentable under the templated base: line 340 disappears with `Set` itself; line 103 becomes a direct write through a non-const `m_Buffer`.

</details>

<!-- smoke-test unit-11 -->