### PR TITLE
ENH: Always finalize CDash submission so PR "CDash" check leaves in-progress

### DIFF
--- a/itk_common.cmake
+++ b/itk_common.cmake
@@ -573,7 +573,14 @@ while(NOT dashboard_done)
       dashboard_hook_submit()
     endif()
     if(NOT dashboard_no_submit)
-      ctest_submit()
+      # Retry the main submission so a transient HTTPS hiccup does not
+      # leave the per-step results unsubmitted.  The Done part is sent
+      # below after the loop, *unconditionally*, so the CDash GitHub
+      # check on the commit can flip from in-progress to success/failure.
+      ctest_submit(RETRY_COUNT 3 RETRY_DELAY 30 RETURN_VALUE submit_return)
+      if(NOT submit_return EQUAL 0)
+        message(WARNING "ctest_submit returned ${submit_return}; final Done submit will retry.")
+      endif()
     endif()
     ci_section_end("submit_${_dashboard_iteration}")
     if(COMMAND dashboard_hook_end)
@@ -592,6 +599,30 @@ while(NOT dashboard_done)
     set(dashboard_done 1)
   endif()
 endwhile()
+
+# Always send the Done sentinel, even if earlier steps reported errors.
+#
+# Without this, CDash leaves the build row's `done` column at 0 and the
+# server-side GitHub check (open-cdash-org App, src reference: CDash
+# `app/cdash/app/Lib/Repository/GitHub.php::getCheckSummaryForBuildRow`)
+# treats the build as still pending forever -- so the "CDash" check on
+# the PR never flips to success or failure.  See discussion in PR #6137
+# triage notes (2026-04-25).
+#
+# Use a longer retry window than the per-step submit because this is the
+# call that actually unblocks PR signalling; we would rather wait two
+# extra minutes than leave a check stuck in-progress for hours.
+if(NOT dashboard_no_submit)
+  ctest_submit(PARTS Done
+               RETRY_COUNT 5
+               RETRY_DELAY 60
+               RETURN_VALUE done_submit_return)
+  if(NOT done_submit_return EQUAL 0)
+    message(WARNING
+      "Final ctest_submit(PARTS Done) returned ${done_submit_return}; "
+      "the CDash PR check may remain in-progress.")
+  endif()
+endif()
 
 set(ci_completed_successfully 0)
 if(NOT ${configure_return} EQUAL 0)


### PR DESCRIPTION
Adds an unconditional final `ctest_submit(PARTS Done)` so CDash's `done` column is always set to 1, which lets the open-cdash-org GitHub App flip the per-PR "CDash" check from `in_progress` to `success` / `failure` instead of leaving it pending forever.

Resolves #6140. Most recently observed on #6137: all five Azure pipelines passed, CDash showed every build row green, but the `CDash` PR check still sat at `pending` because the plain Linux build's row had `done = 0` (its in-loop `ctest_submit()` evidently dropped the Done part on a transient HTTPS error and was never retried).

<details>
<summary>Why the existing single submit isn't enough</summary>

Reading the App code at `Kitware/CDash/app/cdash/app/Lib/Repository/GitHub.php` (`getCheckSummaryForBuildRow`):

```php
} else {
    if ((int) $row['done'] === 1) {
        // Build completed without problems.
        $icon = ':white_check_mark:';
        $msg = 'success';
        $this->numPassed++;
    } else {
        // Build hasn't finished reporting yet.
        $icon = ':hourglass_flowing_sand:';
        $msg = 'pending';
        $this->numPending++;
        // Schedule this check to re-run when the build is finished.
        PendingSubmissions::where('buildid', (int) $row['id'])->update([
            'recheck' => true,
        ]);
    }
}
```

While `numPending > 0`, `generateCheckPayloadFromBuildRows` keeps the check at `status: in_progress`. The recheck only fires when another submission lands for the same build — and after a failed HTTPS submit no further submission ever comes, so the check stays pending until manually retried.

</details>

<details>
<summary>What this PR changes</summary>

Two small additions in `itk_common.cmake`:

1. The in-loop `ctest_submit()` gains `RETRY_COUNT 3 RETRY_DELAY 30` and captures the return value, with a warning if it fails.
2. After the loop ends — and *before* the post-loop diagnostics that may call `message(FATAL_ERROR …)` — an unconditional `ctest_submit(PARTS Done RETRY_COUNT 5 RETRY_DELAY 60)` runs. This is what flips `done` to 1 in the CDash database and is what the App needs to complete the PR check.

Both calls are gated on the existing `dashboard_no_submit` flag, so experimental builds that never want to upload still don't.

</details>

<!--
provenance: claude-code session 2026-04-25
key_facts:
  - resolves_issue: 6140
  - related_pr: 6137
  - cdash_app_repo: Kitware/CDash
  - cdash_app_file: app/cdash/app/Lib/Repository/GitHub.php
  - cdash_app_function: getCheckSummaryForBuildRow
related_files:
  - itk_common.cmake (in-loop submit + new post-loop Done submit)
post_merge_action: monitor next round of PR builds; the CDash row should flip out of in-progress within a few minutes of the last build finishing
-->