### PR TITLE
DOC: incorrect output due to handling of `` `...' ``

### DIFF
--- a/Modules/Core/Common/include/itkStringConvert.h
+++ b/Modules/Core/Common/include/itkStringConvert.h
@@ -41,7 +41,7 @@ namespace itk
  * corresponding `std::sto*` calls, but rethrow conversion failures as
  * `itk::ExceptionObject` whose message includes a caller-supplied
  * `context` describing what was being parsed (e.g.
- * `"NRRD header field 'sizes'"`) plus the offending input string.
+ * ``"NRRD header field 'sizes'"``) plus the offending input string.
  *
  * **Fixed-width integer return types** are used (`int32_t`, `int64_t`,
  * `uint32_t`, `uint64_t`) rather than the platform-dependent C++


### PR DESCRIPTION
In the file https://insightsoftwareconsortium.github.io/ITKDoxygen/group__ITKCommon.htmlwe see near the bottom:
```
‘"NRRD header field 'sizes&rsquo;"`)
```

This is due to the handling in doxygen of the `` `...' `` sequences, doubling the `` ` ``  solves the problem


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)


