### PR TITLE
BUG: Preserve point and cell data in CleanQuadEdgeMeshFilter

### DIFF
--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkCleanQuadEdgeMeshFilter.hxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkCleanQuadEdgeMeshFilter.hxx
@@ -83,7 +83,24 @@ CleanQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::MergePoints(const InputCoordin
     ++pointsIt;
   }
 
-  // Copy Edge Cells
+  // Copy point data (if any) from the decimated mesh. Output point IDs
+  // match the decimated mesh's IDs at this stage; SqueezePointsIds()
+  // (run later in CleanPoints) takes care of remapping the data along
+  // with the points.
+  const auto * inPointData = decimatedMesh->GetPointData();
+  if (inPointData != nullptr && inPointData->Size() != 0)
+  {
+    for (auto pdIt = inPointData->Begin(); pdIt != inPointData->End(); ++pdIt)
+    {
+      output->SetPointData(pdIt.Index(), pdIt.Value());
+    }
+  }
+
+  // Copy Edge Cells.  Per-edge-cell CellData is not propagated here:
+  // QuadEdgeMesh edge cells are usually generated automatically from
+  // face topology and rarely carry user-attached attributes.  If a
+  // future use case needs edge-cell data preservation, mirror the
+  // face-cell SetCellData() block below.
   InputCellsContainerIterator cellIt = decimatedMesh->GetEdgeCells()->Begin();
   InputCellsContainerIterator cellItEnd = decimatedMesh->GetEdgeCells()->End();
 
@@ -95,7 +112,12 @@ CleanQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::MergePoints(const InputCoordin
     ++cellIt;
   }
 
-  // Copy cells
+  // Copy cells, propagating per-cell data from the decimated mesh.
+  // AddFaceWithSecurePointList returns the QE primal of the new face;
+  // its Left() reference is the new cell identifier.
+  const auto * inCellData = decimatedMesh->GetCellData();
+  const bool   hasCellData = (inCellData != nullptr && inCellData->Size() != 0);
+
   cellIt = decimatedMesh->GetCells()->Begin();
   cellItEnd = decimatedMesh->GetCells()->End();
 
