### PR TITLE
COMP: Rename itk::Math::abs to itk::Math::Absolute in JacobianDet test

### DIFF
--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldJacobianDeterminantFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldJacobianDeterminantFilterTest.cxx
@@ -145,9 +145,9 @@ TestDisplacementJacobianDeterminantValue()
   const float detOriginal = GetDeterminantAtPoint(displacementField, physPt);
 
   // Check that this is the same as above, just to be sure the function above works
-  if (itk::Math::abs(detOriginal - expectedJacobianDeterminant) > epsilon)
+  if (itk::Math::Absolute(detOriginal - expectedJacobianDeterminant) > epsilon)
   {
-    std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
+    std::cerr.precision(static_cast<int>(itk::Math::Absolute(std::log10(epsilon))));
     std::cerr << "Test failed " << std::endl;
     std::cerr << "Error in pixel value at physical point " << physPt << std::endl;
     std::cerr << "Expected value " << expectedJacobianDeterminant << std::endl;
@@ -213,13 +213,13 @@ TestDisplacementJacobianDeterminantValue()
 
   constexpr double delta = 1e-13;
 
-  if (itk::Math::abs(detPermuted - detOriginal) > delta)
+  if (itk::Math::Absolute(detPermuted - detOriginal) > delta)
   {
     std::cerr << "Test failed: determinant differs after Permute." << std::endl;
     testPassed = false;
   }
 
-  if (itk::Math::abs(detFlipped - detOriginal) > delta)
+  if (itk::Math::Absolute(detFlipped - detOriginal) > delta)
   {
     std::cerr << "Test failed: determinant differs after Flip." << std::endl;
     testPassed = false;


### PR DESCRIPTION
Fix 4 compile errors on the RogueResearch25 Mac14.x-AppleClang-dbg-Universal nightly build by renaming `itk::Math::abs` → `itk::Math::Absolute` in `itkDisplacementFieldJacobianDeterminantFilterTest.cxx`. The legacy `abs` alias is gated out under `ITK_FUTURE_LEGACY_REMOVE=ON` (introduced in 2dc299df55); this test file was missed in that sweep.

<details>
<summary>CDash failure</summary>

- Build: RogueResearch25 / Mac14.x-AppleClang-dbg-Universal (Nightly 2026-05-07)
- 4 errors at lines 148, 150, 216, 222: *"no member named 'abs' in namespace 'itk::Math'; did you mean simply 'abs'?"*

</details>

<details>
<summary>Local validation</summary>

- `cmake -DITK_FUTURE_LEGACY_REMOVE:BOOL=ON .` then `ninja ITKDisplacementFieldTestDriver` — clean build.
- `pre-commit run --files <changed>` — pass.

</details>
