### PR TITLE
STYLE: Replace vnl_random in I/O tests with std::mt19937

### DIFF
--- a/Modules/Filtering/DisplacementField/test/itkExponentialDisplacementFieldImageFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkExponentialDisplacementFieldImageFilterTest.cxx
@@ -18,7 +18,7 @@
 
 #include "itkExponentialDisplacementFieldImageFilter.h"
 #include "itkTestingMacros.h"
-#include "vnl/vnl_random.h"
+#include <random>
 
 
 int
@@ -231,16 +231,17 @@ itkExponentialDisplacementFieldImageFilterTest(int, char *[])
   computeInverse = false;
   filter->SetComputeInverse(computeInverse);
 
-  // Random number generator
-  vnl_random       rng;
-  constexpr double power{ 5.0 };
+  // Random number generator (deterministic seed for reproducible tests)
+  std::mt19937                     rng{ 12345678 };
+  std::normal_distribution<double> normalDist{ 0.0, 1.0 };
+  constexpr double                 power{ 5.0 };
 
   it.GoToBegin();
   while (!it.IsAtEnd())
   {
     for (unsigned int d = 0; d < ImageDimension; ++d)
     {
-      it.Value()[d] = power * rng.normal();
+      it.Value()[d] = power * normalDist(rng);
     }
     ++it;
   }

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
@@ -22,6 +22,7 @@
 #include "itkTestVerifyMetaData.h"
 #include "itkMath.h"
 #include "itkTestingMacros.h"
+#include <random>
 
 
 template <typename TPixel>
@@ -97,12 +98,12 @@ HDF5ReadWriteTest(const char * fileName)
 
   //
   // fill image buffer
-  vnl_random                          randgen(12345678);
+  std::mt19937                        randomNumberEngine(12345678);
   itk::ImageRegionIterator<ImageType> it(im, im->GetLargestPossibleRegion());
   for (it.GoToBegin(); !it.IsAtEnd(); ++it)
   {
     TPixel pix;
-    itk::IOTestHelper::RandomPix(randgen, pix);
+    itk::IOTestHelper::RandomPix(randomNumberEngine, pix);
     it.Set(pix);
   }
   typename ImageType::Pointer im2;

--- a/Modules/IO/ImageBase/include/itkIOTestHelper.h
+++ b/Modules/IO/ImageBase/include/itkIOTestHelper.h
@@ -23,6 +23,8 @@
 #include "itksys/SystemTools.hxx"
 #include "itkImageFileWriter.h"
 #include "itkImageFileReader.h"
+#include "itkRGBPixel.h"
+#include "itkVector.h"
 #include <cstdint>
 #include <limits>
 #include <random>
@@ -136,33 +138,74 @@ public:
     }
   }
 
-  static void
-  RandomPix(std::mt19937 & randomNumberEngine, itk::RGBPixel<unsigned char> & pix)
+  // Sample a value of arithmetic type T uniformly in [0, bound], avoiding
+  // implementation-defined narrowing and the high-bits-zero artifact that
+  // a single 32-bit engine() output produces for 64-bit integral types.
+  template <typename T>
+  static T
+  BoundedRandom(std::mt19937 & randomNumberEngine, T bound)
   {
-    for (unsigned int i = 0; i < 3; ++i)
+    static_assert(std::is_arithmetic_v<T>, "BoundedRandom: T must be arithmetic");
+    if constexpr (std::is_floating_point_v<T>)
     {
-      pix[i] = static_cast<unsigned char>(randomNumberEngine());
+      std::uniform_real_distribution<T> dist{ static_cast<T>(0), bound };
+      return dist(randomNumberEngine);
+    }
+    else
+    {
+      using U = std::make_unsigned_t<T>;
+      U raw;
+      if constexpr (sizeof(T) > sizeof(std::mt19937::result_type))
+      {
+        // Combine two 32-bit engine outputs to fill the high bits of 64-bit pixel types.
+        raw = (static_cast<U>(randomNumberEngine()) << 32) | static_cast<U>(randomNumberEngine());
+      }
+      else
+      {
+        raw = static_cast<U>(randomNumberEngine());
+      }
+      const U bound_u = static_cast<U>(bound);
+      // No bound to apply when bound saturates U; bound_u + 1 would wrap to 0
+      // and raw % 0 traps with SIGFPE.
+      if (bound_u == std::numeric_limits<U>::max())
+      {
+        return static_cast<T>(raw);
+      }
+      return static_cast<T>(raw % (bound_u + U{ 1 }));
     }
   }
 
   template <typename TPixel>
   static void
-  RandomPix(std::mt19937 & randomNumberEngine, TPixel & pix)
+  RandomPix(std::mt19937 & randomNumberEngine,
+            TPixel &       pix,
+            double         _max = static_cast<double>(itk::NumericTraits<TPixel>::max()))
   {
-    static_assert(std::is_integral_v<TPixel> || std::is_floating_point_v<TPixel>,
-                  "RandomPix: TPixel must be integral or floating-point");
-    if constexpr (std::is_integral_v<TPixel> && sizeof(TPixel) < sizeof(std::mt19937::result_type))
+    static_assert(std::is_arithmetic_v<TPixel>, "RandomPix: TPixel must be arithmetic");
+    pix = BoundedRandom<TPixel>(randomNumberEngine, static_cast<TPixel>(_max));
+  }
+
+  template <typename T>
+  static void
+  RandomPix(std::mt19937 &     randomNumberEngine,
+            itk::RGBPixel<T> & pix,
+            double             _max = static_cast<double>(itk::NumericTraits<T>::max()))
+  {
+    for (unsigned int i = 0; i < 3; ++i)
     {
-      // Bound the engine output to TPixel's representable range so the
-      // narrowing cast cannot drop the high bits silently.  Skipped when
-      // sizeof(TPixel) >= sizeof(engine output) because then
-      // numeric_limits<TPixel>::max() + 1 would itself overflow.
-      pix = static_cast<TPixel>(randomNumberEngine() %
-                                (static_cast<std::mt19937::result_type>(std::numeric_limits<TPixel>::max()) + 1));
+      pix[i] = BoundedRandom<T>(randomNumberEngine, static_cast<T>(_max));
     }
-    else
+  }
+
+  template <typename T, unsigned int VLength>
+  static void
+  RandomPix(std::mt19937 &            randomNumberEngine,
+            itk::Vector<T, VLength> & pix,
+            double                    _max = static_cast<double>(itk::NumericTraits<T>::max()))
+  {
+    for (unsigned int i = 0; i < VLength; ++i)
     {
-      pix = static_cast<TPixel>(randomNumberEngine());
+      pix[i] = BoundedRandom<T>(randomNumberEngine, static_cast<T>(_max));
     }
   }
 

