### PR TITLE
BUG: Fix 3 recurring failures on Windows11-VS2022-Static-DebugTBB nightly

### DIFF
--- a/Modules/Core/Common/test/itkHashTableGTest.cxx
+++ b/Modules/Core/Common/test/itkHashTableGTest.cxx
@@ -22,6 +22,7 @@
 #include <unordered_map>
 #include <iostream>
 #include <cstring>
+#include <string_view>
 
 /**
  * Helper function to prevent compiler's unused variable warning.
@@ -40,8 +41,17 @@ struct eqstr
   }
 };
 
+struct CStrHash
+{
+  size_t
+  operator()(const char * s) const
+  {
+    return std::hash<std::string_view>{}(s);
+  }
+};
+
 void
-lookup(const std::unordered_set<const char *, std::hash<const char *>, eqstr> & Set, const char * word)
+lookup(const std::unordered_set<const char *, CStrHash, eqstr> & Set, const char * word)
 {
   auto it = Set.find(word);
   std::cout << word << ": " << (it != Set.end() ? "present" : "not present") << std::endl;
@@ -70,7 +80,7 @@ TEST(HashTable, StdHash)
 TEST(HashTable, UnorderedSet)
 {
   println("Testing std::unordered_set");
-  using HashSetType = std::unordered_set<const char *, std::hash<const char *>, eqstr>;
+  using HashSetType = std::unordered_set<const char *, CStrHash, eqstr>;
   HashSetType Set;
   Set.insert("kiwi");
   Set.insert("plum");
@@ -102,7 +112,7 @@ TEST(HashTable, UnorderedSet)
 TEST(HashTable, UnorderedMap)
 {
   println("Testing std::unordered_map");
-  using HashMapType = std::unordered_map<const char *, int, std::hash<const char *>, eqstr>;
+  using HashMapType = std::unordered_map<const char *, int, CStrHash, eqstr>;
 
   HashMapType months;
   months["january"] = 31;

--- a/Modules/Core/Transform/test/CMakeLists.txt
+++ b/Modules/Core/Transform/test/CMakeLists.txt
@@ -456,6 +456,8 @@ set_tests_properties(
   PROPERTIES
     COST
       50
+    TIMEOUT
+      3600
 )
 itk_add_test(
   NAME itkTransformGeometryImageFilterTest

--- a/Modules/Segmentation/LevelSetsv4/test/CMakeLists.txt
+++ b/Modules/Segmentation/LevelSetsv4/test/CMakeLists.txt
@@ -400,3 +400,17 @@ itk_add_test(
     ITKLevelSetsv4TestDriver
     itkMultiLevelSetMalcolmImageSubset2DTest
 )
+set_property(
+  TEST
+    itkMultiLevelSetsv4MalcolmImageSubset2DTest
+  APPEND
+  PROPERTY
+    LABELS
+      RUNS_LONG
+)
+set_tests_properties(
+  itkMultiLevelSetsv4MalcolmImageSubset2DTest
+  PROPERTIES
+    TIMEOUT
+      3600
+)


### PR DESCRIPTION
Fix three tests that have been failing on the Windows11-VS2022-Static-DebugTBB
nightly build (CDash build 11261311).

<details>
<summary>Root cause per test</summary>

**HashTable.UnorderedSet** — `std::hash<const char*>` hashes the pointer
address while `eqstr` compares string content. MSVC Debug does not pool
identical string literals, so `insert("mango")` and `count("mango")` use
different pointers, different buckets, and `count()` returns 0.
Fix: replace with `CStrHash` (`std::hash<std::string_view>`) for
content-based hashing consistent with the equality predicate.

**itkTestTransformGetInverse** — calls `GetInverse()` 100,000 times per
thread for 20+ transform types. Debug+TBB mutex instrumentation makes
each call significantly slower, exceeding the default 1000s ctest timeout.
Already labelled `RUNS_LONG`; added `TIMEOUT 3600`.

**itkMultiLevelSetsv4MalcolmImageSubset2DTest** — runs level-set evolution
on a 1000x1000 image. Debug+TBB overhead causes it to exceed the default
1000s timeout. Added `RUNS_LONG` label and `TIMEOUT 3600`.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code (claude-sonnet-4-6)
- Role: CDash log analysis, root-cause identification, fix authorship
- HashTable fix compiled and tested locally (ITK-mci RelWithDebInfo build);
  all 3 HashTable GTests pass (StdHash, UnorderedSet, UnorderedMap)
- CMake timeout changes reviewed; no compilation required

</details>