### PR TITLE
COMP: Remove empty env block from Pixi workflow

### DIFF
--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -29,9 +29,6 @@ concurrency:
   group: '${{ github.workflow }}@${{ github.head_ref || github.ref }}'
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-env:
-
-
 jobs:
     Pixi-Cxx:
       runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Fixes the `Invalid workflow file (Line: 32, Col: 5): Unexpected value ''` error reported on `.github/workflows/pixi.yml` after a recent merge. The workflow had an empty `env:` block, which GitHub Actions rejects; removing it restores parsing.

Reported by @dzenanz.
