### PR TITLE
ENH: Convert six no-arg ImageIntensity tests to GoogleTest

### DIFF
--- a/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
@@ -1,7 +1,6 @@
 itk_module_test()
 set(
   ITKImageIntensityTests
-  itkAddImageFilterFrameTest.cxx
   itkAddImageFilterTest.cxx
   itkAddImageFilterTest2.cxx
   itkAndImageFilterTest.cxx
@@ -313,12 +312,6 @@ itk_add_test(
     itkAddImageFilterTest2
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mha}
     ${TEMP}/itkAddImageFilterTest2.mha
-)
-itk_add_test(
-  NAME itkAddImageFilterFrameTest
-  COMMAND
-    ITKImageIntensityTestDriver
-    itkAddImageFilterFrameTest
 )
 itk_add_test(
   NAME itkPowImageFilterTest
@@ -791,6 +784,7 @@ set(
   itkAdaptImageFilterGTest.cxx
   itkAdaptImageFilterGTest2.cxx
   itkAddImageAdaptorGTest.cxx
+  itkAddImageFilterFrameGTest.cxx
   itkArithmeticOpsFunctorsTest.cxx
   itkBitwiseOpsFunctorsTest.cxx
 )

--- a/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
@@ -1,7 +1,6 @@
 itk_module_test()
 set(
   ITKImageIntensityTests
-  itkAdaptImageFilterTest.cxx
   itkAdaptImageFilterTest2.cxx
   itkAddImageAdaptorTest.cxx
   itkAddImageFilterFrameTest.cxx
@@ -537,12 +536,6 @@ if(NOT ITK_LEGACY_REMOVE)
   )
 endif()
 itk_add_test(
-  NAME itkAdaptImageFilterTest
-  COMMAND
-    ITKImageIntensityTestDriver
-    itkAdaptImageFilterTest
-)
-itk_add_test(
   NAME itkOrImageFilterTest
   COMMAND
     ITKImageIntensityTestDriver
@@ -809,6 +802,7 @@ set(
   ITKImageIntensityGTests
   itkAbsImageFilterAndAdaptorGTest.cxx
   itkAcosImageFilterAndAdaptorGTest.cxx
+  itkAdaptImageFilterGTest.cxx
   itkArithmeticOpsFunctorsTest.cxx
   itkBitwiseOpsFunctorsTest.cxx
 )

--- a/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
@@ -1,7 +1,6 @@
 itk_module_test()
 set(
   ITKImageIntensityTests
-  itkAbsImageFilterAndAdaptorTest.cxx
   itkAcosImageFilterAndAdaptorTest.cxx
   itkAdaptImageFilterTest.cxx
   itkAdaptImageFilterTest2.cxx
@@ -413,12 +412,6 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTernaryMagnitudeImageFilterTest.png
 )
 itk_add_test(
-  NAME itkAbsImageFilterAndAdaptorTest
-  COMMAND
-    ITKImageIntensityTestDriver
-    itkAbsImageFilterAndAdaptorTest
-)
-itk_add_test(
   NAME itkMaximumImageFilterTest
   COMMAND
     ITKImageIntensityTestDriver
@@ -821,6 +814,7 @@ itk_add_test(
 
 set(
   ITKImageIntensityGTests
+  itkAbsImageFilterAndAdaptorGTest.cxx
   itkArithmeticOpsFunctorsTest.cxx
   itkBitwiseOpsFunctorsTest.cxx
 )

--- a/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
@@ -1,7 +1,6 @@
 itk_module_test()
 set(
   ITKImageIntensityTests
-  itkAddImageAdaptorTest.cxx
   itkAddImageFilterFrameTest.cxx
   itkAddImageFilterTest.cxx
   itkAddImageFilterTest2.cxx
@@ -250,12 +249,6 @@ itk_add_test(
   COMMAND
     ITKImageIntensityTestDriver
     itkComplexToModulusFilterAndAdaptorTest
-)
-itk_add_test(
-  NAME itkAddImageAdaptorTest
-  COMMAND
-    ITKImageIntensityTestDriver
-    itkAddImageAdaptorTest
 )
 itk_add_test(
   NAME itkAndImageFilterTest
@@ -797,6 +790,7 @@ set(
   itkAcosImageFilterAndAdaptorGTest.cxx
   itkAdaptImageFilterGTest.cxx
   itkAdaptImageFilterGTest2.cxx
+  itkAddImageAdaptorGTest.cxx
   itkArithmeticOpsFunctorsTest.cxx
   itkBitwiseOpsFunctorsTest.cxx
 )

--- a/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
@@ -1,7 +1,6 @@
 itk_module_test()
 set(
   ITKImageIntensityTests
-  itkAdaptImageFilterTest2.cxx
   itkAddImageAdaptorTest.cxx
   itkAddImageFilterFrameTest.cxx
   itkAddImageFilterTest.cxx
@@ -267,12 +266,6 @@ itk_add_test(
     93d46ee3d5e0c157e2b2d27977ae4d0f
     itkAndImageFilterTest
     ${ITK_TEST_OUTPUT_DIR}/itkAndImageFilterTest.png
-)
-itk_add_test(
-  NAME itkAdaptImageFilterTest2
-  COMMAND
-    ITKImageIntensityTestDriver
-    itkAdaptImageFilterTest2
 )
 itk_add_test(
   NAME itkLogImageFilterAndAdaptorTest
@@ -803,6 +796,7 @@ set(
   itkAbsImageFilterAndAdaptorGTest.cxx
   itkAcosImageFilterAndAdaptorGTest.cxx
   itkAdaptImageFilterGTest.cxx
+  itkAdaptImageFilterGTest2.cxx
   itkArithmeticOpsFunctorsTest.cxx
   itkBitwiseOpsFunctorsTest.cxx
 )

--- a/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
@@ -1,7 +1,6 @@
 itk_module_test()
 set(
   ITKImageIntensityTests
-  itkAcosImageFilterAndAdaptorTest.cxx
   itkAdaptImageFilterTest.cxx
   itkAdaptImageFilterTest2.cxx
   itkAddImageAdaptorTest.cxx
@@ -488,12 +487,6 @@ itk_add_test(
     itkHistogramMatchingImageFilterTest
 )
 itk_add_test(
-  NAME itkAcosImageFilterAndAdaptorTest
-  COMMAND
-    ITKImageIntensityTestDriver
-    itkAcosImageFilterAndAdaptorTest
-)
-itk_add_test(
   NAME itkExpNegativeImageFilterAndAdaptorTest
   COMMAND
     ITKImageIntensityTestDriver
@@ -815,6 +808,7 @@ itk_add_test(
 set(
   ITKImageIntensityGTests
   itkAbsImageFilterAndAdaptorGTest.cxx
+  itkAcosImageFilterAndAdaptorGTest.cxx
   itkArithmeticOpsFunctorsTest.cxx
   itkBitwiseOpsFunctorsTest.cxx
 )

--- a/Modules/Filtering/ImageIntensity/test/itkAbsImageFilterAndAdaptorGTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAbsImageFilterAndAdaptorGTest.cxx
@@ -23,13 +23,10 @@
 #include "itkMath.h"
 #include "itkSubtractImageFilter.h"
 #include "itkUnaryGeneratorImageFilter.h"
-#include "itkTestingMacros.h"
+#include "itkGTest.h"
 
-int
-itkAbsImageFilterAndAdaptorTest(int, char *[])
+TEST(AbsImageFilterAndAdaptor, ConvertedLegacyTest)
 {
-  int testStatus = EXIT_SUCCESS;
-
   // Define the dimension of the images
   constexpr unsigned int ImageDimension{ 3 };
 
@@ -63,12 +60,10 @@ itkAbsImageFilterAndAdaptorTest(int, char *[])
   // Initialize the content of Image A
   const double pi = std::atan(1.0) * 4.0;
   const double value = pi / 6.0;
-  std::cout << "Content of the Input " << std::endl;
   it.GoToBegin();
   while (!it.IsAtEnd())
   {
     it.Set(value);
-    std::cout << it.Get() << std::endl;
     ++it;
   }
 
@@ -78,7 +73,7 @@ itkAbsImageFilterAndAdaptorTest(int, char *[])
   // Create an Abs Filter
   auto filter = FilterType::New();
 
-  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, AbsImageFilter, UnaryGeneratorImageFilter);
+  ITK_GTEST_EXERCISE_BASIC_OBJECT_METHODS(filter, AbsImageFilter, UnaryGeneratorImageFilter);
 
   // Connect the input images
   filter->SetInput(inputImage);
@@ -93,27 +88,15 @@ itkAbsImageFilterAndAdaptorTest(int, char *[])
   OutputIteratorType ot(outputImage, outputImage->GetRequestedRegion());
 
   //  Check the content of the result image
-  std::cout << "Verification of the output " << std::endl;
   constexpr OutputImageType::PixelType epsilon{ 1e-6 };
   ot.GoToBegin();
   it.GoToBegin();
   while (!ot.IsAtEnd())
   {
-    std::cout.precision(static_cast<int>(itk::Math::Absolute(std::log10(epsilon))));
-    std::cout << ot.Get() << " = ";
-    std::cout << itk::Math::Absolute(it.Get()) << std::endl;
     const InputImageType::PixelType  input = it.Get();
     const OutputImageType::PixelType output = ot.Get();
     const OutputImageType::PixelType absolute = itk::Math::Absolute(input);
-    if (!itk::Math::FloatAlmostEqual(absolute, output, 10, epsilon))
-    {
-      std::cerr.precision(static_cast<int>(itk::Math::Absolute(std::log10(epsilon))));
-      std::cerr << "Error in itkAbsImageFilterTest " << std::endl;
-      std::cerr << " itk::Math::Absolute(" << input << ") = " << absolute << std::endl;
-      std::cerr << " differs from " << output;
-      std::cerr << " by more than " << epsilon << std::endl;
-      testStatus = EXIT_FAILURE;
-    }
+    EXPECT_NEAR(absolute, output, epsilon);
     ++ot;
     ++it;
   }
@@ -126,7 +109,7 @@ itkAbsImageFilterAndAdaptorTest(int, char *[])
 
   auto absAdaptor = AdaptorType::New();
 
-  ITK_EXERCISE_BASIC_OBJECT_METHODS(absAdaptor, AbsImageAdaptor, ImageAdaptor);
+  ITK_GTEST_EXERCISE_BASIC_OBJECT_METHODS(absAdaptor, AbsImageAdaptor, ImageAdaptor);
 
   absAdaptor->SetImage(inputImage);
 
@@ -143,30 +126,14 @@ itkAbsImageFilterAndAdaptorTest(int, char *[])
   const OutputImageType::Pointer diffImage = diffFilter->GetOutput();
 
   //  Check the content of the diff image
-  std::cout << "Comparing the results with those of an Adaptor" << std::endl;
-  std::cout << "Verification of the output " << std::endl;
-
   // Create an iterator for going through the image output
   OutputIteratorType dt(diffImage, diffImage->GetRequestedRegion());
 
   dt.GoToBegin();
   while (!dt.IsAtEnd())
   {
-    std::cout.precision(static_cast<int>(itk::Math::Absolute(std::log10(epsilon))));
-    std::cout << dt.Get() << std::endl;
     const OutputImageType::PixelType diff = dt.Get();
-    if (!itk::Math::FloatAlmostEqual(diff, OutputImageType::PixelType{ 0 }, 10, epsilon))
-    {
-      std::cerr.precision(static_cast<int>(itk::Math::Absolute(std::log10(epsilon))));
-      std::cerr << "Error in itkAbsImageFilterTest " << std::endl;
-      std::cerr << "Comparing results with Adaptors" << std::endl;
-      std::cerr << " difference = " << diff << std::endl;
-      std::cerr << " differs from 0 ";
-      std::cerr << " by more than " << epsilon << std::endl;
-      testStatus = EXIT_FAILURE;
-    }
+    EXPECT_NEAR(diff, OutputImageType::PixelType{ 0 }, epsilon);
     ++dt;
   }
-
-  return testStatus;
 }

--- a/Modules/Filtering/ImageIntensity/test/itkAcosImageFilterAndAdaptorGTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAcosImageFilterAndAdaptorGTest.cxx
@@ -22,13 +22,11 @@
 #include "itkMath.h"
 #include "itkSubtractImageFilter.h"
 #include "itkSimpleFilterWatcher.h"
-#include "itkTestingMacros.h"
+#include "itkGTest.h"
 
 
-int
-itkAcosImageFilterAndAdaptorTest(int, char *[])
+TEST(AcosImageFilterAndAdaptor, ConvertedLegacyTest)
 {
-
   // Define the dimension of the images
   constexpr unsigned int ImageDimension{ 3 };
 
@@ -75,7 +73,7 @@ itkAcosImageFilterAndAdaptorTest(int, char *[])
   // Create the Filter
   auto filter = FilterType::New();
 
-  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, AcosImageFilter, UnaryGeneratorImageFilter);
+  ITK_GTEST_EXERCISE_BASIC_OBJECT_METHODS(filter, AcosImageFilter, UnaryGeneratorImageFilter);
 
   const itk::SimpleFilterWatcher watch(filter);
 
@@ -101,15 +99,7 @@ itkAcosImageFilterAndAdaptorTest(int, char *[])
     const InputImageType::PixelType  input = it.Get();
     const OutputImageType::PixelType output = ot.Get();
     const OutputImageType::PixelType arccosinus = std::acos(input);
-    if (!itk::Math::FloatAlmostEqual(arccosinus, output, 10, epsilon))
-    {
-      std::cerr.precision(static_cast<int>(itk::Math::Absolute(std::log10(epsilon))));
-      std::cerr << "Error " << std::endl;
-      std::cerr << " std::acos( " << input << ") = " << arccosinus << std::endl;
-      std::cerr << " differs from " << output;
-      std::cerr << " by more than " << epsilon << std::endl;
-      return EXIT_FAILURE;
-    }
+    EXPECT_NEAR(arccosinus, output, epsilon);
     ++ot;
     ++it;
   }
@@ -123,7 +113,7 @@ itkAcosImageFilterAndAdaptorTest(int, char *[])
 
   auto acosAdaptor = AdaptorType::New();
 
-  ITK_EXERCISE_BASIC_OBJECT_METHODS(acosAdaptor, AcosImageAdaptor, ImageAdaptor);
+  ITK_GTEST_EXERCISE_BASIC_OBJECT_METHODS(acosAdaptor, AcosImageAdaptor, ImageAdaptor);
 
   acosAdaptor->SetImage(inputImage);
 
@@ -149,17 +139,7 @@ itkAcosImageFilterAndAdaptorTest(int, char *[])
   while (!dt.IsAtEnd())
   {
     const OutputImageType::PixelType diff = dt.Get();
-    if (itk::Math::Absolute(diff) > epsilon)
-    {
-      std::cerr.precision(static_cast<int>(itk::Math::Absolute(std::log10(epsilon))));
-      std::cerr << "Error comparing results with Adaptors" << std::endl;
-      std::cerr << " difference = " << diff << std::endl;
-      std::cerr << " differs from 0 ";
-      std::cerr << " by more than " << epsilon << std::endl;
-      return EXIT_FAILURE;
-    }
+    EXPECT_LE(itk::Math::Absolute(diff), epsilon);
     ++dt;
   }
-
-  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterGTest.cxx
@@ -38,6 +38,7 @@
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkSimpleFilterWatcher.h"
 #include "itkMath.h"
+#include "itkGTest.h"
 
 #include <algorithm> // For generate.
 #include <random>    // For mt19937.
@@ -46,6 +47,8 @@
 //-------------------------------------
 //     Typedefs for convenience
 //-------------------------------------
+namespace
+{
 using myRGBImageType = itk::Image<itk::RGBPixel<float>, 2>;
 using myRGBIteratorType = itk::ImageRegionIteratorWithIndex<myRGBImageType>;
 
@@ -55,17 +58,10 @@ using myBlueAccessorType = itk::BluePixelAccessor<float>;
 
 using myImageType = itk::Image<float, 2>;
 using myIteratorType = itk::ImageRegionIteratorWithIndex<myImageType>;
+} // namespace
 
-//-------------------------
-//
-//   Main code
-//
-//-------------------------
-int
-itkAdaptImageFilterTest(int, char *[])
+TEST(AdaptImageFilter, ConvertedLegacyTest)
 {
-
-
   auto size = myRGBImageType::SizeType::Filled(2);
 
   myRGBImageType::IndexType index;
@@ -99,21 +95,6 @@ itkAdaptImageFilterTest(int, char *[])
     ++it1;
   }
 
-  // Reading the values to verify the image content
-  std::cout << "--- Initial image --- " << std::endl;
-  it1.GoToBegin();
-  while (!it1.IsAtEnd())
-  {
-    const myRGBImageType::PixelType c(it1.Get());
-    std::cout << c.GetRed() << "  ";
-    std::cout << c.GetGreen() << "  ";
-    std::cout << c.GetBlue() << std::endl;
-    ++it1;
-  }
-
-
-  bool passed = true;
-
   // Convert to a red image
   const itk::AdaptImageFilter<myRGBImageType, myImageType, myRedAccessorType>::Pointer adaptImageToRed =
     itk::AdaptImageFilter<myRGBImageType, myImageType, myRedAccessorType>::New();
@@ -123,18 +104,11 @@ itkAdaptImageFilterTest(int, char *[])
 
   myIteratorType it(adaptImageToRed->GetOutput(), adaptImageToRed->GetOutput()->GetRequestedRegion());
 
-  std::cout << "--- Red values --- " << std::endl;
-
   it.GoToBegin();
   it1.GoToBegin();
   while (!it.IsAtEnd())
   {
-    std::cout << it.Get() << std::endl;
-    if (itk::Math::NotExactlyEquals(it.Get(), it1.Get().GetRed()))
-    {
-      passed = false;
-    }
-
+    EXPECT_EQ(it.Get(), it1.Get().GetRed());
     ++it;
     ++it1;
   }
@@ -149,18 +123,11 @@ itkAdaptImageFilterTest(int, char *[])
 
   it = myIteratorType(adaptImageToGreen->GetOutput(), adaptImageToGreen->GetOutput()->GetRequestedRegion());
 
-  std::cout << "--- Green values --- " << std::endl;
-
   it.GoToBegin();
   it1.GoToBegin();
   while (!it.IsAtEnd())
   {
-    std::cout << it.Get() << std::endl;
-    if (itk::Math::NotExactlyEquals(it.Get(), it1.Get().GetGreen()))
-    {
-      passed = false;
-    }
-
+    EXPECT_EQ(it.Get(), it1.Get().GetGreen());
     ++it;
     ++it1;
   }
@@ -175,28 +142,12 @@ itkAdaptImageFilterTest(int, char *[])
 
   it = myIteratorType(adaptImageToBlue->GetOutput(), adaptImageToBlue->GetOutput()->GetRequestedRegion());
 
-  std::cout << "--- Blue values --- " << std::endl;
-
   it.GoToBegin();
   it1.GoToBegin();
   while (!it.IsAtEnd())
   {
-    std::cout << it.Get() << std::endl;
-    if (itk::Math::NotExactlyEquals(it.Get(), it1.Get().GetBlue()))
-    {
-      passed = false;
-    }
-
+    EXPECT_EQ(it.Get(), it1.Get().GetBlue());
     ++it;
     ++it1;
   }
-
-  std::cout << std::endl;
-  if (passed)
-  {
-    std::cout << "AdaptImageFilterTest passed." << std::endl;
-    return EXIT_SUCCESS;
-  }
-  std::cerr << "AdaptImageFilterTest failed." << std::endl;
-  return EXIT_FAILURE;
 }

--- a/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterGTest2.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterGTest2.cxx
@@ -35,6 +35,7 @@
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkNthElementPixelAccessor.h"
 #include "itkMath.h"
+#include "itkGTest.h"
 
 #include <algorithm> // For generate.
 #include <random>    // For mt19937.
@@ -43,6 +44,8 @@
 //-------------------------------------
 //     Typedefs for convenience
 //-------------------------------------
+namespace
+{
 using myVectorImageType = itk::Image<itk::Vector<float, 3>, 2>;
 using myVectorIteratorType = itk::ImageRegionIteratorWithIndex<myVectorImageType>;
 
@@ -50,17 +53,10 @@ using myAccessorType = itk::NthElementPixelAccessor<float, itk::Vector<float, 3>
 
 using myImageType = itk::Image<float, 2>;
 using myIteratorType = itk::ImageRegionIteratorWithIndex<myImageType>;
+} // namespace
 
-//-------------------------
-//
-//   Main code
-//
-//-------------------------
-int
-itkAdaptImageFilterTest2(int, char *[])
+TEST(AdaptImageFilter2, ConvertedLegacyTest)
 {
-
-
   auto size = myVectorImageType::SizeType::Filled(2);
 
   myVectorImageType::IndexType index;
@@ -94,21 +90,6 @@ itkAdaptImageFilterTest2(int, char *[])
     ++it1;
   }
 
-  // Reading the values to verify the image content
-  std::cout << "--- Initial image --- " << std::endl;
-  it1.GoToBegin();
-  while (!it1.IsAtEnd())
-  {
-    const myVectorImageType::PixelType c(it1.Get());
-    std::cout << c[0] << "  ";
-    std::cout << c[1] << "  ";
-    std::cout << c[2] << std::endl;
-    ++it1;
-  }
-
-
-  bool passed = true;
-
   // Get the first element
   using AdaptFilterType = itk::AdaptImageFilter<myVectorImageType, myImageType, myAccessorType>;
 
@@ -123,18 +104,11 @@ itkAdaptImageFilterTest2(int, char *[])
 
   myIteratorType it(adaptImage->GetOutput(), adaptImage->GetOutput()->GetRequestedRegion());
 
-  std::cout << "--- First component values --- " << std::endl;
-
   it.GoToBegin();
   it1.GoToBegin();
   while (!it.IsAtEnd())
   {
-    std::cout << it.Get() << std::endl;
-    if (itk::Math::NotExactlyEquals(it.Get(), it1.Get()[0]))
-    {
-      passed = false;
-    }
-
+    EXPECT_EQ(it.Get(), it1.Get()[0]);
     ++it;
     ++it1;
   }
@@ -146,18 +120,11 @@ itkAdaptImageFilterTest2(int, char *[])
 
   it = myIteratorType(adaptImage->GetOutput(), adaptImage->GetOutput()->GetRequestedRegion());
 
-  std::cout << "--- Second component values --- " << std::endl;
-
   it.GoToBegin();
   it1.GoToBegin();
   while (!it.IsAtEnd())
   {
-    std::cout << it.Get() << std::endl;
-    if (itk::Math::NotExactlyEquals(it.Get(), it1.Get()[1]))
-    {
-      passed = false;
-    }
-
+    EXPECT_EQ(it.Get(), it1.Get()[1]);
     ++it;
     ++it1;
   }
@@ -169,31 +136,15 @@ itkAdaptImageFilterTest2(int, char *[])
 
   it = myIteratorType(adaptImage->GetOutput(), adaptImage->GetOutput()->GetRequestedRegion());
 
-  std::cout << "--- Third component values --- " << std::endl;
-
   it.GoToBegin();
   it1.GoToBegin();
   while (!it.IsAtEnd())
   {
-    std::cout << it.Get() << std::endl;
-    if (itk::Math::NotExactlyEquals(it.Get(), it1.Get()[2]))
-    {
-      passed = false;
-    }
-
+    EXPECT_EQ(it.Get(), it1.Get()[2]);
     ++it;
     ++it1;
   }
 
   // Test access to Accessor
-  std::cout << adaptImage->GetAccessor().GetElementNumber() << std::endl;
-
-  std::cout << std::endl;
-  if (passed)
-  {
-    std::cout << "AdaptImageFilterTest2 passed" << std::endl;
-    return EXIT_SUCCESS;
-  }
-  std::cout << "AdaptImageFilterTest2 passed" << std::endl;
-  return EXIT_FAILURE;
+  EXPECT_EQ(adaptImage->GetAccessor().GetElementNumber(), 2u);
 }

--- a/Modules/Filtering/ImageIntensity/test/itkAddImageAdaptorGTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAddImageAdaptorGTest.cxx
@@ -19,11 +19,10 @@
 #include "itkAddImageAdaptor.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkSubtractImageFilter.h"
+#include "itkGTest.h"
 
-int
-itkAddImageAdaptorTest(int, char *[])
+TEST(AddImageAdaptor, ConvertedLegacyTest)
 {
-
   // Define the dimension of the images
   constexpr unsigned int Dimension{ 3 };
 
@@ -60,13 +59,11 @@ itkAddImageAdaptorTest(int, char *[])
   IteratorType it1(inputImage, inputImage->GetBufferedRegion());
 
   // Initialize the content of Image A
-  std::cout << "First operand " << std::endl;
   PixelType value = 13;
   while (!it1.IsAtEnd())
   {
     it1.Set(value);
     value += 1;
-    std::cout << it1.Get() << std::endl;
     ++it1;
   }
 
@@ -96,9 +93,6 @@ itkAddImageAdaptorTest(int, char *[])
   const ImageType::Pointer diffImage = diffFilter->GetOutput();
 
   //  Check the content of the diff image
-  std::cout << "Comparing the results with those of an Adaptor" << std::endl;
-  std::cout << "Verification of the output " << std::endl;
-
   // Create an iterator for going through the image output
   IteratorType dt(diffImage, diffImage->GetBufferedRegion());
 
@@ -108,22 +102,12 @@ itkAddImageAdaptorTest(int, char *[])
 
   while (!dt.IsAtEnd())
   {
-    std::cout << dt.Get() << std::endl;
-
     auto v1 = static_cast<RealPixelType>(dt.Get());
     auto v2 = static_cast<RealPixelType>(additiveConstant);
 
     const RealPixelType diff = itk::Math::Absolute(v1 - v2);
 
-    if (diff > itk::Math::eps)
-    {
-      std::cerr << "Error in itkAddImageFilterTest " << std::endl;
-      std::cerr << "Comparing results with Adaptors" << std::endl;
-      std::cerr << " difference = " << diff << std::endl;
-      std::cerr << " differs from 0 ";
-      std::cerr << " by more than " << itk::Math::eps << std::endl;
-      return EXIT_FAILURE;
-    }
+    EXPECT_LE(diff, itk::Math::eps);
     ++dt;
   }
 
@@ -133,23 +117,14 @@ itkAddImageAdaptorTest(int, char *[])
   index[1] = 1;
   index[2] = 1;
 
-  const PixelType p1 = addAdaptor->GetPixel(index);
-
-  std::cout << " Pixel " << index << " had value = " << p1 << std::endl;
+  // Exercise GetPixel for code coverage; original test printed but did
+  // not assert on this read.
+  (void)addAdaptor->GetPixel(index);
 
   constexpr PixelType newValue{ 27 };
 
-  std::cout << " We set Pixel " << index << " to value = " << newValue << std::endl;
   addAdaptor->SetPixel(index, newValue);
 
   const PixelType p2 = addAdaptor->GetPixel(index);
-  std::cout << " Now Pixel " << index << " has value = " << p2 << std::endl;
-
-  if (p2 != newValue)
-  {
-    std::cerr << "SetPixel()/GetPixel() methods failed" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  return EXIT_SUCCESS;
+  EXPECT_EQ(p2, newValue);
 }

--- a/Modules/Filtering/ImageIntensity/test/itkAddImageFilterFrameGTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkAddImageFilterFrameGTest.cxx
@@ -18,12 +18,11 @@
 
 #include "itkAddImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
+#include "itkGTest.h"
 
 
-int
-itkAddImageFilterFrameTest(int, char *[])
+TEST(AddImageFilterFrame, ConvertedLegacyTest)
 {
-
   // Define the dimension of the images
   constexpr unsigned int myDimension{ 3 };
 
@@ -72,11 +71,9 @@ itkAddImageFilterFrameTest(int, char *[])
   myIteratorType1 it1(inputImageA, inputImageA->GetBufferedRegion());
 
   // Initialize the content of Image A
-  std::cout << "First operand " << std::endl;
   while (!it1.IsAtEnd())
   {
     it1.Set(2.0);
-    std::cout << it1.Get() << std::endl;
     ++it1;
   }
 
@@ -84,11 +81,9 @@ itkAddImageFilterFrameTest(int, char *[])
   myIteratorType2 it2(inputImageB, inputImageB->GetBufferedRegion());
 
   // Initialize the content of Image B
-  std::cout << "Second operand " << std::endl;
   while (!it2.IsAtEnd())
   {
     it2.Set(3.0);
-    std::cout << it2.Get() << std::endl;
     ++it2;
   }
 
@@ -110,17 +105,8 @@ itkAddImageFilterFrameTest(int, char *[])
   inputImageB->SetOrigin(borigin);
 
 
-  // Execute the filter
-  try
-  {
-    filter->Update();
-    std::cout << "No exception thrown for a difference in origins!" << std::endl;
-    return EXIT_FAILURE;
-  }
-  catch (const itk::ExceptionObject & exc)
-  {
-    std::cout << "Known exception caught (origin)! " << exc << std::endl;
-  }
+  // Execute the filter -- expect exception due to differing origins
+  EXPECT_THROW(filter->Update(), itk::ExceptionObject);
 
 
   // Make Image B have a different spacing
@@ -129,17 +115,8 @@ itkAddImageFilterFrameTest(int, char *[])
   auto bspacing = itk::MakeFilled<myImageType2::SpacingType>(1.001);
   inputImageB->SetSpacing(bspacing);
 
-  // Execute the filter
-  try
-  {
-    filter->Update();
-    std::cout << "No exception thrown for a difference in spacings!" << std::endl;
-    return EXIT_FAILURE;
-  }
-  catch (const itk::ExceptionObject & exc)
-  {
-    std::cout << "Known exception caught (spacing)! " << exc << std::endl;
-  }
+  // Execute the filter -- expect exception due to differing spacings
+  EXPECT_THROW(filter->Update(), itk::ExceptionObject);
 
 
   // Make Image B have different direction cosines
@@ -150,19 +127,9 @@ itkAddImageFilterFrameTest(int, char *[])
   bdirections[2][2] = -1.0;
   inputImageB->SetDirection(bdirections);
 
-  // Execute the filter
-  try
-  {
-    filter->Update();
-    std::cout << "No exception thrown for a difference in directions!" << std::endl;
-    return EXIT_FAILURE;
-  }
-  catch (const itk::ExceptionObject & exc)
-  {
-    std::cout << "Known exception caught (directions)! " << exc << std::endl;
-  }
+  // Execute the filter -- expect exception due to differing directions
+  EXPECT_THROW(filter->Update(), itk::ExceptionObject);
 
 
   // All objects should be automatically destroyed at this point
-  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Mechanical CTest → GoogleTest conversion of the six alphabetically-first no-argument tests under \`Modules/Filtering/ImageIntensity/test/\`. Same pattern as #6071 and #6132. All six pass against \`ITKImageIntensityGTestDriver\` locally.

<details>
<summary>Conversions</summary>

| # | Old | New |
|---|---|---|
| 1 | \`itkAbsImageFilterAndAdaptorTest\` | \`itkAbsImageFilterAndAdaptorGTest\` |
| 2 | \`itkAcosImageFilterAndAdaptorTest\` | \`itkAcosImageFilterAndAdaptorGTest\` |
| 3 | \`itkAdaptImageFilterTest\` | \`itkAdaptImageFilterGTest\` |
| 4 | \`itkAdaptImageFilterTest2\` | \`itkAdaptImageFilterGTest2\` |
| 5 | \`itkAddImageAdaptorTest\` | \`itkAddImageAdaptorGTest\` |
| 6 | \`itkAddImageFilterFrameTest\` | \`itkAddImageFilterFrameGTest\` |

Each conversion is a single \`git mv\`-tracked rename + body edit + \`CMakeLists.txt\` update — \`git log --follow\` keeps the pre-conversion history. CMake source-list entries kept alphabetically sorted in both \`ITKImageIntensityTests\` (legacy) and \`ITKImageIntensityGTests\`.

</details>

<details>
<summary>Mechanical-conversion details</summary>

- \`int itkFooTest(int, char *[])\` → \`TEST(Foo, ConvertedLegacyTest)\`.
- \`if (...) return EXIT_FAILURE\` → \`EXPECT_*\` (or \`EXPECT_THROW\` for the three exception cases in \`AddImageFilterFrame\`).
- \`ITK_EXERCISE_BASIC_OBJECT_METHODS\` → \`ITK_GTEST_EXERCISE_BASIC_OBJECT_METHODS\` (avoids the \`return EXIT_FAILURE\` path that breaks under MSVC inside a void TEST body — same gotcha as #6132).
- \`itk::Math::FloatAlmostEqual(a, b, 10, eps)\` → \`EXPECT_NEAR(a, b, eps)\`.
- \`itk::Math::NotExactlyEquals(a, b)\` predicate flips → \`EXPECT_EQ(a, b)\`.
- Removed redundant \`std::cout\`-only diagnostics on the success path; preserved scope-explaining comments.
- Helper typedefs hoisted into anonymous \`namespace { }\` where they were file-scope in the original.

</details>

<details>
<summary>Local verification</summary>

\`\`\`
[----------] Global test environment tear-down
[==========] 11 tests from 8 test suites ran. (1 ms total)
[  PASSED  ] 11 tests.
\`\`\`

Filter: full \`ITKImageIntensityGTestDriver\` (no \`--gtest_filter\`). All converted tests run; pre-existing \`ArithmeticOpsTest\` and \`BitwiseOpsTest\` GTests still pass.

</details>

<!--
provenance: claude-code session 2026-04-25 via /convert-to-gtest skill
key_facts:
  - converted_tests: 6
  - source_dir: Modules/Filtering/ImageIntensity/test
  - branch_base: upstream/main 1180a300d4
  - module_total_no_arg_candidates_remaining: ~54 (this PR took the alphabetically-first 6)
related_files:
  - Modules/Filtering/ImageIntensity/test/itkAbsImageFilterAndAdaptorGTest.cxx
  - Modules/Filtering/ImageIntensity/test/itkAcosImageFilterAndAdaptorGTest.cxx
  - Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterGTest.cxx
  - Modules/Filtering/ImageIntensity/test/itkAdaptImageFilterGTest2.cxx
  - Modules/Filtering/ImageIntensity/test/itkAddImageAdaptorGTest.cxx
  - Modules/Filtering/ImageIntensity/test/itkAddImageFilterFrameGTest.cxx
  - Modules/Filtering/ImageIntensity/test/CMakeLists.txt
followup:
  - 54 remaining no-arg candidates in ImageIntensity (run /convert-to-gtest --next-N)
-->