### PR TITLE
COMP: Use pzero() for SelfadjointMatrixVector accumulators (silences GCC -O3 IPA-CP false positives)

### DIFF
--- a/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Core/products/SelfadjointMatrixVector.h
+++ b/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Core/products/SelfadjointMatrixVector.h
@@ -81,9 +81,9 @@ selfadjoint_matrix_vector_product<Scalar, Index, StorageOrder, UpLo, ConjugateLh
     Packet ptmp1 = pset1<Packet>(t1);
 
     Scalar t2(0);
-    Packet ptmp2 = pset1<Packet>(t2);
+    Packet ptmp2 = pzero(Packet{});
     Scalar t3(0);
-    Packet ptmp3 = pset1<Packet>(t3);
+    Packet ptmp3 = pzero(Packet{});
 
     Index starti = FirstTriangular ? 0 : j + 2;
     Index endi = FirstTriangular ? j : size;


### PR DESCRIPTION
Switch the two `ptmp2` / `ptmp3` packet-accumulator initializations in `Eigen/src/Core/products/SelfadjointMatrixVector.h` from `pset1<Packet>(t)` to `pzero(Packet{})`, matching upstream Eigen master. This silences four false-positive `-Wmaybe-uninitialized` warnings GCC emits at `-O3` after IPA-CP clones the function as `run.constprop.isra`.

Must merge **before** #6164, which switches `ITK.Linux.Python` CI from `MinSizeRel` to `Release` and is currently red because of these exact warnings.

<details>
<summary>Why the existing in-header diagnostic-pop doesn't help</summary>

`Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Core/products/SelfadjointMatrixVector.h` already wraps its body in:

```cpp
#if defined(__GNUC__) && !defined(__clang__)
#  pragma GCC diagnostic push
#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
#endif
```

That suppression is **stateful at parse time** — it applies while GCC parses this header. The actual warnings are emitted from `selfadjoint_matrix_vector_product::run.constprop.isra`, a *cloned* function GCC creates during interprocedural constant propagation at `-O2`/`-O3`. The diagnostic state at the point GCC analyses the clone is whatever the call-site translation unit had active, **not** the suppression baked into the header. This is a long-standing GCC interaction with `-fipa-cp-clone`.

The proper fix is therefore at the source: give GCC IPA-CP a clearly-zero starting packet so it doesn't ever build a "maybe uninit" hypothesis in the first place.

</details>

<details>
<summary>What changed (2-line diff)</summary>

```diff
     Scalar t2(0);
-    Packet ptmp2 = pset1<Packet>(t2);
+    Packet ptmp2 = pzero(Packet{});
     Scalar t3(0);
-    Packet ptmp3 = pset1<Packet>(t3);
+    Packet ptmp3 = pzero(Packet{});
```

Algorithmic behaviour is unchanged: `pset1<Packet>(0)` and `pzero(Packet{})` both produce a zero packet. Upstream Eigen master uses the latter form because:
- `Packet{}` is value-initialization (explicit zero, visible to the optimizer as a constant).
- `pzero` is a small inline that returns a zero packet of the deduced type.
- The combination collapses cleanly under IPA-CP, leaving no "maybe uninit" hypothesis.

`pzero` already exists in our vendored Eigen at `Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Core/GenericPacketMath.h:425`, so no new symbols are needed.

Upstream Eigen master also did a separate, larger refactor of this same kernel (2-column → 4-column processing, four accumulators `ptmp4`–`ptmp7`). That refactor is intentionally **not** included here — it's a bigger change with its own performance trade-offs and reviewer surface, orthogonal to fixing the warning.

</details>

<details>
<summary>Why this affects ITK.Linux.Python specifically</summary>

`ITK.Linux.Python` builds the SuperBuild with `ITK_WRAP_PYTHON=ON`, which generates many SWIG wrapper translation units that include Eigen and instantiate `selfadjoint_matrix_vector_product`. The combination of (a) `-O3` (Release), (b) GCC's `-fipa-cp-clone` enabled at that level, and (c) the high template instantiation count is what makes the warnings reproducible there. `MinSizeRel` (`-Os`) typically disables IPA-CP cloning, which is why the warnings only appeared after #6164's MinSizeRel→Release switch.

Empirical CDash evidence from #6164 build #14600: 0 errors, 4 warnings, 175 tests passed. The warning text was:

```
SelfadjointMatrixVector.h:231: warning: '_28' may be used uninitialized [-Wmaybe-uninitialized]
SelfadjointMatrixVector.h:231: warning: 'result_90' may be used uninitialized [-Wmaybe-uninitialized]
```

`_28` and `result_90` are GCC SSA temporaries inside the cloned function; they correspond to `ptmp2`/`ptmp3` after IPA-CP rewriting.

</details>

## Test plan

- [ ] `ITK.Linux.Python` (`Release`) builds with 0 warnings on this branch (this PR's CI).
- [ ] All other Azure pipelines remain green; no behaviour change is expected.
- [ ] After merge, rebase #6164 onto main and re-run; the `LinuxPython` red should clear.

<!--
provenance: claude-code session 2026-04-28
related_pr: blocks #6164 (CI consolidation that switches LinuxPython MinSizeRel→Release)
upstream_reference: gitlab.com/libeigen/eigen master Eigen/src/Core/products/SelfadjointMatrixVector.h
files_changed:
  - Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Core/products/SelfadjointMatrixVector.h (lines 84, 86: pset1<Packet>(t) → pzero(Packet{}))
post_merge_action: rebase #6164 onto main, push, verify ITK.Linux.Python turns green
-->
