### PR TITLE
WIP: Test CCACHE_MAXSIZE bump 2.4G -> 8G on ITK.Linux.Python

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -1,29 +1,7 @@
 name: ITK.Arm64
 
 on:
-    push:
-        branches:
-            - main
-            - 'release*'
-        paths-ignore:
-            - '*.md'
-            - LICENSE
-            - NOTICE
-            - 'Documentation/**'
-            - 'Utilities/Debugger/**'
-            - 'Utilities/ITKv5Preparation/**'
-            - 'Utilities/Maintenance/**'
-            - 'Modules/Remote/*.remote.cmake'
-    pull_request:
-        paths-ignore:
-            - '*.md'
-            - LICENSE
-            - NOTICE
-            - 'Documentation/**'
-            - 'Utilities/Debugger/**'
-            - 'Utilities/ITKv5Preparation/**'
-            - 'Utilities/Maintenance/**'
-            - 'Modules/Remote/*.remote.cmake'
+    workflow_dispatch:
 
 concurrency:
   group: '${{ github.workflow }}@${{ github.head_ref || github.ref }}'

--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -1,29 +1,7 @@
 name: ITK.Pixi
 
 on:
-    push:
-        branches:
-            - main
-            - 'release*'
-        paths-ignore:
-            - '*.md'
-            - LICENSE
-            - NOTICE
-            - 'Documentation/**'
-            - 'Utilities/Debugger/**'
-            - 'Utilities/ITKv5Preparation/**'
-            - 'Utilities/Maintenance/**'
-            - 'Modules/Remote/*.remote.cmake'
-    pull_request:
-        paths-ignore:
-            - '*.md'
-            - LICENSE
-            - NOTICE
-            - 'Documentation/**'
-            - 'Utilities/Debugger/**'
-            - 'Utilities/ITKv5Preparation/**'
-            - 'Utilities/Maintenance/**'
-            - 'Modules/Remote/*.remote.cmake'
+    workflow_dispatch:
 
 concurrency:
   group: '${{ github.workflow }}@${{ github.head_ref || github.ref }}'

--- a/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
@@ -2,12 +2,7 @@
 
 name: ITK.Batch
 
-trigger:
-  batch: true
-  branches:
-    include:
-    - main
-    - release*
+trigger: none
 pr: none
 
 variables:

--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -1,31 +1,8 @@
 name: ITK.Linux
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
+
 variables:
   ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -128,7 +128,7 @@ jobs:
       displayName: 'Build and test'
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-        CCACHE_MAXSIZE: 2.4G
+        CCACHE_MAXSIZE: 8G
 
     - bash: ccache --show-stats
       condition: always()

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -1,31 +1,8 @@
 name: ITK.macOS
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
+
 variables:
   ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -1,31 +1,8 @@
 name: ITK.macOS.Python
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
+
 variables:
   ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache

--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -1,31 +1,8 @@
 name: ITK.Windows
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
+
 variables:
   ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -1,31 +1,8 @@
 name: ITK.Windows.Python
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
+
 variables:
   ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache


### PR DESCRIPTION
**WIP — measurement only, do not merge.** Single-variable experiment: does raising `CCACHE_MAXSIZE` from `2.4G` to `8G` on the `ITK.Linux.Python` Azure pipeline reduce wall time, by avoiding eviction of hot objects from the per-job ccache?

Baseline: PR #6165 (closed) — same disabled-everything-except-`ITK.Linux.Python` framework, `CCACHE_MAXSIZE=2.4G`.

This PR's CI run gives the bumped-cache wall time; ccache `--show-stats` (already in the pipeline) reports cache hit rate / eviction count for the comparison.

<details>
<summary>What changed vs PR #6165</summary>

Two commits on this branch:
1. `c579f5b16b` — same as #6165: trigger-disable every Azure pipeline / GitHub Actions workflow except `AzurePipelinesLinuxPython.yml`, so only one job runs and its wall time is the only signal.
2. `5686601543` — single-line edit to `Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml`:
   ```diff
   -        CCACHE_MAXSIZE: 2.4G
   +        CCACHE_MAXSIZE: 8G
   ```

No other config touched — same `-j` settings, same dashboard script, same compiler.

</details>

<details>
<summary>What to look for in the run</summary>

- **Wall time** — compare to #6165's baseline run.
- **`ccache --show-stats` output** — specifically `cache hit (direct)`, `cache miss`, and `cleanups performed`. If `cleanups performed` was non-zero in the baseline and drops to zero here, eviction was the bottleneck.
- **Cache fill** — `cache size` at the end of the run. If it's well under 8G, raising the cap won't help and 4G would suffice.

</details>

<!--
provenance: claude-code session 2026-04-29
baseline_pr: 6165 (closed)
baseline_commit: c579f5b16b on hjmjohnson:wip-python-build-acceleration
experiment_commit: 5686601543 (CCACHE_MAXSIZE 2.4G -> 8G)
target_yaml: Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml:131
post_run_action: post comparison comment with ccache stats + wall time, then close (NOT FOR MERGE)
-->