### PR TITLE
BUG: Use check_symbol_exists for TIFFFieldReadCount detection

### DIFF
--- a/Modules/ThirdParty/TIFF/CMakeLists.txt
+++ b/Modules/ThirdParty/TIFF/CMakeLists.txt
@@ -17,9 +17,14 @@ if(ITK_USE_SYSTEM_TIFF)
   # Check availability of different methods to access TIFF's field
   # data structure.
   include(CheckTypeSize)
+  include(CheckSymbolExists)
   set(CMAKE_REQUIRED_LIBRARIES TIFF::TIFF)
   set(CMAKE_EXTRA_INCLUDE_FILES "tiffio.h")
-  check_type_size(TIFFFieldReadCount ITK_TIFF_HAS_TIFFFieldReadCount)
+  # TIFFFieldReadCount is a function, not a type. Using
+  # check_type_size (sizeof) on a function is non-standard and fails
+  # on MSVC, causing the wrong code path and crashes. Use
+  # check_symbol_exists instead.
+  check_symbol_exists(TIFFFieldReadCount "tiffio.h" ITK_TIFF_HAS_TIFFFieldReadCount)
   check_type_size(TIFFField*  ITK_TIFF_HAS_TIFFField)
 else()
   set(ITKTIFF_INCLUDE_DIRS


### PR DESCRIPTION
## Summary

Fixes #6148.

When building with a system TIFF library (`ITK_USE_SYSTEM_TIFF=ON`), the CMake check for `TIFFFieldReadCount` used `check_type_size()`, which internally calls `sizeof()` on the argument. Passing a function name to `sizeof()` is non-standard — GCC and Clang accept it as an extension but MSVC rejects it — so `ITK_TIFF_HAS_TIFFFieldReadCount` was never defined on Windows builds using an external libTIFF.

Without that define, `itkTIFFImageIO` falls through to the libtiff 4.0.0–4.0.2 workaround that directly accesses the internal `_TIFFField` struct. That struct layout is no longer correct for modern libtiff versions, causing reads of garbage data and NULL pointer crashes when encountering tags with unsupported data types (e.g. an ICC profile tag).

## Fix

Replace `check_type_size(TIFFFieldReadCount ...)` with `check_symbol_exists(TIFFFieldReadCount "tiffio.h" ...)`, which correctly detects the function on all compilers including MSVC.