### PR TITLE
STYLE: Strip trailing blank line in 5.4.6.md release notes

### DIFF
--- a/Documentation/docs/releases/5.4.6.md
+++ b/Documentation/docs/releases/5.4.6.md
@@ -226,4 +226,3 @@ We remain dedicated to supporting current users through:
 #### Enhancements
 
 - MINC 2025-02-24 (3b8d9c7e) ([a32b73adbc](https://github.com/InsightSoftwareConsortium/ITK/commit/a32b73adbc))
-


### PR DESCRIPTION
One-character fix to `Documentation/docs/releases/5.4.6.md` so the `end-of-file-fixer` pre-commit hook stops flagging every rebased PR.  Already inlined into #6032, #4221, and #6186; merging this lets those drop the duplicate fixup.

<details>
<summary>Repro</summary>

```
$ pre-commit run end-of-file-fixer --files Documentation/docs/releases/5.4.6.md
fix end of files.........................................................Failed
- hook id: end-of-file-fixer
- files were modified by this hook
```

Trailing line 229 is a stray empty line; `end-of-file-fixer` strips it.

</details>