### PR TITLE
ENH: Dedicate populate-externaldata-cache workflow; consumers restore-only

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -30,7 +30,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-    ExternalDataVersion: 5.4.5
     CMakeVersion: "4.0.1"
 
 jobs:
@@ -119,6 +118,19 @@ jobs:
           restore-keys: |
             ccache-v4-${{ runner.os }}-${{ matrix.name }}-
 
+      - name: Restore ExternalData object store
+        id: restore-externaldata
+        uses: actions/cache/restore@v5
+        with:
+          # ExternalData blobs are platform-agnostic; share a single cache
+          # entry across every workflow/job/OS in the repo.  The SHA suffix
+          # produces an immutable save key per run; restore-keys falls
+          # through to the most recent prior cache under the same version.
+          path: ${{ runner.temp }}/ExternalData
+          key: externaldata-v1-${{ hashFiles('**/*.cid') }}
+          restore-keys: |
+            externaldata-v1-
+
       - name: Show ccache configuration, stats and maintenance
         shell: bash
         run: |
@@ -144,14 +156,15 @@ jobs:
           cmakeVersion: ~${{ env.CMakeVersion }}
           ninjaVersion: latest
 
-      - name: Download dashboard script and testing data
+      - name: Download dashboard script
         run: |
           set -x
           git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
 
-          curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v${{ env.ExternalDataVersion }}/InsightData-${{ env.ExternalDataVersion }}.tar.gz -O
-          cmake -E tar xfz InsightData-${{ env.ExternalDataVersion }}.tar.gz
-          cmake -E rename InsightToolkit-${{ env.ExternalDataVersion }}/.ExternalData/CID ${{ github.workspace }}/.ExternalData/CID
+      - name: Export ExternalData_OBJECT_STORES
+        shell: bash
+        run: |
+          echo "ExternalData_OBJECT_STORES=${{ runner.temp }}/ExternalData" >> "$GITHUB_ENV"
 
       - name: Configure CTest script
         run: |
@@ -188,6 +201,13 @@ jobs:
         with:
           path: ${{ runner.temp }}/ccache
           key: ccache-v4-${{ runner.os }}-${{ matrix.name }}-${{ github.sha }}
+
+      - name: Save ExternalData object store
+        if: ${{ !cancelled() }}
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ runner.temp }}/ExternalData
+          key: externaldata-v1-${{ hashFiles('**/*.cid') }}
 
       - name: ccache stats
         if: always()

--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -202,12 +202,14 @@ jobs:
           path: ${{ runner.temp }}/ccache
           key: ccache-v4-${{ runner.os }}-${{ matrix.name }}-${{ github.sha }}
 
-      - name: Save ExternalData object store
-        if: ${{ !cancelled() }}
-        uses: actions/cache/save@v5
-        with:
-          path: ${{ runner.temp }}/ExternalData
-          key: externaldata-v1-${{ hashFiles('**/*.cid') }}
+      # ExternalData object store is populated by
+      # .github/workflows/populate-externaldata-cache.yml — a dedicated
+      # workflow whose only job is to prefetch every CID and write the
+      # shared cache entry.  Consumer workflows (this one, pixi.yml, the
+      # Azure pipelines) restore-only.  Do not reintroduce a Save step
+      # here: races across platforms overwrite the single shared key with
+      # a fraction of the expected blobs and poison every subsequent
+      # restore.
 
       - name: ccache stats
         if: always()

--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -176,6 +176,19 @@ jobs:
             path: ${{ runner.temp }}/ccache
             key: ccache-v4-${{ runner.os }}-pixi-cxx-${{ github.sha }}
 
