### PR TITLE
WIP: Cache castxml XML output on ITK.Linux.Python (single-variable test)

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -1,29 +1,7 @@
 name: ITK.Arm64
 
 on:
-    push:
-        branches:
-            - main
-            - 'release*'
-        paths-ignore:
-            - '*.md'
-            - LICENSE
-            - NOTICE
-            - 'Documentation/**'
-            - 'Utilities/Debugger/**'
-            - 'Utilities/ITKv5Preparation/**'
-            - 'Utilities/Maintenance/**'
-            - 'Modules/Remote/*.remote.cmake'
-    pull_request:
-        paths-ignore:
-            - '*.md'
-            - LICENSE
-            - NOTICE
-            - 'Documentation/**'
-            - 'Utilities/Debugger/**'
-            - 'Utilities/ITKv5Preparation/**'
-            - 'Utilities/Maintenance/**'
-            - 'Modules/Remote/*.remote.cmake'
+    workflow_dispatch:
 
 concurrency:
   group: '${{ github.workflow }}@${{ github.head_ref || github.ref }}'

--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -1,29 +1,7 @@
 name: ITK.Pixi
 
 on:
-    push:
-        branches:
-            - main
-            - 'release*'
-        paths-ignore:
-            - '*.md'
-            - LICENSE
-            - NOTICE
-            - 'Documentation/**'
-            - 'Utilities/Debugger/**'
-            - 'Utilities/ITKv5Preparation/**'
-            - 'Utilities/Maintenance/**'
-            - 'Modules/Remote/*.remote.cmake'
-    pull_request:
-        paths-ignore:
-            - '*.md'
-            - LICENSE
-            - NOTICE
-            - 'Documentation/**'
-            - 'Utilities/Debugger/**'
-            - 'Utilities/ITKv5Preparation/**'
-            - 'Utilities/Maintenance/**'
-            - 'Modules/Remote/*.remote.cmake'
+    workflow_dispatch:
 
 concurrency:
   group: '${{ github.workflow }}@${{ github.head_ref || github.ref }}'

--- a/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
@@ -2,12 +2,7 @@
 
 name: ITK.Batch
 
-trigger:
-  batch: true
-  branches:
-    include:
-    - main
-    - release*
+trigger: none
 pr: none
 
 variables:

--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -1,31 +1,8 @@
 name: ITK.Linux
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
+
 variables:
   ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -87,6 +87,36 @@ jobs:
         path: $(CCACHE_DIR)
       displayName: 'Restore ccache'
 
+    # WIP: cache the 2.2 GB of castxml-generated XML at
+    # ${BUILD}/Wrapping/castxml_inputs/. Single trailing unquoted glob
+    # per Cache@2 syntax (the prior #6168 attempt failed because it had
+    # multiple ** segments and quoted them). Key invalidates whenever
+    # any wrapped header changes, which is the only time castxml output
+    # actually needs to be regenerated.
+    - task: Cache@2
+      inputs:
+        key: '"castxml-xml-v1" | "$(Agent.OS)" | "LinuxPython" | Modules/**/include/*.h'
+        path: $(Pipeline.Workspace)/castxml-xml-cache
+      displayName: 'Restore castxml XML output cache'
+
+    - bash: |
+        set -x
+        CACHE=$(Pipeline.Workspace)/castxml-xml-cache
+        DEST=$(Build.SourcesDirectory)-build/Wrapping/castxml_inputs
+        if [ -d "$CACHE" ] && [ -n "$(ls -A "$CACHE" 2>/dev/null)" ]; then
+          mkdir -p "$DEST"
+          # rsync preserves the directory structure; touching afterwards
+          # bumps mtimes so Ninja sees the .xml files as up-to-date
+          # relative to the checkout's just-cloned header mtimes and
+          # skips the (slow) castxml regeneration step.
+          rsync -a "$CACHE"/ "$DEST"/
+          find "$DEST" -name '*.xml' -exec touch {} +
+          echo "Restored $(find "$DEST" -name '*.xml' | wc -l) cached castxml XML files."
+        else
+          echo "No castxml cache hit; build will regenerate XML."
+        fi
+      displayName: 'Populate build tree from castxml XML cache (if hit)'
+
     - bash: |
         set -x
         ccache --zero-stats
@@ -133,6 +163,26 @@ jobs:
     - bash: ccache --show-stats
       condition: always()
       displayName: 'ccache stats'
