### PR TITLE
ENH: add missing metadata to DCMTKImageIO

### DIFF
--- a/Modules/IO/DCMTK/include/itkDCMTKFileReader.h
+++ b/Modules/IO/DCMTK/include/itkDCMTKFileReader.h
@@ -498,6 +498,12 @@ public:
   static bool
   IsImageFile(const std::string & filename);
 
+  DcmDataset *
+  GetDataset() const
+  {
+    return m_Dataset;
+  }
+
 private:
   std::string      m_FileName;
   DcmFileFormat *  m_DFile{ nullptr };

--- a/Modules/IO/DCMTK/include/itkDCMTKFileReader.h
+++ b/Modules/IO/DCMTK/include/itkDCMTKFileReader.h
@@ -499,7 +499,7 @@ public:
   IsImageFile(const std::string & filename);
 
   DcmDataset *
-  GetDataset() const
+  GetDataset()
   {
     return m_Dataset;
   }

--- a/Modules/IO/DCMTK/include/itkDCMTKFileReader.h
+++ b/Modules/IO/DCMTK/include/itkDCMTKFileReader.h
@@ -35,6 +35,7 @@
 #include "dcmtk/dcmdata/dcsequen.h"
 #include "itkMacro.h"
 #include "itkImageIOBase.h"
+#include "itkMetaDataDictionary.h"
 
 class DcmSequenceOfItems;
 class DcmFileFormat;
@@ -498,11 +499,8 @@ public:
   static bool
   IsImageFile(const std::string & filename);
 
-  DcmDataset *
-  GetDataset()
-  {
-    return m_Dataset;
-  }
+  void
+  PopulateMetaDataDictionary(MetaDataDictionary & dict) const;
 
 private:
   std::string      m_FileName;

--- a/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
@@ -33,6 +33,7 @@
 #include "dcmtk/dcmdata/dcvrus.h"    /* for DcmUnsignedShort */
 #include "dcmtk/dcmdata/dcvris.h"    /* for DcmIntegerString */
 #include "dcmtk/dcmdata/dcvrobow.h"  /* for DcmOtherByteOtherWord */
+#include "dcmtk/dcmdata/dcelem.h"    /* for DcmElement */
 #include "dcmtk/dcmdata/dcvrui.h"    /* for DcmUniqueIdentifier */
 #include "dcmtk/dcmdata/dcfilefo.h"  /* for DcmFileFormat */
 #include "dcmtk/dcmdata/dcmetinf.h"  /* for DcmMetaInfo */
@@ -47,7 +48,10 @@
 
 #include "vnl/vnl_cross.h"
 #include "itkIntTypes.h"
+#include "itkMetaDataObject.h"
+#include "itksys/Base64.h"
 #include <algorithm>