+        - name: Prefetch every CID into the ExternalData store
+          # The build only fetches blobs for the currently-enabled modules.
+          # Populate every .cid reference now so the cache entry saved below
+          # is the full content-addressed set, not a module-selection slice.
+          if: ${{ !cancelled() && steps.restore-externaldata.outputs.cache-hit != 'true' }}
+          shell: bash
+          env:
+            EXTERNALDATA_STORE: ${{ runner.temp }}/ExternalData
+          run: |
+            python3 Utilities/Maintenance/PrefetchCIDContentLinks.py \
+              --repo-root . \
+              --store "$EXTERNALDATA_STORE"
+
         - name: Save ExternalData object store
           if: ${{ !cancelled() }}
           uses: actions/cache/save@v5

--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -176,25 +176,13 @@ jobs:
             path: ${{ runner.temp }}/ccache
             key: ccache-v4-${{ runner.os }}-pixi-cxx-${{ github.sha }}
 
-        - name: Prefetch every CID into the ExternalData store
-          # The build only fetches blobs for the currently-enabled modules.
-          # Populate every .cid reference now so the cache entry saved below
-          # is the full content-addressed set, not a module-selection slice.
-          if: ${{ !cancelled() && steps.restore-externaldata.outputs.cache-hit != 'true' }}
-          shell: bash
-          env:
-            EXTERNALDATA_STORE: ${{ runner.temp }}/ExternalData
-          run: |
-            python3 Utilities/Maintenance/PrefetchCIDContentLinks.py \
-              --repo-root . \
-              --store "$EXTERNALDATA_STORE"
-
-        - name: Save ExternalData object store
-          if: ${{ !cancelled() }}
-          uses: actions/cache/save@v5
-          with:
-            path: ${{ runner.temp }}/ExternalData
-            key: externaldata-v1-${{ hashFiles('**/*.cid') }}
+        # ExternalData object store is populated by
+        # .github/workflows/populate-externaldata-cache.yml — a dedicated
+        # workflow whose only job is to prefetch every CID and write the
+        # shared cache entry. Consumer workflows restore-only. Do not
+        # reintroduce a prefetch-and-save pair here: races across
+        # platforms overwrite the single shared key with a fraction of
+        # the expected blobs and poison every subsequent restore.
 
         - name: ccache stats
           if: always()

--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -30,7 +30,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-    ExternalDataVersion: 5.4.5
 
 
 jobs:
@@ -74,6 +73,19 @@ jobs:
             restore-keys: |
               ccache-v4-${{ runner.os }}-pixi-cxx-
 
+        - name: Restore ExternalData object store
+          id: restore-externaldata
+          uses: actions/cache/restore@v5
+          with:
+            # ExternalData blobs are platform-agnostic; share a single cache
+            # entry across every workflow/job/OS in the repo.  The SHA suffix
+            # produces an immutable save key per run; restore-keys falls
+            # through to the most recent prior cache under the same version.
+            path: ${{ runner.temp }}/ExternalData
+            key: externaldata-v1-${{ hashFiles('**/*.cid') }}
+            restore-keys: |
+              externaldata-v1-
+
         - name: Show ccache configuration, stats and maintenance
           shell: bash
           run: |
@@ -116,11 +128,10 @@ jobs:
             # TIME_REPORT:         overall | 526        seconds | 31GiB        |
             # TIME_REPORT: == find ====================================================
 
-        - name: Download testing data
+        - name: Export ExternalData_OBJECT_STORES
+          shell: bash
           run: |
-            curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v${{ env.ExternalDataVersion }}/InsightData-${{ env.ExternalDataVersion }}.tar.gz -O
-            cmake -E tar xfz InsightData-${{ env.ExternalDataVersion }}.tar.gz
-            cmake -E rename InsightToolkit-${{ env.ExternalDataVersion }}/.ExternalData/CID ${{ github.workspace }}/.ExternalData/CID
+            echo "ExternalData_OBJECT_STORES=${{ runner.temp }}/ExternalData" >> "$GITHUB_ENV"
 
         - name: Set up Pixi
           uses: prefix-dev/setup-pixi@v0.8.1
@@ -142,10 +153,6 @@ jobs:
             # Remove object files and static libraries (not needed for testing)
             find build -type f -name "*.o" -delete
             find build -type f -name "*.a" -delete