--- a/Modules/IO/ImageBase/include/itkIOTestHelper.h
+++ b/Modules/IO/ImageBase/include/itkIOTestHelper.h
@@ -23,7 +23,10 @@
 #include "itksys/SystemTools.hxx"
 #include "itkImageFileWriter.h"
 #include "itkImageFileReader.h"
-#include "vnl/vnl_random.h"
+#include <cstdint>
+#include <limits>
+#include <random>
+#include <type_traits>
 namespace itk
 {
 class IOTestHelper
@@ -133,48 +136,34 @@ public:
     }
   }
 
-  //
-  // generate random pixels of various types
   static void
-  RandomPix(vnl_random & randgen, itk::RGBPixel<unsigned char> & pix)
+  RandomPix(std::mt19937 & randomNumberEngine, itk::RGBPixel<unsigned char> & pix)
   {
     for (unsigned int i = 0; i < 3; ++i)
     {
-      pix[i] = randgen.lrand32(itk::NumericTraits<unsigned char>::max());
+      pix[i] = static_cast<unsigned char>(randomNumberEngine());
     }
   }
 
   template <typename TPixel>
   static void
-  RandomPix(vnl_random & randgen, TPixel & pix)
+  RandomPix(std::mt19937 & randomNumberEngine, TPixel & pix)
   {
-    pix = randgen.lrand32(itk::NumericTraits<TPixel>::max());
-  }
-
-  static void
-  RandomPix(vnl_random & randgen, long long & pix)
-  {
-    pix = randgen.lrand32(itk::NumericTraits<int>::max());
-    pix = (pix << 32) | randgen.lrand32();
-  }
-
-  static void
-  RandomPix(vnl_random & randgen, unsigned long long & pix)
-  {
-    pix = randgen.lrand32();
-    pix = (pix << 32) | randgen.lrand32();
-  }
-
-  static void
-  RandomPix(vnl_random & randgen, double & pix)
-  {
-    pix = randgen.drand64(itk::NumericTraits<double>::max());
-  }
-
-  static void
-  RandomPix(vnl_random & randgen, float & pix)
-  {
-    pix = randgen.drand64(itk::NumericTraits<float>::max());
+    static_assert(std::is_integral_v<TPixel> || std::is_floating_point_v<TPixel>,
+                  "RandomPix: TPixel must be integral or floating-point");
+    if constexpr (std::is_integral_v<TPixel> && sizeof(TPixel) < sizeof(std::mt19937::result_type))
+    {
+      // Bound the engine output to TPixel's representable range so the
+      // narrowing cast cannot drop the high bits silently.  Skipped when
+      // sizeof(TPixel) >= sizeof(engine output) because then
+      // numeric_limits<TPixel>::max() + 1 would itself overflow.
+      pix = static_cast<TPixel>(randomNumberEngine() %
+                                (static_cast<std::mt19937::result_type>(std::numeric_limits<TPixel>::max()) + 1));
+    }
+    else
+    {
+      pix = static_cast<TPixel>(randomNumberEngine());
+    }
   }
 
   static int

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -23,85 +23,98 @@
 #include "itkIOTestHelper.h"
 #include "itkMetaDataObject.h"
 #include "itkObjectFactoryBase.h"
+#include <random>
 
 static void
