### PR TITLE
BUG: Cover gdcm::VR::OD/OL/OV in GDCMImageIO binary VR handling

### DIFF
--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -765,7 +765,8 @@ GDCMImageIO::InternalReadImageInformation()
     // Process binary field and encode them as mime64: only when we do not know
     // of any better
     // representation. VR::US is binary, but user want ASCII representation.
-    if (vr & (gdcm::VR::OB | gdcm::VR::OF | gdcm::VR::OW | gdcm::VR::SQ | gdcm::VR::UN))
+    if (vr & (gdcm::VR::OB | gdcm::VR::OD | gdcm::VR::OF | gdcm::VR::OL | gdcm::VR::OV | gdcm::VR::OW | gdcm::VR::SQ |
+              gdcm::VR::UN))
     {
       // itkAssertInDebugAndIgnoreInReleaseMacro( vr & gdcm::VR::VRBINARY );
       /*
@@ -894,9 +895,8 @@ GDCMImageIO::Write(const void * buffer)
       {
         // How did we reach here ?
       }
-      else if (vrtype & (gdcm::VR::OB | gdcm::VR::OF | gdcm::VR::OW /*|
-                                                                      gdcm::VR::SQ*/
-                         | gdcm::VR::UN))
+      else if (vrtype &
+               (gdcm::VR::OB | gdcm::VR::OD | gdcm::VR::OF | gdcm::VR::OL | gdcm::VR::OV | gdcm::VR::OW | gdcm::VR::UN))
       {
         // Custom VR::VRBINARY
         // convert value from Base64


### PR DESCRIPTION
Adds `gdcm::VR::OD`, `gdcm::VR::OL`, `gdcm::VR::OV` to the binary-VR masks in `itkGDCMImageIO.cxx` so DICOM Supplement 172/173 bulk-data values survive the ITK `MetaDataDictionary` roundtrip instead of falling through to the text path and being silently dropped (or, on the write side, silently corrupted). Parallels the same fix [#6217](https://github.com/InsightSoftwareConsortium/ITK/pull/6217) is making for DCMTKImageIO; surfaced by Greptile review on that PR.

<details>
<summary>The two affected sites</summary>

| Site | Direction | Old mask | New mask |
|---|---|---|---|
| `InternalReadImageInformation` (line 768) | DICOM file → ITK MetaDataDictionary, base64-encode | `OB \| OF \| OW \| SQ \| UN` | `OB \| OD \| OF \| OL \| OV \| OW \| SQ \| UN` |
| `Write` (line 887) | ITK MetaDataDictionary → DICOM file, base64-decode | `OB \| OF \| OW \| UN` | `OB \| OD \| OF \| OL \| OV \| OW \| UN` |

GDCM defines `gdcm::VR::OD = 2^27`, `gdcm::VR::OL = 2^28`, `gdcm::VR::OV = 2^31` in `Modules/ThirdParty/GDCM/.../gdcmVR.h:73-76`, so the constants are available in the vendored copy.

</details>

<details>
<summary>Why this matters more than the read-side miss</summary>

The read-side miss (DICOM → dictionary) silently drops the value — bad but recoverable.  The write-side miss is worse: a tag that was originally read as text and re-emitted via `Write()` would skip base64-decode and write garbage bytes to the output DICOM file.  Both sides need the fix together for round-trip correctness.

</details>

<details>
<summary>Local verification</summary>

- `pre-commit run --all-files` exit 0 (clang-format auto-formatted the longer mask expressions; no other hook fires)
- 1 file changed, 6 insertions, 4 deletions
- Practical impact remains low until ITKData ships a fixture exercising those VRs (separate work) — but the dispatch is now correct

</details>

<!--
provenance: claude-code session 2026-05-05
key_facts:
  - parallels: PR #6217 (DCMTKImageIO got the same three VRs in 8a98fda; this PR covers GDCMImageIO)
  - greptile_origin: review on PR #6217 (P2) noted GDCM has the same gap
  - gdcm_vr_constants_present: gdcmVR.h:73-76 (OD=2^27 OL=2^28 OV=2^31)
  - branch: hjmjohnson:fix-gdcm-od-ol-ov-vrs based on upstream/main 11c2f38b0d
related_files:
  - Modules/IO/GDCM/src/itkGDCMImageIO.cxx:768
  - Modules/IO/GDCM/src/itkGDCMImageIO.cxx:887
post_merge_action:
  - When ITKData adds an OD/OL/OV fixture, add a roundtrip test to GDCM and DCMTK
-->