-            # Remove downloaded data tarballs (already extracted)
-            rm -f InsightData-*.tar.gz
-            # Remove extracted source tarball directory
-            rm -rf InsightToolkit-${{ env.ExternalDataVersion }}
             # Trim ccache to stay within CCACHE_MAXSIZE and remove orphaned entries
             ccache --cleanup 2>/dev/null || true
             echo "****** df -h /  -- post cleanup"
@@ -168,6 +175,13 @@ jobs:
           with:
             path: ${{ runner.temp }}/ccache
             key: ccache-v4-${{ runner.os }}-pixi-cxx-${{ github.sha }}
+
+        - name: Save ExternalData object store
+          if: ${{ !cancelled() }}
+          uses: actions/cache/save@v5
+          with:
+            path: ${{ runner.temp }}/ExternalData
+            key: externaldata-v1-${{ hashFiles('**/*.cid') }}
 
         - name: ccache stats
           if: always()

--- a/.github/workflows/populate-externaldata-cache.yml
+++ b/.github/workflows/populate-externaldata-cache.yml
@@ -1,0 +1,102 @@
+name: Populate ExternalData Cache
+
+# Single owner of the shared "externaldata-v1-<hashFiles>" GitHub Actions
+# cache entry. Every other workflow restores this entry but never saves
+# it — see the comments in arm.yml and pixi.yml for the race that a
+# multi-writer design caused.
+#
+# The job prefetches every .cid referenced in the source tree through
+# the same gateway list CMake/ITKExternalData.cmake uses, verifies that
+# all objects landed on disk, and only then saves the cache. If any
+# object is missing the save is skipped so a later run can try again
+# without poisoning the key.
+
+on:
+  # PRs that add or modify .cid references produce a new hashFiles
+  # digest, so the cache needs to be repopulated for that digest.
+  pull_request:
+    paths:
+      - '**/*.cid'
+  # Keep main and release branches' caches populated as new .cid files
+  # land.
+  push:
+    branches:
+      - main
+      - 'release*'
+    paths:
+      - '**/*.cid'
+  # Nightly safety net: if a populate run was skipped because some CIDs
+  # were unreachable on one day, the next night retries.
+  schedule:
+    - cron: '17 5 * * *'
+  workflow_dispatch:
+
+concurrency:
+  # Only one populate job per hashFiles digest makes sense, but we key
+  # the concurrency group on the branch ref since hashFiles requires a
+  # checkout. Mid-flight runs cancel; the final one wins.
+  group: 'externaldata-populate@${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: write  # needed to manage cache entries
+
+jobs:
+  populate:
+    name: Populate shared ExternalData cache
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Restore ExternalData object store
+        id: restore-externaldata
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ runner.temp }}/ExternalData
+          key: externaldata-v1-${{ hashFiles('**/*.cid') }}
+
+      - name: Skip if cache already complete
+        if: steps.restore-externaldata.outputs.cache-hit == 'true'
+        run: echo "Cache already present for this hashFiles digest - nothing to do."
+
+      - name: Prefetch every CID
+        if: steps.restore-externaldata.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          EXTERNALDATA_STORE: ${{ runner.temp }}/ExternalData
+        run: |
+          python3 Utilities/Maintenance/PrefetchCIDContentLinks.py \
+            --repo-root . \
+            --store "$EXTERNALDATA_STORE"
+
+      # Integrity gate: refuse to save unless every unique CID in the
+      # source tree has an object on disk. A partial save under the
+      # shared key would propagate holes to every consumer workflow.
+      - name: Verify completeness
+        if: steps.restore-externaldata.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          EXTERNALDATA_STORE: ${{ runner.temp }}/ExternalData
+        run: |
+          expected=$(find . -name '*.cid' -not -path './.git/*' -print0 \
+                       | xargs -0 -I{} cat {} \
+                       | sort -u | wc -l | tr -d ' ')
+          present=$(find "$EXTERNALDATA_STORE/cid" -type f 2>/dev/null | wc -l | tr -d ' ')
+          echo "expected unique CIDs: $expected"
+          echo "present on disk     : $present"
+          if [ "$present" -lt "$expected" ]; then
+            echo "::error::ExternalData prefetch produced $present/$expected objects; refusing to save a partial cache."
+            exit 1
+          fi
+
+      - name: Save ExternalData object store
+        if: steps.restore-externaldata.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ runner.temp }}/ExternalData
+          key: externaldata-v1-${{ hashFiles('**/*.cid') }}

