### PR TITLE
STYLE: Add 2024-2026 bulk formatting commits to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -128,3 +128,21 @@ f1bc82756aaf853c50b6c2b5cfb4dfd88bc4824f
 13f99f81510fd76b0409b98dac6a4670436e007a
 # STYLE: Change to hxx extension for dev tools
 2fccd272862ab7cc408d643c8db2e1cb5d098fcf
+
+# Bulk format changes 2024-2026 (clang-format, black, gersemi)
+# STYLE: Run clang-format.exe manually at the client side
+ffd9ccfb150914e748d69050f4cff18a7ad3865d
+# STYLE: Enforce black formatting for toolkit.
+9c0bd2716fdfb95d1ae7f92b27dfb9fa900a9d38
+# STYLE: Rigorous style conformance with clang-format 19.1.4
+814a24c84d3bf4bdc42ce8f07276997fabdb45d3
+# STYLE: clang-format pre-commit updates
+2659871fef7018d3357c6ca49f7567626043dee9
+# STYLE: Add CMake stubs for gersemi formatting
+322727428c5c947823393cf0cb9d8ca975b584fb
+# STYLE: Upstream clang-format changes applied
+2673ad57b6279a97cfee9847e28fc7b3d5065522
+# STYLE: Run gersemi on ITK's CMake code for thirdparty libraries
+ef3f7ba06fe5d13bc055e2072818ac55cd4d3613
+# STYLE: Apply gersemi style to a deeper layer in Thirdparty libraries
+7401fed2af22e87a39030b49a1bc1099f9beb0f0


### PR DESCRIPTION
Append 8 bulk-format commits (clang-format, black, gersemi) merged on main between 2024-09 and 2026-02 so `git blame` skips over them. Closes #2624.

<details>
<summary>Commits added</summary>

| Date | SHA | Subject |
|---|---|---|
| 2024-09-23 | ffd9ccfb15 | STYLE: Run clang-format.exe manually at the client side |
| 2024-12-04 | 9c0bd2716f | STYLE: Enforce black formatting for toolkit. |
| 2024-12-05 | 814a24c84d | STYLE: Rigorous style conformance with clang-format 19.1.4 |
| 2025-02-11 | 2659871fef | STYLE: clang-format pre-commit updates |
| 2025-06-26 | 322727428c | STYLE: Add CMake stubs for gersemi formatting |
| 2025-10-03 | 2673ad57b6 | STYLE: Upstream clang-format changes applied |
| 2026-02-10 | ef3f7ba06f | STYLE: Run gersemi on ITK's CMake code for thirdparty libraries |
| 2026-02-12 | 7401fed2af | STYLE: Apply gersemi style to a deeper layer in Thirdparty libraries |

Selection criteria: `STYLE:`-prefixed bulk-format commits on `main` since the prior sweep (eb490ff5, 2025-01-23, by @ebrahimebrahim) that touched ≥10 files and reformat-only. Merge commits omitted; the underlying STYLE commit SHA is what `git blame --ignore-revs-file` needs.

</details>

<!--
provenance: claude-code session 2026-04-25
key_facts:
  - closes_issue: 2624
  - prior_sweep_sha: eb490ff5520a4ed42fa607c5e72b2e58518407d2 (2025-01-23, ebrahimebrahim)
  - selection: STYLE-prefixed, ≥10 files, reformat-only, since prior sweep
related_files:
  - .git-blame-ignore-revs
-->