### PR TITLE
BUG: SWIG typechecks must reject foreign wrapped types (fixes IsInsideBuffer, #5310)

### DIFF
--- a/Modules/Core/ImageFunction/wrapping/test/CMakeLists.txt
+++ b/Modules/Core/ImageFunction/wrapping/test/CMakeLists.txt
@@ -7,4 +7,8 @@ if(ITK_WRAP_PYTHON)
     NAME itkWindowedSincInterpolateImageFunctionPythonTest
     EXPRESSION "windowed_sinc = itk.WindowedSincInterpolateImageFunction.New()"
   )
+  itk_python_add_test(
+    NAME itkLinearImageFunctionWrappingTest
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/itkLinearImageFunctionWrappingTest.py
+  )
 endif()

--- a/Modules/Core/ImageFunction/wrapping/test/itkLinearImageFunctionWrappingTest.py
+++ b/Modules/Core/ImageFunction/wrapping/test/itkLinearImageFunctionWrappingTest.py
@@ -1,0 +1,65 @@
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================
+
+# Regression test for Discourse #7495 / GitHub #5310:
+#   `ImageFunction::IsInsideBuffer` has three C++ overloads (Index,
+#   ContinuousIndex, Point), but in older releases SWIG's overload
+#   dispatcher always selected the integer-only Index overload because
+#   the typecheck typemap accepted any object satisfying
+#   PySequence_Check + length == dim — which wrapped ContinuousIndex
+#   and Point instances do via their __getitem__/__len__.  All of the
+#   following calls must succeed, each reaching its intended overload.
+
+import itk
+import numpy as np
+
+image = itk.GetImageFromArray(np.full((10, 10, 10), 1.0))
+interp = itk.LinearInterpolateImageFunction.New(image)
+
+# All four documented overloads must be reachable and produce True for
+# coordinates that are inside the buffer.
+
+# 1. Raw Python list of ints  -> Index overload.
+assert interp.IsInsideBuffer([1, 2, 3]) is True
+
+# 2. Wrapped ContinuousIndex   -> ContinuousIndex overload.
+cindex = itk.ContinuousIndex[itk.D, 3]()
+cindex[0] = 1.5
+cindex[1] = 2.5
+cindex[2] = 3.5
+assert interp.IsInsideBuffer(cindex) is True
+
+# 3. Wrapped Point             -> Point overload.
+point = itk.Point[itk.D, 3]()
+point[0] = 1.5
+point[1] = 2.5
+point[2] = 3.5
+assert interp.IsInsideBuffer(point) is True
+
+# 4. Raw Python list of floats -> ContinuousIndex overload (selected
+#    after the Index typecheck correctly rejects a float-element list).
+assert interp.IsInsideBuffer([1.5, 2.5, 3.5]) is True
+
+# Out-of-buffer cases must return False, not throw.
+assert interp.IsInsideBuffer([100, 100, 100]) is False
+out_point = itk.Point[itk.D, 3]()
+for d in range(3):
+    out_point[d] = 100.0
+assert interp.IsInsideBuffer(out_point) is False
+
+print("All IsInsideBuffer overload-dispatch checks passed.")