--- a/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
@@ -11,7 +11,7 @@ trigger:
 pr: none
 
 variables:
-  ExternalDataVersion: 5.4.5
+  ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache
   CCACHE_BASEDIR: $(Build.SourcesDirectory)
   CCACHE_COMPILERCHECK: content
@@ -61,12 +61,16 @@ jobs:
 
       - script: |
           git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
-
-          curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
-          cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
-          cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/CID $(Build.SourcesDirectory)/.ExternalData/CID
         workingDirectory: $(Agent.BuildDirectory)
-        displayName: 'Download dashboard script and testing data'
+        displayName: 'Download dashboard script'
+
+      - task: Cache@2
+        inputs:
+          key: '"externaldata" | "v1" | **/*.cid'
+          restoreKeys: |
+            "externaldata" | "v1"
+          path: $(ExternalData_OBJECT_STORES)
+        displayName: 'Restore ExternalData object store'
 
       - task: Cache@2
         inputs:

--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -27,7 +27,7 @@ pr:
     - Utilities/Maintenance/*
     - Modules/Remote/*.remote.cmake
 variables:
-  ExternalDataVersion: 5.4.5
+  ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache
   CCACHE_BASEDIR: $(Build.SourcesDirectory)
   CCACHE_COMPILERCHECK: content
@@ -67,12 +67,16 @@ jobs:
     - bash: |
         set -x
         git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
-
-        curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
-        cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
-        cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/CID $(Build.SourcesDirectory)/.ExternalData/CID
       workingDirectory: $(Agent.BuildDirectory)
-      displayName: 'Download dashboard script and testing data'
+      displayName: 'Download dashboard script'
+
+    - task: Cache@2
+      inputs:
+        key: '"externaldata" | "v1" | **/*.cid'
+        restoreKeys: |
+          "externaldata" | "v1"
+        path: $(ExternalData_OBJECT_STORES)
+      displayName: 'Restore ExternalData object store'
 
     - task: Cache@2
       inputs:
@@ -168,12 +172,16 @@ jobs:
     - bash: |
         set -x
         git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
-
-        curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
-        cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
-        cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/CID $(Build.SourcesDirectory)/.ExternalData/CID
       workingDirectory: $(Agent.BuildDirectory)
-      displayName: 'Download dashboard script and testing data'
+      displayName: 'Download dashboard script'
+
+    - task: Cache@2
+      inputs:
+        key: '"externaldata" | "v1" | **/*.cid'
+        restoreKeys: |
+          "externaldata" | "v1"
+        path: $(ExternalData_OBJECT_STORES)
+      displayName: 'Restore ExternalData object store'
 
     - task: Cache@2
       inputs:
@@ -273,11 +281,17 @@ jobs:
     - bash: |
         set -x
         git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
-        curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
-        cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
-        cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/CID $(Build.SourcesDirectory)/.ExternalData/CID
       workingDirectory: $(Agent.BuildDirectory)
