### PR TITLE
BUG: Remove std distribution from ConnectedComponentImageFilter tests + new baselines

### DIFF
--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTest.cxx
@@ -24,6 +24,7 @@
 #include "itkSimpleFilterWatcher.h"
 #include "itkTestingMacros.h"
 #include <algorithm> // For generate.
+#include <cstdint>   // For uint32_t.
 #include <random>    // For mt19937.
 
 int
@@ -125,18 +126,20 @@ itkConnectedComponentImageFilterTest(int argc, char * argv[])
   std::vector<RGBPixelType> colormap;
   colormap.resize(numObjects + 1);
 
-  using RGBComponentType = RGBPixelType::ComponentType;
-  constexpr auto maxRGBComponentValue = std::numeric_limits<RGBComponentType>::max();
-
   constexpr std::mt19937::result_type randomSeed{ 1031571 };
   std::mt19937                        randomNumberEngine(randomSeed);
-  std::uniform_int_distribution<>     randomNumberDistribution(maxRGBComponentValue / 3, maxRGBComponentValue);
 
   for (auto & i : colormap)
   {
     RGBPixelType px;
-    std::generate(px.begin(), px.end(), [&randomNumberEngine, &randomNumberDistribution] {
-      return static_cast<RGBComponentType>(randomNumberDistribution(randomNumberEngine));
+    std::generate(px.begin(), px.end(), [&randomNumberEngine] {
+      using RGBComponentType = RGBPixelType::ComponentType;
+      constexpr uint32_t maxValue{ std::numeric_limits<RGBComponentType>::max() };
+      constexpr uint32_t minValue{ maxValue / 3 };
+      // Modulo reduction is intentional: it accepts a negligible bias
+      // (~1 in 2^32 for an 8-bit range) in exchange for cross-stdlib
+      // determinism, which std::uniform_int_distribution does not provide.
+      return static_cast<RGBComponentType>(randomNumberEngine() % (maxValue - minValue + 1) + minValue);
     });
 
     i = px;

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTestRGB.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterTestRGB.cxx
@@ -24,6 +24,7 @@
 #include "itkSimpleFilterWatcher.h"
 #include "itkTestingMacros.h"
 #include <algorithm> // For generate.
+#include <cstdint>   // For uint32_t.
 #include <random>    // For mt19937.
 
 int
@@ -105,17 +106,19 @@ itkConnectedComponentImageFilterTestRGB(int argc, char * argv[])
   RGBPixelType              px;
   colormap.resize(numObjects + 1);
 
-  using RGBComponentType = RGBPixelType::ComponentType;
-  constexpr auto maxRGBComponentValue = std::numeric_limits<RGBComponentType>::max();
-
   constexpr std::mt19937::result_type randomSeed{ 1031571 };
   std::mt19937                        randomNumberEngine(randomSeed);
-  std::uniform_int_distribution<>     randomNumberDistribution(maxRGBComponentValue / 3, maxRGBComponentValue);
 
   for (auto & i : colormap)
   {
-    std::generate(px.begin(), px.end(), [&randomNumberEngine, &randomNumberDistribution] {
-      return static_cast<RGBComponentType>(randomNumberDistribution(randomNumberEngine));
+    std::generate(px.begin(), px.end(), [&randomNumberEngine] {
+      using RGBComponentType = RGBPixelType::ComponentType;
+      constexpr uint32_t maxValue{ std::numeric_limits<RGBComponentType>::max() };
+      constexpr uint32_t minValue{ maxValue / 3 };
+      // Modulo reduction is intentional: it accepts a negligible bias
+      // (~1 in 2^32 for an 8-bit range) in exchange for cross-stdlib
+      // determinism, which std::uniform_int_distribution does not provide.
+      return static_cast<RGBComponentType>(randomNumberEngine() % (maxValue - minValue + 1) + minValue);
     });
 
     i = px;

--- a/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest.1.png.cid
+++ b/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest.1.png.cid
@@ -1,1 +1,0 @@
-bafkreicqlhg6xztvfqmgynbf3xb6qhbghwfzvkugt6nwxn2kloiwnfalp4

--- a/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest.png.cid
+++ b/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest.png.cid
@@ -1,1 +1,1 @@
-bafkreidv7hznlkcvddhdi7udpvsvqd7q677dhiamqenhskxyq53vogf62q
+bafkreibyjpytxv46k6mkxo3sadppjvs6b5vjqwqcz6u4vkzpp2btmge4fm

--- a/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest2.1.png.cid
+++ b/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest2.1.png.cid
@@ -1,1 +1,0 @@
-bafkreidngvamh6ejxx5j6lzf57p3kqtjjvgm4dtil7ofekz4blhmns3pf4

--- a/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest2.png.cid
+++ b/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest2.png.cid
@@ -1,1 +1,1 @@
-bafkreihut6bgxwhnrmts5ov5hr357n4u7m53f2sjquuobazjizetlqb4ky
+bafkreif6vtfmpapapqk5q5xlitj7g72pdihcrrncdf5cwgtnexu36cj6rm

--- a/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest3.1.png.cid
+++ b/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest3.1.png.cid
@@ -1,1 +1,0 @@
-bafkreiejqekgsjh7frp43eya5fssenr56bfxazjo2ocp7qyevse5xfjjrq

--- a/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest3.png.cid
+++ b/Testing/Data/Baseline/BasicFilters/ConnectedComponentImageFilterTest3.png.cid
@@ -1,1 +1,1 @@
-bafkreifvvwy6zmh7td3cutymiervm7ipqgkfwx6rxuyxej2acw4i5ebcmu
+bafkreibxbxqmcg73nig3ncv7gt2rqdcj7nfw72r3be4r6l5llmqw4wpwru


### PR DESCRIPTION
Successor to [#5836](https://github.com/InsightSoftwareConsortium/ITK/pull/5836) (which is blocked on `maintainerCanModify=off` so the merged baselines could not be wired up). Carries @N-Dekker's RNG fix (preserving authorship), with the `WIP:` prefix dropped now that the baselines are landed; plus a follow-up commit that points the `.cid` content links at the new baselines just merged via [ITKTestingData#38](https://github.com/InsightSoftwareConsortium/ITKTestingData/pull/38).

Verified locally on macOS 15 / Apple Clang Release: `itkConnectedComponentImageFilterTest{,RGB,2,3}` all pass against the new primary baselines, no fall-through to alternates.

<details>
<summary>Commits</summary>

1. `BUG: Remove std distribution from ConnectedComponentImageFilter tests` — @N-Dekker's commit, authorship preserved; rebased onto current `upstream/main` and reworded only to drop the `WIP:` prefix that ghostflow rejected. Replaces `std::uniform_int_distribution` with an explicit modulo expression so `std::mt19937` output reduces identically across `libstdc++` / `libc++` / MSVC.
2. `BUG: Update ConnectedComponentImageFilter test baselines for deterministic RNG` — updates the three primary `.cid` files to the new merged CIDs and deletes the three `.1` per-platform alternates that existed only to paper over the prior cross-stdlib divergence.

</details>

<details>
<summary>New CIDs</summary>

| File | CID | Size |
|---|---|---|
| `Test.png` (also reused by `...TestRGB`) | `bafkreibyjpytxv46k6mkxo3sadppjvs6b5vjqwqcz6u4vkzpp2btmge4fm` | 6655 B |
| `Test2.png` | `bafkreif6vtfmpapapqk5q5xlitj7g72pdihcrrncdf5cwgtnexu36cj6rm` | 5182 B |
| `Test3.png` | `bafkreibxbxqmcg73nig3ncv7gt2rqdcj7nfw72r3be4r6l5llmqw4wpwru` | 3015 B |

Blobs are in `ITKTestingData@gh-pages`, commit `d89fd19`. The `data.kitware.com` and `itk.org/files/ExternalData` mirrors may take a few minutes to publish; CDash CI will fall back to IPFS gateways or directly to gh-pages until then.

</details>

<details>
<summary>Diff stat</summary>

```
 .../itkConnectedComponentImageFilterTest.cxx                  | 11 +++++------
 .../itkConnectedComponentImageFilterTestRGB.cxx               | 11 +++++------
 .../BasicFilters/ConnectedComponentImageFilterTest.1.png.cid  |  1 -
 .../BasicFilters/ConnectedComponentImageFilterTest.png.cid    |  2 +-
 .../BasicFilters/ConnectedComponentImageFilterTest2.1.png.cid |  1 -
 .../BasicFilters/ConnectedComponentImageFilterTest2.png.cid   |  2 +-
 .../BasicFilters/ConnectedComponentImageFilterTest3.1.png.cid |  1 -
 .../BasicFilters/ConnectedComponentImageFilterTest3.png.cid   |  2 +-
```

</details>

Closes #5836 once merged.

<!--
provenance: claude-code session 2026-04-26 (amended after ghostflow reword)
supersedes_pr: 5836 (cannot push due to maintainerCanModify=false)
companion_pr: ITKTestingData#38 (merged, commit d89fd19)
key_facts:
  - cid_test:  bafkreibyjpytxv46k6mkxo3sadppjvs6b5vjqwqcz6u4vkzpp2btmge4fm  (Test.png + TestRGB.png)
  - cid_test2: bafkreif6vtfmpapapqk5q5xlitj7g72pdihcrrncdf5cwgtnexu36cj6rm
  - cid_test3: bafkreibxbxqmcg73nig3ncv7gt2rqdcj7nfw72r3be4r6l5llmqw4wpwru
  - upstream_main_at_branch: matches at PR open time
  - local_test_status: 4/4 pass on macOS 15 Apple Clang Release
  - rework_history:
    - 2026-04-26 reworded N-Dekker's commit to drop WIP: prefix per ghostflow-check-main
post_merge_action: pin 3 blobs to itk-pinata + itk-filebase via Kubo node; close #5836
-->