### PR TITLE
BUG: Allow . and + in -march/-mtune strip regex (issue #6133)

### DIFF
--- a/Wrapping/macro_files/itk_auto_load_submodules.cmake
+++ b/Wrapping/macro_files/itk_auto_load_submodules.cmake
@@ -31,10 +31,12 @@ function(generate_castxml_commandline_flags)
     )
   endif()
 
-  # Aggressive optimization flags cause cast_xml to give invalid error conditions
+  # Aggressive optimization flags cause cast_xml to give invalid error conditions.
+  # The -march=/-mtune= class must accept '.','+','_' to strip extended targets
+  # like armv8.2-a+fp16 or znver3 as one token (issue #6133).
   set(
     INVALID_OPTIMIZATION_FLAGS
-    "-fopenmp;-march=[a-zA-Z0-9\-]*;-mtune=[a-zA-Z0-9\-]*;-mfma"
+    "-fopenmp;-march=[A-Za-z0-9._+\-]*;-mtune=[A-Za-z0-9._+\-]*;-mfma"
   )
   foreach(rmmatch ${INVALID_OPTIMIZATION_FLAGS})
     string(REGEX REPLACE ${rmmatch} "" _castxml_cc_flags "${_castxml_cc_flags}")


### PR DESCRIPTION
Fixes #6133. The `generate_castxml_commandline_flags()` macro strips `-march=`/`-mtune=` from the C++ flags before forwarding them to castxml's bundled clang preprocessor, but the regex character class `[a-zA-Z0-9\-]*` stopped at the first `.` or `+`. On Arch Linux aarch64 with `CXXFLAGS="-march=armv8.2-a+fp16+rcpc+dotprod+crypto"`, only the `armv8` prefix matched, leaving `.2-a+fp16+rcpc+dotprod+crypto` dangling — clang then read it as a positional file argument:

```
clang++: error: no such file or directory: '.2-a+fp16+rcpc+dotprod+crypto'
```

Extending the class to `[A-Za-z0-9._+\-]*` matches the entire token. The same fix covers extended x86 names (`-march=znver3`, `-march=skylake-avx512`).

<details>
<summary>Reproduction</summary>

Minimal CMake script (no full build needed) demonstrates the regex behavior:

```cmake
set(_flags "-O2 -march=armv8.2-a+fp16+rcpc+dotprod+crypto -DNDEBUG -fopenmp -mtune=cortex-a76 -mfma")

# BEFORE (buggy)
set(BAD "-fopenmp;-march=[a-zA-Z0-9\\-]*;-mtune=[a-zA-Z0-9\\-]*;-mfma")
foreach(rmmatch ${BAD})
  string(REGEX REPLACE ${rmmatch} "" out "${_flags}")
  set(_flags "${out}")
endforeach()
# out = "-O2 .2-a+fp16+rcpc+dotprod+crypto -DNDEBUG   "  <-- dangling

# AFTER (fixed)
set(GOOD "-fopenmp;-march=[A-Za-z0-9._+\\-]*;-mtune=[A-Za-z0-9._+\\-]*;-mfma")
# out = "-O2  -DNDEBUG   "  <-- clean
```

End-to-end verification: configured ITK in this branch with
```
cmake -DITK_WRAP_PYTHON=ON \
      -DCMAKE_CXX_FLAGS="-march=armv8.2-a+fp16+rcpc+dotprod+crypto -O2" ..
```
and grep'd the resulting `build.ninja` castxml command lines — no `-march=` fragment remains in the `--castxml-cc-gnu (...)` block (while the host C++ compile commands still receive the full `-march=` flag, which is what we want).

</details>

<details>
<summary>Backport plan</summary>

Per the maintainer comment on #6133, this also wants to land on `release-5.4` for inclusion in 5.4.7. The change is a one-line regex tweak with no API or ABI implications — clean cherry-pick candidate.

</details>

<!--
provenance: claude-code session 2026-04-28, opus-4-7
issue: InsightSoftwareConsortium/ITK#6133
reporter: solskogen (Christer Solskogen)
local_branch: hjmjohnson:fix-issue-6133-march-regex
local_commit: 97ec2a3d
worktree: /Users/johnsonhj/src/ITK-issue-6133
verification: minimal CMake repro at /tmp/itk-issue-6133-repro.cmake; full ITK_WRAP_PYTHON=ON configure at /Users/johnsonhj/src/ITK-issue-6133/build (cmake configure exit 0, build.ninja castxml lines clean)
backport_target: release-5.4
-->