-      displayName: "Download dashboard script and testing data"
+      displayName: "Download dashboard script"
+
+    - task: Cache@2
+      inputs:
+        key: '"externaldata" | "v1" | **/*.cid'
+        restoreKeys: |
+          "externaldata" | "v1"
+        path: $(ExternalData_OBJECT_STORES)
+      displayName: 'Restore ExternalData object store'
+
     - task: Cache@2
       inputs:
         key: '"ccache-v4" | "$(Agent.OS)" | "LinuxCxx20" | "$(Build.SourceVersion)"'

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -27,7 +27,7 @@ pr:
     - Utilities/Maintenance/*
     - Modules/Remote/*.remote.cmake
 variables:
-  ExternalDataVersion: 5.4.5
+  ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache
   CCACHE_BASEDIR: $(Build.SourcesDirectory)
   CCACHE_COMPILERCHECK: content
@@ -67,14 +67,17 @@ jobs:
 
     - bash: |
         set -x
-
         git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
-
-        curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
-        cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
-        cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/CID $(Build.SourcesDirectory)/.ExternalData/CID
       workingDirectory: $(Agent.BuildDirectory)
-      displayName: 'Download dashboard script and testing data'
+      displayName: 'Download dashboard script'
+
+    - task: Cache@2
+      inputs:
+        key: '"externaldata" | "v1" | **/*.cid'
+        restoreKeys: |
+          "externaldata" | "v1"
+        path: $(ExternalData_OBJECT_STORES)
+      displayName: 'Restore ExternalData object store'
 
     - task: Cache@2
       inputs:

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -27,7 +27,7 @@ pr:
     - Utilities/Maintenance/*
     - Modules/Remote/*.remote.cmake
 variables:
-  ExternalDataVersion: 5.4.5
+  ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache
   CCACHE_BASEDIR: $(Build.SourcesDirectory)
   CCACHE_COMPILERCHECK: content
@@ -74,12 +74,16 @@ jobs:
     - bash: |
         set -x
         git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
-
-        curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
-        cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
-        cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/CID $(Build.SourcesDirectory)/.ExternalData/CID
       workingDirectory: $(Agent.BuildDirectory)
-      displayName: 'Download dashboard script and testing data'
+      displayName: 'Download dashboard script'
+
+    - task: Cache@2
+      inputs:
+        key: '"externaldata" | "v1" | **/*.cid'
+        restoreKeys: |
+          "externaldata" | "v1"
+        path: $(ExternalData_OBJECT_STORES)
+      displayName: 'Restore ExternalData object store'
 
     - task: Cache@2
       inputs:

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -27,7 +27,7 @@ pr:
     - Utilities/Maintenance/*
     - Modules/Remote/*.remote.cmake
 variables:
-  ExternalDataVersion: 5.4.5
+  ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache
   CCACHE_BASEDIR: $(Build.SourcesDirectory)
   CCACHE_COMPILERCHECK: content
@@ -75,14 +75,17 @@ jobs:
 
     - bash: |
         set -x
-
         git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
-
-        curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
-        cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
-        cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/CID $(Build.SourcesDirectory)/.ExternalData/CID
       workingDirectory: $(Agent.BuildDirectory)
-      displayName: 'Download dashboard script and testing data'
+      displayName: 'Download dashboard script'
+
+    - task: Cache@2
+      inputs:
+        key: '"externaldata" | "v1" | **/*.cid'
+        restoreKeys: |
+          "externaldata" | "v1"
+        path: $(ExternalData_OBJECT_STORES)
+      displayName: 'Restore ExternalData object store'
 
     - task: Cache@2
       inputs:

