### PR TITLE
BUG: Allow . and + in -march/-mtune strip regex (issue #6133, backport to release-5.4)

### DIFF
--- a/Wrapping/macro_files/itk_auto_load_submodules.cmake
+++ b/Wrapping/macro_files/itk_auto_load_submodules.cmake
@@ -25,8 +25,10 @@ function(generate_castxml_commandline_flags)
     set(_castxml_cc_flags "${_castxml_cc_flags} ${CMAKE_CXX${CMAKE_CXX_STANDARD}_STANDARD_COMPILE_OPTION}")
   endif()
 
-  # Aggressive optimization flags cause cast_xml to give invalid error conditions
-  set(INVALID_OPTIMIZATION_FLAGS "-fopenmp;-march=[a-zA-Z0-9\-]*;-mtune=[a-zA-Z0-9\-]*;-mfma")
+  # Aggressive optimization flags cause cast_xml to give invalid error conditions.
+  # The -march=/-mtune= class must accept '.','+','_' to strip extended targets
+  # like armv8.2-a+fp16 or znver3 as one token (issue #6133).
+  set(INVALID_OPTIMIZATION_FLAGS "-fopenmp;-march=[A-Za-z0-9._+\-]*;-mtune=[A-Za-z0-9._+\-]*;-mfma")
   foreach(rmmatch ${INVALID_OPTIMIZATION_FLAGS})
     string(
       REGEX


### PR DESCRIPTION
Backport of the main-branch fix for #6133 to `release-5.4`, slated for inclusion in 5.4.7. One-line regex tweak in `Wrapping/macro_files/itk_auto_load_submodules.cmake`.

On Arch Linux aarch64 with `CXXFLAGS="-march=armv8.2-a+fp16+rcpc+dotprod+crypto"`, the strip regex `-march=[a-zA-Z0-9\-]*` matched only the `armv8` prefix and left `.2-a+fp16+rcpc+dotprod+crypto` dangling — clang then read it as a positional file and failed:

```
clang++: error: no such file or directory: '.2-a+fp16+rcpc+dotprod+crypto'
```

Widen the class to `[A-Za-z0-9._+\-]*` so the entire `-march=`/`-mtune=` token is consumed.

<details>
<summary>Why a separate backport PR (rather than auto-cherry-pick)</summary>

`release-5.4`'s copy of the file uses the older single-line CMake formatting (pre-`gersemi`), so the line-level diff differs from main even though the change is semantically identical. The fix on main lands separately on `main` against the gersemi-formatted file.

</details>

<details>
<summary>Verification</summary>

Same minimal CMake regex repro as the main-branch PR confirms the buggy class drops the dangling tail and the fixed class consumes it cleanly. No build/test changes; this is a configure-time string tweak with no API/ABI impact.

</details>

Cross-reference:
- Main-branch fix: #6158 (draft)
- Issue: #6133 (reporter: @solskogen)

<!--
provenance: claude-code session 2026-04-28, opus-4-7
issue: InsightSoftwareConsortium/ITK#6133
local_branch: hjmjohnson:fix-issue-6133-march-regex-rel54
local_commit: dd09e8fc41
worktree: /Users/johnsonhj/src/ITK-issue-6133-rel54
base_sha: ccb17dc0e4 (upstream/release-5.4)
companion_main_branch: hjmjohnson:fix-issue-6133-march-regex
target_release: 5.4.7
-->