### PR TITLE
ENH: Convert 10 Numerics/Statistics tests to GoogleTest

### DIFF
--- a/Modules/Numerics/Statistics/test/CMakeLists.txt
+++ b/Modules/Numerics/Statistics/test/CMakeLists.txt
@@ -79,7 +79,6 @@ set(
   itkSubsampleTest3.cxx
   itkTDistributionTest.cxx
   itkUniformRandomSpatialNeighborSubsamplerTest.cxx
-  itkVectorContainerToListSampleAdaptorTest.cxx
   itkWeightedCentroidKdTreeGeneratorTest1.cxx
   itkWeightedCentroidKdTreeGeneratorTest8.cxx
   itkWeightedCentroidKdTreeGeneratorTest9.cxx
@@ -918,12 +917,6 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkUniformRandomSubsamplingTest.mha
 )
 itk_add_test(
-  NAME itkVectorContainerToListSampleAdaptorTest
-  COMMAND
-    ITKStatisticsTestDriver
-    itkVectorContainerToListSampleAdaptorTest
-)
-itk_add_test(
   NAME itkImageToHistogramFilterTest
   COMMAND
     ITKStatisticsTestDriver
@@ -966,5 +959,6 @@ set(
   itkNormalVariateGeneratorGTest1.cxx
   itkRandomVariateGeneratorBaseGTest.cxx
   itkStatisticsTypesGTest.cxx
+  itkVectorContainerToListSampleAdaptorGTest.cxx
 )
 creategoogletestdriver(ITKStatistics "${ITKStatistics-Test_LIBRARIES}" "${ITKStatisticsGTests}")

--- a/Modules/Numerics/Statistics/test/CMakeLists.txt
+++ b/Modules/Numerics/Statistics/test/CMakeLists.txt
@@ -17,7 +17,6 @@ set(
   itkGaussianMixtureModelComponentTest.cxx
   itkGaussianRandomSpatialNeighborSubsamplerTest.cxx
   itkHistogramTest.cxx
-  itkHistogramToTextureFeaturesFilterNaNTest.cxx
   itkHistogramToTextureFeaturesFilterTest.cxx
   itkImageToHistogramFilterTest.cxx
   itkImageToHistogramFilterTest2.cxx
@@ -465,12 +464,6 @@ itk_add_test(
   COMMAND
     ITKStatisticsTestDriver
     itkHistogramToTextureFeaturesFilterTest
-)
-itk_add_test(
-  NAME itkHistogramToTextureFeaturesFilterNaNTest
-  COMMAND
-    ITKStatisticsTestDriver
-    itkHistogramToTextureFeaturesFilterNaNTest
 )
 itk_add_test(
   NAME itkCovarianceSampleFilterTest
@@ -979,6 +972,7 @@ itk_add_test(
 set(
   ITKStatisticsGTests
   itkChiSquareDistributionGTest.cxx
+  itkHistogramToTextureFeaturesFilterNaNGTest.cxx
   itkMaximumDecisionRuleGTest.cxx
   itkMinimumDecisionRuleGTest.cxx
   itkNormalVariateGeneratorGTest1.cxx

--- a/Modules/Numerics/Statistics/test/CMakeLists.txt
+++ b/Modules/Numerics/Statistics/test/CMakeLists.txt
@@ -53,7 +53,6 @@ set(
   itkMinimumDecisionRuleTest.cxx
   itkMixtureModelComponentBaseTest.cxx
   itkNeighborhoodSamplerTest1.cxx
-  itkNormalVariateGeneratorTest1.cxx
   itkPointSetToListSampleAdaptorTest.cxx
   itkProbabilityDistributionTest.cxx
   itkRandomVariateGeneratorBaseTest.cxx
@@ -785,12 +784,6 @@ itk_add_test(
     itkMixtureModelComponentBaseTest
 )
 itk_add_test(
-  NAME itkNormalVariateGeneratorTest1
-  COMMAND
-    ITKStatisticsTestDriver
-    itkNormalVariateGeneratorTest1
-)
-itk_add_test(
   NAME itkSampleTest
   COMMAND
     ITKStatisticsTestDriver
@@ -1011,5 +1004,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkScalarImageToHistogramGeneratorTest.txt
 )
 
-set(ITKStatisticsGTests itkChiSquareDistributionGTest.cxx)
+set(
+  ITKStatisticsGTests
+  itkChiSquareDistributionGTest.cxx
+  itkNormalVariateGeneratorGTest1.cxx
+)
 creategoogletestdriver(ITKStatistics "${ITKStatistics-Test_LIBRARIES}" "${ITKStatisticsGTests}")

--- a/Modules/Numerics/Statistics/test/CMakeLists.txt
+++ b/Modules/Numerics/Statistics/test/CMakeLists.txt
@@ -47,7 +47,6 @@ set(
   itkMembershipSampleTest2.cxx
   itkMembershipSampleTest3.cxx
   itkMembershipSampleTest4.cxx
-  itkMixtureModelComponentBaseTest.cxx
   itkNeighborhoodSamplerTest1.cxx
   itkPointSetToListSampleAdaptorTest.cxx
   itkProbabilityDistributionTest.cxx
@@ -742,12 +741,6 @@ itk_add_test(
     itkNeighborhoodSamplerTest1
 )
 itk_add_test(
-  NAME itkMixtureModelComponentBaseTest
-  COMMAND
-    ITKStatisticsTestDriver
-    itkMixtureModelComponentBaseTest
-)
-itk_add_test(
   NAME itkSampleTest
   COMMAND
     ITKStatisticsTestDriver
@@ -969,6 +962,7 @@ set(
   itkMaximumDecisionRuleGTest.cxx
   itkMaximumRatioDecisionRuleGTest.cxx
   itkMinimumDecisionRuleGTest.cxx
+  itkMixtureModelComponentBaseGTest.cxx
   itkNormalVariateGeneratorGTest1.cxx
   itkRandomVariateGeneratorBaseGTest.cxx
   itkStatisticsTypesGTest.cxx

--- a/Modules/Numerics/Statistics/test/CMakeLists.txt
+++ b/Modules/Numerics/Statistics/test/CMakeLists.txt
@@ -38,7 +38,6 @@ set(
   itkListSampleTest.cxx
   itkMahalanobisDistanceMetricTest.cxx
   itkManhattanDistanceMetricTest.cxx
-  itkMaximumDecisionRuleTest.cxx
   itkMaximumRatioDecisionRuleTest.cxx
   itkMeanSampleFilterTest.cxx
   itkMeanSampleFilterTest2.cxx
@@ -432,12 +431,6 @@ itk_add_test(
   COMMAND
     ITKStatisticsTestDriver
     itkKdTreeTestSamplePoints
-)
-itk_add_test(
-  NAME itkMaximumDecisionRuleTest
-  COMMAND
-    ITKStatisticsTestDriver
-    itkMaximumDecisionRuleTest
 )
 itk_add_test(
   NAME itkMinimumDecisionRuleTest
@@ -1000,6 +993,7 @@ itk_add_test(
 set(
   ITKStatisticsGTests
   itkChiSquareDistributionGTest.cxx
+  itkMaximumDecisionRuleGTest.cxx
   itkNormalVariateGeneratorGTest1.cxx
   itkStatisticsTypesGTest.cxx
 )

--- a/Modules/Numerics/Statistics/test/CMakeLists.txt
+++ b/Modules/Numerics/Statistics/test/CMakeLists.txt
@@ -41,7 +41,6 @@ set(
   itkMeanSampleFilterTest2.cxx
   itkMeanSampleFilterTest3.cxx
   itkMeasurementVectorTraitsTest.cxx
-  itkMembershipFunctionBaseTest.cxx
   itkMembershipFunctionBaseTest2.cxx
   itkMembershipSampleTest1.cxx
   itkMembershipSampleTest2.cxx
@@ -692,12 +691,6 @@ itk_add_test(
     itkManhattanDistanceMetricTest
 )
 itk_add_test(
-  NAME itkMembershipFunctionBaseTest
-  COMMAND
-    ITKStatisticsTestDriver
-    itkMembershipFunctionBaseTest
-)
-itk_add_test(
   NAME itkMembershipFunctionBaseTest2
   COMMAND
     ITKStatisticsTestDriver
@@ -954,6 +947,7 @@ set(
   itkHistogramToTextureFeaturesFilterNaNGTest.cxx
   itkMaximumDecisionRuleGTest.cxx
   itkMaximumRatioDecisionRuleGTest.cxx
+  itkMembershipFunctionBaseGTest.cxx
   itkMinimumDecisionRuleGTest.cxx
   itkMixtureModelComponentBaseGTest.cxx
   itkNormalVariateGeneratorGTest1.cxx

--- a/Modules/Numerics/Statistics/test/CMakeLists.txt
+++ b/Modules/Numerics/Statistics/test/CMakeLists.txt
@@ -80,7 +80,6 @@ set(
   itkStandardDeviationPerComponentSampleFilterTest.cxx
   itkStatisticsAlgorithmTest.cxx
   itkStatisticsAlgorithmTest2.cxx
-  itkStatisticsTypesTest.cxx
   itkSubsampleTest.cxx
   itkSubsampleTest2.cxx
   itkSubsampleTest3.cxx
@@ -914,12 +913,6 @@ itk_add_test(
     itkStandardDeviationPerComponentSampleFilterTest
 )
 itk_add_test(
-  NAME itkStatisticsTypesTest
-  COMMAND
-    ITKStatisticsTestDriver
-    itkStatisticsTypesTest
-)
-itk_add_test(
   NAME itkSubsampleTest
   COMMAND
     ITKStatisticsTestDriver
@@ -1008,5 +1001,6 @@ set(
   ITKStatisticsGTests
   itkChiSquareDistributionGTest.cxx
   itkNormalVariateGeneratorGTest1.cxx
+  itkStatisticsTypesGTest.cxx
 )
 creategoogletestdriver(ITKStatistics "${ITKStatistics-Test_LIBRARIES}" "${ITKStatisticsGTests}")

--- a/Modules/Numerics/Statistics/test/CMakeLists.txt
+++ b/Modules/Numerics/Statistics/test/CMakeLists.txt
@@ -49,7 +49,6 @@ set(
   itkMembershipSampleTest2.cxx
   itkMembershipSampleTest3.cxx
   itkMembershipSampleTest4.cxx
-  itkMinimumDecisionRuleTest.cxx
   itkMixtureModelComponentBaseTest.cxx
   itkNeighborhoodSamplerTest1.cxx
   itkPointSetToListSampleAdaptorTest.cxx
@@ -430,12 +429,6 @@ itk_add_test(
   COMMAND
     ITKStatisticsTestDriver
     itkKdTreeTestSamplePoints
-)
-itk_add_test(
-  NAME itkMinimumDecisionRuleTest
-  COMMAND
-    ITKStatisticsTestDriver
-    itkMinimumDecisionRuleTest
 )
 itk_add_test(
   NAME itkMaximumRatioDecisionRuleTest
@@ -987,6 +980,7 @@ set(
   ITKStatisticsGTests
   itkChiSquareDistributionGTest.cxx
   itkMaximumDecisionRuleGTest.cxx
+  itkMinimumDecisionRuleGTest.cxx
   itkNormalVariateGeneratorGTest1.cxx
   itkRandomVariateGeneratorBaseGTest.cxx
   itkStatisticsTypesGTest.cxx

--- a/Modules/Numerics/Statistics/test/CMakeLists.txt
+++ b/Modules/Numerics/Statistics/test/CMakeLists.txt
@@ -54,7 +54,6 @@ set(
   itkNeighborhoodSamplerTest1.cxx
   itkPointSetToListSampleAdaptorTest.cxx
   itkProbabilityDistributionTest.cxx
-  itkRandomVariateGeneratorBaseTest.cxx
   itkSampleTest.cxx
   itkSampleTest2.cxx
   itkSampleTest3.cxx
@@ -704,12 +703,6 @@ itk_add_test(
     itkProbabilityDistributionTest
 )
 itk_add_test(
-  NAME itkRandomVariateGeneratorBaseTest
-  COMMAND
-    ITKStatisticsTestDriver
-    itkRandomVariateGeneratorBaseTest
-)
-itk_add_test(
   NAME itkMahalanobisDistanceMetricTest
   COMMAND
     ITKStatisticsTestDriver
@@ -995,6 +988,7 @@ set(
   itkChiSquareDistributionGTest.cxx
   itkMaximumDecisionRuleGTest.cxx
   itkNormalVariateGeneratorGTest1.cxx
+  itkRandomVariateGeneratorBaseGTest.cxx
   itkStatisticsTypesGTest.cxx
 )
 creategoogletestdriver(ITKStatistics "${ITKStatistics-Test_LIBRARIES}" "${ITKStatisticsGTests}")

--- a/Modules/Numerics/Statistics/test/CMakeLists.txt
+++ b/Modules/Numerics/Statistics/test/CMakeLists.txt
@@ -37,7 +37,6 @@ set(
   itkListSampleTest.cxx
   itkMahalanobisDistanceMetricTest.cxx
   itkManhattanDistanceMetricTest.cxx
-  itkMaximumRatioDecisionRuleTest.cxx
   itkMeanSampleFilterTest.cxx
   itkMeanSampleFilterTest2.cxx
   itkMeanSampleFilterTest3.cxx
@@ -428,12 +427,6 @@ itk_add_test(
   COMMAND
     ITKStatisticsTestDriver
     itkKdTreeTestSamplePoints
-)
-itk_add_test(
-  NAME itkMaximumRatioDecisionRuleTest
-  COMMAND
-    ITKStatisticsTestDriver
-    itkMaximumRatioDecisionRuleTest
 )
 itk_add_test(
   NAME itkMeanSampleFilterTest
@@ -974,6 +967,7 @@ set(
   itkChiSquareDistributionGTest.cxx
   itkHistogramToTextureFeaturesFilterNaNGTest.cxx
   itkMaximumDecisionRuleGTest.cxx
+  itkMaximumRatioDecisionRuleGTest.cxx
   itkMinimumDecisionRuleGTest.cxx
   itkNormalVariateGeneratorGTest1.cxx
   itkRandomVariateGeneratorBaseGTest.cxx

--- a/Modules/Numerics/Statistics/test/itkHistogramToTextureFeaturesFilterNaNGTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkHistogramToTextureFeaturesFilterNaNGTest.cxx
@@ -18,12 +18,15 @@
 
 // Ensure we do not get NaN's with a constant image
 
-#include "itkScalarImageToCooccurrenceMatrixFilter.h"
 #include "itkHistogramToTextureFeaturesFilter.h"
-#include "itkMath.h"
 
-int
-itkHistogramToTextureFeaturesFilterNaNTest(int, char *[])
+#include "itkMath.h"
+#include "itkScalarImageToCooccurrenceMatrixFilter.h"
+
+#include "itkGTest.h"
+
+
+TEST(HistogramToTextureFeaturesFilter, ConvertedLegacyTestNaN)
 {
   constexpr unsigned int Dimension{ 2 };
   using PixelType = unsigned char;
@@ -53,10 +56,5 @@ itkHistogramToTextureFeaturesFilterNaNTest(int, char *[])
 
   const TextureFilterType::MeasurementType correlation = filter->GetCorrelation();
   std::cout << "Correlation: " << correlation << std::endl;
-  if (itk::Math::isnan(correlation))
-  {
-    return EXIT_FAILURE;
-  }
-
-  return EXIT_SUCCESS;
+  EXPECT_FALSE(itk::Math::isnan(correlation));
 }

--- a/Modules/Numerics/Statistics/test/itkMaximumDecisionRuleGTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMaximumDecisionRuleGTest.cxx
@@ -16,18 +16,15 @@
  *
  *=========================================================================*/
 
-#include <iostream>
-
 #include "itkMaximumDecisionRule.h"
 
+#include "itkGTest.h"
 
-int
-itkMaximumDecisionRuleTest(int, char *[])
+#include <iostream>
+
+
+TEST(MaximumDecisionRule, ConvertedLegacyTest)
 {
-
-  std::cout << "==================================" << std::endl;
-  std::cout << "Testing MaximumDecionRule " << std::endl << std::endl;
-
   using DecisionRuleType = itk::Statistics::MaximumDecisionRule;
   auto decisionRule = DecisionRuleType::New();
 
@@ -38,11 +35,7 @@ itkMaximumDecisionRuleTest(int, char *[])
   discriminantScores[1] = 1.0;
   discriminantScores[2] = 2.0;
 
-  if (decisionRule->Evaluate(discriminantScores) != 2)
-  {
-    std::cout << "[FAILED]" << std::endl;
-    return EXIT_FAILURE;
-  }
+  EXPECT_EQ(decisionRule->Evaluate(discriminantScores), 2);
 
   DecisionRuleType::MembershipVectorType discriminantScores2;
   discriminantScores2.resize(3);
@@ -51,13 +44,5 @@ itkMaximumDecisionRuleTest(int, char *[])
   discriminantScores2[1] = 1.0;
   discriminantScores2[2] = 2.0;
 
-  if (decisionRule->Evaluate(discriminantScores2) != 2)
-  {
-    std::cout << "[FAILED]" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  std::cout << "[SUCCEEDED]" << std::endl;
-
-  return EXIT_SUCCESS;
+  EXPECT_EQ(decisionRule->Evaluate(discriminantScores2), 2);
 }

--- a/Modules/Numerics/Statistics/test/itkMaximumRatioDecisionRuleGTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMaximumRatioDecisionRuleGTest.cxx
@@ -16,20 +16,19 @@
  *
  *=========================================================================*/
 
+#include "itkMaximumRatioDecisionRule.h"
+
+#include "itkGTest.h"
+
 #include <iostream>
 
-#include "itkMaximumRatioDecisionRule.h"
-#include "itkTestingMacros.h"
 
-
-int
-itkMaximumRatioDecisionRuleTest(int, char *[])
+TEST(MaximumRatioDecisionRule, ConvertedLegacyTest)
 {
-
   using DecisionRuleType = itk::Statistics::MaximumRatioDecisionRule;
   auto decisionRule = DecisionRuleType::New();
 
-  ITK_EXERCISE_BASIC_OBJECT_METHODS(decisionRule, MaximumRatioDecisionRule, DecisionRule);
+  ITK_GTEST_EXERCISE_BASIC_OBJECT_METHODS(decisionRule, MaximumRatioDecisionRule, DecisionRule);
 
 
   DecisionRuleType::MembershipVectorType discriminantScores;
@@ -50,14 +49,10 @@ itkMaximumRatioDecisionRuleTest(int, char *[])
   for (auto & value : aPrioris)
   {
     auto index = &value - &aPrioris.front();
-    ITK_TEST_SET_GET_VALUE(value, decisionRule->GetPriorProbabilities()[index]);
+    EXPECT_EQ(value, decisionRule->GetPriorProbabilities()[index]);
   }
 
-  if (decisionRule->Evaluate(discriminantScores) != 2)
-  {
-    std::cout << "[FAILED]" << std::endl;
-    return EXIT_FAILURE;
-  }
+  EXPECT_EQ(decisionRule->Evaluate(discriminantScores), 2);
 
   // run with uniform prior
   aPrioris.clear();
@@ -65,15 +60,8 @@ itkMaximumRatioDecisionRuleTest(int, char *[])
   for (auto & value : aPrioris)
   {
     auto index = &value - &aPrioris.front();
-    ITK_TEST_SET_GET_VALUE(value, decisionRule->GetPriorProbabilities()[index]);
+    EXPECT_EQ(value, decisionRule->GetPriorProbabilities()[index]);
   }
 
-  if (decisionRule->Evaluate(discriminantScores) != 1)
-  {
-    std::cout << "[FAILED]" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  std::cout << "Test finished." << std::endl;
-  return EXIT_SUCCESS;
+  EXPECT_EQ(decisionRule->Evaluate(discriminantScores), 1);
 }

--- a/Modules/Numerics/Statistics/test/itkMembershipFunctionBaseGTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMembershipFunctionBaseGTest.cxx
@@ -16,8 +16,11 @@
  *
  *=========================================================================*/
 
-#include <iostream>
 #include "itkMembershipFunctionBase.h"
+
+#include "itkGTest.h"
+
+#include <iostream>
 
 namespace itk::Statistics::MembershipFunctionBaseTest
 {
@@ -53,10 +56,8 @@ public:
 } // namespace itk::Statistics::MembershipFunctionBaseTest
 
 
-int
-itkMembershipFunctionBaseTest(int, char *[])
+TEST(MembershipFunctionBase, ConvertedLegacyTest)
 {
-
   constexpr unsigned int MeasurementVectorSize{ 17 };
 
   using MeasurementVectorType = itk::FixedArray<float, MeasurementVectorSize>;
@@ -73,26 +74,9 @@ itkMembershipFunctionBaseTest(int, char *[])
 
   function->SetMeasurementVectorSize(MeasurementVectorSize); // for code coverage
 
-  if (function->GetMeasurementVectorSize() != MeasurementVectorSize)
-  {
-    std::cerr << "GetMeasurementVectorSize() Failed !" << std::endl;
-    return EXIT_FAILURE;
-  }
+  EXPECT_EQ(function->GetMeasurementVectorSize(), MeasurementVectorSize);
 
   // Test if an exception will be thrown if we try to resize the measurement vector
   // size
-  try
-  {
-    function->SetMeasurementVectorSize(MeasurementVectorSize + 1);
-    std::cerr
-      << "Exception should have been thrown since we are trying to resize non-resizeable measurement vector type "
-      << std::endl;
-    return EXIT_FAILURE;
-  }
-  catch (const itk::ExceptionObject & excp)
-  {
-    std::cerr << "Caughted expected exception: " << excp << std::endl;
-  }
-
-  return EXIT_SUCCESS;
+  EXPECT_THROW(function->SetMeasurementVectorSize(MeasurementVectorSize + 1), itk::ExceptionObject);
 }

--- a/Modules/Numerics/Statistics/test/itkMinimumDecisionRuleGTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMinimumDecisionRuleGTest.cxx
@@ -16,18 +16,15 @@
  *
  *=========================================================================*/
 
-#include <iostream>
-
 #include "itkMinimumDecisionRule.h"
 
+#include "itkGTest.h"
 
-int
-itkMinimumDecisionRuleTest(int, char *[])
+#include <iostream>
+
+
+TEST(MinimumDecisionRule, ConvertedLegacyTest)
 {
-
-  std::cout << "==================================" << std::endl;
-  std::cout << "Testing MinimumDecionRule " << std::endl << std::endl;
-
   using DecisionRuleType = itk::Statistics::MinimumDecisionRule;
   auto decisionRule = DecisionRuleType::New();
 
@@ -38,11 +35,7 @@ itkMinimumDecisionRuleTest(int, char *[])
   discriminantScores[1] = 1.0;
   discriminantScores[2] = 2.0;
 
-  if (decisionRule->Evaluate(discriminantScores) != 0)
-  {
-    std::cout << "[FAILED]" << std::endl;
-    return EXIT_FAILURE;
-  }
+  EXPECT_EQ(decisionRule->Evaluate(discriminantScores), 0);
 
   DecisionRuleType::MembershipVectorType discriminantScores2;
   discriminantScores2.resize(3);
@@ -51,11 +44,7 @@ itkMinimumDecisionRuleTest(int, char *[])
   discriminantScores2[1] = 1.0;
   discriminantScores2[2] = 2.0;
 
-  if (decisionRule->Evaluate(discriminantScores2) != 0)
-  {
-    std::cout << "[FAILED]" << std::endl;
-    return EXIT_FAILURE;
-  }
+  EXPECT_EQ(decisionRule->Evaluate(discriminantScores2), 0);
 
 
   DecisionRuleType::MembershipVectorType discriminantScores3;
@@ -65,12 +54,5 @@ itkMinimumDecisionRuleTest(int, char *[])
   discriminantScores3[1] = 1.0;
   discriminantScores3[2] = 2.0;
 
-  if (decisionRule->Evaluate(discriminantScores3) != 0)
-  {
-    std::cout << "[FAILED]" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  std::cout << "[SUCCEEDED]" << std::endl;
-  return EXIT_SUCCESS;
+  EXPECT_EQ(decisionRule->Evaluate(discriminantScores3), 0);
 }

--- a/Modules/Numerics/Statistics/test/itkMixtureModelComponentBaseGTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkMixtureModelComponentBaseGTest.cxx
@@ -17,8 +17,10 @@
  *=========================================================================*/
 
 #include "itkMixtureModelComponentBase.h"
+
 #include "itkListSample.h"
-#include "itkTestingMacros.h"
+
+#include "itkGTest.h"
 
 namespace itk::Statistics
 {
@@ -60,8 +62,7 @@ protected:
 } // namespace itk::Statistics
 
 
-int
-itkMixtureModelComponentBaseTest(int, char *[])
+TEST(MixtureModelComponentBase, ConvertedLegacyTest)
 {
   using MeasurementVectorType = itk::Array<double>;
   using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
@@ -72,8 +73,5 @@ itkMixtureModelComponentBaseTest(int, char *[])
   std::cout << "component->GetWeights(): " << component->GetWeights() << std::endl;
   component->RunTests();
 
-  ITK_TRY_EXPECT_EXCEPTION(component->GetWeight(5));
-
-  std::cerr << "[PASSED]" << std::endl;
-  return EXIT_SUCCESS;
+  EXPECT_THROW(component->GetWeight(5), itk::ExceptionObject);
 }

--- a/Modules/Numerics/Statistics/test/itkNormalVariateGeneratorGTest1.cxx
+++ b/Modules/Numerics/Statistics/test/itkNormalVariateGeneratorGTest1.cxx
@@ -18,8 +18,10 @@
 
 #include "itkNormalVariateGenerator.h"
 
-int
-itkNormalVariateGeneratorTest1(int, char *[])
+#include "itkGTest.h"
+
+
+TEST(NormalVariateGenerator, ConvertedLegacyTest)
 {
   using NormalGeneratorType = itk::Statistics::NormalVariateGenerator;
 
@@ -54,8 +56,4 @@ itkNormalVariateGeneratorTest1(int, char *[])
   //
   // FIXME: Add here numerical verification (regression testing)
   //
-
-
-  std::cerr << "[PASSED]" << std::endl;
-  return EXIT_SUCCESS;
 }

--- a/Modules/Numerics/Statistics/test/itkRandomVariateGeneratorBaseGTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkRandomVariateGeneratorBaseGTest.cxx
@@ -17,7 +17,10 @@
  *=========================================================================*/
 
 #include "itkRandomVariateGeneratorBase.h"
+
 #include "itkObjectFactory.h"
+
+#include "itkGTest.h"
 
 namespace itk::Statistics
 {
@@ -53,8 +56,7 @@ public:
 } // namespace itk::Statistics
 
 
-int
-itkRandomVariateGeneratorBaseTest(int, char *[])
+TEST(RandomVariateGeneratorBase, ConvertedLegacyTest)
 {
   using GeneratorType = itk::Statistics::VariateGeneratorTestHelper;
 
@@ -65,7 +67,4 @@ itkRandomVariateGeneratorBaseTest(int, char *[])
   generator->RunTests();
 
   generator->Print(std::cout);
-
-  std::cerr << "[PASSED]" << std::endl;
-  return EXIT_SUCCESS;
 }

--- a/Modules/Numerics/Statistics/test/itkStatisticsTypesGTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkStatisticsTypesGTest.cxx
@@ -18,6 +18,8 @@
 
 #include "itkMeasurementVectorTraits.h"
 
+#include "itkGTest.h"
+
 #define declareType(_x)                                    \
   using _x = itk::Statistics::MeasurementVectorTraits::_x; \
   std::cout << #_x << " = " << sizeof(_x) << " bytes ";    \
@@ -31,15 +33,12 @@
   }                                                        \
   ITK_MACROEND_NOOP_STATEMENT
 
-int
-itkStatisticsTypesTest(int, char *[])
-{
 
+TEST(StatisticsTypes, ConvertedLegacyTest)
+{
   declareType(InstanceIdentifier);
   declareType(AbsoluteFrequencyType);
   declareType(RelativeFrequencyType);
   declareType(TotalAbsoluteFrequencyType);
   declareType(TotalRelativeFrequencyType);
-
-  return EXIT_SUCCESS;
 }

--- a/Modules/Numerics/Statistics/test/itkVectorContainerToListSampleAdaptorGTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkVectorContainerToListSampleAdaptorGTest.cxx
@@ -17,12 +17,12 @@
  *=========================================================================*/
 
 #include "itkVectorContainerToListSampleAdaptor.h"
-#include "itkTestingMacros.h"
 
-int
-itkVectorContainerToListSampleAdaptorTest(int, char *[])
+#include "itkGTest.h"
+
+
+TEST(VectorContainerToListSampleAdaptor, ConvertedLegacyTest)
 {
-
   using VectorType = itk::Vector<double, 5>;
 
   using ContainerType = itk::VectorContainer<VectorType>;
@@ -31,17 +31,17 @@ itkVectorContainerToListSampleAdaptorTest(int, char *[])
 
   auto adaptor = AdaptorType::New();
 
-  ITK_EXERCISE_BASIC_OBJECT_METHODS(adaptor, VectorContainerToListSampleAdaptor, ListSample);
+  ITK_GTEST_EXERCISE_BASIC_OBJECT_METHODS(adaptor, VectorContainerToListSampleAdaptor, ListSample);
 
   // Test the exceptions
-  ITK_TRY_EXPECT_EXCEPTION(adaptor->Size());
+  EXPECT_THROW(adaptor->Size(), itk::ExceptionObject);
 
   constexpr typename AdaptorType::InstanceIdentifier instance = 0;
-  ITK_TRY_EXPECT_EXCEPTION(adaptor->GetMeasurementVector(instance));
+  EXPECT_THROW(adaptor->GetMeasurementVector(instance), itk::ExceptionObject);
 
-  ITK_TRY_EXPECT_EXCEPTION(adaptor->GetFrequency(instance));
+  EXPECT_THROW(adaptor->GetFrequency(instance), itk::ExceptionObject);
 
-  ITK_TRY_EXPECT_EXCEPTION(adaptor->GetTotalFrequency());
+  EXPECT_THROW(adaptor->GetTotalFrequency(), itk::ExceptionObject);
 
   // Set the vector container
   constexpr unsigned int containerSize{ 3 };
@@ -54,21 +54,17 @@ itkVectorContainerToListSampleAdaptorTest(int, char *[])
   }
 
   adaptor->SetVectorContainer(container);
-  ITK_TEST_SET_GET_VALUE(container, adaptor->GetVectorContainer());
+  EXPECT_EQ(container, adaptor->GetVectorContainer());
 
   constexpr typename AdaptorType::InstanceIdentifier expectedSize = 3;
   const typename AdaptorType::InstanceIdentifier     size = adaptor->Size();
-  ITK_TEST_EXPECT_EQUAL(expectedSize, size);
+  EXPECT_EQ(expectedSize, size);
 
   constexpr typename AdaptorType::AbsoluteFrequencyType expectedFreq = 1;
   const typename AdaptorType::AbsoluteFrequencyType     freq = adaptor->GetFrequency(instance);
-  ITK_TEST_EXPECT_EQUAL(expectedFreq, freq);
+  EXPECT_EQ(expectedFreq, freq);
 
   constexpr typename AdaptorType::TotalAbsoluteFrequencyType expectedTotalFreq = 3;
   const typename AdaptorType::TotalAbsoluteFrequencyType     totalFreq = adaptor->GetTotalFrequency();
-  ITK_TEST_EXPECT_EQUAL(expectedTotalFreq, totalFreq);
-
-
-  std::cout << "Test finished." << std::endl;
-  return EXIT_SUCCESS;
+  EXPECT_EQ(expectedTotalFreq, totalFreq);
 }


### PR DESCRIPTION
Mechanical conversion of 10 no-argument legacy CTests in `Modules/Numerics/Statistics/test/` to GoogleTest, per the `convert-to-gtest` skill workflow ("one commit, one change" — N-Dekker).

| Test | Commit |
|---|---|
| `itkNormalVariateGeneratorTest1` | `5ece62b3` |
| `itkStatisticsTypesTest` | `3680b32b` |
| `itkMaximumDecisionRuleTest` | `f325aba3` |
| `itkRandomVariateGeneratorBaseTest` | `98fee239` |
| `itkMinimumDecisionRuleTest` | `c7f02fa8` |
| `itkHistogramToTextureFeaturesFilterNaNTest` | `033d5edc` |
| `itkMaximumRatioDecisionRuleTest` | `3b4c7868` |
| `itkMixtureModelComponentBaseTest` | `f422ac51` |
| `itkVectorContainerToListSampleAdaptorTest` | `669e61f0` |
| `itkMembershipFunctionBaseTest` | `fad64f08` |

Each is a single commit with `git mv` rename (70-96% similarity, history preserved through `git log --follow`), `ITK_EXERCISE_BASIC_OBJECT_METHODS` → `ITK_GTEST_EXERCISE_BASIC_OBJECT_METHODS`, return-on-failure → `EXPECT_EQ` / `EXPECT_THROW`, no logic refactoring, no comment removal.

<details>
<summary>Verification</summary>

- All 10 GTests build and pass locally (combined run: 10 / 10 pass in 6 ms)
- `pre-commit run --all-files` exit 0 on the final tip
- CMakeLists alphabetic ordering preserved on both `ITKStatisticsTests` (legacy) and `ITKStatisticsGTests` sets

Build verification used a dedicated `~/src/ITK-build-test-tree/build-standard/` (separate detached worktree, fully ccache-warm) per the new "one test tree, many configs" architecture — `git reset --hard` between conversions, ~5-15 s incremental rebuild per commit, no source-mirror drift across worktrees.

Net diff: +81 / -211 (conversion strips boilerplate `if (status == EXIT_FAILURE) { std::cout << "[FAILED]"; return EXIT_FAILURE; }` blocks).

</details>

<details>
<summary>Backlog progress</summary>

| Module group | Easy backlog | After this PR |
|---|---:|---:|
| `Numerics/Statistics` | 76 | 66 |
| ITK-wide easy backlog | 457 | 447 |

Followup batches will continue with the same module first (66 remaining → ~7 more PRs to clear it).

</details>

<!--
provenance: claude-code session 2026-05-03, /convert-to-gtest 10 of Numerics/Statistics
target_module: Modules/Numerics/Statistics
build_verification: ~/src/ITK-build-test-tree/build-standard via git reset --hard FETCH_HEAD per-commit
related_umbrella_task: ~/src/ITK/.devlocal/hints/convert-all-compatible-ctests-to-gtest.md
mechanical_only: yes — no logic changes; comments preserved; scope-explaining notes intact
-->
