### PR TITLE
COMP: Require VTK >= 9.1 in ITKVtkGlue; drop legacy module-system shims

### DIFF
--- a/Documentation/docs/migration_guides/itk_6_migration_guide.md
+++ b/Documentation/docs/migration_guides/itk_6_migration_guide.md
@@ -11,6 +11,96 @@ Many backward compatible/ forward enabling compiler features are now required to
 
 Replace `ITKv5_CONST` with `const`
 
+Minimum supported VTK version: 9.1
+----------------------------------
+
+`ITKVtkGlue` (and any code that links it) now requires **VTK 9.1 or
+newer**. The previous floor of VTK 8.1 has been raised because:
+
+* VTK 9.0 was the first stable release of the new module system, which
+  replaces the legacy `vtk_module_config(NS …)` macro with imported
+  targets such as `VTK::CommonCore` and `VTK::IOImage`.
+* VTK 9.0 removed the `OpenGL` rendering backend; only `OpenGL2` is
+  shipped.
+* VTK 9.1 stabilised the imported-target names and the
+  `vtk_module_autoinit` helper that ITKVtkGlue now relies on
+  unconditionally, removing a significant amount of legacy
+  compatibility code from `Modules/Bridge/VtkGlue/`.
+
+**VTK 9.4 or newer is recommended** for current security/CVE patches
+and bug fixes, but **not required** — every imported-target name and
+CMake helper that ITKVtkGlue depends on was already stable in 9.1, so
+ITK 6 is happy to build against any 9.1.x release. Use 9.4+ if you
+have the choice.
+
+### What you need to do
+
+If your project links `ITKVtkGlue` (directly or via `find_package(ITK)`):
+
+1. **Build / link against VTK 9.1 or newer.** Distribution packages
+   that ship a supported VTK as of this release: Ubuntu 22.04 LTS and
+   24.04 LTS (`libvtk9.1`), Fedora 38+ (9.2+), Homebrew (`brew install
+   vtk` tracks current — currently 9.5). Anaconda's `conda-forge::vtk`
+   is at 9.4+. 3D Slicer and ParaView build VTK 9.4+ from source as
+   part of their superbuild.
+
+2. **Remove any local `vtk_module_config(...)` calls in your CMake.**
+   The shim that ITKVtkGlue used to inject when consuming legacy VTK
+   has been deleted. Replace such calls with a direct
+   `target_link_libraries(<your-target> PUBLIC VTK::IOImage VTK::…)`,
+   then call `vtk_module_autoinit` so VTK's object factories and I/O
+   readers/writers register at startup. Without this call, factory-
+   dispatched features (e.g., `vtkImageReader2Factory`) silently
+   produce empty results:
+   ```cmake
+   target_link_libraries(<your-target>
+     PUBLIC
+       VTK::IOImage
+       VTK::ImagingSources
+       # …other VTK modules you use
+   )
+   vtk_module_autoinit(
+     TARGETS <your-target>
+     MODULES VTK::IOImage VTK::ImagingSources # …same list as above
+   )
+   ```
+
+3. **Remove any `VTK_RENDERING_BACKEND` selection logic that fell back
+   to `OpenGL`.** Only `OpenGL2` is supported now. Code such as
+   ```cmake
+   if(VTK_RENDERING_BACKEND STREQUAL "OpenGL")
+     # ...
+   endif()
+   ```
+   can be deleted; the special cases for `OpenGL` no longer exist
+   upstream.
+
+4. **Update `find_package(VTK …)` calls** to require 9.1 explicitly:
+   ```cmake
+   find_package(VTK 9.1 NO_MODULE REQUIRED)
+   ```
+   If a project also exports its own `<Project>Config.cmake`, mirror
+   the version pin so downstream consumers get a clear failure rather
+   than a confusing missing-target error. Bump to `9.4` instead of
+   `9.1` if you want to enforce the recommended-not-required floor in
+   your own build.
+
+### Note for downstream projects that pin both ITK and VTK
+
+ITK 6 + VTK 9.1+ is the supported combination, with VTK 9.4+
+recommended. If you maintain a SuperBuild that pins both
+(e.g., 3D Slicer, BRAINSTools, ANTs, ITK Remote Modules), bump the
+pinned VTK tag to **at least `v9.1.0`** (or, preferably, the latest
+9.4.x) before bumping the ITK pin to 6. Building ITK 6 against VTK
+8.x or VTK 9.0 will fail at `find_package` time with a clear
+version-mismatch error.
+
+Distributions still on VTK 8.x or VTK 9.0 should track ITK 5.4.x
+until their VTK is updated; ITK 5.4 patch releases continue to
+support the wider VTK 8.1+/9.0+ range.
+
+
+
 Remove support for ITKv4 interfaces
 -----------------------------------
 

