### PR TITLE
WIP: Test Python build acceleration with CMake JOB_POOLS

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -1,29 +1,7 @@
 name: ITK.Arm64
 
 on:
-    push:
-        branches:
-            - main
-            - 'release*'
-        paths-ignore:
-            - '*.md'
-            - LICENSE
-            - NOTICE
-            - 'Documentation/**'
-            - 'Utilities/Debugger/**'
-            - 'Utilities/ITKv5Preparation/**'
-            - 'Utilities/Maintenance/**'
-            - 'Modules/Remote/*.remote.cmake'
-    pull_request:
-        paths-ignore:
-            - '*.md'
-            - LICENSE
-            - NOTICE
-            - 'Documentation/**'
-            - 'Utilities/Debugger/**'
-            - 'Utilities/ITKv5Preparation/**'
-            - 'Utilities/Maintenance/**'
-            - 'Modules/Remote/*.remote.cmake'
+    workflow_dispatch:
 
 concurrency:
   group: '${{ github.workflow }}@${{ github.head_ref || github.ref }}'

--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -1,29 +1,7 @@
 name: ITK.Pixi
 
 on:
-    push:
-        branches:
-            - main
-            - 'release*'
-        paths-ignore:
-            - '*.md'
-            - LICENSE
-            - NOTICE
-            - 'Documentation/**'
-            - 'Utilities/Debugger/**'
-            - 'Utilities/ITKv5Preparation/**'
-            - 'Utilities/Maintenance/**'
-            - 'Modules/Remote/*.remote.cmake'
-    pull_request:
-        paths-ignore:
-            - '*.md'
-            - LICENSE
-            - NOTICE
-            - 'Documentation/**'
-            - 'Utilities/Debugger/**'
-            - 'Utilities/ITKv5Preparation/**'
-            - 'Utilities/Maintenance/**'
-            - 'Modules/Remote/*.remote.cmake'
+    workflow_dispatch:
 
 concurrency:
   group: '${{ github.workflow }}@${{ github.head_ref || github.ref }}'

--- a/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
@@ -2,12 +2,7 @@
 
 name: ITK.Batch
 
-trigger:
-  batch: true
-  branches:
-    include:
-    - main
-    - release*
+trigger: none
 pr: none
 
 variables:

--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -1,31 +1,8 @@
 name: ITK.Linux
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
+
 variables:
   ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -111,6 +111,10 @@ jobs:
           CMAKE_C_COMPILER_LAUNCHER:STRING=ccache
           CMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache
           ITK_COMPUTER_MEMORY_SIZE:STRING=4.5
+          CMAKE_JOB_POOLS:STRING=compile=4;link=2
+          CMAKE_JOB_POOL_COMPILE:STRING=compile
+          CMAKE_JOB_POOL_LINK:STRING=link
+          CMAKE_JOB_POOL_PRECOMPILE_HEADER:STRING=compile
         ")
         include(\$ENV{AGENT_BUILDDIRECTORY}/ITK-dashboard/azure_dashboard.cmake)
         EOF
@@ -124,7 +128,7 @@ jobs:
         c++ --version
         cmake --version
 
-        ctest -S $(Agent.BuildDirectory)/ITK-dashboard/dashboard.cmake -V -j 2 -L Python -E "(PythonExtrasTest)|(PythonFastMarching)|(PythonLazyLoadingImage)|(PythonThresholdSegmentationLevelSetWhiteMatterTest)|(PythonVerifyTTypeAPIConsistency)|(PythonWatershedSegmentation1Test)"
+        ctest -S $(Agent.BuildDirectory)/ITK-dashboard/dashboard.cmake -V -j 8 -L Python -E "(PythonExtrasTest)|(PythonFastMarching)|(PythonLazyLoadingImage)|(PythonThresholdSegmentationLevelSetWhiteMatterTest)|(PythonVerifyTTypeAPIConsistency)|(PythonWatershedSegmentation1Test)"
       displayName: 'Build and test'
       env:
         CTEST_OUTPUT_ON_FAILURE: 1

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -1,31 +1,8 @@
 name: ITK.macOS
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
+
 variables:
   ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -1,31 +1,8 @@
 name: ITK.macOS.Python
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
+
 variables:
   ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache

