### PR TITLE
COMP: Expose itkeigen subdir in ITKEigen3_INCLUDE_DIRS for external consumers

### DIFF
--- a/Modules/ThirdParty/Eigen3/CMakeLists.txt
+++ b/Modules/ThirdParty/Eigen3/CMakeLists.txt
@@ -55,7 +55,18 @@ if(ITK_USE_SYSTEM_EIGEN)
   )
 else()
   set(ITKEigen3_LIBRARIES eigen_internal)
-  set(ITKEigen3_INCLUDE_DIRS ${ITKEigen3_SOURCE_DIR}/src)
+  # Two include directories are required so both ITK's own
+  # ITK_EIGEN(X) macro convention <itkeigen/Eigen/X> and the upstream
+  # Eigen convention <Eigen/X> resolve.  ITK code rooted at
+  # ${ITKEigen3_SOURCE_DIR}/src uses the macro form; external
+  # consumers (proxTV, anything else that includes Eigen the
+  # standard way) need the parent of <Eigen/X>, which is
+  # ${ITKEigen3_SOURCE_DIR}/src/itkeigen.
+  set(
+    ITKEigen3_INCLUDE_DIRS
+    ${ITKEigen3_SOURCE_DIR}/src
+    ${ITKEigen3_SOURCE_DIR}/src/itkeigen
+  )
 endif()
 
 # For the generated itk_eigen.h


### PR DESCRIPTION
Add `${ITKEigen3_SOURCE_DIR}/src/itkeigen` to `ITKEigen3_INCLUDE_DIRS` so external consumers using the upstream Eigen include convention (`<Eigen/<header>>`) resolve against the vendored Eigen via ITK's IMPORTED targets — currently they get `fatal error: Eigen/Dense: No such file or directory`. Unblocks InsightSoftwareConsortium/ITKTotalVariation # 57's modern-target-interfaces refactor for proxTV. **Independent of and complementary to #6176** (the Eigen 5 update); the architecture issue predates that PR.

<details>
<summary>Root cause</summary>

ITK ships its vendored Eigen3 headers at:
```
Modules/ThirdParty/Eigen3/src/itkeigen/Eigen/<header>
```

ITK's own internal code uses `ITK_EIGEN(<header>)` from `itk_eigen.h`, which expands to `<itkeigen/Eigen/<header>>`. With include path `${ITKEigen3_SOURCE_DIR}/src` (the parent of `itkeigen/`), the compiler appends `/itkeigen/Eigen/<header>` and resolves correctly. ITK proper has always built fine.

`Modules/ThirdParty/Eigen3/CMakeLists.txt:58` (vendored case, before this PR):
```cmake
set(ITKEigen3_INCLUDE_DIRS ${ITKEigen3_SOURCE_DIR}/src)
```

That single path flowed into `INTERFACE_INCLUDE_DIRECTORIES` of both `ITK::ITKEigen3Module` and `ITK::eigen_internal`. External consumers using the upstream `<Eigen/<header>>` convention got the wrong root and failed to resolve. The `Eigen3::Eigen` IMPORTED target produced by Eigen's own export does have the correct path, but it's declared as `add_library(Eigen3::Eigen ALIAS eigen)` — an in-source-scope alias, invisible to FetchContent sub-builds (verified empirically).

</details>

<details>
<summary>Fix</summary>

Single-block change to `Modules/ThirdParty/Eigen3/CMakeLists.txt:58`:
```diff
-  set(ITKEigen3_INCLUDE_DIRS ${ITKEigen3_SOURCE_DIR}/src)
+  set(
+    ITKEigen3_INCLUDE_DIRS
+    ${ITKEigen3_SOURCE_DIR}/src
+    ${ITKEigen3_SOURCE_DIR}/src/itkeigen
+  )
```

ITK's own `<itkeigen/Eigen/<header>>` consumers continue to find their headers via the first entry. External consumers using `<Eigen/<header>>` find theirs via the second. Both flow into `INTERFACE_INCLUDE_DIRECTORIES` of the IMPORTED `ITK::ITKEigen3Module` so the fix applies in-tree and to `find_package(ITK)` consumers identically.

</details>

<details>
<summary>Local verification</summary>

Full ITK build with `Module_TotalVariation=ON` pinned at ITKTotalVariation # 57's tip (`39e849e`, which previously failed `lapackFunctionsWrap.cpp:11:10: fatal error: Eigen/Dense: No such file or directory`):

| Step | Result |
|---|---|
| Configure (`ITK_BUILD_DEFAULT_MODULES=ON`, Module_TotalVariation pinned at PR # 57 tip) | ✅ clean |
| Build `ninja -j16` | ✅ **6165/6165** targets, 0 failures |
| `libitkproxTV-6.0.so` produced | ✅ |
| `bin/TotalVariationTestDriver` linked | ✅ |
| `ctest -R ProxTV` | ✅ `itkProxTVImageFilterTest` passes |
| `lapackFunctionsWrap.cpp.o` compile flags include `-isystem .../Eigen3/src/itkeigen` | ✅ (the vendored path resolves `<Eigen/Dense>`) |
| Compile flags do **not** include `-isystem /usr/include/eigen3` | ✅ (no longer falling back to system Eigen) |

Compile-commands receipt for `lapackFunctionsWrap.cpp`:
```
-I/tmp/itk-eigen-include-fix-build/_deps/proxtv_fetch-src/src
-I.../Eigen3/src
-I.../build/Modules/ThirdParty/Eigen3/src
-isystem .../Eigen3/src/itkeigen        ← the new include dir from this PR
```

</details>

<details>
<summary>Relationship to other PRs</summary>

- **#6176** (Eigen 5 vendored update) — independent. The architecture issue this PR fixes predates the Eigen 5 update; `upstream/main` has the same setup. PR #6176 is good to merge as-is. After both this PR and #6176 land, no further coordination is needed.
- **InsightSoftwareConsortium/ITKTotalVariation# 57** (cmake_interface_update) — unblocked by this PR. Their `set(proxTV_Eigen_LIBRARIES ITK::ITKEigen3Module)` becomes correct as-is, no further changes needed in TotalVariation. The longstanding "silent fall-through to system Eigen" bug in ITKTotalVariation `main` (where `set(Eigen3_DIR "${ITKInternalEigen3_DIR}")` reads an empty value) becomes moot once # 57 lands, because proxTV no longer needs the broken `Eigen3_DIR` shim.

</details>

<!--
provenance: claude-code session 2026-05-06
deep_dive_origin: PR #6176 deep dive uncovered architectural mismatch
verification_build: /tmp/itk-eigen-include-fix-build (full ITK + ITKTotalVariation# 57 against patched ITK source)
key_evidence: -isystem .../Eigen3/src/itkeigen on lapackFunctionsWrap.cpp.o compile line
unblocks: InsightSoftwareConsortium/ITKTotalVariation# 57
no_dependency_on: PR #6176 (the Eigen 5 update); this fix applies to upstream/main as-is
post_merge_action: ITKTotalVariation# 57 should rebuild cleanly; merge of #6176 is independent
-->