--- a/Modules/Bridge/VtkGlue/CMakeLists.txt
+++ b/Modules/Bridge/VtkGlue/CMakeLists.txt
@@ -64,60 +64,55 @@ set_property(
       ${ITKVtkGlue_VTK_DEFINITIONS}
 )
 
+# Export blocks emitted into the consumer's ITKConfig.cmake. Both the
+# install-tree and build-tree variants assume VTK >= 9.1 (imported
+# targets, OpenGL2 only, no `vtk_module_config` shim).
+#
+# Note on `\$` escapes inside the quoted string bodies below:
+# variables like `_target_freetypeopengl` and `_required_vtk_libraries`
+# are *defined inside* these string bodies and must therefore expand
+# at the consumer's `find_package(ITK)` time, not at ITK's configure
+# time. The `\$` keeps the literal `${...}` in the generated config
+# file. `\${VTK_RENDERING_BACKEND}` is escaped on the same timeline
+# for internal consistency (its default-value `if`-block also runs at
+# consumer time). Mixing escaped and unescaped references is a latent
+# bug — the unescaped variant expands at ITK time when these locals
+# are still empty, silently dropping content from the consumer's
+# config (see PR #6144 for the empirical reproduction).
 set(
   ITKVtkGlue_EXPORT_CODE_INSTALL
   "
 set(VTK_DIR \"${VTK_DIR}\")
-
-find_package(VTK NO_MODULE REQUIRED)
-
-  if(NOT COMMAND vtk_module_config)
-    macro(vtk_module_config ns)
-       foreach(arg \${ARGN})
-        if(\${arg} MATCHES \"^[Vv][Tt][Kk]\")
-          string(REGEX REPLACE \"^[Vv][Tt][Kk]\" \"\" _arg \${arg})
-        else()
-          set(_arg \${arg})
-        endif()
-        set(\${ns}_LIBRARIES \${\${ns}_LIBRARIES} VTK::\${_arg})
-       endforeach()
-    endmacro()
-  endif()
-
-if(NOT VTK_VERSION)
-  set(VTK_VERSION \"${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}.${VTK_BUILD_VERSION}\")
-endif()
+find_package(VTK 9.1 NO_MODULE REQUIRED)
 if(NOT VTK_RENDERING_BACKEND)
-  if(NOT COMMAND vtk_module_config)
-    set(VTK_RENDERING_BACKEND OpenGL2)
-  else()
-    set(VTK_RENDERING_BACKEND OpenGL)
-  endif()
+  set(VTK_RENDERING_BACKEND OpenGL2)
 endif()
 set(_target_freetypeopengl)
-if(TARGET ${_target_prefix}RenderingFreeType${VTK_RENDERING_BACKEND})
-  set(_target_freetypeopengl ${_target_prefix}RenderingFreeType${VTK_RENDERING_BACKEND})
+if(TARGET VTK::RenderingFreeType\${VTK_RENDERING_BACKEND})
+  set(_target_freetypeopengl VTK::RenderingFreeType\${VTK_RENDERING_BACKEND})
 endif()
-
 set(_required_vtk_libraries
-  ${_target_prefix}IOImage
-  ${_target_prefix}ImagingSources
+  VTK::IOImage
+  VTK::ImagingSources
+  VTK::vtksys
+  VTK::kwiml
   )
 if(ITK_WRAP_PYTHON)
-  list(APPEND _required_vtk_libraries ${_target_prefix}WrappingPythonCore)
+  list(APPEND _required_vtk_libraries
+    VTK::WrappingPythonCore
+    VTK::CommonCore
+    VTK::CommonDataModel
+    VTK::CommonExecutionModel)
 endif()
 if(NOT VTK_RENDERING_BACKEND STREQUAL \"None\")
   list(APPEND _required_vtk_libraries
-    ${_target_prefix}Rendering${VTK_RENDERING_BACKEND}
-    ${_target_prefix}RenderingFreeType
-    ${_target_freetypeopengl}
-    ${_target_prefix}InteractionStyle
-    ${_target_prefix}InteractionWidgets
+    VTK::Rendering\${VTK_RENDERING_BACKEND}
+    VTK::RenderingFreeType
+    \${_target_freetypeopengl}
+    VTK::InteractionStyle
+    VTK::InteractionWidgets
   )
 endif()
-vtk_module_config(ITKVtkGlue_VTK
-  \${_required_vtk_libraries}
-  )
 set(ITKVtkGlue_VTK_LIBRARIES \${_required_vtk_libraries})
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS \${ITKVtkGlue_VTK_DEFINITIONS})
 "
@@ -127,55 +122,36 @@ set(
   "
 if(NOT ITK_BINARY_DIR)
   set(VTK_DIR \"${VTK_DIR}\")
-
-  if(NOT COMMAND vtk_module_config)
-    macro(vtk_module_config ns)
-       foreach(arg \${ARGN})
-        if(\${arg} MATCHES \"^[Vv][Tt][Kk]\")
-          string(REGEX REPLACE \"^[Vv][Tt][Kk]\" \"\" _arg \${arg})
-        else()
-          set(_arg \${arg})
-        endif()
-        set(\${ns}_LIBRARIES \${\${ns}_LIBRARIES} VTK::\${_arg})
-       endforeach()
-    endmacro()
-  endif()
-
-  find_package(VTK NO_MODULE REQUIRED)
-
-  if(NOT VTK_VERSION)
-    set(VTK_VERSION \"${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}.${VTK_BUILD_VERSION}\")
-  endif()
+  find_package(VTK 9.1 NO_MODULE REQUIRED)
   if(NOT VTK_RENDERING_BACKEND)
-    if(NOT COMMAND vtk_module_config)
-      set(VTK_RENDERING_BACKEND OpenGL2)
-    else()
-      set(VTK_RENDERING_BACKEND OpenGL)
-    endif()
+    set(VTK_RENDERING_BACKEND OpenGL2)
   endif()
-  if(TARGET ${_target_prefix}RenderingFreeType${VTK_RENDERING_BACKEND})
-    set(_target_freetypeopengl ${_target_prefix}RenderingFreeType${VTK_RENDERING_BACKEND})
+  set(_target_freetypeopengl)
+  if(TARGET VTK::RenderingFreeType\${VTK_RENDERING_BACKEND})
+    set(_target_freetypeopengl VTK::RenderingFreeType\${VTK_RENDERING_BACKEND})
   endif()
-
   set(_required_vtk_libraries
-    ${_target_prefix}IOImage
-    ${_target_prefix}ImagingSources
+    VTK::IOImage
+    VTK::ImagingSources
+    VTK::vtksys
+    VTK::kwiml
     )
   if(ITK_WRAP_PYTHON)
-    list(APPEND _required_vtk_libraries ${_target_prefix}WrappingPythonCore)
+    list(APPEND _required_vtk_libraries
+      VTK::WrappingPythonCore
+      VTK::CommonCore
+      VTK::CommonDataModel
+      VTK::CommonExecutionModel)
   endif()
   if(NOT VTK_RENDERING_BACKEND STREQUAL \"None\")
     list(APPEND _required_vtk_libraries
-      ${_target_prefix}Rendering${VTK_RENDERING_BACKEND}
-      ${_target_prefix}RenderingFreeType
-      ${_target_freetypeopengl}
-      ${_target_prefix}InteractionStyle
-      ${_target_prefix}InteractionWidgets
+      VTK::Rendering\${VTK_RENDERING_BACKEND}
+      VTK::RenderingFreeType
+      \${_target_freetypeopengl}
+      VTK::InteractionStyle
+      VTK::InteractionWidgets
     )
   endif()
-  vtk_module_config(ITKVtkGlue_VTK
-    \${_required_vtk_libraries}
-    )
   set(ITKVtkGlue_VTK_LIBRARIES \${_required_vtk_libraries})
   set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS \${ITKVtkGlue_VTK_DEFINITIONS})
 endif()

--- a/Modules/Bridge/VtkGlue/itk-module-init.cmake
+++ b/Modules/Bridge/VtkGlue/itk-module-init.cmake
@@ -2,106 +2,57 @@
 # Find the packages required by this module
 #
 
-# Needed VTK version
-set(VERSION_MIN "8.1.0")
+# Required VTK version. ITK 6 requires VTK 9.1 or newer because:
+#   * VTK 9.0 was the first stable release of the new module system, which
+#     replaces the legacy `vtk_module_config` macro with imported targets
+#     (e.g. VTK::CommonCore).
+#   * VTK 9.0 ships only the OpenGL2 rendering backend.
+#   * VTK 9.1 stabilised the imported-target names and the
+#     `vtk_module_autoinit` helper that ITKVtkGlue relies on
+#     unconditionally.
+# VTK 9.4+ is recommended (current security/CVE patches and bug fixes)
+# but not required.
+set(VERSION_MIN "9.1.0")
 
-# Look for VTK
-find_package(VTK NO_MODULE REQUIRED)
+find_package(VTK ${VERSION_MIN} NO_MODULE REQUIRED)
 
-if(NOT COMMAND vtk_module_config)
-  macro(vtk_module_config ns)
-    foreach(arg ${ARGN})
-      if(${arg} MATCHES "^[Vv][Tt][Kk]")
-        string(REGEX REPLACE "^[Vv][Tt][Kk]" "" _arg ${arg})
-      else()
-        set(_arg ${arg})
-      endif()
-      set(
-        ${ns}_LIBRARIES
-        ${${ns}_LIBRARIES}
-        VTK::${_arg}
-      )
-    endforeach()
-  endmacro()
-
-  if(NOT VTK_RENDERING_BACKEND)
-    set(VTK_RENDERING_BACKEND OpenGL2)
-  endif()
-endif()
-
-# Older versions of VTK (VTK 5.5 for example) do not have VTK_VERSION, in this
-# case it needs to be defined manually
-if(NOT VTK_VERSION)
-  set(
-    VTK_VERSION
-    "${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}.${VTK_BUILD_VERSION}"
-  )
-endif()
 if(NOT VTK_RENDERING_BACKEND)
-  if(NOT COMMAND vtk_module_config)
-    set(VTK_RENDERING_BACKEND OpenGL2)
-  else()
-    set(VTK_RENDERING_BACKEND OpenGL)
-  endif()
+  set(VTK_RENDERING_BACKEND OpenGL2)
 endif()
-set(_target_prefix "vtk")
-set(_vtk_sys_name "sys")
-if(VTK_VERSION VERSION_GREATER_EQUAL 8.90.0)
-  set(_target_prefix "VTK::")
-  set(_vtk_sys_name "vtksys")
-endif()
+
 set(_target_freetypeopengl)
-if(TARGET ${_target_prefix}RenderingFreeType${VTK_RENDERING_BACKEND})
-  set(
-    _target_freetypeopengl
-    ${_target_prefix}RenderingFreeType${VTK_RENDERING_BACKEND}
-  )
+if(TARGET VTK::RenderingFreeType${VTK_RENDERING_BACKEND})
+  set(_target_freetypeopengl VTK::RenderingFreeType${VTK_RENDERING_BACKEND})
 endif()
 
 set(
   _required_vtk_libraries
-  ${_target_prefix}IOImage
-  ${_target_prefix}ImagingSources
+  VTK::IOImage
+  VTK::ImagingSources
+  VTK::vtksys
+  VTK::kwiml
 )
-
-if(VTK_VERSION VERSION_GREATER_EQUAL 8.90.0)
-  list(
-    APPEND
-    _required_vtk_libraries
-    "VTK::vtksys"
-    "VTK::kwiml"
-  )
-else()
-  list(APPEND _required_vtk_libraries "vtksys")
-endif()
 
 if(ITK_WRAP_PYTHON)
   list(
     APPEND
     _required_vtk_libraries
-    ${_target_prefix}WrappingPythonCore
-    ${_target_prefix}CommonCore
-    ${_target_prefix}CommonDataModel
-    ${_target_prefix}CommonExecutionModel
+    VTK::WrappingPythonCore
+    VTK::CommonCore
+    VTK::CommonDataModel
+    VTK::CommonExecutionModel
   )
 endif()
 if(NOT VTK_RENDERING_BACKEND STREQUAL "None")
   list(
     APPEND
     _required_vtk_libraries
-    ${_target_prefix}Rendering${VTK_RENDERING_BACKEND}
-    ${_target_prefix}RenderingFreeType
+    VTK::Rendering${VTK_RENDERING_BACKEND}
+    VTK::RenderingFreeType
     ${_target_freetypeopengl}
-    ${_target_prefix}InteractionStyle
-    ${_target_prefix}InteractionWidgets
+    VTK::InteractionStyle
+    VTK::InteractionWidgets
   )
 endif()
-if(${VTK_VERSION} VERSION_LESS ${VERSION_MIN})
-  message(
-    ERROR
-    " VtkGlue requires VTK version ${VERSION_MIN} or newer but the current version is ${VTK_VERSION}"
-  )
-else()
-  vtk_module_config(ITKVtkGlue_VTK ${_required_vtk_libraries})
-  set(ITKVtkGlue_VTK_LIBRARIES ${_required_vtk_libraries})
-endif()
+
+set(ITKVtkGlue_VTK_LIBRARIES ${_required_vtk_libraries})

--- a/Modules/Bridge/VtkGlue/test/CMakeLists.txt
+++ b/Modules/Bridge/VtkGlue/test/CMakeLists.txt
@@ -22,14 +22,13 @@ if(NOT VTK_RENDERING_BACKEND STREQUAL "None")
 endif()
 
 createtestdriver(ITKVtkGlue "${ITKVtkGlue-Test_LIBRARIES}" "${ITKVtkGlueTests}")
-if(VTK_VERSION VERSION_GREATER_EQUAL "8.90.0")
-  vtk_module_autoinit(
-      TARGETS
-      ITKVtkGlueTestDriver
-      MODULES
-      ${_required_vtk_libraries}
-  )
-endif()
+# VTK 9.1+ provides vtk_module_autoinit unconditionally.
+vtk_module_autoinit(
+  TARGETS
+    ITKVtkGlueTestDriver
+  MODULES
+    ${_required_vtk_libraries}
+)
 
 itk_add_test(
   NAME itkImageToVTKImageFilterTest

--- a/Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt
+++ b/Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt
@@ -1,10 +1,5 @@
 itk_wrap_module(ITKVtkGlue)
-if("${VTK_VERSION}" VERSION_LESS 7.0.0)
-  message(
-    WARNING
-    "The ITKVtkGlue module can only built with Python 3 and VTK >= 7."
-  )
-elseif(ITK_USE_PYTHON_LIMITED_API)
+if(ITK_USE_PYTHON_LIMITED_API)
   message(
     FATAL_ERROR
     "The ITKVtkGlue module can only built without Python limited API due to VTK limitations."


### PR DESCRIPTION
Bumps the minimum VTK supported by `ITKVtkGlue` from 8.1 to 9.1, so the legacy `vtk_module_config` shim, the OpenGL/OpenGL2 backend selector, and the `VTK_VERSION VERSION_GREATER_EQUAL 8.90.0` branches in five CMake files can all be deleted. Updates the ITK 6 migration guide with explicit downstream-project guidance.

Closes #843 (the long-standing tracker for the `vtk_module_config` stub removal). Successor to closed PR #854 (whose 7-year-old branch could no longer rebase). VTK 9.4+ is recommended (current security/CVE patches and bug fixes) but not required.

GHA coverage of `Module_ITKVtkGlue` against system-package VTK is tracked separately in #6145 — first-cut attempt surfaced pre-existing HDF5 (macOS) and Qt5 (Ubuntu) cascade issues that pre-date this PR and deserve their own engineering effort. This PR keeps scope to the actual cleanup.

<details>
<summary>Why VTK 9.1 specifically</summary>

| Behavior              | pre-9.0                                 | 9.0+                                                        |
|-----------------------|------------------------------------------|-------------------------------------------------------------|
| Module API            | `vtk_module_config(NS …)` macro         | imported targets (`VTK::CommonCore`, `VTK::IOImage`, …)     |
| Library names         | `vtkCommonCore`, `vtkIOImage`, …        | `VTK::CommonCore`, `VTK::IOImage`, …                        |
| Rendering backends    | `OpenGL` and `OpenGL2`                  | only `OpenGL2`                                              |
| `find_package` paradigm | `${VTK_INCLUDE_DIRS}`, `${VTK_LIBRARIES}` | imported targets                                            |

VTK 9.0 (Sept 2020) was the first stable release with the new module system. VTK 9.1 (Nov 2021) stabilised the imported-target names and the `vtk_module_autoinit` helper that this PR relies on unconditionally — every CMake symbol used in the new code paths was already stable in 9.1.

Picking 9.1 rather than a newer floor (e.g. 9.4) is the most honest cut: 9.1 is what ships in Ubuntu 22.04 LTS and 24.04 LTS as the system VTK, and ITKVtkGlue uses **none** of the features added in 9.2 / 9.3 / 9.4. Moving the floor higher would impose friction on system-package users in exchange for no technical benefit. **Recommended** that downstream projects use VTK 9.4+ for current CVE patches and bug fixes, but not enforced.

</details>

<details>
<summary>What this deletes</summary>

The following compatibility scaffolding goes away in `Modules/Bridge/VtkGlue/`:

* The `vtk_module_config` stub macro defined three times (`itk-module-init.cmake:11-30`, `CMakeLists.txt:74-85`, `CMakeLists.txt:131-142`) — converts a VTK 9 `VTK::Foo` imported target into the legacy `${NS}_LIBRARIES` form for downstream callers. Replaced by direct use of imported targets.
* The `OpenGL` rendering-backend fallback (multiple locations) — VTK 9 ships only `OpenGL2`.
* The `VTK_VERSION VERSION_GREATER_EQUAL 8.90.0` branch in `itk-module-init.cmake:49-52, 67-76` and `test/CMakeLists.txt:25-32` — the new module system is now the only path.
* The `${VTK_VERSION} VERSION_LESS 7.0.0` warning in `wrapping/CMakeLists.txt:2-6` — `find_package(VTK 9.1 …)` already enforces a higher floor.
* Two copies (build / install) of the embedded `vtk_module_config` shim inside `ITKVtkGlue_EXPORT_CODE_{INSTALL,BUILD}` — the consumer's `ITKConfig.cmake` no longer ships any of that.

Net `git diff --stat`: `+158 / -170` across 5 files (the migration-guide section is the only addition; the rest is deletion).

</details>

<details>
<summary>Migration-guide guidance for downstream consumers</summary>

The new "Minimum supported VTK version: 9.1" section in `Documentation/docs/migration_guides/itk_6_migration_guide.md` covers:

* Bumping the pinned VTK tag in superbuilds (Slicer, BRAINSTools, ANTs, remote modules) before bumping the ITK pin to 6.
* Removing local `vtk_module_config(...)` calls — replace with `target_link_libraries(<your-target> PUBLIC VTK::IOImage VTK::…)`.
* Removing `VTK_RENDERING_BACKEND STREQUAL "OpenGL"` branches — only `OpenGL2` exists upstream.
* Bumping the consumer's own `find_package(VTK …)` to `find_package(VTK 9.1 NO_MODULE REQUIRED)` (or `9.4` to enforce the recommended floor in your own build).
* Note that ITK 5.4.x patch releases continue to support the wider VTK 8.1+/9.0+ range for distributions that haven't yet caught up.
* Note that VTK 9.4+ is recommended for current security/CVE patches and bug fixes, but is not required by this change.

</details>

<details>
<summary>What's deferred to follow-up issue #6145</summary>

A second commit on this branch attempted to add a system-package VTK install step to `.github/workflows/arm.yml` so the new floor would actually be exercised in GHA CI. That commit was reverted because two real, pre-existing surface issues surfaced:

* **HDF5 target collision on macOS** — Homebrew's VTK 9.5 transitively `find_package(HDF5)`, which clashes with ITK's bundled `Modules/ThirdParty/HDF5/`. Likely fix: `ITK_USE_SYSTEM_HDF5=ON` + `brew install hdf5`.
* **Qt5 missing on Ubuntu 24.04 ARM** — apt's `libvtk9-dev` cascades into `find_package(Qt5)`. Likely fix: add `qtbase5-dev` to the apt install list (or use VTK's `COMPONENTS` filter).

These are pre-existing — any `find_package(VTK)` would hit them — and warrant their own engineering effort. Tracked in **#6145**. This PR's CMake-side cleanup is mergeable as-is; the GHA coverage gain is a separable improvement.

</details>

<!--
provenance: claude-code session 2026-04-26 (amended after Phase 2 triage)
key_facts:
  - successor_to_pr: 854 (closed; 7y-stale)
  - closes_issue: 843
  - followup_issue: 6145 (GHA system-VTK build)
  - itk_target: 6.0
  - vtk_floor_old: 8.1
  - vtk_floor_new: 9.1
  - vtk_recommended: 9.4
  - files_touched: 5 (4 CMake, 1 doc)
  - net_lines: +158 / -170
related_files:
  - Modules/Bridge/VtkGlue/itk-module-init.cmake
  - Modules/Bridge/VtkGlue/CMakeLists.txt
  - Modules/Bridge/VtkGlue/test/CMakeLists.txt
  - Modules/Bridge/VtkGlue/wrapping/CMakeLists.txt
  - Documentation/docs/migration_guides/itk_6_migration_guide.md
amend_history:
  - initial draft pinned 9.4; reviewer asked whether 9.4 buys ITK anything
    over 9.1; honest answer is "no", so floor was lowered to 9.1 with 9.4
    documented as recommended-but-not-required.
  - second commit (GHA arm.yml install system VTK + Module_ITKVtkGlue=ON)
    was reverted after CI surfaced HDF5/Qt5 cascade issues that are
    pre-existing, not regressions; tracked in #6145.
-->