### PR TITLE
ENH: Convert 8 ImageIntensity tests to GoogleTest

### DIFF
--- a/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
@@ -63,7 +63,6 @@ set(
   itkSigmoidImageFilterTest.cxx
   itkSinImageFilterAndAdaptorTest.cxx
   itkSqrtImageFilterAndAdaptorTest.cxx
-  itkSquareImageFilterTest.cxx
   itkSubtractImageFilterTest.cxx
   itkSymmetricEigenAnalysisImageFilterTest.cxx
   itkTanImageFilterAndAdaptorTest.cxx
@@ -408,12 +407,6 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/MatrixIndexSelectionImageFilterTest.png
     itkMatrixIndexSelectionImageFilterTest
     ${ITK_TEST_OUTPUT_DIR}/MatrixIndexSelectionImageFilterTest.png
-)
-itk_add_test(
-  NAME itkSquareImageFilterTest
-  COMMAND
-    ITKImageIntensityTestDriver
-    itkSquareImageFilterTest
 )
 itk_add_test(
   NAME itkRGBToVectorAdaptImageFilterTest.cxx
@@ -781,6 +774,7 @@ set(
   itkArithmeticOpsFunctorsTest.cxx
   itkBitwiseOpsFunctorsTest.cxx
   itkRoundImageFilterGTest.cxx
+  itkSquareImageFilterGTest.cxx
 )
 
 if(MSVC)

--- a/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
@@ -23,7 +23,6 @@ set(
   itkDivideImageFilterTest2.cxx
   itkDivideOrZeroOutImageFilterTest.cxx
   itkEdgePotentialImageFilterTest.cxx
-  itkEqualTest.cxx
   itkExpImageFilterAndAdaptorTest.cxx
   itkExpNegativeImageFilterAndAdaptorTest.cxx
   itkHistogramMatchingImageFilterTest.cxx
@@ -604,12 +603,6 @@ itk_add_test(
     itkNormalizeToConstantImageFilterTest
 )
 itk_add_test(
-  NAME itkEqualTest
-  COMMAND
-    ITKImageIntensityTestDriver
-    itkEqualTest
-)
-itk_add_test(
   NAME itkClampImageFilterTest
   COMMAND
     ITKImageIntensityTestDriver
@@ -738,6 +731,7 @@ set(
   itkAddImageFilterFrameGTest.cxx
   itkArithmeticOpsFunctorsTest.cxx
   itkBitwiseOpsFunctorsTest.cxx
+  itkEqualGTest.cxx
   itkGreaterEqualGTest.cxx
   itkGreaterGTest.cxx
   itkLessEqualGTest.cxx

--- a/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
@@ -33,7 +33,6 @@ set(
   itkIntensityWindowingImageFilterTest.cxx
   itkInvertIntensityImageFilterTest.cxx
   itkLessEqualTest.cxx
-  itkLessTest.cxx
   itkLog10ImageFilterAndAdaptorTest.cxx
   itkLogImageFilterAndAdaptorTest.cxx
   itkMagnitudeAndPhaseToComplexImageFilterTest.cxx
@@ -639,12 +638,6 @@ itk_add_test(
     itkLessEqualTest
 )
 itk_add_test(
-  NAME itkLessTest
-  COMMAND
-    ITKImageIntensityTestDriver
-    itkLessTest
-)
-itk_add_test(
   NAME itkClampImageFilterTest
   COMMAND
     ITKImageIntensityTestDriver
@@ -773,6 +766,7 @@ set(
   itkAddImageFilterFrameGTest.cxx
   itkArithmeticOpsFunctorsTest.cxx
   itkBitwiseOpsFunctorsTest.cxx
+  itkLessGTest.cxx
   itkRoundImageFilterGTest.cxx
   itkSquareImageFilterGTest.cxx
 )

--- a/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
@@ -27,7 +27,6 @@ set(
   itkExpImageFilterAndAdaptorTest.cxx
   itkExpNegativeImageFilterAndAdaptorTest.cxx
   itkGreaterEqualTest.cxx
-  itkGreaterTest.cxx
   itkHistogramMatchingImageFilterTest.cxx
   itkImageAdaptorNthElementTest.cxx
   itkIntensityWindowingImageFilterTest.cxx
@@ -619,12 +618,6 @@ itk_add_test(
     itkGreaterEqualTest
 )
 itk_add_test(
-  NAME itkGreaterTest
-  COMMAND
-    ITKImageIntensityTestDriver
-    itkGreaterTest
-)
-itk_add_test(
   NAME itkLessEqualTest
   COMMAND
     ITKImageIntensityTestDriver
@@ -759,6 +752,7 @@ set(
   itkAddImageFilterFrameGTest.cxx
   itkArithmeticOpsFunctorsTest.cxx
   itkBitwiseOpsFunctorsTest.cxx
+  itkGreaterGTest.cxx
   itkLessGTest.cxx
   itkNotEqualGTest.cxx
   itkRoundImageFilterGTest.cxx

--- a/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
@@ -59,7 +59,6 @@ set(
   itkRescaleIntensityImageFilterTest.cxx
   itkRGBToLuminanceImageFilterAndAdaptorTest.cxx
   itkRGBToVectorAdaptImageFilterTest.cxx
-  itkRoundImageFilterTest.cxx
   itkShiftScaleImageFilterTest.cxx
   itkSigmoidImageFilterTest.cxx
   itkSinImageFilterAndAdaptorTest.cxx
@@ -677,12 +676,6 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkMagnitudeAndPhaseToComplexImageFilterTest.mha
 )
 itk_add_test(
-  NAME itkRoundImageFilterTest
-  COMMAND
-    ITKImageIntensityTestDriver
-    itkRoundImageFilterTest
-)
-itk_add_test(
   NAME itkDiscreteHessianGaussianImageFunctionTest
   COMMAND
     ITKImageIntensityTestDriver
@@ -787,6 +780,7 @@ set(
   itkAddImageFilterFrameGTest.cxx
   itkArithmeticOpsFunctorsTest.cxx
   itkBitwiseOpsFunctorsTest.cxx
+  itkRoundImageFilterGTest.cxx
 )
 
 if(MSVC)

--- a/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
@@ -26,7 +26,6 @@ set(
   itkEqualTest.cxx
   itkExpImageFilterAndAdaptorTest.cxx
   itkExpNegativeImageFilterAndAdaptorTest.cxx
-  itkGreaterEqualTest.cxx
   itkHistogramMatchingImageFilterTest.cxx
   itkImageAdaptorNthElementTest.cxx
   itkIntensityWindowingImageFilterTest.cxx
@@ -612,12 +611,6 @@ itk_add_test(
     itkEqualTest
 )
 itk_add_test(
-  NAME itkGreaterEqualTest
-  COMMAND
-    ITKImageIntensityTestDriver
-    itkGreaterEqualTest
-)
-itk_add_test(
   NAME itkLessEqualTest
   COMMAND
     ITKImageIntensityTestDriver
@@ -752,6 +745,7 @@ set(
   itkAddImageFilterFrameGTest.cxx
   itkArithmeticOpsFunctorsTest.cxx
   itkBitwiseOpsFunctorsTest.cxx
+  itkGreaterEqualGTest.cxx
   itkGreaterGTest.cxx
   itkLessGTest.cxx
   itkNotEqualGTest.cxx

--- a/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
@@ -30,7 +30,6 @@ set(
   itkImageAdaptorNthElementTest.cxx
   itkIntensityWindowingImageFilterTest.cxx
   itkInvertIntensityImageFilterTest.cxx
-  itkLessEqualTest.cxx
   itkLog10ImageFilterAndAdaptorTest.cxx
   itkLogImageFilterAndAdaptorTest.cxx
   itkMagnitudeAndPhaseToComplexImageFilterTest.cxx
@@ -611,12 +610,6 @@ itk_add_test(
     itkEqualTest
 )
 itk_add_test(
-  NAME itkLessEqualTest
-  COMMAND
-    ITKImageIntensityTestDriver
-    itkLessEqualTest
-)
-itk_add_test(
   NAME itkClampImageFilterTest
   COMMAND
     ITKImageIntensityTestDriver
@@ -747,6 +740,7 @@ set(
   itkBitwiseOpsFunctorsTest.cxx
   itkGreaterEqualGTest.cxx
   itkGreaterGTest.cxx
+  itkLessEqualGTest.cxx
   itkLessGTest.cxx
   itkNotEqualGTest.cxx
   itkRoundImageFilterGTest.cxx

--- a/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
@@ -47,7 +47,6 @@ set(
   itkNaryMaximumImageFilterTest.cxx
   itkNormalizeImageFilterTest.cxx
   itkNormalizeToConstantImageFilterTest.cxx
-  itkNotEqualTest.cxx
   itkNotImageFilterTest.cxx
   itkNthElementPixelAccessorTest2.cxx
   itkOrImageFilterTest.cxx
@@ -614,12 +613,6 @@ itk_add_test(
     itkEqualTest
 )
 itk_add_test(
-  NAME itkNotEqualTest
-  COMMAND
-    ITKImageIntensityTestDriver
-    itkNotEqualTest
-)
-itk_add_test(
   NAME itkGreaterEqualTest
   COMMAND
     ITKImageIntensityTestDriver
@@ -767,6 +760,7 @@ set(
   itkArithmeticOpsFunctorsTest.cxx
   itkBitwiseOpsFunctorsTest.cxx
   itkLessGTest.cxx
+  itkNotEqualGTest.cxx
   itkRoundImageFilterGTest.cxx
   itkSquareImageFilterGTest.cxx
 )

--- a/Modules/Filtering/ImageIntensity/test/itkEqualGTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkEqualGTest.cxx
@@ -15,11 +15,14 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#include "itkCommonEnums.h"
 #include "itkLogicOpsFunctors.h"
+
 #include "itkBinaryFunctorImageFilter.h"
+#include "itkCommonEnums.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkLogicTestSupport.h"
+
+#include "itkGTest.h"
 
 namespace
 {
@@ -60,10 +63,9 @@ public:
 };
 } // namespace
 
-int
-itkEqualTest(int, char *[])
-{
 
+TEST(EqualImageFilter, ConvertedLegacyTest)
+{
   // Define the dimension of the images
   constexpr unsigned int myDimension{ 3 };
 
@@ -131,10 +133,7 @@ itkEqualTest(int, char *[])
   {
     // Create a logic Filter
     const myFilterTypePointer filter = myFilterType::New();
-    if (filter.IsNull())
-    {
-      return EXIT_FAILURE;
-    }
+    ASSERT_FALSE(filter.IsNull());
 
     // Connect the input images
     filter->SetInput1(inputImageA);
@@ -153,15 +152,9 @@ itkEqualTest(int, char *[])
     const PixelType FG = filter->GetFunctor().GetForegroundValue();
     const PixelType BG = filter->GetFunctor().GetBackgroundValue();
 
-    const int status1 =
-      checkImOnImRes<myImageType1, myImageType2, myImageType3, std::equal_to<myImageType1::PixelType>>(
-        inputImageA, inputImageB, outputImage, FG, BG);
-    if (status1 == EXIT_FAILURE)
-    {
-      return EXIT_FAILURE;
-    }
-
-    std::cout << "Step 1 passed" << std::endl;
+    ASSERT_EQ((checkImOnImRes<myImageType1, myImageType2, myImageType3, std::equal_to<myImageType1::PixelType>>(
+                inputImageA, inputImageB, outputImage, FG, BG)),
+              EXIT_SUCCESS);
   }
 
   {
@@ -182,14 +175,9 @@ itkEqualTest(int, char *[])
     const PixelType FG = filter->GetFunctor().GetForegroundValue();
     const PixelType BG = filter->GetFunctor().GetBackgroundValue();
     const PixelType C = filter->GetConstant2();
-    const int       status2 = checkImOnConstRes<myImageType1, PixelType, myImageType3, std::equal_to<PixelType>>(
-      inputImageA, C, outputImage, FG, BG);
-    if (status2 == EXIT_FAILURE)
-    {
-      return EXIT_FAILURE;
-    }
-
-    std::cout << "Step 2 passed " << std::endl;
+    ASSERT_EQ((checkImOnConstRes<myImageType1, PixelType, myImageType3, std::equal_to<PixelType>>(
+                inputImageA, C, outputImage, FG, BG)),
+              EXIT_SUCCESS);
   }
   // Now try testing with constant : 3 == Im2
   {
@@ -209,26 +197,17 @@ itkEqualTest(int, char *[])
     const PixelType FG = filter->GetFunctor().GetForegroundValue();
     const PixelType BG = filter->GetFunctor().GetBackgroundValue();
 
-    const int status3 = checkConstOnImRes<PixelType, myImageType2, myImageType3, std::equal_to<PixelType>>(
-      filter->GetConstant1(), inputImageB, outputImage, FG, BG);
-    if (status3 == EXIT_FAILURE)
-    {
-      return EXIT_FAILURE;
-    }
-
-    std::cout << "Step 3 passed" << std::endl;
+    ASSERT_EQ((checkConstOnImRes<PixelType, myImageType2, myImageType3, std::equal_to<PixelType>>(
+                filter->GetConstant1(), inputImageB, outputImage, FG, BG)),
+              EXIT_SUCCESS);
   }
 
   {
     // BinaryImageFilter
     using iFIB = itk::BinaryFunctorImageFilter<itk::Image<double>, itk::Image<double>, itk::Image<double>, Bogus>;
     auto FIB = iFIB::New();
-    if (FIB.IsNull())
-    {
-      return EXIT_FAILURE;
-    }
+    ASSERT_FALSE(FIB.IsNull());
   }
 
   // All objects should be automatically destroyed at this point
-  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageIntensity/test/itkGreaterEqualGTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkGreaterEqualGTest.cxx
@@ -16,14 +16,16 @@
  *
  *=========================================================================*/
 #include "itkLogicOpsFunctors.h"
+
 #include "itkBinaryFunctorImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkLogicTestSupport.h"
 
-int
-itkGreaterEqualTest(int, char *[])
-{
+#include "itkGTest.h"
 
+
+TEST(GreaterEqualImageFilter, ConvertedLegacyTest)
+{
   // Define the dimension of the images
   constexpr unsigned int myDimension{ 3 };
 
@@ -108,15 +110,9 @@ itkGreaterEqualTest(int, char *[])
     const PixelType FG = filter->GetFunctor().GetForegroundValue();
     const PixelType BG = filter->GetFunctor().GetBackgroundValue();
 
-    const int status1 =
-      checkImOnImRes<myImageType1, myImageType2, myImageType3, std::greater_equal<myImageType1::PixelType>>(
-        inputImageA, inputImageB, outputImage, FG, BG);
-    if (status1 == EXIT_FAILURE)
-    {
-      return EXIT_FAILURE;
-    }
-
-    std::cout << "Step 1 passed" << std::endl;
+    ASSERT_EQ((checkImOnImRes<myImageType1, myImageType2, myImageType3, std::greater_equal<myImageType1::PixelType>>(
+                inputImageA, inputImageB, outputImage, FG, BG)),
+              EXIT_SUCCESS);
   }
 
   {
@@ -138,14 +134,9 @@ itkGreaterEqualTest(int, char *[])
     const PixelType FG = filter->GetFunctor().GetForegroundValue();
     const PixelType BG = filter->GetFunctor().GetBackgroundValue();
     const PixelType C = filter->GetConstant2();
-    const int       status2 = checkImOnConstRes<myImageType1, PixelType, myImageType3, std::greater_equal<PixelType>>(
-      inputImageA, C, outputImage, FG, BG);
-    if (status2 == EXIT_FAILURE)
-    {
-      return EXIT_FAILURE;
-    }
-
-    std::cout << "Step 2 passed " << std::endl;
+    ASSERT_EQ((checkImOnConstRes<myImageType1, PixelType, myImageType3, std::greater_equal<PixelType>>(
+                inputImageA, C, outputImage, FG, BG)),
+              EXIT_SUCCESS);
   }
   // Now try testing with constant : 3 != Im2
   {
@@ -165,15 +156,9 @@ itkGreaterEqualTest(int, char *[])
     const PixelType FG = filter->GetFunctor().GetForegroundValue();
     const PixelType BG = filter->GetFunctor().GetBackgroundValue();
 
-    const int status3 = checkConstOnImRes<PixelType, myImageType2, myImageType3, std::greater_equal<PixelType>>(
-      filter->GetConstant1(), inputImageB, outputImage, FG, BG);
-    if (status3 == EXIT_FAILURE)
-    {
-      return EXIT_FAILURE;
-    }
-
-    std::cout << "Step 3 passed" << std::endl;
+    ASSERT_EQ((checkConstOnImRes<PixelType, myImageType2, myImageType3, std::greater_equal<PixelType>>(
+                filter->GetConstant1(), inputImageB, outputImage, FG, BG)),
+              EXIT_SUCCESS);
   }
   // All objects should be automatically destroyed at this point
-  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageIntensity/test/itkGreaterGTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkGreaterGTest.cxx
@@ -16,14 +16,16 @@
  *
  *=========================================================================*/
 #include "itkLogicOpsFunctors.h"
+
 #include "itkBinaryFunctorImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkLogicTestSupport.h"
 
-int
-itkGreaterTest(int, char *[])
-{
+#include "itkGTest.h"
 
+
+TEST(GreaterImageFilter, ConvertedLegacyTest)
+{
   // Define the dimension of the images
   constexpr unsigned int myDimension{ 3 };
 
@@ -108,14 +110,9 @@ itkGreaterTest(int, char *[])
     const PixelType FG = filter->GetFunctor().GetForegroundValue();
     const PixelType BG = filter->GetFunctor().GetBackgroundValue();
 
-    const int status1 = checkImOnImRes<myImageType1, myImageType2, myImageType3, std::greater<myImageType1::PixelType>>(
-      inputImageA, inputImageB, outputImage, FG, BG);
-    if (status1 == EXIT_FAILURE)
-    {
-      return EXIT_FAILURE;
-    }
-
-    std::cout << "Step 1 passed" << std::endl;
+    ASSERT_EQ((checkImOnImRes<myImageType1, myImageType2, myImageType3, std::greater<myImageType1::PixelType>>(
+                inputImageA, inputImageB, outputImage, FG, BG)),
+              EXIT_SUCCESS);
   }
 
   {
@@ -137,14 +134,9 @@ itkGreaterTest(int, char *[])
     const PixelType FG = filter->GetFunctor().GetForegroundValue();
     const PixelType BG = filter->GetFunctor().GetBackgroundValue();
     const PixelType C = filter->GetConstant2();
-    const int       status2 = checkImOnConstRes<myImageType1, PixelType, myImageType3, std::greater<PixelType>>(
-      inputImageA, C, outputImage, FG, BG);
-    if (status2 == EXIT_FAILURE)
-    {
-      return EXIT_FAILURE;
-    }
-
-    std::cout << "Step 2 passed " << std::endl;
+    ASSERT_EQ((checkImOnConstRes<myImageType1, PixelType, myImageType3, std::greater<PixelType>>(
+                inputImageA, C, outputImage, FG, BG)),
+              EXIT_SUCCESS);
   }
   // Now try testing with constant : 3 != Im2
   {
@@ -162,15 +154,9 @@ itkGreaterTest(int, char *[])
     const PixelType FG = filter->GetFunctor().GetForegroundValue();
     const PixelType BG = filter->GetFunctor().GetBackgroundValue();
 
-    const int status3 = checkConstOnImRes<PixelType, myImageType2, myImageType3, std::greater<PixelType>>(
-      filter->GetConstant1(), inputImageB, outputImage, FG, BG);
-    if (status3 == EXIT_FAILURE)
-    {
-      return EXIT_FAILURE;
-    }
-
-    std::cout << "Step 3 passed" << std::endl;
+    ASSERT_EQ((checkConstOnImRes<PixelType, myImageType2, myImageType3, std::greater<PixelType>>(
+                filter->GetConstant1(), inputImageB, outputImage, FG, BG)),
+              EXIT_SUCCESS);
   }
   // All objects should be automatically destroyed at this point
-  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageIntensity/test/itkLessEqualGTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkLessEqualGTest.cxx
@@ -16,14 +16,16 @@
  *
  *=========================================================================*/
 #include "itkLogicOpsFunctors.h"
+
 #include "itkBinaryFunctorImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkLogicTestSupport.h"
 
-int
-itkLessEqualTest(int, char *[])
-{
+#include "itkGTest.h"
 
+
+TEST(LessEqualImageFilter, ConvertedLegacyTest)
+{
   // Define the dimension of the images
   constexpr unsigned int myDimension{ 3 };
 
@@ -109,15 +111,9 @@ itkLessEqualTest(int, char *[])
     const PixelType FG = filter->GetFunctor().GetForegroundValue();
     const PixelType BG = filter->GetFunctor().GetBackgroundValue();
 
-    const int status1 =
-      checkImOnImRes<myImageType1, myImageType2, myImageType3, std::less_equal<myImageType1::PixelType>>(
-        inputImageA, inputImageB, outputImage, FG, BG);
-    if (status1 == EXIT_FAILURE)
-    {
-      return EXIT_FAILURE;
-    }
-
-    std::cout << "Step 1 passed" << std::endl;
+    ASSERT_EQ((checkImOnImRes<myImageType1, myImageType2, myImageType3, std::less_equal<myImageType1::PixelType>>(
+                inputImageA, inputImageB, outputImage, FG, BG)),
+              EXIT_SUCCESS);
   }
 
   {
@@ -138,14 +134,9 @@ itkLessEqualTest(int, char *[])
     const PixelType FG = filter->GetFunctor().GetForegroundValue();
     const PixelType BG = filter->GetFunctor().GetBackgroundValue();
     const PixelType C = filter->GetConstant2();
-    const int       status2 = checkImOnConstRes<myImageType1, PixelType, myImageType3, std::less_equal<PixelType>>(
-      inputImageA, C, outputImage, FG, BG);
-    if (status2 == EXIT_FAILURE)
-    {
-      return EXIT_FAILURE;
-    }
-
-    std::cout << "Step 2 passed " << std::endl;
+    ASSERT_EQ((checkImOnConstRes<myImageType1, PixelType, myImageType3, std::less_equal<PixelType>>(
+                inputImageA, C, outputImage, FG, BG)),
+              EXIT_SUCCESS);
   }
   // Now try testing with constant : 3 != Im2
   {
@@ -163,15 +154,9 @@ itkLessEqualTest(int, char *[])
     const PixelType FG = filter->GetFunctor().GetForegroundValue();
     const PixelType BG = filter->GetFunctor().GetBackgroundValue();
 
-    const int status3 = checkConstOnImRes<PixelType, myImageType2, myImageType3, std::less_equal<PixelType>>(
-      filter->GetConstant1(), inputImageB, outputImage, FG, BG);
-    if (status3 == EXIT_FAILURE)
-    {
-      return EXIT_FAILURE;
-    }
-
-    std::cout << "Step 3 passed" << std::endl;
+    ASSERT_EQ((checkConstOnImRes<PixelType, myImageType2, myImageType3, std::less_equal<PixelType>>(
+                filter->GetConstant1(), inputImageB, outputImage, FG, BG)),
+              EXIT_SUCCESS);
   }
   // All objects should be automatically destroyed at this point
-  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageIntensity/test/itkLessGTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkLessGTest.cxx
@@ -16,14 +16,16 @@
  *
  *=========================================================================*/
 #include "itkLogicOpsFunctors.h"
+
 #include "itkBinaryFunctorImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkLogicTestSupport.h"
 
-int
-itkLessTest(int, char *[])
-{
+#include "itkGTest.h"
 
+
+TEST(LessImageFilter, ConvertedLegacyTest)
+{
   // Define the dimension of the images
   constexpr unsigned int myDimension{ 3 };
 
@@ -107,14 +109,9 @@ itkLessTest(int, char *[])
     const PixelType FG = filter->GetFunctor().GetForegroundValue();
     const PixelType BG = filter->GetFunctor().GetBackgroundValue();
 
-    const int status1 = checkImOnImRes<myImageType1, myImageType2, myImageType3, std::less<myImageType1::PixelType>>(
-      inputImageA, inputImageB, outputImage, FG, BG);
-    if (status1 == EXIT_FAILURE)
-    {
-      return EXIT_FAILURE;
-    }
-
-    std::cout << "Step 1 passed" << std::endl;
+    ASSERT_EQ((checkImOnImRes<myImageType1, myImageType2, myImageType3, std::less<myImageType1::PixelType>>(
+                inputImageA, inputImageB, outputImage, FG, BG)),
+              EXIT_SUCCESS);
   }
 
   {
@@ -135,14 +132,9 @@ itkLessTest(int, char *[])
     const PixelType FG = filter->GetFunctor().GetForegroundValue();
     const PixelType BG = filter->GetFunctor().GetBackgroundValue();
     const PixelType C = filter->GetConstant2();
-    const int       status2 = checkImOnConstRes<myImageType1, PixelType, myImageType3, std::less<PixelType>>(
-      inputImageA, C, outputImage, FG, BG);
-    if (status2 == EXIT_FAILURE)
-    {
-      return EXIT_FAILURE;
-    }
-
-    std::cout << "Step 2 passed " << std::endl;
+    ASSERT_EQ((checkImOnConstRes<myImageType1, PixelType, myImageType3, std::less<PixelType>>(
+                inputImageA, C, outputImage, FG, BG)),
+              EXIT_SUCCESS);
   }
   // Now try testing with constant : 3 != Im2
   {
@@ -160,15 +152,9 @@ itkLessTest(int, char *[])
     const PixelType FG = filter->GetFunctor().GetForegroundValue();
     const PixelType BG = filter->GetFunctor().GetBackgroundValue();
 
-    const int status3 = checkConstOnImRes<PixelType, myImageType2, myImageType3, std::less<PixelType>>(
-      filter->GetConstant1(), inputImageB, outputImage, FG, BG);
-    if (status3 == EXIT_FAILURE)
-    {
-      return EXIT_FAILURE;
-    }
-
-    std::cout << "Step 3 passed" << std::endl;
+    ASSERT_EQ((checkConstOnImRes<PixelType, myImageType2, myImageType3, std::less<PixelType>>(
+                filter->GetConstant1(), inputImageB, outputImage, FG, BG)),
+              EXIT_SUCCESS);
   }
   // All objects should be automatically destroyed at this point
-  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageIntensity/test/itkNotEqualGTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkNotEqualGTest.cxx
@@ -16,14 +16,16 @@
  *
  *=========================================================================*/
 #include "itkLogicOpsFunctors.h"
+
 #include "itkBinaryFunctorImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkLogicTestSupport.h"
 
-int
-itkNotEqualTest(int, char *[])
-{
+#include "itkGTest.h"
 
+
+TEST(NotEqualImageFilter, ConvertedLegacyTest)
+{
   // Define the dimension of the images
   constexpr unsigned int myDimension{ 3 };
 
@@ -109,15 +111,9 @@ itkNotEqualTest(int, char *[])
     const PixelType FG = filter->GetFunctor().GetForegroundValue();
     const PixelType BG = filter->GetFunctor().GetBackgroundValue();
 
-    const int status1 =
-      checkImOnImRes<myImageType1, myImageType2, myImageType3, std::not_equal_to<myImageType1::PixelType>>(
-        inputImageA, inputImageB, outputImage, FG, BG);
-    if (status1 == EXIT_FAILURE)
-    {
-      return EXIT_FAILURE;
-    }
-
-    std::cout << "Step 1 passed" << std::endl;
+    ASSERT_EQ((checkImOnImRes<myImageType1, myImageType2, myImageType3, std::not_equal_to<myImageType1::PixelType>>(
+                inputImageA, inputImageB, outputImage, FG, BG)),
+              EXIT_SUCCESS);
   }
   {
     // Create a logic Filter
@@ -137,14 +133,9 @@ itkNotEqualTest(int, char *[])
     const PixelType FG = filter->GetFunctor().GetForegroundValue();
     const PixelType BG = filter->GetFunctor().GetBackgroundValue();
     const PixelType C = filter->GetConstant2();
-    const int       status2 = checkImOnConstRes<myImageType1, PixelType, myImageType3, std::not_equal_to<PixelType>>(
-      inputImageA, C, outputImage, FG, BG);
-    if (status2 == EXIT_FAILURE)
-    {
-      return EXIT_FAILURE;
-    }
-
-    std::cout << "Step 2 passed " << std::endl;
+    ASSERT_EQ((checkImOnConstRes<myImageType1, PixelType, myImageType3, std::not_equal_to<PixelType>>(
+                inputImageA, C, outputImage, FG, BG)),
+              EXIT_SUCCESS);
   }
   {
     // Now try testing with constant : 3 != Im2
@@ -162,15 +153,9 @@ itkNotEqualTest(int, char *[])
     const PixelType FG = filter->GetFunctor().GetForegroundValue();
     const PixelType BG = filter->GetFunctor().GetBackgroundValue();
 
-    const int status3 = checkConstOnImRes<PixelType, myImageType2, myImageType3, std::not_equal_to<PixelType>>(
-      filter->GetConstant1(), inputImageB, outputImage, FG, BG);
-    if (status3 == EXIT_FAILURE)
-    {
-      return EXIT_FAILURE;
-    }
-
-    std::cout << "Step 3 passed" << std::endl;
+    ASSERT_EQ((checkConstOnImRes<PixelType, myImageType2, myImageType3, std::not_equal_to<PixelType>>(
+                filter->GetConstant1(), inputImageB, outputImage, FG, BG)),
+              EXIT_SUCCESS);
   }
   // All objects should be automatically destroyed at this point
-  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageIntensity/test/itkRoundImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkRoundImageFilterGTest.cxx
@@ -16,17 +16,17 @@
  *
  *=========================================================================*/
 
+#include "itkRoundImageFilter.h"
+
 #include "itkImageRegionIterator.h"
 #include "itkMath.h"
 #include "itkRandomImageSource.h"
-#include "itkRoundImageFilter.h"
-#include "itkTestingMacros.h"
+
+#include "itkGTest.h"
 
 
-int
-itkRoundImageFilterTest(int, char *[])
+TEST(RoundImageFilter, ConvertedLegacyTest)
 {
-
   constexpr unsigned int Dimension{ 2 };
 
   using InputPixelType = float;
@@ -40,7 +40,7 @@ itkRoundImageFilterTest(int, char *[])
   using FilterType = itk::RoundImageFilter<InputImageType, OutputImageType>;
   auto roundImageFilter = FilterType::New();
 
-  ITK_EXERCISE_BASIC_OBJECT_METHODS(roundImageFilter, RoundImageFilter, UnaryGeneratorImageFilter);
+  ITK_GTEST_EXERCISE_BASIC_OBJECT_METHODS(roundImageFilter, RoundImageFilter, UnaryGeneratorImageFilter);
 
 
   // Create a random image
@@ -56,7 +56,7 @@ itkRoundImageFilterTest(int, char *[])
 
   roundImageFilter->SetInput(randomImageSource->GetOutput());
 
-  ITK_TRY_EXPECT_NO_EXCEPTION(roundImageFilter->Update());
+  ASSERT_NO_THROW(roundImageFilter->Update());
 
   itk::ImageRegionIterator<InputImageType>  it1(randomImageSource->GetOutput(),
                                                randomImageSource->GetOutput()->GetLargestPossibleRegion());
@@ -68,13 +68,9 @@ itkRoundImageFilterTest(int, char *[])
 
   while (!it1.IsAtEnd() || !it2.IsAtEnd())
   {
-    ITK_TEST_EXPECT_EQUAL(itk::Math::Round<OutputImageType::ValueType>(it1.Get()), it2.Get());
+    EXPECT_EQ(itk::Math::Round<OutputImageType::ValueType>(it1.Get()), it2.Get());
 
     ++it1;
     ++it2;
   }
-
-
-  std::cout << "Test finished." << std::endl;
-  return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/ImageIntensity/test/itkSquareImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkSquareImageFilterGTest.cxx
@@ -17,14 +17,15 @@
  *=========================================================================*/
 
 #include "itkSquareImageFilter.h"
+
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkMath.h"
-#include "itkTestingMacros.h"
 
-int
-itkSquareImageFilterTest(int, char *[])
+#include "itkGTest.h"
+
+
+TEST(SquareImageFilter, ConvertedLegacyTest)
 {
-
   // Define the dimension of the images
   constexpr unsigned int ImageDimension{ 3 };
 
@@ -60,12 +61,10 @@ itkSquareImageFilterTest(int, char *[])
 
   // Initialize the content of Image A
   constexpr double value{ 30 };
-  std::cout << "Content of the Input " << std::endl;
   it.GoToBegin();
   while (!it.IsAtEnd())
   {
     it.Set(value);
-    std::cout << it.Get() << std::endl;
     ++it;
   }
 
@@ -75,7 +74,7 @@ itkSquareImageFilterTest(int, char *[])
   // Create a Filter
   auto filter = FilterType::New();
 
-  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, SquareImageFilter, UnaryGeneratorImageFilter);
+  ITK_GTEST_EXERCISE_BASIC_OBJECT_METHODS(filter, SquareImageFilter, UnaryGeneratorImageFilter);
 
   // Connect the input images
   filter->SetInput(inputImage);
@@ -102,18 +101,9 @@ itkSquareImageFilterTest(int, char *[])
     const double                     x1 = input;
     const double                     x2 = x1 * x1;
     const auto                       square = static_cast<OutputImageType::PixelType>(x2);
-    if (!itk::Math::FloatAlmostEqual(square, output, 10, epsilon))
-    {
-      std::cerr.precision(static_cast<unsigned int>(itk::Math::Absolute(std::log10(epsilon))));
-      std::cerr << "Error in itkSquareImageFilterTest " << std::endl;
-      std::cerr << " square( " << input << ") = " << square << std::endl;
-      std::cerr << " differs from " << output;
-      std::cerr << " by more than " << epsilon << std::endl;
-      return EXIT_FAILURE;
-    }
+    EXPECT_TRUE(itk::Math::FloatAlmostEqual(square, output, 10, epsilon))
+      << "square(" << input << ") = " << square << " differs from " << output << " by more than " << epsilon;
     ++ot;
     ++it;
   }
-
-  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Mechanical conversion of 8 no-argument legacy CTests in `Modules/Filtering/ImageIntensity/test/` to GoogleTest, per the `convert-to-gtest` skill workflow ("one commit, one change" — N-Dekker).

| Test | Commit |
|---|---|
| `itkRoundImageFilterTest` | `e4b9ee6e` |
| `itkSquareImageFilterTest` | `396bcad6` |
| `itkLessTest` | `afa3f1fb` |
| `itkNotEqualTest` | `79a6e66f` |
| `itkGreaterTest` | `0ebef44a` |
| `itkGreaterEqualTest` | `f200baee` |
| `itkLessEqualTest` | `b82d4b86` |
| `itkEqualTest` | `d678cf4b` |

Each conversion is a single commit with `git mv` rename (81-83% similarity, history preserved through `git log --follow`), `ITK_EXERCISE_BASIC_OBJECT_METHODS` → `ITK_GTEST_EXERCISE_BASIC_OBJECT_METHODS`, `ITK_TRY_EXPECT_NO_EXCEPTION` → `ASSERT_NO_THROW`, and return-on-failure → `ASSERT_EQ(..., EXIT_SUCCESS)`. No logic refactoring, no comment removal, no spurious `[[maybe_unused]]`.

<details>
<summary>Verification</summary>

- All 8 GTests build and pass locally (each <1ms)
- `pre-commit run --all-files` exit 0 on the final tip
- CMakeLists alphabetic ordering preserved on both `ITKImageIntensityTests` (legacy) and `ITKImageIntensityGTests` sets
- The `Equal` conversion preserves its `Bogus` helper class and the 4th sub-block (BinaryFunctorImageFilter instantiation check); all other 7 follow the standard 3-step image-on-image / image-on-constant / constant-on-image pattern

Net: +111 / -267 (conversions are leaner than the originals because the `if (status == EXIT_FAILURE) { return EXIT_FAILURE; std::cout << "Step N passed" << std::endl; }` boilerplate collapses to a single `ASSERT_EQ`).

</details>

<!--
provenance: claude-code session 2026-05-02, /convert-to-gtest 8 tests from Modules/Filtering
target_module: Modules/Filtering/ImageIntensity
conversion_pattern: itkLogicOpsFunctors three-step + RoundImageFilter scalar + SquareImageFilter scalar
mechanical_only: yes — no logic changes, comments preserved, scope-explaining notes intact
-->
