### PR TITLE
ENH: Wrap ObjectToObjectMultiMetricv4 for Python (issue #5652, supersedes #5653)

### DIFF
--- a/Modules/Registration/Metricsv4/wrapping/itkANTSNeighborhoodCorrelationImageToImageMetricv4.wrap
+++ b/Modules/Registration/Metricsv4/wrapping/itkANTSNeighborhoodCorrelationImageToImageMetricv4.wrap
@@ -1,3 +1,18 @@
 itk_wrap_class("itk::ANTSNeighborhoodCorrelationImageToImageMetricv4" POINTER)
-itk_wrap_image_filter("${WRAP_ITK_REAL}" 2 2+)
+foreach(d ${ITK_WRAP_IMAGE_DIMS})
+  foreach(t ${WRAP_ITK_REAL})
+    # Canonical: 3 explicit template arguments (TFixedImage, TMovingImage, TVirtualImage)
+    itk_wrap_template(
+        "${ITKM_${t}}${d}${ITKM_${t}}${d}I${ITKM_${t}}${d}"
+        "itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >"
+    )
+    # Backwards-compat alias: 2-argument key resolves to the same SWIG class.
+    add_python_config_template(
+        "ANTSNeighborhoodCorrelationImageToImageMetricv4"
+        "itk::ANTSNeighborhoodCorrelationImageToImageMetricv4"
+        "itkANTSNeighborhoodCorrelationImageToImageMetricv4${ITKM_${t}}${d}${ITKM_${t}}${d}I${ITKM_${t}}${d}"
+        "itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >"
+    )
+  endforeach()
+endforeach()
 itk_end_wrap_class()

--- a/Modules/Registration/Metricsv4/wrapping/itkCorrelationImageToImageMetricv4.wrap
+++ b/Modules/Registration/Metricsv4/wrapping/itkCorrelationImageToImageMetricv4.wrap
@@ -1,3 +1,18 @@
 itk_wrap_class("itk::CorrelationImageToImageMetricv4" POINTER)
-itk_wrap_image_filter("${WRAP_ITK_REAL}" 2 2+)
+foreach(d ${ITK_WRAP_IMAGE_DIMS})
+  foreach(t ${WRAP_ITK_REAL})
+    # Canonical: 3 explicit template arguments (TFixedImage, TMovingImage, TVirtualImage)
+    itk_wrap_template(
+        "${ITKM_${t}}${d}${ITKM_${t}}${d}I${ITKM_${t}}${d}"
+        "itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >"
+    )
+    # Backwards-compat alias: 2-argument key resolves to the same SWIG class.
+    add_python_config_template(
+        "CorrelationImageToImageMetricv4"
+        "itk::CorrelationImageToImageMetricv4"
+        "itkCorrelationImageToImageMetricv4${ITKM_${t}}${d}${ITKM_${t}}${d}I${ITKM_${t}}${d}"
+        "itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >"
+    )
+  endforeach()
+endforeach()
 itk_end_wrap_class()

--- a/Modules/Registration/Metricsv4/wrapping/itkDemonsImageToImageMetricv4.wrap
+++ b/Modules/Registration/Metricsv4/wrapping/itkDemonsImageToImageMetricv4.wrap
@@ -1,3 +1,18 @@
 itk_wrap_class("itk::DemonsImageToImageMetricv4" POINTER)
-itk_wrap_image_filter("${WRAP_ITK_REAL}" 2 2+)
+foreach(d ${ITK_WRAP_IMAGE_DIMS})
+  foreach(t ${WRAP_ITK_REAL})
+    # Canonical: 3 explicit template arguments (TFixedImage, TMovingImage, TVirtualImage)
+    itk_wrap_template(
+        "${ITKM_${t}}${d}${ITKM_${t}}${d}I${ITKM_${t}}${d}"
+        "itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >"
+    )
+    # Backwards-compat alias: 2-argument key resolves to the same SWIG class.
+    add_python_config_template(
+        "DemonsImageToImageMetricv4"
+        "itk::DemonsImageToImageMetricv4"
+        "itkDemonsImageToImageMetricv4${ITKM_${t}}${d}${ITKM_${t}}${d}I${ITKM_${t}}${d}"
+        "itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >"
+    )
+  endforeach()
+endforeach()
 itk_end_wrap_class()

--- a/Modules/Registration/Metricsv4/wrapping/itkImageToImageMetricv4.wrap
+++ b/Modules/Registration/Metricsv4/wrapping/itkImageToImageMetricv4.wrap
@@ -1,8 +1,19 @@
 itk_wrap_class("itk::ImageToImageMetricv4" POINTER_WITH_SUPERCLASS)
-foreach(d ${ITK_WRAP_DIMS})
+foreach(d ${ITK_WRAP_IMAGE_DIMS})
   foreach(t ${WRAP_ITK_REAL})
-    itk_wrap_template("${ITKM_${t}}${d}${ITKM_${t}}${d}"
-                      "itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >")
+    # Canonical: 3 explicit template arguments (TFixedImage, TMovingImage, TVirtualImage)
+    itk_wrap_template(
+        "${ITKM_${t}}${d}${ITKM_${t}}${d}I${ITKM_${t}}${d}"
+        "itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >"
+    )
+    # Backwards-compat alias: historical 2-argument key resolves to the same
+    # SWIG class because TVirtualImage defaults to TFixedImage at C++.
+    add_python_config_template(
+        "ImageToImageMetricv4"
+        "itk::ImageToImageMetricv4"
+        "itkImageToImageMetricv4${ITKM_${t}}${d}${ITKM_${t}}${d}I${ITKM_${t}}${d}"
+        "itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >"
+    )
   endforeach()
 endforeach()
 itk_end_wrap_class()

--- a/Modules/Registration/Metricsv4/wrapping/itkJointHistogramMutualInformationImageToImageMetricv4.wrap
+++ b/Modules/Registration/Metricsv4/wrapping/itkJointHistogramMutualInformationImageToImageMetricv4.wrap
@@ -1,3 +1,18 @@
 itk_wrap_class("itk::JointHistogramMutualInformationImageToImageMetricv4" POINTER)
-itk_wrap_image_filter("${WRAP_ITK_REAL}" 2 2+)
+foreach(d ${ITK_WRAP_IMAGE_DIMS})
+  foreach(t ${WRAP_ITK_REAL})
+    # Canonical: 3 explicit template arguments (TFixedImage, TMovingImage, TVirtualImage)
+    itk_wrap_template(
+        "${ITKM_${t}}${d}${ITKM_${t}}${d}I${ITKM_${t}}${d}"
+        "itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >"
+    )
+    # Backwards-compat alias: 2-argument key resolves to the same SWIG class.
+    add_python_config_template(
+        "JointHistogramMutualInformationImageToImageMetricv4"
+        "itk::JointHistogramMutualInformationImageToImageMetricv4"
+        "itkJointHistogramMutualInformationImageToImageMetricv4${ITKM_${t}}${d}${ITKM_${t}}${d}I${ITKM_${t}}${d}"
+        "itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >"
+    )
+  endforeach()
+endforeach()
 itk_end_wrap_class()

--- a/Modules/Registration/Metricsv4/wrapping/itkMattesMutualInformationImageToImageMetricv4.wrap
+++ b/Modules/Registration/Metricsv4/wrapping/itkMattesMutualInformationImageToImageMetricv4.wrap
@@ -1,3 +1,18 @@
 itk_wrap_class("itk::MattesMutualInformationImageToImageMetricv4" POINTER_WITH_2_SUPERCLASSES)
-itk_wrap_image_filter("${WRAP_ITK_REAL}" 2 2+)
+foreach(d ${ITK_WRAP_IMAGE_DIMS})
+  foreach(t ${WRAP_ITK_REAL})
+    # Canonical: 3 explicit template arguments (TFixedImage, TMovingImage, TVirtualImage)
+    itk_wrap_template(
+        "${ITKM_${t}}${d}${ITKM_${t}}${d}I${ITKM_${t}}${d}"
+        "itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >"
+    )
+    # Backwards-compat alias: 2-argument key resolves to the same SWIG class.
+    add_python_config_template(
+        "MattesMutualInformationImageToImageMetricv4"
+        "itk::MattesMutualInformationImageToImageMetricv4"
+        "itkMattesMutualInformationImageToImageMetricv4${ITKM_${t}}${d}${ITKM_${t}}${d}I${ITKM_${t}}${d}"
+        "itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >"
+    )
+  endforeach()
+endforeach()
 itk_end_wrap_class()

--- a/Modules/Registration/Metricsv4/wrapping/itkMeanSquaresImageToImageMetricv4.wrap
+++ b/Modules/Registration/Metricsv4/wrapping/itkMeanSquaresImageToImageMetricv4.wrap
@@ -1,3 +1,18 @@
 itk_wrap_class("itk::MeanSquaresImageToImageMetricv4" POINTER_WITH_2_SUPERCLASSES)
-itk_wrap_image_filter("${WRAP_ITK_REAL}" 2 2+)
+foreach(d ${ITK_WRAP_IMAGE_DIMS})
+  foreach(t ${WRAP_ITK_REAL})
+    # Canonical: 3 explicit template arguments (TFixedImage, TMovingImage, TVirtualImage)
+    itk_wrap_template(
+        "${ITKM_${t}}${d}${ITKM_${t}}${d}I${ITKM_${t}}${d}"
+        "itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >"
+    )
+    # Backwards-compat alias: 2-argument key resolves to the same SWIG class.
+    add_python_config_template(
+        "MeanSquaresImageToImageMetricv4"
+        "itk::MeanSquaresImageToImageMetricv4"
+        "itkMeanSquaresImageToImageMetricv4${ITKM_${t}}${d}${ITKM_${t}}${d}I${ITKM_${t}}${d}"
+        "itk::Image< ${ITKT_${t}}, ${d} >, itk::Image< ${ITKT_${t}}, ${d} >"
+    )
+  endforeach()
+endforeach()
 itk_end_wrap_class()

--- a/Modules/Registration/Metricsv4/wrapping/itkObjectToObjectMultiMetricv4.wrap
+++ b/Modules/Registration/Metricsv4/wrapping/itkObjectToObjectMultiMetricv4.wrap
@@ -1,0 +1,10 @@
+itk_wrap_class("itk::ObjectToObjectMultiMetricv4" POINTER)
+foreach(d ${ITK_WRAP_IMAGE_DIMS})
+  foreach(t ${WRAP_ITK_REAL})
+    itk_wrap_template(
+        "${d}${d}I${ITKM_${t}}${d}"
+        "${d}, ${d}, itk::Image< ${ITKT_${t}}, ${d} >"
+    )
+  endforeach()
+endforeach()
+itk_end_wrap_class()

--- a/Modules/Registration/Metricsv4/wrapping/test/CMakeLists.txt
+++ b/Modules/Registration/Metricsv4/wrapping/test/CMakeLists.txt
@@ -59,6 +59,12 @@ if(ITK_WRAP_PYTHON)
     EXPRESSION "instance = itk.MeanSquaresImageToImageMetricv4.New()"
   )
 