--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -1,31 +1,8 @@
 name: ITK.Windows
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
+
 variables:
   ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -1,31 +1,8 @@
 name: ITK.Windows.Python
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
+
 variables:
   ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache


### PR DESCRIPTION
**WIP — measurement only, do not merge.** Two-commit experiment to test whether CMake's Ninja `JOB_POOLS` can decouple compile vs link parallelism on `ITK.Linux.Python` and unlock the wrapping compile phase that's currently throttled to `-j 2` to avoid OOM at link time.

Sequence:
1. **Commit 1 (current HEAD)**: disables every CI lane except `ITK.Linux.Python` so the only pipeline running here is the one we're measuring. This commit's CI run is the **baseline** at the existing `-j 2` / no-pools config.
2. **Commit 2** (held locally as tag `wip-with-pools-local`, pushed after commit 1's CI completes): adds `CMAKE_JOB_POOLS=compile=4;link=2` and bumps `ctest -j 2 → -j 8`. This commit's CI run gives the **with-pools** wall time.

After both runs complete, I'll diff the Azure DevOps timings and post a comparison comment.

<details>
<summary>Why two pushes instead of two commits in one push</summary>

Azure DevOps only runs the pipeline against the latest commit on each push. To get an A/B comparison on the same branch, the baseline commit needs its own CI cycle before the with-pools commit lands. The `wip-with-pools-local` git tag preserves commit 2 locally so it can be force-pushed without re-creating it.

</details>

<details>
<summary>What's disabled on commit 1</summary>

Replaced trigger blocks with `trigger: none` / `pr: none` (Azure) or `on: workflow_dispatch:` (GH Actions):

- `Testing/ContinuousIntegration/AzurePipelinesBatch.yml`
- `Testing/ContinuousIntegration/AzurePipelinesLinux.yml` (Linux + LinuxLegacyRemoved + LinuxCxx20 jobs)
- `Testing/ContinuousIntegration/AzurePipelinesMacOS.yml`
- `Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml`
- `Testing/ContinuousIntegration/AzurePipelinesWindows.yml`
- `Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml`
- `.github/workflows/arm.yml`
- `.github/workflows/pixi.yml`

Kept active:
- `Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml` (the measurement target)
- `.github/workflows/pre-commit.yml` (style gate is mandatory)

</details>

<details>
<summary>What changes on commit 2</summary>

```diff
           ITK_WRAP_PYTHON:BOOL=ON
           CMAKE_C_COMPILER_LAUNCHER:STRING=ccache
           CMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache
           ITK_COMPUTER_MEMORY_SIZE:STRING=4.5
+          CMAKE_JOB_POOLS:STRING=compile=4;link=2
+          CMAKE_JOB_POOL_COMPILE:STRING=compile
+          CMAKE_JOB_POOL_LINK:STRING=link
+          CMAKE_JOB_POOL_PRECOMPILE_HEADER:STRING=compile
         ")
...
-        ctest -S … -j 2 -L Python -E "(...)"
+        ctest -S … -j 8 -L Python -E "(...)"
```

Reference baseline from main HEAD `b836289f1a` (most recent successful merge): ~3h 26min wall on Azure.

</details>

<!--
provenance: claude-code session 2026-04-28
experiment: ITK Python build acceleration via CMake JOB_POOLS
baseline_commit: c579f5b16b (this commit, disables-all-but-LinuxPython)
with_pools_commit: held locally as tag wip-with-pools-local, will be pushed after baseline CI completes
key_facts:
  - baseline wall on main b836289f1a: ~3h 26min ITK.Linux.Python
  - hypothesis: compile=4 link=2 with -j 8 outer beats -j 2 / no pools by 1.5-1.8x on compile-bound phase
  - link cap (=2) preserved to avoid OOM on 7 GB Azure runner
post_merge_action: do NOT merge this branch; restore triggers and discard once measurement complete
-->