-RandomPix(vnl_random &                   randgen,
+RandomPix(std::mt19937 &                 randomNumberEngine,
           itk::RGBPixel<unsigned char> & pix,
           double                         _max = itk::NumericTraits<unsigned char>::max())
 {
+  std::uniform_int_distribution<unsigned int> dist{ 0u, static_cast<unsigned int>(_max) };
   for (unsigned int i = 0; i < 3; ++i)
   {
-    pix[i] = randgen.lrand32(_max);
+    pix[i] = static_cast<unsigned char>(dist(randomNumberEngine));
   }
 }
 
 static void
-RandomPix(vnl_random & randgen, itk::RGBPixel<char> & pix, double _max = itk::NumericTraits<char>::max())
+RandomPix(std::mt19937 & randomNumberEngine, itk::RGBPixel<char> & pix, double _max = itk::NumericTraits<char>::max())
 {
+  std::uniform_int_distribution<int> dist{ 0, static_cast<int>(_max) };
   for (unsigned int i = 0; i < 3; ++i)
   {
-    pix[i] = randgen.lrand32(_max);
+    pix[i] = static_cast<char>(dist(randomNumberEngine));
   }
 }
 
 
 static void
-RandomPix(vnl_random &                     randgen,
+RandomPix(std::mt19937 &                   randomNumberEngine,
           itk::Vector<unsigned short, 3> & pix,
           double                           _max = itk::NumericTraits<unsigned short>::max())
 {
+  std::uniform_int_distribution<unsigned int> dist{ 0u, static_cast<unsigned int>(_max) };
   for (unsigned int i = 0; i < 3; ++i)
   {
-    pix[i] = randgen.lrand32(_max);
+    pix[i] = static_cast<unsigned short>(dist(randomNumberEngine));
   }
 }
 
 static void
-RandomPix(vnl_random & randgen, itk::Vector<short, 3> & pix, double _max = itk::NumericTraits<short>::max())
+RandomPix(std::mt19937 &          randomNumberEngine,
+          itk::Vector<short, 3> & pix,
+          double                  _max = itk::NumericTraits<short>::max())
 {
+  std::uniform_int_distribution<int> dist{ 0, static_cast<int>(_max) };
   for (unsigned int i = 0; i < 3; ++i)
   {
-    pix[i] = randgen.lrand32(_max);
+    pix[i] = static_cast<short>(dist(randomNumberEngine));
   }
 }
 
 static void
-RandomPix(vnl_random &                   randgen,
+RandomPix(std::mt19937 &                 randomNumberEngine,
           itk::Vector<unsigned int, 3> & pix,
           double                         _max = itk::NumericTraits<unsigned int>::max())
 {
   (void)_max;
+  std::uniform_int_distribution<unsigned int> dist;
   for (unsigned int i = 0; i < 3; ++i)
   {
-    pix[i] = randgen.lrand32();
+    pix[i] = dist(randomNumberEngine);
   }
 }
 
 static void
-RandomPix(vnl_random & randgen, itk::Vector<int, 3> & pix, double _max = itk::NumericTraits<int>::max())
+RandomPix(std::mt19937 & randomNumberEngine, itk::Vector<int, 3> & pix, double _max = itk::NumericTraits<int>::max())
 {
   (void)_max;
+  std::uniform_int_distribution<int> dist;
   for (unsigned int i = 0; i < 3; ++i)
   {
-    pix[i] = randgen.lrand32();
+    pix[i] = dist(randomNumberEngine);
   }
 }
 
 static void
-RandomPix(vnl_random & randgen, itk::Vector<float, 3> & pix, float _max = itk::NumericTraits<float>::max())
+RandomPix(std::mt19937 & randomNumberEngine, itk::Vector<float, 3> & pix, float _max = itk::NumericTraits<float>::max())
 {
+  std::uniform_real_distribution<float> dist{ 0.0f, _max };
   for (unsigned int i = 0; i < 3; ++i)
   {
-    pix[i] = randgen.drand64(_max);
+    pix[i] = dist(randomNumberEngine);
   }
 }
 
 static void
-RandomPix(vnl_random & randgen, itk::Vector<double, 3> & pix, double _max = itk::NumericTraits<double>::max())
+RandomPix(std::mt19937 &           randomNumberEngine,
+          itk::Vector<double, 3> & pix,
+          double                   _max = itk::NumericTraits<double>::max())
 {
+  std::uniform_real_distribution<double> dist{ 0.0, _max };
   for (unsigned int i = 0; i < 3; ++i)
   {
-    pix[i] = randgen.drand64(_max);
+    pix[i] = dist(randomNumberEngine);
   }
 }
 
@@ -205,27 +218,31 @@ abs_diff(const itk::Vector<unsigned short> & pix1, const itk::Vector<unsigned sh
 
 
 static void
-RandomPix(vnl_random & randgen, double & pix, double _max = itk::NumericTraits<double>::max())
+RandomPix(std::mt19937 & randomNumberEngine, double & pix, double _max = itk::NumericTraits<double>::max())
 {
-  pix = randgen.drand64(_max);
+  std::uniform_real_distribution<double> dist{ 0.0, _max };
+  pix = dist(randomNumberEngine);
 }
 
 static void
-RandomPix(vnl_random & randgen, float & pix, float _max = itk::NumericTraits<float>::max())
+RandomPix(std::mt19937 & randomNumberEngine, float & pix, float _max = itk::NumericTraits<float>::max())
 {
-  pix = randgen.drand64(_max);
+  std::uniform_real_distribution<float> dist{ 0.0f, _max };
+  pix = dist(randomNumberEngine);
 }
 
 static void
-RandomPix(vnl_random & randgen, int & pix)
+RandomPix(std::mt19937 & randomNumberEngine, int & pix)
 {
-  pix = randgen.lrand32();
+  std::uniform_int_distribution<int> dist;
+  pix = dist(randomNumberEngine);
 }
 
 static void
-RandomPix(vnl_random & randgen, unsigned int & pix)
+RandomPix(std::mt19937 & randomNumberEngine, unsigned int & pix)
 {
-  pix = randgen.lrand32();
+  std::uniform_int_distribution<unsigned int> dist;
+  pix = dist(randomNumberEngine);
 }
 
 template <typename TPixel>
@@ -237,21 +254,25 @@ abs_diff(const TPixel & pix1, const TPixel & pix2)
 
 template <typename TPixel>
 static void
-RandomVectorPix(vnl_random &                        randgen,
+RandomVectorPix(std::mt19937 &                      randomNumberEngine,
                 itk::VariableLengthVector<TPixel> & pix,
                 double                              _max = itk::NumericTraits<TPixel>::max())
 {
+  std::uniform_real_distribution<double> dist{ 0.0, _max };
   for (size_t i = 0; i < pix.GetSize(); ++i)
   {
-    pix.SetElement(i, randgen.drand64(_max));
+    pix.SetElement(i, static_cast<TPixel>(dist(randomNumberEngine)));
   }
 }
 
 template <typename TPixel>
 static void
-RandomPix(vnl_random & randgen, TPixel & pix, double _max = itk::NumericTraits<TPixel>::max())
+RandomPix(std::mt19937 & randomNumberEngine, TPixel & pix, double _max = itk::NumericTraits<TPixel>::max())
 {
-  pix = randgen.lrand32((TPixel)_max);
+  // Templated catch-all: integer pixel types here are short / unsigned short / etc.;
+  // the narrower 8-bit integer types use the explicit overloads above.
+  std::uniform_int_distribution<int> dist{ 0, static_cast<int>(_max) };
+  pix = static_cast<TPixel>(dist(randomNumberEngine));
 }
 
 template <typename TPixel>
@@ -378,7 +399,7 @@ MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double 
 
   //
   // fill image buffer
-  vnl_random                          randgen(12345678);
+  std::mt19937                        randomNumberEngine(12345678);
   itk::ImageRegionIterator<ImageType> it(im, im->GetLargestPossibleRegion());
 
   for (it.GoToBegin(); !it.IsAtEnd(); ++it)
@@ -386,11 +407,11 @@ MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double 
     TPixel pix;
     if (tolerance > 0.0)
     {
-      RandomPix(randgen, pix, 100);
+      RandomPix(randomNumberEngine, pix, 100);
     }
     else
     {
-      RandomPix(randgen, pix);
+      RandomPix(randomNumberEngine, pix);
     }
     it.Set(pix);
   }
@@ -634,7 +655,7 @@ MINCReadWriteTestVector(const char * fileName,
 
   //
   // fill image buffer
-  vnl_random                          randgen(12345678);
+  std::mt19937                        randomNumberEngine(12345678);
   itk::ImageRegionIterator<ImageType> it(im, im->GetLargestPossibleRegion());
 
   for (it.GoToBegin(); !it.IsAtEnd(); ++it)
@@ -642,11 +663,11 @@ MINCReadWriteTestVector(const char * fileName,
     InternalPixelType pix(vector_length);
     if (tolerance > 0.0)
     {
-      RandomVectorPix<TPixel>(randgen, pix, 100.0);
+      RandomVectorPix<TPixel>(randomNumberEngine, pix, 100.0);
     }
     else
     {
-      RandomVectorPix<TPixel>(randgen, pix);
+      RandomVectorPix<TPixel>(randomNumberEngine, pix);
     }
     it.Set(pix);
   }

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -25,99 +25,6 @@
 #include "itkObjectFactoryBase.h"
 #include <random>
 
-static void
-RandomPix(std::mt19937 &                 randomNumberEngine,
-          itk::RGBPixel<unsigned char> & pix,
-          double                         _max = itk::NumericTraits<unsigned char>::max())
-{
-  std::uniform_int_distribution<unsigned int> dist{ 0u, static_cast<unsigned int>(_max) };
-  for (unsigned int i = 0; i < 3; ++i)
-  {
-    pix[i] = static_cast<unsigned char>(dist(randomNumberEngine));
-  }
-}
-
-static void
-RandomPix(std::mt19937 & randomNumberEngine, itk::RGBPixel<char> & pix, double _max = itk::NumericTraits<char>::max())
-{
-  std::uniform_int_distribution<int> dist{ 0, static_cast<int>(_max) };
-  for (unsigned int i = 0; i < 3; ++i)
-  {
-    pix[i] = static_cast<char>(dist(randomNumberEngine));
-  }
-}
-
-
-static void
-RandomPix(std::mt19937 &                   randomNumberEngine,
-          itk::Vector<unsigned short, 3> & pix,
-          double                           _max = itk::NumericTraits<unsigned short>::max())
-{
-  std::uniform_int_distribution<unsigned int> dist{ 0u, static_cast<unsigned int>(_max) };
-  for (unsigned int i = 0; i < 3; ++i)
-  {
-    pix[i] = static_cast<unsigned short>(dist(randomNumberEngine));
-  }
-}
-
-static void
-RandomPix(std::mt19937 &          randomNumberEngine,
-          itk::Vector<short, 3> & pix,
-          double                  _max = itk::NumericTraits<short>::max())
-{
-  std::uniform_int_distribution<int> dist{ 0, static_cast<int>(_max) };
-  for (unsigned int i = 0; i < 3; ++i)
-  {
-    pix[i] = static_cast<short>(dist(randomNumberEngine));
-  }
-}
-
-static void
-RandomPix(std::mt19937 &                 randomNumberEngine,
-          itk::Vector<unsigned int, 3> & pix,
-          double                         _max = itk::NumericTraits<unsigned int>::max())
-{
-  (void)_max;
-  std::uniform_int_distribution<unsigned int> dist;
-  for (unsigned int i = 0; i < 3; ++i)
-  {
-    pix[i] = dist(randomNumberEngine);
-  }
-}
-
-static void
-RandomPix(std::mt19937 & randomNumberEngine, itk::Vector<int, 3> & pix, double _max = itk::NumericTraits<int>::max())
-{
-  (void)_max;
-  std::uniform_int_distribution<int> dist;
-  for (unsigned int i = 0; i < 3; ++i)
-  {
-    pix[i] = dist(randomNumberEngine);
-  }
-}
-
-static void
-RandomPix(std::mt19937 & randomNumberEngine, itk::Vector<float, 3> & pix, float _max = itk::NumericTraits<float>::max())
-{
-  std::uniform_real_distribution<float> dist{ 0.0f, _max };
-  for (unsigned int i = 0; i < 3; ++i)
-  {
-    pix[i] = dist(randomNumberEngine);
-  }
-}
-
-static void
-RandomPix(std::mt19937 &           randomNumberEngine,
-          itk::Vector<double, 3> & pix,
-          double                   _max = itk::NumericTraits<double>::max())
-{
-  std::uniform_real_distribution<double> dist{ 0.0, _max };
-  for (unsigned int i = 0; i < 3; ++i)
-  {
-    pix[i] = dist(randomNumberEngine);
-  }
-}
-
 static double
 abs_diff(const itk::RGBPixel<unsigned char> & pix1, const itk::RGBPixel<unsigned char> & pix2)
 {
@@ -217,34 +124,6 @@ abs_diff(const itk::Vector<unsigned short> & pix1, const itk::Vector<unsigned sh
 }
 
 
-static void
-RandomPix(std::mt19937 & randomNumberEngine, double & pix, double _max = itk::NumericTraits<double>::max())
-{
-  std::uniform_real_distribution<double> dist{ 0.0, _max };
-  pix = dist(randomNumberEngine);
-}
-
-static void
-RandomPix(std::mt19937 & randomNumberEngine, float & pix, float _max = itk::NumericTraits<float>::max())
-{
-  std::uniform_real_distribution<float> dist{ 0.0f, _max };
-  pix = dist(randomNumberEngine);
-}
-
-static void
-RandomPix(std::mt19937 & randomNumberEngine, int & pix)
-{
-  std::uniform_int_distribution<int> dist;
-  pix = dist(randomNumberEngine);
-}
-
-static void
-RandomPix(std::mt19937 & randomNumberEngine, unsigned int & pix)
-{
-  std::uniform_int_distribution<unsigned int> dist;
-  pix = dist(randomNumberEngine);
-}
-
 template <typename TPixel>
 static double
 abs_diff(const TPixel & pix1, const TPixel & pix2)
@@ -263,16 +142,6 @@ RandomVectorPix(std::mt19937 &                      randomNumberEngine,
   {
     pix.SetElement(i, static_cast<TPixel>(dist(randomNumberEngine)));
   }
-}
-
-template <typename TPixel>
-static void
-RandomPix(std::mt19937 & randomNumberEngine, TPixel & pix, double _max = itk::NumericTraits<TPixel>::max())
-{
-  // Templated catch-all: integer pixel types here are short / unsigned short / etc.;
-  // the narrower 8-bit integer types use the explicit overloads above.
-  std::uniform_int_distribution<int> dist{ 0, static_cast<int>(_max) };
-  pix = static_cast<TPixel>(dist(randomNumberEngine));
 }
 
 template <typename TPixel>
@@ -407,11 +276,11 @@ MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double 
     TPixel pix;
     if (tolerance > 0.0)
     {
-      RandomPix(randomNumberEngine, pix, 100);
+      itk::IOTestHelper::RandomPix(randomNumberEngine, pix, 100);
     }
     else
     {
-      RandomPix(randomNumberEngine, pix);
+      itk::IOTestHelper::RandomPix(randomNumberEngine, pix);
     }
     it.Set(pix);
   }

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest.h
@@ -37,7 +37,7 @@
 #include "itkRGBAPixel.h"
 #include "itkRandomImageSource.h"
 
-#include "vnl/vnl_random.h"
+#include <random>
 #include "itkMath.h"
 
 #include "nifti1_io.h"
@@ -321,7 +321,7 @@ TestImageOfSymMats(const std::string & fname)
                 PixelType pixel;
                 for (unsigned int q = 0; q < pixel.Size(); ++q)
                 {
-                  // pixel[q] = randgen.drand32(lowrange,highrange);
+                  // pixel[q] = randomNumberEngine.drand32(lowrange,highrange);
                   pixel[q] = incr_value++;
                 }
                 for (unsigned int q = 0; q < VDimension; ++q)
@@ -475,14 +475,15 @@ RGBTest(int argc, char * argv[])
 
   const typename RGBImageType::Pointer im =
     itk::IOTestHelper::AllocateImageFromRegionAndSpacing<RGBImageType>(imageRegion, spacing);
-  vnl_random                             randgen(12345678);
-  itk::ImageRegionIterator<RGBImageType> it(im, im->GetLargestPossibleRegion());
+  std::mt19937                                randomNumberEngine(12345678);
+  std::uniform_int_distribution<unsigned int> dist{ 0u, 255u };
+  itk::ImageRegionIterator<RGBImageType>      it(im, im->GetLargestPossibleRegion());
   for (it.GoToBegin(); !it.IsAtEnd(); ++it)
   {
     RGBPixelType pix;
     for (unsigned int i = 0; i < RGBPixelType::Dimension; ++i)
     {
-      pix[i] = randgen.lrand32(255);
+      pix[i] = static_cast<typename RGBPixelType::ComponentType>(dist(randomNumberEngine));
     }
     it.Set(pix);
   }

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
@@ -116,7 +116,7 @@ TestImageOfVectors(const std::string & fname, const std::string & intentCode = "
                 FieldPixelType pixel;
                 for (size_t q = 0; q < TVecLength; ++q)
                 {
-                  // pixel[q] = randgen.drand32(lowrange,highrange);
+                  // pixel[q] = randomNumberEngine.drand32(lowrange,highrange);
                   Decrement(value);
                   pixel[q] = value;
                 }

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest4.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest4.cxx
@@ -18,6 +18,7 @@
 
 
 #include "itkNiftiImageIOTest.h"
+#include <random>
 
 using Test4ImageType = itk::Image<unsigned char, 3>;
 
@@ -64,7 +65,8 @@ itkNiftiImageIOTest4(int argc, char * argv[])
 
   // arbitrarily rotate the unit vectors to pick random direction
   // cosines;
-  vnl_random randgen(8775070);
+  std::mt19937                           randomNumberEngine(8775070);
+  std::uniform_real_distribution<double> angleDist{ 0.0, 2.0 * 3.1415926 };
 
   using TransformType = itk::AffineTransform<double, 3>;
   using AxisType = itk::Vector<double, 3>;
@@ -74,15 +76,15 @@ itkNiftiImageIOTest4(int argc, char * argv[])
   axis[0] = 1.0;
   axis[1] = 0.0;
   axis[2] = 0.0;
-  transform->Rotate3D(axis, randgen.drand32(0, 3.1415926 * 2.0));
+  transform->Rotate3D(axis, angleDist(randomNumberEngine));
   axis[0] = 0.0;
   axis[1] = 1.0;
   axis[2] = 0.0;
-  transform->Rotate3D(axis, randgen.drand32(0, 3.1415926 * 2.0));
+  transform->Rotate3D(axis, angleDist(randomNumberEngine));
   axis[0] = 0.0;
   axis[1] = 0.0;
   axis[2] = 1.0;
-  transform->Rotate3D(axis, randgen.drand32(0, 3.1415926 * 2.0));
+  transform->Rotate3D(axis, angleDist(randomNumberEngine));
   TransformType::MatrixType mat = transform->GetMatrix();
   for (unsigned int i = 0; i < 3; ++i)
   {

--- a/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
@@ -18,6 +18,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <random>
 #include "itkMINCTransformIOFactory.h"
 #include "itkMINCImageIOFactory.h"
 #include "itkMINCTransformIO.h"
@@ -40,21 +41,23 @@ using MINCTransformIO = itk::MINCTransformIO;
 
 template <typename T>
 void
-RandomPix(vnl_random & randgen, itk::Vector<T, 3> & pix, double _max = itk::NumericTraits<T>::max())
+RandomPix(std::mt19937 & randomNumberEngine, itk::Vector<T, 3> & pix, double _max = itk::NumericTraits<T>::max())
 {
+  std::uniform_real_distribution<double> dist{ 0.0, _max };
   for (unsigned int i = 0; i < 3; ++i)
   {
-    pix[i] = randgen.drand64(_max);
+    pix[i] = static_cast<T>(dist(randomNumberEngine));
   }
 }
 
 template <typename T>
 void
-RandomPoint(vnl_random & randgen, itk::Point<T, 3> & pix, double _max = itk::NumericTraits<T>::max())
+RandomPoint(std::mt19937 & randomNumberEngine, itk::Point<T, 3> & pix, double _max = itk::NumericTraits<T>::max())
 {
+  std::uniform_real_distribution<double> dist{ 0.0, _max };
   for (unsigned int i = 0; i < 3; ++i)
   {
-    pix[i] = randgen.drand64(_max);
+    pix[i] = static_cast<T>(dist(randomNumberEngine));
   }
 }
 
@@ -122,7 +125,7 @@ check_linear(const char * linear_transform, bool ras_to_lps)
   std::cout << "Read transform : " << std::endl;
   // affine2->Print(std::cout);
 
-  vnl_random randgen(12345678);
+  std::mt19937 randomNumberEngine(12345678);
 
   AffineTransformType::InputPointType pnt, pnt2;
 
@@ -132,7 +135,7 @@ check_linear(const char * linear_transform, bool ras_to_lps)
     AffineTransformType::OutputPointType v1;
     AffineTransformType::OutputPointType v2;
 
-    RandomPoint<double>(randgen, pnt, 100);
+    RandomPoint<double>(randomNumberEngine, pnt, 100);
     pnt2 = pnt;
     v1 = affine->TransformPoint(pnt);
     v2 = affine2->TransformPoint(pnt2);
@@ -185,7 +188,7 @@ check_nonlinear_double(const char * nonlinear_transform, bool ras_to_lps)
   DisplacementFieldType::PixelType zeroDisplacement{};
   field->FillBuffer(zeroDisplacement);
 
-  vnl_random                                      randgen(12345678);
+  std::mt19937                                    randomNumberEngine(12345678);
   itk::ImageRegionIterator<DisplacementFieldType> it(field, field->GetLargestPossibleRegion());
 
   for (it.GoToBegin(); !it.IsAtEnd(); ++it)
@@ -193,11 +196,11 @@ check_nonlinear_double(const char * nonlinear_transform, bool ras_to_lps)
     DisplacementFieldType::PixelType pix;
     if (tolerance > 0.0)
     {
-      RandomPix<double>(randgen, pix, 100);
+      RandomPix<double>(randomNumberEngine, pix, 100);
     }
     else
     {
-      RandomPix<double>(randgen, pix);
+      RandomPix<double>(randomNumberEngine, pix);
     }
     it.Set(pix);
   }
@@ -318,7 +321,7 @@ check_nonlinear_float(const char * nonlinear_transform, bool ras_to_lps)
   DisplacementFieldType::PixelType zeroDisplacement{};
   field->FillBuffer(zeroDisplacement);
 
-  vnl_random                                      randgen(12345678);
+  std::mt19937                                    randomNumberEngine(12345678);
   itk::ImageRegionIterator<DisplacementFieldType> it(field, field->GetLargestPossibleRegion());
 
   for (it.GoToBegin(); !it.IsAtEnd(); ++it)
@@ -326,11 +329,11 @@ check_nonlinear_float(const char * nonlinear_transform, bool ras_to_lps)
     DisplacementFieldType::PixelType pix;
     if (tolerance > 0.0)
     {
-      RandomPix<float>(randgen, pix, 100);
+      RandomPix<float>(randomNumberEngine, pix, 100);
     }
     else
     {
-      RandomPix<float>(randgen, pix);
+      RandomPix<float>(randomNumberEngine, pix);
     }
     it.Set(pix);
   }
@@ -523,7 +526,7 @@ check_composite(const char * transform_file, bool ras_to_lps)
   std::cout << "Read transform : " << std::endl;
   // affine_xfm->(std::cout);
 
-  vnl_random randgen(12345678);
+  std::mt19937 randomNumberEngine(12345678);
 
   AffineTransformType::InputPointType pnt, pnt2;
 
@@ -533,7 +536,7 @@ check_composite(const char * transform_file, bool ras_to_lps)
     AffineTransformType::OutputPointType v1;
     AffineTransformType::OutputPointType v2;
 
-    RandomPoint<double>(randgen, pnt, 100);
+    RandomPoint<double>(randomNumberEngine, pnt, 100);
     pnt2 = pnt;
     v1 = compositeTransform->TransformPoint(pnt);
     v2 = affine_xfm->TransformPoint(pnt2);

--- a/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx
@@ -41,17 +41,6 @@ using MINCTransformIO = itk::MINCTransformIO;
 
 template <typename T>
 void
-RandomPix(std::mt19937 & randomNumberEngine, itk::Vector<T, 3> & pix, double _max = itk::NumericTraits<T>::max())
-{
-  std::uniform_real_distribution<double> dist{ 0.0, _max };
-  for (unsigned int i = 0; i < 3; ++i)
-  {
-    pix[i] = static_cast<T>(dist(randomNumberEngine));
-  }
-}
-
-template <typename T>
-void
 RandomPoint(std::mt19937 & randomNumberEngine, itk::Point<T, 3> & pix, double _max = itk::NumericTraits<T>::max())
 {
   std::uniform_real_distribution<double> dist{ 0.0, _max };
@@ -196,11 +185,11 @@ check_nonlinear_double(const char * nonlinear_transform, bool ras_to_lps)
     DisplacementFieldType::PixelType pix;
     if (tolerance > 0.0)
     {
-      RandomPix<double>(randomNumberEngine, pix, 100);
+      itk::IOTestHelper::RandomPix(randomNumberEngine, pix, 100);
     }
     else
     {
-      RandomPix<double>(randomNumberEngine, pix);
+      itk::IOTestHelper::RandomPix(randomNumberEngine, pix);
     }
     it.Set(pix);
   }
@@ -329,11 +318,11 @@ check_nonlinear_float(const char * nonlinear_transform, bool ras_to_lps)
     DisplacementFieldType::PixelType pix;
     if (tolerance > 0.0)
     {
-      RandomPix<float>(randomNumberEngine, pix, 100);
+      itk::IOTestHelper::RandomPix(randomNumberEngine, pix, 100);
     }
     else
     {
-      RandomPix<float>(randomNumberEngine, pix);
+      itk::IOTestHelper::RandomPix(randomNumberEngine, pix);
     }
     it.Set(pix);
   }

--- a/Modules/IO/TransformMINC/test/itkMINCTransformAdapterTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkMINCTransformAdapterTest.cxx
@@ -40,17 +40,6 @@ static constexpr int    point_counter = 1000;
 
 template <typename T>
 void
-RandomPix(std::mt19937 & randomNumberEngine, itk::Vector<T, 3> & pix, double _max = itk::NumericTraits<T>::max())
-{
-  std::uniform_real_distribution<double> dist{ 0.0, _max };
-  for (unsigned int i = 0; i < 3; ++i)
-  {
-    pix[i] = static_cast<T>(dist(randomNumberEngine));
-  }
-}
-
-template <typename T>
-void
 RandomPoint(std::mt19937 & randomNumberEngine, itk::Point<T, 3> & pix, double _max = itk::NumericTraits<T>::max())
 {
   std::uniform_real_distribution<double> dist{ 0.0, _max };
@@ -173,11 +162,11 @@ compare_nonlinear_double(const char * nonlinear_transform)
     DisplacementFieldType::PixelType pix;
     if (tolerance > 0.0)
     {
-      RandomPix<double>(randomNumberEngine, pix, 100);
+      itk::IOTestHelper::RandomPix(randomNumberEngine, pix, 100);
     }
     else
     {
-      RandomPix<double>(randomNumberEngine, pix);
+      itk::IOTestHelper::RandomPix(randomNumberEngine, pix);
     }
     it.Set(pix);
   }

--- a/Modules/IO/TransformMINC/test/itkMINCTransformAdapterTest.cxx
+++ b/Modules/IO/TransformMINC/test/itkMINCTransformAdapterTest.cxx
@@ -18,6 +18,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <random>
 #include "itkMINCTransformIOFactory.h"
 #include "itkTransformFileWriter.h"
 #include "itkTransformFileReader.h"
@@ -39,21 +40,23 @@ static constexpr int    point_counter = 1000;
 
 template <typename T>
 void
-RandomPix(vnl_random & randgen, itk::Vector<T, 3> & pix, double _max = itk::NumericTraits<T>::max())
+RandomPix(std::mt19937 & randomNumberEngine, itk::Vector<T, 3> & pix, double _max = itk::NumericTraits<T>::max())
 {
+  std::uniform_real_distribution<double> dist{ 0.0, _max };
   for (unsigned int i = 0; i < 3; ++i)
   {
-    pix[i] = randgen.drand64(_max);
+    pix[i] = static_cast<T>(dist(randomNumberEngine));
   }
 }
 
 template <typename T>
 void
-RandomPoint(vnl_random & randgen, itk::Point<T, 3> & pix, double _max = itk::NumericTraits<T>::max())
+RandomPoint(std::mt19937 & randomNumberEngine, itk::Point<T, 3> & pix, double _max = itk::NumericTraits<T>::max())
 {
+  std::uniform_real_distribution<double> dist{ 0.0, _max };
   for (unsigned int i = 0; i < 3; ++i)
   {
-    pix[i] = randgen.drand64(_max);
+    pix[i] = static_cast<T>(dist(randomNumberEngine));
   }
 }
 
@@ -102,7 +105,7 @@ compare_linear(const char * linear_transform)
 
     xfm->OpenXfm(linear_transform);
 
-    vnl_random randgen(12345678);
+    std::mt19937 randomNumberEngine(12345678);
 
     AffineTransformType::InputPointType pnt, pnt2;
 
@@ -111,7 +114,7 @@ compare_linear(const char * linear_transform)
       AffineTransformType::OutputPointType v1;
       AffineTransformType::OutputPointType v2;
 
-      RandomPoint<double>(randgen, pnt, 100);
+      RandomPoint<double>(randomNumberEngine, pnt, 100);
       pnt2 = pnt;
       v1 = affine->TransformPoint(pnt);
       v2 = xfm->TransformPoint(pnt2);
@@ -162,7 +165,7 @@ compare_nonlinear_double(const char * nonlinear_transform)
   DisplacementFieldType::PixelType zeroDisplacement{};
   field->FillBuffer(zeroDisplacement);
 
-  vnl_random                                               randgen(12345678);
+  std::mt19937                                             randomNumberEngine(12345678);
   itk::ImageRegionIteratorWithIndex<DisplacementFieldType> it(field, field->GetLargestPossibleRegion());
 
   for (it.GoToBegin(); !it.IsAtEnd(); ++it)
@@ -170,11 +173,11 @@ compare_nonlinear_double(const char * nonlinear_transform)
     DisplacementFieldType::PixelType pix;
     if (tolerance > 0.0)
     {
-      RandomPix<double>(randgen, pix, 100);
+      RandomPix<double>(randomNumberEngine, pix, 100);
     }
     else
     {
-      RandomPix<double>(randgen, pix);
+      RandomPix<double>(randomNumberEngine, pix);
     }
     it.Set(pix);
   }


### PR DESCRIPTION
Eliminates ITK's only non-vendored uses of `vnl_random` (8 test files, 16 `lrand32`/`drand32`/`drand64`/`normal()` call sites) by switching to C++17 `<random>`. Unblocks an upstream vxl deprecation effort (see vxl/vxl#976) without breaking ITK CI.

<details>
<summary>Why this PR exists</summary>

vxl issue [vxl/vxl#976](https://github.com/vxl/vxl/issues/976) flagged `vnl_random::lrand32()` for type-design problems: `unsigned long` is not a 32-bit type on LP64 platforms, the four overloads share a name despite returning a mix of signed and unsigned types, and the documentation was inaccurate. The vxl maintainers' agreed migration plan is to add a strongly-typed replacement, then mark `lrand32()` as `[[deprecated]]`.

Applying `[[deprecated]]` upstream would emit warnings on every ITK build that includes `Modules/IO/ImageBase/include/itkIOTestHelper.h` — which is also consumed by Slicer, BRAINSTools, and other NAMIC downstream projects. Any CI configuration with `-Werror=deprecated-declarations` would break.

This PR removes ITK's dependence on `vnl_random` so that the upstream deprecation can land cleanly.
</details>

<details>
<summary>Substitution table</summary>

| Old (vxl) | New (`<random>`) |
|---|---|
| `vnl_random rng(seed)` | `std::mt19937 rng(seed)` |
| `vnl_random &` (param) | `std::mt19937 &` |
| `rng.lrand32()` | `std::uniform_int_distribution<uint32_t>{}(rng)` |
| `rng.lrand32(MAX)` | `std::uniform_int_distribution<T>{0, MAX}(rng)` |
| `rng.drand32(a, b)` | `std::uniform_real_distribution<double>{a, b}(rng)` |
| `rng.drand64(MAX)` | `std::uniform_real_distribution<T>{0, MAX}(rng)` |
| `rng.normal()` | `std::normal_distribution<double>{0.0, 1.0}(rng)` |
| `#include "vnl/vnl_random.h"` | `#include <random>` |

For 8-bit integer pixel types (`char`, `signed char`, `unsigned char`) the draw is performed in `int` / `unsigned int` and narrowed back, since `std::uniform_int_distribution` is undefined for char-sized template arguments per the C++ standard.
</details>

<details>
<summary>Files changed</summary>

| File | Notes |
|---|---|
| `Modules/IO/ImageBase/include/itkIOTestHelper.h` | 6 `RandomPix` overloads rewritten + uses `std::conditional_t` to handle small integer pixel types |
| `Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx` | type swap only |
| `Modules/IO/MINC/test/itkMINCImageIOTest.cxx` | 16 `RandomPix` / `RandomVectorPix` overloads rewritten |
| `Modules/IO/NIFTI/test/itkNiftiImageIOTest.h` | RGB random fill |
| `Modules/IO/NIFTI/test/itkNiftiImageIOTest4.cxx` | random rotation angles |
| `Modules/IO/TransformMINC/test/itkIOTransformMINCTest.cxx` | `RandomPix` + `RandomPoint` template helpers |
| `Modules/IO/TransformMINC/test/itkMINCTransformAdapterTest.cxx` | same pattern |
| `Modules/Filtering/DisplacementField/test/itkExponentialDisplacementFieldImageFilterTest.cxx` | `rng.normal()` → `std::normal_distribution`; switched from clock-seeded default to fixed seed for CI reproducibility |
</details>

<details>
<summary>No bit-identity dependence</summary>

Audited every test that uses `vnl_random` in this set:

| Test | Comparison pattern |
|---|---|
| `itkHDF5ImageIOTest` | `it.Get() == it2.Get()` (in-memory iter on written vs read-back) |
| `itkMINCImageIOTest*` | round-trip iter compare |
| `itkIOTransformMINCTest` | `FloatAlmostEqual(expectedDiff, ...)` where `expectedDiff` is computed at runtime from the same data |
| `itkMINCTransformAdapterTest` | same |
| `itkNiftiImageIOTest*` | round-trip iter compare |
| `itkExponentialDisplacementFieldImageFilterTest` | self-comparing |

No test compares against a baseline image, MD5, checksum, or externally-fixed expected pixel value. Random sequence change is safe.
</details>

<details>
<summary>Verification</summary>

Built clean against current `master` (`37c14069c1`) with `-DCMAKE_CXX_STANDARD=17 -DBUILD_TESTING=ON -DModule_ITKIOMINC=ON -DModule_ITKIOTransformMINC=ON`. All 5 affected test drivers compile and link.

Tests that exercise the migrated random-fill paths and ran successfully on the local sandbox:

```
itkExponentialDisplacementFieldImageFilterTest          Passed
itkHDF5ImageIOTest                                      Passed
itkMINCImageIOTest1                                     Passed
itkIOTransformMINCTest                                  Passed
itkMINCTransformAdapterTest                             Passed
itkNiftiIOInternalTests                                 Passed
```

Other test failures observed locally are unrelated missing-`ExternalData` errors (`cthead1.tif`, `t1_z+_byte_cor.mnc`, `SmallVoxels.nii.gz`) — the fresh build hadn't downloaded the required test data. CI will fetch this and exercise the full set.
</details>

<!--
provenance: claude-code session 2026-04-27
companion_prs:
  - vxl/vxl#1026 (DOC: lrand32 doc-comment fix)
  - vxl/vxl#1027 (ENH: next_uint32/next_int32 fixed-width replacement API)
post_merge_action_in_vxl: apply [[deprecated]] to lrand32() overloads in core/vnl/vnl_random.h
files_touched: 8 (Modules/IO + Modules/Filtering/DisplacementField)
production_callers_in_itk: 0 (test-only code)
-->