+  itk_python_add_test(
+    NAME itkObjectToObjectMultiMetricv4PythonTest
+    COMMAND
+      ${CMAKE_CURRENT_SOURCE_DIR}/itkObjectToObjectMultiMetricv4Test.py
+  )
+
   itk_python_expression_add_test(
     NAME itkPointSetToPointSetMetricv4PythonTest
     EXPRESSION "instance = itk.PointSetToPointSetMetricv4.New()"

--- a/Modules/Registration/Metricsv4/wrapping/test/itkObjectToObjectMultiMetricv4Test.py
+++ b/Modules/Registration/Metricsv4/wrapping/test/itkObjectToObjectMultiMetricv4Test.py
@@ -22,22 +22,13 @@
 # classes, while asserting that the historical 2-argument form continues to
 # resolve to the same SWIG class for backward compatibility.
 #
-# AddMetric() requirement and the SWIG cross-module upcast caveat
-# ----------------------------------------------------------------
-# itk::ObjectToObjectMultiMetricv4<F, M, V>::AddMetric expects a
-# pointer to itk::ObjectToObjectMetric<F, M, V>, the immediate parent of
-# itk::ImageToImageMetricv4<F, M, V>. SWIG registers that C++ type under
-# the name itkImageToImageMetricv4F2F2IF2_Superclass through the
-# POINTER_WITH_SUPERCLASS wrap of itk::ImageToImageMetricv4. The derived
-# image-metric classes use POINTER_WITH_2_SUPERCLASSES, which exposes the
-# same C++ instantiation under their *own* _Superclass_Superclass name in a
-# *different* SWIG module. SWIG's runtime does not automatically equate
-# those two names across modules, so an implicit upcast from a derived
-# metric to AddMetric's parameter slot fails. The bridge below uses the
-# .cast() classmethod on the canonical _Superclass typedef, which is a
-# stable, wrap-derived API, to perform the explicit upcast.
-#
-# A friendlier helper for this idiom is added in a follow-up commit.
+# AddMetric() upcast helper
+# -------------------------
+# itk::ObjectToObjectMultiMetricv4<F, M, V>::AddMetric expects a pointer to
+# itk::ObjectToObjectMetric<F, M, V>. SWIG cannot auto-upcast across the
+# POINTER_WITH_2_SUPERCLASSES chain on the derived image-metric classes, so
+# the caller has to perform an explicit upcast. itk.as_metric_base() wraps
+# that idiom.
 
 import itk
 
@@ -86,11 +77,9 @@ assert type(ms_2arg).__name__ == type(ms_3arg).__name__
 # ---------------------------------------------------------------------------
 multi_metric = itk.ObjectToObjectMultiMetricv4[2, 2, ImageType].New()
 
-from itk.itkImageToImageMetricv4Python import itkImageToImageMetricv4F2F2IF2_Superclass
-
-multi_metric.AddMetric(itkImageToImageMetricv4F2F2IF2_Superclass.cast(ms_2arg))
-multi_metric.AddMetric(itkImageToImageMetricv4F2F2IF2_Superclass.cast(mattes_2arg))
-multi_metric.AddMetric(itkImageToImageMetricv4F2F2IF2_Superclass.cast(ms_3arg))
+multi_metric.AddMetric(itk.as_metric_base(ms_2arg))
+multi_metric.AddMetric(itk.as_metric_base(mattes_2arg))
+multi_metric.AddMetric(itk.as_metric_base(ms_3arg))
 assert multi_metric.GetNumberOfMetrics() == 3
 
 weights = itk.Array[itk.D](3)

--- a/Modules/Registration/Metricsv4/wrapping/test/itkObjectToObjectMultiMetricv4Test.py
+++ b/Modules/Registration/Metricsv4/wrapping/test/itkObjectToObjectMultiMetricv4Test.py
@@ -1,0 +1,103 @@
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================
+#
+# Exercises the new Python wrapping for itk::ObjectToObjectMultiMetricv4
+# together with the canonical 3-argument template form (TFixedImage,
+# TMovingImage, TVirtualImage) of itk::ImageToImageMetricv4 and its derived
+# classes, while asserting that the historical 2-argument form continues to
+# resolve to the same SWIG class for backward compatibility.
+#
+# AddMetric() requirement and the SWIG cross-module upcast caveat
+# ----------------------------------------------------------------
+# itk::ObjectToObjectMultiMetricv4<F, M, V>::AddMetric expects a
+# pointer to itk::ObjectToObjectMetric<F, M, V>, the immediate parent of
+# itk::ImageToImageMetricv4<F, M, V>. SWIG registers that C++ type under
+# the name itkImageToImageMetricv4F2F2IF2_Superclass through the
+# POINTER_WITH_SUPERCLASS wrap of itk::ImageToImageMetricv4. The derived
+# image-metric classes use POINTER_WITH_2_SUPERCLASSES, which exposes the
+# same C++ instantiation under their *own* _Superclass_Superclass name in a
+# *different* SWIG module. SWIG's runtime does not automatically equate
+# those two names across modules, so an implicit upcast from a derived
+# metric to AddMetric's parameter slot fails. The bridge below uses the
+# .cast() classmethod on the canonical _Superclass typedef, which is a
+# stable, wrap-derived API, to perform the explicit upcast.
+#
+# A friendlier helper for this idiom is added in a follow-up commit.
+
+import itk
+
+ImageType = itk.Image[itk.F, 2]
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: the historical 2-argument template key continues
+# to resolve. Any existing user code that omits the explicit TVirtualImage
+# parameter must keep working.
+# ---------------------------------------------------------------------------
+i2i_2arg = itk.ImageToImageMetricv4[ImageType, ImageType].New()
+ms_2arg = itk.MeanSquaresImageToImageMetricv4[ImageType, ImageType].New()
+mattes_2arg = itk.MattesMutualInformationImageToImageMetricv4[
+    ImageType, ImageType
+].New()
+corr_2arg = itk.CorrelationImageToImageMetricv4[ImageType, ImageType].New()
+demons_2arg = itk.DemonsImageToImageMetricv4[ImageType, ImageType].New()
+ants_2arg = itk.ANTSNeighborhoodCorrelationImageToImageMetricv4[
+    ImageType, ImageType
+].New()
+jh_2arg = itk.JointHistogramMutualInformationImageToImageMetricv4[
+    ImageType, ImageType
+].New()
+for inst in (
+    i2i_2arg,
+    ms_2arg,
+    mattes_2arg,
+    corr_2arg,
+    demons_2arg,
+    ants_2arg,
+    jh_2arg,
+):
+    assert inst is not None
+
+# ---------------------------------------------------------------------------
+# New 3-argument key (canonical) resolves to the same SWIG class.
+# ---------------------------------------------------------------------------
+i2i_3arg = itk.ImageToImageMetricv4[ImageType, ImageType, ImageType].New()
+ms_3arg = itk.MeanSquaresImageToImageMetricv4[ImageType, ImageType, ImageType].New()
+assert type(i2i_2arg).__name__ == type(i2i_3arg).__name__
+assert type(ms_2arg).__name__ == type(ms_3arg).__name__
+
+# ---------------------------------------------------------------------------
+# New ObjectToObjectMultiMetricv4 wrapping accepts metrics created via
+# either template-key form, exercising AddMetric.
+# ---------------------------------------------------------------------------
+multi_metric = itk.ObjectToObjectMultiMetricv4[2, 2, ImageType].New()
+
+from itk.itkImageToImageMetricv4Python import itkImageToImageMetricv4F2F2IF2_Superclass
+
+multi_metric.AddMetric(itkImageToImageMetricv4F2F2IF2_Superclass.cast(ms_2arg))
+multi_metric.AddMetric(itkImageToImageMetricv4F2F2IF2_Superclass.cast(mattes_2arg))
+multi_metric.AddMetric(itkImageToImageMetricv4F2F2IF2_Superclass.cast(ms_3arg))
+assert multi_metric.GetNumberOfMetrics() == 3
+
+weights = itk.Array[itk.D](3)
+weights[0] = 0.2
+weights[1] = 0.3
+weights[2] = 0.5
+multi_metric.SetMetricWeights(weights)
+assert multi_metric.GetMetricWeights().GetSize() == 3
+
+print("Test passed!")

--- a/Wrapping/Generators/Python/itk/support/extras.py
+++ b/Wrapping/Generators/Python/itk/support/extras.py
@@ -118,6 +118,7 @@ __all__ = [
     "pipeline",
     "auto_pipeline",
     "down_cast",
+    "as_metric_base",
     "template",
     "class_",
     "ctype",
@@ -2027,6 +2028,67 @@ def down_cast(obj: itkt.LightObject):
         raise RuntimeError(f"Can't downcast to a specialization of {class_name}")
     else:
         return t.cast(obj)
+
+
+def as_metric_base(metric, virtual_image_type=None):
+    """Upcast a derived ImageToImageMetricv4 to its ObjectToObjectMetric base.
+
+    itk::ObjectToObjectMultiMetricv4::AddMetric() takes a pointer to
+    itk::ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage>.
+    SWIG does not auto-upcast across the POINTER_WITH_2_SUPERCLASSES chain on
+    the derived image-metric classes (their _Superclass_Superclass typedef is
+    registered in a different SWIG module than the base ImageToImageMetricv4
+    _Superclass typedef that names the same C++ type). This helper performs
+    the explicit upcast through the canonical _Superclass class so that
+    `multi_metric.AddMetric(itk.as_metric_base(ms_metric))` works regardless
+    of which derived metric class is passed in.
+
+    Parameters
+    ----------
+    metric : derived metric instance
+        Any itk::ImageToImageMetricv4-derived metric (MeanSquares, Mattes,
+        Correlation, Demons, ANTSNeighborhoodCorrelation, JointHistogramMI).
+    virtual_image_type : itk class, optional
+        The TVirtualImage instantiation to cast through. Defaults to the
+        metric's own fixed-image template parameter, matching the C++ default
+        TVirtualImage = TFixedImage.
+
+    Returns
+    -------
+    The metric upcast to the SWIG class registered as
+    itk::ImageToImageMetricv4<...>::Superclass — accepted directly by
+    AddMetric().
+    """
+    import sys
+
+    import itk
+    from itk.support.template_class import itkTemplateBase
+
+    cls = metric.__class__
+    template_entry = itkTemplateBase.__template_instantiations_object_to_name__.get(cls)
+    if template_entry is None:
+        raise TypeError(
+            f"Cannot determine template parameters of {cls.__name__}; "
+            "as_metric_base requires a wrapped ImageToImageMetricv4-derived metric."
+        )
+    template, params = template_entry
+    if len(params) < 2:
+        raise TypeError(
+            f"{cls.__name__} does not have at least 2 template arguments; "
+            "as_metric_base expects an ImageToImageMetricv4-derived metric."
+        )
+    fixed_image_type = params[0]
+    moving_image_type = params[1]
+    if virtual_image_type is None:
+        virtual_image_type = params[2] if len(params) >= 3 else fixed_image_type
+
+    base = itk.ImageToImageMetricv4[
+        fixed_image_type, moving_image_type, virtual_image_type
+    ]
+    base_module = sys.modules[base.__module__]
+    superclass_typedef_name = f"{base.__name__}_Superclass"
+    superclass_class = getattr(base_module, superclass_typedef_name)
+    return superclass_class.cast(metric)
 
 
 def attribute_list(inputobject, name: str):


### PR DESCRIPTION
Wrap `itk::ObjectToObjectMultiMetricv4` for Python. Supersedes #5653 — preserves every historical 2-arg template key for `ImageToImageMetricv4` and its 6 derived classes (which #5653 silently broke).

<details>
<summary>Why a new PR rather than rebasing #5653</summary>

#5653 switched 7 `*ImageToImageMetricv4` wraps from 2-arg (`F2F2`) to 3-arg (`F2F2IF2`) keys, silently breaking pre-existing user code (`ImageRegistration{3,4,5}.py`, `ModifiedTime.py`) and turning CI red on CDash + ARMBUILD-Python + ITK.{Linux,macOS}.Python.

This PR registers BOTH keys: canonical 3-arg + 2-arg alias resolving to the same SWIG class via two `add_python_config_template()` entries. `itkTemplate.__add__` keys on the template-arg string and parameter tuple, so duplicate-registration warnings don't fire. No wrap-generator core changes.

</details>

<details>
<summary>Commits</summary>

1. `ENH:` Add Python wrapping for ObjectToObjectMultiMetricv4 (author: @thewtex) — new `itkObjectToObjectMultiMetricv4.wrap` for `(F,2)`, `(F,3)`, `(D,2)`, `(D,3)`; 7 metric wrap files extended with the canonical-3-arg + 2-arg-alias pattern; new `itkObjectToObjectMultiMetricv4Test.py`.
2. `ENH:` Add `itk.as_metric_base` helper for `AddMetric` upcasts — SWIG can't auto-upcast across `POINTER_WITH_2_SUPERCLASSES`, so callers need an explicit upcast through the `_Superclass` typedef. Helper introspects template params and does it.

</details>

<details>
<summary>Local validation</summary>

- `pre-commit run --all-files` clean
- 52/52 tests in `ctest -R 'Metricv4Python|ImageToImageMetric|ModifiedTime'` (no regressions)
- New `itkObjectToObjectMultiMetricv4PythonTest` exercises both 2-arg and 3-arg keys + `AddMetric` for MeanSquares, Mattes, mixed
- Backward-compat: 7 derived classes' 2-arg keys all resolve

</details>

<!--
provenance: claude-code session 2026-05-07, takeover of #5653
key_decision: option-A (preserve 2-arg API via Config.py alias entries)
key_files:
  - Modules/Registration/Metricsv4/wrapping/itk*.wrap (7 modified, 1 new)
  - Modules/Registration/Metricsv4/wrapping/test/itkObjectToObjectMultiMetricv4Test.py (new)
  - Wrapping/Generators/Python/itk/support/extras.py (as_metric_base, in __all__)
post_merge_action: close #5653
-->

Fixes: #5652
