### PR TITLE
WIP: Investigate caching SWIG/CastXML/tarball artifacts on ITK.Linux.Python

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -1,29 +1,7 @@
 name: ITK.Arm64
 
 on:
-    push:
-        branches:
-            - main
-            - 'release*'
-        paths-ignore:
-            - '*.md'
-            - LICENSE
-            - NOTICE
-            - 'Documentation/**'
-            - 'Utilities/Debugger/**'
-            - 'Utilities/ITKv5Preparation/**'
-            - 'Utilities/Maintenance/**'
-            - 'Modules/Remote/*.remote.cmake'
-    pull_request:
-        paths-ignore:
-            - '*.md'
-            - LICENSE
-            - NOTICE
-            - 'Documentation/**'
-            - 'Utilities/Debugger/**'
-            - 'Utilities/ITKv5Preparation/**'
-            - 'Utilities/Maintenance/**'
-            - 'Modules/Remote/*.remote.cmake'
+    workflow_dispatch:
 
 concurrency:
   group: '${{ github.workflow }}@${{ github.head_ref || github.ref }}'

--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -1,29 +1,7 @@
 name: ITK.Pixi
 
 on:
-    push:
-        branches:
-            - main
-            - 'release*'
-        paths-ignore:
-            - '*.md'
-            - LICENSE
-            - NOTICE
-            - 'Documentation/**'
-            - 'Utilities/Debugger/**'
-            - 'Utilities/ITKv5Preparation/**'
-            - 'Utilities/Maintenance/**'
-            - 'Modules/Remote/*.remote.cmake'
-    pull_request:
-        paths-ignore:
-            - '*.md'
-            - LICENSE
-            - NOTICE
-            - 'Documentation/**'
-            - 'Utilities/Debugger/**'
-            - 'Utilities/ITKv5Preparation/**'
-            - 'Utilities/Maintenance/**'
-            - 'Modules/Remote/*.remote.cmake'
+    workflow_dispatch:
 
 concurrency:
   group: '${{ github.workflow }}@${{ github.head_ref || github.ref }}'

--- a/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
@@ -2,12 +2,7 @@
 
 name: ITK.Batch
 
-trigger:
-  batch: true
-  branches:
-    include:
-    - main
-    - release*
+trigger: none
 pr: none
 
 variables:

--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -1,31 +1,8 @@
 name: ITK.Linux
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
+
 variables:
   ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -87,6 +87,35 @@ jobs:
         path: $(CCACHE_DIR)
       displayName: 'Restore ccache'
 
+    # WIP: investigate caching SWIG/CastXML artifacts and tarballs.
+    # Paths are best-guess based on ExternalProject_Add layout and
+    # WRAPPER_LIBRARY_OUTPUT_DIR conventions; the diagnostic step at
+    # the end of the job lists what actually got generated where.
+
+    - task: Cache@2
+      inputs:
+        key: '"swig-castxml-tarballs-v1" | "$(Agent.OS)" | "Wrapping/Generators/SwigInterface/CMakeLists.txt" | "Wrapping/Generators/CastXML/CMakeLists.txt"'
+        restoreKeys: |
+          "swig-castxml-tarballs-v1" | "$(Agent.OS)"
+        path: $(Pipeline.Workspace)/swig-castxml-tarballs
+      displayName: 'Restore SWIG/CastXML downloaded tarballs'
+
+    - task: Cache@2
+      inputs:
+        key: '"castxml-xml-v1" | "$(Agent.OS)" | "LinuxPython" | "Modules/**/include/*.h" | "Modules/**/wrapping/*.cmake"'
+        restoreKeys: |
+          "castxml-xml-v1" | "$(Agent.OS)" | "LinuxPython"
+        path: $(Pipeline.Workspace)/castxml-xml-cache
+      displayName: 'Restore castxml-generated XML files'
+
+    - task: Cache@2
+      inputs:
+        key: '"swig-cxx-v1" | "$(Agent.OS)" | "LinuxPython" | "Modules/**/wrapping/*.i" | "Modules/**/wrapping/*.cmake"'
+        restoreKeys: |
+          "swig-cxx-v1" | "$(Agent.OS)" | "LinuxPython"
+        path: $(Pipeline.Workspace)/swig-cxx-cache
+      displayName: 'Restore SWIG-generated CXX files'
+
     - bash: |
         set -x
         ccache --zero-stats
@@ -133,6 +162,36 @@ jobs:
     - bash: ccache --show-stats
       condition: always()
       displayName: 'ccache stats'
