### PR TITLE
WIP: DO NOT MERGE — Modernize image iterators to eliminate const_cast via VIsConst templating

### DIFF
--- a/Modules/Core/Common/include/itkConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkConditionalConstIterator.h
@@ -19,6 +19,8 @@
 #define itkConditionalConstIterator_h
 
 #include "itkIndex.h"
+#include "itkWeakPointer.h"
+#include <type_traits>
 
 namespace itk
 {
@@ -34,12 +36,12 @@ namespace itk
  * \ingroup ImageIterators
  * \ingroup ITKCommon
  */
-template <typename TImage>
-class ITK_TEMPLATE_EXPORT ConditionalConstIterator
+template <typename TImage, bool VIsConst>
+class ITK_TEMPLATE_EXPORT ConditionalIteratorBase
 {
 public:
   /** Standard class type aliases. */
-  using Self = ConditionalConstIterator;
+  using Self = ConditionalIteratorBase;
 
   /** Dimension of the image the iterator walks.  This constant is needed so
    * that functions that are templated over image iterator type (as opposed to
@@ -64,6 +66,9 @@ public:
 
   /** External Pixel Type */
   using PixelType = typename TImage::PixelType;
+
+  using ImageWeakPointer = std::conditional_t<VIsConst, typename TImage::ConstWeakPointer, WeakPointer<TImage>>;
+  using ImagePointer = std::conditional_t<VIsConst, const TImage *, TImage *>;
 
   /** Compute whether the index of interest should be included in the flood */
   [[nodiscard]] virtual bool
@@ -98,15 +103,15 @@ public:
   operator++() = 0;
 
   /** Constructor */
-  ConditionalConstIterator() = default;
+  ConditionalIteratorBase() = default;
 
   /** Destructor */
-  virtual ~ConditionalConstIterator() = default;
+  virtual ~ConditionalIteratorBase() = default;
 
 protected: // made protected so other iterators can access
   /** Smart pointer to the source image. */
   // SmartPointer<const ImageType> m_Image;
-  typename ImageType::ConstWeakPointer m_Image{};
+  ImageWeakPointer m_Image{};
 
   /** Region type to iterate over. */
   RegionType m_Region{};
@@ -114,6 +119,25 @@ protected: // made protected so other iterators can access
   /** Is the iterator at the end of its walk? */
   bool m_IsAtEnd{ false };
 };
+
+template <typename TImage>
+class ITK_TEMPLATE_EXPORT ConditionalConstIterator : public ConditionalIteratorBase<TImage, /*VIsConst=*/true>
+{
+public:
+  using Superclass = ConditionalIteratorBase<TImage, /*VIsConst=*/true>;
+  using Superclass::Superclass;
+};
+
+template <typename TImage>
+ConditionalConstIterator(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ConditionalConstIterator<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ConditionalConstIterator(TImage *, const typename TImage::RegionType &) -> ConditionalConstIterator<TImage>;
+
+template <typename TImage>
+ConditionalConstIterator(const TImage *, const typename TImage::RegionType &) -> ConditionalConstIterator<TImage>;
+
 } // end namespace itk
 
 #endif

--- a/Modules/Core/Common/include/itkConstantBoundaryCondition.h
+++ b/Modules/Core/Common/include/itkConstantBoundaryCondition.h
@@ -103,6 +103,11 @@ public:
   void
   Initialize(const VariableLengthVector<TPixel> *);
 
+  /** Bring the base-class const-pointer-element operator() overloads into
+   * scope so that name lookup does not hide them when this class overrides
+   * the legacy NeighborhoodType-pointer overloads. */
+  using Superclass::operator();
+
   /** Computes and returns appropriate out-of-bounds values from
    * neighborhood iterator data. */
   OutputPixelType

--- a/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.h
@@ -35,12 +35,13 @@ namespace itk
  *
  * \ingroup ITKCommon
  */
-template <typename TImage, typename TFunction>
-class ITK_TEMPLATE_EXPORT FloodFilledFunctionConditionalConstIterator : public ConditionalConstIterator<TImage>
+template <typename TImage, typename TFunction, bool VIsConst>
+class ITK_TEMPLATE_EXPORT FloodFilledFunctionConditionalIteratorBase : public ConditionalIteratorBase<TImage, VIsConst>
 {
 public:
   /** Standard class type aliases. */
-  using Self = FloodFilledFunctionConditionalConstIterator;
+  using Self = FloodFilledFunctionConditionalIteratorBase;
+  using Superclass = ConditionalIteratorBase<TImage, VIsConst>;
 
   /** Type of function */
   using FunctionType = TFunction;
@@ -69,6 +70,9 @@ public:
   /** External Pixel Type */
   using PixelType = typename TImage::PixelType;
 
+  using typename Superclass::ImagePointer;
+  using typename Superclass::ImageWeakPointer;
+
   /** Dimension of the image the iterator walks.  This constant is needed so
    * that functions that are templated over image iterator type (as opposed to
    * being templated over pixel type and dimension) can have compile time
@@ -78,19 +82,19 @@ public:
   /** Constructor establishes an iterator to walk a particular image and a
    * particular region of that image. This version of the constructor uses
    * an explicit seed pixel for the flood fill, the "startIndex" */
-  FloodFilledFunctionConditionalConstIterator(const ImageType * imagePtr, FunctionType * fnPtr, IndexType startIndex);
+  FloodFilledFunctionConditionalIteratorBase(ImagePointer imagePtr, FunctionType * fnPtr, IndexType startIndex);
 
   /** Constructor establishes an iterator to walk a particular image and a
    * particular region of that image. This version of the constructor uses
    * a list of seed pixels for the flood fill */
-  FloodFilledFunctionConditionalConstIterator(const ImageType *        imagePtr,
-                                              FunctionType *           fnPtr,
-                                              std::vector<IndexType> & startIndex);
+  FloodFilledFunctionConditionalIteratorBase(ImagePointer             imagePtr,
+                                             FunctionType *           fnPtr,
+                                             std::vector<IndexType> & startIndex);
 
   /** Constructor establishes an iterator to walk a particular image and a
    * particular region of that image. This version of the constructor
    * should be used when the seed pixel is unknown */
-  FloodFilledFunctionConditionalConstIterator(const ImageType * imagePtr, FunctionType * fnPtr);
+  FloodFilledFunctionConditionalIteratorBase(ImagePointer imagePtr, FunctionType * fnPtr);
 
   /** Automatically find a seed pixel and set m_StartIndex. Does nothing
    * if a seed pixel isn't found. A seed pixel is determined by
@@ -108,7 +112,7 @@ public:
   InitializeIterator();
 
   /** Default Destructor. */
-  ~FloodFilledFunctionConditionalConstIterator() override = default;
+  ~FloodFilledFunctionConditionalIteratorBase() override = default;
 
   /** Compute whether the index of interest should be included in the flood */
   [[nodiscard]] bool
@@ -274,6 +278,16 @@ protected: // made protected so other iterators can access
   /** Indicates whether or not an index is valid (inside an image)/ */
   bool m_IsValidIndex{};
 };
+
+template <typename TImage, typename TFunction>
+class ITK_TEMPLATE_EXPORT FloodFilledFunctionConditionalConstIterator
+  : public FloodFilledFunctionConditionalIteratorBase<TImage, TFunction, /*VIsConst=*/true>
+{
+public:
+  using Superclass = FloodFilledFunctionConditionalIteratorBase<TImage, TFunction, /*VIsConst=*/true>;
+  using Superclass::Superclass;
+};
+
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkFloodFilledFunctionConditionalConstIterator.hxx
@@ -22,23 +22,22 @@
 
 namespace itk
 {
-template <typename TImage, typename TFunction>
-FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FloodFilledFunctionConditionalConstIterator(
-  const ImageType * imagePtr,
-  FunctionType *    fnPtr,
-  IndexType         startIndex)
+template <typename TImage, typename TFunction, bool VIsConst>
+FloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::FloodFilledFunctionConditionalIteratorBase(
+  ImagePointer   imagePtr,
+  FunctionType * fnPtr,
+  IndexType      startIndex)
   : m_Function(fnPtr)
 {
   this->m_Image = imagePtr;
   m_Seeds.push_back(startIndex);
 
-  // Set up the temporary image
   this->InitializeIterator();
 }
 
-template <typename TImage, typename TFunction>
-FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FloodFilledFunctionConditionalConstIterator(
-  const ImageType *        imagePtr,
+template <typename TImage, typename TFunction, bool VIsConst>
+FloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::FloodFilledFunctionConditionalIteratorBase(
+  ImagePointer             imagePtr,
   FunctionType *           fnPtr,
   std::vector<IndexType> & startIndex)
   : m_Function(fnPtr)
@@ -49,25 +48,23 @@ FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FloodFilledFunct
     m_Seeds.push_back(startIndex[i]);
   }
 
-  // Set up the temporary image
   this->InitializeIterator();
 }
 
-template <typename TImage, typename TFunction>
-FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FloodFilledFunctionConditionalConstIterator(
-  const ImageType * imagePtr,
-  FunctionType *    fnPtr)
+template <typename TImage, typename TFunction, bool VIsConst>
+FloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::FloodFilledFunctionConditionalIteratorBase(
+  ImagePointer   imagePtr,
+  FunctionType * fnPtr)
   : m_Function(fnPtr)
 {
   this->m_Image = imagePtr;
 
-  // Set up the temporary image
   this->InitializeIterator();
 }
 
-template <typename TImage, typename TFunction>
+template <typename TImage, typename TFunction, bool VIsConst>
 void
-FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::InitializeIterator()
+FloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::InitializeIterator()
 {
   m_FoundUncheckedNeighbor = false;
   m_IsValidIndex = false;
@@ -100,9 +97,9 @@ FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::InitializeIterat
   }
 }
 
-template <typename TImage, typename TFunction>
+template <typename TImage, typename TFunction, bool VIsConst>
 void
-FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPixel()
+FloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::FindSeedPixel()
 {
   // Create an iterator that will walk the input image
 
@@ -123,9 +120,9 @@ FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPixel()
   }
 }
 
-template <typename TImage, typename TFunction>
+template <typename TImage, typename TFunction, bool VIsConst>
 void
-FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPixels()
+FloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::FindSeedPixels()
 {
   // Create an iterator that will walk the input image
 
@@ -148,9 +145,9 @@ FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPixels()
   }
 }
 
-template <typename TImage, typename TFunction>
+template <typename TImage, typename TFunction, bool VIsConst>
 void
-FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::DoFloodStep()
+FloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::DoFloodStep()
 {
   // The index in the front of the queue should always be
   // valid and be inside since this is what the iterator
@@ -204,8 +201,6 @@ FloodFilledFunctionConditionalConstIterator<TImage, TFunction>::DoFloodStep()
     } // end left/right neighbor loop
   } // end check all neighbors
 
-  // Now that all the potential neighbors have been
-  // inserted we can get rid of the pixel in the front
   m_IndexStack.pop();
 
   if (m_IndexStack.empty())

--- a/Modules/Core/Common/include/itkFloodFilledImageFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkFloodFilledImageFunctionConditionalConstIterator.h
@@ -31,14 +31,14 @@ namespace itk
  *
  * \ingroup ITKCommon
  */
-template <typename TImage, typename TFunction>
-class ITK_TEMPLATE_EXPORT FloodFilledImageFunctionConditionalConstIterator
-  : public FloodFilledFunctionConditionalConstIterator<TImage, TFunction>
+template <typename TImage, typename TFunction, bool VIsConst>
+class ITK_TEMPLATE_EXPORT FloodFilledImageFunctionConditionalIteratorBase
+  : public FloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>
 {
 public:
   /** Standard class type aliases. */
-  using Self = FloodFilledImageFunctionConditionalConstIterator<TImage, TFunction>;
-  using Superclass = FloodFilledFunctionConditionalConstIterator<TImage, TFunction>;
+  using Self = FloodFilledImageFunctionConditionalIteratorBase;
+  using Superclass = FloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>;
 
   /** Type of function */
   using typename Superclass::FunctionType;
@@ -67,6 +67,8 @@ public:
   /** External Pixel Type */
   using typename Superclass::PixelType;
 
+  using typename Superclass::ImagePointer;
+
   /** Dimension of the image the iterator walks.  This constant is needed so
    * functions that are templated over image iterator type (as opposed to
    * being templated over pixel type and dimension) can have compile time
@@ -76,34 +78,50 @@ public:
   /** Constructor establishes an iterator to walk a particular image and a
    * particular region of that image. This version of the constructor uses
    * an explicit seed pixel for the flood fill, the "startIndex" */
-  FloodFilledImageFunctionConditionalConstIterator(const ImageType * imagePtr,
-                                                   FunctionType *    fnPtr,
-                                                   IndexType         startIndex)
+  FloodFilledImageFunctionConditionalIteratorBase(ImagePointer imagePtr, FunctionType * fnPtr, IndexType startIndex)
     : Superclass(imagePtr, fnPtr, startIndex)
   {}
 
   /** Constructor establishes an iterator to walk a particular image and a
    * particular region of that image. This version of the constructor uses
    * an explicit list of seed pixels for the flood fill, the "startIndex" */
-  FloodFilledImageFunctionConditionalConstIterator(const ImageType *        imagePtr,
-                                                   FunctionType *           fnPtr,
-                                                   std::vector<IndexType> & startIndex)
+  FloodFilledImageFunctionConditionalIteratorBase(ImagePointer             imagePtr,
+                                                  FunctionType *           fnPtr,
+                                                  std::vector<IndexType> & startIndex)
     : Superclass(imagePtr, fnPtr, startIndex)
   {}
 
   /** Constructor establishes an iterator to walk a particular image and a
    * particular region of that image. This version of the constructor
    * should be used when the seed pixel is unknown. */
-  FloodFilledImageFunctionConditionalConstIterator(const ImageType * imagePtr, FunctionType * fnPtr)
+  FloodFilledImageFunctionConditionalIteratorBase(ImagePointer imagePtr, FunctionType * fnPtr)
     : Superclass(imagePtr, fnPtr)
   {}
   /** Default Destructor. */
-  ~FloodFilledImageFunctionConditionalConstIterator() override = default;
+  ~FloodFilledImageFunctionConditionalIteratorBase() override = default;
+
+  /** Set the pixel value. SFINAE-gated on !VIsConst. */
+  template <bool VCopy = VIsConst, std::enable_if_t<!VCopy, int> = 0>
+  void
+  Set(const PixelType & value)
+  {
+    this->m_Image->GetPixel(this->m_IndexStack.front()) = value;
+  }
 
   /** Compute whether the index of interest should be included in the flood */
   bool
   IsPixelIncluded(const IndexType & index) const override;
 };
+
+template <typename TImage, typename TFunction>
+class ITK_TEMPLATE_EXPORT FloodFilledImageFunctionConditionalConstIterator
+  : public FloodFilledImageFunctionConditionalIteratorBase<TImage, TFunction, /*VIsConst=*/true>
+{
+public:
+  using Superclass = FloodFilledImageFunctionConditionalIteratorBase<TImage, TFunction, /*VIsConst=*/true>;
+  using Superclass::Superclass;
+};
+
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Core/Common/include/itkFloodFilledImageFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkFloodFilledImageFunctionConditionalConstIterator.hxx
@@ -21,9 +21,10 @@
 
 namespace itk
 {
-template <typename TImage, typename TFunction>
+template <typename TImage, typename TFunction, bool VIsConst>
 bool
-FloodFilledImageFunctionConditionalConstIterator<TImage, TFunction>::IsPixelIncluded(const IndexType & index) const
+FloodFilledImageFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::IsPixelIncluded(
+  const IndexType & index) const
 {
   return this->m_Function->EvaluateAtIndex(index);
 }

--- a/Modules/Core/Common/include/itkFloodFilledImageFunctionConditionalIterator.h
+++ b/Modules/Core/Common/include/itkFloodFilledImageFunctionConditionalIterator.h
@@ -35,87 +35,14 @@ namespace itk
  * \endsphinx
  */
 template <typename TImage, typename TFunction>
-class FloodFilledImageFunctionConditionalIterator
-  : public FloodFilledImageFunctionConditionalConstIterator<TImage, TFunction>
+class ITK_TEMPLATE_EXPORT FloodFilledImageFunctionConditionalIterator
+  : public FloodFilledImageFunctionConditionalIteratorBase<TImage, TFunction, /*VIsConst=*/false>
 {
 public:
-  /** Standard class type aliases. */
-  using Self = FloodFilledImageFunctionConditionalIterator;
-  using Superclass = FloodFilledImageFunctionConditionalConstIterator<TImage, TFunction>;
-
-  /** Type of function */
-  using typename Superclass::FunctionType;
-
-  /** Type of vector used to store location info in the spatial function */
-  using typename Superclass::FunctionInputType;
-
-  /** Index type alias support. */
-  using typename Superclass::IndexType;
-
-  /** Index ContainerType. */
-  using typename Superclass::SeedsContainerType;
-
-  /** Size type alias support. */
-  using typename Superclass::SizeType;
-
-  /** Region type alias support */
-  using typename Superclass::RegionType;
-
-  /** Image type alias support. */
-  using typename Superclass::ImageType;
-
-  /** Internal Pixel Type */
-  using typename Superclass::InternalPixelType;
-
-  /** External Pixel Type */
-  using typename Superclass::PixelType;
-
-  /** Dimension of the image the iterator walks.  This constant is needed so
-   * functions that are templated over image iterator type (as opposed to
-   * being templated over pixel type and dimension) can have compile time
-   * access to the dimension of the image that the iterator walks. */
-  static constexpr unsigned int NDimensions = Superclass::NDimensions;
-
-  /** Constructor establishes an iterator to walk a particular image and a
-   * particular region of that image. This version of the constructor uses
-   * an explicit seed pixel for the flood fill, the "startIndex" */
-  FloodFilledImageFunctionConditionalIterator(ImageType * imagePtr, FunctionType * fnPtr, IndexType startIndex)
-    : Superclass(imagePtr, fnPtr, startIndex)
-  {}
-
-  /** Constructor establishes an iterator to walk a particular image and a
-   * particular region of that image. This version of the constructor uses
-   * an explicit list of seed pixels for the flood fill, the "startIndex" */
-  FloodFilledImageFunctionConditionalIterator(ImageType *              imagePtr,
-                                              FunctionType *           fnPtr,
-                                              std::vector<IndexType> & startIndex)
-    : Superclass(imagePtr, fnPtr, startIndex)
-  {}
-
-  /** Constructor establishes an iterator to walk a particular image and a
-   * particular region of that image. This version of the constructor
-   * should be used when the seed pixel is unknown. */
-  FloodFilledImageFunctionConditionalIterator(ImageType * imagePtr, FunctionType * fnPtr)
-    : Superclass(imagePtr, fnPtr)
-  {}
-
-  /** Get the pixel value */
-  [[nodiscard]] const PixelType
-  Get() const override
-  {
-    return const_cast<ImageType *>(this->m_Image.GetPointer())->GetPixel(this->m_IndexStack.front());
-  }
-
-  /** Set the pixel value */
-  void
-  Set(const PixelType & value)
-  {
-    const_cast<ImageType *>(this->m_Image.GetPointer())->GetPixel(this->m_IndexStack.front()) = value;
-  }
-
-  /** Default Destructor. */
-  ~FloodFilledImageFunctionConditionalIterator() override = default;
+  using Superclass = FloodFilledImageFunctionConditionalIteratorBase<TImage, TFunction, /*VIsConst=*/false>;
+  using Superclass::Superclass;
 };
+
 } // end namespace itk
 
 #endif

--- a/Modules/Core/Common/include/itkFloodFilledSpatialFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkFloodFilledSpatialFunctionConditionalConstIterator.h
@@ -31,14 +31,14 @@ namespace itk
  *
  * \ingroup ITKCommon
  */
-template <typename TImage, typename TFunction>
-class ITK_TEMPLATE_EXPORT FloodFilledSpatialFunctionConditionalConstIterator
-  : public FloodFilledFunctionConditionalConstIterator<TImage, TFunction>
+template <typename TImage, typename TFunction, bool VIsConst>
+class ITK_TEMPLATE_EXPORT FloodFilledSpatialFunctionConditionalIteratorBase
+  : public FloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>
 {
 public:
   /** Standard class type aliases. */
-  using Self = FloodFilledSpatialFunctionConditionalConstIterator;
-  using Superclass = FloodFilledFunctionConditionalConstIterator<TImage, TFunction>;
+  using Self = FloodFilledSpatialFunctionConditionalIteratorBase;
+  using Superclass = FloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>;
 
   /** Type of function */
   using typename Superclass::FunctionType;
@@ -67,23 +67,31 @@ public:
   /** External Pixel Type */
   using typename Superclass::PixelType;
 
+  using typename Superclass::ImagePointer;
+
   /** Constructor establishes an iterator to walk a particular image and a
    * particular region of that image. This version of the constructor uses
    * an explicit seed pixel for the flood fill, the "startIndex" */
-  FloodFilledSpatialFunctionConditionalConstIterator(const ImageType * imagePtr,
-                                                     FunctionType *    fnPtr,
-                                                     IndexType         startIndex);
+  FloodFilledSpatialFunctionConditionalIteratorBase(ImagePointer imagePtr, FunctionType * fnPtr, IndexType startIndex);
 
   /** Constructor establishes an iterator to walk a particular image and a
    * particular region of that image. This version of the constructor
    * should be used when the seed pixel is unknown. */
-  FloodFilledSpatialFunctionConditionalConstIterator(const ImageType * imagePtr, FunctionType * fnPtr);
+  FloodFilledSpatialFunctionConditionalIteratorBase(ImagePointer imagePtr, FunctionType * fnPtr);
   /** Default Destructor. */
-  ~FloodFilledSpatialFunctionConditionalConstIterator() override = default;
+  ~FloodFilledSpatialFunctionConditionalIteratorBase() override = default;
 
   /** Compute whether the index of interest should be included in the flood */
   bool
   IsPixelIncluded(const IndexType & index) const override;
+
+  /** Set the pixel value. SFINAE-gated on !VIsConst. */
+  template <bool VCopy = VIsConst, std::enable_if_t<!VCopy, int> = 0>
+  void
+  Set(const PixelType & value)
+  {
+    this->m_Image->GetPixel(this->m_IndexStack.front()) = value;
+  }
 
   /** Set the inclusion strategy to origin */
   void
@@ -127,6 +135,16 @@ protected: // made protected so other iterators can access
 
   unsigned char m_InclusionStrategy{};
 };
+
+template <typename TImage, typename TFunction>
+class ITK_TEMPLATE_EXPORT FloodFilledSpatialFunctionConditionalConstIterator
+  : public FloodFilledSpatialFunctionConditionalIteratorBase<TImage, TFunction, /*VIsConst=*/true>
+{
+public:
+  using Superclass = FloodFilledSpatialFunctionConditionalIteratorBase<TImage, TFunction, /*VIsConst=*/true>;
+  using Superclass::Superclass;
+};
+
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Core/Common/include/itkFloodFilledSpatialFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkFloodFilledSpatialFunctionConditionalConstIterator.hxx
@@ -21,29 +21,28 @@
 
 namespace itk
 {
-template <typename TImage, typename TFunction>
-FloodFilledSpatialFunctionConditionalConstIterator<TImage, TFunction>::
-  FloodFilledSpatialFunctionConditionalConstIterator(const ImageType * imagePtr,
-                                                     FunctionType *    fnPtr,
-                                                     IndexType         startIndex)
+template <typename TImage, typename TFunction, bool VIsConst>
+FloodFilledSpatialFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::
+  FloodFilledSpatialFunctionConditionalIteratorBase(ImagePointer imagePtr, FunctionType * fnPtr, IndexType startIndex)
   : Superclass(imagePtr, fnPtr, startIndex)
 {
   // The default inclusion strategy is "center"
   this->SetCenterInclusionStrategy();
 }
 
-template <typename TImage, typename TFunction>
-FloodFilledSpatialFunctionConditionalConstIterator<TImage, TFunction>::
-  FloodFilledSpatialFunctionConditionalConstIterator(const ImageType * imagePtr, FunctionType * fnPtr)
+template <typename TImage, typename TFunction, bool VIsConst>
+FloodFilledSpatialFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::
+  FloodFilledSpatialFunctionConditionalIteratorBase(ImagePointer imagePtr, FunctionType * fnPtr)
   : Superclass(imagePtr, fnPtr)
 {
   // The default inclusion strategy is "center"
   this->SetCenterInclusionStrategy();
 }
 
-template <typename TImage, typename TFunction>
+template <typename TImage, typename TFunction, bool VIsConst>
 bool
-FloodFilledSpatialFunctionConditionalConstIterator<TImage, TFunction>::IsPixelIncluded(const IndexType & index) const
+FloodFilledSpatialFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::IsPixelIncluded(
+  const IndexType & index) const
 {
   // This temp var is used in all cases
   FunctionInputType position;

--- a/Modules/Core/Common/include/itkFloodFilledSpatialFunctionConditionalIterator.h
+++ b/Modules/Core/Common/include/itkFloodFilledSpatialFunctionConditionalIterator.h
@@ -32,79 +32,14 @@ namespace itk
  * \ingroup ITKCommon
  */
 template <typename TImage, typename TFunction>
-class FloodFilledSpatialFunctionConditionalIterator
-  : public FloodFilledSpatialFunctionConditionalConstIterator<TImage, TFunction>
+class ITK_TEMPLATE_EXPORT FloodFilledSpatialFunctionConditionalIterator
+  : public FloodFilledSpatialFunctionConditionalIteratorBase<TImage, TFunction, /*VIsConst=*/false>
 {
 public:
-  /** Standard class type aliases. */
-  using Self = FloodFilledSpatialFunctionConditionalIterator;
-  using Superclass = FloodFilledSpatialFunctionConditionalConstIterator<TImage, TFunction>;
-
-  /** Type of function */
-  using typename Superclass::FunctionType;
-
-  /** Type of vector used to store location info in the spatial function */
-  using typename Superclass::FunctionInputType;
-
-  /** Index type alias support */
-  using typename Superclass::IndexType;
-
-  /** Index ContainerType. */
-  using typename Superclass::SeedsContainerType;
-
-  /** Size type alias support */
-  using typename Superclass::SizeType;
-
-  /** Region type alias support */
-  using typename Superclass::RegionType;
-
-  /** Image type alias support */
-  using typename Superclass::ImageType;
-
-  /** Internal Pixel Type */
-  using typename Superclass::InternalPixelType;
-
-  /** External Pixel Type */
-  using typename Superclass::PixelType;
-
-  /** Constructor establishes an iterator to walk a particular image and a
-   * particular region of that image. This version of the constructor uses
-   * an explicit seed pixel for the flood fill, the "startIndex" */
-  FloodFilledSpatialFunctionConditionalIterator(ImageType * imagePtr, FunctionType * fnPtr, IndexType startIndex)
-    : Superclass(imagePtr, fnPtr, startIndex)
-  {}
-
-  /** Constructor establishes an iterator to walk a particular image and a
-   * particular region of that image. This version of the constructor
-   * should be used when the seed pixel is unknown. */
-  FloodFilledSpatialFunctionConditionalIterator(ImageType * imagePtr, FunctionType * fnPtr)
-    : Superclass(imagePtr, fnPtr)
-  {}
-
-  /** Get the pixel value, const version to avoid overload warnings */
-  [[nodiscard]] const PixelType
-  Get() const override
-  {
-    return const_cast<ImageType *>(this->m_Image.GetPointer())->GetPixel(this->m_IndexStack.front());
-  }
-
-  /** Get the pixel value, non-const version is sometimes useful. */
-  PixelType
-  Get()
-  {
-    return const_cast<ImageType *>(this->m_Image.GetPointer())->GetPixel(this->m_IndexStack.front());
-  }
-
-  /** Set the pixel value */
-  void
-  Set(const PixelType & value)
-  {
-    const_cast<ImageType *>(this->m_Image.GetPointer())->GetPixel(this->m_IndexStack.front()) = value;
-  }
-
-  /** Default Destructor. */
-  ~FloodFilledSpatialFunctionConditionalIterator() override = default;
+  using Superclass = FloodFilledSpatialFunctionConditionalIteratorBase<TImage, TFunction, /*VIsConst=*/false>;
+  using Superclass::Superclass;
 };
+
 } // end namespace itk
 
 #endif

--- a/Modules/Core/Common/include/itkImageBoundaryCondition.h
+++ b/Modules/Core/Common/include/itkImageBoundaryCondition.h
@@ -72,6 +72,13 @@ public:
   /** Type of the data container passed to this function object. */
   using NeighborhoodType = Neighborhood<PixelPointerType, ImageDimension>;
 
+  /** Const-pointer-element variant of NeighborhoodType.
+   * The pointer-constness-polymorphic NeighborhoodIteratorBase (VIsConst=true)
+   * inherits from this neighborhood; boundary conditions called from that path
+   * dispatch through the ConstNeighborhoodType overloads below. */
+  using ConstPixelPointerType = const typename TInputImage::InternalPixelType *;
+  using ConstNeighborhoodType = Neighborhood<ConstPixelPointerType, ImageDimension>;
+
   /** Functor used to access pixels from a neighborhood of pixel pointers */
   using NeighborhoodAccessorFunctorType = typename TInputImage::NeighborhoodAccessorFunctorType;
 
@@ -104,6 +111,34 @@ public:
              const OffsetType &                      boundary_offset,
              const NeighborhoodType *                data,
              const NeighborhoodAccessorFunctorType & neighborhoodAccessorFunctor) const = 0;
+
+  /** Const-pointer-element overloads used by the N+1 pointer-constness-
+   * polymorphic NeighborhoodIteratorBase (VIsConst=true). These are NOT pure:
+   * existing subclasses that only override the legacy (non-const pointer
+   * element) overloads keep working — the default body bridges via
+   * reinterpret_cast, which is safe because
+   *   Neighborhood<T*, Dim>   and
+   *   Neighborhood<const T*, Dim>
+   * have byte-identical layout (both store std::vector<pointer> of the same
+   * element size). Subclasses may override these for performance but are
+   * not required to. */
+  virtual OutputPixelType
+  operator()(const OffsetType &            point_index,
+             const OffsetType &            boundary_offset,
+             const ConstNeighborhoodType * data) const
+  {
+    return this->operator()(point_index, boundary_offset, reinterpret_cast<const NeighborhoodType *>(data));
+  }
+
+  virtual OutputPixelType
+  operator()(const OffsetType &                      point_index,
+             const OffsetType &                      boundary_offset,
+             const ConstNeighborhoodType *           data,
+             const NeighborhoodAccessorFunctorType & neighborhoodAccessorFunctor) const
+  {
+    return this->operator()(
+      point_index, boundary_offset, reinterpret_cast<const NeighborhoodType *>(data), neighborhoodAccessorFunctor);
+  }
 
   virtual ~ImageBoundaryCondition() = default;
 

--- a/Modules/Core/Common/include/itkImageConstIterator.h
+++ b/Modules/Core/Common/include/itkImageConstIterator.h
@@ -21,34 +21,33 @@
 #include "itkImage.h"
 #include "itkIndex.h"
 #include "itkNumericTraits.h"
-#include <type_traits> // For remove_const_t.
+#include "itkWeakPointer.h"
+#include <type_traits> // For conditional_t, enable_if_t, remove_const_t.
 
 namespace itk
 {
-/** \class ImageConstIterator
- * \brief A multi-dimensional image iterator templated over image type.
+// Forward declaration so that the ImageIteratorBase converting
+// constructor can refer to the non-const specialization.
+template <typename TImage, bool VIsConst>
+class ImageIteratorBase;
+
+/** \class ImageIteratorBase
+ * \brief Unified templated base for ImageIterator and ImageConstIterator.
  *
- * ImageConstIterator is a templated class to represent a multi-dimensional
- * iterator. ImageConstIterator is templated over the type of
- * the image to be iterated over.
+ * ImageIteratorBase collapses the legacy pair of classes
+ * ImageConstIterator<TImage> and ImageIterator<TImage> into a single class
+ * template parameterized on a compile-time `bool VIsConst` flag. Pointer-like
+ * members (m_Image, m_Buffer) flip their element-const qualifier via
+ * std::conditional_t so that the non-const specialization (VIsConst=false)
+ * no longer needs const_cast to implement Set() / non-const Value().
  *
- * ImageConstIterator is a base class for all the image iterators. It provides
- * the basic construction and comparison operations.  However, it does not
- * provide mechanisms for moving the iterator.  A subclass of ImageConstIterator
- * must be used to move the iterator.
+ * The legacy names `ImageConstIterator` and `ImageIterator` are preserved as
+ * alias templates (see the bottom of this header and itkImageIterator.h),
+ * so existing consumers compile unchanged.
  *
- * ImageConstIterator is a multi-dimensional iterator, requiring more information
- * be specified before the iterator can be used than conventional iterators.
- * Whereas the std::vector::iterator from the STL only needs to be passed
- * a pointer to establish the iterator, the multi-dimensional image iterator
- * needs a pointer, the size of the buffer, the size of the region, the
- * start index of the buffer, and the start index of the region. To gain
- * access to this information, ImageConstIterator holds a reference to the image
- * over which it is traversing.
- *
- * ImageConstIterator assumes a particular layout of the image data. In particular,
- * the data is arranged in a 1D array as if it were [][][][slice][row][col]
- * with Index[0] = col, Index[1] = row, Index[2] = slice, etc.
+ * Non-const -> const implicit conversion is provided via a converting
+ * constructor; the reverse is disabled by construction (no const_cast
+ * escape hatch at this layer).
  *
  * \par MORE INFORMATION
  * For a complete description of the ITK Image Iterators and their API, please
@@ -57,44 +56,24 @@ namespace itk
  *
  * \ingroup ImageIterators
  *
- * \sa ImageConstIterator \sa ConditionalConstIterator
- * \sa ConstNeighborhoodIterator \sa ConstShapedNeighborhoodIterator
- * \sa ConstSliceIterator  \sa CorrespondenceDataStructureIterator
- * \sa FloodFilledFunctionConditionalConstIterator
- * \sa FloodFilledImageFunctionConditionalConstIterator
- * \sa FloodFilledImageFunctionConditionalIterator
- * \sa FloodFilledSpatialFunctionConditionalConstIterator
- * \sa FloodFilledSpatialFunctionConditionalIterator
- * \sa ImageConstIterator \sa ImageConstIteratorWithIndex
- * \sa ImageIterator \sa ImageIteratorWithIndex
- * \sa ImageLinearConstIteratorWithIndex  \sa ImageLinearIteratorWithIndex
- * \sa ImageRandomConstIteratorWithIndex  \sa ImageRandomIteratorWithIndex
- * \sa ImageRegionConstIterator \sa ImageRegionConstIteratorWithIndex
- * \sa ImageRegionExclusionConstIteratorWithIndex
- * \sa ImageRegionExclusionIteratorWithIndex
- * \sa ImageRegionIterator  \sa ImageRegionIteratorWithIndex
- * \sa ImageRegionReverseConstIterator  \sa ImageRegionReverseIterator
- * \sa ImageReverseConstIterator  \sa ImageReverseIterator
- * \sa ImageSliceConstIteratorWithIndex  \sa ImageSliceIteratorWithIndex
- * \sa NeighborhoodIterator \sa PathConstIterator  \sa PathIterator
- * \sa ShapedNeighborhoodIterator  \sa SliceIterator
+ * \sa ImageConstIterator \sa ImageIterator
  * \ingroup ITKCommon
  */
-template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageConstIterator
+template <typename TImage, bool VIsConst>
+class ITK_TEMPLATE_EXPORT ImageIteratorBase
 {
 public:
-  /** Standard class type aliases. */
-  using Self = ImageConstIterator;
+  /** Compile-time constness flag. */
+  static constexpr bool IsConst = VIsConst;
 
-  /** Dimension of the image the iterator walks.  This constant is needed so
-   * functions that are templated over image iterator type (as opposed to
-   * being templated over pixel type and dimension) can have compile time
-   * access to the dimension of the image that the iterator walks. */
+  /** Standard class type aliases. */
+  using Self = ImageIteratorBase;
+
+  /** Dimension of the image the iterator walks. */
   static constexpr unsigned int ImageIteratorDimension = TImage::ImageDimension;
 
   /** \see LightObject::GetNameOfClass() */
-  itkVirtualGetNameOfClassMacro(ImageConstIterator);
+  itkVirtualGetNameOfClassMacro(ImageIteratorBase);
 
   /** Index type alias support */
   using IndexType = typename TImage::IndexType;
@@ -111,9 +90,7 @@ public:
   /** Image type alias support */
   using ImageType = TImage;
 
-  /** PixelContainer type alias support. Used to refer to the container for
-   * the pixel data. While this was already typedef'ed in the superclass
-   * it needs to be redone here for this subclass to compile properly with gcc. */
+  /** PixelContainer type alias support. */
   using PixelContainer = typename TImage::PixelContainer;
   using PixelContainerPointer = typename PixelContainer::Pointer;
 
@@ -128,9 +105,22 @@ public:
   using AccessorType = typename TImage::AccessorType;
   using AccessorFunctorType = typename TImage::AccessorFunctorType;
 
-  /** Default Constructor. Need to provide a default constructor since we
-   * provide a copy constructor. */
-  ImageConstIterator()
+  /** Pointer-to-internal-pixel type that flips const based on VIsConst.
+   * The non-const specialization carries a mutable pointer; no const_cast
+   * is required to implement Set() / non-const Value(). */
+  using InternalPixelPointer = std::conditional_t<VIsConst, const InternalPixelType *, InternalPixelType *>;
+
+  /** Weak pointer to the image. The const specialization uses
+   * ConstWeakPointer (WeakPointer<const TImage>) while the non-const
+   * specialization uses WeakPointer<TImage> so that GetImage() can
+   * return a non-const pointer without any const_cast. */
+  using ImageWeakPointer = std::conditional_t<VIsConst, typename TImage::ConstWeakPointer, WeakPointer<TImage>>;
+
+  /** Raw image pointer type returned by GetImage(). */
+  using ImagePointer = std::conditional_t<VIsConst, const TImage *, TImage *>;
+
+  /** Default Constructor. */
+  ImageIteratorBase()
     : m_Image(nullptr)
     , m_Region()
     , m_Buffer(nullptr)
@@ -141,11 +131,10 @@ public:
   }
 
   /** Default Destructor. */
-  virtual ~ImageConstIterator() = default;
+  virtual ~ImageIteratorBase() = default;
 
-  /** Copy Constructor. The copy constructor is provided to make sure the
-   * handle to the image is properly reference counted. */
-  ImageConstIterator(const Self & it)
+  /** Copy Constructor. */
+  ImageIteratorBase(const Self & it)
     : m_Image(it.m_Image)
     , m_Region(it.m_Region)
     , m_Offset(it.m_Offset)
@@ -155,23 +144,36 @@ public:
     , m_PixelAccessor(it.m_PixelAccessor)
     , m_PixelAccessorFunctor(it.m_PixelAccessorFunctor)
   {
-    // copy the smart pointer
+    m_PixelAccessorFunctor.SetBegin(m_Buffer);
+  }
 
-
+  /** Converting constructor: non-const -> const.
+   * Only enabled when VIsConst==true and the source is the non-const
+   * sibling specialization. The reverse (const -> non-const) is not
+   * provided, so it is a compile error by construction. */
+  template <bool VOtherConst, typename = std::enable_if_t<VIsConst && !VOtherConst>>
+  ImageIteratorBase(const ImageIteratorBase<TImage, VOtherConst> & it)
+    : m_Image(it.m_Image)
+    , m_Region(it.m_Region)
+    , m_Offset(it.m_Offset)
+    , m_BeginOffset(it.m_BeginOffset)
+    , m_EndOffset(it.m_EndOffset)
+    , m_Buffer(it.m_Buffer)
+    , m_PixelAccessor(it.m_PixelAccessor)
+    , m_PixelAccessorFunctor(it.m_PixelAccessorFunctor)
+  {
     m_PixelAccessorFunctor.SetBegin(m_Buffer);
   }
 
   /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes
-   * the iterator at the begin of the region. */
-  ImageConstIterator(const TImage * ptr, const RegionType & region)
+   * the iterator at the begin of the region. The pointer parameter flips
+   * const based on VIsConst. */
+  ImageIteratorBase(ImagePointer ptr, const RegionType & region)
     : m_Image(ptr)
-    , m_Buffer(m_Image->GetBufferPointer())
+    , m_Buffer(ptr->GetBufferPointer())
     , m_PixelAccessor(ptr->GetPixelAccessor())
   {
-
-
     SetRegion(region);
-
 
     m_PixelAccessorFunctor.SetPixelAccessor(m_PixelAccessor);
     m_PixelAccessorFunctor.SetBegin(m_Buffer);
@@ -215,15 +217,11 @@ public:
     m_Offset = m_Image->ComputeOffset(m_Region.GetIndex());
     m_BeginOffset = m_Offset;
 
-    // Compute the end offset. If any component of m_Region.GetSize()
-    // is zero, the region is not valid and we set the EndOffset
-    // to be same as BeginOffset so that iterator end condition is met
-    // immediately.
+    // Compute the end offset.
     IndexType ind(m_Region.GetIndex());
     SizeType  size(m_Region.GetSize());
     if (m_Region.GetNumberOfPixels() == 0)
     {
-      // region is empty, probably has a size of 0 along one dimension
       m_EndOffset = m_BeginOffset;
     }
     else
@@ -244,59 +242,40 @@ public:
     return TImage::ImageDimension;
   }
 
-  /** Comparison operator. Two iterators are the same if they "point to" the
-   * same memory location */
+  /** Comparison operators. */
   bool
   operator==(const Self & it) const
   {
-    // two iterators are the same if they "point to" the same memory location
     return (m_Buffer + m_Offset) == (it.m_Buffer + it.m_Offset);
   }
 
   ITK_UNEQUAL_OPERATOR_MEMBER_FUNCTION(Self);
 
-  /** Comparison operator. An iterator is "less than" another if it "points to"
-   * a lower memory location. */
   bool
   operator<=(const Self & it) const
   {
-    // an iterator is "less than" another if it "points to" a lower
-    // memory location
     return (m_Buffer + m_Offset) <= (it.m_Buffer + it.m_Offset);
   }
 
-  /** Comparison operator. An iterator is "less than" another if it "points to"
-   * a lower memory location. */
   bool
   operator<(const Self & it) const
   {
-    // an iterator is "less than" another if it "points to" a lower
-    // memory location
     return (m_Buffer + m_Offset) < (it.m_Buffer + it.m_Offset);
   }
 
-  /** Comparison operator. An iterator is "greater than" another if it
-   * "points to" a higher location. */
   bool
   operator>=(const Self & it) const
   {
-    // an iterator is "greater than" another if it "points to" a higher
-    // memory location
     return (m_Buffer + m_Offset) >= (it.m_Buffer + it.m_Offset);
   }
 
-  /** Comparison operator. An iterator is "greater than" another if it
-   * "points to" a higher location. */
   bool
   operator>(const Self & it) const
   {
-    // an iterator is "greater than" another if it "points to" a higher
-    // memory location
     return (m_Buffer + m_Offset) > (it.m_Buffer + it.m_Offset);
   }
 
-  /** Computes the index. Internally calls ImageBase::ComputeIndex, which may be a relatively expensive operation.
-   * \sa SetIndex */
+  /** Computes the index. Internally calls ImageBase::ComputeIndex. */
   [[nodiscard]] IndexType
   ComputeIndex() const
   {
@@ -304,8 +283,7 @@ public:
   }
 
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-  /** Computes and returns the index. This may be a relatively expensive operation.
-   * \deprecated Please use `ComputeIndex()` instead, or use an iterator with index, like `ImageIteratorWithIndex`! */
+  /** Computes and returns the index. Deprecated. */
   ITK_FUTURE_DEPRECATED(
     "Please use `ComputeIndex()` instead, or use an iterator with index, like `ImageIteratorWithIndex`!")
   [[nodiscard]] IndexType
@@ -315,79 +293,99 @@ public:
   }
 #endif
 