--- a/Wrapping/Generators/Python/PyBase/pyBase.i
+++ b/Wrapping/Generators/Python/PyBase/pyBase.i
@@ -1107,13 +1107,26 @@ str = str
 
     %typemap(typecheck) swig_name & {
         void *ptr;
-        if (SWIG_ConvertPtr($input, &ptr, $1_descriptor, 0) == -1
-            && ( !PySequence_Check($input) || PyObject_Length($input) != dim )
-            && !PyInt_Check($input) && !PyFloat_Check($input) ) {
-            _v = 0;
-            PyErr_Clear();
-        } else {
+        _v = 0;
+        if (SWIG_ConvertPtr($input, &ptr, $1_descriptor, 0) != -1) {
             _v = 1;
+        } else {
+            PyErr_Clear();
+            /* Reject inputs that are SWIG-wrapped instances of an
+             * unrelated type.  Wrapped types like itk::Index,
+             * itk::ContinuousIndex and itk::Point all expose
+             * __getitem__ / __len__, which makes them satisfy
+             * PySequence_Check below — that previously caused this
+             * typecheck to claim viability for foreign types and the
+             * overload dispatcher would pick the wrong overload
+             * (see Discourse #7495). */
+            if (SWIG_Python_GetSwigThis($input) != NULL) {
+                _v = 0;
+            } else if (PyInt_Check($input) || PyFloat_Check($input)) {
+                _v = 1;
+            } else if (PySequence_Check($input) && PyObject_Length($input) == dim) {
+                _v = 1;
+            }
         }
     }
 
@@ -1160,13 +1173,18 @@ str = str
 
     %typemap(typecheck) swig_name {
         void *ptr;
-        if (SWIG_ConvertPtr($input, &ptr, $descriptor(swig_name *), 0) == -1
-            && ( !PySequence_Check($input) || PyObject_Length($input) != dim )
-            && !PyInt_Check($input) && !PyFloat_Check($input) ) {
-            _v = 0;
-            PyErr_Clear();
-        } else {
+        _v = 0;
+        if (SWIG_ConvertPtr($input, &ptr, $descriptor(swig_name *), 0) != -1) {
             _v = 1;
+        } else {
+            PyErr_Clear();
+            if (SWIG_Python_GetSwigThis($input) != NULL) {
+                _v = 0;
+            } else if (PyInt_Check($input) || PyFloat_Check($input)) {
+                _v = 1;
+            } else if (PySequence_Check($input) && PyObject_Length($input) == dim) {
+                _v = 1;
+            }
         }
     }
 
@@ -1223,12 +1241,19 @@ str = str
 
     %typemap(typecheck) type & {
         void *ptr;
-        if (SWIG_ConvertPtr($input, &ptr, $1_descriptor, 0) == -1
-            && !PySequence_Check($input) ) {
-            _v = 0;
-            PyErr_Clear();
-        } else {
+        _v = 0;
+        if (SWIG_ConvertPtr($input, &ptr, $1_descriptor, 0) != -1) {
             _v = 1;
+        } else {
+            PyErr_Clear();
+            /* Reject SWIG wrappers of unrelated types — they all expose
+             * __getitem__ / __len__ and would otherwise trick this
+             * typecheck into claiming overload viability. */
+            if (SWIG_Python_GetSwigThis($input) != NULL) {
+                _v = 0;
+            } else if (PySequence_Check($input)) {
+                _v = 1;
+            }
         }
     }
 
@@ -1269,12 +1294,16 @@ str = str
 
     %typemap(typecheck) type {
         void *ptr;
-        if (SWIG_ConvertPtr($input, &ptr, $descriptor(type *), 0) == -1
-            && !PySequence_Check($input) ) {
-            _v = 0;
-            PyErr_Clear();
-        } else {
+        _v = 0;
+        if (SWIG_ConvertPtr($input, &ptr, $descriptor(type *), 0) != -1) {
             _v = 1;
+        } else {
+            PyErr_Clear();
+            if (SWIG_Python_GetSwigThis($input) != NULL) {
+                _v = 0;
+            } else if (PySequence_Check($input)) {
+                _v = 1;
+            }
         }
     }
 
@@ -1332,13 +1361,31 @@ str = str
 
     %typemap(typecheck) swig_name & {
         void *ptr;
-        if (SWIG_ConvertPtr($input, &ptr, $1_descriptor, 0) == -1
-            && ( !PySequence_Check($input) || PyObject_Length($input) != dim )
-            && !PyInt_Check($input) ) {
-            _v = 0;
-            PyErr_Clear();
-        } else {
+        _v = 0;
+        if (SWIG_ConvertPtr($input, &ptr, $1_descriptor, 0) != -1) {
             _v = 1;
+        } else {
+            PyErr_Clear();
+            /* Reject SWIG-wrapped instances of an unrelated type
+             * (see ContinuousIndex/Point note in DECL_PYTHON_VEC_TYPEMAP). */
+            if (SWIG_Python_GetSwigThis($input) != NULL) {
+                _v = 0;
+            } else if (PyInt_Check($input) || PyLong_Check($input)) {
+                _v = 1;
+            } else if (PySequence_Check($input) && PyObject_Length($input) == dim) {
+                /* This typemap is integer-only.  Peek at element 0 and
+                 * reject sequences whose elements are not integers
+                 * (e.g. [1.5, 2.5, 3.5]).  Without this check, the
+                 * Index overload claimed viability for float lists and
+                 * the dispatcher never reached the ContinuousIndex /
+                 * Point overloads (see Discourse #7495). */
+                PyObject *o = PySequence_GetItem($input, 0);
+                if (o != NULL && (PyInt_Check(o) || PyLong_Check(o))) {
+                    _v = 1;
+                }
+                Py_XDECREF(o);
+                PyErr_Clear();
+            }
         }
     }
 
@@ -1378,13 +1425,23 @@ str = str
 
     %typemap(typecheck) swig_name {
         void *ptr;
-        if (SWIG_ConvertPtr($input, &ptr, $descriptor(swig_name *), 0) == -1
-            && ( !PySequence_Check($input) || PyObject_Length($input) != dim )
-            && !(PyInt_Check($input) || PyLong_Check($input)) ) {
-            _v = 0;
-            PyErr_Clear();
-        } else {
+        _v = 0;
+        if (SWIG_ConvertPtr($input, &ptr, $descriptor(swig_name *), 0) != -1) {
             _v = 1;
+        } else {
+            PyErr_Clear();
+            if (SWIG_Python_GetSwigThis($input) != NULL) {
+                _v = 0;
+            } else if (PyInt_Check($input) || PyLong_Check($input)) {
+                _v = 1;
+            } else if (PySequence_Check($input) && PyObject_Length($input) == dim) {
+                PyObject *o = PySequence_GetItem($input, 0);
+                if (o != NULL && (PyInt_Check(o) || PyLong_Check(o))) {
+                    _v = 1;
+                }
+                Py_XDECREF(o);
+                PyErr_Clear();
+            }
         }
     }
 


### PR DESCRIPTION
Fix for [Discourse #7495](https://discourse.itk.org/t/improper-wrapping-of-imagefunction-isinsidebuffer/7495) and supersedes #5310. SWIG's overload dispatcher was always selecting the integer-only `Index` overload of `ImageFunction::IsInsideBuffer` because the typecheck typemaps in `pyBase.i` claimed viability for any object that satisfied `PySequence_Check + length == dim` — including wrapped `ContinuousIndex` / `Point` instances (they expose `__getitem__` / `__len__`).

<details>
<summary>Root cause walk-through</summary>

`itk::ImageFunction::IsInsideBuffer` has three overloads (`IndexType`, `ContinuousIndexType`, `PointType`). The SWIG-generated dispatcher tries them in declaration order:

```cpp
// Index typecheck (DECL_PYTHON_SEQ_TYPEMAP):
if (SWIG_ConvertPtr(arg, &ptr, SWIGTYPE_p_itkIndex3, 0) == -1
    && (!PySequence_Check(arg) || PyObject_Length(arg) != 3)
    && !PyInt_Check(arg))   _v = 0;
else                        _v = 1;
```

For `interp.IsInsideBuffer(itk.ContinuousIndex[itk.D, 3]())`:
- `SWIG_ConvertPtr` to `itkIndex3` returns `-1` (different SWIG type).
- `PySequence_Check` returns `True` (wrapped fixed-length classes expose `__getitem__` / `__len__`).
- `PyObject_Length` returns `3`.

⇒ `_v = 1`, the dispatcher commits to the `Index` overload, then the `in` typemap demands integer elements and emits

```
ValueError: Expecting a sequence of int (or long)
```

The `ContinuousIndex` and `Point` overloads were never reached. The same logic broke `interp.IsInsideBuffer(itk.Point[itk.D, 3]())` and `interp.IsInsideBuffer([1.5, 2.5, 3.5])`.

</details>

<details>
<summary>Fix</summary>

Tighten the four affected typecheck typemaps in `Wrapping/Generators/Python/PyBase/pyBase.i`:

1. If `SWIG_ConvertPtr` succeeds for *our* descriptor → accept (strong type-correct match).
2. Otherwise, if `SWIG_Python_GetSwigThis` returns non-NULL, the input is a SWIG-wrapped instance of an *unrelated* type → reject, so the dispatcher keeps looking for the right overload.
3. Otherwise, fall through to the cheap scalar / sequence-length checks as before. For the integer-only `SEQ` typemap (`Index` / `Size` / `Offset`), additionally peek at element 0 and reject sequences whose first element is not a Python int — so `[1.5, 2.5, 3.5]` no longer claims viability for the `Index` overload.

This applies to:
- `DECL_PYTHON_VEC_TYPEMAP` — `Vector`, `CovariantVector`, `Point`, `ContinuousIndex`, `FixedArray`
- `DECL_PYTHON_SEQ_TYPEMAP` — `Index`, `Size`, `Offset`
- `DECL_PYTHON_VARLEN_SEQ_TYPEMAP` — `Array`, `RGBPixel`, `RGBAPixel`

</details>

<details>
<summary>Verification (hand-traced before the fix builds)</summary>

After the fix, the dispatcher resolves each test case like this:

| Input | `Index` typecheck | `ContinuousIndex` typecheck | `Point` typecheck (fallback) | Selected overload |
|---|---|---|---|---|
| `[1, 2, 3]` (list of ints) | ✅ (elem 0 is int) | — | — | `Index` |
| `itk.ContinuousIndex` instance | ❌ (`GetSwigThis` non-NULL, foreign type) | ✅ (`ConvertPtr` succeeds) | — | `ContinuousIndex` |
| `itk.Point` instance | ❌ (foreign type) | ❌ (foreign type) | ✅ (final fallback) | `Point` |
| `[1.5, 2.5, 3.5]` (list of floats) | ❌ (elem 0 is float) | ✅ (sequence accepts float) | — | `ContinuousIndex` |

Test `itkLinearImageFunctionWrappingTest.py` asserts each of these calls returns `True` for in-buffer coordinates and `False` for out-of-buffer coordinates.

</details>

Closes #5310.

<!--
provenance: claude-code session 2026-05-02, deep SWIG-typecheck investigation requested by hjmjohnson
key_facts: 4 typecheck typemaps in pyBase.i (DECL_PYTHON_VEC_TYPEMAP &+non-ref, DECL_PYTHON_SEQ_TYPEMAP &+non-ref, DECL_PYTHON_VARLEN_SEQ_TYPEMAP &+non-ref); SWIG_Python_GetSwigThis is part of the standard SWIG runtime and inlined into every wrapper file (verified in built itkImageFunctionBasePython.cpp at line 2458)
related_files: Wrapping/Generators/Python/PyBase/pyBase.i:1108-1131 (VEC&), :1183-1198 (VEC), :1342-1372 (SEQ&), :1410-1428 (SEQ), :1235-1247 (VARLEN&), :1281-1293 (VARLEN); test at Modules/Core/ImageFunction/wrapping/test/itkLinearImageFunctionWrappingTest.py
post_merge_action: close #5310 with pointer to merge commit
-->