--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -27,7 +27,7 @@ pr:
     - Utilities/Maintenance/*
     - Modules/Remote/*.remote.cmake
 variables:
-  ExternalDataVersion: 5.4.5
+  ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache
   CCACHE_BASEDIR: $(Build.SourcesDirectory)
   CCACHE_COMPILERCHECK: content
@@ -62,12 +62,16 @@ jobs:
 
     - script: |
         git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
-
-        curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
-        cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
-        cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/CID $(Build.SourcesDirectory)/.ExternalData/CID
       workingDirectory: $(Agent.BuildDirectory)
-      displayName: 'Download dashboard script and testing data'
+      displayName: 'Download dashboard script'
+
+    - task: Cache@2
+      inputs:
+        key: '"externaldata" | "v1" | **/*.cid'
+        restoreKeys: |
+          "externaldata" | "v1"
+        path: $(ExternalData_OBJECT_STORES)
+      displayName: 'Restore ExternalData object store'
 
     - task: Cache@2
       inputs:

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -27,7 +27,7 @@ pr:
     - Utilities/Maintenance/*
     - Modules/Remote/*.remote.cmake
 variables:
-  ExternalDataVersion: 5.4.5
+  ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache
   CCACHE_BASEDIR: $(Build.SourcesDirectory)
   CCACHE_COMPILERCHECK: content
@@ -62,12 +62,16 @@ jobs:
 
     - script: |
         git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
-
-        curl -L https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(ExternalDataVersion)/InsightData-$(ExternalDataVersion).tar.gz -O
-        cmake -E tar xfz InsightData-$(ExternalDataVersion).tar.gz
-        cmake -E rename InsightToolkit-$(ExternalDataVersion)/.ExternalData/CID $(Build.SourcesDirectory)/.ExternalData/CID
       workingDirectory: $(Agent.BuildDirectory)
-      displayName: 'Download dashboard script and testing data'
+      displayName: 'Download dashboard script'
+
+    - task: Cache@2
+      inputs:
+        key: '"externaldata" | "v1" | **/*.cid'
+        restoreKeys: |
+          "externaldata" | "v1"
+        path: $(ExternalData_OBJECT_STORES)
+      displayName: 'Restore ExternalData object store'
 
     - task: Cache@2
       inputs:

