### PR TITLE
COMP: Fix Mac nightly compile errors (VTI test + ImageAlgorithm CTAD)

### DIFF
--- a/Modules/Core/Common/include/itkImageAlgorithm.hxx
+++ b/Modules/Core/Common/include/itkImageAlgorithm.hxx
@@ -53,8 +53,8 @@ ImageAlgorithm::ReferenceCopy(const InputImageType *                       inIma
     return;
   }
 
-  ImageRegionConstIterator it(inImage, inRegion);
-  ImageRegionIterator      ot(outImage, outRegion);
+  ImageRegionConstIterator<InputImageType> it(inImage, inRegion);
+  ImageRegionIterator<OutputImageType>     ot(outImage, outRegion);
 
   while (!it.IsAtEnd())
   {

--- a/Modules/Filtering/RLEImage/test/CMakeLists.txt
+++ b/Modules/Filtering/RLEImage/test/CMakeLists.txt
@@ -16,6 +16,10 @@ set(
 
 createtestdriver( RLEImage "${RLEImage-Test_LIBRARIES}" "${RLEImageTests}" )
 
+set(RLEImageGTests itkRLEImageAlgorithmCopyGTest.cxx)
+
+creategoogletestdriver(RLEImage "${RLEImage-Test_LIBRARIES}" "${RLEImageGTests}")
+
 add_executable(
   runFromIDE
   manualTest.cxx

--- a/Modules/Filtering/RLEImage/test/itkRLEImageAlgorithmCopyGTest.cxx
+++ b/Modules/Filtering/RLEImage/test/itkRLEImageAlgorithmCopyGTest.cxx
@@ -1,0 +1,84 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkImageAlgorithm.h"
+#include "itkRLEImage.h"
+
+#include <gtest/gtest.h>
+
+// Locks in correct iterator deduction in ImageAlgorithm::Copy when the
+// source or destination is a partially-specialized Image-like template.
+namespace
+{
+constexpr unsigned int Dimension = 3;
+using PixelType = short;
+using RLEType = itk::RLEImage<PixelType, Dimension>;
+using ImageType = itk::Image<PixelType, Dimension>;
+
+RLEType::RegionType
+MakeRegion()
+{
+  RLEType::SizeType  size = { { 4, 4, 4 } };
+  RLEType::IndexType start = { { 0, 0, 0 } };
+  return RLEType::RegionType{ start, size };
+}
+} // namespace
+
+TEST(RLEImageAlgorithmCopy, FromRLEToImage)
+{
+  const auto region = MakeRegion();
+
+  auto rle = RLEType::New();
+  rle->SetRegions(region);
+  rle->Allocate();
+  rle->FillBuffer(7);
+
+  auto dst = ImageType::New();
+  dst->SetRegions(region);
+  dst->Allocate();
+  dst->FillBuffer(0);
+
+  itk::ImageAlgorithm::Copy<RLEType, ImageType>(rle.GetPointer(), dst.GetPointer(), region, region);
+
+  for (itk::ImageRegionConstIterator<ImageType> it(dst, region); !it.IsAtEnd(); ++it)
+  {
+    ASSERT_EQ(it.Get(), 7) << "Mismatch at " << it.GetIndex();
+  }
+}
+
+TEST(RLEImageAlgorithmCopy, FromImageToRLE)
+{
+  const auto region = MakeRegion();
+
+  auto src = ImageType::New();
+  src->SetRegions(region);
+  src->Allocate();
+  src->FillBuffer(11);
+
+  auto rleDst = RLEType::New();
+  rleDst->SetRegions(region);
+  rleDst->Allocate();
+  rleDst->FillBuffer(0);
+
+  itk::ImageAlgorithm::Copy<ImageType, RLEType>(src.GetPointer(), rleDst.GetPointer(), region, region);
+
+  for (itk::ImageRegionConstIterator<RLEType> it(rleDst, region); !it.IsAtEnd(); ++it)
+  {
+    ASSERT_EQ(it.Get(), 11) << "Mismatch at " << it.GetIndex();
+  }
+}

--- a/Modules/IO/VTK/test/itkVTIImageIOReadWriteTest.cxx
+++ b/Modules/IO/VTK/test/itkVTIImageIOReadWriteTest.cxx
@@ -89,7 +89,7 @@ itkVTIImageIOReadWriteTest(int argc, char * argv[])
   reader->SetFileName(inputImage);
   ITK_TRY_EXPECT_NO_EXCEPTION(reader->UpdateOutputInformation());
 
-  auto imageIO = reader->GetImageIO();
+  auto imageIO = reader->GetModifiableImageIO();
   imageIO->SetFileName(inputImage);
 
   ITK_TRY_EXPECT_NO_EXCEPTION(imageIO->ReadImageInformation());


### PR DESCRIPTION
Fix two compile-error clusters first observed on the [2026-05-05 nightly dashboard](https://open.cdash.org/index.php?project=Insight&date=2026-05-05): a const-correctness slip in `itkVTIImageIOReadWriteTest.cxx` that surfaces only when `ITK_FUTURE_LEGACY_REMOVE=ON` (Mac dbg-Universal builds), and a CTAD deduction failure in `itkImageAlgorithm.hxx` that surfaces only on AppleClang's stricter deduction (Mac Python + Mac remote-modules builds). Both fixes are one-/two-line changes with no behavioral effect at runtime.

A third commit adds a GoogleTest regression covering `ImageAlgorithm::Copy` with `RLEImage` source/destination — the CTAD bug was discovered while ingesting ITKMorphologicalContourInterpolation (PR #6209), where it caused SIGABRT on gcc-11 and a compile error on AppleClang 17.

<details>
<summary>Failing CDash buildgroups and counts</summary>

Source: <https://open.cdash.org/index.php?project=Insight&date=2026-05-05>

| Buildgroup | Build name | Site | err | tfail | Cause |
|---|---|---|---|---|---|
| Expected Nightly | `Mac14.x-AppleClang-dbg-Universal` | RogueResearch25 | 4 | 0 | #1 (VTI) |
| Expected Nightly | `Mac13.x-AppleClang-dbg-Universal` | RogueResearch24 | 4 | 0 | #1 (VTI) |
| Expected Nightly | `Mac10.15-AppleClang-dbg` | RogueResearch17 | 4 | 0 | #1 (VTI) |
| Nightly | `Mac26.x-ClangMain-dbg-arm64` | RogueResearch27 | 4 | 0 | #1 (VTI) |
| Nightly | `Mac26.x-AppleClang-dbg-TSan` | RogueResearch27 | 4 | 0 | #1 (VTI) |
| Nightly | `Mac15.x-AppleClang-dbg-ASanUBSan` | RogueResearch26 | 4 | 0 | #1 (VTI) |
| Nightly | `Mac11.x-AppleClang-dbg` | RogueResearch20 | 4 | 0 | #1 (VTI) |
| Nightly | `Mac12.x-AppleClang-dbg-arm64` | RogueResearch19 | 1 | 0 | #1 (VTI partial) |
| Expected Nightly Python Wrapping | `MacOS-Rel-Python` | ZukicM1.kitware | 12 | 2 | #2 (CTAD) |
| Expected Nightly Remote Modules | `MacOS-Rel-MorphologicalContourInterpolation` | ZukicM1.kitware | 12 | 0 | #2 (CTAD) |

Total: 8 sites × 4 errors (#1) + 2 sites × 12 errors (#2) = **56 compile errors** cleared.

</details>

<details>
<summary>Fix #1 — `itkVTIImageIOReadWriteTest.cxx` const-correctness under `ITK_FUTURE_LEGACY_REMOVE=ON`</summary>

**Commit**: `COMP: Use GetModifiableImageIO() in VTI test for ITK_FUTURE_LEGACY_REMOVE builds`

**Failing line** (introduced by PR #6032 merged 2026-05-01):

```cpp
auto imageIO = reader->GetImageIO();    // line 92
imageIO->SetFileName(inputImage);        // line 93 — fails
ITK_TRY_EXPECT_NO_EXCEPTION(imageIO->ReadImageInformation()); // line 95 — fails
return internalMain<2>(inputImage, outputImage, imageIO, compress);  // line 104 — fails
```

**Diagnostic** (representative of all 4 errors):
```
itkVTIImageIOReadWriteTest.cxx:93:12: error: no matching member function for call to 'SetFileName'
itkVTIImageIOReadWriteTest.cxx:95:31: error: 'this' argument to member function 'ReadImageInformation'
                                            has type 'const ImageIOBase', but function is not marked const
itkVTIImageIOReadWriteTest.cxx:104:14: error: no matching function for call to 'internalMain'
itkVTIImageIOReadWriteTest.cxx:106:14: error: no matching function for call to 'internalMain'
4 errors generated.
```

**Root cause**: `itkGetModifiableObjectMacro(ImageIO, ImageIOBase)` expands differently based on `ITK_FUTURE_LEGACY_REMOVE`:

- **OFF (default)** — emits all three: `GetModifiableImageIO()` (non-const), `GetImageIO() const` (returning `const ImageIOBase *`), and a legacy-fallback non-const `GetImageIO()`. The bare `reader->GetImageIO()` resolves to the non-const fallback; the test compiles.
- **ON (strict-future mode)** — emits only `GetModifiableImageIO()` and `GetImageIO() const`; the bare `reader->GetImageIO()` returns `const ImageIOBase *`. `auto` deduces const, every subsequent call needing a non-const path errors out.

The PR-time CI green-lit the test because no per-PR builder configures `ITK_FUTURE_LEGACY_REMOVE=ON`. The Rogue Research Mac dbg-Universal nightly pipelines do, exposing the regression.

**Fix**: change the bare-name call to the modifiable getter — works under both legacy and strict-future expansions.

```diff
-  auto imageIO = reader->GetImageIO();
+  auto imageIO = reader->GetModifiableImageIO();
```

</details>

<details>
<summary>Fix #2 — `itkImageAlgorithm.hxx` CTAD deduction on AppleClang</summary>

**Commit**: `COMP: Spell template args on ImageRegion iterators in DispatchedCopy`

**Failing lines** (in `ImageAlgorithm::DispatchedCopy`):

```cpp
ImageRegionConstIterator it(inImage, inRegion);    // line 56
ImageRegionIterator      ot(outImage, outRegion);  // line 57
```

**Diagnostic**:
```
itkImageAlgorithm.hxx:56:28: error: no viable constructor or deduction guide for deduction
                                    of template arguments of 'ImageRegionConstIterator'
itkImageAlgorithm.hxx:57:28: error: no viable constructor or deduction guide for deduction
                                    of template arguments of 'ImageRegionIterator'
```

**Root cause**: class-template-argument-deduction (CTAD) used without an explicit deduction guide. `ImageScanlineConstIterator` / `ImageScanlineIterator` (a few lines above, lines 39-40) ship deduction guides and compile cleanly; `ImageRegionConstIterator` / `ImageRegionIterator` do not. AppleClang's CTAD on the failing builds is stricter than gcc/MSVC, exposing the asymmetry.

The two surfaces affected (`MacOS-Rel-Python` ZukicM1.kitware, `MacOS-Rel-MorphologicalContourInterpolation` ZukicM1.kitware) trigger the same 12-error count because every consumer of `ImageAlgorithm.hxx` from those buildgroups instantiates the path through `DispatchedCopy`.

**Fix**: spell the template argument explicitly. Compiles on every toolchain, removes the deduction-guide dependency. Could alternatively add a deduction guide to `itkImageRegionConstIterator.h` / `itkImageRegionIterator.h` for parity with the Scanline iterators — that's a separate cleanup PR.

```diff
-  ImageRegionConstIterator it(inImage, inRegion);
-  ImageRegionIterator      ot(outImage, outRegion);
+  ImageRegionConstIterator<InputImageType> it(inImage, inRegion);
+  ImageRegionIterator<OutputImageType>     ot(outImage, outRegion);
```

</details>

<details>
<summary>Fix #3 — RLEImage GTest regression for ImageAlgorithm::Copy iterator deduction</summary>

**Commit**: `ENH: Add RLEImage GTest covering ImageAlgorithm::Copy iterator deduction`

The CTAD bug (fix #2) was first identified while ingesting `ITKMorphologicalContourInterpolation` (PR #6209). `RLEImage` is a partially-specialized `Image`-like template whose iterator types lack visible deduction guides at the `itkImageAlgorithm.hxx` parse site. On AppleClang 17 this produced 12 compile errors; on gcc-11 it silently selected the primary-template iterator and caused SIGABRT at runtime.

Two `GoogleTest` cases added to `Modules/Filtering/RLEImage/test/`:

- `RLEImageAlgorithmCopy.FromRLEToImage` — copies a filled `RLEImage` into a standard `Image`; verifies all pixels via `ImageRegionConstIterator`.
- `RLEImageAlgorithmCopy.FromImageToRLE` — copies a filled standard `Image` into an `RLEImage`; verifies all pixels via `ImageRegionConstIterator<RLEType>`.

Both were verified locally with Apple-clang 17 in `~/src/ITK-mci/build` before this push.

</details>

<details>
<summary>What this PR does not address</summary>

Other 2026-05-05 dashboard symptoms have separate root causes and are out of scope here:

- **"Missing" tests** across multiple buildgroups (`itkSquareImageFilterTest`, `itkRoundImageFilterTest`, etc.) — CDash dashboard drift after recent GoogleTest-driver consolidation (PRs #6132, #6177, #6197, #6200). The tests still run; the historical CTest names disappeared. Needs CDash expected-test refresh, not a code change.
- **`Windows11-VS22x64-RelWithDebInfo-Favorite-Remotes` 56 real test failures** — likely MSVC numerical drift in registration tests post recent remote-module ingests (#6171, #6205). Needs nightly bisect.
- **`Windows11-VS2022-Static-DebugTBB` 3 failures** and **`Windows11-VS2026-Shared-ReleaseTBB` 1 failure** — likely TBB-specific.
- **`itk-valgrind` / `itk-coverage`** sporadic — long-running, treat as flake until reproducible.

Each of those merits a separate fix PR if persistent.

</details>

<details>
<summary>Suggested follow-up</summary>

The recurring pattern — *test passes per-PR, fails on nightly because nightly enables strict modes* — argues for adding a `Pixi-Cxx-Strict` or equivalent GHA job that builds with `-DITK_FUTURE_LEGACY_REMOVE=ON`. That would have caught fix #1 at PR time and saved a 24-hour nightly cycle. Comparable rationale for an AppleClang-CTAD job for fix #2, though the case for that one is weaker (Apple-only, low frequency).

</details>

<!--
provenance: claude-code session 2026-05-06
fixes_compile_errors: 56 across 10 buildgroups on 2026-05-05 nightly
related_pr_introducing_fix1: #6032 (VTIImageIO, merged 2026-05-01)
fix1_macro: itkGetModifiableObjectMacro emission in Modules/Core/Common/include/itkMacro.h gated on ITK_FUTURE_LEGACY_REMOVE
fix2_class: ImageRegionConstIterator / ImageRegionIterator missing CTAD deduction guides relative to ImageScanline siblings
fix3_gtest: RLEImageAlgorithmCopy GTest added to lock in fix #2 against regression; discovered during PR #6209 MCI ingest
fix3_verified: Apple-clang 17 local build passing before push
suggested_followup_ci: Pixi-Cxx-Strict GHA job with -DITK_FUTURE_LEGACY_REMOVE=ON
no_runtime_change: true (fixes #1 and #2 are call-site syntax only)
-->