+
+    # Mirror the build's castxml XML output back to the workspace cache
+    # path so the post-job Cache@2 save sees fresh content. Only runs
+    # when the build directory actually exists (i.e. the build step
+    # at least started).
+    - bash: |
+        set -x
+        SRC=$(Build.SourcesDirectory)-build/Wrapping/castxml_inputs
+        CACHE=$(Pipeline.Workspace)/castxml-xml-cache
+        if [ -d "$SRC" ]; then
+          mkdir -p "$CACHE"
+          rsync -a --delete "$SRC"/ "$CACHE"/
+          COUNT=$(find "$CACHE" -name '*.xml' 2>/dev/null | wc -l)
+          SIZE=$(du -sh "$CACHE" 2>/dev/null | cut -f1)
+          echo "Mirrored $COUNT castxml XML files ($SIZE) to cache path."
+        else
+          echo "Build dir absent; skipping castxml cache populate."
+        fi
+      condition: always()
+      displayName: 'Populate castxml XML cache from build tree'
 
     - bash: python3 $(Build.SourcesDirectory)/Testing/ContinuousIntegration/report_build_diagnostics.py $(Build.SourcesDirectory)-build
       condition: succeededOrFailed()

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOS.yml
@@ -1,31 +1,8 @@
 name: ITK.macOS
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
+
 variables:
   ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -1,31 +1,8 @@
 name: ITK.macOS.Python
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
+
 variables:
   ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache

--- a/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindows.yml
@@ -1,31 +1,8 @@
 name: ITK.Windows
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
+
 variables:
   ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -1,31 +1,8 @@
 name: ITK.Windows.Python
 
-trigger:
-  branches:
-    include:
-    - main
-    - release*
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
-pr:
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - NOTICE
-    - Documentation/*
-    - Utilities/Debugger/*
-    - Utilities/ITKv5Preparation/*
-    - Utilities/Maintenance/*
-    - Modules/Remote/*.remote.cmake
+trigger: none
+pr: none
+
 variables:
   ExternalData_OBJECT_STORES: $(Pipeline.Workspace)/ExternalData
   CCACHE_DIR: $(Pipeline.Workspace)/.ccache


### PR DESCRIPTION
**WIP — measurement only, do not merge.** Single-variable experiment: cache the 2.2 GB of castxml-generated XML at `${BUILD}/Wrapping/castxml_inputs/` keyed on header content, so a build with unchanged wrapped headers can skip the (slow) castxml regeneration step. Replaces closed PR #6168 (which tried to cache three classes of artifact at once with a Cache@2 key shape Azure rejected — `**` is only allowed in the last key segment).

Baseline for comparison: PR #6165 (closed) — same disabled-everything-except-`ITK.Linux.Python` framework, no castxml cache.

<details>
<summary>Why castxml output is the right cache target</summary>

The path-discovery run on closed PR #6168 (Azure build 14615) found:

- 814 castxml XML files at `${BUILD}/Wrapping/castxml_inputs/*.xml`
- 2.20 GB raw, ≈237 MB compressed
- Inputs: each XML is regenerated when its corresponding wrapped C++ header changes
- Time cost: castxml is single-threaded per file and takes minutes to regenerate the full set

Tarball downloads (63 MB, already CDN-hashed) and SWIG `.cpp` outputs (smaller, faster to regenerate) were dropped from this PR to keep the experiment a single variable.

</details>

<details>
<summary>How the cache mechanism works</summary>

1. `Cache@2 restore` populates `$(Pipeline.Workspace)/castxml-xml-cache/` if a key match exists.
2. A populate step *before* `ctest -S` rsyncs the cached files into `${BUILD}/Wrapping/castxml_inputs/` and `touch`es the .xml mtimes. Ninja sees them as up-to-date relative to the freshly-cloned header mtimes and skips castxml.
3. CMake configure + Ninja build run normally. On a hit, castxml is a no-op.
4. A mirror step *after* the build rsyncs `${BUILD}/Wrapping/castxml_inputs/` back to the workspace cache path, so Azure's post-job save captures the current build's XML output.

Cache key: `"castxml-xml-v1" | "$(Agent.OS)" | "LinuxPython" | Modules/**/include/*.h` — single trailing unquoted glob, the only form Azure Cache@2 accepts.

</details>

<details>
<summary>Two-push test plan</summary>

- **Run 1** (this push, cold cache): populates the cache; wall time should match baseline #6165 since no castxml work is skipped on first run. Validates that the populate + mirror plumbing works.
- **Run 2** (force-push of an empty commit, warm cache): measures the actual benefit. With the cache hit, castxml regeneration should be skipped on most XML files; wall-time delta vs #6165 baseline is the headline number.

</details>

<!--
provenance: claude-code session 2026-04-29
baseline_pr: 6165
prior_attempt: 6168 (closed; multi-artifact Cache@2 key syntax error)
target_yaml: Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
cache_key: '"castxml-xml-v1" | "$(Agent.OS)" | "LinuxPython" | Modules/**/include/*.h'
cache_path: $(Pipeline.Workspace)/castxml-xml-cache
build_path: $(Build.SourcesDirectory)-build/Wrapping/castxml_inputs
post_run_action_run1: verify Cache@2 save succeeded, then push empty commit for run-2-warm-cache measurement
post_run_action_run2: post comparison comment with wall-time delta vs PR #6165 baseline; close PR
-->