--- a/Utilities/Maintenance/PrefetchCIDContentLinks.py
+++ b/Utilities/Maintenance/PrefetchCIDContentLinks.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Prefetch every CID referenced by a ``.cid`` content link into the
+``ExternalData_OBJECT_STORES`` directory so the GitHub Actions cache entry
+saved after a CI run is complete.
+
+Without this step, only the data for modules selected for compilation (and
+whose tests ran) trigger an ExternalData fetch. Everything else stays out of
+the store, and the next cold boot has to re-download it from the gateways.
+This script walks the whole source tree, reads every ``.cid`` file, and fills
+in any missing object at ``<store>/cid/<cid>`` via the same gateway list used
+by ``CMake/ITKExternalData.cmake``.
+
+Integrity: the IPFS gateways serve content-addressed bytes, so a correctly
+configured gateway cannot return the wrong bytes for a given CID — the CID
+*is* the content hash. CMake's ExternalData verifies the hash again at
+consumer time, so any bad prefetch is self-healing.
+"""
+from __future__ import annotations
+
+import argparse
+import concurrent.futures as cf
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from urllib.parse import urlsplit
+
+# Same ordered list as CMake/ITKExternalData.cmake. The GitHub Pages mirror
+# comes first because it is the lowest-latency bulk-hosted option and does
+# not rate-limit CI.
+GATEWAYS = (
+    "https://insightsoftwareconsortium.github.io/ITKTestingData/cid/{cid}",
+    "https://ipfs.io/ipfs/{cid}",
+    "https://gateway.pinata.cloud/ipfs/{cid}",
+    "https://cloudflare-ipfs.com/ipfs/{cid}",
+    "https://dweb.link/ipfs/{cid}",
+)
+
+PER_URL_TIMEOUT_SECONDS = 60
+MAX_WORKERS_DEFAULT = 16
+
+
+def collect_cids(repo_root: Path) -> dict[str, list[Path]]:
+    """Map each CID found in the repo to the ``.cid`` files that reference it."""
+    cids: dict[str, list[Path]] = {}
+    for p in repo_root.rglob("*.cid"):
+        if ".git" in p.parts:
+            continue
+        try:
+            cid = p.read_text().strip()
+        except OSError as e:
+            print(f"WARN: cannot read {p}: {e}", file=sys.stderr)
+            continue
+        if not cid or any(c.isspace() for c in cid):
+            print(f"WARN: malformed .cid file {p}", file=sys.stderr)
+            continue
+        cids.setdefault(cid, []).append(p)
+    return cids
+
+
+def fetch_one(cid: str, dest: Path) -> tuple[str, str, int]:
+    """Download ``cid`` to ``dest``, trying gateways in order.
+
+    Returns ``(cid, status, bytes_written)`` where status is one of
+    ``ok``, ``skip`` (already present), or ``fail``.
+    """
+    if dest.exists() and dest.stat().st_size > 0:
+        return cid, "skip", dest.stat().st_size
+
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    last_err: str | None = None
+    for tpl in GATEWAYS:
+        url = tpl.format(cid=cid)
+        parts = urlsplit(url)
+        if parts.scheme != "https":
+            last_err = f"refusing non-https URL: {url}"
+            continue
+        # Delegate HTTPS to curl: avoids pulling in third-party HTTP libs
+        # and keeps TLS cert verification entirely in the system stack.
+        cmd = [
+            "curl",
+            "--silent",
+            "--show-error",
+            "--location",
+            "--fail",
+            "--proto",
+            "=https",
+            "--max-time",
+            str(PER_URL_TIMEOUT_SECONDS),
+            "--user-agent",
+            "itk-ci-prefetch/1",
+            "--output",
+            str(tmp),
+            "--",
+            url,
+        ]
+        try:
+            r = subprocess.run(
+                cmd,
+                capture_output=True,
+                check=False,
+                timeout=PER_URL_TIMEOUT_SECONDS + 10,
+            )
+        except subprocess.TimeoutExpired:
+            last_err = f"curl timeout on {url}"
+            continue
+        if r.returncode != 0:
+            last_err = f"curl rc={r.returncode} on {url}: {r.stderr.decode(errors='replace').strip()}"
+            continue
+        try:
+            nbytes = tmp.stat().st_size
+        except OSError as e:
+            last_err = f"{url}: {e}"
+            continue
+        if nbytes == 0:
+            last_err = f"empty body from {url}"
+            continue
+        tmp.replace(dest)
+        return cid, "ok", nbytes
+    if tmp.exists():
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+    return cid, f"fail: {last_err}", 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Root of the source tree to scan for .cid files.",
+    )
+    ap.add_argument(
+        "--store",
+        type=Path,
+        default=Path(os.environ.get("ExternalData_OBJECT_STORES", "")),
+        help="ExternalData_OBJECT_STORES directory. Defaults to the env var.",
+    )
+    ap.add_argument(
+        "--jobs",
+        type=int,
+        default=MAX_WORKERS_DEFAULT,
+        help=f"Parallel download workers (default {MAX_WORKERS_DEFAULT}).",
+    )
+    ap.add_argument(
+        "--fail-on-missing",
+        action="store_true",
+        help="Exit non-zero if any CID could not be fetched.",
+    )
+    args = ap.parse_args()
+
+    if not args.store or str(args.store) == ".":
+        print(
+            "ERROR: --store or ExternalData_OBJECT_STORES must be set", file=sys.stderr
+        )
+        return 2
+    cid_dir = args.store / "cid"
+    cid_dir.mkdir(parents=True, exist_ok=True)
+
+    cids = collect_cids(args.repo_root)
+    print(
+        f"==> {len(cids)} unique CIDs referenced by {sum(len(v) for v in cids.values())} .cid files"
+    )
+
+    start = time.monotonic()
+    ok = skip = fail = 0
+    bytes_ok = 0
+    failed: list[str] = []
+    with cf.ThreadPoolExecutor(max_workers=max(1, args.jobs)) as pool:
+        futures = {pool.submit(fetch_one, cid, cid_dir / cid): cid for cid in cids}
+        for i, fut in enumerate(cf.as_completed(futures), 1):
+            cid, status, nbytes = fut.result()
+            if status == "ok":
+                ok += 1
+                bytes_ok += nbytes
+            elif status == "skip":
+                skip += 1
+            else:
+                fail += 1
+                failed.append(f"{cid}: {status}")
+            if i % 500 == 0 or i == len(futures):
+                elapsed = time.monotonic() - start
+                print(
+                    f"  [{i}/{len(futures)}] ok={ok} skip={skip} fail={fail} "
+                    f"downloaded={bytes_ok / 1e6:.1f} MB in {elapsed:.0f}s",
+                    flush=True,
+                )
+
+    elapsed = time.monotonic() - start
+    print(
+        f"==> prefetch done in {elapsed:.0f}s: ok={ok} skip={skip} fail={fail} "
+        f"downloaded={bytes_ok / 1e6:.1f} MB"
+    )
+    if failed:
+        print(f"==> {len(failed)} CID(s) could not be fetched:", file=sys.stderr)
+        for line in failed[:50]:
+            print(f"  {line}", file=sys.stderr)
+        if len(failed) > 50:
+            print(f"  ... and {len(failed) - 50} more", file=sys.stderr)
+    return 1 if (fail and args.fail_on_missing) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Single-writer owner of the `externaldata-v1-<hashFiles('**/*.cid')>` GitHub Actions cache key. **Stacks on top of #6109** — merge after that lands; diff will shrink to the three-file delta once #6109 is in `main`.

<details>
<summary>Root cause (observed on #6109)</summary>

Cache entry `externaldata-v1-4cf653e4ff...` was 117 MiB. Sampling 50 random CIDs against the `ITKTestingData` GitHub Pages mirror gave a mean object size of ~1.57 MB × 1,509 unique CIDs = **~2.43 GB expected corpus**. 117 MiB ÷ 2,430 MiB = **~4.8% of content** — zstd cannot compress `.mha`/`.nrrd`/`.png` data 20×, so the cache was incomplete, not just compressed.

Timeline on `c2f2e1151639`:
- `pixi.yml` (has Prefetch) failed to start ("workflow file issue") → never saved.
- `arm.yml` / `ARMBUILD-x86_64-rosetta` (no Prefetch) finished 19:32:40Z → saved 117 MiB at 19:32:34Z containing only whatever blobs the ARM build happened to fetch for its enabled modules.
- Every later workflow hit `cache-hit=true` on the shared key, skipped Prefetch by design, and propagated the hole forever.

</details>

<details>
<summary>Fix</summary>

- New workflow `.github/workflows/populate-externaldata-cache.yml` is the **only** writer of the shared key. Runs on: PRs that touch `**/*.cid`, pushes to `main`/`release*`, nightly at 05:17 UTC, and `workflow_dispatch`.
- **Completeness gate** after prefetch compares the number of unique CIDs in the tree against the number of objects on disk; refuses to `actions/cache/save` if any are missing, so a partial cache can never be written under the shared key.
- `arm.yml` and `pixi.yml` Save steps removed; `pixi.yml` Prefetch step removed. Both keep their Restore step and now participate as restore-only consumers. Explanatory comments left where the Save/Prefetch used to be to prevent someone re-introducing the race.
- Azure `Cache@2` subsystem (7 pipelines) is **untouched** — same anti-pattern but a separate cache backend; follow-up.

</details>

<details>
<summary>Verification plan</summary>

1. After this PR merges, manually delete any existing partial `externaldata-v1-*` entries: `gh cache delete --repo InsightSoftwareConsortium/ITK externaldata-v1-<digest>`.
2. Trigger `workflow_dispatch` on `Populate ExternalData Cache`; confirm the completeness gate passes and the save succeeds.
3. Subsequent consumer runs (pixi.yml, arm.yml) should hit `cache-hit=true` on restore and proceed without network fetches.

</details>

<!--
provenance: claude-code session 2026-04-24
key_facts:
  - base_branch: main (stacked on #6109 via shared ancestry; intentional)
  - corpus_estimate_gb: 2.43
  - incident_cache_size_mib: 117
  - unique_cids: 1509
related_files:
  - .github/workflows/populate-externaldata-cache.yml (new)
  - .github/workflows/arm.yml around lines 205-210 removed
  - .github/workflows/pixi.yml around lines 179-197 removed
followup:
  - Azure Cache@2 dedicated populate job (Testing/ContinuousIntegration/AzurePipelines*.yml)
-->