+
+    # WIP: diagnostic for SWIG/CastXML cache investigation. Reports
+    # artifact locations and sizes, then populates the cache paths so
+    # the post-job Cache@2 save sees a non-empty tree.
+    - bash: |
+        set -x
+        BLD=$(Build.SourcesDirectory)-build
+        echo "=== CastXML XML outputs (top 20) ==="
+        find "$BLD" -name "*.xml" -path "*castxml_inputs*" -printf "%s\t%p\n" 2>/dev/null | sort -rn | head -20
+        echo "=== CastXML XML count + size ==="
+        find "$BLD" -name "*.xml" -path "*castxml_inputs*" 2>/dev/null | wc -l
+        find "$BLD" -name "*.xml" -path "*castxml_inputs*" -printf "%s\n" 2>/dev/null | awk '{s+=$1} END {print s/1024/1024" MB"}'
+        echo "=== SWIG-generated cxx (top 20) ==="
+        find "$BLD" -name "*Python.cxx" -printf "%s\t%p\n" 2>/dev/null | sort -rn | head -20
+        echo "=== SWIG cxx count + size ==="
+        find "$BLD" -name "*Python.cxx" 2>/dev/null | wc -l
+        find "$BLD" -name "*Python.cxx" -printf "%s\n" 2>/dev/null | awk '{s+=$1} END {print s/1024/1024" MB"}'
+        echo "=== Tarball / ExternalProject downloads ==="
+        find "$BLD/Wrapping" -path "*-prefix/src/*" -maxdepth 6 -type f \( -name "*.tar.*" -o -name "*.zip" \) 2>/dev/null | xargs -r ls -lh
+        echo "=== Populating cache mirror dirs ==="
+        mkdir -p $(Pipeline.Workspace)/swig-castxml-tarballs
+        mkdir -p $(Pipeline.Workspace)/castxml-xml-cache
+        mkdir -p $(Pipeline.Workspace)/swig-cxx-cache
+        find "$BLD/Wrapping" -path "*-prefix/src/*" -maxdepth 6 -type f \( -name "*.tar.*" -o -name "*.zip" \) -exec cp -v {} $(Pipeline.Workspace)/swig-castxml-tarballs/ \; 2>/dev/null || true
+        find "$BLD" -name "*.xml" -path "*castxml_inputs*" 2>/dev/null | tar -czf $(Pipeline.Workspace)/castxml-xml-cache/xml.tar.gz -T - 2>/dev/null || true
+        find "$BLD" -name "*Python.cxx" 2>/dev/null | tar -czf $(Pipeline.Workspace)/swig-cxx-cache/cxx.tar.gz -T - 2>/dev/null || true
+        echo "=== Cache mirror sizes ==="
+        du -sh $(Pipeline.Workspace)/swig-castxml-tarballs $(Pipeline.Workspace)/castxml-xml-cache $(Pipeline.Workspace)/swig-cxx-cache 2>/dev/null
+      condition: always()
+      displayName: 'WIP: discover SWIG/CastXML artifact paths and populate caches'
 
     - bash: python3 $(Build.SourcesDirectory)/Testing/ContinuousIntegration/report_build_diagnostics.py $(Build.SourcesDirectory)-build
       condition: succeededOrFailed()

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -1,31 +1,8 @@
 name: ITK.macOS
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
+
 variables:
   ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -1,31 +1,8 @@
 name: ITK.macOS.Python
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
+
 variables:
   ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache

--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -1,31 +1,8 @@
 name: ITK.Windows
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
+
 variables:
   ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -1,31 +1,8 @@
 name: ITK.Windows.Python
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
+
 variables:
   ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache


### PR DESCRIPTION
**WIP — measurement & path discovery, do not merge.** Investigate whether caching three classes of wrapping-build artifacts can shorten `ITK.Linux.Python` wall time, using PR #6165's run as the baseline.

Three independent `Cache@2` tasks (separate keys, separate paths):

1. **SWIG/CastXML downloaded tarballs** — keyed on the two `CMakeLists.txt` files that pin URL+SHA. Effectively static across builds; should be a near-100% hit after the first run.
2. **castxml-generated `.xml` files** — keyed on `Modules/**/include/*.h` + `wrapping/*.cmake`. Hit only when the headers a module wraps are unchanged.
3. **SWIG-generated `.cxx` files** — keyed on `Modules/**/wrapping/*.i` + `wrapping/*.cmake`. Hit only when the `.i` interfaces are unchanged.

A diagnostic post-build step lists where each artifact class actually lives and copies them into stable cache paths so the post-job save sees a non-empty tree. Run 1 establishes the *real* paths; a follow-up commit will tighten the cache keys/paths once we know.

<details>
<summary>Why three caches instead of one</summary>

The three artifacts have very different change cadences:
- Tarballs: change ~once per ITK release.
- castxml `.xml`: change whenever a wrapped header changes (frequent).
- SWIG `.cxx`: change whenever a `.i` file changes (rare — most PRs don't touch wrapping).

A single combined cache would invalidate all three on any header change and make the SWIG `.cxx` cache near-useless.

</details>

<details>
<summary>Path assumptions (to be verified by run 1)</summary>

- Tarballs: `Wrapping/Generators/{Swig,CastXML}/...-prefix/src/*.{tar.*,zip}`  (default `ExternalProject_Add` layout)
- castxml: `**/castxml_inputs/*.xml` under the build tree (per `WRAPPER_LIBRARY_OUTPUT_DIR/castxml_inputs/<submodule>.xml` in `Wrapping/macro_files/itk_auto_load_submodules.cmake:420`)
- SWIG: `**/*Python.cxx` under the build tree

The diagnostic step prints `find` output for each so we can correct any wrong assumption in the next iteration.

</details>

<details>
<summary>What "success" looks like</summary>

After the second push (i.e., the second CI run on this branch with the cache populated):
- Tarball cache hit reduces `ExternalProject_Add` download time to ~0.
- castxml cache hit reduces `Generate XML` step time on unchanged modules.
- SWIG cache hit reduces `Generate cxx` step time on unchanged `.i` files.

The wall-time reduction over PR #6165's baseline is the headline number.

</details>

<!--
provenance: claude-code session 2026-04-29
baseline_pr: 6165
baseline_branch: hjmjohnson:wip-python-build-acceleration @ c579f5b16b
related_pr: 6167 (CCACHE_MAXSIZE 2.4G->8G experiment, parallel investigation)
target_yaml: Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
caches_added:
  - swig-castxml-tarballs-v1  (path: $(Pipeline.Workspace)/swig-castxml-tarballs)
  - castxml-xml-v1            (path: $(Pipeline.Workspace)/castxml-xml-cache)
  - swig-cxx-v1               (path: $(Pipeline.Workspace)/swig-cxx-cache)
diagnostic_step: 'WIP: discover SWIG/CastXML artifact paths and populate caches'
post_run_action: examine diagnostic output for actual artifact paths/sizes; refine cache populate logic in follow-up commit; eventually compare wall time vs #6165 baseline
-->