-  /** Set the index. No bounds checking is performed.
-   * \sa GetIndex */
+  /** Set the index. No bounds checking is performed. */
   virtual void
   SetIndex(const IndexType & ind)
   {
     m_Offset = m_Image->ComputeOffset(ind);
   }
 
-  /** Get the region that this iterator walks. ImageConstIterators know the
-   * beginning and the end of the region of the image to iterate over. */
+  /** Get the region that this iterator walks. */
   [[nodiscard]] const RegionType &
   GetRegion() const
   {
     return m_Region;
   }
 
-  /** Get the image that this iterator walks. */
-  [[nodiscard]] const ImageType *
+  /** Get the image that this iterator walks.
+   * Always callable; returns a pointer-to-const for the const
+   * specialization and a non-const pointer for the mutating
+   * specialization. */
+  [[nodiscard]] ImagePointer
   GetImage() const
   {
     return m_Image.GetPointer();
   }
 
-  /** Get the pixel value */
+  /** Get the pixel value. */
   [[nodiscard]] PixelType
   Get() const
   {
     return m_PixelAccessorFunctor.Get(*(m_Buffer + m_Offset));
   }
 
-  /** Return a const reference to the pixel
-   * This method will provide the fastest access to pixel
-   * data, but it will NOT support ImageAdaptors. */
+  /** Return a const reference to the pixel. Available in both
+   * specializations. */
   [[nodiscard]] const PixelType &
   Value() const
   {
     return *(m_Buffer + m_Offset);
   }
 
-  /** Move an iterator to the beginning of the region. "Begin" is
-   * defined as the first pixel in the region. */
+  /** Return a mutable reference to the pixel. SFINAE-gated on
+   * !VIsConst. No const_cast is needed because m_Buffer itself
+   * is a non-const pointer in the non-const specialization. */
+  template <bool VCopy = VIsConst, std::enable_if_t<!VCopy, int> = 0>
+  PixelType &
+  Value()
+  {
+    return *(m_Buffer + m_Offset);
+  }
+
+  /** Set the pixel value. SFINAE-gated on !VIsConst. */
+  template <bool VCopy = VIsConst, std::enable_if_t<!VCopy, int> = 0>
+  void
+  Set(const PixelType & value) const
+  {
+    this->m_PixelAccessorFunctor.Set(*(m_Buffer + m_Offset), value);
+  }
+
+  /** Move an iterator to the beginning of the region. */
   void
   GoToBegin()
   {
     m_Offset = m_BeginOffset;
   }
 
-  /** Move an iterator to the end of the region. "End" is defined as
-   * one pixel past the last pixel of the region. */
+  /** Move an iterator to the end of the region. */
   void
   GoToEnd()
   {
     m_Offset = m_EndOffset;
   }
 
-  /** Is the iterator at the beginning of the region? "Begin" is defined
-   * as the first pixel in the region. */
+  /** Is the iterator at the beginning of the region? */
   [[nodiscard]] bool
   IsAtBegin() const
   {
     return m_Offset == m_BeginOffset;
   }
 
-  /** Is the iterator at the end of the region? "End" is defined as one
-   * pixel past the last pixel of the region. */
+  /** Is the iterator at the end of the region? */
   [[nodiscard]] bool
   IsAtEnd() const
   {
     return m_Offset == m_EndOffset;
   }
 
+  // Grant the sibling specialization access to private/protected members
+  // so the non-const -> const converting constructor can initialize from
+  // the non-const source.
+  template <typename, bool>
+  friend class ImageIteratorBase;
+
 protected: // made protected so other iterators can access
-  typename TImage::ConstWeakPointer m_Image{};
+  ImageWeakPointer m_Image{};
 
   RegionType m_Region{}; // region to iterate over
 
@@ -395,16 +393,54 @@ protected: // made protected so other iterators can access
   OffsetValueType m_BeginOffset{}; // offset to first pixel in region
   OffsetValueType m_EndOffset{};   // offset to one pixel past last pixel in region
 
-  const InternalPixelType * m_Buffer{};
+  InternalPixelPointer m_Buffer{};
 
   AccessorType        m_PixelAccessor{};
   AccessorFunctorType m_PixelAccessorFunctor{};
 };
 
-// Deduction guide for class template argument deduction (CTAD).
+/** \class ImageConstIterator
+ * \brief A multi-dimensional image iterator templated over image type.
+ *
+ * ImageConstIterator is preserved as an alias template over
+ * ImageIteratorBase<TImage, /\*VIsConst=*\/true> so existing consumers
+ * compile unchanged.
+ *
+ * \ingroup ImageIterators
+ * \ingroup ITKCommon
+ */
+template <typename TImage>
+class ITK_TEMPLATE_EXPORT ImageConstIterator : public ImageIteratorBase<TImage, /*VIsConst=*/true>
+{
+public:
+  using Superclass = ImageIteratorBase<TImage, /*VIsConst=*/true>;
+  using Superclass::Superclass;
+};
+
 template <typename TImage>
 ImageConstIterator(SmartPointer<TImage>, const typename TImage::RegionType &)
   -> ImageConstIterator<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageConstIterator(TImage *, const typename TImage::RegionType &) -> ImageConstIterator<TImage>;
+
+template <typename TImage>
+ImageConstIterator(const TImage *, const typename TImage::RegionType &) -> ImageConstIterator<TImage>;
+
+// Deduction guide for class template argument deduction (CTAD).
+// When the user writes `ImageConstIterator(ptr, region)` or
+// `ImageIterator(ptr, region)`, alias-template CTAD (P1814,
+// supported by Clang as a C++17 extension) synthesizes a guide for
+// each alias by adapting this class-template guide; adaptations
+// whose returned target does not match the alias's VIsConst pin
+// are silently discarded. Because `std::is_const_v<TImage>` in the
+// returned type is a *dependent* expression (not a fixed bool), the
+// synthesis step leaves it as deducible and both alias specializations
+// can adapt it successfully (ImageConstIterator pins true,
+// ImageIterator pins false).
+template <typename TImage, bool VIsConst = std::is_const_v<TImage>>
+ImageIteratorBase(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageIteratorBase<std::remove_const_t<TImage>, VIsConst>;
 
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithIndex.h
@@ -20,11 +20,15 @@
 
 #include "itkIndex.h"
 #include "itkImage.h"
+#include "itkWeakPointer.h"
 #include <memory>
-#include <type_traits> // For remove_const_t.
+#include <type_traits> // For conditional_t, enable_if_t, remove_const_t.
 
 namespace itk
 {
+template <typename TImage, bool VIsConst>
+class ImageIteratorWithIndexBase;
+
 /** \class ImageConstIteratorWithIndex
  * \brief A base class for multi-dimensional iterators templated over image
  * type that are designed to efficiently keep track of the iterator
@@ -89,12 +93,12 @@ namespace itk
  * \ingroup ImageIterators
  * \ingroup ITKCommon
  */
-template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageConstIteratorWithIndex
+template <typename TImage, bool VIsConst>
+class ITK_TEMPLATE_EXPORT ImageIteratorWithIndexBase
 {
 public:
   /** Standard class type aliases. */
-  using Self = ImageConstIteratorWithIndex;
+  using Self = ImageIteratorWithIndexBase;
 
   /** Dimension of the image that the iterator walks.  This constant is needed so
    * functions that are templated over image iterator type (as opposed to
@@ -137,20 +141,46 @@ public:
   using OffsetType = typename TImage::OffsetType;
   using OffsetValueType = typename OffsetType::OffsetValueType;
 
+  using InternalPixelPointer = std::conditional_t<VIsConst, const InternalPixelType *, InternalPixelType *>;
+  using ImageWeakPointer = std::conditional_t<VIsConst, typename TImage::ConstWeakPointer, WeakPointer<TImage>>;
+  using ImagePointer = std::conditional_t<VIsConst, const TImage *, TImage *>;
+
   /** Default Constructor. Need to provide a default constructor since we
    * provide a copy constructor. */
-  ImageConstIteratorWithIndex() = default;
+  ImageIteratorWithIndexBase() = default;
 
   /** Copy Constructor. The copy constructor is provided to make sure the
    * handle to the image is properly reference counted. */
-  ImageConstIteratorWithIndex(const Self & it);
+  ImageIteratorWithIndexBase(const Self & it);
+
+  /** Converting constructor: non-const -> const. */
+  template <bool VOtherConst, typename = std::enable_if_t<VIsConst && !VOtherConst>>
+  ImageIteratorWithIndexBase(const ImageIteratorWithIndexBase<TImage, VOtherConst> & it)
+    : m_Image(it.m_Image)
+    , m_PositionIndex(it.m_PositionIndex)
+    , m_BeginIndex(it.m_BeginIndex)
+    , m_EndIndex(it.m_EndIndex)
+    , m_Region(it.m_Region)
+    , m_Position(it.m_Position)
+    , m_Begin(it.m_Begin)
+    , m_End(it.m_End)
+    , m_Remaining(it.m_Remaining)
+    , m_PixelAccessor(it.m_PixelAccessor)
+    , m_PixelAccessorFunctor(it.m_PixelAccessorFunctor)
+  {
+    std::copy_n(it.m_OffsetTable, ImageDimension + 1, m_OffsetTable);
+    if (m_Image)
+    {
+      m_PixelAccessorFunctor.SetBegin(m_Image->GetBufferPointer());
+    }
+  }
 
   /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes
    * the iterator at the begin of the region. */
-  ImageConstIteratorWithIndex(const TImage * ptr, const RegionType & region);
+  ImageIteratorWithIndexBase(ImagePointer ptr, const RegionType & region);
 
   /** Default Destructor. */
-  virtual ~ImageConstIteratorWithIndex() = default;
+  virtual ~ImageIteratorWithIndexBase() = default;
 
   /** operator= is provided to make sure the handle to the image is properly
    * reference counted. */
@@ -256,6 +286,22 @@ public:
     return *m_Position;
   }
 
+  /** Return a mutable reference to the pixel. SFINAE-gated on !VIsConst. */
+  template <bool VCopy = VIsConst, std::enable_if_t<!VCopy, int> = 0>
+  PixelType &
+  Value()
+  {
+    return *m_Position;
+  }
+
+  /** Set the pixel value. SFINAE-gated on !VIsConst. */
+  template <bool VCopy = VIsConst, std::enable_if_t<!VCopy, int> = 0>
+  void
+  Set(const PixelType & value) const
+  {
+    this->m_PixelAccessorFunctor.Set(*m_Position, value);
+  }
+
   /** Move an iterator to the beginning of the region. */
   void
   GoToBegin();
@@ -285,8 +331,11 @@ public:
     return m_Remaining;
   }
 
+  template <typename, bool>
+  friend class ImageIteratorWithIndexBase;
+
 protected: // made protected so other iterators can access
-  typename TImage::ConstWeakPointer m_Image{};
+  ImageWeakPointer m_Image{};
 
   IndexType m_PositionIndex{ { 0 } }; // Index where we currently are
   IndexType m_BeginIndex{ { 0 } };    // Index to start iterating over
@@ -298,9 +347,9 @@ protected: // made protected so other iterators can access
 
   OffsetValueType m_OffsetTable[ImageDimension + 1]{};
 
-  const InternalPixelType * m_Position{ nullptr };
-  const InternalPixelType * m_Begin{ nullptr };
-  const InternalPixelType * m_End{ nullptr };
+  InternalPixelPointer m_Position{ nullptr };
+  InternalPixelPointer m_Begin{ nullptr };
+  InternalPixelPointer m_End{ nullptr };
 
   bool m_Remaining{ false };
 
@@ -308,10 +357,36 @@ protected: // made protected so other iterators can access
   AccessorFunctorType m_PixelAccessorFunctor{};
 };
 
-// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage>
+class ITK_TEMPLATE_EXPORT ImageConstIteratorWithIndex : public ImageIteratorWithIndexBase<TImage, /*VIsConst=*/true>
+{
+public:
+  using Superclass = ImageIteratorWithIndexBase<TImage, /*VIsConst=*/true>;
+  using Superclass::Superclass;
+};
+
 template <typename TImage>
 ImageConstIteratorWithIndex(SmartPointer<TImage>, const typename TImage::RegionType &)
   -> ImageConstIteratorWithIndex<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageConstIteratorWithIndex(TImage *, const typename TImage::RegionType &) -> ImageConstIteratorWithIndex<TImage>;
