### PR TITLE
COMP: Bump Azure Python ccache size from 2.4G to 8G

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -128,7 +128,7 @@ jobs:
       displayName: 'Build and test'
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-        CCACHE_MAXSIZE: 2.4G
+        CCACHE_MAXSIZE: 8G
 
     - bash: ccache --show-stats
       condition: always()

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -136,7 +136,7 @@ jobs:
       displayName: 'Build and test'
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-        CCACHE_MAXSIZE: 2.4G
+        CCACHE_MAXSIZE: 8G
 
     - bash: ccache --show-stats
       condition: always()

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -125,7 +125,7 @@ jobs:
       displayName: 'Build and test'
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-        CCACHE_MAXSIZE: 2.4G
+        CCACHE_MAXSIZE: 8G
 
     - bash: ccache --show-stats
       condition: always()


### PR DESCRIPTION
Bumps `CCACHE_MAXSIZE` from 2.4G to 8G in the three Azure **Python** pipelines (Linux/macOS/Windows). The Python wrapping builds saturate well above 2.4G; the equivalent GitHub Actions ccache settles at ~4.55 GiB. Non-Python pipelines stay at 2.4G — empirically not saturated.

<details>
<summary>Sizing rationale</summary>

| Pipeline (sizing data point) | Setting | Steady-state ccache |
|---|---|---|
| GitHub Actions `ccache-v4-macOS-Python` | 5G | **4.55–4.56 GiB** (98% of cap) |
| GitHub Actions `ccache-v4-Linux-Ubuntu-24.04-arm` | 5G | 540–830 MiB |
| GitHub Actions `ccache-v4-macOS-x86_64-rosetta` | 5G | 530–810 MiB |
| Azure all 9 stages (before this PR) | 2.4G | (Python likely thrashing) |
| Azure 3 Python stages (after this PR) | **8G** | working set ~5–6 GiB; cap unbinding |

8G chosen over 9.9G because:

1. Azure's default per-pipeline cache pool is 10G; 8G leaves a 20% buffer below that ceiling.
2. The existing `ccache --evict-older-than 7d` step (already in every Python YAML) is the binding constraint — it keeps the on-disk and uploaded size at the 7-day working set (~5–6G empirically). Anything beyond ~7G is unreachable in practice; the larger cap is a hit-rate ceiling, not extra storage.
3. Per-build round-trip cost (download + upload) is measurable but small relative to a 60-minute Python wrap+test cycle.

</details>

<details>
<summary>Files changed</summary>

| File | Change |
|---|---|
| `Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml` | `CCACHE_MAXSIZE: 2.4G → 8G` |
| `Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml` | `CCACHE_MAXSIZE: 2.4G → 8G` |
| `Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml` | `CCACHE_MAXSIZE: 2.4G → 8G` |

Non-Python pipelines (`AzurePipelinesLinux.yml` × 3 jobs, `AzurePipelinesMacOS.yml`, `AzurePipelinesWindows.yml`, `AzurePipelinesBatch.yml`) remain at 2.4G because GitHub Actions sibling-runner data shows their ccache footprint stays well under that cap (540–830 MiB steady state).

</details>

<!--
provenance: claude-code session 2026-05-01
key_facts:
  baseline_branch: upstream/main @ 84a53ad74d
  worktree: ~/src/ITK-comp-bump-python-ccache
  rationale_data_source: GitHub Actions ccache-v4-macOS-Python tarball saturated at 4.55 GiB
  azure_pool_default: 10G per pipeline, 8G chosen for 20% buffer
  evict_step: ccache --evict-older-than 7d already runs every build (binding ceiling on actual size)
post_merge_action: monitor first 2-3 Python builds for 'ccache --show-stats' hit rate uplift
-->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any)
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)