+#include <memory>
 
 namespace itk
 {
@@ -1367,6 +1371,72 @@ long
 DCMTKFileReader::GetFileNumber() const
 {
   return m_FileNumber;
+}
+
+void
+DCMTKFileReader::PopulateMetaDataDictionary(MetaDataDictionary & dict) const
+{
+  dict.Clear();
+  if (m_Dataset == nullptr)
+  {
+    return;
+  }
+  const unsigned long numElements = m_Dataset->card();
+  for (unsigned long i = 0; i < numElements; ++i)
+  {
+    DcmElement * element = m_Dataset->getElement(i);
+    if (element == nullptr)
+    {
+      continue;
+    }
+    const DcmTag & tag = element->getTag();
+    // Skip pixel data (7FE0,0010)
+    if (tag.getGroup() == 0x7fe0 && tag.getElement() == 0x0010)
+    {
+      continue;
+    }
+    // Format key as "GGGG|EEEE" (lowercase hex, matching GDCMImageIO)
+    char key[10];
+    std::snprintf(key, sizeof(key), "%04x|%04x", tag.getGroup(), tag.getElement());
+
+    const DcmEVR vr = element->getVR();
+    if (vr == EVR_SQ)
+    {
+      // Sequences are nested datasets, not byte arrays; getUint8Array() does
+      // not return their content.  Skip rather than emit an empty entry.
+      continue;
+    }
+    if (vr == EVR_OB || vr == EVR_OW || vr == EVR_OF || vr == EVR_OD || vr == EVR_OL || vr == EVR_OV || vr == EVR_UN ||
+        vr == EVR_ox || vr == EVR_px)
+    {
+      // Binary VR — base64-encode the raw bytes
+      Uint8 * byteValue = nullptr;
+      if (element->getUint8Array(byteValue) == EC_Normal && byteValue != nullptr)
+      {
+        const Uint32 length = element->getLength();
+        if (length > 0)
+        {
+          int encodedLengthEstimate = 2 * static_cast<int>(length);
+          encodedLengthEstimate = ((encodedLengthEstimate / 4) + 1) * 4;
+          const auto bin = std::make_unique<char[]>(encodedLengthEstimate);
+          const auto encodedLengthActual =
+            static_cast<unsigned int>(itksysBase64_Encode(reinterpret_cast<const unsigned char *>(byteValue),
+                                                          static_cast<SizeValueType>(length),
+                                                          reinterpret_cast<unsigned char *>(bin.get()),
+                                                          0));
+          EncapsulateMetaData<std::string>(dict, key, std::string(bin.get(), encodedLengthActual));
+        }
+      }
+    }
+    else
+    {
+      OFString value;
+      if (element->getOFStringArray(value) == EC_Normal)
+      {
+        EncapsulateMetaData<std::string>(dict, key, std::string(value.c_str()));
+      }
+    }
+  }
 }
 
 void

--- a/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
@@ -506,8 +506,14 @@ DCMTKImageIO::ReadImageInformation()
       std::snprintf(key, sizeof(key), "%04x|%04x", tag.getGroup(), tag.getElement());
 
       const DcmEVR vr = element->getVR();
-      if (vr == EVR_SQ || vr == EVR_OB || vr == EVR_OW || vr == EVR_OF || vr == EVR_OD || vr == EVR_OL ||
-          vr == EVR_OV || vr == EVR_UN || vr == EVR_ox || vr == EVR_px)
+      if (vr == EVR_SQ)
+      {
+        // Sequences are nested datasets, not byte arrays; getUint8Array() does
+        // not return their content.  Skip rather than emit an empty entry.
+        continue;
+      }
+      if (vr == EVR_OB || vr == EVR_OW || vr == EVR_OF || vr == EVR_OD || vr == EVR_OL || vr == EVR_OV ||
+          vr == EVR_UN || vr == EVR_ox || vr == EVR_px)
       {
         // Binary VR — base64-encode the raw bytes
         Uint8 * byteValue = nullptr;

--- a/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
@@ -21,18 +21,15 @@
 #include "itkByteSwapper.h"
 #include "itksys/SystemTools.hxx"
 #include "itkDCMTKFileReader.h"
-#include "itkMetaDataObject.h"
 #include <iostream>
 #include "vnl/vnl_cross.h"
 #include "itkMath.h"
-#include "itksys/Base64.h"
 
 #include "dcmtk/dcmimgle/dcmimage.h"
 #include "dcmtk/dcmjpeg/djdecode.h"
 #include "dcmtk/dcmjpls/djdecode.h"
 #include "dcmtk/dcmdata/dcmetinf.h"
 #include "dcmtk/dcmdata/dcrledrg.h"
-#include "dcmtk/dcmdata/dcelem.h"
 #include "dcmtk/oflog/oflog.h"
 
 namespace
@@ -481,69 +478,7 @@ DCMTKImageIO::ReadImageInformation()
     this->m_Spacing.push_back(1.0);
   }
 
-  // Populate the metadata dictionary with all DICOM tag values
-  MetaDataDictionary & dict = this->GetMetaDataDictionary();
-  dict.Clear();
-  DcmDataset * dataset = reader.GetDataset();
-  if (dataset != nullptr)
-  {
-    const unsigned long numElements = dataset->card();
-    for (unsigned long i = 0; i < numElements; ++i)
-    {
-      DcmElement * element = dataset->getElement(i);
-      if (element == nullptr)
-      {
-        continue;
-      }
-      const DcmTag & tag = element->getTag();
-      // Skip pixel data (7FE0,0010)
-      if (tag.getGroup() == 0x7fe0 && tag.getElement() == 0x0010)
-      {
-        continue;
-      }
-      // Format key as "GGGG|EEEE" (lowercase hex, matching GDCMImageIO)
-      char key[10];
-      std::snprintf(key, sizeof(key), "%04x|%04x", tag.getGroup(), tag.getElement());
-
-      const DcmEVR vr = element->getVR();
-      if (vr == EVR_SQ)
-      {
-        // Sequences are nested datasets, not byte arrays; getUint8Array() does
-        // not return their content.  Skip rather than emit an empty entry.
-        continue;
-      }
-      if (vr == EVR_OB || vr == EVR_OW || vr == EVR_OF || vr == EVR_OD || vr == EVR_OL || vr == EVR_OV ||
-          vr == EVR_UN || vr == EVR_ox || vr == EVR_px)
-      {
-        // Binary VR — base64-encode the raw bytes
-        Uint8 * byteValue = nullptr;
-        if (element->getUint8Array(byteValue) == EC_Normal && byteValue != nullptr)
-        {
-          const Uint32 length = element->getLength();
-          if (length > 0)
-          {
-            int encodedLengthEstimate = 2 * static_cast<int>(length);
-            encodedLengthEstimate = ((encodedLengthEstimate / 4) + 1) * 4;
-            const auto bin = std::make_unique<char[]>(encodedLengthEstimate);
-            const auto encodedLengthActual =
-              static_cast<unsigned int>(itksysBase64_Encode(reinterpret_cast<const unsigned char *>(byteValue),
-                                                            static_cast<SizeValueType>(length),
-                                                            reinterpret_cast<unsigned char *>(bin.get()),
-                                                            0));
-            EncapsulateMetaData<std::string>(dict, key, std::string(bin.get(), encodedLengthActual));
-          }
-        }
-      }
-      else
-      {
-        OFString value;
-        if (element->getOFStringArray(value) == EC_Normal)
-        {
-          EncapsulateMetaData<std::string>(dict, key, std::string(value.c_str()));
-        }
-      }
-    }
-  }
+  reader.PopulateMetaDataDictionary(this->GetMetaDataDictionary());
 
   this->OpenDicomImage();
   const DiPixel * interData = this->m_DImage->getInterData();

--- a/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
@@ -506,7 +506,8 @@ DCMTKImageIO::ReadImageInformation()
       std::snprintf(key, sizeof(key), "%04x|%04x", tag.getGroup(), tag.getElement());
 
       const DcmEVR vr = element->getVR();
-      if (vr == EVR_SQ || vr == EVR_OB || vr == EVR_OW || vr == EVR_OF || vr == EVR_UN || vr == EVR_ox || vr == EVR_px)
+      if (vr == EVR_SQ || vr == EVR_OB || vr == EVR_OW || vr == EVR_OF || vr == EVR_OD || vr == EVR_OL ||
+          vr == EVR_OV || vr == EVR_UN || vr == EVR_ox || vr == EVR_px)
       {
         // Binary VR — base64-encode the raw bytes
         Uint8 * byteValue = nullptr;

--- a/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKImageIO.cxx
@@ -21,15 +21,18 @@
 #include "itkByteSwapper.h"
 #include "itksys/SystemTools.hxx"
 #include "itkDCMTKFileReader.h"
+#include "itkMetaDataObject.h"
 #include <iostream>
 #include "vnl/vnl_cross.h"
 #include "itkMath.h"
+#include "itksys/Base64.h"
 
 #include "dcmtk/dcmimgle/dcmimage.h"
 #include "dcmtk/dcmjpeg/djdecode.h"
 #include "dcmtk/dcmjpls/djdecode.h"
 #include "dcmtk/dcmdata/dcmetinf.h"
 #include "dcmtk/dcmdata/dcrledrg.h"
+#include "dcmtk/dcmdata/dcelem.h"
 #include "dcmtk/oflog/oflog.h"
 
 namespace
@@ -478,6 +481,62 @@ DCMTKImageIO::ReadImageInformation()
     this->m_Spacing.push_back(1.0);
   }
 
+  // Populate the metadata dictionary with all DICOM tag values
+  MetaDataDictionary & dict = this->GetMetaDataDictionary();
+  dict.Clear();
+  DcmDataset * dataset = reader.GetDataset();
+  if (dataset != nullptr)
+  {
+    const unsigned long numElements = dataset->card();
+    for (unsigned long i = 0; i < numElements; ++i)
+    {
+      DcmElement * element = dataset->getElement(i);
+      if (element == nullptr)
+      {
+        continue;
+      }
+      const DcmTag & tag = element->getTag();
+      // Skip pixel data (7FE0,0010)
+      if (tag.getGroup() == 0x7fe0 && tag.getElement() == 0x0010)
+      {
+        continue;
+      }
+      // Format key as "GGGG|EEEE" (lowercase hex, matching GDCMImageIO)
+      char key[10];
+      std::snprintf(key, sizeof(key), "%04x|%04x", tag.getGroup(), tag.getElement());
+
+      const DcmEVR vr = element->getVR();
+      if (vr == EVR_SQ || vr == EVR_OB || vr == EVR_OW || vr == EVR_OF || vr == EVR_UN || vr == EVR_ox || vr == EVR_px)
+      {
+        // Binary VR — base64-encode the raw bytes
+        Uint8 * byteValue = nullptr;
+        if (element->getUint8Array(byteValue) == EC_Normal && byteValue != nullptr)
+        {
+          const Uint32 length = element->getLength();
+          if (length > 0)
+          {
+            int encodedLengthEstimate = 2 * static_cast<int>(length);
+            encodedLengthEstimate = ((encodedLengthEstimate / 4) + 1) * 4;
+            const auto bin = std::make_unique<char[]>(encodedLengthEstimate);
+            const auto encodedLengthActual =
+              static_cast<unsigned int>(itksysBase64_Encode(reinterpret_cast<const unsigned char *>(byteValue),
+                                                            static_cast<SizeValueType>(length),
+                                                            reinterpret_cast<unsigned char *>(bin.get()),
+                                                            0));
+            EncapsulateMetaData<std::string>(dict, key, std::string(bin.get(), encodedLengthActual));
+          }
+        }
+      }
+      else
+      {
+        OFString value;
+        if (element->getOFStringArray(value) == EC_Normal)
+        {
+          EncapsulateMetaData<std::string>(dict, key, std::string(value.c_str()));
+        }
+      }
+    }
+  }
 
   this->OpenDicomImage();
   const DiPixel * interData = this->m_DImage->getInterData();

--- a/Modules/IO/DCMTK/test/CMakeLists.txt
+++ b/Modules/IO/DCMTK/test/CMakeLists.txt
@@ -2,6 +2,7 @@ itk_module_test()
 set(
   ITKIODCMTKTests
   itkDCMTKGetDicomTagsTest.cxx
+  itkDCMTKImageIOMetadataTest.cxx
   itkDCMTKImageIOMultiFrameImageTest.cxx
   itkDCMTKImageIONoPreambleTest.cxx
   itkDCMTKImageIOOrthoDirTest.cxx
@@ -80,6 +81,14 @@ itk_add_test(
     itkDCMTKGetDicomTagsTest
     DATA{${ITK_DATA_ROOT}/Input/DicomSeries/Image0075.dcm}
     ${ITK_TEST_OUTPUT_DIR}/DICOMTags.txt
+)
+
+itk_add_test(
+  NAME itkDCMTKImageIOMetadataTest
+  COMMAND
+    ITKIODCMTKTestDriver
+    itkDCMTKImageIOMetadataTest
+    DATA{${ITK_DATA_ROOT}/Input/DicomSeries/Image0075.dcm}
 )
 
 itk_add_test(

--- a/Modules/IO/DCMTK/test/itkDCMTKImageIOMetadataTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKImageIOMetadataTest.cxx
@@ -55,7 +55,7 @@ itkDCMTKImageIOMetadataTest(int argc, char * argv[])
   // Values are specific to the test file Input/DicomSeries/Image0075.dcm
   std::string value;
 
-  // (0008,0021) DA  StudyDate
+  // (0008,0021) DA  SeriesDate
   ITK_TEST_EXPECT_TRUE(itk::ExposeMetaData<std::string>(dict, "0008|0021", value));
   ITK_TEST_EXPECT_EQUAL(value, std::string("20030625"));
 

--- a/Modules/IO/DCMTK/test/itkDCMTKImageIOMetadataTest.cxx
+++ b/Modules/IO/DCMTK/test/itkDCMTKImageIOMetadataTest.cxx
@@ -1,0 +1,76 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkDCMTKImageIO.h"
+#include "itkMetaDataObject.h"
+#include "itkTestingMacros.h"
+
+#include <iostream>
+
+// Tests that DCMTKImageIO::ReadImageInformation() populates the metadata
+// dictionary with DICOM tag values using "GGGG|EEEE" keys (lowercase
+// matching GDCMImageIO behavior). Expected values are verified against
+// Input/DicomSeries/Image0075.dcm using the same fixture as
+// itkDCMTKGetDicomTagsTest.
+int
+itkDCMTKImageIOMetadataTest(int argc, char * argv[])
+{
+  if (argc != 2)
+  {
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " <DicomImage>" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  auto dcmtkIO = itk::DCMTKImageIO::New();
+
+  ITK_TEST_EXPECT_TRUE(dcmtkIO->CanReadFile(argv[1]));
+  dcmtkIO->SetFileName(argv[1]);
+  ITK_TRY_EXPECT_NO_EXCEPTION(dcmtkIO->ReadImageInformation());
+
+  const itk::MetaDataDictionary & dict = dcmtkIO->GetMetaDataDictionary();
+
+  // Dictionary must be populated
+  ITK_TEST_EXPECT_TRUE(!dict.GetKeys().empty());
+
+  // Pixel data (7FE0,0010) must NOT appear in the dictionary
+  ITK_TEST_EXPECT_TRUE(!dict.HasKey("7fe0|0010"));
+
+  // Verify string-valued DICOM tags using the "GGGG|EEEE" key format.
+  // Values are specific to the test file Input/DicomSeries/Image0075.dcm
+  std::string value;
+
+  // (0008,0021) DA  StudyDate
+  ITK_TEST_EXPECT_TRUE(itk::ExposeMetaData<std::string>(dict, "0008|0021", value));
+  ITK_TEST_EXPECT_EQUAL(value, std::string("20030625"));
+
+  // (0010,0010) PN  PatientName
+  ITK_TEST_EXPECT_TRUE(itk::ExposeMetaData<std::string>(dict, "0010|0010", value));
+  ITK_TEST_EXPECT_EQUAL(value, std::string("Wes Turner"));
+
+  // (0010,0040) CS  PatientSex
+  ITK_TEST_EXPECT_TRUE(itk::ExposeMetaData<std::string>(dict, "0010|0040", value));
+  ITK_TEST_EXPECT_EQUAL(value, std::string("O"));
+
+  // (0028,0004) CS  PhotometricInterpretation
+  ITK_TEST_EXPECT_TRUE(itk::ExposeMetaData<std::string>(dict, "0028|0004", value));
+  ITK_TEST_EXPECT_EQUAL(value, std::string("MONOCHROME2"));
+
+  std::cout << "Test finished." << std::endl;
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
The DCMTKImageIO was not updating the metadata dictionary resulting in empty metadata when reading DICOM files. This commit adds the missing code to update the metadata dictionary with the DICOM tags read from the file.

Note that tags that are part of a DICOM sequence are skipped due to the flat nature of the metadata dictionary. Encoding DICOM sequences requires supporting a hierarchical structure in the metadata dictionary which is not straightforward. This omission is consistent with the GDCMImageIO behavior. Possibly address in the future.

Inspired by PR #6189
Tool: GitHub copilot (claude sonnet 4.6)