### PR TITLE
BUG: Replace multi-line DESCRIPTION strings in 5 ingested itk-module.cmake

### DIFF
--- a/Modules/Filtering/RLEImage/itk-module.cmake
+++ b/Modules/Filtering/RLEImage/itk-module.cmake
@@ -1,14 +1,3 @@
-# the top-level README is used for describing this module, just
-# re-used it for documentation here
-get_filename_component(MY_CURENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-file(READ "${MY_CURENT_DIR}/README.md" DOCUMENTATION)
-
-# itk_module() defines the module dependencies in RLEImage
-# The testing module in RLEImage depends on ITKTestKernel
-# By convention those modules outside of ITK are not prefixed with
-# ITK
-
-# define the dependencies of the include module and the tests
 itk_module(
   RLEImage
   ENABLE_SHARED
@@ -17,5 +6,5 @@ itk_module(
   TEST_DEPENDS
     ITKTestKernel
   EXCLUDE_FROM_DEFAULT
-  DESCRIPTION "${DOCUMENTATION}"
+  DESCRIPTION "Run-length encoded memory compression scheme for an itk::Image."
 )

--- a/Modules/Filtering/SplitComponents/itk-module.cmake
+++ b/Modules/Filtering/SplitComponents/itk-module.cmake
@@ -1,20 +1,9 @@
-# the top-level README is used for describing this module, just
-# re-used it for documentation here
-get_filename_component(MY_CURRENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-file(READ "${MY_CURRENT_DIR}/README.md" DOCUMENTATION)
-
-# itk_module() defines the module dependencies in SplitComponents
-# The testing module in SplitComponents depends on ITKTestKernel
-# By convention those modules outside of ITK are not prefixed with
-# ITK.
-
-# define the dependencies of the include module and the tests
 itk_module(
   SplitComponents
   DEPENDS
     ITKCommon
   TEST_DEPENDS
     ITKTestKernel
-  DESCRIPTION "${DOCUMENTATION}"
+  DESCRIPTION "Generate component images from a vector-pixel itk::Image."
   EXCLUDE_FROM_DEFAULT
 )

--- a/Modules/IO/IOFDF/itk-module.cmake
+++ b/Modules/IO/IOFDF/itk-module.cmake
@@ -1,14 +1,3 @@
-# the top-level README is used for describing this module, just
-# re-used it for documentation here
-get_filename_component(MY_CURRENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-file(READ "${MY_CURRENT_DIR}/README.md" DOCUMENTATION)
-
-# itk_module() defines the module dependencies in IOFDF
-# The testing module in IOFDF depends on ITKTestKernel
-# By convention those modules outside of ITK are not prefixed with
-# ITK
-
-# define the dependencies of the include module and the tests
 itk_module(
   IOFDF
   ENABLE_SHARED
@@ -19,6 +8,6 @@ itk_module(
     ITKTransform
   FACTORY_NAMES
     ImageIO::FDF
-  DESCRIPTION "${DOCUMENTATION}"
+  DESCRIPTION "FDF image format ImageIO plugin for ITK."
   EXCLUDE_FROM_DEFAULT
 )

--- a/Modules/IO/IOMeshMZ3/itk-module.cmake
+++ b/Modules/IO/IOMeshMZ3/itk-module.cmake
@@ -1,8 +1,3 @@
-# the top-level README is used for describing this module, just
-# re-used it for documentation here
-get_filename_component(MY_CURRENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-file(READ "${MY_CURRENT_DIR}/README.md" DOCUMENTATION)
-
 itk_module(
   IOMeshMZ3
   DEPENDS
@@ -17,7 +12,7 @@ itk_module(
     ITKMetaIO
   FACTORY_NAMES
     MeshIO::MZ3
-  DESCRIPTION "${DOCUMENTATION}"
+  DESCRIPTION "Read and write MZ3 triangle mesh files."
   EXCLUDE_FROM_DEFAULT
   ENABLE_SHARED
 )

--- a/Modules/IO/IOMeshSTL/itk-module.cmake
+++ b/Modules/IO/IOMeshSTL/itk-module.cmake
@@ -1,14 +1,3 @@
-# the top-level README is used for describing this module, just
-# re-used it for documentation here
-get_filename_component(MY_CURRENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-file(READ "${MY_CURRENT_DIR}/README.md" DOCUMENTATION)
-
-# itk_module() defines the module dependencies in IOMeshSTL
-# The testing module in IOMeshSTL depends on ITKTestKernel
-# By convention those modules outside of ITK are not prefixed with
-# ITK.
-
-# define the dependencies of the include module and the tests
 itk_module(
   IOMeshSTL
   ENABLE_SHARED
@@ -20,6 +9,6 @@ itk_module(
     ITKQuadEdgeMesh
   FACTORY_NAMES
     MeshIO::STL
-  DESCRIPTION "${DOCUMENTATION}"
+  DESCRIPTION "Read and write STL triangle mesh files."
   EXCLUDE_FROM_DEFAULT
 )


### PR DESCRIPTION
BUG: Fix CMake configure warnings from multi-line DESCRIPTION in itk_module()

Five recently-ingested modules (RLEImage, SplitComponents, IOFDF,
IOMeshMZ3, IOMeshSTL) produce `CMake Warning (dev): Unknown argument`
on every configure because their `itk-module.cmake` reads the archival
`README.md` into a `DESCRIPTION` argument and the README contains
semicolons and `[` characters that CMake list expansion splits into
spurious arguments.

<details>
<summary>Root cause</summary>

`CMake/ITKModuleMacros.cmake` used `foreach(arg ${ARGN})` to iterate
over `itk_module()` arguments. When `DESCRIPTION` holds a multi-line
string with semicolons, CMake expands `${ARGN}` and re-splits on `;`
before iteration, so each semicolon-delimited fragment becomes a
separate loop element and hits the "Unknown argument" warning.

Two complementary fixes:

1. **`ITKModuleMacros.cmake`** — `foreach(arg IN LISTS ARGN)` iterates
   the actual list elements without re-splitting. This is a safety net
   for any DESCRIPTION that contains semicolons.

2. **Five `itk-module.cmake` files** — replace the
   `get_filename_component / file(READ README.md DOCUMENTATION)` preamble
   and `DESCRIPTION "${DOCUMENTATION}"` with a static one-liner. The
   archival `README.md` (a migration notice) is not meaningful module
   documentation and should not be the source of CMake metadata.

</details>

<details>
<summary>Affected modules and CDash evidence</summary>

All 12 configure warnings on the latest Mac nightly build trace to
`ITKModuleMacros.cmake:111` via `message(AUTHOR_WARNING "Unknown argument [${arg}]")`.

| Module | README semicolons | README `[` chars |
|---|---|---|
| RLEImage | 3 | 2 |
| SplitComponents | 4 | 2 |
| IOFDF | 3 | 2 |
| IOMeshMZ3 | 3 | 2 |
| IOMeshSTL | 1 | 1 |

A companion fix to PR #6204 (`sanitize-history.py`) adds
`patch_dynamic_description()` so future ingests never introduce the
pattern.

</details>

<!--
provenance: claude-code session 2026-05-06
key_facts:
  branch: hjmjohnson:fix-cmake-configure-warnings
  base: InsightSoftwareConsortium/ITK:main
  cdash_configure_warnings: Mac10.15-AppleClang-dbg nightly, 12 warnings
  companion_pr_6204: update adds patch_dynamic_description() to sanitize-history.py
related_files:
  CMake/ITKModuleMacros.cmake:72
  Modules/Filtering/RLEImage/itk-module.cmake
  Modules/Filtering/SplitComponents/itk-module.cmake
  Modules/IO/IOFDF/itk-module.cmake
  Modules/IO/IOMeshMZ3/itk-module.cmake
  Modules/IO/IOMeshSTL/itk-module.cmake
-->
