### PR TITLE
WIP: Diagnose ITK.Linux.Python ccache (20G + verbose stats)

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -128,9 +128,9 @@ jobs:
       displayName: 'Build and test'
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-        CCACHE_MAXSIZE: 2.4G
+        CCACHE_MAXSIZE: 20G
 
-    - bash: ccache --show-stats
+    - bash: ccache --show-stats -v
       condition: always()
       displayName: 'ccache stats'
 


### PR DESCRIPTION
Two-line diagnostic-only change to `AzurePipelinesLinuxPython.yml`: bump `CCACHE_MAXSIZE` `2.4G → 20G` and switch `ccache --show-stats` → `ccache --show-stats -v` so the next CI run prints the per-category uncacheable breakdown. Measurement-only — do not merge.

<details>
<summary>Background and what we learned from PR #6170 Run-2</summary>

PR #6170's warm-cache run reported:

| | Value |
|---|---|
| Hits | 2,646 / 3,423 (**77.30%** cacheable) |
| Misses | 777 |
| **Uncacheable** | **1,726** (34% of all ccache invocations) |
| Cache size | 2.15 / 5.00 GB |
| Cleanups | **6** during a single build |

Two clear signals:

1. **34% uncacheable** — Effective hit rate across all compile-like calls is 51%, not the 77% the headline shows. The non-verbose `ccache --show-stats` doesn't break out *why* they were uncacheable (`Multiple source files`, `Called for linking`, `Compilation failed`, `Multi-arch`, `Preprocessing failed`, etc.). With `-v`, the next CI run will list each category with counts. That tells us whether the fix is at the cmake-launcher layer, the SWIG-output layer, or somewhere else.
2. **Cleanups: 6** during one build means `CCACHE_MAXSIZE: 2.4G` is below the working set. ccache evicted hot entries mid-build, which then re-miss next build. Bumping to 20G removes that pressure so subsequent measurements reflect true reuse, not eviction noise.

</details>

<details>
<summary>What this PR is NOT</summary>

- Not a real fix for the 3h22m wall time. The actionable optimization waits for the verbose breakdown landed by this PR.
- Not a workflow change. `ccache --show-stats -v` produces a few more log lines and no other behavior change.
- Not modifying any other YAML. Single-variable diagnostic change.

</details>

<details>
<summary>Expected outcome of next CI run</summary>

The "ccache stats" step will print something like:

```
Cacheable calls:                 3423 / 5149 (66.5%)
  Hits:                          2646 / 3423 (77.3%)
  Misses:                         777 / 3423 (22.7%)
Uncacheable calls:               1726 / 5149 (33.5%)
  Called for linking:             ??? / 1726
  Multiple source files:          ??? / 1726
  Compilation failed:             ??? / 1726
  ...
Local storage:
  Cache size (GB): 2.X / 20.0
  Cleanups: 0   (← should drop to 0 with 20 GB)
```

The category breakdown of those 1,726 uncacheable calls is the diagnostic that tells us where to push next.

</details>

<!--
provenance: claude-code session 2026-04-29 (hjmjohnson)
purpose: diagnostic-only; gather verbose ccache stats from ITK.Linux.Python warm-cache run
parent_findings:
  - PR #6170 warm-cache: 51% effective hit rate, 1726 uncacheable, 6 cleanups in 5GB cache
  - PR #6165 baseline: 12131s wall on -j 2; build is CPU-bound and parallelism-saturated
expected_signal: ccache --show-stats -v output listing uncacheable reasons by category
post_run_action: read verbose stats, file targeted fix PR, close this WIP
do_not_merge: true
-->