### PR TITLE
COMP: Use pzero() init for Packet locals in SelfadjointMatrixVector loop

### DIFF
--- a/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Core/products/SelfadjointMatrixVector.h
+++ b/Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Core/products/SelfadjointMatrixVector.h
@@ -112,13 +112,17 @@ selfadjoint_matrix_vector_product<Scalar, Index, StorageOrder, UpLo, ConjugateLh
     const Scalar* EIGEN_RESTRICT rhsIt = rhs + alignedStart;
     Scalar* EIGEN_RESTRICT resIt = res + alignedStart;
     for (Index i = alignedStart; i < alignedEnd; i += PacketSize) {
-      Packet A0i = ploadu<Packet>(a0It);
+      Packet A0i = pzero(Packet{});
+      A0i = ploadu<Packet>(a0It);
       a0It += PacketSize;
-      Packet A1i = ploadu<Packet>(a1It);
+      Packet A1i = pzero(Packet{});
+      A1i = ploadu<Packet>(a1It);
       a1It += PacketSize;
-      Packet Bi = ploadu<Packet>(rhsIt);
+      Packet Bi = pzero(Packet{});
+      Bi = ploadu<Packet>(rhsIt);
       rhsIt += PacketSize;  // FIXME should be aligned in most cases
-      Packet Xi = pload<Packet>(resIt);
+      Packet Xi = pzero(Packet{});
+      Xi = pload<Packet>(resIt);
 
       Xi = pcj0.pmadd(A0i, ptmp0, pcj0.pmadd(A1i, ptmp1, Xi));
       ptmp2 = pcj1.pmadd(A0i, Bi, ptmp2);


### PR DESCRIPTION
Follow-up to #6166 covering the additional GCC -O3 IPA-CP false-positive `-Wmaybe-uninitialized` warnings exposed when #6164 lands its `ubuntu-24.04` + GCC 13/14 + C++20 toolchain. Mirrors #6166's `pzero(Packet{})` pattern at the inner-loop Packet load sites.

<details>
<summary>Symptom on PR #6164</summary>

`ITK.Linux.Python` build at SHA `bf6e691b8` (CDash buildid 1124-2153): 0 compile errors, 0 test failures, 4 warnings — all 4 in `Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Core/products/SelfadjointMatrixVector.h:231` of the form

```
SelfadjointMatrixVector.h:231: warning: 'result_90' may be used uninitialized [-Wmaybe-uninitialized]
SelfadjointMatrixVector.h:231: warning: '_28' may be used uninitialized [-Wmaybe-uninitialized]
```

with GCC's note `by argument 3 of type 'const float *' to 'run.constprop' declared here`. `report_build_diagnostics.py` treats warnings as fatal → exit 255.

The Continuous build of `main` at the same toolchain-pre-#6164 baseline (`Linux-Build14631-main-Python`) shows `warn=0`. The toolchain bump in #6164 (`ubuntu-22.04` → `ubuntu-24.04`, C++17 → C++20) is what exposes the additional IPA-CP cloning paths.

</details>

<details>
<summary>Why this works</summary>

`pzero(Packet{})` is visible to GCC's IPA-CP as a definite zero starting state for the Packet SSA value. A bare `Packet Bi = ploadu<Packet>(rhsIt);` is opaque — GCC's IPA-CP-cloned `run.constprop.isra` can trace the SSA value back through the cloned signature's `argument 3` (the `rhs` pointer in the clone after constant args are stripped) and decide along some specialized path the read is from uninitialized memory. The added `Packet X = pzero(Packet{}); X = pload...;` pattern gives IPA-CP a known starting state for `A0i`, `A1i`, `Bi`, and `Xi` — same trick #6166 used for the `ptmp2`/`ptmp3` accumulators.

</details>

<details>
<summary>How to verify</summary>

This file's warning surface is only triggered on the toolchain combination embedded in #6164 (ubuntu-24.04 + C++20). Local verification on macOS does not reproduce. CI verification:

1. Merge this PR.
2. Rebase #6164 on top of new `main`.
3. Confirm `ITK.Linux.Python` lands clean on rebased #6164.

</details>

<!--
provenance: claude-code session 2026-04-29 (gh-triage-pr on #6164)
related_pr: #6166 (prior pzero fix for ptmp2/ptmp3 accumulators)
related_pr_blocked: #6164 (CI matrix minimization, blocked by these warnings)
key_facts:
  - file: Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/src/Core/products/SelfadjointMatrixVector.h
  - lines: 115-121 (loop-local Packet loads)
  - failing_buildid_cdash: 1124-2153
  - failing_pr_head_sha: bf6e691b8
  - new_warnings_count: 4 (result_90 x2, _28 x2; const float* and const double* clones)
  - upstream_eigen_master_has_4col_phase_restructure: yes (heavier backport not pursued here)
post_merge_action: rebase #6164 onto this commit, expect ITK.Linux.Python green
-->