### PR TITLE
BUG: Prefetch script uses /cid/, GitHub Pages serves /CID/ (case-sensitive)

### DIFF
--- a/Utilities/Maintenance/PrefetchCIDContentLinks.py
+++ b/Utilities/Maintenance/PrefetchCIDContentLinks.py
@@ -30,7 +30,7 @@ from urllib.parse import urlsplit
 # comes first because it is the lowest-latency bulk-hosted option and does
 # not rate-limit CI.
 GATEWAYS = (
-    "https://insightsoftwareconsortium.github.io/ITKTestingData/cid/{cid}",
+    "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/{cid}",
     "https://ipfs.io/ipfs/{cid}",
     "https://gateway.pinata.cloud/ipfs/{cid}",
     "https://cloudflare-ipfs.com/ipfs/{cid}",


### PR DESCRIPTION
One-character fix: `Utilities/Maintenance/PrefetchCIDContentLinks.py` line 33 fetches from `/cid/<cid>` (lowercase) but the GitHub Pages mirror serves from `/CID/<cid>` (uppercase). Recently uploaded blobs that live only on GitHub Pages (Montage, GrowCut, AnisotropicDiffusionLBR, etc.) silently 404 on Pages and fall through to the IPFS gateways, where they're not pinned, producing the "refusing to save a partial cache" failure currently seen in the populate-externaldata-cache workflow.

<details>
<summary>Diagnostic walkthrough</summary>

Failing CI run: https://github.com/InsightSoftwareConsortium/ITK/actions/runs/24918704955/job/73007454137 — 71 of 2043 CIDs fail with `curl rc=22 on https://dweb.link/ipfs/<cid>: 504`.

Direct curl confirms the case bug:

| URL | HTTP | size |
|---|---|---|
| `https://insightsoftwareconsortium.github.io/ITKTestingData/cid/bafkreic6bv4q6zngkeychplskxwabwr3p2nukhtda2bdp26a2zmfkfyil4` | **404** | 9,379 (error page) |
| `https://insightsoftwareconsortium.github.io/ITKTestingData/CID/bafkreic6bv4q6zngkeychplskxwabwr3p2nukhtda2bdp26a2zmfkfyil4` | **200** | 2,522,160 (the actual blob) |

Why the failure was misleading:
- The script's per-CID error message reports only the **last** URL tried. GitHub Pages' 404 was silent; ExternalData fell through `ipfs.io`, `pinata`, `cloudflare`, and finally `dweb.link` — only `dweb.link`'s 504 made the log.
- The 1972 "successful" CIDs are blobs that are *also* pinned to a public IPFS gateway, so the fall-through accidentally worked.
- The 71 failures are recently uploaded blobs (Montage, GrowCut, etc.) that live **only** on the GitHub Pages mirror — never pinned to public IPFS — so the typo blocked them entirely.

The convention is consistent: the gh-pages branch publishes `/CID/`, `/MD5/`, and `/SHA512/` (all uppercase). `CMake/ITKExternalData.cmake` uses `%(algo)/%(hash)` and `%(algo)` resolves to the uppercase file extension, so configure-time fetches via `ExternalData` already work. Only this Python prefetch sidecar deviated.

</details>

<details>
<summary>Test plan</summary>

- [ ] CI: re-run `populate-externaldata-cache` and confirm `2043/2043 ok` instead of `1972/2043`
- [ ] Spot-check several previously-failing CIDs resolve via the new path locally:
  ```bash
  python3 Utilities/Maintenance/PrefetchCIDContentLinks.py --repo-root . --store /tmp/edcache
  ```

</details>

<!--
provenance: claude-code session 2026-04-25
key_facts:
  - root_cause: "PrefetchCIDContentLinks.py uses lowercase /cid/, GitHub Pages branch serves /CID/"
  - fix_scope: 1-char edit, line 33 of Utilities/Maintenance/PrefetchCIDContentLinks.py
  - failing_run: 24918704955 (populate-externaldata-cache, 71/2043 CIDs failed)
  - sample_cid: bafkreic6bv4q6zngkeychplskxwabwr3p2nukhtda2bdp26a2zmfkfyil4 (2,522,160 bytes)
  - blocked_work: ITKMontage #6103, ITKGenericLabelInterpolator (local), AnisotropicDiffusionLBR re-runs
post_merge_action: re-trigger failing populate-externaldata-cache job; advance Montage #6103 + GenericLabelInterpolator ingest PR.
-->