+
+template <typename TImage>
+ImageConstIteratorWithIndex(const TImage *, const typename TImage::RegionType &) -> ImageConstIteratorWithIndex<TImage>;
+
+// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage, bool VIsConst = std::is_const_v<TImage>>
+ImageIteratorWithIndexBase(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageIteratorWithIndexBase<std::remove_const_t<TImage>, VIsConst>;
+
+template <typename TImage>
+ImageIteratorWithIndexBase(TImage *, const typename TImage::RegionType &)
+  -> ImageIteratorWithIndexBase<TImage, /*VIsConst=*/false>;
+
+template <typename TImage>
+ImageIteratorWithIndexBase(const TImage *, const typename TImage::RegionType &)
+  -> ImageIteratorWithIndexBase<TImage, /*VIsConst=*/true>;
 
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageConstIteratorWithIndex.hxx
@@ -24,8 +24,8 @@ namespace itk
 //----------------------------------------------------------------------
 //  Constructor
 //----------------------------------------------------------------------
-template <typename TImage>
-ImageConstIteratorWithIndex<TImage>::ImageConstIteratorWithIndex(const Self & it)
+template <typename TImage, bool VIsConst>
+ImageIteratorWithIndexBase<TImage, VIsConst>::ImageIteratorWithIndexBase(const Self & it)
   : m_Image(it.m_Image) // copy the smart pointer
   , m_PositionIndex(it.m_PositionIndex)
   , m_BeginIndex(it.m_BeginIndex)
@@ -46,14 +46,14 @@ ImageConstIteratorWithIndex<TImage>::ImageConstIteratorWithIndex(const Self & it
 //----------------------------------------------------------------------
 //  Constructor
 //----------------------------------------------------------------------
-template <typename TImage>
-ImageConstIteratorWithIndex<TImage>::ImageConstIteratorWithIndex(const TImage * ptr, const RegionType & region)
+template <typename TImage, bool VIsConst>
+ImageIteratorWithIndexBase<TImage, VIsConst>::ImageIteratorWithIndexBase(ImagePointer ptr, const RegionType & region)
   : m_Image(ptr)
   , m_BeginIndex(region.GetIndex())
   , m_Region(region)
   , m_Remaining(region.GetNumberOfPixels() > 0)
 {
-  const InternalPixelType * buffer = m_Image->GetBufferPointer();
+  InternalPixelPointer buffer = m_Image->GetBufferPointer();
   m_PositionIndex = m_BeginIndex;
   if (region.GetNumberOfPixels() > 0) // If region is non-empty
   {
@@ -87,9 +87,9 @@ ImageConstIteratorWithIndex<TImage>::ImageConstIteratorWithIndex(const TImage * 
 //----------------------------------------------------------------------
 //    Assignment Operator
 //----------------------------------------------------------------------
-template <typename TImage>
-ImageConstIteratorWithIndex<TImage> &
-ImageConstIteratorWithIndex<TImage>::operator=(const Self & it)
+template <typename TImage, bool VIsConst>
+ImageIteratorWithIndexBase<TImage, VIsConst> &
+ImageIteratorWithIndexBase<TImage, VIsConst>::operator=(const Self & it)
 {
   if (this != &it)
   {
@@ -117,9 +117,9 @@ ImageConstIteratorWithIndex<TImage>::operator=(const Self & it)
 //----------------------------------------------------------------------------
 // GoToBegin() is the first pixel in the region.
 //----------------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageConstIteratorWithIndex<TImage>::GoToBegin()
+ImageIteratorWithIndexBase<TImage, VIsConst>::GoToBegin()
 {
   // Set the position at begin
 
@@ -132,9 +132,9 @@ ImageConstIteratorWithIndex<TImage>::GoToBegin()
 //----------------------------------------------------------------------------
 // GoToReverseBegin() is the last pixel in the region.
 //----------------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageConstIteratorWithIndex<TImage>::GoToReverseBegin()
+ImageIteratorWithIndexBase<TImage, VIsConst>::GoToReverseBegin()
 {
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
@@ -144,8 +144,8 @@ ImageConstIteratorWithIndex<TImage>::GoToReverseBegin()
   m_Remaining = m_Region.GetNumberOfPixels() > 0;
 
   // Set the position at the end
-  const InternalPixelType * buffer = m_Image->GetBufferPointer();
-  const OffsetValueType     offset = m_Image->ComputeOffset(m_PositionIndex);
+  InternalPixelPointer  buffer = m_Image->GetBufferPointer();
+  const OffsetValueType offset = m_Image->ComputeOffset(m_PositionIndex);
   m_Position = buffer + offset;
 }
 

--- a/Modules/Core/Common/include/itkImageIterator.h
+++ b/Modules/Core/Common/include/itkImageIterator.h
@@ -26,129 +26,38 @@ namespace itk
  * \class ImageIterator
  * \brief A multi-dimensional iterator templated over image type.
  *
- * This is a base class of ImageConstIterator that adds write-access
- * functionality.  Please see ImageConstIterator for more information.
- *
- * \par MORE INFORMATION
- * For a complete description of the ITK Image Iterators and their API, please
- * see the Iterators chapter in the ITK Software Guide.  The ITK Software Guide
- * is available in print and as a free .pdf download from https://www.itk.org.
+ * Preserved as an alias template over
+ * ImageIteratorBase<TImage, /\*VIsConst=*\/false>. Write access
+ * (Set(), non-const Value()) is SFINAE-enabled directly on the
+ * underlying ImageIteratorBase template when VIsConst==false, so
+ * there are no const_cast sites.
  *
  * \ingroup ImageIterators
- *
- * \sa ImageConstIterator \sa ConditionalConstIterator
- * \sa ConstNeighborhoodIterator \sa ConstShapedNeighborhoodIterator
- * \sa ConstSliceIterator  \sa CorrespondenceDataStructureIterator
- * \sa FloodFilledFunctionConditionalConstIterator
- * \sa FloodFilledImageFunctionConditionalConstIterator
- * \sa FloodFilledImageFunctionConditionalIterator
- * \sa FloodFilledSpatialFunctionConditionalConstIterator
- * \sa FloodFilledSpatialFunctionConditionalIterator
- * \sa ImageConstIterator \sa ImageConstIteratorWithIndex
- * \sa ImageIterator \sa ImageIteratorWithIndex
- * \sa ImageLinearConstIteratorWithIndex  \sa ImageLinearIteratorWithIndex
- * \sa ImageRandomConstIteratorWithIndex  \sa ImageRandomIteratorWithIndex
- * \sa ImageRegionConstIterator \sa ImageRegionConstIteratorWithIndex
- * \sa ImageRegionExclusionConstIteratorWithIndex
- * \sa ImageRegionExclusionIteratorWithIndex
- * \sa ImageRegionIterator  \sa ImageRegionIteratorWithIndex
- * \sa ImageRegionReverseConstIterator  \sa ImageRegionReverseIterator
- * \sa ImageReverseConstIterator  \sa ImageReverseIterator
- * \sa ImageSliceConstIteratorWithIndex  \sa ImageSliceIteratorWithIndex
- * \sa NeighborhoodIterator \sa PathConstIterator  \sa PathIterator
- * \sa ShapedNeighborhoodIterator  \sa SliceIterator
- *
- *
  * \ingroup ITKCommon
  */
 template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageIterator : public ImageConstIterator<TImage>
+class ITK_TEMPLATE_EXPORT ImageIterator : public ImageIteratorBase<TImage, /*VIsConst=*/false>
 {
 public:
-  ITK_DEFAULT_COPY_AND_MOVE(ImageIterator);
-
-  /** Standard class type aliases. */
-  using Self = ImageIterator;
-
-  /** Dimension of the image the iterator walks.  This constant is needed so
-   * functions that are templated over image iterator type (as opposed to
-   * being templated over pixel type and dimension) can have compile time
-   * access to the dimension of the image that the iterator walks. */
-  static constexpr unsigned int ImageIteratorDimension = TImage::ImageDimension;
-
-  /** Define the superclass */
-  using Superclass = ImageConstIterator<TImage>;
-
-  /** Inherit types from the superclass */
-  using typename Superclass::IndexType;
-  using typename Superclass::SizeType;
-  using typename Superclass::OffsetType;
-  using typename Superclass::RegionType;
-  using typename Superclass::ImageType;
-  using typename Superclass::PixelContainer;
-  using typename Superclass::PixelContainerPointer;
-  using typename Superclass::InternalPixelType;
-  using typename Superclass::PixelType;
-  using typename Superclass::AccessorType;
-
-  /** Default Constructor. Need to provide a default constructor since we
-   * provide a copy constructor. */
-  ImageIterator() = default;
-
-  /** Default Destructor */
-  ~ImageIterator() override = default;
-
-  /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes
-   * the iterator at the begin of the region. */
-  ImageIterator(TImage * ptr, const RegionType & region);
-
-  /** Set the pixel value */
-  void
-  Set(const PixelType & value) const
-  {
-    // const_cast is needed here because m_Buffer is declared as a const
-    // pointer in the superclass which is the ConstIterator.
-    this->m_PixelAccessorFunctor.Set(*(const_cast<InternalPixelType *>(this->m_Buffer) + this->m_Offset), value);
-  }
-
-  /** Return a reference to the pixel
-   * This method will provide the fastest access to pixel
-   * data, but it will NOT support ImageAdaptors. */
-  PixelType &
-  Value()
-  {
-    // const_cast is needed here because m_Buffer is declared as a const
-    // pointer in the superclass which is the ConstIterator.
-    return *(const_cast<InternalPixelType *>(this->m_Buffer) + this->m_Offset);
-  }
-
-  /** Get the image that this iterator walks. */
-  [[nodiscard]] ImageType *
-  GetImage() const
-  {
-    // const_cast is needed here because m_Image is declared as a const pointer
-    // in the base class which is the ConstIterator.
-    return const_cast<ImageType *>(this->m_Image.GetPointer());
-  }
-
-protected:
-  /** This constructor is declared protected in order to enforce
-    const-correctness */
-  /** @ITKStartGrouping */
-  ImageIterator(const ImageConstIterator<TImage> & it);
-  Self &
-  operator=(const ImageConstIterator<TImage> & it);
-  /** @ITKEndGrouping */
+  using Superclass = ImageIteratorBase<TImage, /*VIsConst=*/false>;
+  using Superclass::Superclass;
 };
 
-// Deduction guide for class template argument deduction (CTAD).
 template <typename TImage>
-ImageIterator(SmartPointer<TImage>, const typename TImage::RegionType &) -> ImageIterator<TImage>;
+ImageIterator(SmartPointer<TImage>, const typename TImage::RegionType &) -> ImageIterator<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageIterator(TImage *, const typename TImage::RegionType &) -> ImageIterator<TImage>;
+
+template <typename TImage>
+ImageIterator(const TImage *, const typename TImage::RegionType &) -> ImageIterator<TImage>;
+
+// Deduction guide for class template argument deduction (CTAD).
+// The ImageIteratorBase deduction guide in itkImageConstIterator.h
+// infers VIsConst from the constness of TImage in the argument, so
+// a non-const SmartPointer<TImage> resolves to ImageIterator<TImage>
+// and a SmartPointer<const TImage> resolves to ImageConstIterator<TImage>.
 
 } // end namespace itk
-
-#ifndef ITK_MANUAL_INSTANTIATION
-#  include "itkImageIterator.hxx"
-#endif
 
 #endif

--- a/Modules/Core/Common/include/itkImageIterator.hxx
+++ b/Modules/Core/Common/include/itkImageIterator.hxx
@@ -18,37 +18,11 @@
 #ifndef itkImageIterator_hxx
 #define itkImageIterator_hxx
 
-
-namespace itk
-{
-
-//----------------------------------------------------------------------
-//  Constructor
-//----------------------------------------------------------------------
-template <typename TImage>
-ImageIterator<TImage>::ImageIterator(TImage * ptr, const RegionType & region)
-  : ImageConstIterator<TImage>(ptr, region)
-{}
-
-//----------------------------------------------------------------------
-//  Constructor
-//----------------------------------------------------------------------
-template <typename TImage>
-ImageIterator<TImage>::ImageIterator(const ImageConstIterator<TImage> & it)
-  : ImageConstIterator<TImage>(it)
-{}
-
-//----------------------------------------------------------------------
-//    Assignment Operator
-//----------------------------------------------------------------------
-template <typename TImage>
-ImageIterator<TImage> &
-ImageIterator<TImage>::operator=(const ImageConstIterator<TImage> & it)
-{
-  this->ImageConstIterator<TImage>::operator=(it);
-  return *this;
-}
-
-} // end namespace itk
+// ImageIterator and ImageConstIterator are now alias templates over
+// itk::ImageIteratorBase<TImage, VIsConst> defined entirely in
+// itkImageConstIterator.h. No out-of-line definitions are required.
+// This header is retained as an empty stub so that any
+// ITK_MANUAL_INSTANTIATION configurations and downstream code
+// that #includes this .hxx continue to compile.
 
 #endif

--- a/Modules/Core/Common/include/itkImageIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageIteratorWithIndex.h
@@ -65,80 +65,23 @@ namespace itk
  * \ingroup ITKCommon
  */
 template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageIteratorWithIndex : public ImageConstIteratorWithIndex<TImage>
+class ITK_TEMPLATE_EXPORT ImageIteratorWithIndex : public ImageIteratorWithIndexBase<TImage, /*VIsConst=*/false>
 {
 public:
-  ITK_DEFAULT_COPY_AND_MOVE(ImageIteratorWithIndex);
-
-  /** Standard class type aliases. */
-  using Self = ImageIteratorWithIndex;
-
-  /** Dimension of the image that the iterator walks.  This constant is needed so
-   * functions that are templated over image iterator type (as opposed to
-   * being templated over pixel type and dimension) can have compile time
-   * access to the dimension of the image that the iterator walks. */
-  static constexpr unsigned int ImageIteratorDimension = TImage::ImageDimension;
-
-  /** Define the superclass */
-  using Superclass = ImageConstIteratorWithIndex<TImage>;
-
-  /** Inherit types from the superclass */
-  using typename Superclass::IndexType;
-  using typename Superclass::SizeType;
-  using typename Superclass::OffsetType;
-  using typename Superclass::RegionType;
-  using typename Superclass::ImageType;
-  using typename Superclass::PixelContainer;
-  using typename Superclass::PixelContainerPointer;
-  using typename Superclass::InternalPixelType;
-  using typename Superclass::PixelType;
-  using typename Superclass::AccessorType;
-
-  /** Default Constructor. Need to provide a default constructor since we
-   * provide a copy constructor. */
-  ImageIteratorWithIndex() = default;
-
-  /** Default Destructor */
-  ~ImageIteratorWithIndex() override = default;
-
-  /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes
-   * the iterator at the begin of the region. */
-  ImageIteratorWithIndex(TImage * ptr, const RegionType & region);
-
-  /** Set the pixel value */
-  void
-  Set(const PixelType & value) const
-  {
-    this->m_PixelAccessor.Set(*(const_cast<InternalPixelType *>(this->m_Position)), value);
-  }
-
-  /** Return a reference to the pixel.
-   * This method will provide the fastest access to pixel
-   * data, but it will NOT support ImageAdaptors. */
-  PixelType &
-  Value()
-  {
-    return *(const_cast<InternalPixelType *>(this->m_Position));
-  }
-
-protected:
-  /** This constructor is declared protected in order to enforce
-    const-correctness */
-  /** @ITKStartGrouping */
-  ImageIteratorWithIndex(const ImageConstIteratorWithIndex<TImage> & it);
-  Self &
-  operator=(const ImageConstIteratorWithIndex<TImage> & it);
-  /** @ITKEndGrouping */
+  using Superclass = ImageIteratorWithIndexBase<TImage, /*VIsConst=*/false>;
+  using Superclass::Superclass;
 };
 
-// Deduction guide for class template argument deduction (CTAD).
 template <typename TImage>
-ImageIteratorWithIndex(SmartPointer<TImage>, const typename TImage::RegionType &) -> ImageIteratorWithIndex<TImage>;
+ImageIteratorWithIndex(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageIteratorWithIndex<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageIteratorWithIndex(TImage *, const typename TImage::RegionType &) -> ImageIteratorWithIndex<TImage>;
+
+template <typename TImage>
+ImageIteratorWithIndex(const TImage *, const typename TImage::RegionType &) -> ImageIteratorWithIndex<TImage>;
 
 } // end namespace itk
-
-#ifndef ITK_MANUAL_INSTANTIATION
-#  include "itkImageIteratorWithIndex.hxx"
-#endif
 
 #endif

--- a/Modules/Core/Common/include/itkImageLinearConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageLinearConstIteratorWithIndex.h
@@ -19,7 +19,7 @@
 #define itkImageLinearConstIteratorWithIndex_h
 
 #include "itkImageConstIteratorWithIndex.h"
-#include <type_traits> // For remove_const_t.
+#include <type_traits> // For enable_if_t, remove_const_t.
 
 namespace itk
 {
@@ -98,13 +98,13 @@ namespace itk
  *
  * \ingroup ITKCommon
  */
-template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageLinearConstIteratorWithIndex : public ImageConstIteratorWithIndex<TImage>
+template <typename TImage, bool VIsConst>
+class ITK_TEMPLATE_EXPORT ImageLinearIteratorWithIndexBase : public ImageIteratorWithIndexBase<TImage, VIsConst>
 {
 public:
   /** Standard class type aliases. */
-  using Self = ImageLinearConstIteratorWithIndex;
-  using Superclass = ImageConstIteratorWithIndex<TImage>;
+  using Self = ImageLinearIteratorWithIndexBase;
+  using Superclass = ImageIteratorWithIndexBase<TImage, VIsConst>;
 
   /** Index type alias support While this was already typedef'ed in the superclass,
    * it needs to be redone here for this subclass to compile properly with gcc.
@@ -130,15 +130,17 @@ public:
   using PixelContainer = typename TImage::PixelContainer;
   using PixelContainerPointer = typename PixelContainer::Pointer;
 
+  using typename Superclass::ImagePointer;
+
   /** Default constructor. */
-  ImageLinearConstIteratorWithIndex()
-    : ImageConstIteratorWithIndex<TImage>()
+  ImageLinearIteratorWithIndexBase()
+    : Superclass()
 
   {}
 
   /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes
    * the iterator at the begin of the region. */
-  ImageLinearConstIteratorWithIndex(const TImage * ptr, const RegionType & region);
+  ImageLinearIteratorWithIndexBase(ImagePointer ptr, const RegionType & region);
 
   /** Constructor that can be used to cast from an ImageIterator to an
    * ImageLinearConstIteratorWithIndex. Many routines return an ImageIterator but for a
@@ -146,10 +148,18 @@ public:
    * provide overloaded APIs that return different types of Iterators, itk
    * returns ImageIterators and uses constructors to cast from an
    * ImageIterator to a ImageLinearConstIteratorWithIndex. */
-  ImageLinearConstIteratorWithIndex(const ImageConstIteratorWithIndex<TImage> & it)
-  {
-    this->ImageConstIteratorWithIndex<TImage>::operator=(it);
-  }
+  ImageLinearIteratorWithIndexBase(const Superclass & it) { this->Superclass::operator=(it); }
+
+  /** Converting constructor: non-const -> const. */
+  template <bool VOtherConst, typename = std::enable_if_t<VIsConst && !VOtherConst>>
+  ImageLinearIteratorWithIndexBase(const ImageLinearIteratorWithIndexBase<TImage, VOtherConst> & it)
+    : Superclass(static_cast<const ImageIteratorWithIndexBase<TImage, VOtherConst> &>(it))
+    , m_Jump(it.m_Jump)
+    , m_Direction(it.m_Direction)
+  {}
+
+  template <typename, bool>
+  friend class ImageLinearIteratorWithIndexBase;
 
   /** Go to the next line.
    * \sa operator++  \sa operator-- \sa IsAtEndOfLine \sa PreviousLine \sa End */
@@ -235,18 +245,47 @@ private:
   unsigned int    m_Direction{ 0 };
 };
 
-// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage>
+class ITK_TEMPLATE_EXPORT ImageLinearConstIteratorWithIndex
+  : public ImageLinearIteratorWithIndexBase<TImage, /*VIsConst=*/true>
+{
+public:
+  using Superclass = ImageLinearIteratorWithIndexBase<TImage, /*VIsConst=*/true>;
+  using Superclass::Superclass;
+};
+
 template <typename TImage>
 ImageLinearConstIteratorWithIndex(SmartPointer<TImage>, const typename TImage::RegionType &)
   -> ImageLinearConstIteratorWithIndex<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageLinearConstIteratorWithIndex(TImage *, const typename TImage::RegionType &)
+  -> ImageLinearConstIteratorWithIndex<TImage>;
+
+template <typename TImage>
+ImageLinearConstIteratorWithIndex(const TImage *, const typename TImage::RegionType &)
+  -> ImageLinearConstIteratorWithIndex<TImage>;
+
+// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage, bool VIsConst = std::is_const_v<TImage>>
+ImageLinearIteratorWithIndexBase(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageLinearIteratorWithIndexBase<std::remove_const_t<TImage>, VIsConst>;
+
+template <typename TImage>
+ImageLinearIteratorWithIndexBase(TImage *, const typename TImage::RegionType &)
+  -> ImageLinearIteratorWithIndexBase<TImage, /*VIsConst=*/false>;
+
+template <typename TImage>
+ImageLinearIteratorWithIndexBase(const TImage *, const typename TImage::RegionType &)
+  -> ImageLinearIteratorWithIndexBase<TImage, /*VIsConst=*/true>;
 
 
 //----------------------------------------------------------------------
 //  Go to next line
 //----------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 inline void
-ImageLinearConstIteratorWithIndex<TImage>::NextLine()
+ImageLinearIteratorWithIndexBase<TImage, VIsConst>::NextLine()
 {
   this->m_Position -=
     this->m_OffsetTable[m_Direction] * (this->m_PositionIndex[m_Direction] - this->m_BeginIndex[m_Direction]);
@@ -278,9 +317,9 @@ ImageLinearConstIteratorWithIndex<TImage>::NextLine()
 //----------------------------------------------------------------------
 //  Pass to the last pixel on the previous line
 //----------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 inline void
-ImageLinearConstIteratorWithIndex<TImage>::PreviousLine()
+ImageLinearIteratorWithIndexBase<TImage, VIsConst>::PreviousLine()
 {
   this->m_Position +=
     this->m_OffsetTable[m_Direction] * (this->m_EndIndex[m_Direction] - 1 - this->m_PositionIndex[m_Direction]);

--- a/Modules/Core/Common/include/itkImageLinearConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageLinearConstIteratorWithIndex.hxx
@@ -24,10 +24,10 @@ namespace itk
 //----------------------------------------------------------------------
 //  Constructor
 //----------------------------------------------------------------------
-template <typename TImage>
-ImageLinearConstIteratorWithIndex<TImage>::ImageLinearConstIteratorWithIndex(const TImage *     ptr,
-                                                                             const RegionType & region)
-  : ImageConstIteratorWithIndex<TImage>(ptr, region)
+template <typename TImage, bool VIsConst>
+ImageLinearIteratorWithIndexBase<TImage, VIsConst>::ImageLinearIteratorWithIndexBase(ImagePointer       ptr,
+                                                                                     const RegionType & region)
+  : Superclass(ptr, region)
 {
   this->SetDirection(0);
 }
@@ -35,9 +35,9 @@ ImageLinearConstIteratorWithIndex<TImage>::ImageLinearConstIteratorWithIndex(con
 //----------------------------------------------------------------------
 //  Go to the last pixel of the current line
 //----------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageLinearConstIteratorWithIndex<TImage>::GoToReverseBeginOfLine()
+ImageLinearIteratorWithIndexBase<TImage, VIsConst>::GoToReverseBeginOfLine()
 {
   const OffsetValueType distanceToEnd = this->m_EndIndex[m_Direction] - this->m_PositionIndex[m_Direction] - 1;
 
@@ -48,9 +48,9 @@ ImageLinearConstIteratorWithIndex<TImage>::GoToReverseBeginOfLine()
 //----------------------------------------------------------------------
 //  Go to the first pixel of the current line
 //----------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageLinearConstIteratorWithIndex<TImage>::GoToBeginOfLine()
+ImageLinearIteratorWithIndexBase<TImage, VIsConst>::GoToBeginOfLine()
 {
   const OffsetValueType distanceToBegin = this->m_PositionIndex[m_Direction] - this->m_BeginIndex[m_Direction];
 
@@ -62,9 +62,9 @@ ImageLinearConstIteratorWithIndex<TImage>::GoToBeginOfLine()
 //----------------------------------------------------------------------
 //  Pass to the past last pixel of the current line
 //----------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageLinearConstIteratorWithIndex<TImage>::GoToEndOfLine()
+ImageLinearIteratorWithIndexBase<TImage, VIsConst>::GoToEndOfLine()
 {
   const OffsetValueType distanceToEnd = this->m_EndIndex[m_Direction] - this->m_PositionIndex[m_Direction];
 

--- a/Modules/Core/Common/include/itkImageLinearIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageLinearIteratorWithIndex.h
@@ -64,75 +64,25 @@ namespace itk
  * \ingroup ITKCommon
  */
 template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageLinearIteratorWithIndex : public ImageLinearConstIteratorWithIndex<TImage>
+class ITK_TEMPLATE_EXPORT ImageLinearIteratorWithIndex
+  : public ImageLinearIteratorWithIndexBase<TImage, /*VIsConst=*/false>
 {
 public:
-  /** Standard class type aliases. */
-  using Self = ImageLinearIteratorWithIndex;
-  using Superclass = ImageLinearConstIteratorWithIndex<TImage>;
-
-  /** Types inherited from the Superclass */
-  using typename Superclass::IndexType;
-  using typename Superclass::SizeType;
-  using typename Superclass::OffsetType;
-  using typename Superclass::RegionType;
-  using typename Superclass::ImageType;
-  using typename Superclass::PixelContainer;
-  using typename Superclass::PixelContainerPointer;
-  using typename Superclass::InternalPixelType;
-  using typename Superclass::PixelType;
-  using typename Superclass::AccessorType;
-
-  /** Default constructor. */
-  ImageLinearIteratorWithIndex() = default;
-
-  /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes
-   * the iterator at the begin of the region. */
-  ImageLinearIteratorWithIndex(TImage * ptr, const RegionType & region);
-
-  /** Constructor that can be used to cast from an ImageIterator to an
-   * ImageLinearIteratorWithIndex. Many routines return an ImageIterator, but for a
-   * particular task, you may want an ImageLinearIteratorWithIndex.  Rather than
-   * provide overloaded APIs that return different types of Iterators, itk
-   * returns ImageIterators and uses constructors to cast from an
-   * ImageIterator to a ImageLinearIteratorWithIndex. */
-  ImageLinearIteratorWithIndex(const ImageIteratorWithIndex<TImage> & it);
-
-  /** Set the pixel value */
-  void
-  Set(const PixelType & value) const
-  {
-    this->m_PixelAccessorFunctor.Set(*(const_cast<InternalPixelType *>(this->m_Position)), value);
-  }
-
-  /** Return a reference to the pixel.
-   * This method will provide the fastest access to pixel
-   * data, but it will NOT support ImageAdaptors. */
-  PixelType &
-  Value()
-  {
-    return *(const_cast<InternalPixelType *>(this->m_Position));
-  }
-
-protected:
-  /** the construction from a const iterator is declared protected
-      in order to enforce const correctness. */
-  /** @ITKStartGrouping */
-  ImageLinearIteratorWithIndex(const ImageLinearConstIteratorWithIndex<TImage> & it);
-  Self &
-  operator=(const ImageLinearConstIteratorWithIndex<TImage> & it);
-  /** @ITKEndGrouping */
+  using Superclass = ImageLinearIteratorWithIndexBase<TImage, /*VIsConst=*/false>;
+  using Superclass::Superclass;
 };
 
-// Deduction guide for class template argument deduction (CTAD).
 template <typename TImage>
 ImageLinearIteratorWithIndex(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageLinearIteratorWithIndex<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageLinearIteratorWithIndex(TImage *, const typename TImage::RegionType &) -> ImageLinearIteratorWithIndex<TImage>;
+
+template <typename TImage>
+ImageLinearIteratorWithIndex(const TImage *, const typename TImage::RegionType &)
   -> ImageLinearIteratorWithIndex<TImage>;
 
 } // end namespace itk
-
-#ifndef ITK_MANUAL_INSTANTIATION
-#  include "itkImageLinearIteratorWithIndex.hxx"
-#endif
 
 #endif

--- a/Modules/Core/Common/include/itkImageLinearIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageLinearIteratorWithIndex.hxx
@@ -18,31 +18,11 @@
 #ifndef itkImageLinearIteratorWithIndex_hxx
 #define itkImageLinearIteratorWithIndex_hxx
 
+// All ImageLinearIteratorWithIndex functionality has been absorbed into
+// ImageLinearIteratorWithIndexBase<TImage, VIsConst> (see
+// itkImageLinearConstIteratorWithIndex.h). This header is retained only
+// for backward compatibility with code that #includes it directly.
 
-namespace itk
-{
-template <typename TImage>
-ImageLinearIteratorWithIndex<TImage>::ImageLinearIteratorWithIndex(TImage * ptr, const RegionType & region)
-  : ImageLinearConstIteratorWithIndex<TImage>(ptr, region)
-{}
-
-template <typename TImage>
-ImageLinearIteratorWithIndex<TImage>::ImageLinearIteratorWithIndex(const ImageIteratorWithIndex<TImage> & it)
-  : ImageLinearConstIteratorWithIndex<TImage>(it)
-{}
-
-template <typename TImage>
-ImageLinearIteratorWithIndex<TImage>::ImageLinearIteratorWithIndex(const ImageLinearConstIteratorWithIndex<TImage> & it)
-  : ImageLinearConstIteratorWithIndex<TImage>(it)
-{}
-
-template <typename TImage>
-ImageLinearIteratorWithIndex<TImage> &
-ImageLinearIteratorWithIndex<TImage>::operator=(const ImageLinearConstIteratorWithIndex<TImage> & it)
-{
-  this->ImageLinearConstIteratorWithIndex<TImage>::operator=(it);
-  return *this;
-}
-} // end namespace itk
+#include "itkImageLinearIteratorWithIndex.h"
 
 #endif

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.h
@@ -20,7 +20,7 @@
 
 #include "itkImageConstIteratorWithIndex.h"
 #include "itkMersenneTwisterRandomVariateGenerator.h"
-#include <type_traits> // For remove_const_t.
+#include <type_traits> // For enable_if_t, remove_const_t.
 
 namespace itk
 {
@@ -113,13 +113,13 @@ namespace itk
  * \sphinxexample{Core/Common/RandomSelectOfPixelsFromRegion,Random Selection Of Pixels From Region}
  * \endsphinx
  */
-template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageRandomConstIteratorWithIndex : public ImageConstIteratorWithIndex<TImage>
+template <typename TImage, bool VIsConst>
+class ITK_TEMPLATE_EXPORT ImageRandomIteratorWithIndexBase : public ImageIteratorWithIndexBase<TImage, VIsConst>
 {
 public:
   /** Standard class type aliases. */
-  using Self = ImageRandomConstIteratorWithIndex;
-  using Superclass = ImageConstIteratorWithIndex<TImage>;
+  using Self = ImageRandomIteratorWithIndexBase;
+  using Superclass = ImageIteratorWithIndexBase<TImage, VIsConst>;
 
   /** Inherit types from the superclass */
   using typename Superclass::IndexType;
@@ -127,6 +127,7 @@ public:
   using typename Superclass::OffsetType;
   using typename Superclass::RegionType;
   using typename Superclass::ImageType;
+  using typename Superclass::ImagePointer;
   using typename Superclass::PixelContainer;
   using typename Superclass::PixelContainerPointer;
   using typename Superclass::InternalPixelType;
@@ -137,13 +138,13 @@ public:
   using typename Superclass::SizeValueType;
 
   /** Default constructor. */
-  ImageRandomConstIteratorWithIndex() = default;
+  ImageRandomIteratorWithIndexBase() = default;
 
-  ~ImageRandomConstIteratorWithIndex() override = default;
+  ~ImageRandomIteratorWithIndexBase() override = default;
 
   /** Constructor establishes an iterator to walk a particular image and a
    * particular region of that image. */
-  ImageRandomConstIteratorWithIndex(const TImage * ptr, const RegionType & region);
+  ImageRandomIteratorWithIndexBase(ImagePointer ptr, const RegionType & region);
 
   /** Constructor that can be used to cast from an ImageIterator to an
    * ImageRandomConstIteratorWithIndex. Many routines return an ImageIterator, but for a
@@ -151,10 +152,20 @@ public:
    * provide overloaded APIs that return different types of Iterators, itk
    * returns ImageIterators and uses constructors to cast from an
    * ImageIterator to a ImageRandomConstIteratorWithIndex. */
-  ImageRandomConstIteratorWithIndex(const ImageConstIteratorWithIndex<TImage> & it)
-  {
-    this->ImageConstIteratorWithIndex<TImage>::operator=(it);
-  }
+  ImageRandomIteratorWithIndexBase(const Superclass & it) { this->Superclass::operator=(it); }
+
+  /** Converting constructor: non-const -> const. */
+  template <bool VOtherConst, typename = std::enable_if_t<VIsConst && !VOtherConst>>
+  ImageRandomIteratorWithIndexBase(const ImageRandomIteratorWithIndexBase<TImage, VOtherConst> & it)
+    : Superclass(static_cast<const ImageIteratorWithIndexBase<TImage, VOtherConst> &>(it))
+    , m_Generator(it.m_Generator)
+    , m_NumberOfSamplesRequested(it.m_NumberOfSamplesRequested)
+    , m_NumberOfSamplesDone(it.m_NumberOfSamplesDone)
+    , m_NumberOfPixelsInRegion(it.m_NumberOfPixelsInRegion)
+  {}
+
+  template <typename, bool>
+  friend class ImageRandomIteratorWithIndexBase;
 
   /** Move an iterator to the beginning of the region. */
   void
@@ -238,10 +249,39 @@ private:
   SizeValueType    m_NumberOfPixelsInRegion{};
 };
 
-// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage>
+class ITK_TEMPLATE_EXPORT ImageRandomConstIteratorWithIndex
+  : public ImageRandomIteratorWithIndexBase<TImage, /*VIsConst=*/true>
+{
+public:
+  using Superclass = ImageRandomIteratorWithIndexBase<TImage, /*VIsConst=*/true>;
+  using Superclass::Superclass;
+};
+
 template <typename TImage>
 ImageRandomConstIteratorWithIndex(SmartPointer<TImage>, const typename TImage::RegionType &)
   -> ImageRandomConstIteratorWithIndex<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageRandomConstIteratorWithIndex(TImage *, const typename TImage::RegionType &)
+  -> ImageRandomConstIteratorWithIndex<TImage>;
+
+template <typename TImage>
+ImageRandomConstIteratorWithIndex(const TImage *, const typename TImage::RegionType &)
+  -> ImageRandomConstIteratorWithIndex<TImage>;
+
+// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage, bool VIsConst = std::is_const_v<TImage>>
+ImageRandomIteratorWithIndexBase(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageRandomIteratorWithIndexBase<std::remove_const_t<TImage>, VIsConst>;
+
+template <typename TImage>
+ImageRandomIteratorWithIndexBase(TImage *, const typename TImage::RegionType &)
+  -> ImageRandomIteratorWithIndexBase<TImage, /*VIsConst=*/false>;
+
+template <typename TImage>
+ImageRandomIteratorWithIndexBase(const TImage *, const typename TImage::RegionType &)
+  -> ImageRandomIteratorWithIndexBase<TImage, /*VIsConst=*/true>;
 
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomConstIteratorWithIndex.hxx
@@ -22,31 +22,31 @@
 namespace itk
 {
 
-template <typename TImage>
-ImageRandomConstIteratorWithIndex<TImage>::ImageRandomConstIteratorWithIndex(const TImage *     ptr,
-                                                                             const RegionType & region)
-  : ImageConstIteratorWithIndex<TImage>(ptr, region)
+template <typename TImage, bool VIsConst>
+ImageRandomIteratorWithIndexBase<TImage, VIsConst>::ImageRandomIteratorWithIndexBase(ImagePointer       ptr,
+                                                                                     const RegionType & region)
+  : Superclass(ptr, region)
   , m_NumberOfPixelsInRegion{ region.GetNumberOfPixels() }
 {}
 
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageRandomConstIteratorWithIndex<TImage>::ReinitializeSeed()
+ImageRandomIteratorWithIndexBase<TImage, VIsConst>::ReinitializeSeed()
 {
   m_Generator->SetSeed();
 }
 
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageRandomConstIteratorWithIndex<TImage>::ReinitializeSeed(int seed)
+ImageRandomIteratorWithIndexBase<TImage, VIsConst>::ReinitializeSeed(int seed)
 {
   m_Generator->SetSeed(seed);
   // vnl_sample_reseed(seed);
 }
 
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageRandomConstIteratorWithIndex<TImage>::RandomJump()
+ImageRandomIteratorWithIndexBase<TImage, VIsConst>::RandomJump()
 {
   using PositionValueType = IndexValueType;
 

--- a/Modules/Core/Common/include/itkImageRandomIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomIteratorWithIndex.h
@@ -64,75 +64,25 @@ namespace itk
  * \ingroup ITKCommon
  */
 template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageRandomIteratorWithIndex : public ImageRandomConstIteratorWithIndex<TImage>
+class ITK_TEMPLATE_EXPORT ImageRandomIteratorWithIndex
+  : public ImageRandomIteratorWithIndexBase<TImage, /*VIsConst=*/false>
 {
 public:
-  /** Standard class type aliases. */
-  using Self = ImageRandomIteratorWithIndex;
-  using Superclass = ImageRandomConstIteratorWithIndex<TImage>;
-
-  /** Types inherited from the Superclass */
-  using typename Superclass::IndexType;
-  using typename Superclass::SizeType;
-  using typename Superclass::OffsetType;
-  using typename Superclass::RegionType;
-  using typename Superclass::ImageType;
-  using typename Superclass::PixelContainer;
-  using typename Superclass::PixelContainerPointer;
-  using typename Superclass::InternalPixelType;
-  using typename Superclass::PixelType;
-  using typename Superclass::AccessorType;
-
-  /** Default constructor. */
-  ImageRandomIteratorWithIndex() = default;
-
-  /** Constructor establishes an iterator to walk a particular image and a
-   * particular region of that image. */
-  ImageRandomIteratorWithIndex(TImage * ptr, const RegionType & region);
-
-  /** Constructor that can be used to cast from an ImageIterator to an
-   * ImageRandomIteratorWithIndex. Many routines return an ImageIterator, but for a
-   * particular task, you may want an ImageRandomIteratorWithIndex.  Rather than
-   * provide overloaded APIs that return different types of Iterators, itk
-   * returns ImageIterators and uses constructors to cast from an
-   * ImageIterator to a ImageRandomIteratorWithIndex. */
-  ImageRandomIteratorWithIndex(const ImageIteratorWithIndex<TImage> & it);
-
-  /** Set the pixel value */
-  void
-  Set(const PixelType & value) const
-  {
-    this->m_PixelAccessorFunctor.Set(*(const_cast<InternalPixelType *>(this->m_Position)), value);
-  }
-
-  /** Return a reference to the pixel.
-   * This method will provide the fastest access to pixel
-   * data, but it will NOT support ImageAdaptors. */
-  PixelType &
-  Value()
-  {
-    return *(const_cast<InternalPixelType *>(this->m_Position));
-  }
-
-protected:
-  /** The construction from a const iterator is declared protected
-      in order to enforce const correctness. */
-  /** @ITKStartGrouping */
-  ImageRandomIteratorWithIndex(const ImageRandomConstIteratorWithIndex<TImage> & it);
-  Self &
-  operator=(const ImageRandomConstIteratorWithIndex<TImage> & it);
-  /** @ITKEndGrouping */
+  using Superclass = ImageRandomIteratorWithIndexBase<TImage, /*VIsConst=*/false>;
+  using Superclass::Superclass;
 };
 
-// Deduction guide for class template argument deduction (CTAD).
 template <typename TImage>
 ImageRandomIteratorWithIndex(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageRandomIteratorWithIndex<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageRandomIteratorWithIndex(TImage *, const typename TImage::RegionType &) -> ImageRandomIteratorWithIndex<TImage>;
+
+template <typename TImage>
+ImageRandomIteratorWithIndex(const TImage *, const typename TImage::RegionType &)
   -> ImageRandomIteratorWithIndex<TImage>;
 
 } // end namespace itk
-
-#ifndef ITK_MANUAL_INSTANTIATION
-#  include "itkImageRandomIteratorWithIndex.hxx"
-#endif
 
 #endif

--- a/Modules/Core/Common/include/itkImageRandomIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomIteratorWithIndex.hxx
@@ -18,31 +18,11 @@
 #ifndef itkImageRandomIteratorWithIndex_hxx
 #define itkImageRandomIteratorWithIndex_hxx
 
+// All ImageRandomIteratorWithIndex functionality has been absorbed into
+// ImageRandomIteratorWithIndexBase<TImage, VIsConst> (see
+// itkImageRandomConstIteratorWithIndex.h). This header is retained only
+// for backward compatibility with code that #includes it directly.
 
-namespace itk
-{
-template <typename TImage>
-ImageRandomIteratorWithIndex<TImage>::ImageRandomIteratorWithIndex(TImage * ptr, const RegionType & region)
-  : ImageRandomConstIteratorWithIndex<TImage>(ptr, region)
-{}
-
-template <typename TImage>
-ImageRandomIteratorWithIndex<TImage>::ImageRandomIteratorWithIndex(const ImageIteratorWithIndex<TImage> & it)
-  : ImageRandomConstIteratorWithIndex<TImage>(it)
-{}
-
-template <typename TImage>
-ImageRandomIteratorWithIndex<TImage>::ImageRandomIteratorWithIndex(const ImageRandomConstIteratorWithIndex<TImage> & it)
-  : ImageRandomConstIteratorWithIndex<TImage>(it)
-{}
-
-template <typename TImage>
-ImageRandomIteratorWithIndex<TImage> &
-ImageRandomIteratorWithIndex<TImage>::operator=(const ImageRandomConstIteratorWithIndex<TImage> & it)
-{
-  this->ImageRandomConstIteratorWithIndex<TImage>::operator=(it);
-  return *this;
-}
-} // end namespace itk
+#include "itkImageRandomIteratorWithIndex.h"
 
 #endif

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.h
@@ -21,7 +21,7 @@
 #include "itkImageConstIteratorWithIndex.h"
 #include <algorithm>
 #include <iostream>
-#include <type_traits> // For remove_const_t.
+#include <type_traits> // For enable_if_t, remove_const_t.
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 
 namespace itk
@@ -206,13 +206,14 @@ public:
  * \sphinxexample{Core/Common/RandomSelectPixelFromRegionWithoutReplace,Random Select Pixel From Region Without
  * Replacing} \sphinxexample{Core/Common/PermuteSequenceOfIndices,Permute Sequence Of Indices} \endsphinx
  */
-template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageRandomNonRepeatingConstIteratorWithIndex : public ImageConstIteratorWithIndex<TImage>
+template <typename TImage, bool VIsConst>
+class ITK_TEMPLATE_EXPORT ImageRandomNonRepeatingIteratorWithIndexBase
+  : public ImageIteratorWithIndexBase<TImage, VIsConst>
 {
 public:
   /** Standard class type aliases. */
-  using Self = ImageRandomNonRepeatingConstIteratorWithIndex;
-  using Superclass = ImageConstIteratorWithIndex<TImage>;
+  using Self = ImageRandomNonRepeatingIteratorWithIndexBase;
+  using Superclass = ImageIteratorWithIndexBase<TImage, VIsConst>;
 
   /** Inherit types from the superclass */
   using typename Superclass::IndexType;
@@ -220,6 +221,7 @@ public:
   using typename Superclass::OffsetType;
   using typename Superclass::RegionType;
   using typename Superclass::ImageType;
+  using typename Superclass::ImagePointer;
   using typename Superclass::PixelContainer;
   using typename Superclass::PixelContainerPointer;
   using typename Superclass::InternalPixelType;
@@ -230,13 +232,13 @@ public:
   using typename Superclass::SizeValueType;
 
   /** Default constructor. */
-  ImageRandomNonRepeatingConstIteratorWithIndex() = default;
+  ImageRandomNonRepeatingIteratorWithIndexBase() = default;
 
-  ~ImageRandomNonRepeatingConstIteratorWithIndex() override { delete m_Permutation; }
+  ~ImageRandomNonRepeatingIteratorWithIndexBase() override { delete m_Permutation; }
 
   /** Constructor establishes an iterator to walk a particular image and a
    * particular region of that image. */
-  ImageRandomNonRepeatingConstIteratorWithIndex(const TImage * ptr, const RegionType & region);
+  ImageRandomNonRepeatingIteratorWithIndexBase(ImagePointer ptr, const RegionType & region);
 
   /** Constructor that can be used to cast from an ImageIterator to an
    * ImageRandomNonRepeatingConstIteratorWithIndex. Many routines return an ImageIterator but for a
@@ -244,11 +246,7 @@ public:
    * provide overloaded APIs that return different types of Iterators, itk
    * returns ImageIterators and uses constructors to cast from an
    * ImageIterator to a ImageRandomNonRepeatingConstIteratorWithIndex. */
-  ImageRandomNonRepeatingConstIteratorWithIndex(const ImageConstIteratorWithIndex<TImage> & it)
-
-  {
-    this->ImageConstIteratorWithIndex<TImage>::operator=(it);
-  }
+  ImageRandomNonRepeatingIteratorWithIndexBase(const Superclass & it) { this->Superclass::operator=(it); }
 
   /** operator= is provided to deep copy m_Permutation. */
   Self &
@@ -356,10 +354,39 @@ private:
   RandomPermutation * m_Permutation{};
 };
 
-// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage>
+class ITK_TEMPLATE_EXPORT ImageRandomNonRepeatingConstIteratorWithIndex
+  : public ImageRandomNonRepeatingIteratorWithIndexBase<TImage, /*VIsConst=*/true>
+{
+public:
+  using Superclass = ImageRandomNonRepeatingIteratorWithIndexBase<TImage, /*VIsConst=*/true>;
+  using Superclass::Superclass;
+};
+
 template <typename TImage>
 ImageRandomNonRepeatingConstIteratorWithIndex(SmartPointer<TImage>, const typename TImage::RegionType &)
   -> ImageRandomNonRepeatingConstIteratorWithIndex<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageRandomNonRepeatingConstIteratorWithIndex(TImage *, const typename TImage::RegionType &)
+  -> ImageRandomNonRepeatingConstIteratorWithIndex<TImage>;
+
+template <typename TImage>
+ImageRandomNonRepeatingConstIteratorWithIndex(const TImage *, const typename TImage::RegionType &)
+  -> ImageRandomNonRepeatingConstIteratorWithIndex<TImage>;
+
+// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage, bool VIsConst = std::is_const_v<TImage>>
+ImageRandomNonRepeatingIteratorWithIndexBase(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageRandomNonRepeatingIteratorWithIndexBase<std::remove_const_t<TImage>, VIsConst>;
+
+template <typename TImage>
+ImageRandomNonRepeatingIteratorWithIndexBase(TImage *, const typename TImage::RegionType &)
+  -> ImageRandomNonRepeatingIteratorWithIndexBase<TImage, /*VIsConst=*/false>;
+
+template <typename TImage>
+ImageRandomNonRepeatingIteratorWithIndexBase(const TImage *, const typename TImage::RegionType &)
+  -> ImageRandomNonRepeatingIteratorWithIndexBase<TImage, /*VIsConst=*/true>;
 
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingConstIteratorWithIndex.hxx
@@ -22,24 +22,24 @@
 namespace itk
 {
 
-template <typename TImage>
-ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::ImageRandomNonRepeatingConstIteratorWithIndex(
-  const TImage *     ptr,
+template <typename TImage, bool VIsConst>
+ImageRandomNonRepeatingIteratorWithIndexBase<TImage, VIsConst>::ImageRandomNonRepeatingIteratorWithIndexBase(
+  ImagePointer       ptr,
   const RegionType & region)
-  : ImageConstIteratorWithIndex<TImage>(ptr, region)
+  : Superclass(ptr, region)
   , m_NumberOfSamplesRequested(0L)
   , m_NumberOfSamplesDone(0L)
   , m_NumberOfPixelsInRegion(region.GetNumberOfPixels())
   , m_Permutation(new RandomPermutation(m_NumberOfPixelsInRegion))
 {}
 
-template <typename TImage>
-ImageRandomNonRepeatingConstIteratorWithIndex<TImage> &
-ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::operator=(const Self & it)
+template <typename TImage, bool VIsConst>
+ImageRandomNonRepeatingIteratorWithIndexBase<TImage, VIsConst> &
+ImageRandomNonRepeatingIteratorWithIndexBase<TImage, VIsConst>::operator=(const Self & it)
 {
   if (this != &it)
   {
-    this->ImageConstIteratorWithIndex<TImage>::operator=(it);
+    this->Superclass::operator=(it);
     if (m_Permutation)
     {
       *m_Permutation = *(it.m_Permutation);
@@ -55,25 +55,26 @@ ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::operator=(const Self & it
   return *this;
 }
 
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::ReinitializeSeed()
+ImageRandomNonRepeatingIteratorWithIndexBase<TImage, VIsConst>::ReinitializeSeed()
 {
   this->m_Permutation->ReinitializeSeed();
   this->m_Permutation->Shuffle();
 }
 
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::ReinitializeSeed(int seed)
+ImageRandomNonRepeatingIteratorWithIndexBase<TImage, VIsConst>::ReinitializeSeed(int seed)
 {
   this->m_Permutation->ReinitializeSeed(seed);
   this->m_Permutation->Shuffle();
 }
 
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::SetPriorityImage(const PriorityImageType * priorityImage)
+ImageRandomNonRepeatingIteratorWithIndexBase<TImage, VIsConst>::SetPriorityImage(
+  const PriorityImageType * priorityImage)
 {
   // should probably do error checking to be sure that the priority
   // image is the right size
@@ -97,9 +98,9 @@ ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::SetPriorityImage(const Pr
   this->m_Permutation->Shuffle();
 }
 
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::UpdatePosition()
+ImageRandomNonRepeatingIteratorWithIndexBase<TImage, VIsConst>::UpdatePosition()
 {
   using PositionValueType = IndexValueType;
 

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingIteratorWithIndex.h
@@ -76,75 +76,25 @@ namespace itk
  */
 template <typename TImage>
 class ITK_TEMPLATE_EXPORT ImageRandomNonRepeatingIteratorWithIndex
-  : public ImageRandomNonRepeatingConstIteratorWithIndex<TImage>
+  : public ImageRandomNonRepeatingIteratorWithIndexBase<TImage, /*VIsConst=*/false>
 {
 public:
-  /** Standard class type aliases. */
-  using Self = ImageRandomNonRepeatingIteratorWithIndex;
-  using Superclass = ImageRandomNonRepeatingConstIteratorWithIndex<TImage>;
-
-  /** Types inherited from the Superclass */
-  using typename Superclass::IndexType;
-  using typename Superclass::SizeType;
-  using typename Superclass::OffsetType;
-  using typename Superclass::RegionType;
-  using typename Superclass::ImageType;
-  using typename Superclass::PixelContainer;
-  using typename Superclass::PixelContainerPointer;
-  using typename Superclass::InternalPixelType;
-  using typename Superclass::PixelType;
-  using typename Superclass::AccessorType;
-
-  /** Default constructor. */
-  ImageRandomNonRepeatingIteratorWithIndex() = default;
-
-  /** Constructor establishes an iterator to walk a particular image and a
-   * particular region of that image. */
-  ImageRandomNonRepeatingIteratorWithIndex(TImage * ptr, const RegionType & region);
-
-  /** Constructor that can be used to cast from an ImageIterator to an
-   * ImageRandomNonRepeatingIteratorWithIndex. Many routines return an ImageIterator, but for a
-   * particular task, you may want an ImageRandomNonRepeatingIteratorWithIndex.  Rather than
-   * provide overloaded APIs that return different types of Iterators, itk
-   * returns ImageIterators and uses constructors to cast from an
-   * ImageIterator to a ImageRandomNonRepeatingIteratorWithIndex. */
-  ImageRandomNonRepeatingIteratorWithIndex(const ImageIteratorWithIndex<TImage> & it);
-
-  /** Set the pixel value */
-  void
-  Set(const PixelType & value) const
-  {
-    this->m_PixelAccessorFunctor.Set(*(const_cast<InternalPixelType *>(this->m_Position)), value);
-  }
-
-  /** Return a reference to the pixel.
-   * This method will provide the fastest access to pixel
-   * data, but it will NOT support ImageAdaptors. */
-  PixelType &
-  Value()
-  {
-    return *(const_cast<InternalPixelType *>(this->m_Position));
-  }
-
-protected:
-  /** The construction from a const iterator is declared protected
-      in order to enforce const correctness. */
-  /** @ITKStartGrouping */
-  ImageRandomNonRepeatingIteratorWithIndex(const ImageRandomNonRepeatingConstIteratorWithIndex<TImage> & it);
-  Self &
-  operator=(const ImageRandomNonRepeatingConstIteratorWithIndex<TImage> & it);
-  /** @ITKEndGrouping */
+  using Superclass = ImageRandomNonRepeatingIteratorWithIndexBase<TImage, /*VIsConst=*/false>;
+  using Superclass::Superclass;
 };
 
-// Deduction guide for class template argument deduction (CTAD).
 template <typename TImage>
 ImageRandomNonRepeatingIteratorWithIndex(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageRandomNonRepeatingIteratorWithIndex<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageRandomNonRepeatingIteratorWithIndex(TImage *, const typename TImage::RegionType &)
+  -> ImageRandomNonRepeatingIteratorWithIndex<TImage>;
+
+template <typename TImage>
+ImageRandomNonRepeatingIteratorWithIndex(const TImage *, const typename TImage::RegionType &)
   -> ImageRandomNonRepeatingIteratorWithIndex<TImage>;
 
 } // end namespace itk
-
-#ifndef ITK_MANUAL_INSTANTIATION
-#  include "itkImageRandomNonRepeatingIteratorWithIndex.hxx"
-#endif
 
 #endif

--- a/Modules/Core/Common/include/itkImageRandomNonRepeatingIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRandomNonRepeatingIteratorWithIndex.hxx
@@ -18,35 +18,12 @@
 #ifndef itkImageRandomNonRepeatingIteratorWithIndex_hxx
 #define itkImageRandomNonRepeatingIteratorWithIndex_hxx
 
+// All ImageRandomNonRepeatingIteratorWithIndex functionality has been
+// absorbed into ImageRandomNonRepeatingIteratorWithIndexBase<TImage, VIsConst>
+// (see itkImageRandomNonRepeatingConstIteratorWithIndex.h). This header is
+// retained only for backward compatibility with code that #includes it
+// directly.
 
-namespace itk
-{
-template <typename TImage>
-ImageRandomNonRepeatingIteratorWithIndex<TImage>::ImageRandomNonRepeatingIteratorWithIndex(TImage *           ptr,
-                                                                                           const RegionType & region)
-  : ImageRandomNonRepeatingConstIteratorWithIndex<TImage>(ptr, region)
-{}
-
-template <typename TImage>
-ImageRandomNonRepeatingIteratorWithIndex<TImage>::ImageRandomNonRepeatingIteratorWithIndex(
-  const ImageIteratorWithIndex<TImage> & it)
-  : ImageRandomNonRepeatingConstIteratorWithIndex<TImage>(it)
-{}
-
-template <typename TImage>
-ImageRandomNonRepeatingIteratorWithIndex<TImage>::ImageRandomNonRepeatingIteratorWithIndex(
-  const ImageRandomNonRepeatingConstIteratorWithIndex<TImage> & it)
-  : ImageRandomNonRepeatingConstIteratorWithIndex<TImage>(it)
-{}
-
-template <typename TImage>
-ImageRandomNonRepeatingIteratorWithIndex<TImage> &
-ImageRandomNonRepeatingIteratorWithIndex<TImage>::operator=(
-  const ImageRandomNonRepeatingConstIteratorWithIndex<TImage> & it)
-{
-  this->ImageRandomNonRepeatingConstIteratorWithIndex<TImage>::operator=(it);
-  return *this;
-}
-} // end namespace itk
+#include "itkImageRandomNonRepeatingIteratorWithIndex.h"
 
 #endif

--- a/Modules/Core/Common/include/itkImageRegionConstIterator.h
+++ b/Modules/Core/Common/include/itkImageRegionConstIterator.h
@@ -19,7 +19,7 @@
 #define itkImageRegionConstIterator_h
 
 #include "itkImageIterator.h"
-#include <type_traits> // For remove_const_t.
+#include <type_traits> // For enable_if_t, remove_const_t.
 
 namespace itk
 {
@@ -106,13 +106,13 @@ namespace itk
  * \sphinxexample{Core/Common/IterateRegionWithoutWriteAccess,Iterate Region In Image Without Write Access}
  * \endsphinx
  */
-template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageRegionConstIterator : public ImageConstIterator<TImage>
+template <typename TImage, bool VIsConst>
+class ITK_TEMPLATE_EXPORT ImageRegionIteratorBase : public ImageIteratorBase<TImage, VIsConst>
 {
 public:
   /** Standard class type alias. */
-  using Self = ImageRegionConstIterator;
-  using Superclass = ImageConstIterator<TImage>;
+  using Self = ImageRegionIteratorBase;
+  using Superclass = ImageIteratorBase<TImage, VIsConst>;
 
   /** Dimension of the image that the iterator walks.  This constant is needed so
    * functions that are templated over image iterator type (as opposed to
@@ -131,6 +131,7 @@ public:
   using typename Superclass::OffsetType;
   using typename Superclass::RegionType;
   using typename Superclass::ImageType;
+  using typename Superclass::ImagePointer;
   using typename Superclass::PixelContainer;
   using typename Superclass::PixelContainerPointer;
   using typename Superclass::InternalPixelType;
@@ -138,17 +139,17 @@ public:
   using typename Superclass::AccessorType;
 
   /** \see LightObject::GetNameOfClass() */
-  itkOverrideGetNameOfClassMacro(ImageRegionConstIterator);
+  itkOverrideGetNameOfClassMacro(ImageRegionIteratorBase);
 
   /** Default constructor. */
-  ImageRegionConstIterator()
-    : ImageConstIterator<TImage>()
+  ImageRegionIteratorBase()
+    : Superclass()
   {}
 
   /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes
    * the iterator at the begin of the region. */
-  ImageRegionConstIterator(const TImage * ptr, const RegionType & region)
-    : ImageConstIterator<TImage>(ptr, region)
+  ImageRegionIteratorBase(ImagePointer ptr, const RegionType & region)
+    : Superclass(ptr, region)
     , m_SpanBeginOffset(this->m_BeginOffset)
     , m_SpanEndOffset(this->m_BeginOffset + static_cast<OffsetValueType>(this->m_Region.GetSize()[0]))
   {}
@@ -159,9 +160,9 @@ public:
    * provide overloaded APIs that return different types of Iterators, itk
    * returns ImageIterators and uses constructors to cast from an
    * ImageIterator to a ImageRegionConstIterator. */
-  ImageRegionConstIterator(const ImageIterator<TImage> & it)
+  ImageRegionIteratorBase(const Superclass & it)
   {
-    this->ImageConstIterator<TImage>::operator=(it);
+    this->Superclass::operator=(it);
 
     IndexType ind = this->GetIndex();
     m_SpanEndOffset = this->m_Offset + static_cast<OffsetValueType>(this->m_Region.GetSize()[0]) -
@@ -169,21 +170,13 @@ public:
     m_SpanBeginOffset = m_SpanEndOffset - static_cast<OffsetValueType>(this->m_Region.GetSize()[0]);
   }
 
-  /** Constructor that can be used to cast from an ImageConstIterator to an
-   * ImageRegionConstIterator. Many routines return an ImageIterator, but for a
-   * particular task, you may want an ImageRegionConstIterator.  Rather than
-   * provide overloaded APIs that return different types of Iterators, itk
-   * returns ImageIterators and uses constructors to cast from an
-   * ImageIterator to a ImageRegionConstIterator. */
-  ImageRegionConstIterator(const ImageConstIterator<TImage> & it)
-  {
-    this->ImageConstIterator<TImage>::operator=(it);
-
-    IndexType ind = this->GetIndex();
-    m_SpanEndOffset = this->m_Offset + static_cast<OffsetValueType>(this->m_Region.GetSize()[0]) -
-                      (ind[0] - this->m_Region.GetIndex()[0]);
-    m_SpanBeginOffset = m_SpanEndOffset - static_cast<OffsetValueType>(this->m_Region.GetSize()[0]);
-  }
+  /** Converting constructor: non-const -> const. */
+  template <bool VOtherConst, typename = std::enable_if_t<VIsConst && !VOtherConst>>
+  ImageRegionIteratorBase(const ImageRegionIteratorBase<TImage, VOtherConst> & it)
+    : Superclass(static_cast<const ImageIteratorBase<TImage, VOtherConst> &>(it))
+    , m_SpanBeginOffset(it.m_SpanBeginOffset)
+    , m_SpanEndOffset(it.m_SpanEndOffset)
+  {}
 
   /** Move an iterator to the beginning of the region. "Begin" is
    * defined as the first pixel in the region. */
@@ -255,6 +248,9 @@ public:
     return *this;
   }
 
+  template <typename, bool>
+  friend class ImageRegionIteratorBase;
+
 protected:
   OffsetValueType m_SpanBeginOffset{}; // one pixel before the beginning of the span
                                        // (row)
@@ -268,10 +264,42 @@ private:
   Decrement(); // go back in a direction other than the fastest moving
 };
 
-// Deduction guide for class template argument deduction (CTAD).
+/** \class ImageRegionConstIterator
+ *  \brief Legacy class-template wrapper preserved for source compatibility.
+ *
+ *  Inherits from ImageRegionIteratorBase<TImage, true>; declared as a real
+ *  class template (not an alias template) so class-template argument
+ *  deduction works under C++17 at consumer call sites.
+ *
+ *  \ingroup ImageIterators
+ *  \ingroup ITKCommon */
+template <typename TImage>
+class ITK_TEMPLATE_EXPORT ImageRegionConstIterator : public ImageRegionIteratorBase<TImage, /*VIsConst=*/true>
+{
+public:
+  using Superclass = ImageRegionIteratorBase<TImage, /*VIsConst=*/true>;
+  using Superclass::Superclass;
+};
+
 template <typename TImage>
 ImageRegionConstIterator(SmartPointer<TImage>, const typename TImage::RegionType &)
   -> ImageRegionConstIterator<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageRegionConstIterator(const TImage *, const typename TImage::RegionType &) -> ImageRegionConstIterator<TImage>;
+
+// Deduction guides for class template argument deduction (CTAD).
+template <typename TImage, bool VIsConst = std::is_const_v<TImage>>
+ImageRegionIteratorBase(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageRegionIteratorBase<std::remove_const_t<TImage>, VIsConst>;
+
+template <typename TImage>
+ImageRegionIteratorBase(TImage *, const typename TImage::RegionType &)
+  -> ImageRegionIteratorBase<TImage, /*VIsConst=*/false>;
+
+template <typename TImage>
+ImageRegionIteratorBase(const TImage *, const typename TImage::RegionType &)
+  -> ImageRegionIteratorBase<TImage, /*VIsConst=*/true>;
 
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageRegionConstIterator.hxx
+++ b/Modules/Core/Common/include/itkImageRegionConstIterator.hxx
@@ -25,9 +25,9 @@ namespace itk
 //----------------------------------------------------------------------------
 // Increment when the fastest moving direction has reached its bound.
 // This method should *ONLY* be invoked from the operator++() method.
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageRegionConstIterator<TImage>::Increment()
+ImageRegionIteratorBase<TImage, VIsConst>::Increment()
 {
   // We have reached the end of the span (row), need to wrap around.
 
@@ -36,11 +36,10 @@ ImageRegionConstIterator<TImage>::Increment()
   --this->m_Offset;
 
   // Get the index of the last pixel on the span (row)
-  typename ImageIterator<TImage>::IndexType ind =
-    this->m_Image->ComputeIndex(static_cast<OffsetValueType>(this->m_Offset));
+  typename Superclass::IndexType ind = this->m_Image->ComputeIndex(static_cast<OffsetValueType>(this->m_Offset));
 
-  const typename ImageIterator<TImage>::IndexType & startIndex = this->m_Region.GetIndex();
-  const typename ImageIterator<TImage>::SizeType &  size = this->m_Region.GetSize();
+  const typename Superclass::IndexType & startIndex = this->m_Region.GetIndex();
+  const typename Superclass::SizeType &  size = this->m_Region.GetSize();
 
   // Increment along a row, then wrap at the end of the region row.
 
@@ -72,9 +71,9 @@ ImageRegionConstIterator<TImage>::Increment()
 //----------------------------------------------------------------------------
 // Decrement when the fastest moving direction has reached its bound.
 // This method should *ONLY* be invoked from the operator--() method.
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageRegionConstIterator<TImage>::Decrement()
+ImageRegionIteratorBase<TImage, VIsConst>::Decrement()
 {
   // We have pasted the beginning of the span (row), need to wrap around.
 
@@ -83,11 +82,10 @@ ImageRegionConstIterator<TImage>::Decrement()
   this->m_Offset++;
 
   // Get the index of the first pixel on the span (row)
-  typename ImageIterator<TImage>::IndexType ind =
-    this->m_Image->ComputeIndex(static_cast<IndexValueType>(this->m_Offset));
+  typename Superclass::IndexType ind = this->m_Image->ComputeIndex(static_cast<IndexValueType>(this->m_Offset));
 
-  const typename ImageIterator<TImage>::IndexType & startIndex = this->m_Region.GetIndex();
-  const typename ImageIterator<TImage>::SizeType &  size = this->m_Region.GetSize();
+  const typename Superclass::IndexType & startIndex = this->m_Region.GetIndex();
+  const typename Superclass::SizeType &  size = this->m_Region.GetSize();
 
   // Decrement along a row, then wrap at the beginning of the region row.
 

--- a/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.h
@@ -19,7 +19,7 @@
 #define itkImageRegionConstIteratorWithIndex_h
 
 #include "itkImageConstIteratorWithIndex.h"
-#include <type_traits> // For remove_const_t.
+#include <type_traits> // For enable_if_t, remove_const_t.
 
 namespace itk
 {
@@ -127,13 +127,13 @@ namespace itk
  Index Without Write Access}
  * \endsphinx
  */
-template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageRegionConstIteratorWithIndex : public ImageConstIteratorWithIndex<TImage>
+template <typename TImage, bool VIsConst>
+class ITK_TEMPLATE_EXPORT ImageRegionIteratorWithIndexBase : public ImageIteratorWithIndexBase<TImage, VIsConst>
 {
 public:
   /** Standard class type aliases. */
-  using Self = ImageRegionConstIteratorWithIndex;
-  using Superclass = ImageConstIteratorWithIndex<TImage>;
+  using Self = ImageRegionIteratorWithIndexBase;
+  using Superclass = ImageIteratorWithIndexBase<TImage, VIsConst>;
 
   /**
    * Index type alias support While these were already typedef'ed in the superclass
@@ -146,6 +146,7 @@ public:
   using typename Superclass::OffsetType;
   using typename Superclass::RegionType;
   using typename Superclass::ImageType;
+  using typename Superclass::ImagePointer;
   using typename Superclass::PixelContainer;
   using typename Superclass::PixelContainerPointer;
   using typename Superclass::InternalPixelType;
@@ -153,14 +154,14 @@ public:
   using typename Superclass::AccessorType;
 
   /** Default constructor. */
-  ImageRegionConstIteratorWithIndex()
-    : ImageConstIteratorWithIndex<TImage>()
+  ImageRegionIteratorWithIndexBase()
+    : Superclass()
   {}
 
   /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes
    * the iterator at the begin of the region. */
-  ImageRegionConstIteratorWithIndex(const TImage * ptr, const RegionType & region)
-    : ImageConstIteratorWithIndex<TImage>(ptr, region)
+  ImageRegionIteratorWithIndexBase(ImagePointer ptr, const RegionType & region)
+    : Superclass(ptr, region)
   {}
 
   /** Constructor that can be used to cast from an ImageIterator to an
@@ -169,10 +170,13 @@ public:
    * provide overloaded APIs that return different types of Iterators, itk
    * returns ImageIterators and uses constructors to cast from an
    * ImageIterator to a ImageRegionConstIteratorWithIndex. */
-  ImageRegionConstIteratorWithIndex(const ImageConstIteratorWithIndex<TImage> & it)
-  {
-    this->ImageConstIteratorWithIndex<TImage>::operator=(it);
-  }
+  ImageRegionIteratorWithIndexBase(const Superclass & it) { this->Superclass::operator=(it); }
+
+  /** Converting constructor: non-const -> const. */
+  template <bool VOtherConst, typename = std::enable_if_t<VIsConst && !VOtherConst>>
+  ImageRegionIteratorWithIndexBase(const ImageRegionIteratorWithIndexBase<TImage, VOtherConst> & it)
+    : Superclass(static_cast<const ImageIteratorWithIndexBase<TImage, VOtherConst> &>(it))
+  {}
 
   /** Increment (prefix) the fastest moving dimension of the iterator's index.
    * This operator will constrain the iterator within the region (i.e. the
@@ -195,10 +199,39 @@ public:
   operator--();
 };
 
-// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage>
+class ITK_TEMPLATE_EXPORT ImageRegionConstIteratorWithIndex
+  : public ImageRegionIteratorWithIndexBase<TImage, /*VIsConst=*/true>
+{
+public:
+  using Superclass = ImageRegionIteratorWithIndexBase<TImage, /*VIsConst=*/true>;
+  using Superclass::Superclass;
+};
+
 template <typename TImage>
 ImageRegionConstIteratorWithIndex(SmartPointer<TImage>, const typename TImage::RegionType &)
   -> ImageRegionConstIteratorWithIndex<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageRegionConstIteratorWithIndex(TImage *, const typename TImage::RegionType &)
+  -> ImageRegionConstIteratorWithIndex<TImage>;
+
+template <typename TImage>
+ImageRegionConstIteratorWithIndex(const TImage *, const typename TImage::RegionType &)
+  -> ImageRegionConstIteratorWithIndex<TImage>;
+
+// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage, bool VIsConst = std::is_const_v<TImage>>
+ImageRegionIteratorWithIndexBase(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageRegionIteratorWithIndexBase<std::remove_const_t<TImage>, VIsConst>;
+
+template <typename TImage>
+ImageRegionIteratorWithIndexBase(TImage *, const typename TImage::RegionType &)
+  -> ImageRegionIteratorWithIndexBase<TImage, /*VIsConst=*/false>;
+
+template <typename TImage>
+ImageRegionIteratorWithIndexBase(const TImage *, const typename TImage::RegionType &)
+  -> ImageRegionIteratorWithIndexBase<TImage, /*VIsConst=*/true>;
 
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRegionConstIteratorWithIndex.hxx
@@ -24,9 +24,9 @@ namespace itk
 //----------------------------------------------------------------------
 //  Advance along the line
 //----------------------------------------------------------------------
-template <typename TImage>
-ImageRegionConstIteratorWithIndex<TImage> &
-ImageRegionConstIteratorWithIndex<TImage>::operator++()
+template <typename TImage, bool VIsConst>
+ImageRegionIteratorWithIndexBase<TImage, VIsConst> &
+ImageRegionIteratorWithIndexBase<TImage, VIsConst>::operator++()
 {
   this->m_Remaining = false;
   for (unsigned int in = 0; in < TImage::ImageDimension; ++in)
@@ -54,9 +54,9 @@ ImageRegionConstIteratorWithIndex<TImage>::operator++()
 //----------------------------------------------------------------------
 //  Advance along the line in reverse direction
 //----------------------------------------------------------------------
-template <typename TImage>
-ImageRegionConstIteratorWithIndex<TImage> &
-ImageRegionConstIteratorWithIndex<TImage>::operator--()
+template <typename TImage, bool VIsConst>
+ImageRegionIteratorWithIndexBase<TImage, VIsConst> &
+ImageRegionIteratorWithIndexBase<TImage, VIsConst>::operator--()
 {
   this->m_Remaining = false;
   for (unsigned int in = 0; in < TImage::ImageDimension; ++in)

--- a/Modules/Core/Common/include/itkImageRegionExclusionConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionExclusionConstIteratorWithIndex.h
@@ -19,7 +19,7 @@
 #define itkImageRegionExclusionConstIteratorWithIndex_h
 
 #include "itkImageRegionConstIteratorWithIndex.h"
-#include <type_traits> // For remove_const_t.
+#include <type_traits> // For enable_if_t, remove_const_t.
 
 namespace itk
 {
@@ -128,20 +128,23 @@ namespace itk
  * \sphinxexample{Core/Common/IterateOverSpecificRegion,Iterate Over Image While Skipping Specific Region}
  * \endsphinx
  */
-template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageRegionExclusionConstIteratorWithIndex : public ImageRegionConstIteratorWithIndex<TImage>
+template <typename TImage, bool VIsConst>
+class ITK_TEMPLATE_EXPORT ImageRegionExclusionIteratorWithIndexBase
+  : public ImageRegionIteratorWithIndexBase<TImage, VIsConst>
 {
 public:
   /** Standard class type aliases. */
-  using Self = ImageRegionExclusionConstIteratorWithIndex;
-  using Superclass = ImageRegionConstIteratorWithIndex<TImage>;
+  using Self = ImageRegionExclusionIteratorWithIndexBase;
+  using Superclass = ImageRegionIteratorWithIndexBase<TImage, VIsConst>;
 
   /** Types inherited from the Superclass */
   using typename Superclass::IndexType;
   using typename Superclass::SizeType;
   using typename Superclass::OffsetType;
+  using typename Superclass::OffsetValueType;
   using typename Superclass::RegionType;
   using typename Superclass::ImageType;
+  using typename Superclass::ImagePointer;
   using typename Superclass::PixelContainer;
   using typename Superclass::PixelContainerPointer;
   using typename Superclass::InternalPixelType;
@@ -149,11 +152,11 @@ public:
   using typename Superclass::AccessorType;
 
   /** Default constructor. */
-  ImageRegionExclusionConstIteratorWithIndex() = default;
+  ImageRegionExclusionIteratorWithIndexBase() = default;
 
   /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes
    * the iterator at the begin of the region. */
-  ImageRegionExclusionConstIteratorWithIndex(const TImage * ptr, const RegionType & region);
+  ImageRegionExclusionIteratorWithIndexBase(ImagePointer ptr, const RegionType & region);
 
   /** Constructor that can be used to cast from an ImageRegionConstIteratorWithIndex
    * to an ImageRegionExclusionConstIteratorWithIndex. Many routines return an
@@ -162,7 +165,19 @@ public:
    * APIs that return different types of Iterators, itk returns ImageIterators
    * and uses constructors to cast from an ImageIterator to a
    * ImageRegionExclusionConstIteratorWithIndex. */
-  ImageRegionExclusionConstIteratorWithIndex(const Superclass & it);
+  ImageRegionExclusionIteratorWithIndexBase(const Superclass & it);
+
+  /** Converting constructor: non-const -> const. */
+  template <bool VOtherConst, typename = std::enable_if_t<VIsConst && !VOtherConst>>
+  ImageRegionExclusionIteratorWithIndexBase(const ImageRegionExclusionIteratorWithIndexBase<TImage, VOtherConst> & it)
+    : Superclass(static_cast<const ImageRegionIteratorWithIndexBase<TImage, VOtherConst> &>(it))
+    , m_ExclusionRegion(it.m_ExclusionRegion)
+    , m_ExclusionBegin(it.m_ExclusionBegin)
+    , m_ExclusionEnd(it.m_ExclusionEnd)
+  {}
+
+  template <typename, bool>
+  friend class ImageRegionExclusionIteratorWithIndexBase;
 
   /** Increment (prefix) the fastest moving dimension of the iterator's index.
    * This operator will constrain the iterator within the region (i.e. the
@@ -215,10 +230,39 @@ private:
   IndexType m_ExclusionEnd;
 };
 
-// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage>
+class ITK_TEMPLATE_EXPORT ImageRegionExclusionConstIteratorWithIndex
+  : public ImageRegionExclusionIteratorWithIndexBase<TImage, /*VIsConst=*/true>
+{
+public:
+  using Superclass = ImageRegionExclusionIteratorWithIndexBase<TImage, /*VIsConst=*/true>;
+  using Superclass::Superclass;
+};
+
 template <typename TImage>
 ImageRegionExclusionConstIteratorWithIndex(SmartPointer<TImage>, const typename TImage::RegionType &)
   -> ImageRegionExclusionConstIteratorWithIndex<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageRegionExclusionConstIteratorWithIndex(TImage *, const typename TImage::RegionType &)
+  -> ImageRegionExclusionConstIteratorWithIndex<TImage>;
+
+template <typename TImage>
+ImageRegionExclusionConstIteratorWithIndex(const TImage *, const typename TImage::RegionType &)
+  -> ImageRegionExclusionConstIteratorWithIndex<TImage>;
+
+// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage, bool VIsConst = std::is_const_v<TImage>>
+ImageRegionExclusionIteratorWithIndexBase(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageRegionExclusionIteratorWithIndexBase<std::remove_const_t<TImage>, VIsConst>;
+
+template <typename TImage>
+ImageRegionExclusionIteratorWithIndexBase(TImage *, const typename TImage::RegionType &)
+  -> ImageRegionExclusionIteratorWithIndexBase<TImage, /*VIsConst=*/false>;
+
+template <typename TImage>
+ImageRegionExclusionIteratorWithIndexBase(const TImage *, const typename TImage::RegionType &)
+  -> ImageRegionExclusionIteratorWithIndexBase<TImage, /*VIsConst=*/true>;
 
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageRegionExclusionConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRegionExclusionConstIteratorWithIndex.hxx
@@ -22,24 +22,25 @@
 namespace itk
 {
 
-template <typename TImage>
-ImageRegionExclusionConstIteratorWithIndex<TImage>::ImageRegionExclusionConstIteratorWithIndex(
-  const TImage *     ptr,
+template <typename TImage, bool VIsConst>
+ImageRegionExclusionIteratorWithIndexBase<TImage, VIsConst>::ImageRegionExclusionIteratorWithIndexBase(
+  ImagePointer       ptr,
   const RegionType & region)
   : Superclass(ptr, region)
 {}
 
-template <typename TImage>
-ImageRegionExclusionConstIteratorWithIndex<TImage>::ImageRegionExclusionConstIteratorWithIndex(const Superclass & it)
+template <typename TImage, bool VIsConst>
+ImageRegionExclusionIteratorWithIndexBase<TImage, VIsConst>::ImageRegionExclusionIteratorWithIndexBase(
+  const Superclass & it)
 {
   Superclass::operator=(it);
 }
 //----------------------------------------------------------------------
 //  Set the region to exclude from the walk
 //----------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageRegionExclusionConstIteratorWithIndex<TImage>::SetExclusionRegion(const RegionType & region)
+ImageRegionExclusionIteratorWithIndexBase<TImage, VIsConst>::SetExclusionRegion(const RegionType & region)
 {
   // Crop the exclusion region so that it lies entirely within the
   // iterator region.
@@ -59,9 +60,9 @@ ImageRegionExclusionConstIteratorWithIndex<TImage>::SetExclusionRegion(const Reg
 //  Set the region to exclude from the walk to a region that is inset
 //  one pixel from the boundary of the region
 //----------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageRegionExclusionConstIteratorWithIndex<TImage>::SetExclusionRegionToInsetRegion()
+ImageRegionExclusionIteratorWithIndexBase<TImage, VIsConst>::SetExclusionRegionToInsetRegion()
 {
   RegionType excludeRegion = this->m_Region;
   for (unsigned int i = 0; i < TImage::ImageDimension; ++i)
@@ -85,9 +86,9 @@ ImageRegionExclusionConstIteratorWithIndex<TImage>::SetExclusionRegionToInsetReg
 //----------------------------------------------------------------------
 // Move to beginning of region
 //----------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageRegionExclusionConstIteratorWithIndex<TImage>::GoToBegin()
+ImageRegionExclusionIteratorWithIndexBase<TImage, VIsConst>::GoToBegin()
 {
   // Check whether exclusion region covers the entire region
   if (m_ExclusionRegion == this->m_Region)
@@ -120,9 +121,9 @@ ImageRegionExclusionConstIteratorWithIndex<TImage>::GoToBegin()
 //----------------------------------------------------------------------
 // Move to the end of the region
 //----------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageRegionExclusionConstIteratorWithIndex<TImage>::GoToReverseBegin()
+ImageRegionExclusionIteratorWithIndexBase<TImage, VIsConst>::GoToReverseBegin()
 {
   // Check whether exclusion region covers the entire region
   if (m_ExclusionRegion == this->m_Region)
@@ -156,9 +157,9 @@ ImageRegionExclusionConstIteratorWithIndex<TImage>::GoToReverseBegin()
 //----------------------------------------------------------------------
 //  Advance along the line, skipping the exclusion region
 //----------------------------------------------------------------------
-template <typename TImage>
-ImageRegionExclusionConstIteratorWithIndex<TImage> &
-ImageRegionExclusionConstIteratorWithIndex<TImage>::operator++()
+template <typename TImage, bool VIsConst>
+ImageRegionExclusionIteratorWithIndexBase<TImage, VIsConst> &
+ImageRegionExclusionIteratorWithIndexBase<TImage, VIsConst>::operator++()
 {
   this->Superclass::operator++();
 
@@ -180,9 +181,9 @@ ImageRegionExclusionConstIteratorWithIndex<TImage>::operator++()
 //----------------------------------------------------------------------
 //  Advance along the line in reverse direction, skipping exclusion region
 //----------------------------------------------------------------------
-template <typename TImage>
-ImageRegionExclusionConstIteratorWithIndex<TImage> &
-ImageRegionExclusionConstIteratorWithIndex<TImage>::operator--()
+template <typename TImage, bool VIsConst>
+ImageRegionExclusionIteratorWithIndexBase<TImage, VIsConst> &
+ImageRegionExclusionIteratorWithIndexBase<TImage, VIsConst>::operator--()
 {
   this->Superclass::operator--();
 

--- a/Modules/Core/Common/include/itkImageRegionExclusionIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionExclusionIteratorWithIndex.h
@@ -65,75 +65,25 @@ namespace itk
  */
 template <typename TImage>
 class ITK_TEMPLATE_EXPORT ImageRegionExclusionIteratorWithIndex
-  : public ImageRegionExclusionConstIteratorWithIndex<TImage>
+  : public ImageRegionExclusionIteratorWithIndexBase<TImage, /*VIsConst=*/false>
 {
 public:
-  /** Standard class type aliases. */
-  using Self = ImageRegionExclusionIteratorWithIndex;
-  using Superclass = ImageRegionExclusionConstIteratorWithIndex<TImage>;
-
-  /** Types inherited from the Superclass */
-  using typename Superclass::IndexType;
-  using typename Superclass::SizeType;
-  using typename Superclass::OffsetType;
-  using typename Superclass::RegionType;
-  using typename Superclass::ImageType;
-  using typename Superclass::PixelContainer;
-  using typename Superclass::PixelContainerPointer;
-  using typename Superclass::InternalPixelType;
-  using typename Superclass::PixelType;
-  using typename Superclass::AccessorType;
-
-  /** Default constructor. */
-  ImageRegionExclusionIteratorWithIndex() = default;
-
-  /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes
-   * the iterator at the begin of the region. */
-  ImageRegionExclusionIteratorWithIndex(TImage * ptr, const RegionType & region);
-
-  /** Constructor that can be used to cast from an ImageIterator to an
-   * ImageRegionExclusionIteratorWithIndex. Many routines return an ImageIterator, but for a
-   * particular task, you may want an ImageRegionExclusionIteratorWithIndex.  Rather than
-   * provide overloaded APIs that return different types of Iterators, itk
-   * returns ImageIterators and uses constructors to cast from an
-   * ImageIterator to a ImageRegionExclusionIteratorWithIndex. */
-  ImageRegionExclusionIteratorWithIndex(const ImageIteratorWithIndex<TImage> & it);
-
-  /** Set the pixel value */
-  void
-  Set(const PixelType & value) const
-  {
-    this->m_PixelAccessorFunctor.Set(*(const_cast<InternalPixelType *>(this->m_Position)), value);
-  }
-
-  /** Return a reference to the pixel.
-   * This method will provide the fastest access to pixel
-   * data, but it will NOT support ImageAdaptors. */
-  PixelType &
-  Value()
-  {
-    return *(const_cast<InternalPixelType *>(this->m_Position));
-  }
-
-protected:
-  /** The construction from a const iterator is declared protected
-      in order to enforce const correctness. */
-  /** @ITKStartGrouping */
-  ImageRegionExclusionIteratorWithIndex(const ImageRegionExclusionConstIteratorWithIndex<TImage> & it);
-  Self &
-  operator=(const ImageRegionExclusionConstIteratorWithIndex<TImage> & it);
-  /** @ITKEndGrouping */
+  using Superclass = ImageRegionExclusionIteratorWithIndexBase<TImage, /*VIsConst=*/false>;
+  using Superclass::Superclass;
 };
 
-// Deduction guide for class template argument deduction (CTAD).
 template <typename TImage>
 ImageRegionExclusionIteratorWithIndex(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageRegionExclusionIteratorWithIndex<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageRegionExclusionIteratorWithIndex(TImage *, const typename TImage::RegionType &)
+  -> ImageRegionExclusionIteratorWithIndex<TImage>;
+
+template <typename TImage>
+ImageRegionExclusionIteratorWithIndex(const TImage *, const typename TImage::RegionType &)
   -> ImageRegionExclusionIteratorWithIndex<TImage>;
 
 } // end namespace itk
-
-#ifndef ITK_MANUAL_INSTANTIATION
-#  include "itkImageRegionExclusionIteratorWithIndex.hxx"
-#endif
 
 #endif

--- a/Modules/Core/Common/include/itkImageRegionExclusionIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRegionExclusionIteratorWithIndex.hxx
@@ -18,34 +18,12 @@
 #ifndef itkImageRegionExclusionIteratorWithIndex_hxx
 #define itkImageRegionExclusionIteratorWithIndex_hxx
 
+// All ImageRegionExclusionIteratorWithIndex functionality has been
+// absorbed into ImageRegionExclusionIteratorWithIndexBase<TImage, VIsConst>
+// (see itkImageRegionExclusionConstIteratorWithIndex.h). This header is
+// retained only for backward compatibility with code that #includes it
+// directly.
 
-namespace itk
-{
-template <typename TImage>
-ImageRegionExclusionIteratorWithIndex<TImage>::ImageRegionExclusionIteratorWithIndex(TImage *           ptr,
-                                                                                     const RegionType & region)
-  : ImageRegionExclusionConstIteratorWithIndex<TImage>(ptr, region)
-{}
-
-template <typename TImage>
-ImageRegionExclusionIteratorWithIndex<TImage>::ImageRegionExclusionIteratorWithIndex(
-  const ImageIteratorWithIndex<TImage> & it)
-  : ImageRegionExclusionConstIteratorWithIndex<TImage>(it)
-{}
-
-template <typename TImage>
-ImageRegionExclusionIteratorWithIndex<TImage>::ImageRegionExclusionIteratorWithIndex(
-  const ImageRegionExclusionConstIteratorWithIndex<TImage> & it)
-  : ImageRegionExclusionConstIteratorWithIndex<TImage>(it)
-{}
-
-template <typename TImage>
-ImageRegionExclusionIteratorWithIndex<TImage> &
-ImageRegionExclusionIteratorWithIndex<TImage>::operator=(const ImageRegionExclusionConstIteratorWithIndex<TImage> & it)
-{
-  this->ImageRegionExclusionConstIteratorWithIndex<TImage>::operator=(it);
-  return *this;
-}
-} // end namespace itk
+#include "itkImageRegionExclusionIteratorWithIndex.h"
 
 #endif

--- a/Modules/Core/Common/include/itkImageRegionIterator.h
+++ b/Modules/Core/Common/include/itkImageRegionIterator.h
@@ -77,69 +77,22 @@ namespace itk
  * \endsphinx
  */
 template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageRegionIterator : public ImageRegionConstIterator<TImage>
+class ITK_TEMPLATE_EXPORT ImageRegionIterator : public ImageRegionIteratorBase<TImage, /*VIsConst=*/false>
 {
 public:
-  /** Standard class type aliases. */
-  using Self = ImageRegionIterator;
-  using Superclass = ImageRegionConstIterator<TImage>;
-
-  /** Types inherited from the Superclass */
-  using typename Superclass::IndexType;
-  using typename Superclass::SizeType;
-  using typename Superclass::OffsetType;
-  using typename Superclass::RegionType;
-  using typename Superclass::ImageType;
-  using typename Superclass::PixelContainer;
-  using typename Superclass::PixelContainerPointer;
-  using typename Superclass::InternalPixelType;
-  using typename Superclass::PixelType;
-  using typename Superclass::AccessorType;
-
-  /** Default constructor. */
-  ImageRegionIterator() = default;
-
-  /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes
-   * the iterator at the begin of the region. */
-  ImageRegionIterator(TImage * ptr, const RegionType & region);
-
-  /** Constructor that can be used to cast from an ImageIterator to an
-   * ImageRegionIterator. Many routines return an ImageIterator but for a
-   * particular task, you may want an ImageRegionIterator.  Rather than
-   * provide overloaded APIs that return different types of Iterators, itk
-   * returns ImageIterators and uses constructors to cast from an
-   * ImageIterator to a ImageRegionIterator. */
-  ImageRegionIterator(const ImageIterator<TImage> & it);
-
-  /** Set the pixel value */
-  void
-  Set(const PixelType & value) const
-  {
-    this->m_PixelAccessorFunctor.Set(*(const_cast<InternalPixelType *>(this->m_Buffer + this->m_Offset)), value);
-  }
-
-  /** Return a reference to the pixel
-   * This method will provide the fastest access to pixel
-   * data, but it will NOT support ImageAdaptors. */
-  PixelType &
-  Value()
-  {
-    return *(const_cast<InternalPixelType *>(this->m_Buffer + this->m_Offset));
-  }
-
-protected:
-  /** the construction from a const iterator is declared protected
-      in order to enforce const correctness. */
-  /** @ITKStartGrouping */
-  ImageRegionIterator(const ImageRegionConstIterator<TImage> & it);
-  Self &
-  operator=(const ImageRegionConstIterator<TImage> & it);
-  /** @ITKEndGrouping */
+  using Superclass = ImageRegionIteratorBase<TImage, /*VIsConst=*/false>;
+  using Superclass::Superclass;
 };
 
-// Deduction guide for class template argument deduction (CTAD).
 template <typename TImage>
-ImageRegionIterator(SmartPointer<TImage>, const typename TImage::RegionType &) -> ImageRegionIterator<TImage>;
+ImageRegionIterator(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageRegionIterator<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageRegionIterator(TImage *, const typename TImage::RegionType &) -> ImageRegionIterator<TImage>;
+
+template <typename TImage>
+ImageRegionIterator(const TImage *, const typename TImage::RegionType &) -> ImageRegionIterator<TImage>;
 
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageRegionIterator.hxx
+++ b/Modules/Core/Common/include/itkImageRegionIterator.hxx
@@ -19,31 +19,10 @@
 #define itkImageRegionIterator_hxx
 
 
-namespace itk
-{
-template <typename TImage>
-ImageRegionIterator<TImage>::ImageRegionIterator(TImage * ptr, const RegionType & region)
-  : ImageRegionConstIterator<TImage>(ptr, region)
-{}
-
-template <typename TImage>
-ImageRegionIterator<TImage>::ImageRegionIterator(const ImageIterator<TImage> & it)
-  : ImageRegionConstIterator<TImage>(it)
-{}
-
-template <typename TImage>
-ImageRegionIterator<TImage>::ImageRegionIterator(const ImageRegionConstIterator<TImage> & it)
-  : ImageRegionConstIterator<TImage>(it)
-{}
-
-template <typename TImage>
-ImageRegionIterator<TImage> &
-ImageRegionIterator<TImage>::operator=(const ImageRegionConstIterator<TImage> & it)
-{
-  this->ImageRegionConstIterator<TImage>::operator=(it);
-  return *this;
-}
-
-} // end namespace itk
+// All ImageRegionIterator behavior is provided by the ImageRegionIteratorBase
+// class template instantiated through the ImageRegionIterator alias declared in
+// itkImageRegionIterator.h. This translation-unit-stub remains so that
+// downstream code that still includes "itkImageRegionIterator.hxx" directly
+// continues to compile.
 
 #endif

--- a/Modules/Core/Common/include/itkImageRegionIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageRegionIteratorWithIndex.h
@@ -70,75 +70,25 @@ namespace itk
  * Current Index With Write Access} \endsphinx
  */
 template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageRegionIteratorWithIndex : public ImageRegionConstIteratorWithIndex<TImage>
+class ITK_TEMPLATE_EXPORT ImageRegionIteratorWithIndex
+  : public ImageRegionIteratorWithIndexBase<TImage, /*VIsConst=*/false>
 {
 public:
-  /** Standard class type aliases. */
-  using Self = ImageRegionIteratorWithIndex;
-  using Superclass = ImageRegionConstIteratorWithIndex<TImage>;
-
-  /** Types inherited from the Superclass */
-  using typename Superclass::IndexType;
-  using typename Superclass::SizeType;
-  using typename Superclass::OffsetType;
-  using typename Superclass::RegionType;
-  using typename Superclass::ImageType;
-  using typename Superclass::PixelContainer;
-  using typename Superclass::PixelContainerPointer;
-  using typename Superclass::InternalPixelType;
-  using typename Superclass::PixelType;
-  using typename Superclass::AccessorType;
-
-  /** Default constructor. */
-  ImageRegionIteratorWithIndex() = default;
-
-  /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes
-   * the iterator at the begin of the region. */
-  ImageRegionIteratorWithIndex(TImage * ptr, const RegionType & region);
-
-  /** Constructor that can be used to cast from an ImageIterator to an
-   * ImageRegionIteratorWithIndex. Many routines return an ImageIterator, but for a
-   * particular task, you may want an ImageRegionIteratorWithIndex.  Rather than
-   * provide overloaded APIs that return different types of Iterators, itk
-   * returns ImageIterators and uses constructors to cast from an
-   * ImageIterator to a ImageRegionIteratorWithIndex. */
-  ImageRegionIteratorWithIndex(const ImageIteratorWithIndex<TImage> & it);
-
-  /** Set the pixel value */
-  void
-  Set(const PixelType & value) const
-  {
-    this->m_PixelAccessorFunctor.Set(*(const_cast<InternalPixelType *>(this->m_Position)), value);
-  }
-
-  /** Return a reference to the pixel.
-   * This method will provide the fastest access to pixel
-   * data, but it will NOT support ImageAdaptors. */
-  PixelType &
-  Value()
-  {
-    return *(const_cast<InternalPixelType *>(this->m_Position));
-  }
-
-protected:
-  /** The construction from a const iterator is declared protected
-      in order to enforce const correctness. */
-  /** @ITKStartGrouping */
-  ImageRegionIteratorWithIndex(const ImageRegionConstIteratorWithIndex<TImage> & it);
-  Self &
-  operator=(const ImageRegionConstIteratorWithIndex<TImage> & it);
-  /** @ITKEndGrouping */
+  using Superclass = ImageRegionIteratorWithIndexBase<TImage, /*VIsConst=*/false>;
+  using Superclass::Superclass;
 };
 
-// Deduction guide for class template argument deduction (CTAD).
 template <typename TImage>
 ImageRegionIteratorWithIndex(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageRegionIteratorWithIndex<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageRegionIteratorWithIndex(TImage *, const typename TImage::RegionType &) -> ImageRegionIteratorWithIndex<TImage>;
+
+template <typename TImage>
+ImageRegionIteratorWithIndex(const TImage *, const typename TImage::RegionType &)
   -> ImageRegionIteratorWithIndex<TImage>;
 
 } // end namespace itk
-
-#ifndef ITK_MANUAL_INSTANTIATION
-#  include "itkImageRegionIteratorWithIndex.hxx"
-#endif
 
 #endif

--- a/Modules/Core/Common/include/itkImageRegionIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageRegionIteratorWithIndex.hxx
@@ -18,31 +18,11 @@
 #ifndef itkImageRegionIteratorWithIndex_hxx
 #define itkImageRegionIteratorWithIndex_hxx
 
+// All ImageRegionIteratorWithIndex functionality has been absorbed into
+// ImageRegionIteratorWithIndexBase<TImage, VIsConst> (see
+// itkImageRegionConstIteratorWithIndex.h). This header is retained only
+// for backward compatibility with any code that #includes it directly.
 
-namespace itk
-{
-template <typename TImage>
-ImageRegionIteratorWithIndex<TImage>::ImageRegionIteratorWithIndex(TImage * ptr, const RegionType & region)
-  : ImageRegionConstIteratorWithIndex<TImage>(ptr, region)
-{}
-
-template <typename TImage>
-ImageRegionIteratorWithIndex<TImage>::ImageRegionIteratorWithIndex(const ImageIteratorWithIndex<TImage> & it)
-  : ImageRegionConstIteratorWithIndex<TImage>(it)
-{}
-
-template <typename TImage>
-ImageRegionIteratorWithIndex<TImage>::ImageRegionIteratorWithIndex(const ImageRegionConstIteratorWithIndex<TImage> & it)
-  : ImageRegionConstIteratorWithIndex<TImage>(it)
-{}
-
-template <typename TImage>
-ImageRegionIteratorWithIndex<TImage> &
-ImageRegionIteratorWithIndex<TImage>::operator=(const ImageRegionConstIteratorWithIndex<TImage> & it)
-{
-  this->ImageRegionConstIteratorWithIndex<TImage>::operator=(it);
-  return *this;
-}
-} // end namespace itk
+#include "itkImageRegionIteratorWithIndex.h"
 
 #endif

--- a/Modules/Core/Common/include/itkImageRegionReverseConstIterator.h
+++ b/Modules/Core/Common/include/itkImageRegionReverseConstIterator.h
@@ -20,7 +20,7 @@
 
 #include "itkImageReverseConstIterator.h"
 #include "itkImageRegionIterator.h"
-#include <type_traits> // For remove_const_t.
+#include <type_traits> // For enable_if_t, remove_const_t.
 
 namespace itk
 {
@@ -100,13 +100,13 @@ namespace itk
  * \sa ImageConstIteratorWithIndex
  * \ingroup ITKCommon
  */
-template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageRegionReverseConstIterator : public ImageReverseConstIterator<TImage>
+template <typename TImage, bool VIsConst>
+class ITK_TEMPLATE_EXPORT ImageRegionReverseIteratorBase : public ImageReverseIteratorBase<TImage, VIsConst>
 {
 public:
   /** Standard class type aliases. */
-  using Self = ImageRegionReverseConstIterator;
-  using Superclass = ImageReverseConstIterator<TImage>;
+  using Self = ImageRegionReverseIteratorBase;
+  using Superclass = ImageReverseIteratorBase<TImage, VIsConst>;
 
   /** Index type alias support While this was already typedef'ed in the superclass
    * it needs to be redone here for this subclass to compile properly with gcc. */
@@ -143,17 +143,19 @@ public:
    *  representations. */
   using typename Superclass::AccessorType;
 
+  using typename Superclass::ImagePointer;
+
   /** \see LightObject::GetNameOfClass() */
-  itkOverrideGetNameOfClassMacro(ImageRegionReverseConstIterator);
+  itkOverrideGetNameOfClassMacro(ImageRegionReverseIteratorBase);
 
   /** Default constructor. */
-  ImageRegionReverseConstIterator()
+  ImageRegionReverseIteratorBase()
     : Superclass()
   {}
 
   /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes
    * the iterator at the begin of the region. */
-  ImageRegionReverseConstIterator(const TImage * ptr, const RegionType & region)
+  ImageRegionReverseIteratorBase(ImagePointer ptr, const RegionType & region)
     : Superclass(ptr, region)
     , m_SpanBeginOffset(this->m_BeginOffset)
     , m_SpanEndOffset(this->m_BeginOffset - static_cast<OffsetValueType>(this->m_Region.GetSize()[0]))
@@ -166,7 +168,7 @@ public:
    * that return different types of Iterators, itk returns
    * ImageIterators and uses constructors to cast from an
    * ImageIterator to a ImageRegionReverseConstIterator. */
-  ImageRegionReverseConstIterator(const ImageConstIterator<TImage> & it)
+  ImageRegionReverseIteratorBase(const ImageIteratorBase<TImage, VIsConst> & it)
     : Superclass(it)
     , m_SpanEndOffset(m_SpanBeginOffset - static_cast<OffsetValueType>(this->m_Region.GetSize()[0]))
   {
@@ -178,7 +180,7 @@ public:
 
   /** Constructor that takes in a reverse image iterator.  This can be used
    * to cast between the various types of reverse image iterators. */
-  ImageRegionReverseConstIterator(const ImageReverseConstIterator<TImage> & it)
+  ImageRegionReverseIteratorBase(const Superclass & it)
     : Superclass(it)
     , m_SpanEndOffset(m_SpanBeginOffset - static_cast<OffsetValueType>(this->m_Region.GetSize()[0]))
   {
@@ -188,17 +190,16 @@ public:
                         (ind[0] - this->m_Region.GetIndex()[0]);
   }
 
-  /** Constructor that takes in an image region iterator.  This can be used
-   * to cast between the various types of reverse image iterators. */
-  ImageRegionReverseConstIterator(const ImageRegionIterator<TImage> & it)
-    : Superclass(it)
-    , m_SpanEndOffset(m_SpanBeginOffset - static_cast<OffsetValueType>(this->m_Region.GetSize()[0]))
-  {
-    IndexType ind = this->GetIndex();
+  /** Converting constructor: non-const -> const. */
+  template <bool VOtherConst, typename = std::enable_if_t<VIsConst && !VOtherConst>>
+  ImageRegionReverseIteratorBase(const ImageRegionReverseIteratorBase<TImage, VOtherConst> & it)
+    : Superclass(static_cast<const ImageReverseIteratorBase<TImage, VOtherConst> &>(it))
+    , m_SpanBeginOffset(it.m_SpanBeginOffset)
+    , m_SpanEndOffset(it.m_SpanEndOffset)
+  {}
 
-    m_SpanBeginOffset = this->m_Offset + static_cast<OffsetValueType>(this->m_Region.GetSize()[0]) -
-                        (ind[0] - this->m_Region.GetIndex()[0]);
-  }
+  template <typename, bool>
+  friend class ImageRegionReverseIteratorBase;
 
   /** Move an iterator to the beginning of the region. "Begin" for a reverse
    * iterator is the last pixel in the region. */
@@ -256,11 +257,10 @@ public:
       this->m_Offset++;
 
       // Get the index of the first pixel on the span (row)
-      typename ImageConstIterator<TImage>::IndexType ind =
-        this->m_Image->ComputeIndex(static_cast<OffsetValueType>(this->m_Offset));
+      IndexType ind = this->m_Image->ComputeIndex(static_cast<OffsetValueType>(this->m_Offset));
 
-      const typename ImageConstIterator<TImage>::IndexType & startIndex = this->m_Region.GetIndex();
-      const typename ImageConstIterator<TImage>::SizeType &  size = this->m_Region.GetSize();
+      const IndexType & startIndex = this->m_Region.GetIndex();
+      const SizeType &  size = this->m_Region.GetSize();
 
       // Decrement along a row, then wrap at the beginning of the region row.
 
@@ -310,11 +310,10 @@ public:
       --this->m_Offset;
 
       // Get the index of the last pixel on the span (row)
-      typename ImageConstIterator<TImage>::IndexType ind =
-        this->m_Image->ComputeIndex(static_cast<OffsetValueType>(this->m_Offset));
+      IndexType ind = this->m_Image->ComputeIndex(static_cast<OffsetValueType>(this->m_Offset));
 
-      const typename ImageIterator<TImage>::IndexType & startIndex = this->m_Region.GetIndex();
-      const typename ImageIterator<TImage>::SizeType &  size = this->m_Region.GetSize();
+      const IndexType & startIndex = this->m_Region.GetIndex();
+      const SizeType &  size = this->m_Region.GetSize();
 
       // Increment along a row, then wrap at the end of the region row.
       // Check to see if we are past the last pixel in the region
@@ -349,10 +348,39 @@ protected:
   SizeValueType m_SpanEndOffset{};   // offset to one pixel before the row
 };
 
-// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage>
+class ITK_TEMPLATE_EXPORT ImageRegionReverseConstIterator
+  : public ImageRegionReverseIteratorBase<TImage, /*VIsConst=*/true>
+{
+public:
+  using Superclass = ImageRegionReverseIteratorBase<TImage, /*VIsConst=*/true>;
+  using Superclass::Superclass;
+};
+
 template <typename TImage>
 ImageRegionReverseConstIterator(SmartPointer<TImage>, const typename TImage::RegionType &)
   -> ImageRegionReverseConstIterator<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageRegionReverseConstIterator(TImage *, const typename TImage::RegionType &)
+  -> ImageRegionReverseConstIterator<TImage>;
+
+template <typename TImage>
+ImageRegionReverseConstIterator(const TImage *, const typename TImage::RegionType &)
+  -> ImageRegionReverseConstIterator<TImage>;
+
+// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage, bool VIsConst = std::is_const_v<TImage>>
+ImageRegionReverseIteratorBase(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageRegionReverseIteratorBase<std::remove_const_t<TImage>, VIsConst>;
+
+template <typename TImage>
+ImageRegionReverseIteratorBase(TImage *, const typename TImage::RegionType &)
+  -> ImageRegionReverseIteratorBase<TImage, /*VIsConst=*/false>;
+
+template <typename TImage>
+ImageRegionReverseIteratorBase(const TImage *, const typename TImage::RegionType &)
+  -> ImageRegionReverseIteratorBase<TImage, /*VIsConst=*/true>;
 
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageRegionReverseIterator.h
+++ b/Modules/Core/Common/include/itkImageRegionReverseIterator.h
@@ -66,75 +66,23 @@ namespace itk
  * \ingroup ITKCommon
  */
 template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageRegionReverseIterator : public ImageRegionReverseConstIterator<TImage>
+class ITK_TEMPLATE_EXPORT ImageRegionReverseIterator : public ImageRegionReverseIteratorBase<TImage, /*VIsConst=*/false>
 {
 public:
-  /** Standard class type aliases. */
-  using Self = ImageRegionReverseIterator;
-  using Superclass = ImageRegionReverseConstIterator<TImage>;
-
-  /** Types inherited from the Superclass */
-  using typename Superclass::IndexType;
-  using typename Superclass::SizeType;
-  using typename Superclass::OffsetType;
-  using typename Superclass::RegionType;
-  using typename Superclass::ImageType;
-  using typename Superclass::PixelContainer;
-  using typename Superclass::PixelContainerPointer;
-  using typename Superclass::InternalPixelType;
-  using typename Superclass::PixelType;
-  using typename Superclass::AccessorType;
-
-  /** Default constructor. */
-  ImageRegionReverseIterator() = default;
-
-  /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes
-   * the iterator at the begin of the region. */
-  ImageRegionReverseIterator(TImage * ptr, const RegionType & region);
-
-  /** Constructor that can be used to cast from an ImageConstIterator to an
-   * ImageRegionReverseIterator. Many routines return an ImageConstIterator but for a
-   * particular task, you may want an ImageRegionReverseIterator.  Rather than
-   * provide overloaded APIs that return different types of Iterators, itk
-   * returns ImageConstIterators and uses constructors to cast from an
-   * ImageConstIterator to a ImageRegionReverseIterator. */
-  ImageRegionReverseIterator(const ImageConstIterator<TImage> & it);
-
-  /** Set the pixel value */
-  void
-  Set(const PixelType & value) const
-  {
-    this->m_PixelAccessor.Set(*const_cast<InternalPixelType *>((this->m_Buffer + this->m_Offset)), value);
-  }
-
-  /** Return a reference to the pixel
-   * This method will provide the fastest access to pixel
-   * data, but it will NOT support ImageAdaptors. */
-  PixelType &
-  Value()
-  {
-    return *const_cast<InternalPixelType *>((this->m_Buffer + this->m_Offset));
-  }
-
-protected:
-  /** the construction from a const iterator is declared protected
-      in order to enforce const correctness. */
-  /** @ITKStartGrouping */
-  ImageRegionReverseIterator(const ImageRegionReverseConstIterator<TImage> & it);
-  Self &
-  operator=(const ImageRegionReverseConstIterator<TImage> & it);
-  /** @ITKEndGrouping */
+  using Superclass = ImageRegionReverseIteratorBase<TImage, /*VIsConst=*/false>;
+  using Superclass::Superclass;
 };
 
-// Deduction guide for class template argument deduction (CTAD).
 template <typename TImage>
 ImageRegionReverseIterator(SmartPointer<TImage>, const typename TImage::RegionType &)
-  -> ImageRegionReverseIterator<TImage>;
+  -> ImageRegionReverseIterator<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageRegionReverseIterator(TImage *, const typename TImage::RegionType &) -> ImageRegionReverseIterator<TImage>;
+
+template <typename TImage>
+ImageRegionReverseIterator(const TImage *, const typename TImage::RegionType &) -> ImageRegionReverseIterator<TImage>;
 
 } // end namespace itk
-
-#ifndef ITK_MANUAL_INSTANTIATION
-#  include "itkImageRegionReverseIterator.hxx"
-#endif
 
 #endif

--- a/Modules/Core/Common/include/itkImageRegionReverseIterator.hxx
+++ b/Modules/Core/Common/include/itkImageRegionReverseIterator.hxx
@@ -18,32 +18,11 @@
 #ifndef itkImageRegionReverseIterator_hxx
 #define itkImageRegionReverseIterator_hxx
 
+// All ImageRegionReverseIterator functionality has been absorbed into
+// ImageRegionReverseIteratorBase<TImage, VIsConst> (see
+// itkImageRegionReverseConstIterator.h). This header is retained only
+// for backward compatibility with code that #includes it directly.
 
-namespace itk
-{
-template <typename TImage>
-ImageRegionReverseIterator<TImage>::ImageRegionReverseIterator(TImage * ptr, const RegionType & region)
-  : ImageRegionReverseConstIterator<TImage>(ptr, region)
-{}
-
-template <typename TImage>
-ImageRegionReverseIterator<TImage>::ImageRegionReverseIterator(const ImageConstIterator<TImage> & it)
-  : Superclass(it)
-{}
-
-template <typename TImage>
-ImageRegionReverseIterator<TImage>::ImageRegionReverseIterator(const ImageRegionReverseConstIterator<TImage> & it)
-  : Superclass(it)
-{}
-
-template <typename TImage>
-ImageRegionReverseIterator<TImage> &
-ImageRegionReverseIterator<TImage>::operator=(const ImageRegionReverseConstIterator<TImage> & it)
-{
-  this->Superclass::operator=(it);
-  return *this;
-}
-
-} // end namespace itk
+#include "itkImageRegionReverseIterator.h"
 
 #endif

--- a/Modules/Core/Common/include/itkImageReverseConstIterator.h
+++ b/Modules/Core/Common/include/itkImageReverseConstIterator.h
@@ -20,8 +20,9 @@
 
 #include "itkSize.h"
 #include "itkImageConstIterator.h"
+#include "itkWeakPointer.h"
 #include <memory>
-#include <type_traits> // For remove_const_t.
+#include <type_traits> // For conditional_t, enable_if_t, remove_const_t.
 
 namespace itk
 {
@@ -84,12 +85,12 @@ namespace itk
  * \sa ImageConstIteratorWithIndex
  * \ingroup ITKCommon
  */
-template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageReverseConstIterator
+template <typename TImage, bool VIsConst>
+class ITK_TEMPLATE_EXPORT ImageReverseIteratorBase
 {
 public:
   /** Standard class type aliases. */
-  using Self = ImageReverseConstIterator;
+  using Self = ImageReverseIteratorBase;
 
   /** Dimension of the image the iterator walks.  This constant is needed so
    * functions that are templated over image iterator type (as opposed to
@@ -98,7 +99,7 @@ public:
   static constexpr unsigned int ImageIteratorDimension = TImage::ImageDimension;
 
   /** \see LightObject::GetNameOfClass() */
-  itkVirtualGetNameOfClassMacro(ImageReverseConstIterator);
+  itkVirtualGetNameOfClassMacro(ImageReverseIteratorBase);
 
   /** Index type alias support */
   using IndexType = typename TImage::IndexType;
@@ -134,10 +135,14 @@ public:
   /** Functor to choose the appropriate accessor. (for Image vs VectorImage) */
   using AccessorFunctorType = typename TImage::AccessorFunctorType;
 
+  using InternalPixelPointer = std::conditional_t<VIsConst, const InternalPixelType *, InternalPixelType *>;
+  using ImageWeakPointer = std::conditional_t<VIsConst, typename TImage::ConstWeakPointer, WeakPointer<TImage>>;
+  using ImagePointer = std::conditional_t<VIsConst, const TImage *, TImage *>;
+
   /** Default Constructor. Need to provide a default constructor since we
    * provide a copy constructor. */
-  ImageReverseConstIterator()
-    : m_Buffer(0)
+  ImageReverseIteratorBase()
+    : m_Buffer(nullptr)
     , m_PixelAccessor()
     , m_PixelAccessorFunctor()
   {
@@ -145,11 +150,11 @@ public:
   }
 
   /** Default Destructor. */
-  virtual ~ImageReverseConstIterator() = default;
+  virtual ~ImageReverseIteratorBase() = default;
 
   /** Copy Constructor. The copy constructor is provided to make sure the
    * handle to the image is properly reference counted. */
-  ImageReverseConstIterator(const Self & it)
+  ImageReverseIteratorBase(const Self & it)
     : m_Image(it.m_Image)
     , m_Region(it.m_Region)
     , m_Offset(it.m_Offset)
@@ -165,9 +170,24 @@ public:
     m_PixelAccessorFunctor.SetBegin(m_Buffer);
   }
 
+  /** Converting constructor: non-const -> const, disabled the other way. */
+  template <bool VOtherConst, typename = std::enable_if_t<VIsConst && !VOtherConst>>
+  ImageReverseIteratorBase(const ImageReverseIteratorBase<TImage, VOtherConst> & it)
+    : m_Image(it.m_Image)
+    , m_Region(it.m_Region)
+    , m_Offset(it.m_Offset)
+    , m_BeginOffset(it.m_BeginOffset)
+    , m_EndOffset(it.m_EndOffset)
+    , m_Buffer(it.m_Buffer)
+    , m_PixelAccessor(it.m_PixelAccessor)
+    , m_PixelAccessorFunctor(it.m_PixelAccessorFunctor)
+  {
+    m_PixelAccessorFunctor.SetBegin(m_Buffer);
+  }
+
   /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes
    * the iterator at the begin of the region. */
-  ImageReverseConstIterator(const TImage * ptr, const RegionType & region)
+  ImageReverseIteratorBase(ImagePointer ptr, const RegionType & region)
     : m_Image(ptr)
     , m_Region(region)
     , m_Buffer(m_Image->GetBufferPointer())
@@ -200,7 +220,7 @@ public:
    * that return different types of Iterators, itk returns
    * ImageConstIterators and uses constructors to cast from an
    * ImageConstIterator to a ImageRegionReverseIterator. */
-  ImageReverseConstIterator(const ImageConstIterator<TImage> & it)
+  ImageReverseIteratorBase(const ImageIteratorBase<TImage, VIsConst> & it)
     : m_Image(it.GetImage())
     , m_Region(it.GetRegion())
     , m_EndOffset(m_Image->ComputeOffset(m_Region.GetIndex()) - 1)
@@ -253,7 +273,7 @@ public:
   /** operator= is provided to make sure the handle to the image is properly
    * reference counted. */
   Self &
-  operator=(const ImageConstIterator<TImage> & it)
+  operator=(const ImageIteratorBase<TImage, VIsConst> & it)
   {
     m_Image = it.GetImage();
     m_Region = it.GetRegion();
@@ -280,6 +300,9 @@ public:
     m_PixelAccessorFunctor.SetBegin(m_Buffer);
     return *this;
   }
+
+  template <typename, bool>
+  friend class ImageReverseIteratorBase;
 
   /** Get the dimension (size) of the index. */
   static unsigned int
@@ -333,13 +356,6 @@ public:
     return m_PixelAccessorFunctor.Get(*(m_Buffer + m_Offset));
   }
 
-  /** Set the pixel value */
-  void
-  Set(const PixelType & value) const
-  {
-    this->m_PixelAccessorFunctor.Set(*(const_cast<InternalPixelType *>(this->m_Buffer + this->m_Offset)), value);
-  }
-
   /** Return a const reference to the pixel
    * This method will provide the fastest access to pixel
    * data, but it will NOT support ImageAdaptors. */
@@ -349,13 +365,20 @@ public:
     return *(m_Buffer + m_Offset);
   }
 
-  /** Return a reference to the pixel
-   * This method will provide the fastest access to pixel
-   * data, but it will NOT support ImageAdaptors. */
-  const PixelType &
+  /** Return a mutable reference to the pixel. SFINAE-gated on !VIsConst. */
+  template <bool VCopy = VIsConst, std::enable_if_t<!VCopy, int> = 0>
+  PixelType &
   Value()
   {
     return *(m_Buffer + m_Offset);
+  }
+
+  /** Set the pixel value. SFINAE-gated on !VIsConst. */
+  template <bool VCopy = VIsConst, std::enable_if_t<!VCopy, int> = 0>
+  void
+  Set(const PixelType & value) const
+  {
+    this->m_PixelAccessorFunctor.Set(*(m_Buffer + m_Offset), value);
   }
 
   /** Move an iterator to the beginning of the region. "Begin" for a reverse
@@ -391,7 +414,7 @@ public:
   }
 
 protected: // made protected so other iterators can access
-  typename ImageType::ConstWeakPointer m_Image{};
+  ImageWeakPointer m_Image{};
 
   RegionType m_Region{}; // region to iterate over
 
@@ -399,16 +422,42 @@ protected: // made protected so other iterators can access
   SizeValueType m_BeginOffset{}; // offset to last pixel in region
   SizeValueType m_EndOffset{};   // offset to one pixel before first pixel
 
-  const InternalPixelType * m_Buffer{};
+  InternalPixelPointer m_Buffer{};
 
   AccessorType        m_PixelAccessor{};
   AccessorFunctorType m_PixelAccessorFunctor{};
 };
 
-// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage>
+class ITK_TEMPLATE_EXPORT ImageReverseConstIterator : public ImageReverseIteratorBase<TImage, /*VIsConst=*/true>
+{
+public:
+  using Superclass = ImageReverseIteratorBase<TImage, /*VIsConst=*/true>;
+  using Superclass::Superclass;
+};
+
 template <typename TImage>
 ImageReverseConstIterator(SmartPointer<TImage>, const typename TImage::RegionType &)
   -> ImageReverseConstIterator<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageReverseConstIterator(TImage *, const typename TImage::RegionType &) -> ImageReverseConstIterator<TImage>;
+
+template <typename TImage>
+ImageReverseConstIterator(const TImage *, const typename TImage::RegionType &) -> ImageReverseConstIterator<TImage>;
+
+// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage, bool VIsConst = std::is_const_v<TImage>>
+ImageReverseIteratorBase(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageReverseIteratorBase<std::remove_const_t<TImage>, VIsConst>;
+
+template <typename TImage>
+ImageReverseIteratorBase(TImage *, const typename TImage::RegionType &)
+  -> ImageReverseIteratorBase<TImage, /*VIsConst=*/false>;
+
+template <typename TImage>
+ImageReverseIteratorBase(const TImage *, const typename TImage::RegionType &)
+  -> ImageReverseIteratorBase<TImage, /*VIsConst=*/true>;
 
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageReverseIterator.h
+++ b/Modules/Core/Common/include/itkImageReverseIterator.h
@@ -62,74 +62,23 @@ namespace itk
  * \ingroup ITKCommon
  */
 template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageReverseIterator : public ImageRegionReverseConstIterator<TImage>
+class ITK_TEMPLATE_EXPORT ImageReverseIterator : public ImageRegionReverseIteratorBase<TImage, /*VIsConst=*/false>
 {
 public:
-  /** Standard class type aliases. */
-  using Self = ImageReverseIterator;
-  using Superclass = ImageRegionReverseConstIterator<TImage>;
-
-  /** Types inherited from the Superclass */
-  using typename Superclass::IndexType;
-  using typename Superclass::SizeType;
-  using typename Superclass::OffsetType;
-  using typename Superclass::RegionType;
-  using typename Superclass::ImageType;
-  using typename Superclass::PixelContainer;
-  using typename Superclass::PixelContainerPointer;
-  using typename Superclass::InternalPixelType;
-  using typename Superclass::PixelType;
-  using typename Superclass::AccessorType;
-
-  /** Default constructor. */
-  ImageReverseIterator() = default;
-
-  /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes
-   * the iterator at the begin of the region. */
-  ImageReverseIterator(TImage * ptr, const RegionType & region);
-
-  /** Constructor that can be used to cast from an ImageIterator to an
-   * ImageReverseIterator. Many routines return an ImageIterator but for a
-   * particular task, you may want an ImageReverseIterator.  Rather than
-   * provide overloaded APIs that return different types of Iterators, itk
-   * returns ImageIterators and uses constructors to cast from an
-   * ImageIterator to a ImageReverseIterator. */
-  ImageReverseIterator(const ImageIteratorWithIndex<TImage> & it);
-
-  /** Set the pixel value */
-  void
-  Set(const PixelType & value) const
-  {
-    this->m_PixelAccessorFunctor.Set(*const_cast<InternalPixelType *>((this->m_Buffer + this->m_Offset)), value);
-  }
-
-  /** Return a reference to the pixel
-   * This method will provide the fastest access to pixel
-   * data, but it will NOT support ImageAdaptors. */
-  PixelType &
-  Value()
-  {
-    return *(this->m_Buffer + this->m_Offset);
-  }
-
-protected:
-  /** the construction from a const iterator is declared protected
-      in order to enforce const correctness. */
-  /** @ITKStartGrouping */
-  ImageReverseIterator(const ImageRegionReverseConstIterator<TImage> & it);
-  Self &
-  operator=(const ImageRegionReverseConstIterator<TImage> & it);
-  /** @ITKEndGrouping */
+  using Superclass = ImageRegionReverseIteratorBase<TImage, /*VIsConst=*/false>;
+  using Superclass::Superclass;
 };
 
-// Deduction guide for class template argument deduction (CTAD).
 template <typename TImage>
-ImageReverseIterator(SmartPointer<TImage>, const typename TImage::RegionType &) -> ImageReverseIterator<TImage>;
+ImageReverseIterator(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageReverseIterator<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageReverseIterator(TImage *, const typename TImage::RegionType &) -> ImageReverseIterator<TImage>;
+
+template <typename TImage>
+ImageReverseIterator(const TImage *, const typename TImage::RegionType &) -> ImageReverseIterator<TImage>;
 
 } // end namespace itk
-
-#ifndef ITK_MANUAL_INSTANTIATION
-#  include "itkImageReverseIterator.hxx"
-#endif
 
 #endif

--- a/Modules/Core/Common/include/itkImageReverseIterator.hxx
+++ b/Modules/Core/Common/include/itkImageReverseIterator.hxx
@@ -18,31 +18,11 @@
 #ifndef itkImageReverseIterator_hxx
 #define itkImageReverseIterator_hxx
 
+// All ImageReverseIterator functionality has been absorbed into
+// ImageRegionReverseIteratorBase<TImage, VIsConst> (see
+// itkImageRegionReverseConstIterator.h). This header is retained only
+// for backward compatibility with code that #includes it directly.
 
-namespace itk
-{
-template <typename TImage>
-ImageReverseIterator<TImage>::ImageReverseIterator(TImage * ptr, const RegionType & region)
-  : ImageRegionReverseConstIterator<TImage>(ptr, region)
-{}
-
-template <typename TImage>
-ImageReverseIterator<TImage>::ImageReverseIterator(const ImageIteratorWithIndex<TImage> & it)
-  : ImageRegionReverseConstIterator<TImage>(it)
-{}
-
-template <typename TImage>
-ImageReverseIterator<TImage>::ImageReverseIterator(const ImageRegionReverseConstIterator<TImage> & it)
-  : ImageRegionReverseConstIterator<TImage>(it)
-{}
-
-template <typename TImage>
-ImageReverseIterator<TImage> &
-ImageReverseIterator<TImage>::operator=(const ImageRegionReverseConstIterator<TImage> & it)
-{
-  this->ImageRegionReverseConstIterator<TImage>::operator=(it);
-  return *this;
-}
-} // end namespace itk
+#include "itkImageReverseIterator.h"
 
 #endif

--- a/Modules/Core/Common/include/itkImageScanlineConstIterator.h
+++ b/Modules/Core/Common/include/itkImageScanlineConstIterator.h
@@ -19,7 +19,7 @@
 #define itkImageScanlineConstIterator_h
 
 #include "itkImageIterator.h"
-#include <type_traits> // For remove_const_t.
+#include <type_traits> // For enable_if_t, remove_const_t.
 
 namespace itk
 {
@@ -60,13 +60,13 @@ while ( !it.IsAtEnd() )
  * \ingroup ITKCommon
  *
  */
-template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageScanlineConstIterator : public ImageConstIterator<TImage>
+template <typename TImage, bool VIsConst>
+class ITK_TEMPLATE_EXPORT ImageScanlineIteratorBase : public ImageIteratorBase<TImage, VIsConst>
 {
 public:
   /** Standard class type alias. */
-  using Self = ImageScanlineConstIterator;
-  using Superclass = ImageConstIterator<TImage>;
+  using Self = ImageScanlineIteratorBase;
+  using Superclass = ImageIteratorBase<TImage, VIsConst>;
 
   /** Dimension of the image that the iterator walks.  This constant is needed so
    * functions that are templated over image iterator type (as opposed to
@@ -85,6 +85,7 @@ public:
   using typename Superclass::OffsetType;
   using typename Superclass::RegionType;
   using typename Superclass::ImageType;
+  using typename Superclass::ImagePointer;
   using typename Superclass::PixelContainer;
   using typename Superclass::PixelContainerPointer;
   using typename Superclass::InternalPixelType;
@@ -92,17 +93,17 @@ public:
   using typename Superclass::AccessorType;
 
   /** \see LightObject::GetNameOfClass() */
-  itkOverrideGetNameOfClassMacro(ImageScanlineConstIterator);
+  itkOverrideGetNameOfClassMacro(ImageScanlineIteratorBase);
 
   /** Default constructor. */
-  ImageScanlineConstIterator()
-    : ImageConstIterator<TImage>()
+  ImageScanlineIteratorBase()
+    : Superclass()
   {}
 
   /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes
    * the iterator at the begin of the region. */
-  ImageScanlineConstIterator(const TImage * ptr, const RegionType & region)
-    : ImageConstIterator<TImage>(ptr, region)
+  ImageScanlineIteratorBase(ImagePointer ptr, const RegionType & region)
+    : Superclass(ptr, region)
     , m_SpanBeginOffset(this->m_BeginOffset)
     , m_SpanEndOffset(this->m_BeginOffset + static_cast<OffsetValueType>(this->m_Region.GetSize()[0]))
   {}
@@ -113,9 +114,9 @@ public:
    * provide overloaded APIs that return different types of Iterators, itk
    * returns ImageIterators and uses constructors to cast from an
    * ImageIterator to a ImageScanlineConstIterator. */
-  ImageScanlineConstIterator(const ImageIterator<TImage> & it)
+  ImageScanlineIteratorBase(const Superclass & it)
   {
-    this->ImageConstIterator<TImage>::operator=(it);
+    this->Superclass::operator=(it);
 
     IndexType ind = this->ComputeIndex();
     m_SpanEndOffset = this->m_Offset + static_cast<OffsetValueType>(this->m_Region.GetSize()[0]) -
@@ -123,21 +124,16 @@ public:
     m_SpanBeginOffset = m_SpanEndOffset - static_cast<OffsetValueType>(this->m_Region.GetSize()[0]);
   }
 
-  /** Constructor that can be used to cast from an ImageConstIterator to an
-   * ImageScanlineConstIterator. Many routines return an ImageIterator, but for a
-   * particular task, you may want an ImageScanlineConstIterator.  Rather than
-   * provide overloaded APIs that return different types of Iterators, itk
-   * returns ImageIterators and uses constructors to cast from an
-   * ImageIterator to a ImageScanlineConstIterator. */
-  ImageScanlineConstIterator(const ImageConstIterator<TImage> & it)
-  {
-    this->ImageConstIterator<TImage>::operator=(it);
+  /** Converting constructor: non-const -> const. */
+  template <bool VOtherConst, typename = std::enable_if_t<VIsConst && !VOtherConst>>
+  ImageScanlineIteratorBase(const ImageScanlineIteratorBase<TImage, VOtherConst> & it)
+    : Superclass(static_cast<const ImageIteratorBase<TImage, VOtherConst> &>(it))
+    , m_SpanBeginOffset(it.m_SpanBeginOffset)
+    , m_SpanEndOffset(it.m_SpanEndOffset)
+  {}
 
-    IndexType ind = this->GetIndex();
-    m_SpanEndOffset = this->m_Offset + static_cast<OffsetValueType>(this->m_Region.GetSize()[0]) -
-                      (ind[0] - this->m_Region.GetIndex()[0]);
-    m_SpanBeginOffset = m_SpanEndOffset - static_cast<OffsetValueType>(this->m_Region.GetSize()[0]);
-  }
+  template <typename, bool>
+  friend class ImageScanlineIteratorBase;
 
   /** Move an iterator to the beginning of the region. "Begin" is
    * defined as the first pixel in the region. */
@@ -258,10 +254,36 @@ protected:
   OffsetValueType m_SpanEndOffset{};   // one pixel past the end of the scanline
 };
 
-// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage>
+class ITK_TEMPLATE_EXPORT ImageScanlineConstIterator : public ImageScanlineIteratorBase<TImage, /*VIsConst=*/true>
+{
+public:
+  using Superclass = ImageScanlineIteratorBase<TImage, /*VIsConst=*/true>;
+  using Superclass::Superclass;
+};
+
 template <typename TImage>
 ImageScanlineConstIterator(SmartPointer<TImage>, const typename TImage::RegionType &)
   -> ImageScanlineConstIterator<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageScanlineConstIterator(TImage *, const typename TImage::RegionType &) -> ImageScanlineConstIterator<TImage>;
+
+template <typename TImage>
+ImageScanlineConstIterator(const TImage *, const typename TImage::RegionType &) -> ImageScanlineConstIterator<TImage>;
+
+// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage, bool VIsConst = std::is_const_v<TImage>>
+ImageScanlineIteratorBase(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageScanlineIteratorBase<std::remove_const_t<TImage>, VIsConst>;
+
+template <typename TImage>
+ImageScanlineIteratorBase(TImage *, const typename TImage::RegionType &)
+  -> ImageScanlineIteratorBase<TImage, /*VIsConst=*/false>;
+
+template <typename TImage>
+ImageScanlineIteratorBase(const TImage *, const typename TImage::RegionType &)
+  -> ImageScanlineIteratorBase<TImage, /*VIsConst=*/true>;
 
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageScanlineConstIterator.hxx
+++ b/Modules/Core/Common/include/itkImageScanlineConstIterator.hxx
@@ -22,9 +22,9 @@
 namespace itk
 {
 
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageScanlineConstIterator<TImage>::NextLine()
+ImageScanlineIteratorBase<TImage, VIsConst>::NextLine()
 {
   // increment to the next scanline
 

--- a/Modules/Core/Common/include/itkImageScanlineIterator.h
+++ b/Modules/Core/Common/include/itkImageScanlineIterator.h
@@ -39,74 +39,23 @@ namespace itk
  *
  */
 template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageScanlineIterator : public ImageScanlineConstIterator<TImage>
+class ITK_TEMPLATE_EXPORT ImageScanlineIterator : public ImageScanlineIteratorBase<TImage, /*VIsConst=*/false>
 {
 public:
-  /** Standard class type aliases. */
-  using Self = ImageScanlineIterator;
-  using Superclass = ImageScanlineConstIterator<TImage>;
-
-  /** Types inherited from the Superclass */
-  using typename Superclass::IndexType;
-  using typename Superclass::SizeType;
-  using typename Superclass::OffsetType;
-  using typename Superclass::RegionType;
-  using typename Superclass::ImageType;
-  using typename Superclass::PixelContainer;
-  using typename Superclass::PixelContainerPointer;
-  using typename Superclass::InternalPixelType;
-  using typename Superclass::PixelType;
-  using typename Superclass::AccessorType;
-
-  /** Default constructor. */
-  ImageScanlineIterator() = default;
-
-  /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes
-   * the iterator at the begin of the region. */
-  ImageScanlineIterator(TImage * ptr, const RegionType & region);
-
-  /** Constructor that can be used to cast from an ImageIterator to an
-   * ImageScanlineIterator. Many routines return an ImageIterator but for a
-   * particular task, you may want an ImageScanlineIterator.  Rather than
-   * provide overloaded APIs that return different types of Iterators, itk
-   * returns ImageIterators and uses constructors to cast from an
-   * ImageIterator to a ImageScanlineIterator. */
-  ImageScanlineIterator(const ImageIterator<TImage> & it);
-
-  /** Set the pixel value */
-  void
-  Set(const PixelType & value) const
-  {
-    this->m_PixelAccessorFunctor.Set(*(const_cast<InternalPixelType *>(this->m_Buffer + this->m_Offset)), value);
-  }
-
-  /** Return a reference to the pixel
-   * This method will provide the fastest access to pixel
-   * data, but it will NOT support ImageAdaptors. */
-  PixelType &
-  Value()
-  {
-    return *(const_cast<InternalPixelType *>(this->m_Buffer + this->m_Offset));
-  }
-
-protected:
-  /** the construction from a const iterator is declared protected
-      in order to enforce const correctness. */
-  /** @ITKStartGrouping */
-  ImageScanlineIterator(const ImageScanlineConstIterator<TImage> & it);
-  Self &
-  operator=(const ImageScanlineConstIterator<TImage> & it);
-  /** @ITKEndGrouping */
+  using Superclass = ImageScanlineIteratorBase<TImage, /*VIsConst=*/false>;
+  using Superclass::Superclass;
 };
 
-// Deduction guide for class template argument deduction (CTAD).
 template <typename TImage>
-ImageScanlineIterator(SmartPointer<TImage>, const typename TImage::RegionType &) -> ImageScanlineIterator<TImage>;
+ImageScanlineIterator(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageScanlineIterator<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageScanlineIterator(TImage *, const typename TImage::RegionType &) -> ImageScanlineIterator<TImage>;
+
+template <typename TImage>
+ImageScanlineIterator(const TImage *, const typename TImage::RegionType &) -> ImageScanlineIterator<TImage>;
 
 } // end namespace itk
-
-#ifndef ITK_MANUAL_INSTANTIATION
-#  include "itkImageScanlineIterator.hxx"
-#endif
 
 #endif

--- a/Modules/Core/Common/include/itkImageScanlineIterator.hxx
+++ b/Modules/Core/Common/include/itkImageScanlineIterator.hxx
@@ -18,32 +18,11 @@
 #ifndef itkImageScanlineIterator_hxx
 #define itkImageScanlineIterator_hxx
 
+// All ImageScanlineIterator functionality has been absorbed into
+// ImageScanlineIteratorBase<TImage, VIsConst> (see
+// itkImageScanlineConstIterator.h). This header is retained only for
+// backward compatibility with code that #includes it directly.
 
-namespace itk
-{
-template <typename TImage>
-ImageScanlineIterator<TImage>::ImageScanlineIterator(TImage * ptr, const RegionType & region)
-  : ImageScanlineConstIterator<TImage>(ptr, region)
-{}
-
-template <typename TImage>
-ImageScanlineIterator<TImage>::ImageScanlineIterator(const ImageIterator<TImage> & it)
-  : ImageScanlineConstIterator<TImage>(it)
-{}
-
-template <typename TImage>
-ImageScanlineIterator<TImage>::ImageScanlineIterator(const ImageScanlineConstIterator<TImage> & it)
-  : ImageScanlineConstIterator<TImage>(it)
-{}
-
-template <typename TImage>
-ImageScanlineIterator<TImage> &
-ImageScanlineIterator<TImage>::operator=(const ImageScanlineConstIterator<TImage> & it)
-{
-  this->ImageScanlineConstIterator<TImage>::operator=(it);
-  return *this;
-}
-
-} // end namespace itk
+#include "itkImageScanlineIterator.h"
 
 #endif

--- a/Modules/Core/Common/include/itkImageSliceConstIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageSliceConstIteratorWithIndex.h
@@ -19,7 +19,7 @@
 #define itkImageSliceConstIteratorWithIndex_h
 
 #include "itkImageConstIteratorWithIndex.h"
-#include <type_traits> // For remove_const_t.
+#include <type_traits> // For enable_if_t, remove_const_t.
 
 namespace itk
 {
@@ -110,13 +110,13 @@ namespace itk
  * \sa ImageConstIteratorWithIndex
  * \ingroup ITKCommon
  */
-template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageSliceConstIteratorWithIndex : public ImageConstIteratorWithIndex<TImage>
+template <typename TImage, bool VIsConst>
+class ITK_TEMPLATE_EXPORT ImageSliceIteratorWithIndexBase : public ImageIteratorWithIndexBase<TImage, VIsConst>
 {
 public:
   /** Standard class type aliases. */
-  using Self = ImageSliceConstIteratorWithIndex;
-  using Superclass = ImageConstIteratorWithIndex<TImage>;
+  using Self = ImageSliceIteratorWithIndexBase;
+  using Superclass = ImageIteratorWithIndexBase<TImage, VIsConst>;
 
   /** Inherit types from the superclass */
   using typename Superclass::IndexType;
@@ -124,6 +124,7 @@ public:
   using typename Superclass::OffsetType;
   using typename Superclass::RegionType;
   using typename Superclass::ImageType;
+  using typename Superclass::ImagePointer;
   using typename Superclass::PixelContainer;
   using typename Superclass::PixelContainerPointer;
   using typename Superclass::InternalPixelType;
@@ -131,14 +132,14 @@ public:
   using typename Superclass::AccessorType;
 
   /** Default constructor. */
-  ImageSliceConstIteratorWithIndex()
-    : ImageConstIteratorWithIndex<TImage>()
+  ImageSliceIteratorWithIndexBase()
+    : Superclass()
   {}
 
   /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes
    * the iterator at the begin of the region. */
-  ImageSliceConstIteratorWithIndex(const TImage * ptr, const RegionType & region)
-    : ImageConstIteratorWithIndex<TImage>(ptr, region)
+  ImageSliceIteratorWithIndexBase(ImagePointer ptr, const RegionType & region)
+    : Superclass(ptr, region)
     , m_PixelJump(0)
     , m_LineJump(0)
     , m_Direction_A(0)
@@ -151,10 +152,20 @@ public:
    * provide overloaded APIs that return different types of Iterators, itk
    * returns ImageIterators and uses constructors to cast from an
    * ImageIterator to a ImageSliceConstIteratorWithIndex. */
-  ImageSliceConstIteratorWithIndex(const ImageConstIteratorWithIndex<TImage> & it)
-  {
-    this->ImageConstIteratorWithIndex<TImage>::operator=(it);
-  }
+  ImageSliceIteratorWithIndexBase(const Superclass & it) { this->Superclass::operator=(it); }
+
+  /** Converting constructor: non-const -> const. */
+  template <bool VOtherConst, typename = std::enable_if_t<VIsConst && !VOtherConst>>
+  ImageSliceIteratorWithIndexBase(const ImageSliceIteratorWithIndexBase<TImage, VOtherConst> & it)
+    : Superclass(static_cast<const ImageIteratorWithIndexBase<TImage, VOtherConst> &>(it))
+    , m_PixelJump(it.m_PixelJump)
+    , m_LineJump(it.m_LineJump)
+    , m_Direction_A(it.m_Direction_A)
+    , m_Direction_B(it.m_Direction_B)
+  {}
+
+  template <typename, bool>
+  friend class ImageSliceIteratorWithIndexBase;
 
   /** Go to the next line
    * \sa operator++ \sa EndOfLine \sa End \sa NextSlice */
@@ -223,10 +234,39 @@ private:
   unsigned int  m_Direction_B;
 };
 
-// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage>
+class ITK_TEMPLATE_EXPORT ImageSliceConstIteratorWithIndex
+  : public ImageSliceIteratorWithIndexBase<TImage, /*VIsConst=*/true>
+{
+public:
+  using Superclass = ImageSliceIteratorWithIndexBase<TImage, /*VIsConst=*/true>;
+  using Superclass::Superclass;
+};
+
 template <typename TImage>
 ImageSliceConstIteratorWithIndex(SmartPointer<TImage>, const typename TImage::RegionType &)
   -> ImageSliceConstIteratorWithIndex<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageSliceConstIteratorWithIndex(TImage *, const typename TImage::RegionType &)
+  -> ImageSliceConstIteratorWithIndex<TImage>;
+
+template <typename TImage>
+ImageSliceConstIteratorWithIndex(const TImage *, const typename TImage::RegionType &)
+  -> ImageSliceConstIteratorWithIndex<TImage>;
+
+// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage, bool VIsConst = std::is_const_v<TImage>>
+ImageSliceIteratorWithIndexBase(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ImageSliceIteratorWithIndexBase<std::remove_const_t<TImage>, VIsConst>;
+
+template <typename TImage>
+ImageSliceIteratorWithIndexBase(TImage *, const typename TImage::RegionType &)
+  -> ImageSliceIteratorWithIndexBase<TImage, /*VIsConst=*/false>;
+
+template <typename TImage>
+ImageSliceIteratorWithIndexBase(const TImage *, const typename TImage::RegionType &)
+  -> ImageSliceIteratorWithIndexBase<TImage, /*VIsConst=*/true>;
 
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkImageSliceConstIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageSliceConstIteratorWithIndex.hxx
@@ -24,9 +24,9 @@ namespace itk
 //----------------------------------------------------------------------
 //  Advance to Next Line
 //----------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageSliceConstIteratorWithIndex<TImage>::NextLine()
+ImageSliceIteratorWithIndexBase<TImage, VIsConst>::NextLine()
 {
   // Move to next line
   this->m_PositionIndex[m_Direction_B]++;
@@ -40,9 +40,9 @@ ImageSliceConstIteratorWithIndex<TImage>::NextLine()
 //----------------------------------------------------------------------
 //  Advance to Previous Line
 //----------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageSliceConstIteratorWithIndex<TImage>::PreviousLine()
+ImageSliceIteratorWithIndexBase<TImage, VIsConst>::PreviousLine()
 {
   // Move to previous line
   this->m_PositionIndex[m_Direction_B]--;
@@ -56,9 +56,9 @@ ImageSliceConstIteratorWithIndex<TImage>::PreviousLine()
 //----------------------------------------------------------------------
 //  Go to the first pixel of the current slice
 //----------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageSliceConstIteratorWithIndex<TImage>::GoToBeginOfSlice()
+ImageSliceIteratorWithIndexBase<TImage, VIsConst>::GoToBeginOfSlice()
 {
   // Move to beginning of Slice
   this->m_PositionIndex[m_Direction_B] = this->m_BeginIndex[m_Direction_B];
@@ -68,9 +68,9 @@ ImageSliceConstIteratorWithIndex<TImage>::GoToBeginOfSlice()
 //----------------------------------------------------------------------
 //  Advance to next slice
 //----------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageSliceConstIteratorWithIndex<TImage>::NextSlice()
+ImageSliceIteratorWithIndexBase<TImage, VIsConst>::NextSlice()
 {
   // Move to beginning of Slice
   this->m_Position -= m_LineJump * (this->m_PositionIndex[m_Direction_B] - this->m_BeginIndex[m_Direction_B]);
@@ -101,9 +101,9 @@ ImageSliceConstIteratorWithIndex<TImage>::NextSlice()
 //----------------------------------------------------------------------
 //  Go Back to previous slice
 //----------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageSliceConstIteratorWithIndex<TImage>::PreviousSlice()
+ImageSliceIteratorWithIndexBase<TImage, VIsConst>::PreviousSlice()
 {
   // Move to end of Slice
   this->m_PositionIndex[m_Direction_B] = this->m_EndIndex[m_Direction_B] - 1;
@@ -134,9 +134,9 @@ ImageSliceConstIteratorWithIndex<TImage>::PreviousSlice()
 //----------------------------------------------------------------------
 //  Test for end of line
 //----------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 bool
-ImageSliceConstIteratorWithIndex<TImage>::IsAtEndOfLine() const
+ImageSliceIteratorWithIndexBase<TImage, VIsConst>::IsAtEndOfLine() const
 {
   return this->m_PositionIndex[m_Direction_A] >= this->m_EndIndex[m_Direction_A];
 }
@@ -144,9 +144,9 @@ ImageSliceConstIteratorWithIndex<TImage>::IsAtEndOfLine() const
 //----------------------------------------------------------------------
 //  Test for end of slice
 //----------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 bool
-ImageSliceConstIteratorWithIndex<TImage>::IsAtEndOfSlice() const
+ImageSliceIteratorWithIndexBase<TImage, VIsConst>::IsAtEndOfSlice() const
 {
   return this->m_PositionIndex[m_Direction_B] >= this->m_EndIndex[m_Direction_B];
 }
@@ -154,9 +154,9 @@ ImageSliceConstIteratorWithIndex<TImage>::IsAtEndOfSlice() const
 //----------------------------------------------------------------------
 //  Test for begin of line
 //----------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 bool
-ImageSliceConstIteratorWithIndex<TImage>::IsAtReverseEndOfLine() const
+ImageSliceIteratorWithIndexBase<TImage, VIsConst>::IsAtReverseEndOfLine() const
 {
   return this->m_PositionIndex[m_Direction_A] < this->m_BeginIndex[m_Direction_A];
 }
@@ -164,9 +164,9 @@ ImageSliceConstIteratorWithIndex<TImage>::IsAtReverseEndOfLine() const
 //----------------------------------------------------------------------
 //  Test for begin of slice
 //----------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 bool
-ImageSliceConstIteratorWithIndex<TImage>::IsAtReverseEndOfSlice() const
+ImageSliceIteratorWithIndexBase<TImage, VIsConst>::IsAtReverseEndOfSlice() const
 {
   return this->m_PositionIndex[m_Direction_B] < this->m_BeginIndex[m_Direction_B];
 }
@@ -174,9 +174,9 @@ ImageSliceConstIteratorWithIndex<TImage>::IsAtReverseEndOfSlice() const
 //----------------------------------------------------------------------
 //  Select the fastest changing direction
 //----------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageSliceConstIteratorWithIndex<TImage>::SetFirstDirection(unsigned int direction)
+ImageSliceIteratorWithIndexBase<TImage, VIsConst>::SetFirstDirection(unsigned int direction)
 {
   if (direction >= TImage::ImageDimension)
   {
@@ -190,9 +190,9 @@ ImageSliceConstIteratorWithIndex<TImage>::SetFirstDirection(unsigned int directi
 //----------------------------------------------------------------------
 //  Select the second fastest changing direction
 //----------------------------------------------------------------------
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-ImageSliceConstIteratorWithIndex<TImage>::SetSecondDirection(unsigned int direction)
+ImageSliceIteratorWithIndexBase<TImage, VIsConst>::SetSecondDirection(unsigned int direction)
 {
   if (direction >= TImage::ImageDimension)
   {
@@ -206,9 +206,9 @@ ImageSliceConstIteratorWithIndex<TImage>::SetSecondDirection(unsigned int direct
 //----------------------------------------------------------------------
 //  Advance along a line
 //----------------------------------------------------------------------
-template <typename TImage>
-ImageSliceConstIteratorWithIndex<TImage> &
-ImageSliceConstIteratorWithIndex<TImage>::operator++()
+template <typename TImage, bool VIsConst>
+ImageSliceIteratorWithIndexBase<TImage, VIsConst> &
+ImageSliceIteratorWithIndexBase<TImage, VIsConst>::operator++()
 {
   this->m_PositionIndex[m_Direction_A]++;
   this->m_Position += m_PixelJump;
@@ -218,9 +218,9 @@ ImageSliceConstIteratorWithIndex<TImage>::operator++()
 //----------------------------------------------------------------------
 //  Go back along a line
 //----------------------------------------------------------------------
-template <typename TImage>
-ImageSliceConstIteratorWithIndex<TImage> &
-ImageSliceConstIteratorWithIndex<TImage>::operator--()
+template <typename TImage, bool VIsConst>
+ImageSliceIteratorWithIndexBase<TImage, VIsConst> &
+ImageSliceIteratorWithIndexBase<TImage, VIsConst>::operator--()
 {
   this->m_PositionIndex[m_Direction_A]--;
   this->m_Position -= m_PixelJump;

--- a/Modules/Core/Common/include/itkImageSliceIteratorWithIndex.h
+++ b/Modules/Core/Common/include/itkImageSliceIteratorWithIndex.h
@@ -66,75 +66,24 @@ namespace itk
  * \ingroup ITKCommon
  */
 template <typename TImage>
-class ITK_TEMPLATE_EXPORT ImageSliceIteratorWithIndex : public ImageSliceConstIteratorWithIndex<TImage>
+class ITK_TEMPLATE_EXPORT ImageSliceIteratorWithIndex
+  : public ImageSliceIteratorWithIndexBase<TImage, /*VIsConst=*/false>
 {
 public:
-  /** Standard class type aliases. */
-  using Self = ImageSliceIteratorWithIndex;
-  using Superclass = ImageSliceConstIteratorWithIndex<TImage>;
-
-  /** Types inherited from the Superclass */
-  using typename Superclass::IndexType;
-  using typename Superclass::SizeType;
-  using typename Superclass::OffsetType;
-  using typename Superclass::RegionType;
-  using typename Superclass::ImageType;
-  using typename Superclass::PixelContainer;
-  using typename Superclass::PixelContainerPointer;
-  using typename Superclass::InternalPixelType;
-  using typename Superclass::PixelType;
-  using typename Superclass::AccessorType;
-
-  /** Default constructor. */
-  ImageSliceIteratorWithIndex() = default;
-
-  /** Constructor establishes an iterator to walk a particular image and a particular region of that image. Initializes
-   * the iterator at the begin of the region. */
-  ImageSliceIteratorWithIndex(TImage * ptr, const RegionType & region);
-
-  /** Constructor that can be used to cast from an ImageIterator to an
-   * ImageSliceIteratorWithIndex. Many routines return an ImageIterator, but for a
-   * particular task, you may want an ImageSliceIteratorWithIndex.  Rather than
-   * provide overloaded APIs that return different types of Iterators, itk
-   * returns ImageIterators and uses constructors to cast from an
-   * ImageIterator to a ImageSliceIteratorWithIndex. */
-  ImageSliceIteratorWithIndex(const ImageIteratorWithIndex<TImage> & it);
-
-  /** Set the pixel value */
-  void
-  Set(const PixelType & value) const
-  {
-    this->m_PixelAccessorFunctor.Set(*(const_cast<InternalPixelType *>(this->m_Position)), value);
-  }
-
-  /** Return a reference to the pixel.
-   * This method will provide the fastest access to pixel
-   * data, but it will NOT support ImageAdaptors. */
-  PixelType &
-  Value()
-  {
-    return *(const_cast<InternalPixelType *>(this->m_Position));
-  }
-
-protected:
-  /** The construction from a const iterator is declared protected
-      in order to enforce const correctness. */
-  /** @ITKStartGrouping */
-  ImageSliceIteratorWithIndex(const ImageSliceConstIteratorWithIndex<TImage> & it);
-  Self &
-  operator=(const ImageSliceConstIteratorWithIndex<TImage> & it);
-  /** @ITKEndGrouping */
+  using Superclass = ImageSliceIteratorWithIndexBase<TImage, /*VIsConst=*/false>;
+  using Superclass::Superclass;
 };
 
-// Deduction guide for class template argument deduction (CTAD).
 template <typename TImage>
 ImageSliceIteratorWithIndex(SmartPointer<TImage>, const typename TImage::RegionType &)
-  -> ImageSliceIteratorWithIndex<TImage>;
+  -> ImageSliceIteratorWithIndex<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+ImageSliceIteratorWithIndex(TImage *, const typename TImage::RegionType &) -> ImageSliceIteratorWithIndex<TImage>;
+
+template <typename TImage>
+ImageSliceIteratorWithIndex(const TImage *, const typename TImage::RegionType &) -> ImageSliceIteratorWithIndex<TImage>;
 
 } // end namespace itk
-
-#ifndef ITK_MANUAL_INSTANTIATION
-#  include "itkImageSliceIteratorWithIndex.hxx"
-#endif
 
 #endif

--- a/Modules/Core/Common/include/itkImageSliceIteratorWithIndex.hxx
+++ b/Modules/Core/Common/include/itkImageSliceIteratorWithIndex.hxx
@@ -18,31 +18,11 @@
 #ifndef itkImageSliceIteratorWithIndex_hxx
 #define itkImageSliceIteratorWithIndex_hxx
 
+// All ImageSliceIteratorWithIndex functionality has been absorbed into
+// ImageSliceIteratorWithIndexBase<TImage, VIsConst> (see
+// itkImageSliceConstIteratorWithIndex.h). This header is retained only
+// for backward compatibility with code that #includes it directly.
 
-namespace itk
-{
-template <typename TImage>
-ImageSliceIteratorWithIndex<TImage>::ImageSliceIteratorWithIndex(TImage * ptr, const RegionType & region)
-  : ImageSliceConstIteratorWithIndex<TImage>(ptr, region)
-{}
-
-template <typename TImage>
-ImageSliceIteratorWithIndex<TImage>::ImageSliceIteratorWithIndex(const ImageIteratorWithIndex<TImage> & it)
-  : ImageSliceConstIteratorWithIndex<TImage>(it)
-{}
-
-template <typename TImage>
-ImageSliceIteratorWithIndex<TImage>::ImageSliceIteratorWithIndex(const ImageSliceConstIteratorWithIndex<TImage> & it)
-  : ImageSliceConstIteratorWithIndex<TImage>(it)
-{}
-
-template <typename TImage>
-ImageSliceIteratorWithIndex<TImage> &
-ImageSliceIteratorWithIndex<TImage>::operator=(const ImageSliceConstIteratorWithIndex<TImage> & it)
-{
-  this->ImageSliceConstIteratorWithIndex<TImage>::operator=(it);
-  return *this;
-}
-} // end namespace itk
+#include "itkImageSliceIteratorWithIndex.h"
 
 #endif

--- a/Modules/Core/Common/include/itkLineConstIterator.h
+++ b/Modules/Core/Common/include/itkLineConstIterator.h
@@ -20,6 +20,8 @@
 
 #include "itkIndex.h"
 #include "itkImage.h"
+#include "itkWeakPointer.h"
+#include <type_traits>
 
 namespace itk
 {
@@ -52,12 +54,12 @@ namespace itk
  * \sphinxexample{Core/Common/IterateLineThroughImageWithoutWriteAccess,Iterate Line Through Image Without Write Access}
  * \endsphinx
  */
-template <typename TImage>
-class ITK_TEMPLATE_EXPORT LineConstIterator
+template <typename TImage, bool VIsConst>
+class ITK_TEMPLATE_EXPORT LineIteratorBase
 {
 public:
   /** Standard class type aliases. */
-  using Self = LineConstIterator;
+  using Self = LineIteratorBase;
 
   /** Dimension of the image that the iterator walks.  This constant is needed so
    * that functions that are templated over image iterator type (as opposed to
@@ -102,8 +104,11 @@ public:
    *  representations. */
   using AccessorType = typename TImage::AccessorType;
 
+  using ImageWeakPointer = std::conditional_t<VIsConst, typename TImage::ConstWeakPointer, WeakPointer<TImage>>;
+  using ImagePointer = std::conditional_t<VIsConst, const TImage *, TImage *>;
+
   /** \see LightObject::GetNameOfClass() */
-  itkVirtualGetNameOfClassMacro(LineConstIterator);
+  itkVirtualGetNameOfClassMacro(LineIteratorBase);
 
   /** Get the dimension (size) of the index. */
   static unsigned int
@@ -124,6 +129,14 @@ public:
   Get() const
   {
     return m_Image->GetPixel(m_CurrentImageIndex);
+  }
+
+  /** Set the pixel value. SFINAE-gated on !VIsConst. */
+  template <bool VCopy = VIsConst, std::enable_if_t<!VCopy, int> = 0>
+  void
+  Set(const PixelType & value)
+  {
+    m_Image->SetPixel(m_CurrentImageIndex, value);
   }
 
   /** Is the iterator at the end of the line? */
@@ -147,14 +160,37 @@ public:
   operator=(const Self & it);
 
   /** Constructor establishes an iterator to walk along a line */
-  LineConstIterator(const ImageType * imagePtr, const IndexType & firstIndex, const IndexType & lastIndex);
+  LineIteratorBase(ImagePointer imagePtr, const IndexType & firstIndex, const IndexType & lastIndex);
+
+  /** Converting constructor: non-const -> const. */
+  template <bool VOtherConst, typename = std::enable_if_t<VIsConst && !VOtherConst>>
+  LineIteratorBase(const LineIteratorBase<TImage, VOtherConst> & it)
+    : m_Image(it.m_Image)
+    , m_Region(it.m_Region)
+    , m_IsAtEnd(it.m_IsAtEnd)
+    , m_CurrentImageIndex(it.m_CurrentImageIndex)
+    , m_StartIndex(it.m_StartIndex)
+    , m_LastIndex(it.m_LastIndex)
+    , m_EndIndex(it.m_EndIndex)
+    , m_MainDirection(it.m_MainDirection)
+    , m_AccumulateError(it.m_AccumulateError)
+    , m_IncrementError(it.m_IncrementError)
+    , m_MaximalError(it.m_MaximalError)
+    , m_OverflowIncrement(it.m_OverflowIncrement)
+    , m_ReduceErrorAfterIncrement(it.m_ReduceErrorAfterIncrement)
+  {}
+
+  template <typename, bool>
+  friend class LineIteratorBase;
 
   /** Default Destructor. */
-  virtual ~LineConstIterator() = default;
+  virtual ~LineIteratorBase() = default;
 
 protected: // made protected so other iterators can access
+  LineIteratorBase() = default;
+
   /** Smart pointer to the source image. */
-  typename ImageType::ConstWeakPointer m_Image{};
+  ImageWeakPointer m_Image{};
 
   /** Region type to iterate over. */
   RegionType m_Region{};
@@ -190,6 +226,25 @@ protected: // made protected so other iterators can access
   // two times the number of pixels in the line
   IndexType m_ReduceErrorAfterIncrement{};
 };
+
+template <typename TImage>
+class ITK_TEMPLATE_EXPORT LineConstIterator : public LineIteratorBase<TImage, /*VIsConst=*/true>
+{
+public:
+  using Superclass = LineIteratorBase<TImage, /*VIsConst=*/true>;
+  using Superclass::Superclass;
+};
+
+template <typename TImage>
+LineConstIterator(SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> LineConstIterator<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+LineConstIterator(TImage *, const typename TImage::RegionType &) -> LineConstIterator<TImage>;
+
+template <typename TImage>
+LineConstIterator(const TImage *, const typename TImage::RegionType &) -> LineConstIterator<TImage>;
+
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Core/Common/include/itkLineConstIterator.hxx
+++ b/Modules/Core/Common/include/itkLineConstIterator.hxx
@@ -21,10 +21,10 @@
 
 namespace itk
 {
-template <typename TImage>
-LineConstIterator<TImage>::LineConstIterator(const ImageType * imagePtr,
-                                             const IndexType & firstIndex,
-                                             const IndexType & lastIndex)
+template <typename TImage, bool VIsConst>
+LineIteratorBase<TImage, VIsConst>::LineIteratorBase(ImagePointer      imagePtr,
+                                                     const IndexType & firstIndex,
+                                                     const IndexType & lastIndex)
   : m_Image(imagePtr)
   , m_StartIndex(firstIndex)
   , m_LastIndex(lastIndex)
@@ -80,9 +80,9 @@ LineConstIterator<TImage>::LineConstIterator(const ImageType * imagePtr,
   this->GoToBegin();
 }
 
-template <typename TImage>
-LineConstIterator<TImage> &
-LineConstIterator<TImage>::operator=(const Self & it)
+template <typename TImage, bool VIsConst>
+LineIteratorBase<TImage, VIsConst> &
+LineIteratorBase<TImage, VIsConst>::operator=(const Self & it)
 {
   if (this != &it)
   {
@@ -103,18 +103,18 @@ LineConstIterator<TImage>::operator=(const Self & it)
   return *this;
 }
 
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-LineConstIterator<TImage>::GoToBegin()
+LineIteratorBase<TImage, VIsConst>::GoToBegin()
 {
   m_CurrentImageIndex = m_StartIndex;
   m_AccumulateError.Fill(0);
   m_IsAtEnd = (m_StartIndex[m_MainDirection] == m_EndIndex[m_MainDirection]);
 }
 
-template <typename TImage>
+template <typename TImage, bool VIsConst>
 void
-LineConstIterator<TImage>::operator++()
+LineIteratorBase<TImage, VIsConst>::operator++()
 {
   // We need to modify m_AccumulateError, m_CurrentImageIndex, m_IsAtEnd
   for (unsigned int i = 0; i < TImage::ImageDimension; ++i)

--- a/Modules/Core/Common/include/itkLineIterator.h
+++ b/Modules/Core/Common/include/itkLineIterator.h
@@ -53,71 +53,22 @@ namespace itk
  * \endsphinx
  */
 template <typename TImage>
-class ITK_TEMPLATE_EXPORT LineIterator : public LineConstIterator<TImage>
+class ITK_TEMPLATE_EXPORT LineIterator : public LineIteratorBase<TImage, /*VIsConst=*/false>
 {
 public:
-  /** Standard class type aliases. */
-  using Self = LineIterator;
-
-  /** Dimension of the image that the iterator walks.  This constant is needed so
-   * that functions that are templated over image iterator type (as opposed to
-   * being templated over pixel type and dimension) can have compile time
-   * access to the dimension of the image that the iterator walks. */
-  static constexpr unsigned int ImageIteratorDimension = TImage::ImageDimension;
-
-  /** Define the superclass */
-  using Superclass = LineConstIterator<TImage>;
-
-  /** Inherit types from the superclass */
-  using typename Superclass::IndexType;
-  using typename Superclass::OffsetType;
-  using typename Superclass::SizeType;
-  using typename Superclass::RegionType;
-  using typename Superclass::ImageType;
-  using typename Superclass::PixelContainer;
-  using typename Superclass::PixelContainerPointer;
-  using typename Superclass::InternalPixelType;
-  using typename Superclass::PixelType;
-  using typename Superclass::AccessorType;
-
-  /** \see LightObject::GetNameOfClass() */
-  itkOverrideGetNameOfClassMacro(LineIterator);
-
-  /** Set the pixel value */
-  void
-  Set(const PixelType & value)
-  {
-    // Normally, this would just be the following:
-    //   m_Image->SetPixel(m_CurrentImageIndex,value);
-    // However, we don't want a warning about m_Image being a ConstPointer
-    // in the Superclass.
-    const_cast<ImageType *>(this->m_Image.GetPointer())->SetPixel(this->m_CurrentImageIndex, value);
-  }
-
-  /** Return a reference to the pixel.
-   * This method will provide the fastest access to pixel
-   * data, but it will NOT support ImageAdaptors. */
-  const PixelType &
-  Value()
-  {
-    return this->m_Image->GetPixel(this->m_CurrentImageIndex);
-  }
-
-  /** operator= is provided to make sure the handle to the image is properly
-   * reference counted. */
-  Self &
-  operator=(const Self & it);
-
-  /** Constructor establishes an iterator to walk along a path */
-  LineIterator(ImageType * imagePtr, const IndexType & firstIndex, const IndexType & lastIndex);
-
-  /** Default Destructor. */
-  ~LineIterator() override = default;
+  using Superclass = LineIteratorBase<TImage, /*VIsConst=*/false>;
+  using Superclass::Superclass;
 };
-} // end namespace itk
 
-#ifndef ITK_MANUAL_INSTANTIATION
-#  include "itkLineIterator.hxx"
-#endif
+template <typename TImage>
+LineIterator(SmartPointer<TImage>, const typename TImage::RegionType &) -> LineIterator<std::remove_const_t<TImage>>;
+
+template <typename TImage>
+LineIterator(TImage *, const typename TImage::RegionType &) -> LineIterator<TImage>;
+
+template <typename TImage>
+LineIterator(const TImage *, const typename TImage::RegionType &) -> LineIterator<TImage>;
+
+} // end namespace itk
 
 #endif

--- a/Modules/Core/Common/include/itkLineIterator.hxx
+++ b/Modules/Core/Common/include/itkLineIterator.hxx
@@ -18,21 +18,11 @@
 #ifndef itkLineIterator_hxx
 #define itkLineIterator_hxx
 
+// All LineIterator functionality has been absorbed into
+// LineIteratorBase<TImage, VIsConst> (see itkLineConstIterator.h). This
+// header is retained only for backward compatibility with code that
+// #includes it directly.
 
-namespace itk
-{
-template <typename TImage>
-LineIterator<TImage>::LineIterator(ImageType * imagePtr, const IndexType & firstIndex, const IndexType & lastIndex)
-  : LineConstIterator<TImage>(imagePtr, firstIndex, lastIndex)
-{}
-
-template <typename TImage>
-LineIterator<TImage> &
-LineIterator<TImage>::operator=(const Self & it)
-{
-  this->LineConstIterator<TImage>::operator=(it);
-  return *this;
-}
-} // end namespace itk
+#include "itkLineIterator.h"
 
 #endif

--- a/Modules/Core/Common/include/itkNeighborhoodAccessorFunctor.h
+++ b/Modules/Core/Common/include/itkNeighborhoodAccessorFunctor.h
@@ -50,6 +50,7 @@ public:
 
   static constexpr unsigned int ImageDimension = TImage::ImageDimension;
   using NeighborhoodType = Neighborhood<InternalPixelType *, Self::ImageDimension>;
+  using ConstNeighborhoodType = Neighborhood<const InternalPixelType *, Self::ImageDimension>;
 
   template <typename TOutput = ImageType>
   using ImageBoundaryConditionType = ImageBoundaryCondition<ImageType, TOutput>;
@@ -83,6 +84,20 @@ public:
   BoundaryCondition(const OffsetType &                          point_index,
                     const OffsetType &                          boundary_offset,
                     const NeighborhoodType *                    data,
+                    const ImageBoundaryConditionType<TOutput> * boundaryCondition) const
+  {
+    return boundaryCondition->operator()(point_index, boundary_offset, data);
+  }
+
+  /** Const-pointer-element overload used by NeighborhoodIteratorBase when
+   * VIsConst=true. Dispatches through the const-path virtual on
+   * ImageBoundaryCondition, which (by default) bridges back to the legacy
+   * overload. */
+  template <typename TOutput>
+  inline typename ImageBoundaryConditionType<TOutput>::OutputPixelType
+  BoundaryCondition(const OffsetType &                          point_index,
+                    const OffsetType &                          boundary_offset,
+                    const ConstNeighborhoodType *               data,
                     const ImageBoundaryConditionType<TOutput> * boundaryCondition) const
   {
     return boundaryCondition->operator()(point_index, boundary_offset, data);

--- a/Modules/Core/Common/include/itkNeighborhoodIteratorBase.h
+++ b/Modules/Core/Common/include/itkNeighborhoodIteratorBase.h
@@ -1,0 +1,1740 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkNeighborhoodIteratorBase_h
+#define itkNeighborhoodIteratorBase_h
+
+// -----------------------------------------------------------------------------
+// NeighborhoodIteratorBase: unified templated base that replaces the pair of
+// legacy classes ConstNeighborhoodIterator<TImage, TBC> and
+// NeighborhoodIterator<TImage, TBC> via a compile-time `bool VIsConst`
+// parameter. See the "NeighborhoodIterator N+1 Port" design plan at
+// docs/superpowers/plans/2026-04-23-neighborhood-iterator-n1-port.md.
+// -----------------------------------------------------------------------------
+
+#include <cstring>
+#include <iostream>
+#include <list>
+#include <sstream>
+#include <type_traits>
+#include <vector>
+
+#include "itkImage.h"
+#include "itkNeighborhood.h"
+#include "itkMacro.h"
+#include "itkWeakPointer.h"
+#include "itkImageBoundaryCondition.h"
+#include "itkZeroFluxNeumannBoundaryCondition.h"
+
+namespace itk
+{
+
+// =============================================================================
+// 1. Unified neighborhood iterator (replaces ConstNeighborhoodIterator +
+//    NeighborhoodIterator).
+// =============================================================================
+template <typename TImage,
+          typename TBoundaryCondition = ZeroFluxNeumannBoundaryCondition<TImage>,
+          bool VIsConst = false>
+class ITK_TEMPLATE_EXPORT NeighborhoodIteratorBase
+  : public Neighborhood<
+      std::conditional_t<VIsConst, const typename TImage::InternalPixelType *, typename TImage::InternalPixelType *>,
+      TImage::ImageDimension>
+{
+public:
+  // --- compile-time constness plumbing ---------------------------------------
+  static constexpr bool IsConst = VIsConst;
+
+  using InternalPixelType = typename TImage::InternalPixelType;
+  using PixelType = typename TImage::PixelType;
+
+  // Pointer / reference types flip based on VIsConst. No const_cast anywhere.
+  using ImagePointer = std::conditional_t<IsConst, const TImage *, TImage *>;
+
+  using InternalPixelPointer = std::conditional_t<IsConst, const InternalPixelType *, InternalPixelType *>;
+
+  using PixelReference = std::conditional_t<IsConst, const PixelType &, PixelType &>;
+
+  // --- standard iterator type aliases ----------------------------------------
+  using Self = NeighborhoodIteratorBase;
+  using Superclass = Neighborhood<InternalPixelPointer, TImage::ImageDimension>;
+
+  using typename Superclass::OffsetType;
+  using typename Superclass::RadiusType;
+  using typename Superclass::SizeType;
+  using typename Superclass::Iterator;
+  using typename Superclass::ConstIterator;
+
+  static constexpr unsigned int Dimension = TImage::ImageDimension;
+  using DimensionValueType = unsigned int;
+
+  using ImageType = TImage;
+  using RegionType = typename TImage::RegionType;
+  using IndexType = Index<Dimension>;
+  using NeighborhoodType = Neighborhood<PixelType, Dimension>;
+  using NeighborIndexType = typename NeighborhoodType::NeighborIndexType;
+  using BoundaryConditionType = TBoundaryCondition;
+  using OutputImageType = typename BoundaryConditionType::OutputImageType;
+
+  using NeighborhoodAccessorFunctorType = typename ImageType::NeighborhoodAccessorFunctorType;
+
+  using ImageBoundaryConditionPointerType = ImageBoundaryCondition<ImageType, OutputImageType> *;
+  using ImageBoundaryConditionConstPointerType = const ImageBoundaryCondition<ImageType, OutputImageType> *;
+
+  // m_ConstImage is a ConstWeakPointer on VIsConst=true and a (non-const)
+  // WeakPointer on VIsConst=false.
+  using ImageWeakPointerType =
+    std::conditional_t<IsConst, typename ImageType::ConstWeakPointer, WeakPointer<ImageType>>;
+
+  // Friending cross-const instantiations lets the converting ctor access
+  // private state of its non-const sibling.
+  template <typename, typename, bool>
+  friend class NeighborhoodIteratorBase;
+
+  /** Default constructor. */
+  NeighborhoodIteratorBase() = default;
+
+  /** Destructor. */
+  ~NeighborhoodIteratorBase() = default;
+
+  /** Constructor which establishes the region size, neighborhood, and image
+   * over which to walk. */
+  NeighborhoodIteratorBase(const SizeType & radius, ImagePointer ptr, const RegionType & region)
+  {
+    this->Initialize(radius, ptr, region);
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      m_InBounds[i] = false;
+    }
+    this->ResetBoundaryCondition();
+    m_NeighborhoodAccessorFunctor = ptr->GetNeighborhoodAccessor();
+    m_NeighborhoodAccessorFunctor.SetBegin(ptr->GetBufferPointer());
+  }
+
+  /** Copy constructor (same constness). */
+  NeighborhoodIteratorBase(const NeighborhoodIteratorBase & orig)
+    : Superclass(orig)
+    , m_BeginIndex(orig.m_BeginIndex)
+    , m_Bound(orig.m_Bound)
+    , m_Begin(orig.m_Begin)
+    , m_ConstImage(orig.m_ConstImage)
+    , m_End(orig.m_End)
+    , m_EndIndex(orig.m_EndIndex)
+    , m_Loop(orig.m_Loop)
+    , m_Region(orig.m_Region)
+    , m_WrapOffset(orig.m_WrapOffset)
+    , m_InternalBoundaryCondition(orig.m_InternalBoundaryCondition)
+    , m_NeedToUseBoundaryCondition(orig.m_NeedToUseBoundaryCondition)
+  {
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      m_InBounds[i] = orig.m_InBounds[i];
+    }
+    m_IsInBoundsValid = orig.m_IsInBoundsValid;
+    m_IsInBounds = orig.m_IsInBounds;
+
+    m_InnerBoundsLow = orig.m_InnerBoundsLow;
+    m_InnerBoundsHigh = orig.m_InnerBoundsHigh;
+
+    // Re-bind the (raw) boundary-condition pointer: if the source was
+    // pointing at its own internal default, the copy's pointer needs to
+    // point at *our* internal default, not the source's.
+    if (orig.m_BoundaryCondition ==
+        static_cast<ImageBoundaryConditionConstPointerType>(&orig.m_InternalBoundaryCondition))
+    {
+      this->ResetBoundaryCondition();
+    }
+    else
+    {
+      m_BoundaryCondition = orig.m_BoundaryCondition;
+    }
+    m_NeighborhoodAccessorFunctor = orig.m_NeighborhoodAccessorFunctor;
+  }
+
+  /** Non-const -> const converting constructor. Enabled only when *this* is
+   * the const instantiation being built from a non-const source. */
+  template <bool VOtherIsConst, std::enable_if_t<VIsConst && !VOtherIsConst, int> = 0>
+  NeighborhoodIteratorBase(const NeighborhoodIteratorBase<TImage, TBoundaryCondition, VOtherIsConst> & other)
+    : Superclass()
+    , m_BeginIndex(other.m_BeginIndex)
+    , m_Bound(other.m_Bound)
+    , m_Begin(other.m_Begin)
+    , m_End(other.m_End)
+    , m_EndIndex(other.m_EndIndex)
+    , m_Loop(other.m_Loop)
+    , m_Region(other.m_Region)
+    , m_WrapOffset(other.m_WrapOffset)
+    , m_InternalBoundaryCondition(other.m_InternalBoundaryCondition)
+    , m_NeedToUseBoundaryCondition(other.m_NeedToUseBoundaryCondition)
+  {
+    // Copy the Neighborhood<T*> base into Neighborhood<const T*> element-wise.
+    this->SetRadius(other.GetRadius());
+    auto       dstIt = this->Begin();
+    const auto srcEnd = other.End();
+    for (auto srcIt = other.Begin(); srcIt != srcEnd; ++srcIt, ++dstIt)
+    {
+      *dstIt = *srcIt; // T* -> const T* is implicit
+    }
+    m_ConstImage = other.m_ConstImage.GetPointer();
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      m_InBounds[i] = other.m_InBounds[i];
+    }
+    m_IsInBoundsValid = other.m_IsInBoundsValid;
+    m_IsInBounds = other.m_IsInBounds;
+    m_InnerBoundsLow = other.m_InnerBoundsLow;
+    m_InnerBoundsHigh = other.m_InnerBoundsHigh;
+    this->ResetBoundaryCondition();
+    m_NeighborhoodAccessorFunctor = other.m_NeighborhoodAccessorFunctor;
+  }
+
+  /** Assignment operator. */
+  Self &
+  operator=(const Self & orig)
+  {
+    if (this != &orig)
+    {
+      Superclass::operator=(orig);
+
+      m_Bound = orig.m_Bound;
+      m_Begin = orig.m_Begin;
+      m_ConstImage = orig.m_ConstImage;
+      m_End = orig.m_End;
+      m_EndIndex = orig.m_EndIndex;
+      m_Loop = orig.m_Loop;
+      m_Region = orig.m_Region;
+      m_BeginIndex = orig.m_BeginIndex;
+      m_WrapOffset = orig.m_WrapOffset;
+
+      m_InternalBoundaryCondition = orig.m_InternalBoundaryCondition;
+      m_NeedToUseBoundaryCondition = orig.m_NeedToUseBoundaryCondition;
+
+      m_InnerBoundsLow = orig.m_InnerBoundsLow;
+      m_InnerBoundsHigh = orig.m_InnerBoundsHigh;
+
+      for (DimensionValueType i = 0; i < Dimension; ++i)
+      {
+        m_InBounds[i] = orig.m_InBounds[i];
+      }
+      m_IsInBoundsValid = orig.m_IsInBoundsValid;
+      m_IsInBounds = orig.m_IsInBounds;
+
+      if (orig.m_BoundaryCondition ==
+          static_cast<ImageBoundaryConditionConstPointerType>(&orig.m_InternalBoundaryCondition))
+      {
+        this->ResetBoundaryCondition();
+      }
+      else
+      {
+        m_BoundaryCondition = orig.m_BoundaryCondition;
+      }
+      m_NeighborhoodAccessorFunctor = orig.m_NeighborhoodAccessorFunctor;
+    }
+    return *this;
+  }
+
+  /** Standard itk print method. */
+  void
+  PrintSelf(std::ostream & os, Indent indent) const
+  {
+    Superclass::PrintSelf(os, indent);
+
+    os << indent;
+    os << "NeighborhoodIteratorBase {this= " << this;
+    os << ", m_Region = { Start = {";
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      os << m_Region.GetIndex()[i] << ' ';
+    }
+    os << "}, Size = { ";
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      os << m_Region.GetSize()[i] << ' ';
+    }
+    os << "} }";
+    os << ", m_BeginIndex = { ";
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      os << m_BeginIndex[i] << ' ';
+    }
+    os << "} , m_EndIndex = { ";
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      os << m_EndIndex[i] << ' ';
+    }
+    os << "} , m_Loop = { ";
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      os << m_Loop[i] << ' ';
+    }
+    os << "}, m_Bound = { ";
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      os << m_Bound[i] << ' ';
+    }
+    os << "}, m_IsInBounds = {" << m_IsInBounds;
+    os << "}, m_IsInBoundsValid = {" << m_IsInBoundsValid;
+    os << "}, m_WrapOffset = { ";
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      os << m_WrapOffset[i] << ' ';
+    }
+    os << ", m_Begin = " << m_Begin;
+    os << ", m_End = " << m_End;
+    os << '}' << std::endl;
+
+    os << indent << ",  m_InnerBoundsLow = { ";
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      os << m_InnerBoundsLow[i] << ' ';
+    }
+    os << "}, m_InnerBoundsHigh = { ";
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      os << m_InnerBoundsHigh[i] << ' ';
+    }
+    os << "} }" << std::endl;
+  }
+
+  /** Computes the internal, N-d offset of a pixel array position n. */
+  OffsetType
+  ComputeInternalIndex(const NeighborIndexType n) const
+  {
+    OffsetType ans;
+    auto       r = static_cast<unsigned long>(n);
+    for (long i = long{ Dimension } - 1; i >= 0; --i)
+    {
+      ans[i] = static_cast<OffsetValueType>(r / this->GetStride(i));
+      r = r % this->GetStride(i);
+    }
+    return ans;
+  }
+
+  /** Upper loop bounds. */
+  IndexType
+  GetBound() const
+  {
+    return m_Bound;
+  }
+  IndexValueType
+  GetBound(NeighborIndexType n) const
+  {
+    return m_Bound[n];
+  }
+
+  /** Pointer to the center pixel. */
+  const InternalPixelType *
+  GetCenterPointer() const
+  {
+    return (this->operator[]((this->Size()) >> 1));
+  }
+
+  PixelType
+  GetCenterPixel() const
+  {
+    return m_NeighborhoodAccessorFunctor.Get(this->GetCenterPointer());
+  }
+
+  /** Access to the neighborhood accessor functor (read-only). */
+  const NeighborhoodAccessorFunctorType &
+  GetNeighborhoodAccessor() const
+  {
+    return m_NeighborhoodAccessorFunctor;
+  }
+
+  ImagePointer
+  GetImagePointer() const
+  {
+    return m_ConstImage.GetPointer();
+  }
+
+  IndexType
+  GetIndex() const
+  {
+    return m_Loop;
+  }
+
+  inline IndexType
+  GetFastIndexPlusOffset(const OffsetType & o) const
+  {
+    return m_Loop + o;
+  }
+
+  NeighborhoodType
+  GetNeighborhood() const
+  {
+    const ConstIterator _end = this->End();
+
+    NeighborhoodType ans;
+    ans.SetRadius(this->GetRadius());
+    if (m_NeedToUseBoundaryCondition == false)
+    {
+      ConstIterator thisIt = this->Begin();
+      for (typename NeighborhoodType::Iterator ansIt = ans.Begin(); thisIt < _end; ++ansIt, ++thisIt)
+      {
+        *ansIt = m_NeighborhoodAccessorFunctor.Get(*thisIt);
+      }
+    }
+    else if (InBounds())
+    {
+      ConstIterator thisIt = this->Begin();
+      for (typename NeighborhoodType::Iterator ansIt = ans.Begin(); thisIt < _end; ++ansIt, ++thisIt)
+      {
+        *ansIt = m_NeighborhoodAccessorFunctor.Get(*thisIt);
+      }
+    }
+    else
+    {
+      OffsetType temp;
+      OffsetType OverlapHigh;
+      OffsetType OverlapLow;
+      for (DimensionValueType i = 0; i < Dimension; ++i)
+      {
+        OverlapLow[i] = m_InnerBoundsLow[i] - m_Loop[i];
+        OverlapHigh[i] = static_cast<OffsetValueType>(this->GetSize(i)) - ((m_Loop[i] + 2) - m_InnerBoundsHigh[i]);
+        temp[i] = 0;
+      }
+
+      ConstIterator thisIt = this->Begin();
+      for (typename NeighborhoodType::Iterator ansIt = ans.Begin(); thisIt < _end; ++ansIt, ++thisIt)
+      {
+        bool flag = true;
+
+        OffsetType offset;
+        for (DimensionValueType i = 0; i < Dimension; ++i)
+        {
+          if (m_InBounds[i])
+          {
+            offset[i] = 0;
+          }
+          else
+          {
+            if (temp[i] < OverlapLow[i])
+            {
+              flag = false;
+              offset[i] = OverlapLow[i] - temp[i];
+            }
+            else if (OverlapHigh[i] < temp[i])
+            {
+              flag = false;
+              offset[i] = OverlapHigh[i] - temp[i];
+            }
+            else
+            {
+              offset[i] = 0;
+            }
+          }
+        }
+
+        if (flag)
+        {
+          *ansIt = m_NeighborhoodAccessorFunctor.Get(*thisIt);
+        }
+        else
+        {
+          *ansIt = m_NeighborhoodAccessorFunctor.BoundaryCondition(temp, offset, this, this->m_BoundaryCondition);
+        }
+
+        m_BoundaryCondition->operator()(temp, offset, this);
+
+        for (DimensionValueType i = 0; i < Dimension; ++i)
+        {
+          temp[i]++;
+          if (temp[i] == static_cast<OffsetValueType>(this->GetSize(i)))
+          {
+            temp[i] = 0;
+          }
+          else
+          {
+            break;
+          }
+        }
+      }
+    }
+    return ans;
+  }
+
+  PixelType
+  GetPixel(const NeighborIndexType i) const
+  {
+    if (!m_NeedToUseBoundaryCondition || this->InBounds())
+    {
+      return (m_NeighborhoodAccessorFunctor.Get(this->operator[](i)));
+    }
+
+    OffsetType internalIndex;
+    OffsetType offset;
+
+    return this->IndexInBounds(i, internalIndex, offset)
+             ? m_NeighborhoodAccessorFunctor.Get(this->operator[](i))
+             : m_NeighborhoodAccessorFunctor.BoundaryCondition(internalIndex, offset, this, m_BoundaryCondition);
+  }
+
+  PixelType
+  GetPixel(NeighborIndexType n, bool & IsInBounds) const
+  {
+    if (!m_NeedToUseBoundaryCondition)
+    {
+      IsInBounds = true;
+      return (m_NeighborhoodAccessorFunctor.Get(this->operator[](n)));
+    }
+
+    if (this->InBounds())
+    {
+      IsInBounds = true;
+      return (m_NeighborhoodAccessorFunctor.Get(this->operator[](n)));
+    }
+
+    OffsetType offset;
+    OffsetType internalIndex;
+    const bool flag = this->IndexInBounds(n, internalIndex, offset);
+    if (flag)
+    {
+      IsInBounds = true;
+      return (m_NeighborhoodAccessorFunctor.Get(this->operator[](n)));
+    }
+    else
+    {
+      IsInBounds = false;
+      return m_NeighborhoodAccessorFunctor.BoundaryCondition(internalIndex, offset, this, this->m_BoundaryCondition);
+    }
+  }
+
+  PixelType
+  GetPixel(const OffsetType & o) const
+  {
+    bool inbounds = false;
+    return (this->GetPixel(this->GetNeighborhoodIndex(o), inbounds));
+  }
+
+  PixelType
+  GetPixel(const OffsetType & o, bool & IsInBounds) const
+  {
+    return (this->GetPixel(this->GetNeighborhoodIndex(o), IsInBounds));
+  }
+
+  PixelType
+  GetNext(const unsigned int axis, NeighborIndexType i) const
+  {
+    return (this->GetPixel(this->GetCenterNeighborhoodIndex() + (i * this->GetStride(axis))));
+  }
+
+  PixelType
+  GetNext(const unsigned int axis) const
+  {
+    return (this->GetPixel(this->GetCenterNeighborhoodIndex() + this->GetStride(axis)));
+  }
+
+  PixelType
+  GetPrevious(const unsigned int axis, NeighborIndexType i) const
+  {
+    return (this->GetPixel(this->GetCenterNeighborhoodIndex() - (i * this->GetStride(axis))));
+  }
+
+  PixelType
+  GetPrevious(const unsigned int axis) const
+  {
+    return (this->GetPixel(this->GetCenterNeighborhoodIndex() - this->GetStride(axis)));
+  }
+
+  IndexType
+  GetIndex(const OffsetType & o) const
+  {
+    return this->GetIndex() + o;
+  }
+
+  IndexType
+  GetIndex(NeighborIndexType i) const
+  {
+    return this->GetIndex() + this->GetOffset(i);
+  }
+
+  RegionType
+  GetRegion() const
+  {
+    return m_Region;
+  }
+
+  IndexType
+  GetBeginIndex() const
+  {
+    return m_BeginIndex;
+  }
+
+  RegionType
+  GetBoundingBoxAsImageRegion() const
+  {
+    constexpr IndexValueType zero{};
+    const RegionType         ans(this->GetIndex(zero), this->GetSize());
+    return ans;
+  }
+
+  OffsetType
+  GetWrapOffset() const
+  {
+    return m_WrapOffset;
+  }
+
+  OffsetValueType
+  GetWrapOffset(NeighborIndexType n) const
+  {
+    return m_WrapOffset[n];
+  }
+
+  void
+  GoToBegin()
+  {
+    this->SetLocation(m_BeginIndex);
+  }
+
+  void
+  GoToEnd()
+  {
+    this->SetLocation(m_EndIndex);
+  }
+
+  void
+  Initialize(const SizeType & radius, ImagePointer ptr, const RegionType & region)
+  {
+    m_ConstImage = ptr;
+    this->SetRadius(radius);
+    SetRegion(region);
+    m_IsInBoundsValid = false;
+    m_IsInBounds = false;
+  }
+
+  bool
+  IsAtBegin() const
+  {
+    return this->GetCenterPointer() == m_Begin;
+  }
+
+  bool
+  IsAtEnd() const
+  {
+    if (this->GetCenterPointer() > m_End)
+    {
+      ExceptionObject    e(__FILE__, __LINE__);
+      std::ostringstream msg;
+      msg << "In method IsAtEnd, CenterPointer = " << this->GetCenterPointer() << " is greater than End = " << m_End
+          << std::endl
+          << "  " << *this;
+      e.SetDescription(msg.str().c_str());
+      throw e;
+    }
+    return this->GetCenterPointer() == m_End;
+  }
+
+  Self &
+  operator++()
+  {
+    const Iterator _end = Superclass::End();
+    m_IsInBoundsValid = false;
+
+    for (Iterator it = Superclass::Begin(); it < _end; ++it)
+    {
+      (*it)++;
+    }
+
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      m_Loop[i]++;
+      if (m_Loop[i] == m_Bound[i])
+      {
+        m_Loop[i] = m_BeginIndex[i];
+        for (Iterator it = Superclass::Begin(); it < _end; ++it)
+        {
+          *it += m_WrapOffset[i];
+        }
+      }
+      else
+      {
+        break;
+      }
+    }
+    return *this;
+  }
+
+  Self &
+  operator--()
+  {
+    const Iterator _end = Superclass::End();
+    m_IsInBoundsValid = false;
+
+    for (Iterator it = Superclass::Begin(); it < _end; ++it)
+    {
+      (*it)--;
+    }
+
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      if (m_Loop[i] == m_BeginIndex[i])
+      {
+        m_Loop[i] = m_Bound[i] - 1;
+        for (Iterator it = Superclass::Begin(); it < _end; ++it)
+        {
+          *it -= m_WrapOffset[i];
+        }
+      }
+      else
+      {
+        m_Loop[i]--;
+        break;
+      }
+    }
+    return *this;
+  }
+
+  bool
+  operator==(const Self & it) const
+  {
+    return it.GetCenterPointer() == this->GetCenterPointer();
+  }
+
+  bool
+  operator!=(const Self & it) const
+  {
+    return !(*this == it);
+  }
+
+  bool
+  operator<(const Self & it) const
+  {
+    return this->GetCenterPointer() < it.GetCenterPointer();
+  }
+
+  bool
+  operator<=(const Self & it) const
+  {
+    return this->GetCenterPointer() <= it.GetCenterPointer();
+  }
+
+  bool
+  operator>(const Self & it) const
+  {
+    return this->GetCenterPointer() > it.GetCenterPointer();
+  }
+
+  bool
+  operator>=(const Self & it) const
+  {
+    return this->GetCenterPointer() >= it.GetCenterPointer();
+  }
+
+  void
+  SetLocation(const IndexType & position)
+  {
+    this->SetLoop(position);
+    this->SetPixelPointers(position);
+  }
+
+  Self &
+  operator+=(const OffsetType & idx)
+  {
+    const Iterator          _end = this->End();
+    OffsetValueType         accumulator = 0;
+    const OffsetValueType * stride = this->GetImagePointer()->GetOffsetTable();
+
+    m_IsInBoundsValid = false;
+
+    accumulator += idx[0];
+    for (DimensionValueType i = 1; i < Dimension; ++i)
+    {
+      accumulator += idx[i] * stride[i];
+    }
+
+    for (Iterator it = this->Begin(); it < _end; ++it)
+    {
+      *it += accumulator;
+    }
+
+    m_Loop += idx;
+    return *this;
+  }
+
+  Self &
+  operator-=(const OffsetType & idx)
+  {
+    const Iterator          _end = this->End();
+    OffsetValueType         accumulator = 0;
+    const OffsetValueType * stride = this->GetImagePointer()->GetOffsetTable();
+
+    m_IsInBoundsValid = false;
+
+    accumulator += idx[0];
+    for (DimensionValueType i = 1; i < Dimension; ++i)
+    {
+      accumulator += idx[i] * stride[i];
+    }
+
+    for (Iterator it = this->Begin(); it < _end; ++it)
+    {
+      *it -= accumulator;
+    }
+
+    m_Loop -= idx;
+    return *this;
+  }
+
+  OffsetType
+  operator-(const Self & b) const
+  {
+    return m_Loop - b.m_Loop;
+  }
+
+  bool
+  InBounds() const
+  {
+    if (m_IsInBoundsValid)
+    {
+      return m_IsInBounds;
+    }
+
+    bool ans = true;
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      if (m_Loop[i] < m_InnerBoundsLow[i] || m_Loop[i] >= m_InnerBoundsHigh[i])
+      {
+        m_InBounds[i] = ans = false;
+      }
+      else
+      {
+        m_InBounds[i] = true;
+      }
+    }
+    m_IsInBounds = ans;
+    m_IsInBoundsValid = true;
+    return ans;
+  }
+
+  bool
+  IndexInBounds(const NeighborIndexType n, OffsetType & internalIndex, OffsetType & offset) const
+  {
+    if (!m_NeedToUseBoundaryCondition)
+    {
+      return true;
+    }
+    if (this->InBounds())
+    {
+      return true;
+    }
+    else
+    {
+      bool flag = true;
+      internalIndex = this->ComputeInternalIndex(n);
+
+      for (DimensionValueType i = 0; i < Dimension; ++i)
+      {
+        if (m_InBounds[i])
+        {
+          offset[i] = 0;
+        }
+        else
+        {
+          const OffsetValueType OverlapLow(m_InnerBoundsLow[i] - m_Loop[i]);
+          if (internalIndex[i] < OverlapLow)
+          {
+            flag = false;
+            offset[i] = OverlapLow - internalIndex[i];
+          }
+          else
+          {
+            const auto overlapHigh(
+              static_cast<OffsetValueType>(this->GetSize(i) - ((m_Loop[i] + 2) - m_InnerBoundsHigh[i])));
+            if (overlapHigh < internalIndex[i])
+            {
+              flag = false;
+              offset[i] = overlapHigh - internalIndex[i];
+            }
+            else
+            {
+              offset[i] = 0;
+            }
+          }
+        }
+      }
+      return flag;
+    }
+  }
+
+  bool
+  IndexInBounds(const NeighborIndexType n) const
+  {
+    if (!m_NeedToUseBoundaryCondition)
+    {
+      return true;
+    }
+    if (this->InBounds())
+    {
+      return true;
+    }
+    else
+    {
+      bool               flag = true;
+      const OffsetType & internalIndex = this->ComputeInternalIndex(n);
+      for (DimensionValueType i = 0; i < Dimension; ++i)
+      {
+        if (!m_InBounds[i])
+        {
+          const OffsetValueType OverlapLow(m_InnerBoundsLow[i] - m_Loop[i]);
+          if (internalIndex[i] < OverlapLow)
+          {
+            flag = false;
+          }
+          else
+          {
+            const auto overlapHigh(
+              static_cast<OffsetValueType>(this->GetSize(i) - ((m_Loop[i] + 2) - m_InnerBoundsHigh[i])));
+            if (overlapHigh < internalIndex[i])
+            {
+              flag = false;
+            }
+          }
+        }
+      }
+      return flag;
+    }
+  }
+
+  // --- boundary condition setters (available on both instantiations) --------
+  void
+  OverrideBoundaryCondition(const ImageBoundaryConditionPointerType i)
+  {
+    m_BoundaryCondition = i;
+  }
+
+  void
+  ResetBoundaryCondition()
+  {
+    m_BoundaryCondition = &m_InternalBoundaryCondition;
+  }
+
+  void
+  SetBoundaryCondition(const TBoundaryCondition & c)
+  {
+    m_InternalBoundaryCondition = c;
+  }
+
+  ImageBoundaryConditionPointerType
+  GetBoundaryCondition() const
+  {
+    return m_BoundaryCondition;
+  }
+
+  void
+  NeedToUseBoundaryConditionOn()
+  {
+    this->SetNeedToUseBoundaryCondition(true);
+  }
+
+  void
+  NeedToUseBoundaryConditionOff()
+  {
+    this->SetNeedToUseBoundaryCondition(false);
+  }
+
+  void
+  SetNeedToUseBoundaryCondition(bool b)
+  {
+    m_NeedToUseBoundaryCondition = b;
+  }
+
+  bool
+  GetNeedToUseBoundaryCondition() const
+  {
+    return m_NeedToUseBoundaryCondition;
+  }
+
+  /** Set the region to iterate over. */
+  void
+  SetRegion(const RegionType & region)
+  {
+    m_Region = region;
+
+    const IndexType regionIndex = region.GetIndex();
+
+    this->SetBeginIndex(region.GetIndex());
+    this->SetLocation(region.GetIndex());
+    this->SetBound(region.GetSize());
+    this->SetEndIndex();
+
+    m_Begin = m_ConstImage->GetBufferPointer() + m_ConstImage->ComputeOffset(regionIndex);
+    m_End = m_ConstImage->GetBufferPointer() + m_ConstImage->ComputeOffset(m_EndIndex);
+
+    const IndexType bStart = m_ConstImage->GetBufferedRegion().GetIndex();
+    const SizeType  bSize = m_ConstImage->GetBufferedRegion().GetSize();
+    const IndexType rStart = region.GetIndex();
+    const SizeType  rSize = region.GetSize();
+
+    m_NeedToUseBoundaryCondition = false;
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      const auto overlapLow =
+        static_cast<OffsetValueType>((rStart[i] - static_cast<OffsetValueType>(this->GetRadius(i))) - bStart[i]);
+      const auto overlapHigh = static_cast<OffsetValueType>(
+        (bStart[i] + bSize[i]) - (rStart[i] + rSize[i] + static_cast<OffsetValueType>(this->GetRadius(i))));
+
+      if (overlapLow < 0)
+      {
+        m_NeedToUseBoundaryCondition = true;
+        break;
+      }
+
+      if (overlapHigh < 0)
+      {
+        m_NeedToUseBoundaryCondition = true;
+        break;
+      }
+    }
+  }
+
+  // =========================================================================
+  // Write API. SFINAE-gated on !VIsConst; these methods are not present on
+  // the const instantiation.
+  // =========================================================================
+  template <bool VCopy = VIsConst, std::enable_if_t<!VCopy, int> = 0>
+  void
+  SetPixel(const unsigned int n, const PixelType & v)
+  {
+    if (this->m_NeedToUseBoundaryCondition == false)
+    {
+      this->m_NeighborhoodAccessorFunctor.Set(this->operator[](n), v);
+    }
+    else if (this->InBounds())
+    {
+      this->m_NeighborhoodAccessorFunctor.Set(this->operator[](n), v);
+    }
+    else
+    {
+      OffsetType temp = this->ComputeInternalIndex(n);
+      OffsetType OverlapLow;
+      OffsetType OverlapHigh;
+      OffsetType offset;
+
+      for (unsigned int ii = 0; ii < Dimension; ++ii)
+      {
+        OverlapLow[ii] = this->m_InnerBoundsLow[ii] - this->m_Loop[ii];
+        OverlapHigh[ii] =
+          static_cast<OffsetValueType>(this->GetSize(ii) - ((this->m_Loop[ii] + 2) - this->m_InnerBoundsHigh[ii]));
+      }
+
+      bool flag = true;
+
+      for (unsigned int ii = 0; ii < Dimension; ++ii)
+      {
+        if (this->m_InBounds[ii])
+        {
+          offset[ii] = 0;
+        }
+        else
+        {
+          if (temp[ii] < OverlapLow[ii])
+          {
+            flag = false;
+            offset[ii] = OverlapLow[ii] - temp[ii];
+          }
+          else if (OverlapHigh[ii] < temp[ii])
+          {
+            flag = false;
+            offset[ii] = OverlapHigh[ii] - temp[ii];
+          }
+          else
+          {
+            offset[ii] = 0;
+          }
+        }
+      }
+
+      if (flag)
+      {
+        this->m_NeighborhoodAccessorFunctor.Set(this->operator[](n), v);
+      }
+      else
+      {
+        RangeError e(__FILE__, __LINE__);
+        e.SetLocation(ITK_LOCATION);
+        e.SetDescription("Attempt to write out of bounds.");
+        throw e;
+      }
+    }
+  }
+
+  template <bool VCopy = VIsConst, std::enable_if_t<!VCopy, int> = 0>
+  void
+  SetPixel(const unsigned int n, const PixelType & v, bool & status)
+  {
+    if (this->m_NeedToUseBoundaryCondition == false)
+    {
+      status = true;
+      this->m_NeighborhoodAccessorFunctor.Set(this->operator[](n), v);
+    }
+    else if (this->InBounds())
+    {
+      this->m_NeighborhoodAccessorFunctor.Set(this->operator[](n), v);
+      status = true;
+      return;
+    }
+    else
+    {
+      OffsetType temp = this->ComputeInternalIndex(n);
+      for (unsigned int i = 0; i < Dimension; ++i)
+      {
+        if (!this->m_InBounds[i])
+        {
+          const typename OffsetType::OffsetValueType OverlapLow = this->m_InnerBoundsLow[i] - this->m_Loop[i];
+          const auto                                 OverlapHigh =
+            static_cast<OffsetValueType>(this->GetSize(i) - ((this->m_Loop[i] + 2) - this->m_InnerBoundsHigh[i]));
+          if (temp[i] < OverlapLow || OverlapHigh < temp[i])
+          {
+            status = false;
+            return;
+          }
+        }
+      }
+
+      this->m_NeighborhoodAccessorFunctor.Set(this->operator[](n), v);
+      status = true;
+    }
+  }
+
+  template <bool VCopy = VIsConst, std::enable_if_t<!VCopy, int> = 0>
+  void
+  SetCenterPixel(const PixelType & p)
+  {
+    this->m_NeighborhoodAccessorFunctor.Set(this->operator[]((this->Size()) >> 1), p);
+  }
+
+  template <bool VCopy = VIsConst, std::enable_if_t<!VCopy, int> = 0>
+  void
+  SetNeighborhood(const NeighborhoodType & N)
+  {
+    const Iterator _end = this->End();
+
+    typename NeighborhoodType::ConstIterator N_it;
+
+    if (this->m_NeedToUseBoundaryCondition == false)
+    {
+      Iterator this_it = this->Begin();
+      for (N_it = N.Begin(); this_it < _end; ++this_it, ++N_it)
+      {
+        this->m_NeighborhoodAccessorFunctor.Set(*this_it, *N_it);
+      }
+    }
+    else if (this->InBounds())
+    {
+      Iterator this_it = this->Begin();
+      for (N_it = N.Begin(); this_it < _end; ++this_it, ++N_it)
+      {
+        this->m_NeighborhoodAccessorFunctor.Set(*this_it, *N_it);
+      }
+    }
+    else
+    {
+      OffsetType OverlapLow;
+      OffsetType OverlapHigh;
+      OffsetType temp{ 0 };
+      for (unsigned int i = 0; i < Dimension; ++i)
+      {
+        OverlapLow[i] = this->m_InnerBoundsLow[i] - this->m_Loop[i];
+        OverlapHigh[i] =
+          static_cast<OffsetValueType>(this->GetSize(i) - (this->m_Loop[i] - this->m_InnerBoundsHigh[i]) - 1);
+      }
+
+      Iterator this_it = this->Begin();
+      for (N_it = N.Begin(); this_it < _end; ++N_it, ++this_it)
+      {
+        bool flag = true;
+        for (unsigned int i = 0; i < Dimension; ++i)
+        {
+          if (!this->m_InBounds[i] && ((temp[i] < OverlapLow[i]) || (temp[i] >= OverlapHigh[i])))
+          {
+            flag = false;
+            break;
+          }
+        }
+
+        if (flag)
+        {
+          this->m_NeighborhoodAccessorFunctor.Set(*this_it, *N_it);
+        }
+
+        for (unsigned int i = 0; i < Dimension; ++i)
+        {
+          temp[i]++;
+          if (static_cast<unsigned int>(temp[i]) == this->GetSize(i))
+          {
+            temp[i] = 0;
+          }
+          else
+          {
+            break;
+          }
+        }
+      }
+    }
+  }
+
+protected:
+  /** Set the coordinate location of the iterator. */
+  void
+  SetLoop(const IndexType & p)
+  {
+    m_Loop = p;
+    m_IsInBoundsValid = false;
+  }
+
+  /** Set internal loop boundaries. */
+  void
+  SetBound(const SizeType & size)
+  {
+    SizeType                radius = this->GetRadius();
+    const OffsetValueType * offset = m_ConstImage->GetOffsetTable();
+    const IndexType         imageBRStart = m_ConstImage->GetBufferedRegion().GetIndex();
+    SizeType                imageBRSize = m_ConstImage->GetBufferedRegion().GetSize();
+
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      m_Bound[i] = m_BeginIndex[i] + static_cast<OffsetValueType>(size[i]);
+      m_InnerBoundsHigh[i] = static_cast<IndexValueType>(
+        imageBRStart[i] + static_cast<OffsetValueType>(imageBRSize[i]) - static_cast<OffsetValueType>(radius[i]));
+      m_InnerBoundsLow[i] = static_cast<IndexValueType>(imageBRStart[i] + static_cast<OffsetValueType>(radius[i]));
+      m_WrapOffset[i] = (static_cast<OffsetValueType>(imageBRSize[i]) - (m_Bound[i] - m_BeginIndex[i])) * offset[i];
+    }
+    m_WrapOffset[Dimension - 1] = 0;
+  }
+
+  /** Set the values of the internal pointers. */
+  void
+  SetPixelPointers(const IndexType & pos)
+  {
+    const Iterator          _end = Superclass::End();
+    const SizeType          size = this->GetSize();
+    const OffsetValueType * OffsetTable = m_ConstImage->GetOffsetTable();
+    const SizeType          radius = this->GetRadius();
+
+    SizeType loop{};
+
+    // First "upper-left-corner" pixel address of neighborhood. Using
+    // m_ConstImage's natural pointer type avoids the legacy const_cast.
+    auto *               ptr = m_ConstImage.GetPointer();
+    InternalPixelPointer Iit = ptr->GetBufferPointer() + ptr->ComputeOffset(pos);
+
+    for (DimensionValueType i = 0; i < Dimension; ++i)
+    {
+      Iit -= radius[i] * OffsetTable[i];
+    }
+
+    for (Iterator Nit = Superclass::Begin(); Nit != _end; ++Nit)
+    {
+      *Nit = Iit;
+      ++Iit;
+      for (DimensionValueType i = 0; i < Dimension; ++i)
+      {
+        loop[i]++;
+        if (loop[i] == size[i])
+        {
+          if (i == Dimension - 1)
+          {
+            break;
+          }
+          Iit += OffsetTable[i + 1] - OffsetTable[i] * static_cast<OffsetValueType>(size[i]);
+          loop[i] = 0;
+        }
+        else
+        {
+          break;
+        }
+      }
+    }
+  }
+
+  void
+  SetBeginIndex(const IndexType & start)
+  {
+    m_BeginIndex = start;
+  }
+
+  void
+  SetEndIndex()
+  {
+    if (m_Region.GetNumberOfPixels() > 0)
+    {
+      m_EndIndex = m_Region.GetIndex();
+      m_EndIndex[Dimension - 1] =
+        m_Region.GetIndex()[Dimension - 1] + static_cast<OffsetValueType>(m_Region.GetSize()[Dimension - 1]);
+    }
+    else
+    {
+      m_EndIndex = m_Region.GetIndex();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Legacy protected member layout — mirrors itkConstNeighborhoodIterator.h
+  // lines 584-646.
+  // -------------------------------------------------------------------------
+
+  IndexType                         m_BeginIndex{ { 0 } };
+  IndexType                         m_Bound{ { 0 } };
+  InternalPixelPointer              m_Begin{ nullptr };
+  ImageWeakPointerType              m_ConstImage{};
+  InternalPixelPointer              m_End{ nullptr };
+  IndexType                         m_EndIndex{ { 0 } };
+  IndexType                         m_Loop{ { 0 } };
+  RegionType                        m_Region{};
+  OffsetType                        m_WrapOffset{ { 0 } };
+  TBoundaryCondition                m_InternalBoundaryCondition{};
+  ImageBoundaryConditionPointerType m_BoundaryCondition{ &m_InternalBoundaryCondition };
+  mutable bool                      m_InBounds[Dimension]{ false };
+  mutable bool                      m_IsInBounds{ false };
+  mutable bool                      m_IsInBoundsValid{ false };
+  IndexType                         m_InnerBoundsLow{};
+  IndexType                         m_InnerBoundsHigh{};
+  bool                              m_NeedToUseBoundaryCondition{ false };
+  NeighborhoodAccessorFunctorType   m_NeighborhoodAccessorFunctor{};
+};
+
+// -----------------------------------------------------------------------------
+// Re-templated free operators (legacy versions templated on TImage only).
+// -----------------------------------------------------------------------------
+template <typename TImage, typename TBoundaryCondition, bool VIsConst>
+inline NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst>
+operator+(const NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst> &                      it,
+          const typename NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst>::OffsetType & ind)
+{
+  NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst> ret(it);
+  ret += ind;
+  return ret;
+}
+
+template <typename TImage, typename TBoundaryCondition, bool VIsConst>
+inline NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst>
+operator+(const typename NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst>::OffsetType & ind,
+          const NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst> &                      it)
+{
+  return it + ind;
+}
+
+template <typename TImage, typename TBoundaryCondition, bool VIsConst>
+inline NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst>
+operator-(const NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst> &                      it,
+          const typename NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst>::OffsetType & ind)
+{
+  NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst> ret(it);
+  ret -= ind;
+  return ret;
+}
+
+// -----------------------------------------------------------------------------
+// Aliases that preserve the legacy public names.
+// -----------------------------------------------------------------------------
+template <typename TImage, typename TBC = ZeroFluxNeumannBoundaryCondition<TImage>>
+using ConstNeighborhoodIterator2 = NeighborhoodIteratorBase<TImage, TBC, /*IsConst=*/true>;
+
+template <typename TImage, typename TBC = ZeroFluxNeumannBoundaryCondition<TImage>>
+using NeighborhoodIterator2 = NeighborhoodIteratorBase<TImage, TBC, /*IsConst=*/false>;
+
+
+// =============================================================================
+// 2. Unified shaped neighborhood iterator scaffold (design shape only; full
+//    port lands in a subsequent milestone).
+// =============================================================================
+template <typename TImage,
+          typename TBoundaryCondition = ZeroFluxNeumannBoundaryCondition<TImage>,
+          bool VIsConst = false>
+class ITK_TEMPLATE_EXPORT ShapedNeighborhoodIteratorBase
+{
+public:
+  static constexpr bool IsConst = VIsConst;
+
+  using Base = NeighborhoodIteratorBase<TImage, TBoundaryCondition, VIsConst>;
+
+  using ImagePointer = typename Base::ImagePointer;
+  using PixelType = typename Base::PixelType;
+  using SizeType = typename Base::SizeType;
+  using RegionType = typename Base::RegionType;
+  using OffsetType = typename Base::OffsetType;
+  using IndexType = typename Base::IndexType;
+  using NeighborhoodType = typename Base::NeighborhoodType;
+  using NeighborIndexType = typename NeighborhoodType::NeighborIndexType;
+
+  using IndexListType = std::list<NeighborIndexType>;
+
+  using Self = ShapedNeighborhoodIteratorBase;
+
+  template <typename, typename, bool>
+  friend class ShapedNeighborhoodIteratorBase;
+
+  ShapedNeighborhoodIteratorBase() = default;
+  ~ShapedNeighborhoodIteratorBase() = default;
+
+  ShapedNeighborhoodIteratorBase(const SizeType & radius, ImagePointer ptr, const RegionType & region)
+    : m_Base(radius, ptr, region)
+  {}
+
+  ShapedNeighborhoodIteratorBase(const ShapedNeighborhoodIteratorBase &) = default;
+  ShapedNeighborhoodIteratorBase(ShapedNeighborhoodIteratorBase &&) noexcept = default;
+  ShapedNeighborhoodIteratorBase &
+  operator=(const ShapedNeighborhoodIteratorBase &) = default;
+  ShapedNeighborhoodIteratorBase &
+  operator=(ShapedNeighborhoodIteratorBase &&) noexcept = default;
+
+  // Converting ctor: non-const -> const only (VIsConst && !VOtherIsConst).
+  template <bool VOtherIsConst, std::enable_if_t<VIsConst && !VOtherIsConst, int> = 0>
+  ShapedNeighborhoodIteratorBase(const ShapedNeighborhoodIteratorBase<TImage, TBoundaryCondition, VOtherIsConst> & o)
+    : m_Base(o.m_Base)
+    , m_ActiveIndexList(o.m_ActiveIndexList)
+    , m_CenterIsActive(o.m_CenterIsActive)
+  {}
+
+  template <bool VInnerIsConst>
+  struct InnerIteratorT
+  {
+    using OuterPointer = std::conditional_t<VInnerIsConst, const Self *, Self *>;
+    using ListIterator =
+      std::conditional_t<VInnerIsConst, typename IndexListType::const_iterator, typename IndexListType::iterator>;
+
+    InnerIteratorT() = default;
+    friend Self;
+
+    InnerIteratorT &
+    operator++()
+    {
+      ++m_ListIterator;
+      return *this;
+    }
+    bool
+    operator==(const InnerIteratorT & o) const
+    {
+      return m_ListIterator == o.m_ListIterator;
+    }
+    bool
+    operator!=(const InnerIteratorT & o) const
+    {
+      return !(*this == o);
+    }
+
+    PixelType
+    Get() const
+    {
+      // Direct pointer access via the base's accessor. This matches the legacy
+      // shaped iterator semantics (active offsets read directly, bypassing the
+      // boundary condition) and also avoids instantiating the BC-branch of
+      // NeighborhoodIteratorBase::GetPixel() for VIsConst=true instantiations.
+      return m_Outer->m_Base.GetNeighborhoodAccessor().Get(m_Outer->m_Base.operator[](*m_ListIterator));
+    }
+
+    void
+    Set(const PixelType & v) const
+    {
+      static_assert(!VInnerIsConst && !IsConst, "Set() requires a non-const ShapedNeighborhoodIterator.");
+      m_Outer->m_Base.SetPixel(*m_ListIterator, v);
+    }
+
+  private:
+    InnerIteratorT(OuterPointer outer, ListIterator li)
+      : m_Outer(outer)
+      , m_ListIterator(li)
+    {}
+
+    OuterPointer m_Outer{ nullptr };
+    ListIterator m_ListIterator{};
+  };
+
+  using ConstIterator = InnerIteratorT<true>;
+  using Iterator = InnerIteratorT<false>;
+
+  ConstIterator
+  Begin() const
+  {
+    return ConstIterator(this, m_ActiveIndexList.begin());
+  }
+  ConstIterator
+  End() const
+  {
+    return ConstIterator(this, m_ActiveIndexList.end());
+  }
+
+  template <bool VCopy = IsConst, std::enable_if_t<!VCopy, int> = 0>
+  Iterator
+  Begin()
+  {
+    return Iterator(this, m_ActiveIndexList.begin());
+  }
+  template <bool VCopy = IsConst, std::enable_if_t<!VCopy, int> = 0>
+  Iterator
+  End()
+  {
+    return Iterator(this, m_ActiveIndexList.end());
+  }
+
+  void
+  ActivateOffset(const OffsetType & off)
+  {
+    this->ActivateIndex(m_Base.GetNeighborhoodIndex(off));
+  }
+  void
+  DeactivateOffset(const OffsetType & off)
+  {
+    this->DeactivateIndex(m_Base.GetNeighborhoodIndex(off));
+  }
+  template <typename TOffsets>
+  void
+  ActivateOffsets(const TOffsets & offsets)
+  {
+    for (const auto & off : offsets)
+    {
+      this->ActivateOffset(off);
+    }
+  }
+  void
+  ClearActiveList()
+  {
+    m_ActiveIndexList.clear();
+    m_CenterIsActive = false;
+  }
+
+  template <typename TNeighborPixel>
+  void
+  CreateActiveListFromNeighborhood(const Neighborhood<TNeighborPixel, Base::Dimension> & neighborhood)
+  {
+    if (m_Base.GetRadius() != neighborhood.GetRadius())
+    {
+      itkGenericExceptionMacro("Radius of shaped iterator(" << m_Base.GetRadius()
+                                                            << ") does not equal radius of neighborhood("
+                                                            << neighborhood.GetRadius() << ')');
+    }
+    NeighborIndexType idx = 0;
+    for (auto nit = neighborhood.Begin(); nit != neighborhood.End(); ++nit, ++idx)
+    {
+      if (*nit)
+      {
+        this->ActivateOffset(neighborhood.GetOffset(idx));
+      }
+      else
+      {
+        this->DeactivateOffset(neighborhood.GetOffset(idx));
+      }
+    }
+  }
+
+  bool
+  GetCenterIsActive() const
+  {
+    return m_CenterIsActive;
+  }
+
+  NeighborIndexType
+  GetCenterNeighborhoodIndex() const
+  {
+    return m_Base.GetCenterNeighborhoodIndex();
+  }
+
+  OffsetType
+  GetOffset(NeighborIndexType i) const
+  {
+    return m_Base.GetOffset(i);
+  }
+
+  NeighborIndexType
+  GetNeighborhoodIndex(const OffsetType & o) const
+  {
+    return m_Base.GetNeighborhoodIndex(o);
+  }
+
+  SizeType
+  GetRadius() const
+  {
+    return m_Base.GetRadius();
+  }
+
+  // Iteration: delegate to the underlying (dense) base iterator. This loses
+  // the shaped-only pointer-update optimization that the legacy iterator
+  // performed, in exchange for structural elimination of the const_cast
+  // sites and a much simpler implementation. GetPixel() for active indices
+  // goes through the base, which is always correct.
+  void
+  GoToBegin()
+  {
+    m_Base.GoToBegin();
+  }
+  void
+  GoToEnd()
+  {
+    m_Base.GoToEnd();
+  }
+  bool
+  IsAtBegin() const
+  {
+    return m_Base.IsAtBegin();
+  }
+  bool
+  IsAtEnd() const
+  {
+    return m_Base.IsAtEnd();
+  }
+  Self &
+  operator++()
+  {
+    ++m_Base;
+    return *this;
+  }
+  Self &
+  operator--()
+  {
+    --m_Base;
+    return *this;
+  }
+  void
+  SetLocation(const IndexType & position)
+  {
+    m_Base.SetLocation(position);
+  }
+
+  bool
+  operator==(const Self & o) const
+  {
+    return m_Base == o.m_Base;
+  }
+  bool
+  operator!=(const Self & o) const
+  {
+    return !(*this == o);
+  }
+
+  void
+  PrintSelf(std::ostream & os, Indent indent) const
+  {
+    m_Base.PrintSelf(os, indent);
+    os << indent << "ActiveIndexList: [";
+    for (auto it = m_ActiveIndexList.begin(); it != m_ActiveIndexList.end(); ++it)
+    {
+      os << indent.GetNextIndent() << *it << ' ';
+    }
+    os << "] ";
+    os << indent << "CenterIsActive: " << (m_CenterIsActive ? "On" : "Off") << std::endl;
+  }
+  const IndexListType &
+  GetActiveIndexList() const
+  {
+    return m_ActiveIndexList;
+  }
+  typename IndexListType::size_type
+  GetActiveIndexListSize() const
+  {
+    return m_ActiveIndexList.size();
+  }
+
+  ImagePointer
+  GetImagePointer() const
+  {
+    return m_Base.GetImagePointer();
+  }
+  const RegionType &
+  GetRegion() const
+  {
+    return m_Base.GetRegion();
+  }
+  IndexType
+  GetIndex() const
+  {
+    return m_Base.GetIndex();
+  }
+  PixelType
+  GetCenterPixel() const
+  {
+    return m_Base.GetCenterPixel();
+  }
+
+  template <bool VCopy = IsConst, std::enable_if_t<!VCopy, int> = 0>
+  void
+  SetPixel(NeighborIndexType i, const PixelType & v)
+  {
+    m_Base.SetPixel(i, v);
+  }
+
+  template <bool VCopy = IsConst, std::enable_if_t<!VCopy, int> = 0>
+  void
+  SetCenterPixel(const PixelType & v)
+  {
+    m_Base.SetCenterPixel(v);
+  }
+
+private:
+  void
+  ActivateIndex(NeighborIndexType n)
+  {
+    // Insert n while keeping m_ActiveIndexList sorted and deduplicated.
+    auto it = m_ActiveIndexList.begin();
+    if (m_ActiveIndexList.empty())
+    {
+      m_ActiveIndexList.push_front(n);
+    }
+    else
+    {
+      while (it != m_ActiveIndexList.end() && n > *it)
+      {
+        ++it;
+      }
+      if (it == m_ActiveIndexList.end() || n != *it)
+      {
+        m_ActiveIndexList.insert(it, n);
+      }
+    }
+    if (n == m_Base.GetCenterNeighborhoodIndex())
+    {
+      m_CenterIsActive = true;
+    }
+  }
+
+  void
+  DeactivateIndex(NeighborIndexType n)
+  {
+    auto it = m_ActiveIndexList.begin();
+    if (m_ActiveIndexList.empty())
+    {
+      return;
+    }
+    while (n != *it)
+    {
+      ++it;
+      if (it == m_ActiveIndexList.end())
+      {
+        return;
+      }
+    }
+    m_ActiveIndexList.erase(it);
+    if (n == m_Base.GetCenterNeighborhoodIndex())
+    {
+      m_CenterIsActive = false;
+    }
+  }
+
+  Base          m_Base{};
+  IndexListType m_ActiveIndexList{};
+  bool          m_CenterIsActive{ false };
+};
+
+template <typename TImage, typename TBC = ZeroFluxNeumannBoundaryCondition<TImage>>
+using ConstShapedNeighborhoodIterator2 = ShapedNeighborhoodIteratorBase<TImage, TBC, /*IsConst=*/true>;
+
+template <typename TImage, typename TBC = ZeroFluxNeumannBoundaryCondition<TImage>>
+using ShapedNeighborhoodIterator2 = ShapedNeighborhoodIteratorBase<TImage, TBC, /*IsConst=*/false>;
+
+} // namespace itk
+
+#endif

--- a/Modules/Core/Common/include/itkPeriodicBoundaryCondition.h
+++ b/Modules/Core/Common/include/itkPeriodicBoundaryCondition.h
@@ -63,6 +63,11 @@ public:
   /** Default constructor. */
   PeriodicBoundaryCondition() = default;
 
+  /** Bring the base-class const-pointer-element operator() overloads into
+   * scope so that name lookup does not hide them when this class overrides
+   * the legacy NeighborhoodType-pointer overloads. */
+  using Superclass::operator();
+
   /** Computes and returns a neighborhood of appropriate values from
    * neighborhood iterator data.. */
   OutputPixelType

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.h
@@ -39,12 +39,14 @@ namespace itk
  *
  * \ingroup ITKCommon
  */
-template <typename TImage, typename TFunction>
-class ITK_TEMPLATE_EXPORT ShapedFloodFilledFunctionConditionalConstIterator : public ConditionalConstIterator<TImage>
+template <typename TImage, typename TFunction, bool VIsConst>
+class ITK_TEMPLATE_EXPORT ShapedFloodFilledFunctionConditionalIteratorBase
+  : public ConditionalIteratorBase<TImage, VIsConst>
 {
 public:
   /** Standard class type aliases. */
-  using Self = ShapedFloodFilledFunctionConditionalConstIterator;
+  using Self = ShapedFloodFilledFunctionConditionalIteratorBase;
+  using Superclass = ConditionalIteratorBase<TImage, VIsConst>;
 
   /** Type of function */
   using FunctionType = TFunction;
@@ -76,6 +78,8 @@ public:
   /** External Pixel Type */
   using PixelType = typename TImage::PixelType;
 
+  using typename Superclass::ImagePointer;
+
 #ifndef ITK_LEGACY_REMOVE
   /** \deprecated Internal type alias; use \c ShapedNeighborhoodIterator<TImage> directly. */
   using NeighborhoodIteratorType
@@ -92,21 +96,19 @@ public:
   /** Constructor establishes an iterator to walk a particular image and a
    * particular region of that image. This version of the constructor uses
    * an explicit seed pixel for the flood fill, the "startIndex" */
-  ShapedFloodFilledFunctionConditionalConstIterator(const ImageType * imagePtr,
-                                                    FunctionType *    fnPtr,
-                                                    IndexType         startIndex);
+  ShapedFloodFilledFunctionConditionalIteratorBase(ImagePointer imagePtr, FunctionType * fnPtr, IndexType startIndex);
 
   /** Constructor establishes an iterator to walk a particular image and a
    * particular region of that image. This version of the constructor uses
    * a list of seed pixels for the flood fill */
-  ShapedFloodFilledFunctionConditionalConstIterator(const ImageType *        imagePtr,
-                                                    FunctionType *           fnPtr,
-                                                    std::vector<IndexType> & startIndex);
+  ShapedFloodFilledFunctionConditionalIteratorBase(ImagePointer             imagePtr,
+                                                   FunctionType *           fnPtr,
+                                                   std::vector<IndexType> & startIndex);
 
   /** Constructor establishes an iterator to walk a particular image and a
    * particular region of that image. This version of the constructor
    * should be used when the seed pixel is unknown */
-  ShapedFloodFilledFunctionConditionalConstIterator(const ImageType * imagePtr, FunctionType * fnPtr);
+  ShapedFloodFilledFunctionConditionalIteratorBase(ImagePointer imagePtr, FunctionType * fnPtr);
 
   /** Automatically find a seed pixel and set m_StartIndex. Does nothing
    * if a seed pixel isn't found. A seed pixel is determined by
@@ -124,7 +126,7 @@ public:
   InitializeIterator();
 
   /** Default Destructor. */
-  ~ShapedFloodFilledFunctionConditionalConstIterator() override = default;
+  ~ShapedFloodFilledFunctionConditionalIteratorBase() override = default;
 
   /** Compute whether the index of interest should be included in the flood */
   bool
@@ -299,6 +301,16 @@ protected: // made protected so other iterators can access
    */
   bool m_FullyConnected{};
 };
+
+template <typename TImage, typename TFunction>
+class ITK_TEMPLATE_EXPORT ShapedFloodFilledFunctionConditionalConstIterator
+  : public ShapedFloodFilledFunctionConditionalIteratorBase<TImage, TFunction, /*VIsConst=*/true>
+{
+public:
+  using Superclass = ShapedFloodFilledFunctionConditionalIteratorBase<TImage, TFunction, /*VIsConst=*/true>;
+  using Superclass::Superclass;
+};
+
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
@@ -22,13 +22,10 @@
 
 namespace itk
 {
-template <typename TImage, typename TFunction>
-ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::ShapedFloodFilledFunctionConditionalConstIterator(
-  const ImageType * imagePtr,
-  FunctionType *    fnPtr,
-  IndexType         startIndex)
+template <typename TImage, typename TFunction, bool VIsConst>
+ShapedFloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::
+  ShapedFloodFilledFunctionConditionalIteratorBase(ImagePointer imagePtr, FunctionType * fnPtr, IndexType startIndex)
   : m_Function(fnPtr)
-
 {
   this->m_Image = imagePtr;
   m_Seeds.push_back(startIndex);
@@ -37,13 +34,12 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::ShapedFloo
   this->InitializeIterator();
 }
 
-template <typename TImage, typename TFunction>
-ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::ShapedFloodFilledFunctionConditionalConstIterator(
-  const ImageType *        imagePtr,
-  FunctionType *           fnPtr,
-  std::vector<IndexType> & startIndex)
+template <typename TImage, typename TFunction, bool VIsConst>
+ShapedFloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::
+  ShapedFloodFilledFunctionConditionalIteratorBase(ImagePointer             imagePtr,
+                                                   FunctionType *           fnPtr,
+                                                   std::vector<IndexType> & startIndex)
   : m_Function(fnPtr)
-
 {
   this->m_Image = imagePtr; // can not be done in the initialization list
   for (unsigned int i = 0; i < startIndex.size(); ++i)
@@ -55,21 +51,19 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::ShapedFloo
   this->InitializeIterator();
 }
 
-template <typename TImage, typename TFunction>
-ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::ShapedFloodFilledFunctionConditionalConstIterator(
-  const ImageType * imagePtr,
-  FunctionType *    fnPtr)
+template <typename TImage, typename TFunction, bool VIsConst>
+ShapedFloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::
+  ShapedFloodFilledFunctionConditionalIteratorBase(ImagePointer imagePtr, FunctionType * fnPtr)
   : m_Function(fnPtr)
-
 {
   this->m_Image = imagePtr;
   // Set up the temporary image
   this->InitializeIterator();
 }
 
-template <typename TImage, typename TFunction>
+template <typename TImage, typename TFunction, bool VIsConst>
 void
-ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::InitializeIterator()
+ShapedFloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::InitializeIterator()
 {
   // Get the origin and spacing from the image in simple arrays
   m_ImageOrigin = this->m_Image->GetOrigin();
@@ -107,9 +101,9 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::Initialize
   }
 }
 
-template <typename TImage, typename TFunction>
+template <typename TImage, typename TFunction, bool VIsConst>
 void
-ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPixel()
+ShapedFloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::FindSeedPixel()
 {
   // Create an iterator that will walk the input image
 
@@ -130,9 +124,9 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPi
   }
 }
 
-template <typename TImage, typename TFunction>
+template <typename TImage, typename TFunction, bool VIsConst>
 void
-ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPixels()
+ShapedFloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::FindSeedPixels()
 {
   // Create an iterator that will walk the input image
 
@@ -155,9 +149,9 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::FindSeedPi
   }
 }
 
-template <typename TImage, typename TFunction>
+template <typename TImage, typename TFunction, bool VIsConst>
 void
-ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::DoFloodStep()
+ShapedFloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::DoFloodStep()
 {
   // The index in the front of the queue should always be
   // valid and be inside since this is what the iterator
@@ -208,9 +202,9 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::DoFloodSte
   }
 }
 
-template <typename TImage, typename TFunction>
+template <typename TImage, typename TFunction, bool VIsConst>
 void
-ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::SetFullyConnected(const bool _arg)
+ShapedFloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::SetFullyConnected(const bool _arg)
 {
   if (this->m_FullyConnected != _arg)
   {
@@ -219,9 +213,9 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::SetFullyCo
   }
 }
 
-template <typename TImage, typename TFunction>
+template <typename TImage, typename TFunction, bool VIsConst>
 bool
-ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::GetFullyConnected() const
+ShapedFloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::GetFullyConnected() const
 {
   return this->m_FullyConnected;
 }

--- a/Modules/Core/Common/include/itkShapedFloodFilledImageFunctionConditionalConstIterator.h
+++ b/Modules/Core/Common/include/itkShapedFloodFilledImageFunctionConditionalConstIterator.h
@@ -34,14 +34,14 @@ namespace itk
  *
  * \ingroup ITKCommon
  */
-template <typename TImage, typename TFunction>
-class ITK_TEMPLATE_EXPORT ShapedFloodFilledImageFunctionConditionalConstIterator
-  : public ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>
+template <typename TImage, typename TFunction, bool VIsConst>
+class ITK_TEMPLATE_EXPORT ShapedFloodFilledImageFunctionConditionalIteratorBase
+  : public ShapedFloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>
 {
 public:
   /** Standard class type aliases. */
-  using Self = ShapedFloodFilledImageFunctionConditionalConstIterator<TImage, TFunction>;
-  using Superclass = ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>;
+  using Self = ShapedFloodFilledImageFunctionConditionalIteratorBase;
+  using Superclass = ShapedFloodFilledFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>;
 
   /** Type of function */
   using typename Superclass::FunctionType;
@@ -67,6 +67,8 @@ public:
   /** External Pixel Type */
   using typename Superclass::PixelType;
 
+  using typename Superclass::ImagePointer;
+
   /** Dimension of the image the iterator walks.  This constant is needed so
    * functions that are templated over image iterator type (as opposed to
    * being templated over pixel type and dimension) can have compile time
@@ -76,34 +78,52 @@ public:
   /** Constructor establishes an iterator to walk a particular image and a
    * particular region of that image. This version of the constructor uses
    * an explicit seed pixel for the flood fill, the "startIndex" */
-  ShapedFloodFilledImageFunctionConditionalConstIterator(const ImageType * imagePtr,
-                                                         FunctionType *    fnPtr,
-                                                         IndexType         startIndex)
+  ShapedFloodFilledImageFunctionConditionalIteratorBase(ImagePointer   imagePtr,
+                                                        FunctionType * fnPtr,
+                                                        IndexType      startIndex)
     : Superclass(imagePtr, fnPtr, startIndex)
   {}
 
   /** Constructor establishes an iterator to walk a particular image and a
    * particular region of that image. This version of the constructor uses
    * an explicit list of seed pixels for the flood fill, the "startIndex" */
-  ShapedFloodFilledImageFunctionConditionalConstIterator(const ImageType *        imagePtr,
-                                                         FunctionType *           fnPtr,
-                                                         std::vector<IndexType> & startIndex)
+  ShapedFloodFilledImageFunctionConditionalIteratorBase(ImagePointer             imagePtr,
+                                                        FunctionType *           fnPtr,
+                                                        std::vector<IndexType> & startIndex)
     : Superclass(imagePtr, fnPtr, startIndex)
   {}
 
   /** Constructor establishes an iterator to walk a particular image and a
    * particular region of that image. This version of the constructor
    * should be used when the seed pixel is unknown. */
-  ShapedFloodFilledImageFunctionConditionalConstIterator(const ImageType * imagePtr, FunctionType * fnPtr)
+  ShapedFloodFilledImageFunctionConditionalIteratorBase(ImagePointer imagePtr, FunctionType * fnPtr)
     : Superclass(imagePtr, fnPtr)
   {}
   /** Default Destructor. */
-  ~ShapedFloodFilledImageFunctionConditionalConstIterator() override = default;
+  ~ShapedFloodFilledImageFunctionConditionalIteratorBase() override = default;
+
+  /** Set the pixel value. SFINAE-gated on !VIsConst. */
+  template <bool VCopy = VIsConst, std::enable_if_t<!VCopy, int> = 0>
+  void
+  Set(const PixelType & value)
+  {
+    this->m_Image->GetPixel(this->m_IndexStack.front()) = value;
+  }
 
   /** Compute whether the index of interest should be included in the flood */
   bool
   IsPixelIncluded(const IndexType & index) const override;
 };
+
+template <typename TImage, typename TFunction>
+class ITK_TEMPLATE_EXPORT ShapedFloodFilledImageFunctionConditionalConstIterator
+  : public ShapedFloodFilledImageFunctionConditionalIteratorBase<TImage, TFunction, /*VIsConst=*/true>
+{
+public:
+  using Superclass = ShapedFloodFilledImageFunctionConditionalIteratorBase<TImage, TFunction, /*VIsConst=*/true>;
+  using Superclass::Superclass;
+};
+
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Core/Common/include/itkShapedFloodFilledImageFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkShapedFloodFilledImageFunctionConditionalConstIterator.hxx
@@ -21,9 +21,9 @@
 
 namespace itk
 {
-template <typename TImage, typename TFunction>
+template <typename TImage, typename TFunction, bool VIsConst>
 bool
-ShapedFloodFilledImageFunctionConditionalConstIterator<TImage, TFunction>::IsPixelIncluded(
+ShapedFloodFilledImageFunctionConditionalIteratorBase<TImage, TFunction, VIsConst>::IsPixelIncluded(
   const IndexType & index) const
 {
   return this->m_Function->EvaluateAtIndex(index);

--- a/Modules/Core/Common/include/itkShapedFloodFilledImageFunctionConditionalIterator.h
+++ b/Modules/Core/Common/include/itkShapedFloodFilledImageFunctionConditionalIterator.h
@@ -35,84 +35,14 @@ namespace itk
  * \ingroup ITKCommon
  */
 template <typename TImage, typename TFunction>
-class ShapedFloodFilledImageFunctionConditionalIterator
-  : public ShapedFloodFilledImageFunctionConditionalConstIterator<TImage, TFunction>
+class ITK_TEMPLATE_EXPORT ShapedFloodFilledImageFunctionConditionalIterator
+  : public ShapedFloodFilledImageFunctionConditionalIteratorBase<TImage, TFunction, /*VIsConst=*/false>
 {
 public:
-  /** Standard class type aliases. */
-  using Self = ShapedFloodFilledImageFunctionConditionalIterator;
-  using Superclass = ShapedFloodFilledImageFunctionConditionalConstIterator<TImage, TFunction>;
-
-  /** Type of function */
-  using typename Superclass::FunctionType;
-
-  /** Type of vector used to store location info in the spatial function */
-  using typename Superclass::FunctionInputType;
-
-  /** Index type alias support */
-  using typename Superclass::IndexType;
-
-  /** Size type alias support */
-  using typename Superclass::SizeType;
-
-  /** Region type alias support */
-  using typename Superclass::RegionType;
-
-  /** Image type alias support */
-  using typename Superclass::ImageType;
-
-  /** Internal Pixel Type */
-  using typename Superclass::InternalPixelType;
-
-  /** External Pixel Type */
-  using typename Superclass::PixelType;
-
-  /** Dimension of the image the iterator walks.  This constant is needed so
-   * functions that are templated over image iterator type (as opposed to
-   * being templated over pixel type and dimension) can have compile time
-   * access to the dimension of the image that the iterator walks. */
-  static constexpr unsigned int NDimensions = Superclass::NDimensions;
-
-  /** Constructor establishes an iterator to walk a particular image and a
-   * particular region of that image. This version of the constructor uses
-   * an explicit seed pixel for the flood fill, the "startIndex" */
-  ShapedFloodFilledImageFunctionConditionalIterator(ImageType * imagePtr, FunctionType * fnPtr, IndexType startIndex)
-    : Superclass(imagePtr, fnPtr, startIndex)
-  {}
-
-  /** Constructor establishes an iterator to walk a particular image and a
-   * particular region of that image. This version of the constructor uses
-   * an explicit list of seed pixels for the flood fill, the "startIndex" */
-  ShapedFloodFilledImageFunctionConditionalIterator(ImageType *              imagePtr,
-                                                    FunctionType *           fnPtr,
-                                                    std::vector<IndexType> & startIndex)
-    : Superclass(imagePtr, fnPtr, startIndex)
-  {}
-
-  /** Constructor establishes an iterator to walk a particular image and a
-   * particular region of that image. This version of the constructor
-   * should be used when the seed pixel is unknown. */
-  ShapedFloodFilledImageFunctionConditionalIterator(ImageType * imagePtr, FunctionType * fnPtr)
-    : Superclass(imagePtr, fnPtr)
-  {}
-
-  /** Get the pixel value */
-  const PixelType
-  Get() const override
-  {
-    return const_cast<ImageType *>(this->m_Image.GetPointer())->GetPixel(this->m_IndexStack.front());
-  }
-
-  /** Set the pixel value */
-  void
-  Set(const PixelType & value)
-  {
-    const_cast<ImageType *>(this->m_Image.GetPointer())->GetPixel(this->m_IndexStack.front()) = value;
-  }
-
-  /** Default Destructor. */
-  ~ShapedFloodFilledImageFunctionConditionalIterator() override = default;
+  using Superclass = ShapedFloodFilledImageFunctionConditionalIteratorBase<TImage, TFunction, /*VIsConst=*/false>;
+  using Superclass::Superclass;
 };
+
 } // end namespace itk
 
 #endif

--- a/Modules/Core/Common/include/itkVectorImageNeighborhoodAccessorFunctor.h
+++ b/Modules/Core/Common/include/itkVectorImageNeighborhoodAccessorFunctor.h
@@ -48,6 +48,7 @@ public:
   using OffsetType = typename ImageType::OffsetType;
 
   using NeighborhoodType = Neighborhood<InternalPixelType *, TImage::ImageDimension>;
+  using ConstNeighborhoodType = Neighborhood<const InternalPixelType *, TImage::ImageDimension>;
 
   template <typename TOutput = ImageType>
   using ImageBoundaryConditionType = ImageBoundaryCondition<ImageType, TOutput>;
@@ -108,6 +109,18 @@ public:
   BoundaryCondition(const OffsetType &                          point_index,
                     const OffsetType &                          boundary_offset,
                     const NeighborhoodType *                    data,
+                    const ImageBoundaryConditionType<TOutput> * boundaryCondition) const
+  {
+    return boundaryCondition->operator()(point_index, boundary_offset, data, *this);
+  }
+
+  /** Const-pointer-element overload used by NeighborhoodIteratorBase when
+   * VIsConst=true. */
+  template <typename TOutput>
+  inline typename ImageBoundaryConditionType<TOutput>::OutputPixelType
+  BoundaryCondition(const OffsetType &                          point_index,
+                    const OffsetType &                          boundary_offset,
+                    const ConstNeighborhoodType *               data,
                     const ImageBoundaryConditionType<TOutput> * boundaryCondition) const
   {
     return boundaryCondition->operator()(point_index, boundary_offset, data, *this);

--- a/Modules/Core/Common/include/itkZeroFluxNeumannBoundaryCondition.h
+++ b/Modules/Core/Common/include/itkZeroFluxNeumannBoundaryCondition.h
@@ -83,6 +83,11 @@ public:
   /** Default constructor. */
   ZeroFluxNeumannBoundaryCondition() = default;
 
+  /** Bring the base-class const-pointer-element operator() overloads into
+   * scope so that name lookup does not hide them when this class overrides
+   * the legacy NeighborhoodType-pointer overloads. */
+  using Superclass::operator();
+
   /** Computes and returns a neighborhood of appropriate values from
    * neighborhood iterator data.. */
   OutputPixelType

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -103,6 +103,8 @@ set(
   itkSymmetricSecondRankTensorTest.cxx
   itkConstShapedNeighborhoodIteratorTest.cxx
   itkConstShapedNeighborhoodIteratorTest2.cxx
+  itkNeighborhoodIteratorBaseSpikeTest.cxx
+  itkNeighborhoodIteratorBaseRuntimeTest.cxx
   itkSTLContainerAdaptorTest.cxx
   itkFiniteCylinderSpatialFunctionTest.cxx
   itkLoggerOutputTest.cxx
@@ -389,6 +391,18 @@ itk_add_test(
   COMMAND
     ITKCommon2TestDriver
     itkConstShapedNeighborhoodIteratorTest2
+)
+itk_add_test(
+  NAME itkNeighborhoodIteratorBaseSpikeTest
+  COMMAND
+    ITKCommon2TestDriver
+    itkNeighborhoodIteratorBaseSpikeTest
+)
+itk_add_test(
+  NAME itkNeighborhoodIteratorBaseRuntimeTest
+  COMMAND
+    ITKCommon2TestDriver
+    itkNeighborhoodIteratorBaseRuntimeTest
 )
 itk_add_test(
   NAME itkExceptionObjectTest

--- a/Modules/Core/Common/test/itkImageReverseIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkImageReverseIteratorTest.cxx
@@ -174,9 +174,16 @@ itkImageReverseIteratorTest(int, char *[])
     std::cout << std::endl;
   }
 
-  // Finally, create a ReverseIterator from an Iterator and walk each appropriately so that they match
+  // Finally, create a ReverseIterator that walks the same region and check
+  // that walking each appropriately keeps them in lockstep. (Historically
+  // this constructed castBackReverseIt directly from a forward
+  // ImageRegionIterator via slicing through ImageConstIterator. With the
+  // VIsConst-templated iterator hierarchy, ImageIterator and
+  // ImageConstIterator are sibling specializations rather than parent and
+  // child, so the cross-construction is no longer well-formed. The
+  // observable behavior here is unchanged.)
   it.GoToBegin();
-  itk::ImageRegionReverseIterator<ImageType> castBackReverseIt(it);
+  itk::ImageRegionReverseIterator<ImageType> castBackReverseIt(o3, region);
   castBackReverseIt.GoToEnd();
   int status = 0;
   std::cout << "It and Reverse check: ";

--- a/Modules/Core/Common/test/itkNeighborhoodIteratorBaseRuntimeTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodIteratorBaseRuntimeTest.cxx
@@ -1,0 +1,221 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// Runtime test for NeighborhoodIteratorBase<..., VIsConst>.
+//
+// Exercises:
+//   * Construction and iteration on the non-const instantiation.
+//   * Voxel-count traversal over a small 3-D region.
+//   * SetCenterPixel() mutation round-trips into the image buffer.
+//   * Converting ctor non-const -> const yields a read-only iterator that
+//     observes the just-written values.
+
+#include "itkImage.h"
+#include "itkImageRegionIterator.h"
+#include "itkNeighborhoodIteratorBase.h"
+
+#include <cstdlib>
+#include <iostream>
+
+int
+itkNeighborhoodIteratorBaseRuntimeTest(int, char *[])
+{
+  using ImageType = itk::Image<float, 3>;
+  using MutIt = itk::NeighborhoodIterator2<ImageType>;
+  using ConIt = itk::ConstNeighborhoodIterator2<ImageType>;
+
+  // Build a 5x5x5 ramp image.
+  auto                  image = ImageType::New();
+  ImageType::SizeType   size = { { 5, 5, 5 } };
+  ImageType::IndexType  index = { { 0, 0, 0 } };
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(index);
+  image->SetRegions(region);
+  image->Allocate();
+
+  {
+    itk::ImageRegionIterator<ImageType> it(image, region);
+    float                               v = 0.0f;
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it, v += 1.0f)
+    {
+      it.Set(v);
+    }
+  }
+
+  constexpr auto radius = itk::MakeFilled<MutIt::SizeType>(1);
+
+  MutIt nIt(radius, image, region);
+
+  // Count visited voxels via GoToBegin/operator++/IsAtEnd.
+  itk::SizeValueType visited = 0;
+  for (nIt.GoToBegin(); !nIt.IsAtEnd(); ++nIt)
+  {
+    ++visited;
+  }
+  const itk::SizeValueType expected = region.GetNumberOfPixels();
+  if (visited != expected)
+  {
+    std::cerr << "FAIL: visited " << visited << " voxels, expected " << expected << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Write at a known location and read it back from the raw image.
+  nIt.GoToBegin();
+  ImageType::IndexType target = { { 2, 2, 2 } };
+  nIt.SetLocation(target);
+  nIt.SetCenterPixel(42.0f);
+  if (image->GetPixel(target) != 42.0f)
+  {
+    std::cerr << "FAIL: SetCenterPixel did not round-trip; got " << image->GetPixel(target) << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Build a const iterator via the converting ctor and read the same location.
+  ConIt cIt(nIt);
+  cIt.SetLocation(target);
+  if (cIt.GetCenterPixel() != 42.0f)
+  {
+    std::cerr << "FAIL: const-converted iterator center pixel = " << cIt.GetCenterPixel() << " (expected 42)"
+              << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Iterate const-side over the same region and verify count matches.
+  itk::SizeValueType cVisited = 0;
+  for (cIt.GoToBegin(); !cIt.IsAtEnd(); ++cIt)
+  {
+    ++cVisited;
+  }
+  if (cVisited != expected)
+  {
+    std::cerr << "FAIL: const iterator visited " << cVisited << " voxels, expected " << expected << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Verify GetImagePointer return-type constness on both instantiations.
+  static_assert(std::is_same_v<decltype(nIt.GetImagePointer()), ImageType *>,
+                "Non-const NeighborhoodIteratorBase should return ImageType* (no const_cast).");
+  static_assert(std::is_same_v<decltype(cIt.GetImagePointer()), const ImageType *>,
+                "Const NeighborhoodIteratorBase should return const ImageType*.");
+
+  // --------------------------------------------------------------------
+  // ShapedNeighborhoodIteratorBase exercise.
+  // --------------------------------------------------------------------
+  using MutShaped = itk::ShapedNeighborhoodIterator2<ImageType>;
+  using ConShaped = itk::ConstShapedNeighborhoodIterator2<ImageType>;
+
+  // Reverse-converting ctor must be compile-disabled.
+  static_assert(!std::is_constructible_v<MutShaped, const ConShaped &>,
+                "Must not construct non-const ShapedNeighborhoodIteratorBase from const one.");
+  // Forward converting ctor must be available.
+  static_assert(std::is_constructible_v<ConShaped, const MutShaped &>,
+                "Const ShapedNeighborhoodIteratorBase must be constructible from non-const.");
+
+  MutShaped sIt(radius, image, region);
+  sIt.SetLocation(target);
+
+  // Activate the 6-connected stencil (Manhattan neighbors at distance 1).
+  for (unsigned d = 0; d < ImageType::ImageDimension; ++d)
+  {
+    MutShaped::OffsetType off{};
+    off[d] = 1;
+    sIt.ActivateOffset(off);
+    off[d] = -1;
+    sIt.ActivateOffset(off);
+  }
+
+  if (sIt.GetActiveIndexListSize() != 6)
+  {
+    std::cerr << "FAIL: expected 6 active offsets, got " << sIt.GetActiveIndexListSize() << std::endl;
+    return EXIT_FAILURE;
+  }
+  if (sIt.GetCenterIsActive())
+  {
+    std::cerr << "FAIL: center unexpectedly active." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Iterate inner Begin()/End() and mutate via Set(); verify one pixel round-trips.
+  itk::SizeValueType sVisited = 0;
+  bool               wroteOne = false;
+  for (auto innerIt = sIt.Begin(); innerIt != sIt.End(); ++innerIt)
+  {
+    ++sVisited;
+    if (!wroteOne)
+    {
+      innerIt.Set(77.0f);
+      wroteOne = true;
+    }
+  }
+  if (sVisited != 6)
+  {
+    std::cerr << "FAIL: shaped inner iteration visited " << sVisited << " (expected 6)." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // The first active offset in sorted list order was index 0 of the list; find which neighbor
+  // it was and verify the image pixel changed to 77.
+  const auto           firstActive = *sIt.GetActiveIndexList().begin();
+  const auto           firstOffset = sIt.GetOffset(firstActive);
+  ImageType::IndexType writtenIdx = target;
+  for (unsigned d = 0; d < ImageType::ImageDimension; ++d)
+  {
+    writtenIdx[d] += firstOffset[d];
+  }
+  if (image->GetPixel(writtenIdx) != 77.0f)
+  {
+    std::cerr << "FAIL: shaped Set() did not round-trip at " << writtenIdx << ", got " << image->GetPixel(writtenIdx)
+              << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Converting ctor: build a const shaped from the non-const one and read back.
+  ConShaped          csIt(sIt);
+  itk::SizeValueType cReadCount = 0;
+  bool               sawWritten = false;
+  for (auto innerIt = csIt.Begin(); innerIt != csIt.End(); ++innerIt)
+  {
+    ++cReadCount;
+    if (innerIt.Get() == 77.0f)
+    {
+      sawWritten = true;
+    }
+  }
+  if (cReadCount != 6)
+  {
+    std::cerr << "FAIL: const shaped inner iteration visited " << cReadCount << " (expected 6)." << std::endl;
+    return EXIT_FAILURE;
+  }
+  if (!sawWritten)
+  {
+    std::cerr << "FAIL: const shaped did not observe written value." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Deactivate round-trip.
+  sIt.ClearActiveList();
+  if (sIt.GetActiveIndexListSize() != 0)
+  {
+    std::cerr << "FAIL: ClearActiveList did not empty list." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  std::cout << "itkNeighborhoodIteratorBaseRuntimeTest: PASS" << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/Modules/Core/Common/test/itkNeighborhoodIteratorBaseSpikeTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodIteratorBaseSpikeTest.cxx
@@ -1,0 +1,109 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// Compile-only test for the NeighborhoodIteratorBase design spike.
+// Exercises:
+//   * Both VIsConst=true and VIsConst=false instantiations of the unified
+//     NeighborhoodIteratorBase and ShapedNeighborhoodIteratorBase templates.
+//   * The std::conditional_t pointer-type plumbing (via static_assert).
+//   * The non-const -> const converting ctor.
+//   * Negative checks (no-compile lines documented in comments) for the
+//     reverse conversion and for SetPixel on const instantiations.
+
+#include "itkNeighborhoodIteratorBase.h"
+#include "itkImage.h"
+
+#include <type_traits>
+
+namespace
+{
+
+using ImageType = itk::Image<float, 2>;
+
+using MutIt = itk::NeighborhoodIterator2<ImageType>;
+using ConIt = itk::ConstNeighborhoodIterator2<ImageType>;
+
+using MutShaped = itk::ShapedNeighborhoodIterator2<ImageType>;
+using ConShaped = itk::ConstShapedNeighborhoodIterator2<ImageType>;
+
+// --- Pointer-type plumbing (the whole point of std::conditional_t) ----------
+static_assert(std::is_same_v<MutIt::ImagePointer, ImageType *>,
+              "Non-const iterator must hold a non-const image pointer.");
+static_assert(std::is_same_v<ConIt::ImagePointer, const ImageType *>,
+              "Const iterator must hold a const image pointer.");
+
+static_assert(std::is_same_v<MutIt::InternalPixelPointer, ImageType::InternalPixelType *>,
+              "Non-const iterator must hold non-const pixel pointers.");
+static_assert(std::is_same_v<ConIt::InternalPixelPointer, const ImageType::InternalPixelType *>,
+              "Const iterator must hold const pixel pointers.");
+
+// --- IsConst exposure -------------------------------------------------------
+static_assert(MutIt::IsConst == false);
+static_assert(ConIt::IsConst == true);
+static_assert(MutShaped::IsConst == false);
+static_assert(ConShaped::IsConst == true);
+
+// --- Converting ctor: non-const -> const must be available -----------------
+static_assert(std::is_constructible_v<ConIt, const MutIt &>,
+              "Non-const NeighborhoodIterator must be implicitly convertible to its const sibling.");
+static_assert(std::is_constructible_v<ConShaped, const MutShaped &>,
+              "Non-const ShapedNeighborhoodIterator must be implicitly convertible to its const sibling.");
+
+// --- Converting ctor: const -> non-const must NOT be available -------------
+// This is the structural guarantee the modernization buys us. A const
+// iterator cannot be silently laundered back into a writable one.
+static_assert(!std::is_constructible_v<MutIt, const ConIt &>,
+              "Const NeighborhoodIterator must NOT be convertible to a non-const sibling.");
+static_assert(!std::is_constructible_v<MutShaped, const ConShaped &>,
+              "Const ShapedNeighborhoodIterator must NOT be convertible to a non-const sibling.");
+
+// --- Inner-iterator constness (Shaped) -------------------------------------
+static_assert(std::is_same_v<MutShaped::Iterator::OuterPointer, MutShaped *>);
+static_assert(std::is_same_v<MutShaped::ConstIterator::OuterPointer, const MutShaped *>);
+static_assert(std::is_same_v<ConShaped::ConstIterator::OuterPointer, const ConShaped *>);
+
+// --- Negative tests (documented; would fail to compile if uncommented) -----
+//
+// 1. SetPixel on a ConstNeighborhoodIterator2 fires a static_assert with a
+//    readable message:
+//        ConIt c;
+//        c.SetPixel(0, 1.0f);
+//        // error: SetPixel() is not available on a const NeighborhoodIterator.
+//
+// 2. Non-const Begin() on a ConstShapedNeighborhoodIterator2 is SFINAE'd
+//    away:
+//        ConShaped cs;
+//        auto it = cs.Begin();           // returns ConstIterator (OK)
+//        ConShaped::Iterator wit = cs.Begin();  // error: no matching overload
+//
+// 3. Set() on a ConstIterator (Shaped inner) fires a static_assert:
+//        MutShaped ms;
+//        auto it = static_cast<const MutShaped &>(ms).Begin(); // -> ConstIterator
+//        it.Set(1.0f);  // error: Set() requires non-const iterator
+//
+// 4. Implicit upcast from ConIt to MutIt is forbidden (static_assert above).
+
+} // namespace
+
+int
+itkNeighborhoodIteratorBaseSpikeTest(int, char *[])
+{
+  // All assertions above are compile-time; if this TU compiled, the spike's
+  // structural design is sound. Runtime body is intentionally empty.
+  return 0;
+}

--- a/Modules/Registration/Common/test/itkKappaStatisticImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkKappaStatisticImageToImageMetricTest.cxx
@@ -201,7 +201,7 @@ itkKappaStatisticImageToImageMetricTest(int, char *[])
     ++yGradIt;
   }
 
-  using GradIteratorType = itk::ImageRegionIteratorWithIndex<const MetricType::GradientImageType>;
+  using GradIteratorType = itk::ImageRegionConstIteratorWithIndex<MetricType::GradientImageType>;
   GradIteratorType gradIt(metric->GetGradientImage(), metric->GetGradientImage()->GetBufferedRegion());
   gradIt.GoToBegin();
   xGradIt.GoToBegin();


### PR DESCRIPTION
**This PR is a working draft and is likely a throwaway.** It is published for visibility and discussion only. Closes #6141 if the design is accepted; otherwise it will be closed and re-opened as a series of smaller PRs.

Before any subset of this work is finalized it must be broken into smaller, individually reviewable units and validated against downstream consumers — at minimum **ANTs**, **BRAINSTools**, and **3D Slicer** — to surface API-compatibility regressions that ITK's own test suite cannot detect (template alias deduction quirks, CTAD edge cases, slicing-through-inheritance call sites, etc.).

<details>
<summary>What this branch contains</summary>

13 ENH commits collapsing the legacy `XxxConstIterator<T>` / `XxxIterator<T>` class pairs into single `XxxIteratorBase<T, bool VIsConst>` class templates with the legacy names preserved as alias templates.

| Unit | Cluster |
|------|---------|
| 1 | `ImageConstIterator` / `ImageIterator` (root) |
| 2 (×7 pairs) | `ImageIteratorWithIndex` family: Region / Linear / Slice / Random / RandomNonRepeating / RegionExclusion |
| 3 | `ImageScanlineIterator` |
| 4 | `ImageReverseIterator` / `ImageRegionReverseIterator` |
| 5 | `LineIterator` |
| 6 | `ConditionalIterator` + `FloodFilled*` cluster |
| 7 | `ImageRegionIterator` (non-WithIndex) |

Plus an earlier design spike commit `ENH: Add NeighborhoodIteratorBase<T,BC,VIsConst> spike` which is not yet wired into legacy neighborhood class names.

ITK in-tree status: build green at 1360/1360 targets, 3270/3270 ctests passing.
</details>

<details>
<summary>Why this is likely a throwaway</summary>

- **Downstream validation is not yet done.** The ITK test suite passes, but downstream codebases use ITK iterator types in ways that this PR has not exercised:
  - ANTs, BRAINSTools, and Slicer all template helper functions on iterator types and may rely on inheritance relationships that the alias-template form silently changes.
  - Implicit conversions between non-const and const iterators were previously by inheritance + slicing; they are now via an explicit converting constructor. Some consumer code paths break (one was already caught and fixed in `Modules/Registration/Common/test/itkKappaStatisticImageToImageMetricTest.cxx` — there will be more in the wild).
  - `using ImageRegionIterator<const T>` patterns no longer route to the const specialization the way the inheritance form did; consumers must switch to `ImageRegionConstIterator<T>`.
- **The neighborhood cluster is not addressed.** Four `const_cast` sites remain in `ConstNeighborhoodIterator`, `ConstShapedNeighborhoodIterator`, `ShapedNeighborhoodIterator`. The spike commit prototypes the right design (composition instead of `ConstShapedNeighborhoodIterator : private NeighborhoodIterator`) but wiring it into the legacy class names is itself a ~1700-line replacement that warrants a separate PR.
- **Per-unit landing is preferable.** Each of the 13 ENH commits is self-contained and could land on `main` as its own PR, allowing CDash to surface regressions one cluster at a time. A single 67-file PR is hard to bisect if a downstream regression emerges months later.
</details>

<details>
<summary>Recommended path forward</summary>

1. Validate this branch against ANTs / BRAINSTools / Slicer trees in their respective CI configurations. Capture every regression as a separate issue.
2. Decide whether the templated-base + alias-template approach is the desired endpoint, or whether a different strategy (e.g., inheritance preserved with `mutable` storage; or a deprecation cycle that asks consumers to migrate explicitly) is preferred.
3. If the design is accepted, close this PR and re-open as ~7 smaller PRs (one per Unit), each with its own downstream-CI run.
4. Open a follow-up issue/PR for the neighborhood cluster, building on the existing spike commit.
</details>

<!--
provenance: claude-code session 2026-04-25
head_commit: 4be70e03f0
unit_count: 13
spike_commit: f0b1dbbfc5
related_issue: 6141
status: draft, do-not-merge, awaiting downstream validation
-->