### PR TITLE
COMP: Strip dead cmake_minimum_required + standalone wrapper from 4 ingests

### DIFF
--- a/Modules/Filtering/AnisotropicDiffusionLBR/CMakeLists.txt
+++ b/Modules/Filtering/AnisotropicDiffusionLBR/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16.3)
-
 project(
   AnisotropicDiffusionLBR
   VERSION
@@ -10,14 +8,8 @@ project(
 
 # Header only module, no libraries set(AnisotropicDiffusionLBR_LIBRARIES AnisotropicDiffusionLBR)
 
-if(NOT ITK_SOURCE_DIR)
-  find_package(ITK 5.1 REQUIRED)
-  list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
-  include(ITKModuleExternal)
-else()
-  set(ITK_DIR ${CMAKE_BINARY_DIR})
-  itk_module_impl()
-endif()
+set(ITK_DIR ${CMAKE_BINARY_DIR})
+itk_module_impl()
 
 # itk_module_examples() is intentionally omitted: the upstream
 # examples/ directory is not part of the whitelist-based ingest

--- a/Modules/Filtering/Cuberille/CMakeLists.txt
+++ b/Modules/Filtering/Cuberille/CMakeLists.txt
@@ -1,10 +1,3 @@
-cmake_minimum_required(VERSION 3.16.3)
 project(Cuberille)
 
-if(NOT ITK_SOURCE_DIR)
-  find_package(ITK 4.10 REQUIRED)
-  list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
-  include(ITKModuleExternal)
-else()
-  itk_module_impl()
-endif()
+itk_module_impl()

--- a/Modules/Filtering/LabelErodeDilate/CMakeLists.txt
+++ b/Modules/Filtering/LabelErodeDilate/CMakeLists.txt
@@ -1,10 +1,3 @@
-cmake_minimum_required(VERSION 3.16.3)
 project(LabelErodeDilate)
 
-if(NOT ITK_SOURCE_DIR)
-  find_package(ITK REQUIRED)
-  list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
-  include(ITKModuleExternal)
-else()
-  itk_module_impl()
-endif()
+itk_module_impl()

--- a/Modules/Registration/Montage/CMakeLists.txt
+++ b/Modules/Registration/Montage/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16.3)
-
 if(CMAKE_CXX_STANDARD EQUAL "98")
   message(
     FATAL_ERROR
@@ -33,13 +31,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   endif()
 endif()
 
-if(NOT ITK_SOURCE_DIR)
-  find_package(ITK REQUIRED)
-  list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
-  include(ITKModuleExternal)
-else()
-  set(ITK_DIR ${CMAKE_BINARY_DIR})
-  itk_module_impl()
-endif()
+set(ITK_DIR ${CMAKE_BINARY_DIR})
+itk_module_impl()
 
 itk_module_examples()


### PR DESCRIPTION
Strips two upstream-original boilerplate idioms from four already-merged remote-module ingests: per-module `cmake_minimum_required(VERSION X.Y.Z)` declarations (redundant with ITK's top-level pin) and `if(NOT ITK_SOURCE_DIR) ... else() itk_module_impl() endif()` standalone-build wrappers (dead code in-tree, since `ITK_SOURCE_DIR` is always defined). Matches the v4 sanitizer rules now codified in [#6204](https://github.com/InsightSoftwareConsortium/ITK/pull/6204) so every future ingest will be born clean.

<details>
<summary>Files changed (4 modules)</summary>

| Module | Status before | Action |
|---|---|---|
| `Modules/Filtering/AnisotropicDiffusionLBR` | Both idioms present | Both removed; `set(ITK_DIR ${CMAKE_BINARY_DIR})` from the in-tree else-branch preserved as unconditional |
| `Modules/Filtering/Cuberille` | Both idioms present | Both removed |
| `Modules/Filtering/LabelErodeDilate` | Both idioms present | Both removed |
| `Modules/Registration/Montage` | Both idioms present | Both removed; `set(ITK_DIR ${CMAKE_BINARY_DIR})` preserved as unconditional |

The other four already-merged ingests (`GenericLabelInterpolator`, `MGHIO`, `FastBilateral`, `MeshNoise`) were already cleaned up during their respective ingest PRs and need no change.

The six **open** ingest PRs (#6206, #6208, #6211, #6212, #6214, #6215) each had an analogous cleanup applied directly on their branches earlier today.

</details>

<details>
<summary>Why both idioms are dead in-tree</summary>

**`cmake_minimum_required(VERSION X.Y.Z)`**: the project's top-level `CMakeLists.txt` already pins a higher minimum than any of these per-module declarations (commonly 3.10.2 / 3.16.3). The per-module line at best does nothing and at worst lowers the floor for that subdirectory below ITK's policy.

**`if(NOT ITK_SOURCE_DIR)` standalone-build guard**: the upstream remote-module repos used this idiom so the module's `CMakeLists.txt` could be configured both as a fetched ITK module and as a stand-alone CMake project. In an in-tree ingested module, `ITK_SOURCE_DIR` is always defined, so the if-branch is unreachable.

Both patterns are flagged consistently by reviewers (e.g. @dzenanz on PRs #6206 / #6215) and by the v4 sanitizer's run summary.

</details>

<details>
<summary>Local verification</summary>

- `pre-commit run --all-files` exit 0
- `cmake .` reconfigure on the build tree clean (32 s)
- 4 files modified, 6 insertions, 36 deletions

</details>

<!--
provenance: claude-code session 2026-05-05
key_facts:
  - branch: hjmjohnson:cleanup-ingested-cmake-min
  - base_at_pr_open: 777a69ffab30c704ce021d6ccb59bf59ae97da38 (upstream/main)
  - tip: 867c69910a
  - modules_touched: [AnisotropicDiffusionLBR, Cuberille, LabelErodeDilate, Montage]
  - already_clean_at_branch_creation: [GenericLabelInterpolator, MGHIO, FastBilateral, MeshNoise]
related_prs:
  - "#6204 — v4 ingest pipeline (codifies the same rules in sanitize-history.py)"
  - "#6206 #6208 #6211 #6212 #6214 #6215 — open ingest PRs each cleaned on their own branch"
-->