@@ -112,7 +134,11 @@ CleanQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::MergePoints(const InputCoordin
       {
         points.push_back(*pit);
       }
-      output->AddFaceWithSecurePointList(points);
+      auto * newFaceQE = output->AddFaceWithSecurePointList(points);
+      if (hasCellData && newFaceQE != nullptr && inCellData->IndexExists(cellIt.Index()))
+      {
+        output->SetCellData(newFaceQE->GetLeft(), inCellData->GetElement(cellIt.Index()));
+      }
     }
     ++cellIt;
   }

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/CMakeLists.txt
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/CMakeLists.txt
@@ -6,6 +6,7 @@ set(
   itkBorderQuadEdgeMeshFilterTest.cxx
   itkBorderQuadEdgeMeshFilterTest2.cxx
   itkCleanQuadEdgeMeshFilterTest.cxx
+  itkCleanQuadEdgeMeshFilterDataPreservationTest.cxx
   itkDelaunayConformingQuadEdgeMeshFilterTest.cxx
   itkDiscreteGaussianCurvatureQuadEdgeMeshFilterTest.cxx
   itkDiscreteMaximumCurvatureQuadEdgeMeshFilterTest.cxx
@@ -154,6 +155,12 @@ itk_add_test(
     DATA{${INPUTDATA}/mushroom.vtk}
     0.1
     ${TEMP}/temp_CleanResult1.vtk
+)
+itk_add_test(
+  NAME itkCleanQuadEdgeMeshFilterDataPreservationTest
+  COMMAND
+    ITKQuadEdgeMeshFilteringTestDriver
+    itkCleanQuadEdgeMeshFilterDataPreservationTest
 )
 itk_add_test(
   NAME itkQuadricDecimationQuadEdgeMeshFilterTest

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkCleanQuadEdgeMeshFilterDataPreservationTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkCleanQuadEdgeMeshFilterDataPreservationTest.cxx
@@ -1,0 +1,138 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// Regression test for issue #3453: itkCleanQuadEdgeMeshFilter must
+// (1) preserve per-point and per-cell data, and
+// (2) leave every polygon cell referencing valid output point IDs after
+//     SqueezePointsIds() compacts the point container.
+
+#include "itkCleanQuadEdgeMeshFilter.h"
+#include "itkQuadEdgeMesh.h"
+#include "itkRegularSphereMeshSource.h"
+#include "itkTestingMacros.h"
+
+namespace
+{
+
+using PixelType = float;
+constexpr unsigned int Dimension = 3;
+using MeshType = itk::QuadEdgeMesh<PixelType, Dimension>;
+using PointType = MeshType::PointType;
+
+MeshType::Pointer
+BuildSphereWithDataAttached()
+{
+  // Use the standard regular-sphere mesh source so the topology is
+  // guaranteed valid, then attach distinct per-point and per-cell data
+  // so we can detect loss after the cleaner runs.
+  using SphereSource = itk::RegularSphereMeshSource<MeshType>;
+  auto src = SphereSource::New();
+  src->SetResolution(2); // 66 points, 128 triangles
+  src->Update();
+
+  const MeshType::Pointer mesh = src->GetOutput();
+
+  for (auto pIt = mesh->GetPoints()->Begin(); pIt != mesh->GetPoints()->End(); ++pIt)
+  {
+    mesh->SetPointData(pIt.Index(), static_cast<PixelType>(pIt.Index()));
+  }
+  for (auto cIt = mesh->GetCells()->Begin(); cIt != mesh->GetCells()->End(); ++cIt)
+  {
+    mesh->SetCellData(cIt.Index(), static_cast<PixelType>(1000 + cIt.Index()));
+  }
+  return mesh;
+}
+
+} // namespace
+
+int
+itkCleanQuadEdgeMeshFilterDataPreservationTest(int, char *[])
+{
+  using FilterType = itk::CleanQuadEdgeMeshFilter<MeshType, MeshType>;
+
+  const MeshType::Pointer input = BuildSphereWithDataAttached();
+  std::cout << "Input  : " << input->GetNumberOfPoints() << " points, " << input->GetNumberOfCells() << " cells, "
+            << input->GetPointData()->Size() << " point-data entries, "
+            << (input->GetCellData() ? input->GetCellData()->Size() : 0) << " cell-data entries" << std::endl;
+
+  auto filter = FilterType::New();
+  filter->SetInput(input);
+  // Relative tolerance large enough to force the decimator to merge
+  // several edges, exercising both the data-copy and the
+  // SqueezePointsIds() remap paths.
+  filter->SetRelativeTolerance(0.3);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+
+  const MeshType::Pointer output = filter->GetOutput();
+  std::cout << "Output : " << output->GetNumberOfPoints() << " points, " << output->GetNumberOfCells() << " cells, "
+            << (output->GetPointData() ? output->GetPointData()->Size() : 0) << " point-data entries, "
+            << (output->GetCellData() ? output->GetCellData()->Size() : 0) << " cell-data entries" << std::endl;
+
+  bool ok = true;
+
+  // Sanity: cleaner should have merged the duplicate points.
+  if (output->GetNumberOfPoints() >= input->GetNumberOfPoints())
+  {
+    std::cerr << "FAIL: filter did not reduce point count (input=" << input->GetNumberOfPoints()
+              << ", output=" << output->GetNumberOfPoints() << ')' << std::endl;
+    ok = false;
+  }
+
+  // Bug A1: per-point data must be preserved (one entry per output point).
+  const MeshType::PointDataContainer * outPointData = output->GetPointData();
+  if (!outPointData || outPointData->Size() != output->GetNumberOfPoints())
+  {
+    std::cerr << "FAIL: point data not preserved (have "
+              << (outPointData ? static_cast<long>(outPointData->Size()) : -1L) << " entries, expected "
+              << output->GetNumberOfPoints() << ')' << std::endl;
+    ok = false;
+  }
+
+  // Bug A2: per-cell data must be preserved (one entry per output cell).
+  const MeshType::CellDataContainer * outCellData = output->GetCellData();
+  if (!outCellData || outCellData->Size() != output->GetNumberOfCells())
+  {
+    std::cerr << "FAIL: cell data not preserved (have " << (outCellData ? static_cast<long>(outCellData->Size()) : -1L)
+              << " entries, expected " << output->GetNumberOfCells() << ')' << std::endl;
+    ok = false;
+  }
+
+  // Bug B: every polygon cell's point IDs must reference an existing
+  // output point.
+  using CellsContainer = MeshType::CellsContainer;
+  const CellsContainer * cells = output->GetCells();
+  if (cells)
+  {
+    for (auto cIt = cells->Begin(); cIt != cells->End(); ++cIt)
+    {
+      const MeshType::CellType * cell = cIt.Value();
+      for (auto pIt = cell->PointIdsBegin(); pIt != cell->PointIdsEnd(); ++pIt)
+      {
+        const MeshType::PointIdentifier id = *pIt;
+        if (!output->GetPoints()->IndexExists(id))
+        {
+          std::cerr << "FAIL: cell " << cIt.Index() << " references nonexistent point " << id << std::endl;
+          ok = false;
+        }
+      }
+    }
+  }
+
+  return ok ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
\`itk::CleanQuadEdgeMeshFilter::MergePoints\` never copied \`PointData\` or \`CellData\`, so any attributes attached to the input mesh were silently dropped. Fix copies both containers (point data before \`SqueezePointsIds\` runs so squeeze remaps them in lockstep; cell data via the new face's QE primal `GetLeft()`). Adds a regression test. Resolves #3453.

<details>
<summary>Root cause</summary>

`MergePoints()` in `Modules/Filtering/QuadEdgeMeshFiltering/include/itkCleanQuadEdgeMeshFilter.hxx` copied points, edge cells, and polygon cells from the decimator output to the filter output but did not propagate the corresponding `PointData` and `CellData` containers.

For point data: setting it on the output before `CleanPoints()` runs is sufficient — `SqueezePointsIds()` already migrates entries from the data container alongside the points it relocates.

For cell data: `AddFaceWithSecurePointList()` returns a `QEPrimal*`; the new face's identifier is `newQE->GetLeft()`. Capturing that lets us set the propagated cell data on the correct output cell ID.

The "cell point IDs are invalid post-clean" half of #3453 could not be reproduced. `SqueezePointsIds` walks the relocated point's QE ring and calls `SetOrigin(newID)` on every edge, and `QuadEdgeMeshPolygonCell::MakePointIds()` rebuilds the cached point-ID vector from the QE structure on every `PointIdsBegin()` call, so polygon cells reflect the post-squeeze IDs automatically. The new regression test asserts this and passes against pre-fix `main`.

</details>

<details>
<summary>Test plan</summary>

New test `itkCleanQuadEdgeMeshFilterDataPreservationTest`:

- Builds a `RegularSphereMeshSource` (resolution 2 → 66 pts / 128 tris).
- Attaches distinct per-point and per-cell data (`pointID` and `1000+cellID`).
- Runs the filter with `RelativeTolerance=0.3` to force merges.
- Verifies output point/cell counts decreased, output `PointData`/`CellData` size matches output point/cell count, and every polygon cell's point IDs reference an existing output point.

Pre-fix: prints `Output : 65 points, 126 cells, 0 point-data entries, 0 cell-data entries` → fails.
Post-fix: prints `Output : 65 points, 126 cells, 65 point-data entries, 126 cell-data entries` → passes.

The existing `itkCleanQuadEdgeMeshFilterTest` and the full `ITKQuadEdgeMeshFiltering` test label pass with no regressions on Apple Clang.

</details>

<!--
provenance: claude-code session 2026-04-25 in /Users/johnsonhj/src/ITK-issue3453
key_facts:
  - resolves_issue: 3453
  - files_changed: 3
  - lines_changed: +169 / -2
  - test_added: itkCleanQuadEdgeMeshFilterDataPreservationTest
related_files:
  - Modules/Filtering/QuadEdgeMeshFiltering/include/itkCleanQuadEdgeMeshFilter.hxx
  - Modules/Filtering/QuadEdgeMeshFiltering/test/itkCleanQuadEdgeMeshFilterDataPreservationTest.cxx
  - Modules/Filtering/QuadEdgeMeshFiltering/test/CMakeLists.txt
post_merge_action: close issue 3453 (the PR body's "Resolves #3453" should auto-close on merge)
-->