### PR TITLE
DOC: Document /CID/ case convention on ITKTestingData gh-pages

### DIFF
--- a/CMake/ITKExternalData.cmake
+++ b/CMake/ITKExternalData.cmake
@@ -49,7 +49,11 @@ if(NOT ITK_FORBID_DOWNLOADS)
   list(
     APPEND
     ExternalData_URL_TEMPLATES
-    # Data published on GitHub Pages
+    # Data published on GitHub Pages — primary CID source.
+    # %(algo) substitutes the uppercase algorithm name (CID, MD5, SHA512),
+    # matching the case-sensitive directory layout on the ITKTestingData
+    # gh-pages branch (/CID/, /MD5/, /SHA512/). See commit 317ab5fdaed2
+    # for the parallel fix to PrefetchCIDContentLinks.py.
     "https://insightsoftwareconsortium.github.io/ITKTestingData/%(algo)/%(hash)"
     # Data published on Girder
     "https://data.kitware.com:443/api/v1/file/hashsum/%(algo)/%(hash)/download"


### PR DESCRIPTION
Add a comment near the GitHub Pages URL template in `CMake/ITKExternalData.cmake` documenting that `%(algo)` substitutes the uppercase algorithm name (`CID`, `MD5`, `SHA512`), matching the case-sensitive directory layout on the gh-pages branch of [ITKTestingData](https://github.com/InsightSoftwareConsortium/ITKTestingData/tree/gh-pages). Follow-up to 317ab5fdaed2.

<details>
<summary>Background</summary>

The CMake-side ExternalData URL template has always produced the correct case — `ExternalData.cmake` runs `string(TOUPPER ${CMAKE_MATCH_1} algo)` before substitution, so a `.cid` tag becomes `/CID/<hash>` in the URL.

However, the parallel Python prefetch script `Utilities/Maintenance/PrefetchCIDContentLinks.py` used `/cid/` (lowercase) and silently 404'd against the case-sensitive GitHub Pages mirror. That was fixed in 317ab5fdaed2:

> The GitHub Pages mirror published from the gh-pages branch of InsightSoftwareConsortium/ITKTestingData stores blobs under /CID/<cid> (uppercase), matching the convention used by every other algo bucket (/MD5/, /SHA512/) and the CMake-side ExternalData URL template that resolves %(algo) to the uppercase file extension.

This PR adds a 4-line comment so a future reader doesn't re-introduce the lowercase typo on the CMake side.
</details>

<details>
<summary>Verification</summary>

```
$ curl -sI https://insightsoftwareconsortium.github.io/ITKTestingData/CID/bafkreihyzykbgzsefshdyxsmrnrgohigczhbezhxa36fultj2dgsgjjxka | head -1
HTTP/2 200

$ curl -sI https://insightsoftwareconsortium.github.io/ITKTestingData/cid/bafkreihyzykbgzsefshdyxsmrnrgohigczhbezhxa36fultj2dgsgjjxka | head -1
HTTP/2 404
```
</details>

<!--
provenance: claude-code session 2026-04-29
related: 317ab5fdaed2 (BUG: Use case-correct /CID/ path in PrefetchCIDContentLinks.py)
files: CMake/ITKExternalData.cmake (5 insertions, 1 deletion)
-->