### PR TITLE
COMP: Use itk::MakeFilled in MeshNoise tests for gcc compatibility

### DIFF
--- a/Modules/Filtering/MeshNoise/test/itkAdditiveGaussianNoiseMeshFilterTest.cxx
+++ b/Modules/Filtering/MeshNoise/test/itkAdditiveGaussianNoiseMeshFilterTest.cxx
@@ -18,6 +18,7 @@
 #include <itkMesh.h>
 #include <itkRegularSphereMeshSource.h>
 #include <itkAdditiveGaussianNoiseMeshFilter.h>
+#include "itkMakeFilled.h"
 #include "itkTestingMacros.h"
 
 int
@@ -53,7 +54,7 @@ itkAdditiveGaussianNoiseMeshFilterTest(int itkNotUsed(argc), char * itkNotUsed(a
   TSphere::Pointer sphere = TSphere::New();
 
   sphere->SetResolution(SPHERE_RESOLUTION);
-  sphere->SetScale(TSphere::VectorType::Filled(static_cast<float>(SPHERE_SCALE)));
+  sphere->SetScale(itk::MakeFilled<TSphere::VectorType>(static_cast<float>(SPHERE_SCALE)));
 
   TNoise::Pointer noise = TNoise::New();
 

--- a/Modules/Filtering/MeshNoise/test/itkAdditiveGaussianNoiseQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/MeshNoise/test/itkAdditiveGaussianNoiseQuadEdgeMeshFilterTest.cxx
@@ -18,6 +18,7 @@
 #include <itkQuadEdgeMesh.h>
 #include <itkRegularSphereMeshSource.h>
 #include <itkAdditiveGaussianNoiseQuadEdgeMeshFilter.h>
+#include "itkMakeFilled.h"
 #include "itkTestingMacros.h"
 
 int
@@ -53,7 +54,7 @@ itkAdditiveGaussianNoiseQuadEdgeMeshFilterTest(int itkNotUsed(argc), char * itkN
   TSphere::Pointer sphere = TSphere::New();
 
   sphere->SetResolution(SPHERE_RESOLUTION);
-  sphere->SetScale(TSphere::VectorType::Filled(static_cast<float>(SPHERE_SCALE)));
+  sphere->SetScale(itk::MakeFilled<TSphere::VectorType>(static_cast<float>(SPHERE_SCALE)));
 
   TNoise::Pointer noise = TNoise::New();
 


### PR DESCRIPTION
Follow-up to fbbb93e7 ([#5174](https://github.com/InsightSoftwareConsortium/ITK/issues/5174)) — that earlier fix used `VectorType::Filled(...)`, which compiles under clang but fails on gcc with:

```
error: cannot convert 'itk::FixedArray<float, 3>' to
  'itk::RegularSphereMeshSource<...>::VectorType' {aka 'itk::Vector<float, 3>'}
```

`FixedArray::Filled()` is inherited from the base class and returns `FixedArray<T,N>`; gcc rejects the base→derived conversion that clang silently accepts. `itk::MakeFilled<VectorType>(value)` returns the requested derived type directly and works under both compilers.

<details>
<summary>Files changed</summary>

| File | Change |
|---|---|
| `Modules/Filtering/MeshNoise/test/itkAdditiveGaussianNoiseMeshFilterTest.cxx` | `VectorType::Filled` → `itk::MakeFilled<VectorType>` + add `#include "itkMakeFilled.h"` |
| `Modules/Filtering/MeshNoise/test/itkAdditiveGaussianNoiseQuadEdgeMeshFilterTest.cxx` | same |

</details>

<!--
provenance: claude-code session 2026-05-02
follow_up_to: fbbb93e706 BUG: Fix MeshNoise test compile error (issue #5174)
trigger: gcc build failure on Linux workstation, in-tree MeshNoise test build path
verification: pre-commit run --all-files passes; CI will exercise gcc on Linux pipelines
-->
