### PR TITLE
ENH: Migrate Eigen3 includes to canonical <Eigen/x> via Eigen3::Eigen (supersedes #5952)

### DIFF
--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
@@ -19,8 +19,7 @@
 #define itkSymmetricEigenAnalysis_h
 
 #include "itkMacro.h"
-#include "itk_eigen.h"
-#include ITK_EIGEN(Eigenvalues)
+#include <Eigen/Eigenvalues>
 #include <numeric>
 #include <vector>
 // For GetPointerToMatrixData

--- a/Modules/Registration/Montage/include/itkTileMontage.hxx
+++ b/Modules/Registration/Montage/include/itkTileMontage.hxx
@@ -25,8 +25,7 @@
 #include "itkThreadPool.h"
 #include "itkConfigure.h" // for ITK_USE_FFTWF and ITK_USE_FFTWD
 
-#include "itk_eigen.h"
-#include ITK_EIGEN(Sparse)
+#include <Eigen/Sparse>
 
 #include <algorithm>
 #include <cassert>

--- a/Modules/ThirdParty/Eigen3/src/itk_eigen.h.in
+++ b/Modules/ThirdParty/Eigen3/src/itk_eigen.h.in
@@ -19,7 +19,14 @@
 #ifndef itk_eigen_h
 #define itk_eigen_h
 
-/* Usage:
+/* Legacy include shim. New code should write `#include <Eigen/Eigenvalues>`
+ * (or any other Eigen header) directly.  The Eigen3::Eigen CMake target,
+ * which is automatically linked when a module declares ITKEigen3 as a
+ * dependency in itk-module.cmake, provides the include path and (for
+ * bundled Eigen) the EIGEN_MPL2_ONLY define and Eigen-specific Clang
+ * warning suppressions.
+ *
+ * Legacy usage:
  *  ITK_EIGEN(Eigenvalues)
  *  If using a Eigen3 header containing non MPL2 code
  *  It would generate errors when using internal Eigen, but not with system Eigen.

--- a/Modules/ThirdParty/Eigen3/src/itkeigen/CMakeLists.txt
+++ b/Modules/ThirdParty/Eigen3/src/itkeigen/CMakeLists.txt
@@ -955,12 +955,23 @@ if(ITK_USE_EIGEN_MPL2_ONLY)
   target_compile_definitions (eigen_internal INTERFACE "EIGEN_MPL2_ONLY")
 endif()
 
-# BUILD: go one directory before to localize the headers:
-#   #include <itkeigen/Eigen/x>
-# INSTALL: headers require pre-prend itkeigen/Eigen/X.
+# Resolve both #include <Eigen/x> (preferred, ITKv6 canonical syntax) and
+# #include <itkeigen/Eigen/x> (legacy ITK_EIGEN(x) macro expansion).
 target_include_directories (eigen_internal SYSTEM INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+  $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}/itkeigen>
   $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>
+  )
+
+# Eigen headers trip several Clang warnings that don't fire elsewhere in ITK.
+target_compile_options (eigen_internal INTERFACE
+  $<$<COMPILE_LANG_AND_ID:CXX,Clang,AppleClang>:-Wno-alloca>
+  $<$<COMPILE_LANG_AND_ID:CXX,Clang,AppleClang>:-Wno-used-but-marked-unused>
+  $<$<COMPILE_LANG_AND_ID:CXX,Clang,AppleClang>:-Wno-unused-template>
+  $<$<COMPILE_LANG_AND_ID:CXX,Clang,AppleClang>:-Wno-missing-noreturn>
+  $<$<COMPILE_LANG_AND_ID:CXX,Clang,AppleClang>:-Wno-zero-as-null-pointer-constant>
+  $<$<COMPILE_LANG_AND_ID:CXX,Clang,AppleClang>:-Wno-deprecated>
   )
 
 # Export as title case Eigen


### PR DESCRIPTION
Establishes `#include <Eigen/x>` (via the `Eigen3::Eigen` CMake target) as the canonical syntax for ITK code that uses bundled Eigen3, and migrates the only two in-tree call sites of the legacy `ITK_EIGEN(x)` macro. Step 1 of the ITKv6 deprecation plan for `itk_eigen.h`. Supersedes #5952.

The legacy `itk_eigen.h` and `ITK_EIGEN(x)` macro are unchanged and remain available as a compatibility shim for external consumers; this PR is behavior-preserving for them.

<details>
<summary>Why & background</summary>

After PR #6223 (`COMP: Expose itkeigen subdir in ITKEigen3_INCLUDE_DIRS for external consumers`), `<Eigen/Core>` already resolves to the bundled headers via the `Eigen3::Eigen` (= `eigen` ALIAS) interface target's `INTERFACE_INCLUDE_DIRECTORIES`. The legacy `ITK_EIGEN(x)` macro pre-dated that wiring and was the only mechanism that switched between `Eigen/x` (system) and `itkeigen/Eigen/x` (bundled). The build system now does that switching itself.

Three things stop the migration from being just a sed-replace in the 2 callers:

1. The macro form provides `EIGEN_MPL2_ONLY` per-TU (when `ITK_USE_EIGEN_MPL2_ONLY=ON`). This already lives on `eigen_internal`'s `INTERFACE_COMPILE_DEFINITIONS` (line 955 of `Modules/ThirdParty/Eigen3/src/itkeigen/CMakeLists.txt`). For the bundled-Eigen case, `ITKEigen3_LIBRARIES` is already `eigen_internal` (line 57 of `Modules/ThirdParty/Eigen3/CMakeLists.txt`), so dependent ITK modules transitively get the define — **no source change to propagate MPL2**.

2. The macro form's generated `itk_eigen.h` carries six `#pragma clang diagnostic ignored` lines for warnings that fire only inside Eigen headers. This PR moves them to `INTERFACE_COMPILE_OPTIONS` on `eigen_internal`, gated by `$<COMPILE_LANG_AND_ID:CXX,Clang,AppleClang>`.

3. `eigen_internal`'s include path (`${CMAKE_CURRENT_SOURCE_DIR}/..`) currently only resolves `<itkeigen/Eigen/x>`. This PR adds `${CMAKE_CURRENT_SOURCE_DIR}` so `<Eigen/x>` (the canonical upstream Eigen syntax) also resolves through it — both forms work.

After this PR, the only places that still use `ITK_EIGEN(x)` are external (out-of-tree) consumers; the legacy header and macro are unchanged for them.

</details>

<details>
<summary>What changes in this PR</summary>

| File | Change |
|---|---|
| `Modules/ThirdParty/Eigen3/src/itkeigen/CMakeLists.txt` | `eigen_internal` `INTERFACE_INCLUDE_DIRECTORIES` adds `${CMAKE_CURRENT_SOURCE_DIR}` (and matching `INSTALL_INTERFACE` entry); new `INTERFACE_COMPILE_OPTIONS` block with the 6 Clang `-Wno-...` flags previously in `itk_eigen.h.in`. |
| `Modules/Core/Common/include/itkSymmetricEigenAnalysis.h` | `#include "itk_eigen.h"` + `#include ITK_EIGEN(Eigenvalues)` → `#include <Eigen/Eigenvalues>` |
| `Modules/Registration/Montage/include/itkTileMontage.hxx` | `#include "itk_eigen.h"` + `#include ITK_EIGEN(Sparse)` → `#include <Eigen/Sparse>` |
| `Modules/ThirdParty/Eigen3/src/itk_eigen.h.in` | Documentation-only: leading docstring marks the header as a legacy shim and points new code at the canonical syntax. |

</details>

<details>
<summary>Local build verification</summary>

Configured with `-DModule_Montage=ON -DITK_USE_EIGEN_MPL2_ONLY=ON` to exercise both callers and the MPL2 path. Built `ITKCommon` and `Montage` cleanly:

```
[102/102] Linking CXX static library lib/libITKCommon-6.0.a
[35/35]   Linking CXX static library lib/libitkMontage-6.0.a
```

Verified the MPL2 define and warning flags reach the compile line via the interface target:

```
$ ninja -t commands ITKCommon | grep itkPoolMultiThreader.cxx | tr ' ' '\n' | grep -E 'EIGEN_MPL2|Wno-'
-DEIGEN_MPL2_ONLY
-Wno-alloca
-Wno-unused-template
...
```

`pre-commit run --all-files` passed.

</details>

<details>
<summary>Future work (not in this PR)</summary>

This PR is the ITKv5.x foundation. Two follow-ups land in subsequent releases:

- **ITKv6 release notes:** document `<Eigen/x>` + `Eigen3::Eigen` as the supported route for both in-tree code and external consumers; mark `itk_eigen.h` and `ITK_EIGEN(x)` deprecated.
- **ITKv7 (or whenever `ITK_LEGACY_REMOVE` defaults to ON):** delete `itk_eigen.h.in`, the `ITK_EIGEN(x)` macro, and the `if(NOT ITK_LEGACY_REMOVE)` guards.

</details>

<details>
<summary>Relationship to PR #5952</summary>

PR #5952 (blowekamp, draft since 2026-03-16) proposed an alternative shape — generating one wrapper header per Eigen module (`itk_Cholesky`, `itk_Core`, etc.). That approach predates the include-path expose in #6223. Now that `<Eigen/x>` already resolves through `Eigen3::Eigen`, generating 30+ wrapper headers adds little value. dzenanz's unresolved review on #5952 also flagged that it migrated only 1 of the 2 callers; this PR migrates both and uses the canonical Eigen syntax directly.

This PR does not include the per-module wrapper headers. blowekamp is credited via `Co-Authored-By` in the commit.

</details>

<!--
provenance: claude-code session 2026-05-06, ITKv5.x foundation work for ITKv6 Eigen-include canonicalisation
supersedes: #5952
related_files:
  - Modules/ThirdParty/Eigen3/src/itkeigen/CMakeLists.txt:946-980 (eigen_internal interface target)
  - Modules/ThirdParty/Eigen3/CMakeLists.txt:57 (ITKEigen3_LIBRARIES = eigen_internal in bundled case)
  - Modules/Core/Common/include/itkSymmetricEigenAnalysis.h:21-22
  - Modules/Registration/Montage/include/itkTileMontage.hxx:28
post_merge_action: write ITKv6 release-note paragraph documenting <Eigen/x> as canonical; close #5952 as superseded
-->
