### PR TITLE
ENH: Replace PrintSelf NumericTraits-cast boilerplate with itk::print_helper::PrintNumericTrait helper (supersedes #3909)

### DIFF
--- a/Modules/Core/Common/include/itkAnnulusOperator.h
+++ b/Modules/Core/Common/include/itkAnnulusOperator.h
@@ -20,6 +20,7 @@
 
 #include "itkNeighborhoodOperator.h"
 #include "itkVector.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -225,13 +226,10 @@ public:
     os << indent << "Thickness: " << m_Thickness << std::endl;
     os << indent << "Normalize: " << m_Normalize << std::endl;
     os << indent << "BrightCenter: " << m_BrightCenter << std::endl;
-    os << indent << "InteriorValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_InteriorValue)
-       << std::endl;
-    os << indent << "AnnulusValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_AnnulusValue)
-       << std::endl;
-    os << indent << "ExteriorValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_ExteriorValue)
-       << std::endl;
-    os << indent << "Spacing: " << static_cast<typename NumericTraits<SpacingType>::PrintType>(m_Spacing) << std::endl;
+    print_helper::PrintNumericTrait(os, indent, "InteriorValue", m_InteriorValue);
+    print_helper::PrintNumericTrait(os, indent, "AnnulusValue", m_AnnulusValue);
+    print_helper::PrintNumericTrait(os, indent, "ExteriorValue", m_ExteriorValue);
+    print_helper::PrintNumericTrait(os, indent, "Spacing", m_Spacing);
   }
 
 protected:

--- a/Modules/Core/Common/include/itkBinaryThresholdSpatialFunction.hxx
+++ b/Modules/Core/Common/include/itkBinaryThresholdSpatialFunction.hxx
@@ -19,6 +19,7 @@
 #define itkBinaryThresholdSpatialFunction_hxx
 
 
+#include "itkPrintHelper.h"
 namespace itk
 {
 
@@ -28,12 +29,8 @@ BinaryThresholdSpatialFunction<TFunction>::PrintSelf(std::ostream & os, Indent i
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "LowerThreshold: " << static_cast<typename NumericTraits<FunctionOutputType>::PrintType>(m_LowerThreshold)
-     << std::endl;
-  os << indent
-     << "UpperThreshold: " << static_cast<typename NumericTraits<FunctionOutputType>::PrintType>(m_UpperThreshold)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "LowerThreshold", m_LowerThreshold);
+  print_helper::PrintNumericTrait(os, indent, "UpperThreshold", m_UpperThreshold);
 
   itkPrintSelfObjectMacro(Function);
 }

--- a/Modules/Core/Common/include/itkImageDuplicator.hxx
+++ b/Modules/Core/Common/include/itkImageDuplicator.hxx
@@ -19,6 +19,7 @@
 #define itkImageDuplicator_hxx
 
 #include "itkImageAlgorithm.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -64,8 +65,7 @@ ImageDuplicator<TInputImage>::PrintSelf(std::ostream & os, Indent indent) const
   itkPrintSelfObjectMacro(InputImage);
   itkPrintSelfObjectMacro(DuplicateImage);
 
-  os << indent << "InternalImageTime: " << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_InternalImageTime)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "InternalImageTime", m_InternalImageTime);
 }
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkMinimumMaximumImageCalculator.hxx
+++ b/Modules/Core/Common/include/itkMinimumMaximumImageCalculator.hxx
@@ -19,6 +19,7 @@
 #define itkMinimumMaximumImageCalculator_hxx
 
 #include "itkImageRegionConstIteratorWithIndex.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -113,8 +114,8 @@ MinimumMaximumImageCalculator<TInputImage>::PrintSelf(std::ostream & os, Indent 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Minimum: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_Minimum) << std::endl;
-  os << indent << "Maximum: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_Maximum) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Minimum", m_Minimum);
+  print_helper::PrintNumericTrait(os, indent, "Maximum", m_Maximum);
   os << indent << "Index of Minimum: " << m_IndexOfMinimum << std::endl;
   os << indent << "Index of Maximum: " << m_IndexOfMaximum << std::endl;
   itkPrintSelfObjectMacro(Image);

--- a/Modules/Core/Common/include/itkNeighborhood.hxx
+++ b/Modules/Core/Common/include/itkNeighborhood.hxx
@@ -117,8 +117,8 @@ void
 Neighborhood<TPixel, VDimension, TContainer>::PrintSelf(std::ostream & os, Indent indent) const
 {
   using namespace itk::print_helper;
-  os << indent << "Size: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_Size) << std::endl;
-  os << indent << "Radius: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_Radius) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Size", m_Size);
+  print_helper::PrintNumericTrait(os, indent, "Radius", m_Radius);
   os << indent << "StrideTable: " << m_StrideTable << std::endl;
   os << indent << "OffsetTable: " << m_OffsetTable << std::endl;
 }

--- a/Modules/Core/Common/include/itkObjectStore.hxx
+++ b/Modules/Core/Common/include/itkObjectStore.hxx
@@ -134,9 +134,8 @@ ObjectStore<TObjectType>::PrintSelf(std::ostream & os, Indent indent) const
   Superclass::PrintSelf(os, indent);
 
   os << indent << "GrowthStrategy: " << m_GrowthStrategy << std::endl;
-  os << indent << "Size: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_Size) << std::endl;
-  os << indent << "LinearGrowthSize: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_LinearGrowthSize)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Size", m_Size);
+  print_helper::PrintNumericTrait(os, indent, "LinearGrowthSize", m_LinearGrowthSize);
   os << indent << "FreeList: " << m_FreeList << std::endl;
 }
 } // end namespace itk

--- a/Modules/Core/Common/include/itkPointSetToImageFilter.hxx
+++ b/Modules/Core/Common/include/itkPointSetToImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkBoundingBox.h"
 #include "itkNumericTraits.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -227,10 +228,8 @@ PointSetToImageFilter<TInputPointSet, TOutputImage>::PrintSelf(std::ostream & os
   os << indent << "Origin: " << m_Origin << std::endl;
   os << indent << "Spacing: " << m_Spacing << std::endl;
   os << indent << "Direction: " << m_Direction << std::endl;
-  os << indent << "Inside Value : " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_InsideValue)
-     << std::endl;
-  os << indent << "Outside Value : " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_OutsideValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Inside Value ", m_InsideValue);
+  print_helper::PrintNumericTrait(os, indent, "Outside Value ", m_OutsideValue);
 }
 } // end namespace itk
 

--- a/Modules/Core/Common/include/itkPrintHelper.h
+++ b/Modules/Core/Common/include/itkPrintHelper.h
@@ -81,7 +81,7 @@ operator<<(std::ostream & os, const T (&arr)[VLength]);
  * Equivalent to the boilerplate
  * \code
  *   os << indent << "Name: "
- *      << static_cast<typename NumericTraits<T>::PrintType>(this->m_Name)
+ *      << static_cast<typename NumericTraits<T>::PrintType>(m_Name)
  *      << std::endl;
  * \endcode
  * but with explicit \a os and \a indent parameters and no preprocessor
@@ -89,7 +89,7 @@ operator<<(std::ostream & os, const T (&arr)[VLength]);
  *
  * Typical use inside a \c PrintSelf override:
  * \code
- *   itk::print_helper::PrintNumericTrait(os, indent, "Threshold", this->m_Threshold);
+ *   print_helper::PrintNumericTrait(os, indent, "Threshold", m_Threshold);
  * \endcode
  */
 template <typename T>

--- a/Modules/Core/Common/include/itkPrintHelper.h
+++ b/Modules/Core/Common/include/itkPrintHelper.h
@@ -19,6 +19,8 @@
 #ifndef itkPrintHelper_h
 #define itkPrintHelper_h
 
+#include "itkIndent.h"
+
 #include <array>
 #include <iostream>
 #include <iterator>
@@ -27,6 +29,17 @@
 #include <type_traits>
 
 
+namespace itk
+{
+// Forward declaration so itkPrintHelper.h can be safely included from
+// itkMacro.h without re-entering itkNumericTraits.h (which itself uses
+// macros defined later in itkMacro.h).  Every PrintNumericTrait() call
+// site needs the full NumericTraits<T> specialization in scope, but those
+// sites already #include "itkNumericTraits.h" directly or transitively.
+template <typename T>
+class NumericTraits;
+} // namespace itk
+
 namespace itk::print_helper
 {
 
@@ -34,6 +47,9 @@ namespace itk::print_helper
 // definition time.  Required for nested cases like vector<list<T>>, where the
 // recursive `os << *it` is parsed before the list overload would otherwise be
 // declared, and ADL on std container types never reaches itk::print_helper.
+// PrintNumericTrait further down also dispatches through `os << value` and
+// must see these forward declarations to instantiate against std container
+// member types at the call site.
 template <typename T>
 std::ostream &
 operator<<(std::ostream & os, const std::vector<T> & v);
@@ -49,6 +65,48 @@ operator<<(std::ostream & os, const std::array<T, VLength> & container);
 template <typename T, size_t VLength, typename = std::enable_if_t<!std::is_same_v<T, char>>>
 std::ostream &
 operator<<(std::ostream & os, const T (&arr)[VLength]);
+
+/** \brief Print "<name>: <value>\n" indented, matching ITK's PrintSelf style.
+ *
+ * Formats and writes a single named member to \a os preceded by \a indent,
+ * followed by a newline.  When \c NumericTraits<T>::PrintType differs from
+ * \a T (the relevant case being the \c char family, whose \c PrintType is
+ * \c int, so values render numerically rather than as ASCII characters) the
+ * value is forwarded through a \c static_cast.  When the two types coincide
+ * (the common case, including all built-in scalars wider than \c char and
+ * \c std::complex specialisations whose \c PrintType is \c Self) the cast
+ * step is skipped entirely so the value's own stream insertion overload is
+ * selected directly.
+ *
+ * Equivalent to the boilerplate
+ * \code
+ *   os << indent << "Name: "
+ *      << static_cast<typename NumericTraits<T>::PrintType>(this->m_Name)
+ *      << std::endl;
+ * \endcode
+ * but with explicit \a os and \a indent parameters and no preprocessor
+ * macro expansion.
+ *
+ * Typical use inside a \c PrintSelf override:
+ * \code
+ *   itk::print_helper::PrintNumericTrait(os, indent, "Threshold", this->m_Threshold);
+ * \endcode
+ */
+template <typename T>
+inline void
+PrintNumericTrait(std::ostream & os, const Indent & indent, const char * name, const T & value)
+{
+  os << indent << name << ": ";
+  if constexpr (std::is_same_v<T, typename NumericTraits<T>::PrintType>)
+  {
+    os << value;
+  }
+  else
+  {
+    os << static_cast<typename NumericTraits<T>::PrintType>(value);
+  }
+  os << std::endl;
+}
 
 template <typename T>
 std::ostream &

--- a/Modules/Core/Common/include/itkResourceProbe.hxx
+++ b/Modules/Core/Common/include/itkResourceProbe.hxx
@@ -58,24 +58,16 @@ ResourceProbe<ValueType, MeanType>::Print(std::ostream & os, Indent indent) cons
 {
   using namespace print_helper;
 
-  os << indent << "StartValue: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_StartValue)
-     << std::endl;
-  os << indent << "TotalValue: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_TotalValue)
-     << std::endl;
-  os << indent << "MinimumValue: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_MinimumValue)
-     << std::endl;
-  os << indent << "MaximumValue: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_MaximumValue)
-     << std::endl;
-  os << indent
-     << "StandardDeviation: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_StandardDeviation)
-     << std::endl;
-  os << indent << "StandardError: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_StandardError)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "StartValue", m_StartValue);
+  print_helper::PrintNumericTrait(os, indent, "TotalValue", m_TotalValue);
+  print_helper::PrintNumericTrait(os, indent, "MinimumValue", m_MinimumValue);
+  print_helper::PrintNumericTrait(os, indent, "MaximumValue", m_MaximumValue);
+  print_helper::PrintNumericTrait(os, indent, "StandardDeviation", m_StandardDeviation);
+  print_helper::PrintNumericTrait(os, indent, "StandardError", m_StandardError);
 
-  os << indent << "NumberOfStarts: " << static_cast<NumericTraits<CountType>::PrintType>(m_NumberOfStarts) << std::endl;
-  os << indent << "NumberOfStops: " << static_cast<NumericTraits<CountType>::PrintType>(m_NumberOfStops) << std::endl;
-  os << indent << "NumberOfIteration: " << static_cast<NumericTraits<CountType>::PrintType>(m_NumberOfIteration)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumberOfStarts", m_NumberOfStarts);
+  print_helper::PrintNumericTrait(os, indent, "NumberOfStops", m_NumberOfStops);
+  print_helper::PrintNumericTrait(os, indent, "NumberOfIteration", m_NumberOfIteration);
 
   os << indent << "ProbeValueList: " << m_ProbeValueList << std::endl;
 

--- a/Modules/Core/Common/test/itkPrintHelperGTest.cxx
+++ b/Modules/Core/Common/test/itkPrintHelperGTest.cxx
@@ -20,6 +20,7 @@
 #include "itkOffset.h"
 #include "gtest/gtest.h"
 #include <array>
+#include <complex>
 #include <sstream>
 #include <vector>
 #include <list>
@@ -129,4 +130,56 @@ TEST(PrintHelper, ArrayOfVector)
   std::ostringstream              oss;
   oss << a;
   EXPECT_EQ(oss.str(), "([1, 2], [3])");
+}
+
+TEST(PrintHelper, PrintNumericTraitDouble)
+{
+  std::ostringstream oss;
+  itk::print_helper::PrintNumericTrait(oss, itk::Indent{}, "Value", 3.5);
+  EXPECT_EQ(oss.str(), "Value: 3.5\n");
+}
+
+TEST(PrintHelper, PrintNumericTraitIntIsIdentityCast)
+{
+  // PrintType<int> == int, so the constexpr branch skips static_cast and
+  // streams the value directly.
+  std::ostringstream oss;
+  itk::print_helper::PrintNumericTrait(oss, itk::Indent{}, "Count", 42);
+  EXPECT_EQ(oss.str(), "Count: 42\n");
+}
+
+TEST(PrintHelper, PrintNumericTraitCharRendersNumerically)
+{
+  // PrintType<unsigned char> == int.  Without the cast the value would be
+  // emitted as the ASCII character; the helper must produce the integer.
+  std::ostringstream  oss;
+  const unsigned char ch = 65;
+  itk::print_helper::PrintNumericTrait(oss, itk::Indent{}, "Byte", ch);
+  EXPECT_EQ(oss.str(), "Byte: 65\n");
+}
+
+TEST(PrintHelper, PrintNumericTraitSignedCharRendersNumerically)
+{
+  std::ostringstream oss;
+  const signed char  sc = -7;
+  itk::print_helper::PrintNumericTrait(oss, itk::Indent{}, "Offset", sc);
+  EXPECT_EQ(oss.str(), "Offset: -7\n");
+}
+
+TEST(PrintHelper, PrintNumericTraitComplexIsIdentityCast)
+{
+  // NumericTraits<std::complex<T>>::PrintType is Self, so PrintNumericTrait
+  // forwards to the value's own ostream insertion overload unchanged.
+  std::ostringstream   oss;
+  std::complex<double> z{ 1.0, -2.5 };
+  itk::print_helper::PrintNumericTrait(oss, itk::Indent{}, "Z", z);
+  EXPECT_EQ(oss.str(), "Z: (1,-2.5)\n");
+}
+
+TEST(PrintHelper, PrintNumericTraitIndentation)
+{
+  std::ostringstream oss;
+  itk::Indent        indent{ 4 };
+  itk::print_helper::PrintNumericTrait(oss, indent, "Threshold", 0.125);
+  EXPECT_EQ(oss.str(), "    Threshold: 0.125\n");
 }

--- a/Modules/Core/GPUCommon/include/itkGPUReduction.hxx
+++ b/Modules/Core/GPUCommon/include/itkGPUReduction.hxx
@@ -19,6 +19,7 @@
 #define itkGPUReduction_hxx
 
 #include "itkMacro.h"
+#include "itkPrintHelper.h"
 
 // #define CPU_VERIFY
 
@@ -59,8 +60,8 @@ GPUReduction<TElement>::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "Size: " << m_Size << std::endl;
   itkPrintSelfBooleanMacro(SmallBlock);
 
-  os << indent << "GPUResult: " << static_cast<typename NumericTraits<TElement>::PrintType>(m_GPUResult) << std::endl;
-  os << indent << "CPUResult: " << static_cast<typename NumericTraits<TElement>::PrintType>(m_CPUResult) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "GPUResult", m_GPUResult);
+  print_helper::PrintNumericTrait(os, indent, "CPUResult", m_CPUResult);
 }
 
 template <typename TElement>

--- a/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineInterpolateImageFunction.hxx
@@ -59,9 +59,7 @@ BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::Prin
   Superclass::PrintSelf(os, indent);
 
   os << indent << "Scratch: " << m_Scratch << std::endl;
-  os << indent
-     << "DataLength: " << static_cast<typename NumericTraits<typename TImageType::SizeType>::PrintType>(m_DataLength)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "DataLength", m_DataLength);
   os << indent << "SplineOrder: " << m_SplineOrder << std::endl;
 
   itkPrintSelfObjectMacro(Coefficients);
@@ -73,8 +71,7 @@ BSplineInterpolateImageFunction<TImageType, TCoordinate, TCoefficientType>::Prin
 
   itkPrintSelfBooleanMacro(UseImageDirection);
 
-  os << indent << "NumberOfWorkUnits: " << static_cast<NumericTraits<ThreadIdType>::PrintType>(m_NumberOfWorkUnits)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumberOfWorkUnits", m_NumberOfWorkUnits);
 
   os << indent << "ThreadedEvaluateIndex: ";
   if (m_ThreadedEvaluateIndex != nullptr)

--- a/Modules/Core/ImageFunction/include/itkNeighborhoodOperatorImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkNeighborhoodOperatorImageFunction.hxx
@@ -22,6 +22,7 @@
 #include "itkConstNeighborhoodIterator.h"
 
 #include <cassert>
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -32,8 +33,7 @@ NeighborhoodOperatorImageFunction<TInputImage, TOutput>::PrintSelf(std::ostream 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Operator: " << static_cast<typename NumericTraits<NeighborhoodType>::PrintType>(m_Operator)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Operator", m_Operator);
 }
 
 template <typename TInputImage, typename TOutput>

--- a/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkBinaryMask3DMeshSource.hxx
@@ -21,6 +21,7 @@
 #include "itkContinuousIndex.h"
 #include "itkNumericTraits.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -2650,9 +2651,8 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::PrintSelf(std::ostream & os, I
 
   os << indent << "LUT: " << m_LUT << std::endl;
 
-  os << indent << "LastVoxel: " << static_cast<NumericTraits<IdentifierType>::PrintType>(*m_LastVoxel) << std::endl;
-  os << indent << "CurrentVoxel: " << static_cast<NumericTraits<IdentifierType>::PrintType>(*m_CurrentVoxel)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "LastVoxel", *m_LastVoxel);
+  print_helper::PrintNumericTrait(os, indent, "CurrentVoxel", *m_CurrentVoxel);
 
   os << indent << "LastRow: ";
   if (m_LastRow != nullptr)
@@ -2716,10 +2716,8 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::PrintSelf(std::ostream & os, I
 
   os << indent << "LocationOffset: " << m_LocationOffset << std::endl;
 
-  os << indent << "NumberOfNodes: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfNodes)
-     << std::endl;
-  os << indent << "NumberOfCells: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfCells)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumberOfNodes", m_NumberOfNodes);
+  print_helper::PrintNumericTrait(os, indent, "NumberOfCells", m_NumberOfCells);
 
   os << indent << "NodeLimit: " << m_NodeLimit << std::endl;
   os << indent << "CellLimit: " << m_CellLimit << std::endl;
@@ -2734,8 +2732,7 @@ BinaryMask3DMeshSource<TInputImage, TOutputMesh>::PrintSelf(std::ostream & os, I
   os << indent << "LastFrameIndex: " << m_LastFrameIndex << std::endl;
 
   os << indent << "PointFound: " << m_PointFound << std::endl;
-  os << indent << "ObjectValue: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_ObjectValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ObjectValue", m_ObjectValue);
 
   os << indent << "m_OutputMesh: ";
   if (m_OutputMesh != nullptr)

--- a/Modules/Core/Mesh/include/itkSimplexMesh.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMesh.hxx
@@ -24,6 +24,7 @@
 
 #include "vxl_version.h"
 #include "vnl/vnl_cross.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -219,8 +220,7 @@ SimplexMesh<TPixelType, VDimension, TMeshTraits>::PrintSelf(std::ostream & os, I
 {
   this->Superclass::PrintSelf(os, indent);
 
-  os << indent << "LastCellId: " << static_cast<typename NumericTraits<CellIdentifier>::PrintType>(m_LastCellId)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "LastCellId", m_LastCellId);
 
   itkPrintSelfObjectMacro(GeometryData);
 }

--- a/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshAdaptTopologyFilter.hxx
@@ -29,6 +29,7 @@
 #define itkSimplexMeshAdaptTopologyFilter_hxx
 
 
+#include "itkPrintHelper.h"
 namespace itk
 {
 template <typename TInputMesh, typename TOutputMesh>
@@ -378,8 +379,7 @@ SimplexMeshAdaptTopologyFilter<TInputMesh, TOutputMesh>::PrintSelf(std::ostream 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "IdOffset: " << static_cast<typename NumericTraits<CellIdentifier>::PrintType>(m_IdOffset)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "IdOffset", m_IdOffset);
   os << indent << "Threshold: " << m_Threshold << std::endl;
   os << indent << "SelectionMethod: " << m_SelectionMethod << std::endl;
   os << indent << "ModifiedCount: " << m_ModifiedCount << std::endl;

--- a/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
+++ b/Modules/Core/Mesh/include/itkSimplexMeshVolumeCalculator.hxx
@@ -19,6 +19,7 @@
 #define itkSimplexMeshVolumeCalculator_hxx
 
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -273,11 +274,10 @@ SimplexMeshVolumeCalculator<TInputMesh>::PrintSelf(std::ostream & os, Indent ind
   os << indent << "Wxy: " << m_Wxy << std::endl;
   os << indent << "Wxz: " << m_Wxz << std::endl;
   os << indent << "Wyz: " << m_Wyz << std::endl;
-  os << indent << "Muncx: " << static_cast<NumericTraits<IndexValueType>::PrintType>(m_Muncx) << std::endl;
-  os << indent << "Muncy: " << static_cast<NumericTraits<IndexValueType>::PrintType>(m_Muncy) << std::endl;
-  os << indent << "Muncz: " << static_cast<NumericTraits<IndexValueType>::PrintType>(m_Muncz) << std::endl;
-  os << indent << "NumberOfTriangles: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfTriangles)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Muncx", m_Muncx);
+  print_helper::PrintNumericTrait(os, indent, "Muncy", m_Muncy);
+  print_helper::PrintNumericTrait(os, indent, "Muncz", m_Muncz);
+  print_helper::PrintNumericTrait(os, indent, "NumberOfTriangles", m_NumberOfTriangles);
 }
 } // namespace itk
 

--- a/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToBinaryImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkNumericTraits.h"
 #include <cstdlib>
 #include <algorithm> // For max.
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -489,10 +490,8 @@ TriangleMeshToBinaryImageFilter<TInputMesh, TOutputImage>::PrintSelf(std::ostrea
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Size : " << m_Size << std::endl;
-  os << indent << "Inside Value : " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_InsideValue)
-     << std::endl;
-  os << indent << "Outside Value : " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_OutsideValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Inside Value ", m_InsideValue);
+  print_helper::PrintNumericTrait(os, indent, "Outside Value ", m_OutsideValue);
   os << indent << "Tolerance: " << m_Tolerance << std::endl;
   os << indent << "Origin: " << m_Origin << std::endl;
   os << indent << "Spacing: " << m_Spacing << std::endl;

--- a/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshToSimplexMeshFilter.hxx
@@ -18,6 +18,8 @@
 #ifndef itkTriangleMeshToSimplexMeshFilter_hxx
 #define itkTriangleMeshToSimplexMeshFilter_hxx
 
+
+#include "itkPrintHelper.h"
 namespace itk
 {
 template <typename TInputMesh, typename TOutputMesh>
@@ -277,15 +279,10 @@ TriangleMeshToSimplexMeshFilter<TInputMesh, TOutputMesh>::PrintSelf(std::ostream
   itkPrintSelfObjectMacro(VertexNeighborList);
   itkPrintSelfObjectMacro(LineCellIndices);
 
-  os << indent << "IdOffset: " << static_cast<typename NumericTraits<PointIdentifier>::PrintType>(m_IdOffset)
-     << std::endl;
-  os << indent << "EdgeCellId: " << static_cast<typename NumericTraits<CellIdentifier>::PrintType>(m_EdgeCellId)
-     << std::endl;
-  os << indent
-     << "HandledEdgeIds: " << static_cast<typename NumericTraits<IdVectorPointer>::PrintType>(m_HandledEdgeIds)
-     << std::endl;
-  os << indent << "IdOffset: " << static_cast<typename NumericTraits<PointIdentifier>::PrintType>(m_IdOffset)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "IdOffset", m_IdOffset);
+  print_helper::PrintNumericTrait(os, indent, "EdgeCellId", m_EdgeCellId);
+  print_helper::PrintNumericTrait(os, indent, "HandledEdgeIds", m_HandledEdgeIds);
+  print_helper::PrintNumericTrait(os, indent, "IdOffset", m_IdOffset);
 
   // ToDo
   // os << indent << "NewInputMeshCellPointer: " << m_NewInputMeshCellPointer << std::endl;

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.hxx
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshEulerOperatorJoinVertexFunction.hxx
@@ -23,6 +23,7 @@
 
 #include <list>
 #include <algorithm>
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -39,8 +40,7 @@ QuadEdgeMeshEulerOperatorJoinVertexFunction<TMesh, TQEType>::PrintSelf(std::ostr
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "OldPointID: " << static_cast<typename NumericTraits<PointIdentifier>::PrintType>(m_OldPointID)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "OldPointID", m_OldPointID);
   os << indent << "EdgeStatus: ";
 
   switch (m_EdgeStatus)

--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
@@ -19,6 +19,7 @@
 #define itkArrowSpatialObject_hxx
 
 
+#include "itkPrintHelper.h"
 namespace itk
 {
 
@@ -159,9 +160,7 @@ ArrowSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) cons
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "PositionInObjectSpace: " << static_cast<typename NumericTraits<PointType>::PrintType>(m_PositionInObjectSpace)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "PositionInObjectSpace", m_PositionInObjectSpace);
   os << indent << "LengthInObjectSpace: " << m_LengthInObjectSpace << std::endl;
 }
 } // end namespace itk

--- a/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
@@ -19,6 +19,7 @@
 #define itkBoxSpatialObject_hxx
 
 #include "itkNumericTraits.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -99,11 +100,8 @@ BoxSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "SizeInObjectSpace: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_SizeInObjectSpace)
-     << std::endl;
-  os << indent
-     << "PositionInObjectSpace: " << static_cast<typename NumericTraits<PointType>::PrintType>(m_PositionInObjectSpace)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "SizeInObjectSpace", m_SizeInObjectSpace);
+  print_helper::PrintNumericTrait(os, indent, "PositionInObjectSpace", m_PositionInObjectSpace);
 }
 } // end namespace itk
 

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
@@ -20,6 +20,7 @@
 
 #include "itkNumericTraits.h"
 #include <algorithm> // For min and max.
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -157,8 +158,7 @@ ContourSpatialObject<TDimension>::PrintSelf(std::ostream & os, Indent indent) co
   os << indent << "InterpolationFactor: " << m_InterpolationFactor << std::endl;
   itkPrintSelfBooleanMacro(IsClosed);
   os << indent << "OrientationInObjectSpace: " << m_OrientationInObjectSpace << std::endl;
-  os << indent << "OrientationInObjectSpaceMTime: "
-     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_OrientationInObjectSpaceMTime) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "OrientationInObjectSpaceMTime", m_OrientationInObjectSpaceMTime);
   os << indent << "AttachedToSlice: " << m_AttachedToSlice << std::endl;
 }
 

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObjectPoint.hxx
@@ -19,6 +19,7 @@
 #define itkContourSpatialObjectPoint_hxx
 
 
+#include "itkPrintHelper.h"
 namespace itk
 {
 
@@ -64,9 +65,7 @@ ContourSpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent 
   Superclass::PrintSelf(os, indent);
 
   os << indent << "PickedPointInObjectSpace: " << m_PickedPointInObjectSpace << std::endl;
-  os << indent
-     << "NormalInObjectSpace: " << static_cast<typename NumericTraits<PointType>::PrintType>(m_NormalInObjectSpace)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NormalInObjectSpace", m_NormalInObjectSpace);
 }
 } // end namespace itk
 

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.hxx
@@ -20,6 +20,7 @@
 
 #include "itkSize.h"
 #include "itkDefaultConvertPixelTraits.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -221,8 +222,7 @@ ImageSpatialObject<TDimension, PixelType>::PrintSelf(std::ostream & os, Indent i
 
   itkPrintSelfObjectMacro(Image);
 
-  os << indent << "SliceNumber: " << static_cast<typename NumericTraits<IndexType>::PrintType>(m_SliceNumber)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "SliceNumber", m_SliceNumber);
 
 #if !defined(ITK_LEGACY_REMOVE)
   os << indent << "PixelType: " << m_PixelType << std::endl;

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectPoint.hxx
@@ -19,6 +19,7 @@
 #define itkSpatialObjectPoint_hxx
 
 
+#include "itkPrintHelper.h"
 namespace itk
 {
 
@@ -128,10 +129,8 @@ void
 SpatialObjectPoint<TPointDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   os << indent << "Id: " << m_Id << std::endl;
-  os << indent
-     << "PositionInObjectSpace: " << static_cast<typename NumericTraits<PointType>::PrintType>(m_PositionInObjectSpace)
-     << std::endl;
-  os << indent << "Color: " << static_cast<NumericTraits<ColorType>::PrintType>(m_Color) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "PositionInObjectSpace", m_PositionInObjectSpace);
+  print_helper::PrintNumericTrait(os, indent, "Color", m_Color);
 
   os << indent << "ScalarDictionary: " << std::endl;
   for (const auto & keyval : m_ScalarDictionary)

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
@@ -24,6 +24,7 @@
 #include "itkCovarianceSampleFilter.h"
 #include "itkImageMaskSpatialObject.h"
 #include <algorithm> // For max.
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -219,16 +220,13 @@ SpatialObjectToImageStatisticsCalculator<TInputImage, TInputSpatialObject, TSamp
   itkPrintSelfObjectMacro(SpatialObject);
 
   os << indent << "Mean: " << m_Mean << std::endl;
-  os << indent << "Sum: " << static_cast<typename NumericTraits<AccumulateType>::PrintType>(m_Sum) << std::endl;
-  os << indent << "NumberOfPixels: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixels)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Sum", m_Sum);
+  print_helper::PrintNumericTrait(os, indent, "NumberOfPixels", m_NumberOfPixels);
   os << indent << "CovarianceMatrix: " << m_CovarianceMatrix << std::endl;
   os << indent << "SampleDirection: " << m_SampleDirection << std::endl;
-  os << indent << "InternalImageTime: " << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_InternalImageTime)
-     << std::endl;
-  os << indent << "InternalSpatialObjectTime: "
-     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_InternalSpatialObjectTime) << std::endl;
-  os << indent << "ModifiedTime: " << static_cast<NumericTraits<TimeStamp>::PrintType>(m_ModifiedTime) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "InternalImageTime", m_InternalImageTime);
+  print_helper::PrintNumericTrait(os, indent, "InternalSpatialObjectTime", m_InternalSpatialObjectTime);
+  print_helper::PrintNumericTrait(os, indent, "ModifiedTime", m_ModifiedTime);
 
   itkPrintSelfObjectMacro(Sample);
 }

--- a/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.hxx
@@ -19,6 +19,7 @@
 #define itkPipelineMonitorImageFilter_hxx
 
 
+#include "itkPrintHelper.h"
 namespace itk
 {
 
@@ -327,14 +328,9 @@ PipelineMonitorImageFilter<TImageType>::PrintSelf(std::ostream & os, Indent inde
     i->Print(os, indent.GetNextIndent());
   }
 
-  os << indent
-     << "UpdatedOutputOrigin: " << static_cast<typename NumericTraits<PointType>::PrintType>(m_UpdatedOutputOrigin)
-     << std::endl;
-  os << indent << "UpdatedOutputDirection: "
-     << static_cast<typename NumericTraits<DirectionType>::PrintType>(m_UpdatedOutputDirection) << std::endl;
-  os << indent
-     << "UpdatedOutputSpacing: " << static_cast<typename NumericTraits<SpacingType>::PrintType>(m_UpdatedOutputSpacing)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "UpdatedOutputOrigin", m_UpdatedOutputOrigin);
+  print_helper::PrintNumericTrait(os, indent, "UpdatedOutputDirection", m_UpdatedOutputDirection);
+  print_helper::PrintNumericTrait(os, indent, "UpdatedOutputSpacing", m_UpdatedOutputSpacing);
   os << indent << "UpdatedOutputLargestPossibleRegion: " << m_UpdatedOutputLargestPossibleRegion << std::endl;
 }
 

--- a/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
+++ b/Modules/Core/TestKernel/include/itkRandomImageSource.hxx
@@ -31,6 +31,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkObjectFactory.h"
 #include "itkTotalProgressReporter.h"
+#include "itkPrintHelper.h"
 
 
 namespace itk
@@ -119,8 +120,8 @@ void
 RandomImageSource<TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Max: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_Max) << std::endl;
-  os << indent << "Min: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_Min) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Max", m_Max);
+  print_helper::PrintNumericTrait(os, indent, "Min", m_Min);
 
   os << indent << "Origin: [";
   unsigned int ii = 0;

--- a/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingStretchIntensityImageFilter.hxx
@@ -33,6 +33,7 @@
 #include "itkImageRegionConstIterator.h"
 #include "itkMath.h"
 #include "itkTotalProgressReporter.h"
+#include "itkPrintHelper.h"
 
 namespace itk::Testing
 {
@@ -150,17 +151,13 @@ StretchIntensityImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream &
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Scale: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_Scale) << std::endl;
-  os << indent << "Shift: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_Shift) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Scale", m_Scale);
+  print_helper::PrintNumericTrait(os, indent, "Shift", m_Shift);
 
-  os << indent << "Input Minimum: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_InputMinimum)
-     << std::endl;
-  os << indent << "Input Maximum: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_InputMaximum)
-     << std::endl;
-  os << indent << "Output Minimum: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_OutputMinimum)
-     << std::endl;
-  os << indent << "Output Maximum: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_OutputMaximum)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Input Minimum", m_InputMinimum);
+  print_helper::PrintNumericTrait(os, indent, "Input Maximum", m_InputMaximum);
+  print_helper::PrintNumericTrait(os, indent, "Output Minimum", m_OutputMinimum);
+  print_helper::PrintNumericTrait(os, indent, "Output Maximum", m_OutputMaximum);
 }
 } // namespace itk::Testing
 

--- a/Modules/Core/Transform/include/itkCompositeTransform.hxx
+++ b/Modules/Core/Transform/include/itkCompositeTransform.hxx
@@ -19,6 +19,7 @@
 #define itkCompositeTransform_hxx
 
 
+#include "itkPrintHelper.h"
 namespace itk
 {
 
@@ -961,8 +962,8 @@ CompositeTransform<TParametersValueType, VDimension>::PrintSelf(std::ostream & o
     os << std::endl;
   }
 
-  os << indent << "PreviousTransformsToOptimizeUpdateTime: "
-     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_PreviousTransformsToOptimizeUpdateTime) << std::endl;
+  print_helper::PrintNumericTrait(
+    os, indent, "PreviousTransformsToOptimizeUpdateTime", m_PreviousTransformsToOptimizeUpdateTime);
 }
 
 

--- a/Modules/Core/Transform/include/itkElasticBodyReciprocalSplineKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkElasticBodyReciprocalSplineKernelTransform.hxx
@@ -18,6 +18,8 @@
 #ifndef itkElasticBodyReciprocalSplineKernelTransform_hxx
 #define itkElasticBodyReciprocalSplineKernelTransform_hxx
 
+
+#include "itkPrintHelper.h"
 namespace itk
 {
 template <typename TParametersValueType, unsigned int VDimension>
@@ -57,8 +59,7 @@ ElasticBodyReciprocalSplineKernelTransform<TParametersValueType, VDimension>::Pr
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Alpha: " << static_cast<typename NumericTraits<TParametersValueType>::PrintType>(m_Alpha)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Alpha", m_Alpha);
 }
 } // namespace itk
 #endif

--- a/Modules/Core/Transform/include/itkElasticBodySplineKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkElasticBodySplineKernelTransform.hxx
@@ -18,6 +18,8 @@
 #ifndef itkElasticBodySplineKernelTransform_hxx
 #define itkElasticBodySplineKernelTransform_hxx
 
+
+#include "itkPrintHelper.h"
 namespace itk
 {
 template <typename TParametersValueType, unsigned int VDimension>
@@ -55,8 +57,7 @@ ElasticBodySplineKernelTransform<TParametersValueType, VDimension>::PrintSelf(st
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Alpha: " << static_cast<typename NumericTraits<TParametersValueType>::PrintType>(m_Alpha)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Alpha", m_Alpha);
 }
 } // namespace itk
 #endif

--- a/Modules/Core/Transform/include/itkEuler3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkEuler3DTransform.hxx
@@ -19,6 +19,7 @@
 #define itkEuler3DTransform_hxx
 
 
+#include "itkPrintHelper.h"
 namespace itk
 {
 
@@ -361,9 +362,9 @@ Euler3DTransform<TParametersValueType>::PrintSelf(std::ostream & os, Indent inde
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "AngleX: " << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_AngleX) << std::endl;
-  os << indent << "AngleY: " << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_AngleY) << std::endl;
-  os << indent << "AngleZ: " << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_AngleZ) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "AngleX", m_AngleX);
+  print_helper::PrintNumericTrait(os, indent, "AngleY", m_AngleY);
+  print_helper::PrintNumericTrait(os, indent, "AngleZ", m_AngleZ);
   itkPrintSelfBooleanMacro(ComputeZYX);
 }
 

--- a/Modules/Core/Transform/include/itkRigid2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkRigid2DTransform.hxx
@@ -19,6 +19,7 @@
 #define itkRigid2DTransform_hxx
 
 #include "vnl/algo/vnl_svd.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -49,8 +50,7 @@ Rigid2DTransform<TParametersValueType>::PrintSelf(std::ostream & os, Indent inde
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Angle: " << static_cast<typename NumericTraits<TParametersValueType>::PrintType>(m_Angle)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Angle", m_Angle);
 }
 
 

--- a/Modules/Core/Transform/include/itkSimilarity2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkSimilarity2DTransform.hxx
@@ -19,6 +19,7 @@
 #define itkSimilarity2DTransform_hxx
 
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -215,7 +216,7 @@ Similarity2DTransform<TParametersValueType>::PrintSelf(std::ostream & os, Indent
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Scale: " << static_cast<typename NumericTraits<ScaleType>::PrintType>(m_Scale) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Scale", m_Scale);
 }
 
 

--- a/Modules/Core/Transform/include/itkSimilarity3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkSimilarity3DTransform.hxx
@@ -20,6 +20,7 @@
 
 #include "itkMath.h"
 #include "vnl/vnl_det.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -304,7 +305,7 @@ Similarity3DTransform<TParametersValueType>::PrintSelf(std::ostream & os, Indent
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Scale: " << static_cast<typename NumericTraits<ScaleType>::PrintType>(m_Scale) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Scale", m_Scale);
 }
 
 } // namespace itk

--- a/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.hxx
+++ b/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.hxx
@@ -20,6 +20,7 @@
 
 #include "itkMinimumMaximumImageCalculator.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -121,12 +122,8 @@ AntiAliasBinaryImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "UpperBinaryValue: " << static_cast<typename NumericTraits<BinaryValueType>::PrintType>(m_UpperBinaryValue)
-     << std::endl;
-  os << indent
-     << "LowerBinaryValue: " << static_cast<typename NumericTraits<BinaryValueType>::PrintType>(m_LowerBinaryValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "UpperBinaryValue", m_UpperBinaryValue);
+  print_helper::PrintNumericTrait(os, indent, "LowerBinaryValue", m_LowerBinaryValue);
 
   itkPrintSelfObjectMacro(InputImage);
 }

--- a/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRIBiasFieldCorrectionFilter.hxx
@@ -19,6 +19,7 @@
 #define itkMRIBiasFieldCorrectionFilter_hxx
 
 
+#include "itkPrintHelper.h"
 namespace itk
 {
 
@@ -932,14 +933,12 @@ MRIBiasFieldCorrectionFilter<TInputImage, TOutputImage, TMaskImage>::PrintSelf(s
   itkPrintSelfBooleanMacro(GeneratingOutput);
 
   os << indent << "SlabNumberOfSamples: " << m_SlabNumberOfSamples << std::endl;
-  os << indent << "SlabBackgroundMinimumThreshold: "
-     << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_SlabBackgroundMinimumThreshold)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "SlabBackgroundMinimumThreshold", m_SlabBackgroundMinimumThreshold);
   os << indent << "SlabTolerance" << m_SlabTolerance << std::endl;
 
   os << indent << "BiasFieldDegree: " << m_BiasFieldDegree << std::endl;
   os << indent << "NumberOfLevels: " << m_NumberOfLevels << std::endl;
-  os << indent << "Schedule: " << static_cast<NumericTraits<ScheduleType>::PrintType>(m_Schedule) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Schedule", m_Schedule);
 
   os << indent << "VolumeCorrectionMaximumIteration: " << m_VolumeCorrectionMaximumIteration << std::endl;
   os << indent << "InterSliceCorrectionMaximumIteration: " << m_InterSliceCorrectionMaximumIteration << std::endl;

--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
@@ -37,6 +37,7 @@ ITK_GCC_SUPPRESS_Wfloat_equal
 #include "vnl/algo/vnl_fft_1d.h"
 #include "vnl/vnl_complex_traits.h"
 #include "complex"
+#include "itkPrintHelper.h"
 ITK_GCC_PRAGMA_POP
 
 namespace itk
@@ -689,8 +690,7 @@ N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::PrintSe
   Superclass::PrintSelf(os, indent);
 
   os << indent << "Use Mask Label: " << m_UseMaskLabel << std::endl;
-  os << indent << "Mask label: " << static_cast<typename NumericTraits<MaskPixelType>::PrintType>(this->m_MaskLabel)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Mask label", this->m_MaskLabel);
   os << indent << "Number of histogram bins: " << this->m_NumberOfHistogramBins << std::endl;
   os << indent << "Wiener filter noise: " << this->m_WienerFilterNoise << std::endl;
   os << indent << "Bias field FWHM: " << this->m_BiasFieldFullWidthAtHalfMaximum << std::endl;

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.hxx
@@ -25,6 +25,7 @@
 #include "itkConstantPadImageFilter.h"
 #include "itkConstNeighborhoodIterator.h"
 #include "itkNeighborhoodIterator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -108,9 +109,7 @@ BinaryClosingByReconstructionImageFilter<TInputImage, TKernel>::PrintSelf(std::o
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "ForegroundValue: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_ForegroundValue);
   itkPrintSelfBooleanMacro(FullyConnected);
 }
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryDilateImageFilter.hxx
@@ -26,6 +26,7 @@
 #include "itkOffset.h"
 #include "itkProgressReporter.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -460,9 +461,7 @@ void
 BinaryDilateImageFilter<TInputImage, TOutput, TKernel>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent
-     << "Dilate Value: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(this->GetForegroundValue())
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Dilate Value", this->GetForegroundValue());
 }
 } // end namespace itk
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryErodeImageFilter.hxx
@@ -26,6 +26,7 @@
 #include "itkOffset.h"
 #include "itkProgressReporter.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -468,9 +469,7 @@ void
 BinaryErodeImageFilter<TInputImage, TOutput, TKernel>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent
-     << "Dilate Value: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(this->GetForegroundValue())
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Dilate Value", this->GetForegroundValue());
 }
 } // end namespace itk
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.hxx
@@ -25,6 +25,7 @@
 #include "itkConstantPadImageFilter.h"
 #include "itkNeighborhoodIterator.h"
 #include "itkProgressReporter.h"
+#include "itkPrintHelper.h"
 
 /*
  * This code was contributed in the Insight Journal paper:
@@ -158,9 +159,7 @@ BinaryMorphologicalClosingImageFilter<TInputImage, TOutputImage, TKernel>::Print
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "ForegroundValue: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_ForegroundValue);
   os << indent << "SafeBorder: " << m_SafeBorder << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkBinaryErodeImageFilter.h"
 #include "itkBinaryDilateImageFilter.h"
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 /*
  *
@@ -83,10 +84,8 @@ BinaryMorphologicalOpeningImageFilter<TInputImage, TOutputImage, TKernel>::Print
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "ForegroundValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
-  os << indent << "BackgroundValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_ForegroundValue);
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.hxx
@@ -25,6 +25,7 @@
 #include "itkConstantBoundaryCondition.h"
 #include "itkOffset.h"
 #include "itkProgressReporter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -321,12 +322,8 @@ void
 BinaryMorphologyImageFilter<TInputImage, TOutput, TKernel>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent
-     << "Foreground Value: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
-  os << indent
-     << "Background Value: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Foreground Value", m_ForegroundValue);
+  print_helper::PrintNumericTrait(os, indent, "Background Value", m_BackgroundValue);
   os << indent << "BoundaryToForeground: " << m_BoundaryToForeground << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkBinaryErodeImageFilter.h"
 #include "itkBinaryReconstructionByDilationImageFilter.h"
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -89,10 +90,8 @@ BinaryOpeningByReconstructionImageFilter<TInputImage, TKernel>::PrintSelf(std::o
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "ForegroundValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
-  os << indent << "BackgroundValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_ForegroundValue);
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
   itkPrintSelfBooleanMacro(FullyConnected);
 }
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
@@ -25,6 +25,7 @@
 #include "itkTotalProgressReporter.h"
 #include "itkImageRegionConstIterator.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -217,9 +218,8 @@ ObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::PrintSelf(std::
   m_DefaultBoundaryCondition.Print(os, indent);
 
   itkPrintSelfBooleanMacro(UseBoundaryCondition);
-  os << indent << "Kernel: " << static_cast<typename NumericTraits<KernelType>::PrintType>(m_Kernel) << std::endl;
-  os << indent << "ObjectValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_ObjectValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Kernel", m_Kernel);
+  print_helper::PrintNumericTrait(os, indent, "ObjectValue", m_ObjectValue);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/Colormap/include/itkColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkColormapFunction.h
@@ -22,6 +22,7 @@
 #include "itkObjectFactory.h"
 #include "itkNumericTraits.h"
 #include "itkRGBPixel.h"
+#include "itkPrintHelper.h"
 
 namespace itk::Function
 {
@@ -115,16 +116,10 @@ protected:
   {
     Superclass::PrintSelf(os, indent);
 
-    os << indent << "Minimum RGB Component Value: "
-       << static_cast<typename NumericTraits<RGBComponentType>::PrintType>(this->GetMinimumRGBComponentValue())
-       << std::endl;
-    os << indent << "Maximum RGB Component Value: "
-       << static_cast<typename NumericTraits<RGBComponentType>::PrintType>(this->GetMaximumRGBComponentValue())
-       << std::endl;
-    os << indent << "Minimum Input Value: "
-       << static_cast<typename NumericTraits<ScalarType>::PrintType>(this->GetMinimumInputValue()) << std::endl;
-    os << indent << "Maximum Input Value: "
-       << static_cast<typename NumericTraits<ScalarType>::PrintType>(this->GetMaximumInputValue()) << std::endl;
+    print_helper::PrintNumericTrait(os, indent, "Minimum RGB Component Value", this->GetMinimumRGBComponentValue());
+    print_helper::PrintNumericTrait(os, indent, "Maximum RGB Component Value", this->GetMaximumRGBComponentValue());
+    print_helper::PrintNumericTrait(os, indent, "Minimum Input Value", this->GetMinimumInputValue());
+    print_helper::PrintNumericTrait(os, indent, "Maximum Input Value", this->GetMaximumInputValue());
   }
 
 private:

--- a/Modules/Filtering/Cuberille/include/itkCuberilleImageToMeshFilter.hxx
+++ b/Modules/Filtering/Cuberille/include/itkCuberilleImageToMeshFilter.hxx
@@ -25,6 +25,7 @@
 #include <array>
 #include <utility>
 #include <bitset>
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -989,16 +990,10 @@ CuberilleImageToMeshFilter<TInputImage, TOutputMesh, TInterpolator>::PrintSelf(s
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "IsoSurfaceValue: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_IsoSurfaceValue)
-     << std::endl;
-  os << indent << "MaxSpacing: " << static_cast<typename NumericTraits<SpacingValueType>::PrintType>(m_MaxSpacing)
-     << std::endl;
-  os << indent << "GenerateTriangleFaces: " << static_cast<NumericTraits<bool>::PrintType>(m_GenerateTriangleFaces)
-     << std::endl;
-  os << indent
-     << "ProjectVerticesToIsoSurface: " << static_cast<NumericTraits<bool>::PrintType>(m_ProjectVerticesToIsoSurface)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "IsoSurfaceValue", m_IsoSurfaceValue);
+  print_helper::PrintNumericTrait(os, indent, "MaxSpacing", m_MaxSpacing);
+  print_helper::PrintNumericTrait(os, indent, "GenerateTriangleFaces", m_GenerateTriangleFaces);
+  print_helper::PrintNumericTrait(os, indent, "ProjectVerticesToIsoSurface", m_ProjectVerticesToIsoSurface);
   os << indent << "ProjectVertexSurfaceDistanceThreshold: " << m_ProjectVertexSurfaceDistanceThreshold << std::endl;
   os << indent << "ProjectVertexStepLength: " << m_ProjectVertexStepLength << std::endl;
   os << indent << "ProjectVertexStepLengthRelaxationFactor: " << m_ProjectVertexStepLengthRelaxationFactor << std::endl;

--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowImageFilter.hxx
@@ -19,6 +19,7 @@
 #define itkCurvatureFlowImageFilter_hxx
 
 #include "itkMacro.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -40,7 +41,7 @@ CurvatureFlowImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "TimeStep: " << static_cast<typename NumericTraits<TimeStepType>::PrintType>(m_TimeStep) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "TimeStep", m_TimeStep);
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowImageFilter.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowImageFilter.hxx
@@ -20,6 +20,7 @@
 
 
 #include "itkMacro.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -39,8 +40,7 @@ MinMaxCurvatureFlowImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostrea
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "StencilRadius: " << static_cast<typename NumericTraits<RadiusValueType>::PrintType>(m_StencilRadius)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "StencilRadius", m_StencilRadius);
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.hxx
@@ -23,6 +23,7 @@
 #include "itkImageDuplicator.h"
 #include "itkImportImageFilter.h"
 #include "itkMultiplyImageFilter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -195,7 +196,7 @@ BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::Prin
      << "NumberOfControlPointsForTheConstantVelocityField: " << m_NumberOfControlPointsForTheConstantVelocityField
      << std::endl;
   os << indent << "NumberOfControlPointsForTheUpdateField: " << m_NumberOfControlPointsForTheUpdateField << std::endl;
-  os << indent << "SplineOrder: " << static_cast<NumericTraits<SplineOrderType>::PrintType>(m_SplineOrder) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "SplineOrder", m_SplineOrder);
 }
 
 } // namespace itk

--- a/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.hxx
@@ -22,6 +22,7 @@
 #include "itkImageAlgorithm.h"
 #include "itkContinuousIndex.h"
 #include "itkImportImageFilter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -213,7 +214,7 @@ BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimens
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "SplineOrder: " << static_cast<NumericTraits<SplineOrderType>::PrintType>(m_SplineOrder) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "SplineOrder", m_SplineOrder);
   itkPrintSelfBooleanMacro(EnforceStationaryBoundary);
   os << indent << "NumberOfControlPointsForTheUpdateField: " << m_NumberOfControlPointsForTheUpdateField << std::endl;
   os << indent << "NumberOfControlPointsForTheTotalField: " << m_NumberOfControlPointsForTheTotalField << std::endl;

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
@@ -266,12 +266,9 @@ DisplacementFieldJacobianDeterminantFilter<TInputImage, TRealType, TOutputImage>
   os << indent << "DerivativeWeights: " << m_DerivativeWeights << std::endl;
   os << indent << "HalfDerivativeWeights: " << m_HalfDerivativeWeights << std::endl;
   itkPrintSelfBooleanMacro(UseImageSpacing);
-  os << indent << "RequestedNumberOfThreads: "
-     << static_cast<NumericTraits<ThreadIdType>::PrintType>(m_RequestedNumberOfWorkUnits) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "RequestedNumberOfThreads", m_RequestedNumberOfWorkUnits);
   os << indent << "RealValuedInputImage: " << m_RealValuedInputImage.GetPointer() << std::endl;
-  os << indent
-     << "NeighborhoodRadius: " << static_cast<typename NumericTraits<RadiusType>::PrintType>(m_NeighborhoodRadius)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NeighborhoodRadius", m_NeighborhoodRadius);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkContinuousIndex.h"
 #include "itkImportImageFilter.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -416,16 +417,10 @@ DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>
 
   itkPrintSelfBooleanMacro(UsePointWeights);
 
-  os << indent
-     << "BSplineDomainOrigin: " << static_cast<typename NumericTraits<OriginType>::PrintType>(m_BSplineDomainOrigin)
-     << std::endl;
-  os << indent
-     << "BSplineDomainSpacing: " << static_cast<typename NumericTraits<SpacingType>::PrintType>(m_BSplineDomainSpacing)
-     << std::endl;
-  os << indent << "BSplineDomainSize: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_BSplineDomainSize)
-     << std::endl;
-  os << indent << "BSplineDomainDirection: "
-     << static_cast<typename NumericTraits<DirectionType>::PrintType>(m_BSplineDomainDirection) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BSplineDomainOrigin", m_BSplineDomainOrigin);
+  print_helper::PrintNumericTrait(os, indent, "BSplineDomainSpacing", m_BSplineDomainSpacing);
+  print_helper::PrintNumericTrait(os, indent, "BSplineDomainSize", m_BSplineDomainSize);
+  print_helper::PrintNumericTrait(os, indent, "BSplineDomainDirection", m_BSplineDomainDirection);
 
   itkPrintSelfBooleanMacro(BSplineDomainIsDefined);
   itkPrintSelfBooleanMacro(UseInputFieldToDefineTheBSplineDomain);

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -25,6 +25,7 @@
 #include "vnl/algo/vnl_matrix_inverse.h"
 #include "itkCastImageFilter.h"
 #include <algorithm> // For min and max.
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -586,12 +587,9 @@ DisplacementFieldTransform<TParametersValueType, VDimension>::PrintSelf(std::ost
   itkPrintSelfObjectMacro(Interpolator);
   itkPrintSelfObjectMacro(InverseInterpolator);
 
-  os << indent << "DisplacementFieldSetTime: "
-     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_DisplacementFieldSetTime) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "DisplacementFieldSetTime", m_DisplacementFieldSetTime);
 
-  os << indent
-     << "IdentityJacobian: " << static_cast<typename NumericTraits<JacobianType>::PrintType>(m_IdentityJacobian)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "IdentityJacobian", m_IdentityJacobian);
 
   os << indent << "CoordinateTolerance: " << m_CoordinateTolerance << std::endl;
   os << indent << "DirectionTolerance: " << m_DirectionTolerance << std::endl;

--- a/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianExponentialDiffeomorphicTransform.hxx
@@ -23,6 +23,7 @@
 #include "itkImageDuplicator.h"
 #include "itkImportImageFilter.h"
 #include "itkMultiplyImageFilter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -229,13 +230,12 @@ GaussianExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::Pri
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "GaussianSmoothingVarianceForTheConstantVelocityField: "
-     << static_cast<typename NumericTraits<ScalarType>::PrintType>(
-          m_GaussianSmoothingVarianceForTheConstantVelocityField)
-     << std::endl;
-  os << indent << "GaussianSmoothingVarianceForTheUpdateField: "
-     << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_GaussianSmoothingVarianceForTheUpdateField)
-     << std::endl;
+  print_helper::PrintNumericTrait(os,
+                                  indent,
+                                  "GaussianSmoothingVarianceForTheConstantVelocityField",
+                                  m_GaussianSmoothingVarianceForTheConstantVelocityField);
+  print_helper::PrintNumericTrait(
+    os, indent, "GaussianSmoothingVarianceForTheUpdateField", m_GaussianSmoothingVarianceForTheUpdateField);
 }
 
 } // namespace itk

--- a/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransform.hxx
@@ -27,6 +27,7 @@
 #include "itkImportImageFilter.h"
 #include "itkMultiplyImageFilter.h"
 #include "itkVectorNeighborhoodOperatorImageFilter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -244,12 +245,10 @@ GaussianSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType, VDimen
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "GaussianSmoothingVarianceForTheUpdateField: "
-     << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_GaussianSmoothingVarianceForTheUpdateField)
-     << std::endl;
-  os << indent << "GaussianSmoothingVarianceForTheTotalField: "
-     << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_GaussianSmoothingVarianceForTheTotalField)
-     << std::endl;
+  print_helper::PrintNumericTrait(
+    os, indent, "GaussianSmoothingVarianceForTheUpdateField", m_GaussianSmoothingVarianceForTheUpdateField);
+  print_helper::PrintNumericTrait(
+    os, indent, "GaussianSmoothingVarianceForTheTotalField", m_GaussianSmoothingVarianceForTheTotalField);
   os << indent << "GaussianSmoothingOperator: " << m_GaussianSmoothingOperator << std::endl;
 }
 } // namespace itk

--- a/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDirectedHausdorffDistanceImageFilter.hxx
@@ -199,16 +199,13 @@ DirectedHausdorffDistanceImageFilter<TInputImage1, TInputImage2>::PrintSelf(std:
 
   itkPrintSelfObjectMacro(DistanceMap);
 
-  os << indent << "MaxDistance: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_MaxDistance)
-     << std::endl;
-  os << indent << "PixelCount: " << static_cast<NumericTraits<IdentifierType>::PrintType>(m_PixelCount) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "MaxDistance", m_MaxDistance);
+  print_helper::PrintNumericTrait(os, indent, "PixelCount", m_PixelCount);
   os << indent << "Sum: " << m_Sum.GetSum();
 
   os << std::endl;
-  os << indent << "DirectedHausdorffDistance: "
-     << static_cast<typename NumericTraits<RealType>::PrintType>(m_DirectedHausdorffDistance) << std::endl;
-  os << indent << "AverageHausdorffDistance: "
-     << static_cast<typename NumericTraits<RealType>::PrintType>(m_AverageHausdorffDistance) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "DirectedHausdorffDistance", m_DirectedHausdorffDistance);
+  print_helper::PrintNumericTrait(os, indent, "AverageHausdorffDistance", m_AverageHausdorffDistance);
   itkPrintSelfBooleanMacro(UseImageSpacing);
 }
 } // end namespace itk

--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkIndex.h"
 #include <mutex>
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -49,11 +50,9 @@ IsoContourDistanceImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "LevelSetValue: " << static_cast<typename NumericTraits<PixelRealType>::PrintType>(m_LevelSetValue)
-     << std::endl;
-  os << indent << "FarValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_FarValue) << std::endl;
-  os << indent << "Spacing: " << static_cast<typename NumericTraits<InputSpacingType>::PrintType>(m_Spacing)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "LevelSetValue", m_LevelSetValue);
+  print_helper::PrintNumericTrait(os, indent, "FarValue", m_FarValue);
+  print_helper::PrintNumericTrait(os, indent, "Spacing", m_Spacing);
   itkPrintSelfBooleanMacro(NarrowBanding);
 
   itkPrintSelfObjectMacro(NarrowBand);

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilter.hxx
@@ -20,6 +20,7 @@
 
 #include "itkNumericTraits.h"
 #include <algorithm>
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -56,8 +57,7 @@ FastMarchingImageFilter<TLevelSet, TSpeedImage>::PrintSelf(std::ostream & os, In
   os << indent << "Trial points: " << m_TrialPoints.GetPointer() << std::endl;
   os << indent << "Speed constant: " << m_SpeedConstant << std::endl;
   os << indent << "Stopping value: " << m_StoppingValue << std::endl;
-  os << indent << "Large Value: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_LargeValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Large Value", m_LargeValue);
   os << indent << "Normalization Factor: " << m_NormalizationFactor << std::endl;
   os << indent << "Collect points: " << m_CollectPoints << std::endl;
   os << indent << "OverrideOutputInformation: ";

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkNumericTraits.h"
 #include "itkMath.h"
 #include <algorithm>
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -48,8 +49,7 @@ FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::PrintSelf(std::os
   os << indent << "TargetOffset: " << m_TargetOffset << std::endl;
   os << indent << "TargetReachedMode: " << m_TargetReachedMode << std::endl;
   os << indent << "TargetValue: " << m_TargetValue << std::endl;
-  os << indent << "NumberOfTargets: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfTargets)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumberOfTargets", m_NumberOfTargets);
 }
 
 template <typename TLevelSet, typename TSpeedImage>

--- a/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx
+++ b/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx
@@ -32,9 +32,7 @@ STAPLEImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inden
 
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "ForegroundValue: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_ForegroundValue);
   os << indent << "ElapsedIterations: " << m_ElapsedIterations << std::endl;
   os << indent << "MaximumIterations: " << m_MaximumIterations << std::endl;
   os << indent << "ConfidenceWeight: " << m_ConfidenceWeight << std::endl;

--- a/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkCannyEdgeDetectionImageFilter.hxx
@@ -26,6 +26,7 @@
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkMath.h"
 #include "itkProgressTransformer.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -458,12 +459,8 @@ CannyEdgeDetectionImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream
 
   os << indent << "Variance: " << m_Variance << std::endl;
   os << indent << "MaximumError: " << m_MaximumError << std::endl;
-  os << indent
-     << "UpperThreshold: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_UpperThreshold)
-     << std::endl;
-  os << indent
-     << "LowerThreshold: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_LowerThreshold)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "UpperThreshold", m_UpperThreshold);
+  print_helper::PrintNumericTrait(os, indent, "LowerThreshold", m_LowerThreshold);
   os << indent << "Center: " << m_Center << std::endl;
   os << indent << "Stride: " << m_Stride << std::endl;
   itkPrintSelfObjectMacro(GaussianFilter);

--- a/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMaskFeaturePointSelectionFilter.hxx
@@ -50,8 +50,7 @@ MaskFeaturePointSelectionFilter<TImage, TMask, TFeatures>::PrintSelf(std::ostrea
 
   os << indent << "NonConnectivity: " << m_NonConnectivity << std::endl;
   os << indent << "NonConnectivityOffsets: " << m_NonConnectivityOffsets << std::endl;
-  os << indent << "BlockRadius: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_BlockRadius)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BlockRadius", m_BlockRadius);
   os << indent << "SelectFraction: " << m_SelectFraction << std::endl;
   itkPrintSelfBooleanMacro(ComputeStructureTensors);
 }

--- a/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkSimpleContourExtractorImageFilter.hxx
@@ -24,6 +24,7 @@
 #include "itkNeighborhoodAlgorithm.h"
 #include "itkOffset.h"
 #include "itkTotalProgressReporter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -114,14 +115,10 @@ void
 SimpleContourExtractorImageFilter<TInputImage, TOutput>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Input Foreground Value: "
-     << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_InputForegroundValue) << std::endl;
-  os << indent << "Input Background Value: "
-     << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_InputBackgroundValue) << std::endl;
-  os << indent << "Output Foreground Value: "
-     << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_OutputForegroundValue) << std::endl;
-  os << indent << "Output Background Value: "
-     << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_OutputBackgroundValue) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Input Foreground Value", m_InputForegroundValue);
+  print_helper::PrintNumericTrait(os, indent, "Input Background Value", m_InputBackgroundValue);
+  print_helper::PrintNumericTrait(os, indent, "Output Foreground Value", m_OutputForegroundValue);
+  print_helper::PrintNumericTrait(os, indent, "Output Background Value", m_OutputBackgroundValue);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingBasedEdgeDetectionImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingBasedEdgeDetectionImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkLaplacianImageFilter.h"
 #include "itkZeroCrossingImageFilter.h"
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -83,12 +84,8 @@ ZeroCrossingBasedEdgeDetectionImageFilter<TInputImage, TOutputImage>::PrintSelf(
   Superclass::PrintSelf(os, indent);
   os << indent << "Variance: " << m_Variance << std::endl;
   os << indent << "MaximumError: " << m_MaximumError << std::endl;
-  os << indent
-     << "ForegroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_ForegroundValue);
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
 }
 } // namespace itk
 

--- a/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkZeroCrossingImageFilter.hxx
@@ -24,6 +24,7 @@
 #include "itkFixedArray.h"
 #include "itkTotalProgressReporter.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -164,12 +165,8 @@ ZeroCrossingImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os,
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "ForegroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_ForegroundValue);
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
 }
 } // namespace itk
 

--- a/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMaskNeighborhoodOperatorImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkConstNeighborhoodIterator.h"
 #include "itkTotalProgressReporter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -159,8 +160,7 @@ MaskNeighborhoodOperatorImageFilter<TInputImage, TMaskImage, TOutputImage, TOper
   Indent         indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "Default value : " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_DefaultValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Default value ", m_DefaultValue);
   os << indent << "UseDefaultValue : " << m_UseDefaultValue << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.hxx
@@ -53,8 +53,7 @@ VectorGradientMagnitudeImageFilter<TInputImage, TRealType, TOutputImage>::PrintS
   os << indent << "SqrtComponentWeights: " << m_SqrtComponentWeights << std::endl;
   itkPrintSelfBooleanMacro(UseImageSpacing);
   os << indent << "UsePrincipleComponents: " << m_UsePrincipleComponents << std::endl;
-  os << indent << "RequestedNumberOfThreads: "
-     << static_cast<NumericTraits<ThreadIdType>::PrintType>(m_RequestedNumberOfWorkUnits) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "RequestedNumberOfThreads", m_RequestedNumberOfWorkUnits);
 
   itkPrintSelfObjectMacro(RealValuedInputImage);
 }

--- a/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkChangeInformationImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkContinuousIndex.h"
 #include "itkObjectFactory.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -187,19 +188,12 @@ ChangeInformationImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent i
   itkPrintSelfBooleanMacro(ChangeRegion);
   itkPrintSelfBooleanMacro(UseReferenceImage);
 
-  os << indent << "OutputSpacing: " << static_cast<typename NumericTraits<SpacingType>::PrintType>(m_OutputSpacing)
-     << std::endl;
-  os << indent << "OutputOrigin: " << static_cast<typename NumericTraits<PointType>::PrintType>(m_OutputOrigin)
-     << std::endl;
-  os << indent
-     << "OutputDirection: " << static_cast<typename NumericTraits<DirectionType>::PrintType>(m_OutputDirection)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "OutputSpacing", m_OutputSpacing);
+  print_helper::PrintNumericTrait(os, indent, "OutputOrigin", m_OutputOrigin);
+  print_helper::PrintNumericTrait(os, indent, "OutputDirection", m_OutputDirection);
 
-  os << indent
-     << "OutputOffset: " << static_cast<typename NumericTraits<OutputImageOffsetType>::PrintType>(m_OutputOffset)
-     << std::endl;
-  os << indent << "Shift: " << static_cast<typename NumericTraits<OutputImageOffsetType>::PrintType>(m_Shift)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "OutputOffset", m_OutputOffset);
+  print_helper::PrintNumericTrait(os, indent, "Shift", m_Shift);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageGrid/include/itkConstantPadImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkConstantPadImageFilter.hxx
@@ -19,6 +19,7 @@
 #define itkConstantPadImageFilter_hxx
 
 #include "itkObjectFactory.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -42,9 +43,7 @@ ConstantPadImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Constant: "
-     << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_InternalBoundaryCondition.GetConstant())
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Constant", m_InternalBoundaryCondition.GetConstant());
 }
 
 } // end namespace itk

--- a/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkPasteImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkTotalProgressReporter.h"
 #include "itkImageAlgorithm.h"
 #include "itkImageScanlineIterator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -303,9 +304,7 @@ PasteImageFilter<TInputImage, TSourceImage, TOutputImage>::PrintSelf(std::ostrea
   Superclass::PrintSelf(os, indent);
 
   os << indent << "SourceRegion: " << m_SourceRegion << std::endl;
-  os << indent
-     << "DestinationIndex: " << static_cast<typename NumericTraits<InputImageIndexType>::PrintType>(m_DestinationIndex)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "DestinationIndex", m_DestinationIndex);
   os << indent << "DestinationSkipAxes: " << m_DestinationSkipAxes << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkResampleImageFilter.hxx
@@ -29,6 +29,7 @@
 
 #include <algorithm>   // For max.
 #include <type_traits> // For is_same.
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -658,9 +659,7 @@ ResampleImageFilter<TInputImage, TOutputImage, TInterpolatorPrecisionType, TTran
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "DefaultPixelValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_DefaultPixelValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "DefaultPixelValue", m_DefaultPixelValue);
   os << indent << "Size: " << m_Size << std::endl;
   os << indent << "OutputStartIndex: " << m_OutputStartIndex << std::endl;
   os << indent << "OutputSpacing: " << m_OutputSpacing << std::endl;

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
@@ -27,6 +27,7 @@
 #include "itkNumericTraitsRGBPixel.h"
 #include "itkProgressAccumulator.h"
 #include "itkDefaultConvertPixelTraits.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -400,9 +401,7 @@ TileImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "DefaultPixelValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_DefaultPixelValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "DefaultPixelValue", m_DefaultPixelValue);
   os << indent << "Layout: " << m_Layout << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
@@ -27,6 +27,7 @@
 #include "itkContinuousIndex.h"
 #include "itkMath.h"
 #include "itkTransform.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -64,8 +65,7 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::PrintSelf(std::o
   os << indent << "OutputDirection: " << m_OutputDirection << std::endl;
   os << indent << "OutputSize: " << m_OutputSize << std::endl;
   os << indent << "OutputStartIndex: " << m_OutputStartIndex << std::endl;
-  os << indent << "EdgePaddingValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_EdgePaddingValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "EdgePaddingValue", m_EdgePaddingValue);
   os << indent << "Interpolator: " << m_Interpolator.GetPointer() << std::endl;
 }
 

--- a/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkTotalProgressReporter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -58,8 +59,7 @@ WarpVectorImageFilter<TInputImage, TOutputImage, TDisplacementField>::PrintSelf(
   os << indent << "OutputSpacing: " << m_OutputSpacing << std::endl;
   os << indent << "OutputOrigin: " << m_OutputOrigin << std::endl;
   os << indent << "OutputDirection: " << m_OutputDirection << std::endl;
-  os << indent << "EdgePaddingValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_EdgePaddingValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "EdgePaddingValue", m_EdgePaddingValue);
   os << indent << "Interpolator: " << m_Interpolator.GetPointer() << std::endl;
 }
 

--- a/Modules/Filtering/ImageIntensity/include/itkClampImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkClampImageFilter.hxx
@@ -20,6 +20,7 @@
 
 #include "itkProgressReporter.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -123,12 +124,8 @@ ClampImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "Lower bound: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(this->GetLowerBound())
-     << std::endl;
-  os << indent
-     << "Upper bound: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(this->GetUpperBound())
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Lower bound", this->GetLowerBound());
+  print_helper::PrintNumericTrait(os, indent, "Upper bound", this->GetUpperBound());
 }
 } // namespace itk
 

--- a/Modules/Filtering/ImageIntensity/include/itkIntensityWindowingImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkIntensityWindowingImageFilter.hxx
@@ -30,6 +30,7 @@
 
 #include "itkMinimumMaximumImageCalculator.h"
 #include <algorithm> // For min.
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -106,22 +107,12 @@ IntensityWindowingImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "Output Minimum: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(this->m_OutputMinimum)
-     << std::endl;
-  os << indent
-     << "Output Maximum: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(this->m_OutputMaximum)
-     << std::endl;
-  os << indent
-     << "Window Minimum: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(this->m_WindowMinimum)
-     << std::endl;
-  os << indent
-     << "Window Maximum: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(this->m_WindowMaximum)
-     << std::endl;
-  os << indent << "Scale Factor: " << static_cast<typename NumericTraits<RealType>::PrintType>(this->m_Scale)
-     << std::endl;
-  os << indent << "Shift offset: " << static_cast<typename NumericTraits<RealType>::PrintType>(this->m_Shift)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Output Minimum", this->m_OutputMinimum);
+  print_helper::PrintNumericTrait(os, indent, "Output Maximum", this->m_OutputMaximum);
+  print_helper::PrintNumericTrait(os, indent, "Window Minimum", this->m_WindowMinimum);
+  print_helper::PrintNumericTrait(os, indent, "Window Maximum", this->m_WindowMaximum);
+  print_helper::PrintNumericTrait(os, indent, "Scale Factor", this->m_Scale);
+  print_helper::PrintNumericTrait(os, indent, "Shift offset", this->m_Shift);
 }
 
 } // end namespace itk

--- a/Modules/Filtering/ImageIntensity/include/itkInvertIntensityImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkInvertIntensityImageFilter.hxx
@@ -29,6 +29,7 @@
 #define itkInvertIntensityImageFilter_hxx
 
 #include "itkMinimumMaximumImageCalculator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -51,7 +52,7 @@ InvertIntensityImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Maximum: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_Maximum) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Maximum", m_Maximum);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -28,6 +28,7 @@
 #include "itkPathIterator.h"
 #include "itkVector.h"
 #include "itkBoundingBox.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -491,9 +492,8 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::PrintSel
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Viewing vector: " << static_cast<typename NumericTraits<VectorType>::PrintType>(m_ViewVector)
-     << std::endl;
-  os << indent << "Up Vector: " << static_cast<typename NumericTraits<VectorType>::PrintType>(m_UpVector) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Viewing vector", m_ViewVector);
+  print_helper::PrintNumericTrait(os, indent, "Up Vector", m_UpVector);
   os << indent << "Camera Center Point: " << m_CameraCenterPoint << std::endl;
   os << indent << "Focal  Point       : " << m_FocalPoint << std::endl;
   os << indent << "Focal Distance     : " << m_FocalDistance << std::endl;

--- a/Modules/Filtering/ImageIntensity/include/itkRescaleIntensityImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkRescaleIntensityImageFilter.hxx
@@ -30,6 +30,7 @@
 
 #include "itkMinimumMaximumImageCalculator.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -95,12 +96,8 @@ RescaleIntensityImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream &
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "Output Minimum: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(this->m_OutputMinimum)
-     << std::endl;
-  os << indent
-     << "Output Maximum: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(this->m_OutputMaximum)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Output Minimum", this->m_OutputMinimum);
+  print_helper::PrintNumericTrait(os, indent, "Output Maximum", this->m_OutputMaximum);
 }
 
 } // end namespace itk

--- a/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkVectorRescaleIntensityImageFilter.hxx
@@ -29,6 +29,7 @@
 #define itkVectorRescaleIntensityImageFilter_hxx
 
 #include "itkImageRegionConstIterator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -81,14 +82,10 @@ VectorRescaleIntensityImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ost
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Output Maximum Magnitude: "
-     << static_cast<typename NumericTraits<OutputRealType>::PrintType>(m_OutputMaximumMagnitude) << std::endl;
-  os << indent << "Input Maximum Magnitude: "
-     << static_cast<typename NumericTraits<InputRealType>::PrintType>(m_InputMaximumMagnitude) << std::endl;
-  os << indent << "Internal Scale : " << static_cast<typename NumericTraits<InputRealType>::PrintType>(m_Scale)
-     << std::endl;
-  os << indent << "Internal Shift : " << static_cast<typename NumericTraits<InputRealType>::PrintType>(m_Shift)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Output Maximum Magnitude", m_OutputMaximumMagnitude);
+  print_helper::PrintNumericTrait(os, indent, "Input Maximum Magnitude", m_InputMaximumMagnitude);
+  print_helper::PrintNumericTrait(os, indent, "Internal Scale ", m_Scale);
+  print_helper::PrintNumericTrait(os, indent, "Internal Shift ", m_Shift);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.hxx
+++ b/Modules/Filtering/ImageLabel/include/itkBinaryContourImageFilter.hxx
@@ -25,6 +25,7 @@
 #include "itkConnectedComponentAlgorithm.h"
 #include "itkProgressTransformer.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -247,12 +248,8 @@ BinaryContourImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "ForegroundValue: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_ForegroundValue);
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageLabel/include/itkLabelContourImageFilter.hxx
+++ b/Modules/Filtering/ImageLabel/include/itkLabelContourImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkImageScanlineIterator.h"
 #include "itkConnectedComponentAlgorithm.h"
 #include "itkProgressTransformer.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -219,9 +220,7 @@ LabelContourImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os,
   Superclass::PrintSelf(os, indent);
 
   os << indent << "FullyConnected: " << this->m_FullyConnected << std::endl;
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
 }
 
 } // end namespace itk

--- a/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkImageScanlineIterator.h"
 #include "itkTotalProgressReporter.h"
 #include "itkNormalVariateGenerator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -87,9 +88,8 @@ AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostr
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Mean: " << static_cast<NumericTraits<double>::PrintType>(m_Mean) << std::endl;
-  os << indent << "StandardDeviation: " << static_cast<NumericTraits<double>::PrintType>(m_StandardDeviation)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Mean", m_Mean);
+  print_helper::PrintNumericTrait(os, indent, "StandardDeviation", m_StandardDeviation);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.hxx
@@ -19,6 +19,7 @@
 #define itkNoiseBaseImageFilter_hxx
 
 #include <ctime>
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -70,7 +71,7 @@ NoiseBaseImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, In
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Seed: " << static_cast<NumericTraits<uint32_t>::PrintType>(m_Seed) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Seed", m_Seed);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSaltAndPepperNoiseImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkImageScanlineIterator.h"
 #include "itkTotalProgressReporter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -102,7 +103,7 @@ SaltAndPepperNoiseImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Probability: " << static_cast<NumericTraits<double>::PrintType>(m_Probability) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Probability", m_Probability);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
@@ -23,6 +23,7 @@
 #include "itkImageScanlineIterator.h"
 #include "itkTotalProgressReporter.h"
 #include "itkNormalVariateGenerator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -113,7 +114,7 @@ ShotNoiseImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, In
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Scale: " << static_cast<NumericTraits<double>::PrintType>(m_Scale) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Scale", m_Scale);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 #include "itkImageScanlineIterator.h"
 #include "itkTotalProgressReporter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -122,8 +123,7 @@ SpeckleNoiseImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os,
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "StandardDeviation: " << static_cast<NumericTraits<double>::PrintType>(m_StandardDeviation)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "StandardDeviation", m_StandardDeviation);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageSources/include/itkGenerateImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGenerateImageSource.hxx
@@ -20,6 +20,7 @@
 #define itkGenerateImageSource_hxx
 
 
+#include "itkPrintHelper.h"
 namespace itk
 {
 template <typename TOutputImage>
@@ -96,11 +97,10 @@ GenerateImageSource<TOutputImage>::PrintSelf(std::ostream & os, Indent indent) c
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Size: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_Size) << std::endl;
-  os << indent << "Spacing: " << static_cast<typename NumericTraits<SpacingType>::PrintType>(m_Spacing) << std::endl;
-  os << indent << "Origin: " << static_cast<typename NumericTraits<PointType>::PrintType>(m_Origin) << std::endl;
-  os << indent << "Direction: " << static_cast<typename NumericTraits<DirectionType>::PrintType>(m_Direction)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Size", m_Size);
+  print_helper::PrintNumericTrait(os, indent, "Spacing", m_Spacing);
+  print_helper::PrintNumericTrait(os, indent, "Origin", m_Origin);
+  print_helper::PrintNumericTrait(os, indent, "Direction", m_Direction);
   os << indent << "UseReferenceImage: " << this->GetUseReferenceImage() << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/ImageStatistics/include/itkAdaptiveHistogramEqualizationImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkAdaptiveHistogramEqualizationImageFilter.hxx
@@ -27,6 +27,7 @@
 #include "itkNeighborhoodAlgorithm.h"
 #include "itkProgressReporter.h"
 #include "itkMinimumMaximumImageFilter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -60,10 +61,8 @@ AdaptiveHistogramEqualizationImageFilter<TImageType, TKernel>::PrintSelf(std::os
   os << indent << "Alpha: " << m_Alpha << std::endl;
   os << indent << "Beta: " << m_Beta << std::endl;
 
-  os << indent << "InputMinimum: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_InputMinimum)
-     << std::endl;
-  os << indent << "InputMaximum: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_InputMaximum)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "InputMinimum", m_InputMinimum);
+  print_helper::PrintNumericTrait(os, indent, "InputMaximum", m_InputMaximum);
 
   itkPrintSelfBooleanMacro(UseLookupTable);
 }

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCADecompositionCalculator.hxx
@@ -143,13 +143,13 @@ ImagePCADecompositionCalculator<TInputImage, TBasisImage>::PrintSelf(std::ostrea
 
   itkPrintSelfObjectMacro(MeanImage);
 
-  os << indent << "m_Size: " << static_cast<typename NumericTraits<BasisSizeType>::PrintType>(m_Size) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "m_Size", m_Size);
 
   itkPrintSelfObjectMacro(Image);
 
   os << indent << "BasisMatrix: " << m_BasisMatrix << std::endl;
   itkPrintSelfBooleanMacro(BasisMatrixCalculated);
-  os << indent << "NumPixels: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumPixels) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumPixels", m_NumPixels);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
@@ -45,8 +45,7 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::PrintSelf(std::ostream &
   os << indent << "EigenVectors: " << m_EigenVectors << std::endl;
   os << indent << "EigenValues: " << m_EigenValues << std::endl;
   os << indent << "EigenVectorNormalizedEnergy: " << m_EigenVectorNormalizedEnergy << std::endl;
-  os << indent << "InputImageSize: " << static_cast<typename NumericTraits<ImageSizeType>::PrintType>(m_InputImageSize)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "InputImageSize", m_InputImageSize);
   os << indent << "NumberOfPixels: " << m_NumberOfPixels << std::endl;
   os << indent << "NumberOfTrainingImages: " << m_NumberOfTrainingImages << std::endl;
   os << indent << "NumberOfPrincipalComponentsRequired: " << m_NumberOfPrincipalComponentsRequired << std::endl;

--- a/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelStatisticsImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkImageScanlineConstIterator.h"
 #include "itkTotalProgressReporter.h"
 #include <algorithm> // For min and max.
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -471,8 +472,8 @@ LabelStatisticsImageFilter<TImage, TLabelImage>::PrintSelf(std::ostream & os, In
   os << indent << "ValidLabelValues: " << m_ValidLabelValues << std::endl;
   itkPrintSelfBooleanMacro(UseHistograms);
   os << indent << "NumBins: " << m_NumBins << std::endl;
-  os << indent << "LowerBound: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_LowerBound) << std::endl;
-  os << indent << "UpperBound: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_UpperBound) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "LowerBound", m_LowerBound);
+  print_helper::PrintNumericTrait(os, indent, "UpperBound", m_UpperBound);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/ImageStatistics/include/itkMinimumMaximumImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkMinimumMaximumImageFilter.hxx
@@ -23,6 +23,7 @@
 #include <mutex>
 
 #include <vector>
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -123,10 +124,8 @@ MinimumMaximumImageFilter<TImage>::PrintSelf(std::ostream & os, Indent indent) c
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Minimum: " << static_cast<typename NumericTraits<PixelType>::PrintType>(this->GetMinimum())
-     << std::endl;
-  os << indent << "Maximum: " << static_cast<typename NumericTraits<PixelType>::PrintType>(this->GetMaximum())
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Minimum", this->GetMinimum());
+  print_helper::PrintNumericTrait(os, indent, "Maximum", this->GetMaximum());
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkStatisticsImageFilter.hxx
@@ -21,6 +21,7 @@
 
 #include "itkImageScanlineIterator.h"
 #include <mutex>
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -139,11 +140,9 @@ StatisticsImageFilter<TImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Count: " << static_cast<NumericTraits<SizeValueType>::PrintType>(this->m_Count) << std::endl;
-  os << indent << "Minimum: " << static_cast<typename NumericTraits<PixelType>::PrintType>(this->GetMinimum())
-     << std::endl;
-  os << indent << "Maximum: " << static_cast<typename NumericTraits<PixelType>::PrintType>(this->GetMaximum())
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Count", this->m_Count);
+  print_helper::PrintNumericTrait(os, indent, "Minimum", this->GetMinimum());
+  print_helper::PrintNumericTrait(os, indent, "Maximum", this->GetMaximum());
   os << indent << "Sum: " << this->GetSum() << std::endl;
   os << indent << "Mean: " << this->GetMean() << std::endl;
   os << indent << "Sigma: " << this->GetSigma() << std::endl;

--- a/Modules/Filtering/LabelMap/include/itkAttributeOpeningLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAttributeOpeningLabelMapFilter.hxx
@@ -19,6 +19,7 @@
 #define itkAttributeOpeningLabelMapFilter_hxx
 
 #include "itkProgressReporter.h"
+#include "itkPrintHelper.h"
 
 
 namespace itk
@@ -83,8 +84,7 @@ AttributeOpeningLabelMapFilter<TImage, TAttributeAccessor>::PrintSelf(std::ostre
   Superclass::PrintSelf(os, indent);
 
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
-  os << indent << "Lambda: " << static_cast<typename NumericTraits<AttributeValueType>::PrintType>(m_Lambda)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Lambda", m_Lambda);
 }
 
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkBinaryFillholeImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryFillholeImageFilter.hxx
@@ -23,6 +23,7 @@
 #include "itkShapeOpeningLabelMapFilter.h"
 #include "itkLabelMapMaskImageFilter.h"
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -129,9 +130,7 @@ BinaryFillholeImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent inde
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "ForegroundValue: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_ForegroundValue);
   itkPrintSelfBooleanMacro(FullyConnected);
 }
 

--- a/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryGrindPeakImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkShapeOpeningLabelMapFilter.h"
 #include "itkLabelMapToBinaryImageFilter.h"
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -103,12 +104,8 @@ BinaryGrindPeakImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent ind
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "ForegroundValue: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_ForegroundValue);
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
   itkPrintSelfBooleanMacro(FullyConnected);
 }
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.hxx
@@ -24,6 +24,7 @@
 #include "itkConnectedComponentAlgorithm.h"
 #include "itkProgressReporter.h"
 #include "itkProgressTransformer.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -202,11 +203,8 @@ BinaryImageToLabelMapFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream &
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "InputForegroundValue: "
-     << static_cast<typename NumericTraits<InputPixelType>::PrintType>(this->m_InputForegroundValue) << std::endl;
-  os << indent << "OutputBackgroundValue: "
-     << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(this->m_OutputBackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "InputForegroundValue", this->m_InputForegroundValue);
+  print_helper::PrintNumericTrait(os, indent, "OutputBackgroundValue", this->m_OutputBackgroundValue);
   os << indent << "Number of Objects: " << this->m_NumberOfObjects << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToShapeLabelMapFilter.hxx
@@ -19,6 +19,7 @@
 #define itkBinaryImageToShapeLabelMapFilter_hxx
 
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -91,10 +92,8 @@ BinaryImageToShapeLabelMapFilter<TInputImage, TOutputImage>::PrintSelf(std::ostr
   Superclass::PrintSelf(os, indent);
 
   itkPrintSelfBooleanMacro(FullyConnected);
-  os << indent << "BackgroundValue: "
-     << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_OutputBackgroundValue) << std::endl;
-  os << indent << "ForegroundValue: "
-     << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_InputForegroundValue) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_OutputBackgroundValue);
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_InputForegroundValue);
   os << indent << "ComputeFeretDiameter: " << m_ComputeFeretDiameter << std::endl;
   os << indent << "ComputePerimeter: " << m_ComputePerimeter << std::endl;
   os << indent << "ComputeOrientedBoundingBox: " << m_ComputeOrientedBoundingBox << std::endl;

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToStatisticsLabelMapFilter.hxx
@@ -19,6 +19,7 @@
 #define itkBinaryImageToStatisticsLabelMapFilter_hxx
 
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -99,10 +100,8 @@ BinaryImageToStatisticsLabelMapFilter<TInputImage, TFeatureImage, TOutputImage>:
   Superclass::PrintSelf(os, indent);
 
   itkPrintSelfBooleanMacro(FullyConnected);
-  os << indent << "OutputBackgroundValue: "
-     << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_OutputBackgroundValue) << std::endl;
-  os << indent << "InputForegroundValue: "
-     << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_InputForegroundValue) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "OutputBackgroundValue", m_OutputBackgroundValue);
+  print_helper::PrintNumericTrait(os, indent, "InputForegroundValue", m_InputForegroundValue);
   os << indent << "ComputeFeretDiameter: " << m_ComputeFeretDiameter << std::endl;
   os << indent << "ComputePerimeter: " << m_ComputePerimeter << std::endl;
   os << indent << "ComputeHistogram: " << m_ComputeHistogram << std::endl;

--- a/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByDilationImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByDilationImageFilter.hxx
@@ -19,6 +19,7 @@
 #define itkBinaryReconstructionByDilationImageFilter_hxx
 
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 
 namespace itk
@@ -116,12 +117,8 @@ BinaryReconstructionByDilationImageFilter<TInputImage>::PrintSelf(std::ostream &
   Superclass::PrintSelf(os, indent);
 
   itkPrintSelfBooleanMacro(FullyConnected);
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
-  os << indent
-     << "ForegroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_ForegroundValue);
 }
 
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByErosionImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryReconstructionByErosionImageFilter.hxx
@@ -19,6 +19,7 @@
 #define itkBinaryReconstructionByErosionImageFilter_hxx
 
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 
 namespace itk
@@ -132,12 +133,8 @@ BinaryReconstructionByErosionImageFilter<TInputImage>::PrintSelf(std::ostream & 
   Superclass::PrintSelf(os, indent);
 
   itkPrintSelfBooleanMacro(FullyConnected);
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
-  os << indent
-     << "ForegroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_ForegroundValue);
 }
 
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkBinaryReconstructionLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryReconstructionLabelMapFilter.hxx
@@ -19,6 +19,7 @@
 #define itkBinaryReconstructionLabelMapFilter_hxx
 
 #include "itkProgressReporter.h"
+#include "itkPrintHelper.h"
 
 
 namespace itk
@@ -67,9 +68,7 @@ BinaryReconstructionLabelMapFilter<TImage, TMarkerImage, TAttributeAccessor>::Pr
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "ForegroundValue: " << static_cast<typename NumericTraits<MarkerImagePixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_ForegroundValue);
 }
 
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkBinaryShapeKeepNObjectsImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryShapeKeepNObjectsImageFilter.hxx
@@ -19,6 +19,7 @@
 #define itkBinaryShapeKeepNObjectsImageFilter_hxx
 
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -112,12 +113,8 @@ BinaryShapeKeepNObjectsImageFilter<TInputImage>::PrintSelf(std::ostream & os, In
   Superclass::PrintSelf(os, indent);
 
   itkPrintSelfBooleanMacro(FullyConnected);
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
-  os << indent
-     << "ForegroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_ForegroundValue);
   os << indent << "NumberOfObjects: " << m_NumberOfObjects << std::endl;
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
   os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'

--- a/Modules/Filtering/LabelMap/include/itkBinaryShapeOpeningImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryShapeOpeningImageFilter.hxx
@@ -19,6 +19,7 @@
 #define itkBinaryShapeOpeningImageFilter_hxx
 
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -112,12 +113,8 @@ BinaryShapeOpeningImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent 
   Superclass::PrintSelf(os, indent);
 
   itkPrintSelfBooleanMacro(FullyConnected);
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
-  os << indent
-     << "ForegroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_ForegroundValue);
   os << indent << "Lambda: " << m_Lambda << std::endl;
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
   os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'

--- a/Modules/Filtering/LabelMap/include/itkBinaryStatisticsKeepNObjectsImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryStatisticsKeepNObjectsImageFilter.hxx
@@ -19,6 +19,7 @@
 #define itkBinaryStatisticsKeepNObjectsImageFilter_hxx
 
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -116,12 +117,8 @@ BinaryStatisticsKeepNObjectsImageFilter<TInputImage, TFeatureImage>::PrintSelf(s
   Superclass::PrintSelf(os, indent);
 
   itkPrintSelfBooleanMacro(FullyConnected);
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
-  os << indent
-     << "ForegroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_ForegroundValue);
   os << indent << "NumberOfObjects: " << m_NumberOfObjects << std::endl;
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
   os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'

--- a/Modules/Filtering/LabelMap/include/itkBinaryStatisticsOpeningImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryStatisticsOpeningImageFilter.hxx
@@ -19,6 +19,7 @@
 #define itkBinaryStatisticsOpeningImageFilter_hxx
 
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -116,12 +117,8 @@ BinaryStatisticsOpeningImageFilter<TInputImage, TFeatureImage>::PrintSelf(std::o
   Superclass::PrintSelf(os, indent);
 
   itkPrintSelfBooleanMacro(FullyConnected);
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
-  os << indent
-     << "ForegroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_ForegroundValue);
   os << indent << "Lambda: " << m_Lambda << std::endl;
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
   os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToLabelMapFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkNumericTraits.h"
 #include "itkTotalProgressReporter.h"
 #include "itkImageLinearConstIteratorWithIndex.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -165,9 +166,7 @@ LabelImageToLabelMapFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToShapeLabelMapFilter.hxx
@@ -19,6 +19,7 @@
 #define itkLabelImageToShapeLabelMapFilter_hxx
 
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -87,9 +88,7 @@ LabelImageToShapeLabelMapFilter<TInputImage, TOutputImage>::PrintSelf(std::ostre
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
   os << indent << "ComputeFeretDiameter: " << m_ComputeFeretDiameter << std::endl;
   os << indent << "ComputePerimeter: " << m_ComputePerimeter << std::endl;
   os << indent << "ComputeOrientedBoundingBox: " << m_ComputeOrientedBoundingBox << std::endl;

--- a/Modules/Filtering/LabelMap/include/itkLabelImageToStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelImageToStatisticsLabelMapFilter.hxx
@@ -19,6 +19,7 @@
 #define itkLabelImageToStatisticsLabelMapFilter_hxx
 
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -95,9 +96,7 @@ LabelImageToStatisticsLabelMapFilter<TInputImage, TFeatureImage, TOutputImage>::
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
   os << indent << "ComputeFeretDiameter: " << m_ComputeFeretDiameter << std::endl;
   os << indent << "ComputePerimeter: " << m_ComputePerimeter << std::endl;
   os << indent << "ComputeHistogram: " << m_ComputeHistogram << std::endl;

--- a/Modules/Filtering/LabelMap/include/itkLabelMap.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMap.hxx
@@ -31,6 +31,7 @@
 #include "itkProcessObject.h"
 
 #include <algorithm>
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -41,8 +42,7 @@ LabelMap<TLabelObject>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "BackgroundValue: " << static_cast<typename NumericTraits<LabelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
   os << indent << "LabelObjectContainer: " << &m_LabelObjectContainer << std::endl;
 }
 

--- a/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.hxx
@@ -23,6 +23,7 @@
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageAlgorithm.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -380,14 +381,12 @@ LabelMapMaskImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os,
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Label: " << static_cast<typename NumericTraits<LabelType>::PrintType>(m_Label) << std::endl;
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Label", m_Label);
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
   os << indent << "Negated: " << m_Negated << std::endl;
   os << indent << "Crop: " << m_Crop << std::endl;
   os << indent << "CropBorder: " << m_CropBorder << std::endl;
-  os << indent << "CropTimeStamp: " << static_cast<NumericTraits<TimeStamp>::PrintType>(m_CropTimeStamp) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "CropTimeStamp", m_CropTimeStamp);
 }
 
 

--- a/Modules/Filtering/LabelMap/include/itkLabelMapToAttributeImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapToAttributeImageFilter.hxx
@@ -20,6 +20,7 @@
 
 #include "itkNumericTraits.h"
 #include "itkProgressReporter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -94,9 +95,7 @@ LabelMapToAttributeImageFilter<TInputImage, TOutputImage, TAttributeAccessor>::P
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
 }
 
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkLabelMapToBinaryImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapToBinaryImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkProgressReporter.h"
 #include "itkImageRegionIterator.h"
 #include "itkProgressTransformer.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -148,10 +149,8 @@ LabelMapToBinaryImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream &
 {
   this->Superclass::PrintSelf(os, indent);
 
-  os << indent << "ForegroundValue: "
-     << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(this->m_ForegroundValue) << std::endl;
-  os << indent << "BackgroundValue: "
-     << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(this->m_BackgroundValue) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", this->m_ForegroundValue);
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", this->m_BackgroundValue);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelObject.hxx
@@ -21,6 +21,7 @@
 #include "itkLabelObjectLineComparator.h"
 #include "itkMath.h"
 #include <algorithm>
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -384,7 +385,7 @@ LabelObject<TLabel, VImageDimension>::PrintSelf(std::ostream & os, Indent indent
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "LineContainer: " << &m_LineContainer << std::endl;
-  os << indent << "Label: " << static_cast<typename NumericTraits<LabelType>::PrintType>(m_Label) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Label", m_Label);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/LabelMap/include/itkLabelShapeKeepNObjectsImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelShapeKeepNObjectsImageFilter.hxx
@@ -19,6 +19,7 @@
 #define itkLabelShapeKeepNObjectsImageFilter_hxx
 
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -107,9 +108,7 @@ LabelShapeKeepNObjectsImageFilter<TInputImage>::PrintSelf(std::ostream & os, Ind
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
   os << indent << "NumberOfObjects: " << m_NumberOfObjects << std::endl;
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
   os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'

--- a/Modules/Filtering/LabelMap/include/itkLabelShapeOpeningImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelShapeOpeningImageFilter.hxx
@@ -19,6 +19,7 @@
 #define itkLabelShapeOpeningImageFilter_hxx
 
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -106,9 +107,7 @@ LabelShapeOpeningImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent i
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
   os << indent << "Lambda: " << m_Lambda << std::endl;
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
   os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'

--- a/Modules/Filtering/LabelMap/include/itkLabelStatisticsKeepNObjectsImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelStatisticsKeepNObjectsImageFilter.hxx
@@ -19,6 +19,7 @@
 #define itkLabelStatisticsKeepNObjectsImageFilter_hxx
 
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -111,9 +112,7 @@ LabelStatisticsKeepNObjectsImageFilter<TInputImage, TFeatureImage>::PrintSelf(st
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
   os << indent << "NumberOfObjects: " << m_NumberOfObjects << std::endl;
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
   os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'

--- a/Modules/Filtering/LabelMap/include/itkLabelStatisticsOpeningImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelStatisticsOpeningImageFilter.hxx
@@ -19,6 +19,7 @@
 #define itkLabelStatisticsOpeningImageFilter_hxx
 
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -110,9 +111,7 @@ LabelStatisticsOpeningImageFilter<TInputImage, TFeatureImage>::PrintSelf(std::os
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
   os << indent << "Lambda: " << m_Lambda << std::endl;
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
   os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'

--- a/Modules/Filtering/LabelMap/include/itkObjectByObjectLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkObjectByObjectLabelMapFilter.hxx
@@ -28,6 +28,7 @@
 #include "itkLabelMapToLabelImageFilter.h"
 #include "itkLabelSelectionLabelMapFilter.h"
 #include "itkAutoCropLabelMapFilter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -336,12 +337,10 @@ ObjectByObjectLabelMapFilter<TInputImage,
   os << indent << "PadSize: " << m_PadSize << std::endl;
   os << indent << "BinaryInternalOutput: " << m_BinaryInternalOutput << std::endl;
   os << indent << "KeepLabels: " << m_KeepLabels << std::endl;
-  os << indent << "InternalForegroundValue: "
-     << static_cast<typename NumericTraits<InternalOutputPixelType>::PrintType>(m_InternalForegroundValue) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "InternalForegroundValue", m_InternalForegroundValue);
   os << indent << "InputFilter: " << m_InputFilter << std::endl;
   os << indent << "OutputFilter: " << m_OutputFilter << std::endl;
-  os << indent << "Label: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Label)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Label", m_Label);
 }
 
 } // end namespace itk

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelObject.h
@@ -22,6 +22,7 @@
 #include "itkLabelMap.h"
 #include "itkMath.h"
 #include "itkAffineTransform.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -733,14 +734,10 @@ protected:
     Superclass::PrintSelf(os, indent);
 
     os << indent << "BoundingBox: " << m_BoundingBox << std::endl;
-    os << indent << "NumberOfPixels: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixels)
-       << std::endl;
+    print_helper::PrintNumericTrait(os, indent, "NumberOfPixels", m_NumberOfPixels);
     os << indent << "PhysicalSize: " << m_PhysicalSize << std::endl;
-    os << indent << "Centroid: " << static_cast<typename NumericTraits<CentroidType>::PrintType>(m_Centroid)
-       << std::endl;
-    os << indent
-       << "NumberOfPixelsOnBorder: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsOnBorder)
-       << std::endl;
+    print_helper::PrintNumericTrait(os, indent, "Centroid", m_Centroid);
+    print_helper::PrintNumericTrait(os, indent, "NumberOfPixelsOnBorder", m_NumberOfPixelsOnBorder);
     os << indent << "PerimeterOnBorder: " << m_PerimeterOnBorder << std::endl;
     os << indent << "FeretDiameter: " << m_FeretDiameter << std::endl;
     os << indent << "PrincipalMoments: " << m_PrincipalMoments << std::endl;
@@ -753,12 +750,8 @@ protected:
     os << indent << "EquivalentEllipsoidDiameter: " << m_EquivalentEllipsoidDiameter << std::endl;
     os << indent << "Flatness: " << m_Flatness << std::endl;
     os << indent << "PerimeterOnBorderRatio: " << m_PerimeterOnBorderRatio << std::endl;
-    os << indent << "OrientedBoundingBoxSize: "
-       << static_cast<typename NumericTraits<OrientedBoundingBoxSizeType>::PrintType>(m_OrientedBoundingBoxSize)
-       << std::endl;
-    os << indent << "OrientedBoundingBoxOrigin: "
-       << static_cast<typename NumericTraits<OrientedBoundingBoxPointType>::PrintType>(m_OrientedBoundingBoxOrigin)
-       << std::endl;
+    print_helper::PrintNumericTrait(os, indent, "OrientedBoundingBoxSize", m_OrientedBoundingBoxSize);
+    print_helper::PrintNumericTrait(os, indent, "OrientedBoundingBoxOrigin", m_OrientedBoundingBoxOrigin);
   }
 
 private:

--- a/Modules/Filtering/LabelMap/include/itkShapeRelabelImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeRelabelImageFilter.hxx
@@ -19,6 +19,7 @@
 #define itkShapeRelabelImageFilter_hxx
 
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -106,9 +107,7 @@ ShapeRelabelImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent indent
   Superclass::PrintSelf(os, indent);
 
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
   os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'
      << std::endl;
 }

--- a/Modules/Filtering/LabelMap/include/itkStatisticsRelabelImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsRelabelImageFilter.hxx
@@ -19,6 +19,7 @@
 #define itkStatisticsRelabelImageFilter_hxx
 
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -110,9 +111,7 @@ StatisticsRelabelImageFilter<TInputImage, TFeatureImage>::PrintSelf(std::ostream
   Superclass::PrintSelf(os, indent);
 
   os << indent << "ReverseOrdering: " << m_ReverseOrdering << std::endl;
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
   os << indent << "Attribute: " << LabelObjectType::GetNameFromAttribute(m_Attribute) << " (" << m_Attribute << ')'
      << std::endl;
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenCloseImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkAnchorUtilities.h"
 #include "itkImageRegionIterator.h"
 #include "itkIndexRange.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -202,10 +203,8 @@ AnchorOpenCloseImageFilter<TImage, TKernel, TCompare1, TCompare2>::PrintSelf(std
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Boundary1: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Boundary1)
-     << std::endl;
-  os << indent << "Boundary2: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Boundary2)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Boundary1", m_Boundary1);
+  print_helper::PrintNumericTrait(os, indent, "Boundary2", m_Boundary2);
 }
 
 } // end namespace itk

--- a/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkDoubleThresholdImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkReconstructionByDilationImageFilter.h"
 #include "itkBinaryThresholdImageFilter.h"
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -116,18 +117,12 @@ DoubleThresholdImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Threshold1: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_Threshold1)
-     << std::endl;
-  os << indent << "Threshold2: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_Threshold2)
-     << std::endl;
-  os << indent << "Threshold3: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_Threshold3)
-     << std::endl;
-  os << indent << "Threshold4: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_Threshold4)
-     << std::endl;
-  os << indent << "InsideValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_InsideValue)
-     << std::endl;
-  os << indent << "OutsideValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_OutsideValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Threshold1", m_Threshold1);
+  print_helper::PrintNumericTrait(os, indent, "Threshold2", m_Threshold2);
+  print_helper::PrintNumericTrait(os, indent, "Threshold3", m_Threshold3);
+  print_helper::PrintNumericTrait(os, indent, "Threshold4", m_Threshold4);
+  print_helper::PrintNumericTrait(os, indent, "InsideValue", m_InsideValue);
+  print_helper::PrintNumericTrait(os, indent, "OutsideValue", m_OutsideValue);
   os << indent << "NumberOfIterationsUsed: " << m_NumberOfIterationsUsed << std::endl;
   itkPrintSelfBooleanMacro(FullyConnected);
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleDilateImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkNumericTraits.h"
 #include "itkProgressAccumulator.h"
 #include <string>
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -215,7 +216,7 @@ GrayscaleDilateImageFilter<TInputImage, TOutputImage, TKernel>::PrintSelf(std::o
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Boundary: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_Boundary) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Boundary", m_Boundary);
   os << indent << "Algorithm: " << m_Algorithm << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleErodeImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkNumericTraits.h"
 #include "itkProgressAccumulator.h"
 #include <string>
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -215,7 +216,7 @@ GrayscaleErodeImageFilter<TInputImage, TOutputImage, TKernel>::PrintSelf(std::os
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Boundary: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_Boundary) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Boundary", m_Boundary);
   os << indent << "Algorithm: " << m_Algorithm << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConcaveImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkHMinimaImageFilter.h"
 #include "itkSubtractImageFilter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -94,8 +95,7 @@ HConcaveImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Ind
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Depth of local minima (contrast): "
-     << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Height) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Depth of local minima (contrast)", m_Height);
   os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
   itkPrintSelfBooleanMacro(FullyConnected);
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHConvexImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkHMaximaImageFilter.h"
 #include "itkSubtractImageFilter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -95,8 +96,7 @@ HConvexImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inde
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Height of local maxima (contrast): "
-     << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Height) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Height of local maxima (contrast)", m_Height);
   os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
   itkPrintSelfBooleanMacro(FullyConnected);
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMaximaImageFilter.hxx
@@ -23,6 +23,7 @@
 #include "itkCastImageFilter.h"
 #include "itkProgressAccumulator.h"
 #include "itkReconstructionByDilationImageFilter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -103,8 +104,7 @@ HMaximaImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inde
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Height of local maxima (contrast): "
-     << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Height) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Height of local maxima (contrast)", m_Height);
   os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
   itkPrintSelfBooleanMacro(FullyConnected);
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkHMinimaImageFilter.hxx
@@ -23,6 +23,7 @@
 #include "itkShiftScaleImageFilter.h"
 #include "itkCastImageFilter.h"
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -103,8 +104,7 @@ HMinimaImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inde
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Depth of local maxima (contrast): "
-     << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Height) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Depth of local maxima (contrast)", m_Height);
   os << indent << "Number of iterations used to produce current output: " << m_NumberOfIterationsUsed << std::endl;
   itkPrintSelfBooleanMacro(FullyConnected);
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMaskedMovingHistogramImageFilter.hxx
@@ -25,6 +25,7 @@
 
 #include "itkImageRegionIterator.h"
 #include "itkImageLinearConstIteratorWithIndex.h"
+#include "itkPrintHelper.h"
 
 /*
  *
@@ -356,13 +357,9 @@ MaskedMovingHistogramImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel,
   Superclass::PrintSelf(os, indent);
 
   os << indent << "GenerateOutputMask: " << m_GenerateOutputMask << std::endl;
-  os << indent << "FillValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_FillValue)
-     << std::endl;
-  os << indent << "MaskValue: " << static_cast<typename NumericTraits<MaskPixelType>::PrintType>(m_MaskValue)
-     << std::endl;
-  os << indent
-     << "BackgroundMaskValue: " << static_cast<typename NumericTraits<MaskPixelType>::PrintType>(m_BackgroundMaskValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "FillValue", m_FillValue);
+  print_helper::PrintNumericTrait(os, indent, "MaskValue", m_MaskValue);
+  print_helper::PrintNumericTrait(os, indent, "BackgroundMaskValue", m_BackgroundMaskValue);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkMaskedRankImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkMaskedRankImageFilter.hxx
@@ -26,6 +26,7 @@
 
 #include <iomanip>
 #include <sstream>
+#include "itkPrintHelper.h"
 
 /*
  *
@@ -57,7 +58,7 @@ MaskedRankImageFilter<TInputImage, TMaskImage, TOutputImage, TKernel>::PrintSelf
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Rank: " << static_cast<NumericTraits<float>::PrintType>(m_Rank) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Rank", m_Rank);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkRankImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRankImageFilter.hxx
@@ -26,6 +26,7 @@
 
 #include <iomanip>
 #include <sstream>
+#include "itkPrintHelper.h"
 
 /*
  *
@@ -56,7 +57,7 @@ RankImageFilter<TInputImage, TOutputImage, TKernel>::PrintSelf(std::ostream & os
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Rank: " << static_cast<NumericTraits<float>::PrintType>(m_Rank) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Rank", m_Rank);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMaximaImageFilter.hxx
@@ -24,6 +24,7 @@
 #include "itkBinaryThresholdImageFilter.h"
 #include "itkProgressReporter.h"
 #include "itkImageRegionIterator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -131,12 +132,8 @@ RegionalMaximaImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & o
 
   itkPrintSelfBooleanMacro(FullyConnected);
   os << indent << "FlatIsMaxima: " << m_FlatIsMaxima << std::endl;
-  os << indent
-     << "ForegroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_ForegroundValue);
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
 }
 
 } // end namespace itk

--- a/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkRegionalMinimaImageFilter.hxx
@@ -24,6 +24,7 @@
 #include "itkBinaryThresholdImageFilter.h"
 #include "itkProgressReporter.h"
 #include "itkImageRegionIterator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -134,12 +135,8 @@ RegionalMinimaImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & o
 
   itkPrintSelfBooleanMacro(FullyConnected);
   os << indent << "FlatIsMinima: " << m_FlatIsMinima << std::endl;
-  os << indent
-     << "ForegroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
-  os << indent
-     << "BackgroundValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_ForegroundValue);
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
 }
 
 } // end namespace itk

--- a/Modules/Filtering/Path/include/itkChainCodePath.hxx
+++ b/Modules/Filtering/Path/include/itkChainCodePath.hxx
@@ -95,7 +95,7 @@ ChainCodePath<VDimension>::PrintSelf(std::ostream & os, Indent indent) const
 
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Start: " << static_cast<typename NumericTraits<IndexType>::PrintType>(m_Start) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Start", m_Start);
   os << indent << "Chain: " << m_Chain << std::endl;
 }
 } // end namespace itk

--- a/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkExtractOrthogonalSwath2DImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkProgressReporter.h"
 #include "itkNumericTraits.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -173,9 +174,7 @@ ExtractOrthogonalSwath2DImageFilter<TImage>::PrintSelf(std::ostream & os, Indent
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Size:  " << m_Size << std::endl;
-  os << indent
-     << "DefaultPixelValue:  " << static_cast<typename NumericTraits<ImagePixelType>::PrintType>(m_DefaultPixelValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "DefaultPixelValue:  ", m_DefaultPixelValue);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkOrthogonalSwath2DPathFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkMakeUniqueForOverwrite.h"
 #include "itkMath.h"
 #include "itkNumericTraits.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -198,7 +199,7 @@ OrthogonalSwath2DPathFilter<TParametricPath, TSwathMeritImage>::PrintSelf(std::o
 
   itkPrintSelfObjectMacro(FinalOffsetValues);
 
-  os << indent << "SwathSize: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_SwathSize) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "SwathSize", m_SwathSize);
 }
 
 // The next three functions are private helper functions

--- a/Modules/Filtering/Path/include/itkParametricPath.hxx
+++ b/Modules/Filtering/Path/include/itkParametricPath.hxx
@@ -19,6 +19,7 @@
 #define itkParametricPath_hxx
 
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -117,9 +118,7 @@ ParametricPath<VDimension>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "DefaultInputStepSize: " << static_cast<typename NumericTraits<InputType>::PrintType>(m_DefaultInputStepSize)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "DefaultInputStepSize", m_DefaultInputStepSize);
 }
 } // namespace itk
 

--- a/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathToImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkPathIterator.h"
 #include "itkNumericTraits.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -234,12 +235,11 @@ PathToImageFilter<TInputPath, TOutputImage>::PrintSelf(std::ostream & os, Indent
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Size: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_Size) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Size", m_Size);
   os << indent << "Spacing: " << m_Spacing << std::endl;
   os << indent << "Origin: " << m_Origin << std::endl;
-  os << indent << "PathValue : " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_PathValue) << std::endl;
-  os << indent << "BackgroundValue : " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "PathValue ", m_PathValue);
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue ", m_BackgroundValue);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/Thresholding/include/itkBinaryThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkBinaryThresholdImageFilter.hxx
@@ -29,6 +29,7 @@
 #define itkBinaryThresholdImageFilter_hxx
 
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -235,16 +236,10 @@ BinaryThresholdImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "OutsideValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_OutsideValue)
-     << std::endl;
-  os << indent << "InsideValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_InsideValue)
-     << std::endl;
-  os << indent
-     << "LowerThreshold: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(this->GetLowerThreshold())
-     << std::endl;
-  os << indent
-     << "UpperThreshold: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(this->GetUpperThreshold())
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "OutsideValue", m_OutsideValue);
+  print_helper::PrintNumericTrait(os, indent, "InsideValue", m_InsideValue);
+  print_helper::PrintNumericTrait(os, indent, "LowerThreshold", this->GetLowerThreshold());
+  print_helper::PrintNumericTrait(os, indent, "UpperThreshold", this->GetUpperThreshold());
 }
 } // end namespace itk
 

--- a/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkBinaryThresholdImageFilter.h"
 #include "itkMaskImageFilter.h"
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -151,15 +152,10 @@ HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::PrintSelf(
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "OutsideValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_OutsideValue)
-     << std::endl;
-  os << indent << "InsideValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_InsideValue)
-     << std::endl;
-  os << indent
-     << "Threshold (computed): " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_Threshold)
-     << std::endl;
-  os << indent << "MaskValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_MaskValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "OutsideValue", m_OutsideValue);
+  print_helper::PrintNumericTrait(os, indent, "InsideValue", m_InsideValue);
+  print_helper::PrintNumericTrait(os, indent, "Threshold (computed)", m_Threshold);
+  print_helper::PrintNumericTrait(os, indent, "MaskValue", m_MaskValue);
   itkPrintSelfObjectMacro(Calculator);
   os << indent << "NumberOfHistogramBins: " << m_NumberOfHistogramBins << std::endl;
   os << indent << "AutoMinimumMaximm: " << m_AutoMinimumMaximum << std::endl;

--- a/Modules/Filtering/Thresholding/include/itkHuangThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkHuangThresholdCalculator.hxx
@@ -21,6 +21,7 @@
 
 #include "itkMath.h"
 #include "itkProgressReporter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -154,11 +155,9 @@ HuangThresholdCalculator<THistogram, TOutput>::PrintSelf(std::ostream & os, Inde
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FirstBin: " << static_cast<typename itk::NumericTraits<InstanceIdentifier>::PrintType>(m_FirstBin)
-     << std::endl;
-  os << indent << "LastBin: " << static_cast<typename itk::NumericTraits<InstanceIdentifier>::PrintType>(m_LastBin)
-     << std::endl;
-  os << indent << "Size: " << static_cast<typename itk::NumericTraits<SizeValueType>::PrintType>(m_Size) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "FirstBin", m_FirstBin);
+  print_helper::PrintNumericTrait(os, indent, "LastBin", m_LastBin);
+  print_helper::PrintNumericTrait(os, indent, "Size", m_Size);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/Thresholding/include/itkIntermodesThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkIntermodesThresholdCalculator.hxx
@@ -19,6 +19,7 @@
 #define itkIntermodesThresholdCalculator_hxx
 
 #include "itkProgressReporter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -147,8 +148,7 @@ IntermodesThresholdCalculator<THistogram, TOutput>::PrintSelf(std::ostream & os,
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "MaximumSmoothingIterations: "
-     << static_cast<itk::NumericTraits<SizeValueType>::PrintType>(m_MaximumSmoothingIterations) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "MaximumSmoothingIterations", m_MaximumSmoothingIterations);
   os << indent << "UseInterMode: " << m_UseInterMode << std::endl;
 }
 

--- a/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageCalculator.hxx
@@ -20,6 +20,7 @@
 
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkImageRegionConstIterator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -121,8 +122,7 @@ KappaSigmaThresholdImageCalculator<TInputImage, TMaskImage>::PrintSelf(std::ostr
   os << indent << "SigmaFactor: " << this->m_SigmaFactor << std::endl;
   os << indent << "NumberOfIterations: " << this->m_NumberOfIterations << std::endl;
 
-  os << indent << "Output: " << static_cast<typename itk::NumericTraits<InputPixelType>::PrintType>(m_Output)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Output", m_Output);
 
   itkPrintSelfObjectMacro(Image);
   itkPrintSelfObjectMacro(Mask);

--- a/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkKappaSigmaThresholdImageFilter.hxx
@@ -20,6 +20,7 @@
 
 #include "itkBinaryThresholdImageFilter.h"
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -75,18 +76,12 @@ KappaSigmaThresholdImageFilter<TInputImage, TMaskImage, TOutputImage>::PrintSelf
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Threshold: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_Threshold)
-     << std::endl;
-  os << indent << "MaskValue: " << static_cast<typename NumericTraits<MaskPixelType>::PrintType>(m_MaskValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Threshold", m_Threshold);
+  print_helper::PrintNumericTrait(os, indent, "MaskValue", m_MaskValue);
   os << indent << "SigmaFactor: " << m_SigmaFactor << std::endl;
   os << indent << "NumberOfIterations: " << this->m_NumberOfIterations << std::endl;
-  os << indent
-     << "Inside value: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(this->m_InsideValue)
-     << std::endl;
-  os << indent
-     << "Outside value: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(this->m_OutsideValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Inside value", this->m_InsideValue);
+  print_helper::PrintNumericTrait(os, indent, "Outside value", this->m_OutsideValue);
 }
 } // end namespace itk
 #endif

--- a/Modules/Filtering/Thresholding/include/itkRenyiEntropyThresholdCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkRenyiEntropyThresholdCalculator.hxx
@@ -21,6 +21,7 @@
 
 #include "itkProgressReporter.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -325,11 +326,9 @@ RenyiEntropyThresholdCalculator<THistogram, TOutput>::PrintSelf(std::ostream & o
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FirstBin: " << static_cast<typename itk::NumericTraits<InstanceIdentifier>::PrintType>(m_FirstBin)
-     << std::endl;
-  os << indent << "LastBin: " << static_cast<typename itk::NumericTraits<InstanceIdentifier>::PrintType>(m_LastBin)
-     << std::endl;
-  os << indent << "Size: " << static_cast<typename itk::NumericTraits<SizeValueType>::PrintType>(m_Size) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "FirstBin", m_FirstBin);
+  print_helper::PrintNumericTrait(os, indent, "LastBin", m_LastBin);
+  print_helper::PrintNumericTrait(os, indent, "Size", m_Size);
 }
 } // end namespace itk
 

--- a/Modules/Filtering/Thresholding/include/itkThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkThresholdImageFilter.hxx
@@ -34,6 +34,7 @@
 #include "itkTotalProgressReporter.h"
 #include "itkMacro.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -136,10 +137,9 @@ ThresholdImageFilter<TImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "OutsideValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_OutsideValue)
-     << std::endl;
-  os << indent << "Lower: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_Lower) << std::endl;
-  os << indent << "Upper: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_Upper) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "OutsideValue", m_OutsideValue);
+  print_helper::PrintNumericTrait(os, indent, "Lower", m_Lower);
+  print_helper::PrintNumericTrait(os, indent, "Upper", m_Upper);
 }
 } // end namespace itk
 

--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
@@ -22,6 +22,7 @@
 #include "itksys/SystemTools.hxx"
 #include "itkMetaDataObject.h"
 #include "itkStringConvert.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -928,9 +929,7 @@ Bruker2dseqImageIO::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "OnDiskComponentType" << static_cast<NumericTraits<IOComponentEnum>::PrintType>(m_OnDiskComponentType)
-     << std::endl;
-  os << indent << "MachineByteOrder" << static_cast<NumericTraits<IOByteOrderEnum>::PrintType>(m_MachineByteOrder)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "OnDiskComponentType", m_OnDiskComponentType);
+  print_helper::PrintNumericTrait(os, indent, "MachineByteOrder", m_MachineByteOrder);
 }
 } // end namespace itk

--- a/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
+++ b/Modules/IO/MeshBYU/src/itkBYUMeshIO.cxx
@@ -21,6 +21,7 @@
 #include "itkBYUMeshIO.h"
 
 #include "itksys/SystemTools.hxx"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -503,8 +504,7 @@ BYUMeshIO::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "FilePosition: " << static_cast<NumericTraits<StreamOffsetType>::PrintType>(m_FilePosition)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "FilePosition", m_FilePosition);
   os << indent << "PartId: " << m_PartId << std::endl;
   os << indent << "First Cell Id: " << m_FirstCellId << std::endl;
   os << indent << "Last Cell Id: " << m_LastCellId << std::endl;

--- a/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkAttributeMorphologyBaseImageFilter.hxx
@@ -25,6 +25,7 @@
 #include "itkNeighborhoodAlgorithm.h"
 #include "itkCastImageFilter.h"
 #include "itkMakeUniqueForOverwrite.h"
+#include "itkPrintHelper.h"
 
 /*
  * This code was contributed in the Insight Journal paper
@@ -230,7 +231,7 @@ AttributeMorphologyBaseImageFilter<TInputImage, TOutputImage, TAttribute, TFunct
   Superclass::PrintSelf(os, indent);
 
   itkPrintSelfBooleanMacro(FullyConnected);
-  os << indent << "Lambda: " << static_cast<typename NumericTraits<AttributeType>::PrintType>(m_Lambda) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Lambda", m_Lambda);
 }
 } // end namespace itk
 

--- a/Modules/Nonunit/Review/include/itkGridForwardWarpImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkGridForwardWarpImageFilter.hxx
@@ -23,6 +23,7 @@
 #include "itkImageRegionConstIterator.h"
 #include "itkNumericTraits.h"
 #include "itkLineIterator.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -141,10 +142,8 @@ GridForwardWarpImageFilter<TDisplacementField, TOutputImage>::PrintSelf(std::ost
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "BackgroundValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
-  os << indent << "ForegroundValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
+  print_helper::PrintNumericTrait(os, indent, "ForegroundValue", m_ForegroundValue);
   os << indent << "GridPixSpacing: " << m_GridPixSpacing << std::endl;
 }
 } // end namespace itk

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
@@ -1347,19 +1347,13 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
   Superclass::PrintSelf(os, indent);
 
   os << indent << "ConstantGradientValue: " << m_ConstantGradientValue << std::endl;
-  os << indent << "ValueOne: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_ValueOne) << std::endl;
-  os << indent << "ValueZero: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_ValueZero) << std::endl;
-  os << indent << "StatusChanging: " << static_cast<typename NumericTraits<StatusType>::PrintType>(m_StatusChanging)
-     << std::endl;
-  os << indent << "StatusActiveChangingUp: "
-     << static_cast<typename NumericTraits<StatusType>::PrintType>(m_StatusActiveChangingUp) << std::endl;
-  os << indent << "StatusActiveChangingDown: "
-     << static_cast<typename NumericTraits<StatusType>::PrintType>(m_StatusActiveChangingDown) << std::endl;
-  os << indent
-     << "StatusBoundaryPixel: " << static_cast<typename NumericTraits<StatusType>::PrintType>(m_StatusBoundaryPixel)
-     << std::endl;
-  os << indent << "StatusNull: " << static_cast<typename NumericTraits<StatusType>::PrintType>(m_StatusNull)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ValueOne", m_ValueOne);
+  print_helper::PrintNumericTrait(os, indent, "ValueZero", m_ValueZero);
+  print_helper::PrintNumericTrait(os, indent, "StatusChanging", m_StatusChanging);
+  print_helper::PrintNumericTrait(os, indent, "StatusActiveChangingUp", m_StatusActiveChangingUp);
+  print_helper::PrintNumericTrait(os, indent, "StatusActiveChangingDown", m_StatusActiveChangingDown);
+  print_helper::PrintNumericTrait(os, indent, "StatusBoundaryPixel", m_StatusBoundaryPixel);
+  print_helper::PrintNumericTrait(os, indent, "StatusNull", m_StatusNull);
 
   os << indent << "SparseData: ";
   for (IdCellType i = 0; i < this->m_FunctionCount; ++i)
@@ -1395,10 +1389,8 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
   }
 
   os << indent << "NumberOfLayers: " << m_NumberOfLayers << std::endl;
-  os << indent << "IsoSurfaceValue: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_IsoSurfaceValue)
-     << std::endl;
-  os << indent << "BackgroundValue: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "IsoSurfaceValue", m_IsoSurfaceValue);
+  print_helper::PrintNumericTrait(os, indent, "BackgroundValue", m_BackgroundValue);
   os << indent << "InterpolateSurfaceLocation: " << m_InterpolateSurfaceLocation << std::endl;
   os << indent << "CurrentFunctionIndex: " << m_CurrentFunctionIndex << std::endl;
   os << indent << "RMSSum: " << m_RMSSum << std::endl;

--- a/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdCalculator.hxx
+++ b/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdCalculator.hxx
@@ -19,6 +19,7 @@
 #define itkRobustAutomaticThresholdCalculator_hxx
 
 #include "itkImageRegionConstIterator.h"
+#include "itkPrintHelper.h"
 
 
 namespace itk
@@ -76,7 +77,7 @@ RobustAutomaticThresholdCalculator<TInputImage, TGradientImage>::PrintSelf(std::
 
   os << indent << "Valid: " << m_Valid << std::endl;
   os << indent << "Pow: " << m_Pow << std::endl;
-  os << indent << "Output: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_Output) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Output", m_Output);
 
   itkPrintSelfObjectMacro(Input);
   itkPrintSelfObjectMacro(Gradient);

--- a/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkRobustAutomaticThresholdImageFilter.hxx
@@ -20,6 +20,7 @@
 
 #include "itkBinaryThresholdImageFilter.h"
 #include "itkProgressAccumulator.h"
+#include "itkPrintHelper.h"
 
 
 namespace itk
@@ -77,13 +78,10 @@ RobustAutomaticThresholdImageFilter<TInputImage, TGradientImage, TOutputImage>::
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Threshold: " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_Threshold)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Threshold", m_Threshold);
   os << indent << "Pow: " << m_Pow << std::endl;
-  os << indent << "OutsideValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_OutsideValue)
-     << std::endl;
-  os << indent << "InsideValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_InsideValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "OutsideValue", m_OutsideValue);
+  print_helper::PrintNumericTrait(os, indent, "InsideValue", m_InsideValue);
 }
 } // end namespace itk
 #endif

--- a/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.hxx
+++ b/Modules/Numerics/NarrowBand/include/itkNarrowBandImageFilterBase.hxx
@@ -19,6 +19,7 @@
 #define itkNarrowBandImageFilterBase_hxx
 
 #include "itkShiftScaleImageFilter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -289,8 +290,7 @@ void
 NarrowBandImageFilterBase<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "IsoSurfaceValue: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_IsoSurfaceValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "IsoSurfaceValue", m_IsoSurfaceValue);
 }
 } // end namespace itk
 

--- a/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkExhaustiveOptimizer.cxx
@@ -16,6 +16,7 @@
  *
  *=========================================================================*/
 #include "itkExhaustiveOptimizer.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -196,20 +197,16 @@ ExhaustiveOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "CurrentValue: " << static_cast<NumericTraits<MeasureType>::PrintType>(m_CurrentValue) << std::endl;
-  os << indent << "NumberOfSteps: " << static_cast<NumericTraits<StepsType>::PrintType>(m_NumberOfSteps) << std::endl;
-  os << indent << "CurrentIteration: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_CurrentIteration)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "CurrentValue", m_CurrentValue);
+  print_helper::PrintNumericTrait(os, indent, "NumberOfSteps", m_NumberOfSteps);
+  print_helper::PrintNumericTrait(os, indent, "CurrentIteration", m_CurrentIteration);
   itkPrintSelfBooleanMacro(Stop);
   os << indent << "CurrentParameter: " << m_CurrentParameter << std::endl;
   os << indent << "StepLength: " << m_StepLength << std::endl;
   os << indent << "CurrentIndex: " << m_CurrentIndex << std::endl;
-  os << indent << "MaximumNumberOfIterations: "
-     << static_cast<NumericTraits<SizeValueType>::PrintType>(m_MaximumNumberOfIterations) << std::endl;
-  os << indent << "MaximumMetricValue: " << static_cast<NumericTraits<MeasureType>::PrintType>(m_MaximumMetricValue)
-     << std::endl;
-  os << indent << "MinimumMetricValue: " << static_cast<NumericTraits<MeasureType>::PrintType>(m_MinimumMetricValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "MaximumNumberOfIterations", m_MaximumNumberOfIterations);
+  print_helper::PrintNumericTrait(os, indent, "MaximumMetricValue", m_MaximumMetricValue);
+  print_helper::PrintNumericTrait(os, indent, "MinimumMetricValue", m_MinimumMetricValue);
   os << indent << "MinimumMetricValuePosition: " << m_MinimumMetricValuePosition << std::endl;
   os << indent << "MaximumMetricValuePosition: " << m_MaximumMetricValuePosition << std::endl;
 

--- a/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSPSAOptimizer.cxx
@@ -18,6 +18,7 @@
 #include "itkSPSAOptimizer.h"
 
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -44,28 +45,23 @@ SPSAOptimizer::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Gradient: " << static_cast<NumericTraits<DerivativeType>::PrintType>(m_Gradient) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Gradient", m_Gradient);
   os << indent << "LearningRate: " << m_LearningRate << std::endl;
-  os << indent << "Delta: " << static_cast<NumericTraits<DerivativeType>::PrintType>(m_Delta) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Delta", m_Delta);
   itkPrintSelfBooleanMacro(Stop);
   os << indent << "StopCondition: " << m_StopCondition << std::endl;
   os << indent << "StateOfConvergence: " << m_StateOfConvergence << std::endl;
-  os << indent << "CurrentIteration: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_CurrentIteration)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "CurrentIteration", m_CurrentIteration);
 
   itkPrintSelfObjectMacro(Generator);
 
-  os << indent << "MinimumNumberOfIterations: "
-     << static_cast<NumericTraits<SizeValueType>::PrintType>(m_MinimumNumberOfIterations) << std::endl;
-  os << indent << "MaximumNumberOfIterations: "
-     << static_cast<NumericTraits<SizeValueType>::PrintType>(m_MaximumNumberOfIterations) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "MinimumNumberOfIterations", m_MinimumNumberOfIterations);
+  print_helper::PrintNumericTrait(os, indent, "MaximumNumberOfIterations", m_MaximumNumberOfIterations);
   os << indent << "StateOfConvergenceDecayRate: " << m_StateOfConvergenceDecayRate << std::endl;
   os << indent << "Tolerance: " << m_Tolerance << std::endl;
   itkPrintSelfBooleanMacro(Maximize);
   os << indent << "GradientMagnitude: " << m_GradientMagnitude << std::endl;
-  os << indent
-     << "NumberOfPerturbations: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfPerturbations)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumberOfPerturbations", m_NumberOfPerturbations);
 
   os << indent << "Sa: " << m_Sa << std::endl;
   os << indent << "Sc: " << m_Sc << std::endl;

--- a/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
@@ -19,6 +19,7 @@
 #define itkExhaustiveOptimizerv4_hxx
 
 
+#include "itkPrintHelper.h"
 namespace itk
 {
 
@@ -224,18 +225,13 @@ ExhaustiveOptimizerv4<TInternalComputationValueType>::PrintSelf(std::ostream & o
   Superclass::PrintSelf(os, indent);
 
   os << indent << "InitialPosition: " << m_InitialPosition << std::endl;
-  os << indent << "CurrentValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_CurrentValue)
-     << std::endl;
-  os << indent << "NumberOfSteps: " << static_cast<NumericTraits<StepsType>::PrintType>(m_NumberOfSteps) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "CurrentValue", m_CurrentValue);
+  print_helper::PrintNumericTrait(os, indent, "NumberOfSteps", m_NumberOfSteps);
   itkPrintSelfBooleanMacro(Stop);
   os << indent << "StepLength: " << m_StepLength << std::endl;
   os << indent << "CurrentIndex: " << m_CurrentIndex << std::endl;
-  os << indent
-     << "MaximumMetricValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_MaximumMetricValue)
-     << std::endl;
-  os << indent
-     << "MinimumMetricValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_MinimumMetricValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "MaximumMetricValue", m_MaximumMetricValue);
+  print_helper::PrintNumericTrait(os, indent, "MinimumMetricValue", m_MinimumMetricValue);
   os << indent << "MinimumMetricValuePosition: " << m_MinimumMetricValuePosition << std::endl;
   os << indent << "MaximumMetricValuePosition: " << m_MaximumMetricValuePosition << std::endl;
 

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
@@ -19,6 +19,7 @@
 #define itkGradientDescentLineSearchOptimizerv4_hxx
 
 
+#include "itkPrintHelper.h"
 namespace itk
 {
 
@@ -43,19 +44,11 @@ GradientDescentLineSearchOptimizerv4Template<TInternalComputationValueType>::Pri
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "LowerLimit: " << static_cast<typename NumericTraits<TInternalComputationValueType>::PrintType>(m_LowerLimit)
-     << std::endl;
-  os << indent
-     << "UpperLimit: " << static_cast<typename NumericTraits<TInternalComputationValueType>::PrintType>(m_UpperLimit)
-     << std::endl;
-  os << indent << "Phi: " << static_cast<typename NumericTraits<TInternalComputationValueType>::PrintType>(m_Phi)
-     << std::endl;
-  os << indent << "Resphi: " << static_cast<typename NumericTraits<TInternalComputationValueType>::PrintType>(m_Resphi)
-     << std::endl;
-  os << indent
-     << "Epsilon: " << static_cast<typename NumericTraits<TInternalComputationValueType>::PrintType>(m_Epsilon)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "LowerLimit", m_LowerLimit);
+  print_helper::PrintNumericTrait(os, indent, "UpperLimit", m_UpperLimit);
+  print_helper::PrintNumericTrait(os, indent, "Phi", m_Phi);
+  print_helper::PrintNumericTrait(os, indent, "Resphi", m_Resphi);
+  print_helper::PrintNumericTrait(os, indent, "Epsilon", m_Epsilon);
 
   os << indent << "MaximumLineSearchIterations: " << m_MaximumLineSearchIterations << std::endl;
   os << indent << "LineSearchIterations: " << m_LineSearchIterations << std::endl;

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
@@ -20,6 +20,7 @@
 
 #include "itkGradientDescentOptimizerBasev4ModifyGradientByScalesThreader.h"
 #include "itkGradientDescentOptimizerBasev4ModifyGradientByLearningRateThreader.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -55,13 +56,9 @@ GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::PrintSelf
 
   itkPrintSelfBooleanMacro(DoEstimateLearningRateAtEachIteration);
   itkPrintSelfBooleanMacro(DoEstimateLearningRateOnce);
-  os << indent << "MaximumStepSizeInPhysicalUnits: "
-     << static_cast<typename NumericTraits<TInternalComputationValueType>::PrintType>(m_MaximumStepSizeInPhysicalUnits)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "MaximumStepSizeInPhysicalUnits", m_MaximumStepSizeInPhysicalUnits);
   itkPrintSelfBooleanMacro(UseConvergenceMonitoring);
-  os << indent
-     << "ConvergenceWindowSize: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_ConvergenceWindowSize)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ConvergenceWindowSize", m_ConvergenceWindowSize);
 
   itkPrintSelfObjectMacro(ConvergenceMonitoring);
   itkPrintSelfObjectMacro(ModifyGradientByScalesThreader);
@@ -70,8 +67,7 @@ GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::PrintSelf
   itkPrintSelfBooleanMacro(Stop);
   os << indent << "StopCondition: " << m_StopCondition << std::endl;
   os << indent << "StopConditionDescription: " << m_StopConditionDescription.str() << std::endl;
-  os << indent << "Gradient: " << static_cast<typename NumericTraits<DerivativeType>::PrintType>(m_Gradient)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Gradient", m_Gradient);
 }
 
 template <typename TInternalComputationValueType>

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
@@ -19,6 +19,7 @@
 #define itkGradientDescentOptimizerv4_hxx
 
 
+#include "itkPrintHelper.h"
 namespace itk
 {
 
@@ -279,23 +280,13 @@ GradientDescentOptimizerv4Template<TInternalComputationValueType>::PrintSelf(std
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "LearningRate: "
-     << static_cast<typename NumericTraits<TInternalComputationValueType>::PrintType>(this->m_LearningRate)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "LearningRate", this->m_LearningRate);
   os << indent << "MinimumConvergenceValue: " << this->m_MinimumConvergenceValue << std::endl;
-  os << indent << "ConvergenceValue: "
-     << static_cast<typename NumericTraits<TInternalComputationValueType>::PrintType>(this->m_ConvergenceValue)
-     << std::endl;
-  os << indent
-     << "CurrentBestValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(this->m_CurrentBestValue)
-     << std::endl;
-  os << indent
-     << "BestParameters: " << static_cast<typename NumericTraits<ParametersType>::PrintType>(this->m_BestParameters)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ConvergenceValue", this->m_ConvergenceValue);
+  print_helper::PrintNumericTrait(os, indent, "CurrentBestValue", this->m_CurrentBestValue);
+  print_helper::PrintNumericTrait(os, indent, "BestParameters", this->m_BestParameters);
   itkPrintSelfBooleanMacro(ReturnBestParametersAndValue);
-  os << indent
-     << "PreviousGradient: " << static_cast<typename NumericTraits<DerivativeType>::PrintType>(this->m_PreviousGradient)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "PreviousGradient", this->m_PreviousGradient);
 }
 } // namespace itk
 

--- a/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiGradientOptimizerv4.hxx
@@ -47,12 +47,8 @@ MultiGradientOptimizerv4Template<TInternalComputationValueType>::PrintSelf(std::
   os << indent << "StopConditionDescription: " << m_StopConditionDescription.str() << std::endl;
   os << indent << "OptimizersList: " << m_OptimizersList << std::endl;
   os << indent << "MetricValuesList: " << m_MetricValuesList << std::endl;
-  os << indent
-     << "MinimumMetricValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_MinimumMetricValue)
-     << std::endl;
-  os << indent
-     << "MaximumMetricValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_MaximumMetricValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "MinimumMetricValue", m_MinimumMetricValue);
+  print_helper::PrintNumericTrait(os, indent, "MaximumMetricValue", m_MaximumMetricValue);
 }
 
 template <typename TInternalComputationValueType>

--- a/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkMultiStartOptimizerv4.hxx
@@ -50,14 +50,9 @@ MultiStartOptimizerv4Template<TInternalComputationValueType>::PrintSelf(std::ost
   os << indent << "ParametersList: " << m_ParametersList << std::endl;
   os << indent << "MetricValuesList: " << m_MetricValuesList << std::endl;
 
-  os << indent
-     << "MinimumMetricValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_MinimumMetricValue)
-     << std::endl;
-  os << indent
-     << "MaximumMetricValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_MaximumMetricValue)
-     << std::endl;
-  os << indent << "BestParametersIndex: "
-     << static_cast<typename NumericTraits<ParameterListSizeType>::PrintType>(m_BestParametersIndex) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "MinimumMetricValue", m_MinimumMetricValue);
+  print_helper::PrintNumericTrait(os, indent, "MaximumMetricValue", m_MaximumMetricValue);
+  print_helper::PrintNumericTrait(os, indent, "BestParametersIndex", m_BestParametersIndex);
 
   itkPrintSelfObjectMacro(LocalOptimizer);
 }

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.hxx
@@ -21,6 +21,7 @@
 #include "itkTransform.h"
 #include "itkIdentityTransform.h"
 #include "itkCompositeTransform.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -541,8 +542,7 @@ ObjectToObjectMetric<TFixedDimension, TMovingDimension, TVirtualImage, TParamete
   itkPrintSelfObjectMacro(VirtualImage);
 
   itkPrintSelfBooleanMacro(UserHasSetVirtualDomain);
-  os << indent << "NumberOfValidPoints: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfValidPoints)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumberOfValidPoints", m_NumberOfValidPoints);
 }
 
 } // namespace itk

--- a/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkRegistrationParameterScalesEstimator.hxx
@@ -622,13 +622,9 @@ RegistrationParameterScalesEstimator<TMetric>::PrintSelf(std::ostream & os, Inde
   itkPrintSelfObjectMacro(Metric);
 
   os << indent << "SamplePoints: " << m_SamplePoints << std::endl;
-  os << indent << "SamplingTime: " << static_cast<NumericTraits<TimeStamp>::PrintType>(m_SamplingTime) << std::endl;
-  os << indent
-     << "NumberOfRandomSamples: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfRandomSamples)
-     << std::endl;
-  os << indent
-     << "CentralRegionRadius: " << static_cast<NumericTraits<IndexValueType>::PrintType>(m_CentralRegionRadius)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "SamplingTime", m_SamplingTime);
+  print_helper::PrintNumericTrait(os, indent, "NumberOfRandomSamples", m_NumberOfRandomSamples);
+  print_helper::PrintNumericTrait(os, indent, "CentralRegionRadius", m_CentralRegionRadius);
 
   itkPrintSelfObjectMacro(VirtualDomainPointSet);
 

--- a/Modules/Numerics/Optimizersv4/src/itkObjectToObjectOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkObjectToObjectOptimizerBase.cxx
@@ -18,6 +18,7 @@
 #define ITK_TEMPLATE_EXPLICIT_ObjectToObjectOptimizerBaseTemplate
 #include "itkObjectToObjectOptimizerBase.h"
 #include "itkMultiThreaderBase.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -49,20 +50,12 @@ ObjectToObjectOptimizerBaseTemplate<TInternalComputationValueType>::PrintSelf(st
 
   itkPrintSelfObjectMacro(Metric);
 
-  os << indent
-     << "NumberOfWorkUnits: " << static_cast<typename NumericTraits<ThreadIdType>::PrintType>(m_NumberOfWorkUnits)
-     << std::endl;
-  os << indent
-     << "CurrentIteration: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_CurrentIteration)
-     << std::endl;
-  os << indent
-     << "NumberOfIterations: " << static_cast<typename NumericTraits<SizeValueType>::PrintType>(m_NumberOfIterations)
-     << std::endl;
-  os << indent
-     << "CurrentMetricValue: " << static_cast<typename NumericTraits<MeasureType>::PrintType>(m_CurrentMetricValue)
-     << std::endl;
-  os << indent << "Scales: " << static_cast<typename NumericTraits<ScalesType>::PrintType>(m_Scales) << std::endl;
-  os << indent << "Weights: " << static_cast<typename NumericTraits<ScalesType>::PrintType>(m_Weights) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumberOfWorkUnits", m_NumberOfWorkUnits);
+  print_helper::PrintNumericTrait(os, indent, "CurrentIteration", m_CurrentIteration);
+  print_helper::PrintNumericTrait(os, indent, "NumberOfIterations", m_NumberOfIterations);
+  print_helper::PrintNumericTrait(os, indent, "CurrentMetricValue", m_CurrentMetricValue);
+  print_helper::PrintNumericTrait(os, indent, "Scales", m_Scales);
+  print_helper::PrintNumericTrait(os, indent, "Weights", m_Weights);
 
   itkPrintSelfBooleanMacro(ScalesAreIdentity);
 

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -659,7 +659,7 @@ Histogram<TMeasurement, TFrequencyContainer>::PrintSelf(std::ostream & os, Inden
 
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Size: " << static_cast<NumericTraits<SizeType>::PrintType>(m_Size) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Size", m_Size);
   os << indent << "OffsetTable: " << std::endl;
   for (const auto & elem : m_OffsetTable)
   {
@@ -691,7 +691,7 @@ Histogram<TMeasurement, TFrequencyContainer>::PrintSelf(std::ostream & os, Inden
   }
 
   os << indent << "TempMeasurementVector: " << m_TempMeasurementVector << std::endl;
-  os << indent << "TempIndex: " << static_cast<NumericTraits<IndexType>::PrintType>(m_TempIndex) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "TempIndex", m_TempIndex);
   itkPrintSelfBooleanMacro(ClipBinsAtEnds);
 }
 

--- a/Modules/Numerics/Statistics/include/itkImageToListSampleFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToListSampleFilter.hxx
@@ -19,6 +19,7 @@
 #define itkImageToListSampleFilter_hxx
 
 #include "itkImageRegionConstIterator.h"
+#include "itkPrintHelper.h"
 
 namespace itk::Statistics
 {
@@ -37,8 +38,7 @@ void
 ImageToListSampleFilter<TImage, TMaskImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "MaskValue: " << static_cast<typename NumericTraits<MaskPixelType>::PrintType>(this->GetMaskValue())
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "MaskValue", this->GetMaskValue());
 }
 
 template <typename TImage, typename TMaskImage>

--- a/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
@@ -19,6 +19,7 @@
 #define itkImageToNeighborhoodSampleAdaptor_hxx
 
 
+#include "itkPrintHelper.h"
 namespace itk
 {
 namespace Statistics
@@ -101,15 +102,10 @@ ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::PrintSelf(std::ost
 
   itkPrintSelfObjectMacro(Image);
 
-  os << indent << "MeasurementVectorInternal: "
-     << static_cast<typename NumericTraits<MeasurementVectorType>::PrintType>(m_MeasurementVectorInternal) << std::endl;
-  os << indent << "InstanceIdentifierInternal: "
-     << static_cast<typename NumericTraits<InstanceIdentifier>::PrintType>(m_InstanceIdentifierInternal) << std::endl;
-  os << indent
-     << "NeighborIndexInternal: " << static_cast<typename NumericTraits<IndexType>::PrintType>(m_NeighborIndexInternal)
-     << std::endl;
-  os << indent << "Radius: " << static_cast<typename NumericTraits<NeighborhoodRadiusType>::PrintType>(m_Radius)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "MeasurementVectorInternal", m_MeasurementVectorInternal);
+  print_helper::PrintNumericTrait(os, indent, "InstanceIdentifierInternal", m_InstanceIdentifierInternal);
+  print_helper::PrintNumericTrait(os, indent, "NeighborIndexInternal", m_NeighborIndexInternal);
+  print_helper::PrintNumericTrait(os, indent, "Radius", m_Radius);
   os << indent << "Region: " << m_Region << std::endl;
   os << indent << "OffsetTable: " << m_OffsetTable << std::endl;
   itkPrintSelfBooleanMacro(UseImageRegion);

--- a/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
+++ b/Modules/Numerics/Statistics/include/itkScalarImageToRunLengthMatrixFilter.hxx
@@ -23,6 +23,7 @@
 #include "itkNeighborhood.h"
 #include "itkMacro.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk::Statistics
 {
@@ -300,14 +301,11 @@ ScalarImageToRunLengthMatrixFilter<TImageType, THistogramFrequencyContainer>::Pr
   Superclass::PrintSelf(os, indent);
 
   os << indent << "NumberOfBinsPerAxis: " << m_NumberOfBinsPerAxis << std::endl;
-  os << indent << "Min: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_Min) << std::endl;
-  os << indent << "Max: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_Max) << std::endl;
-  os << indent << "MinDistance: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_MinDistance)
-     << std::endl;
-  os << indent << "MaxDistance: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_MaxDistance)
-     << std::endl;
-  os << indent << "InsidePixelValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_InsidePixelValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Min", m_Min);
+  print_helper::PrintNumericTrait(os, indent, "Max", m_Max);
+  print_helper::PrintNumericTrait(os, indent, "MinDistance", m_MinDistance);
+  print_helper::PrintNumericTrait(os, indent, "MaxDistance", m_MaxDistance);
+  print_helper::PrintNumericTrait(os, indent, "InsidePixelValue", m_InsidePixelValue);
   os << indent << "LowerBound: " << m_LowerBound << std::endl;
   os << indent << "UpperBound: " << m_UpperBound << std::endl;
 

--- a/Modules/Registration/Common/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
@@ -19,6 +19,7 @@
 #define itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor_hxx
 
 
+#include "itkPrintHelper.h"
 namespace itk
 {
 
@@ -126,12 +127,10 @@ BSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor<TTransform>:
 
   os << indent << "NumberOfControlPointsForTheUpdateField: " << m_NumberOfControlPointsForTheUpdateField << std::endl;
   os << indent << "NumberOfControlPointsForTheTotalField: " << m_NumberOfControlPointsForTheTotalField << std::endl;
-  os << indent << "NumberOfControlPointsForTheUpdateFieldSetTime: "
-     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_NumberOfControlPointsForTheUpdateFieldSetTime)
-     << std::endl;
-  os << indent << "NumberOfControlPointsForTheTotalFieldSetTime: "
-     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_NumberOfControlPointsForTheTotalFieldSetTime)
-     << std::endl;
+  print_helper::PrintNumericTrait(
+    os, indent, "NumberOfControlPointsForTheUpdateFieldSetTime", m_NumberOfControlPointsForTheUpdateFieldSetTime);
+  print_helper::PrintNumericTrait(
+    os, indent, "NumberOfControlPointsForTheTotalFieldSetTime", m_NumberOfControlPointsForTheTotalFieldSetTime);
 }
 
 } // namespace itk

--- a/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkBlockMatchingImageFilter.hxx
@@ -23,6 +23,7 @@
 #include <limits>
 #include "itkMultiThreaderBase.h"
 #include "itkMakeUniqueForOverwrite.h"
+#include "itkPrintHelper.h"
 
 
 namespace itk
@@ -60,11 +61,9 @@ BlockMatchingImageFilter<TFixedImage, TMovingImage, TFeatures, TDisplacements, T
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "BlockRadius: " << static_cast<typename NumericTraits<ImageSizeType>::PrintType>(m_BlockRadius)
-     << std::endl;
-  os << indent << "SearchRadius: " << static_cast<typename NumericTraits<ImageSizeType>::PrintType>(m_SearchRadius)
-     << std::endl;
-  os << indent << "PointsCount: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_PointsCount) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BlockRadius", m_BlockRadius);
+  print_helper::PrintNumericTrait(os, indent, "SearchRadius", m_SearchRadius);
+  print_helper::PrintNumericTrait(os, indent, "PointsCount", m_PointsCount);
 
   os << indent << "DisplacementsVectorsArray: ";
   if (m_DisplacementsVectorsArray != nullptr)

--- a/Modules/Registration/Common/include/itkGaussianExponentialDiffeomorphicTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkGaussianExponentialDiffeomorphicTransformParametersAdaptor.hxx
@@ -19,6 +19,7 @@
 #define itkGaussianExponentialDiffeomorphicTransformParametersAdaptor_hxx
 
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -83,20 +84,20 @@ GaussianExponentialDiffeomorphicTransformParametersAdaptor<TTransform>::PrintSel
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "GaussianSmoothingVarianceForTheConstantVelocityField: "
-     << static_cast<typename NumericTraits<ScalarType>::PrintType>(
-          m_GaussianSmoothingVarianceForTheConstantVelocityField)
-     << std::endl;
-  os << indent << "GaussianSmoothingVarianceForTheUpdateField: "
-     << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_GaussianSmoothingVarianceForTheUpdateField)
-     << std::endl;
-  os << indent << "GaussianSmoothingVarianceForTheConstantVelocityFieldSetTime: "
-     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(
-          m_GaussianSmoothingVarianceForTheConstantVelocityFieldSetTime)
-     << std::endl;
-  os << indent << "GaussianSmoothingVarianceForTheUpdateFieldSetTime: "
-     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_GaussianSmoothingVarianceForTheUpdateFieldSetTime)
-     << std::endl;
+  print_helper::PrintNumericTrait(os,
+                                  indent,
+                                  "GaussianSmoothingVarianceForTheConstantVelocityField",
+                                  m_GaussianSmoothingVarianceForTheConstantVelocityField);
+  print_helper::PrintNumericTrait(
+    os, indent, "GaussianSmoothingVarianceForTheUpdateField", m_GaussianSmoothingVarianceForTheUpdateField);
+  print_helper::PrintNumericTrait(os,
+                                  indent,
+                                  "GaussianSmoothingVarianceForTheConstantVelocityFieldSetTime",
+                                  m_GaussianSmoothingVarianceForTheConstantVelocityFieldSetTime);
+  print_helper::PrintNumericTrait(os,
+                                  indent,
+                                  "GaussianSmoothingVarianceForTheUpdateFieldSetTime",
+                                  m_GaussianSmoothingVarianceForTheUpdateFieldSetTime);
 }
 
 } // namespace itk

--- a/Modules/Registration/Common/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
@@ -19,6 +19,7 @@
 #define itkGaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor_hxx
 
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -81,19 +82,17 @@ GaussianSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor<TTransform>
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "GaussianSmoothingVarianceForTheUpdateField: "
-     << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_GaussianSmoothingVarianceForTheUpdateField)
-     << std::endl;
-  os << indent << "GaussianSmoothingVarianceForTheTotalField: "
-     << static_cast<typename NumericTraits<ScalarType>::PrintType>(m_GaussianSmoothingVarianceForTheTotalField)
-     << std::endl;
+  print_helper::PrintNumericTrait(
+    os, indent, "GaussianSmoothingVarianceForTheUpdateField", m_GaussianSmoothingVarianceForTheUpdateField);
+  print_helper::PrintNumericTrait(
+    os, indent, "GaussianSmoothingVarianceForTheTotalField", m_GaussianSmoothingVarianceForTheTotalField);
 
-  os << indent << "GaussianSmoothingVarianceForTheUpdateFieldSetTime: "
-     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_GaussianSmoothingVarianceForTheUpdateFieldSetTime)
-     << std::endl;
-  os << indent << "GaussianSmoothingVarianceForTheTotalFieldSetTime: "
-     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_GaussianSmoothingVarianceForTheTotalFieldSetTime)
-     << std::endl;
+  print_helper::PrintNumericTrait(os,
+                                  indent,
+                                  "GaussianSmoothingVarianceForTheUpdateFieldSetTime",
+                                  m_GaussianSmoothingVarianceForTheUpdateFieldSetTime);
+  print_helper::PrintNumericTrait(
+    os, indent, "GaussianSmoothingVarianceForTheTotalFieldSetTime", m_GaussianSmoothingVarianceForTheTotalFieldSetTime);
 }
 
 } // namespace itk

--- a/Modules/Registration/Common/include/itkHistogramImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkHistogramImageToImageMetric.hxx
@@ -22,6 +22,7 @@
 #include "itkNumericTraits.h"
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -357,9 +358,7 @@ void
 HistogramImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent
-     << "Padding value: " << static_cast<typename NumericTraits<FixedImagePixelType>::PrintType>(m_PaddingValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Padding value", m_PaddingValue);
   os << indent << "Use padding value?: " << m_UsePaddingValue << std::endl;
   os << indent << "Derivative step length: " << m_DerivativeStepLength << std::endl;
   os << indent << "Derivative step length scales: ";

--- a/Modules/Registration/Common/include/itkImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.hxx
@@ -1212,17 +1212,12 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Inde
   itkPrintSelfBooleanMacro(UseFixedImageIndexes);
   os << indent << "FixedImageIndexes: " << m_FixedImageIndexes << std::endl;
   itkPrintSelfBooleanMacro(UseFixedImageSamplesIntensityThreshold);
-  os << indent << "FixedImageSamplesIntensityThreshold: "
-     << static_cast<typename NumericTraits<FixedImagePixelType>::PrintType>(m_FixedImageSamplesIntensityThreshold)
-     << std::endl;
+  print_helper::PrintNumericTrait(
+    os, indent, "FixedImageSamplesIntensityThreshold", m_FixedImageSamplesIntensityThreshold);
   os << indent << "FixedImageSamples: " << m_FixedImageSamples << std::endl;
-  os << indent << "NumberOfParameters: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfParameters)
-     << std::endl;
-  os << indent << "NumberOfFixedImageSamples: "
-     << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfFixedImageSamples) << std::endl;
-  os << indent
-     << "NumberOfPixelsCounted: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsCounted)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumberOfParameters", m_NumberOfParameters);
+  print_helper::PrintNumericTrait(os, indent, "NumberOfFixedImageSamples", m_NumberOfFixedImageSamples);
+  print_helper::PrintNumericTrait(os, indent, "NumberOfPixelsCounted", m_NumberOfPixelsCounted);
 
   itkPrintSelfObjectMacro(MovingImage);
   itkPrintSelfObjectMacro(FixedImage);
@@ -1246,8 +1241,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Inde
   itkPrintSelfObjectMacro(MovingImageMask);
   itkPrintSelfObjectMacro(FixedImageMask);
 
-  os << indent << "NumberOfWorkUnits: " << static_cast<NumericTraits<ThreadIdType>::PrintType>(m_NumberOfWorkUnits)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumberOfWorkUnits", m_NumberOfWorkUnits);
   itkPrintSelfBooleanMacro(UseAllPixels);
   itkPrintSelfBooleanMacro(UseSequentialSampling);
   itkPrintSelfBooleanMacro(ReseedIterator);
@@ -1257,8 +1251,7 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Inde
   itkPrintSelfBooleanMacro(TransformIsBSpline);
 #endif
 
-  os << indent << "NumBSplineWeights: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumBSplineWeights)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumBSplineWeights", m_NumBSplineWeights);
 
   itkPrintSelfObjectMacro(BSplineTransform);
 
@@ -1266,17 +1259,11 @@ ImageToImageMetric<TFixedImage, TMovingImage>::PrintSelf(std::ostream & os, Inde
   os << indent << "BSplineTransformIndicesArray: " << m_BSplineTransformIndicesArray << std::endl;
   os << indent << "BSplinePreTransformPointsArray: " << m_BSplinePreTransformPointsArray << std::endl;
   os << indent << "WithinBSplineSupportRegionArray: " << m_WithinBSplineSupportRegionArray << std::endl;
-  os << indent << "BSplineParametersOffset: "
-     << static_cast<typename NumericTraits<BSplineParametersOffsetType>::PrintType>(m_BSplineParametersOffset)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BSplineParametersOffset", m_BSplineParametersOffset);
 
   itkPrintSelfBooleanMacro(UseCachingOfBSplineWeights);
-  os << indent << "BSplineTransformWeights: "
-     << static_cast<typename NumericTraits<BSplineTransformWeightsType>::PrintType>(m_BSplineTransformWeights)
-     << std::endl;
-  os << indent << "BSplineTransformIndices: "
-     << static_cast<typename NumericTraits<BSplineTransformIndexArrayType>::PrintType>(m_BSplineTransformIndices)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BSplineTransformWeights", m_BSplineTransformWeights);
+  print_helper::PrintNumericTrait(os, indent, "BSplineTransformIndices", m_BSplineTransformIndices);
 
   os << indent << "ThreaderBSplineTransformWeights: ";
   if (m_ThreaderBSplineTransformWeights.get() != nullptr)

--- a/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.hxx
+++ b/Modules/Registration/Common/include/itkImageToSpatialObjectMetric.hxx
@@ -19,6 +19,7 @@
 #define itkImageToSpatialObjectMetric_hxx
 
 
+#include "itkPrintHelper.h"
 namespace itk
 {
 
@@ -82,7 +83,7 @@ ImageToSpatialObjectMetric<TFixedImage, TMovingSpatialObject>::PrintSelf(std::os
   Superclass::PrintSelf(os, indent);
 
 
-  os << indent << "MatchMeasure: " << static_cast<NumericTraits<MeasureType>::PrintType>(m_MatchMeasure) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "MatchMeasure", m_MatchMeasure);
   os << indent << "MatchMeasureDerivatives: " << m_MatchMeasureDerivatives << std::endl;
 
   itkPrintSelfObjectMacro(Transform);

--- a/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.hxx
+++ b/Modules/Registration/Common/include/itkMeanSquareRegistrationFunction.hxx
@@ -20,6 +20,7 @@
 
 #include "itkMacro.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -55,14 +56,12 @@ MeanSquareRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::P
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "FixedImageSpacing: " << static_cast<typename NumericTraits<SpacingType>::PrintType>(m_FixedImageSpacing)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "FixedImageSpacing", m_FixedImageSpacing);
 
   itkPrintSelfObjectMacro(FixedImageGradientCalculator);
   itkPrintSelfObjectMacro(MovingImageInterpolator);
 
-  os << indent << "TimeStep: " << static_cast<typename NumericTraits<TimeStepType>::PrintType>(m_TimeStep) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "TimeStep", m_TimeStep);
 
   os << indent << "DenominatorThreshold: " << m_DenominatorThreshold << std::endl;
   os << indent << "IntensityDifferenceThreshold: " << m_IntensityDifferenceThreshold << std::endl;

--- a/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
@@ -270,27 +270,21 @@ MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::PrintSelf(std
   itkPrintSelfObjectMacro(MovingImagePyramid);
   itkPrintSelfObjectMacro(FixedImagePyramid);
 
-  os << indent << "InitialTransformParameters: "
-     << static_cast<typename NumericTraits<ParametersType>::PrintType>(m_InitialTransformParameters) << std::endl;
-  os << indent << "InitialTransformParametersOfNextLevel: "
-     << static_cast<typename NumericTraits<ParametersType>::PrintType>(m_InitialTransformParametersOfNextLevel)
-     << std::endl;
-  os << indent << "LastTransformParameters: "
-     << static_cast<typename NumericTraits<ParametersType>::PrintType>(m_LastTransformParameters) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "InitialTransformParameters", m_InitialTransformParameters);
+  print_helper::PrintNumericTrait(
+    os, indent, "InitialTransformParametersOfNextLevel", m_InitialTransformParametersOfNextLevel);
+  print_helper::PrintNumericTrait(os, indent, "LastTransformParameters", m_LastTransformParameters);
 
   os << indent << "FixedImageRegion: " << m_FixedImageRegion << std::endl;
   os << indent << "FixedImageRegionPyramid: " << m_FixedImageRegionPyramid << std::endl;
 
-  os << indent << "NumberOfLevels: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfLevels)
-     << std::endl;
-  os << indent << "CurrentLevel: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_CurrentLevel) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumberOfLevels", m_NumberOfLevels);
+  print_helper::PrintNumericTrait(os, indent, "CurrentLevel", m_CurrentLevel);
 
   itkPrintSelfBooleanMacro(Stop);
 
-  os << indent << "FixedImagePyramidSchedule: "
-     << static_cast<typename NumericTraits<ScheduleType>::PrintType>(m_FixedImagePyramidSchedule) << std::endl;
-  os << indent << "MovingImagePyramidSchedule: "
-     << static_cast<typename NumericTraits<ScheduleType>::PrintType>(m_MovingImagePyramidSchedule) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "FixedImagePyramidSchedule", m_FixedImagePyramidSchedule);
+  print_helper::PrintNumericTrait(os, indent, "MovingImagePyramidSchedule", m_MovingImagePyramidSchedule);
 
   itkPrintSelfBooleanMacro(ScheduleSpecified);
   itkPrintSelfBooleanMacro(Stop);

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
@@ -27,6 +27,7 @@
 #include "itkIdentityTransform.h"
 
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -293,7 +294,7 @@ MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ost
 
   os << indent << "MaximumError: " << m_MaximumError << std::endl;
   os << indent << "NumberOfLevels: " << m_NumberOfLevels << std::endl;
-  os << indent << "Schedule: " << static_cast<NumericTraits<ScheduleType>::PrintType>(m_Schedule) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Schedule", m_Schedule);
   itkPrintSelfBooleanMacro(UseShrinkImageFilter);
 }
 

--- a/Modules/Registration/Common/include/itkPointSetToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkPointSetToImageMetric.hxx
@@ -19,6 +19,7 @@
 #define itkPointSetToImageMetric_hxx
 
 
+#include "itkPrintHelper.h"
 namespace itk
 {
 
@@ -108,9 +109,7 @@ PointSetToImageMetric<TFixedPointSet, TMovingImage>::PrintSelf(std::ostream & os
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "NumberOfPixelsCounted: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsCounted)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumberOfPixelsCounted", m_NumberOfPixelsCounted);
 
   itkPrintSelfObjectMacro(FixedPointSet);
   itkPrintSelfObjectMacro(MovingImage);

--- a/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.hxx
+++ b/Modules/Registration/FEM/include/itkFEMFiniteDifferenceFunctionLoad.hxx
@@ -18,6 +18,8 @@
 #ifndef itkFEMFiniteDifferenceFunctionLoad_hxx
 #define itkFEMFiniteDifferenceFunctionLoad_hxx
 
+
+#include "itkPrintHelper.h"
 namespace itk::fem
 {
 
@@ -340,12 +342,8 @@ FiniteDifferenceFunctionLoad<TMoving, TFixed>::PrintSelf(std::ostream & os, Inde
 
   os << indent << "MetricRadius: " << m_MetricRadius << std::endl;
 
-  os << indent << "MovingSize: "
-     << static_cast<typename itk::NumericTraits<typename MovingImageType::SizeType>::PrintType>(m_MovingSize)
-     << std::endl;
-  os << indent << "FixedSize: "
-     << static_cast<typename itk::NumericTraits<typename FixedImageType::SizeType>::PrintType>(m_FixedSize)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "MovingSize", m_MovingSize);
+  print_helper::PrintNumericTrait(os, indent, "FixedSize", m_FixedSize);
 
   os << indent << "NumberOfIntegrationPoints: " << m_NumberOfIntegrationPoints << std::endl;
   os << indent << "SolutionIndex: " << m_SolutionIndex << std::endl;
@@ -362,7 +360,7 @@ FiniteDifferenceFunctionLoad<TMoving, TFixed>::PrintSelf(std::ostream & os, Inde
     os << "(null)" << std::endl;
   }
 
-  os << indent << "GradSigma: " << static_cast<typename NumericTraits<Float>::PrintType>(m_GradSigma) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "GradSigma", m_GradSigma);
   os << indent << "Sign: " << m_Sign << std::endl;
   os << indent << "WhichMetric: " << m_WhichMetric << std::endl;
 

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
@@ -32,6 +32,7 @@
 #include "itkRecursiveGaussianImageFilter.h"
 
 #include "vnl/algo/vnl_determinant.h"
+#include "itkPrintHelper.h"
 
 namespace itk::fem
 {
@@ -1438,9 +1439,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::PrintSelf(std::ost
   os << indent << "MaxLevel: " << m_MaxLevel << std::endl;
   os << indent << "FileCount: " << m_FileCount << std::endl;
   os << indent << "CurrentLevel: " << m_CurrentLevel << std::endl;
-  os << indent << "CurrentLevelImageSize: "
-     << static_cast<typename NumericTraits<typename FixedImageType::SizeType>::PrintType>(m_CurrentLevelImageSize)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "CurrentLevelImageSize", m_CurrentLevelImageSize);
   os << indent << "WhichMetric: " << m_WhichMetric << std::endl;
 
   os << indent << "MeshPixelsPerElementAtEachResolution: " << m_MeshPixelsPerElementAtEachResolution << std::endl;
@@ -1461,21 +1460,14 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::PrintSelf(std::ost
   os << indent << "EmployRegridding: " << m_EmployRegridding << std::endl;
   os << indent << "DescentDirection: " << m_DescentDirection << std::endl;
   os << indent << "EnergyReductionFactor: " << m_EnergyReductionFactor << std::endl;
-  os << indent << "FullImageSize: " << static_cast<typename NumericTraits<ImageSizeType>::PrintType>(m_FullImageSize)
-     << std::endl;
-  os << indent << "ImageOrigin: " << static_cast<typename NumericTraits<ImageSizeType>::PrintType>(m_ImageOrigin)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "FullImageSize", m_FullImageSize);
+  print_helper::PrintNumericTrait(os, indent, "ImageOrigin", m_ImageOrigin);
 
-  os << indent << "ImageScaling: " << static_cast<typename NumericTraits<ImageSizeType>::PrintType>(m_ImageScaling)
-     << std::endl;
-  os << indent
-     << "CurrentImageScaling: " << static_cast<typename NumericTraits<ImageSizeType>::PrintType>(m_CurrentImageScaling)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ImageScaling", m_ImageScaling);
+  print_helper::PrintNumericTrait(os, indent, "CurrentImageScaling", m_CurrentImageScaling);
 
   os << indent << "FieldRegion: " << m_FieldRegion << std::endl;
-  os << indent
-     << "FieldSize: " << static_cast<typename NumericTraits<typename FieldType::SizeType>::PrintType>(m_FieldSize)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "FieldSize", m_FieldSize);
 
   itkPrintSelfObjectMacro(Field);
   itkPrintSelfObjectMacro(TotalField);
@@ -1485,9 +1477,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::PrintSelf(std::ost
   itkPrintSelfObjectMacro(FloatImage);
 
   os << indent << "Wregion: " << m_Wregion << std::endl;
-  os << indent
-     << "Windex: " << static_cast<typename NumericTraits<typename FixedImageType::IndexType>::PrintType>(m_Windex)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Windex", m_Windex);
 
   itkPrintSelfObjectMacro(MovingImage);
   itkPrintSelfObjectMacro(OriginalMovingImage);
@@ -1509,8 +1499,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::PrintSelf(std::ost
   os << indent << "MaximumError: " << m_MaximumError << std::endl;
   os << indent << "MaximumKernelWidth: " << m_MaximumKernelWidth << std::endl;
 
-  os << indent << "StandardDeviation: "
-     << static_cast<typename NumericTraits<StandardDeviationsType>::PrintType>(m_StandardDeviations) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "StandardDeviation", m_StandardDeviations);
 }
 
 } // namespace itk::fem

--- a/Modules/Registration/FEM/include/itkMIRegistrationFunction.hxx
+++ b/Modules/Registration/FEM/include/itkMIRegistrationFunction.hxx
@@ -24,6 +24,7 @@
 #include "itkNeighborhoodIterator.h"
 
 #include "vnl/vnl_matrix.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -524,12 +525,8 @@ MIRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PrintSelf
   Superclass::PrintSelf(os, indent);
 
   os << indent << "TimeStep: " << m_TimeStep << std::endl;
-  os << indent
-     << "FixedImageSpacing: " << static_cast<typename itk::NumericTraits<SpacingType>::PrintType>(m_FixedImageSpacing)
-     << std::endl;
-  os << indent
-     << "FixedImageOrigin: " << static_cast<typename itk::NumericTraits<PointType>::PrintType>(m_FixedImageOrigin)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "FixedImageSpacing", m_FixedImageSpacing);
+  print_helper::PrintNumericTrait(os, indent, "FixedImageOrigin", m_FixedImageOrigin);
 
   itkPrintSelfObjectMacro(FixedImageGradientCalculator);
   itkPrintSelfObjectMacro(MovingImageGradientCalculator);

--- a/Modules/Registration/FEM/include/itkNCCRegistrationFunction.hxx
+++ b/Modules/Registration/FEM/include/itkNCCRegistrationFunction.hxx
@@ -21,6 +21,7 @@
 #include "itkMacro.h"
 #include "itkNeighborhoodIterator.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -190,9 +191,7 @@ NCCRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::PrintSel
   Superclass::PrintSelf(os, indent);
 
   os << indent << "TimeStep: " << m_TimeStep << std::endl;
-  os << indent
-     << "FixedImageSpacing: " << static_cast<typename itk::NumericTraits<SpacingType>::PrintType>(m_FixedImageSpacing)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "FixedImageSpacing", m_FixedImageSpacing);
 
   itkPrintSelfObjectMacro(FixedImageGradientCalculator);
   itkPrintSelfObjectMacro(MovingImageInterpolator);

--- a/Modules/Registration/FEM/include/itkPhysicsBasedNonRigidRegistrationMethod.hxx
+++ b/Modules/Registration/FEM/include/itkPhysicsBasedNonRigidRegistrationMethod.hxx
@@ -20,6 +20,7 @@
 
 #include <iostream>
 #include "itkTimeProbe.h"
+#include "itkPrintHelper.h"
 
 namespace itk::fem
 {
@@ -102,10 +103,8 @@ PhysicsBasedNonRigidRegistrationMethod<TFixedImage, TMovingImage, TMaskImage, TM
 
   os << indent << "SelectFraction: " << m_SelectFraction << std::endl;
   os << indent << "NonConnectivity: " << m_NonConnectivity << std::endl;
-  os << indent << "BlockRadius: " << static_cast<typename NumericTraits<ImageSizeType>::PrintType>(m_BlockRadius)
-     << std::endl;
-  os << indent << "SearchRadius: " << static_cast<typename NumericTraits<ImageSizeType>::PrintType>(m_SearchRadius)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "BlockRadius", m_BlockRadius);
+  print_helper::PrintNumericTrait(os, indent, "SearchRadius", m_SearchRadius);
   os << indent << "ApproximationSteps: " << m_ApproximationSteps << std::endl;
   os << indent << "OutlierRejectionSteps: " << m_OutlierRejectionSteps << std::endl;
 

--- a/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/GPUPDEDeformable/include/itkGPUDemonsRegistrationFunction.hxx
@@ -20,6 +20,7 @@
 
 #include "itkMacro.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -97,8 +98,7 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Pr
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "ZeroUpdateReturn: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_ZeroUpdateReturn)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ZeroUpdateReturn", m_ZeroUpdateReturn);
   os << indent << "Normalizer: " << m_Normalizer << std::endl;
 
   itkPrintSelfObjectMacro(FixedImageGradientCalculator);
@@ -108,16 +108,14 @@ GPUDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Pr
 
   itkPrintSelfObjectMacro(MovingImageInterpolator);
 
-  os << indent << "TimeStep: " << static_cast<typename NumericTraits<TimeStepType>::PrintType>(m_TimeStep) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "TimeStep", m_TimeStep);
 
   os << indent << "DenominatorThreshold: " << m_DenominatorThreshold << std::endl;
   os << indent << "IntensityDifferenceThreshold: " << m_IntensityDifferenceThreshold << std::endl;
 
   os << indent << "Metric: " << m_Metric << std::endl;
   os << indent << "SumOfSquaredDifference: " << m_SumOfSquaredDifference << std::endl;
-  os << indent
-     << "NumberOfPixelsProcessed: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsProcessed)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumberOfPixelsProcessed", m_NumberOfPixelsProcessed);
   os << indent << "RMSChange: " << m_RMSChange << std::endl;
   os << indent << "SumOfSquaredChange: " << m_SumOfSquaredChange << std::endl;
 

--- a/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4.hxx
@@ -19,6 +19,7 @@
 #define itkJensenHavrdaCharvatTsallisPointSetToPointSetMetricv4_hxx
 
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -201,20 +202,16 @@ JensenHavrdaCharvatTsallisPointSetToPointSetMetricv4<TPointSet, TInternalComputa
 
   itkPrintSelfBooleanMacro(UseAnisotropicCovariances);
 
-  os << indent << "PointSetSigma: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_PointSetSigma)
-     << std::endl;
-  os << indent << "KernelSigma: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_KernelSigma)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "PointSetSigma", m_PointSetSigma);
+  print_helper::PrintNumericTrait(os, indent, "KernelSigma", m_KernelSigma);
   os << indent << "CovarianceKNeighborhood: " << m_CovarianceKNeighborhood << std::endl;
   os << indent << "EvaluationKNeighborhood: " << m_EvaluationKNeighborhood << std::endl;
 
-  os << indent << "Alpha: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_Alpha) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Alpha", m_Alpha);
 
-  os << indent
-     << "TotalNumberOfPoints: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_TotalNumberOfPoints)
-     << std::endl;
-  os << indent << "Prefactor0: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_Prefactor0) << std::endl;
-  os << indent << "Prefactor1: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_Prefactor1) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "TotalNumberOfPoints", m_TotalNumberOfPoints);
+  print_helper::PrintNumericTrait(os, indent, "Prefactor0", m_Prefactor0);
+  print_helper::PrintNumericTrait(os, indent, "Prefactor1", m_Prefactor1);
 }
 } // end namespace itk
 

--- a/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkPointSetToPointSetMetricWithIndexv4.hxx
@@ -20,6 +20,7 @@
 
 #include "itkIdentityTransform.h"
 #include "itkCompensatedSummation.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -658,10 +659,8 @@ PointSetToPointSetMetricWithIndexv4<TFixedPointSet, TMovingPointSet, TInternalCo
   itkPrintSelfBooleanMacro(HaveWarnedAboutNumberOfValidPoints);
   itkPrintSelfBooleanMacro(StoreDerivativeAsSparseFieldForLocalSupportTransforms);
 
-  os << indent << "MovingTransformedPointSetTime: "
-     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_MovingTransformedPointSetTime) << std::endl;
-  os << indent << "FixedTransformedPointSetTime: "
-     << static_cast<NumericTraits<ModifiedTimeType>::PrintType>(m_FixedTransformedPointSetTime) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "MovingTransformedPointSetTime", m_MovingTransformedPointSetTime);
+  print_helper::PrintNumericTrait(os, indent, "FixedTransformedPointSetTime", m_FixedTransformedPointSetTime);
 }
 } // end namespace itk
 

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.hxx
@@ -20,6 +20,7 @@
 
 #include "itkMacro.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -74,16 +75,14 @@ FastSymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDispla
   itkPrintSelfObjectMacro(MovingImageInterpolator);
   itkPrintSelfObjectMacro(MovingImageWarper);
 
-  os << indent << "TimeStep: " << static_cast<typename NumericTraits<TimeStepType>::PrintType>(m_TimeStep) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "TimeStep", m_TimeStep);
 
   os << indent << "DenominatorThreshold: " << m_DenominatorThreshold << std::endl;
   os << indent << "IntensityDifferenceThreshold: " << m_IntensityDifferenceThreshold << std::endl;
 
   os << indent << "Metric: " << m_Metric << std::endl;
   os << indent << "SumOfSquaredDifference: " << m_SumOfSquaredDifference << std::endl;
-  os << indent
-     << "NumberOfPixelsProcessed: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsProcessed)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumberOfPixelsProcessed", m_NumberOfPixelsProcessed);
   os << indent << "RMSChange: " << m_RMSChange << std::endl;
   os << indent << "SumOfSquaredChange: " << m_SumOfSquaredChange << std::endl;
 }

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.hxx
@@ -20,6 +20,7 @@
 
 #include "itkMacro.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -66,11 +67,8 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "FixedImageSpacing: " << static_cast<typename NumericTraits<SpacingType>::PrintType>(m_FixedImageSpacing)
-     << std::endl;
-  os << indent << "FixedImageOrigin: " << static_cast<typename NumericTraits<PointType>::PrintType>(m_FixedImageOrigin)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "FixedImageSpacing", m_FixedImageSpacing);
+  print_helper::PrintNumericTrait(os, indent, "FixedImageOrigin", m_FixedImageOrigin);
 
   itkPrintSelfObjectMacro(MovingImageSmoothingFilter);
 
@@ -84,9 +82,7 @@ LevelSetMotionRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField
 
   os << indent << "Metric: " << m_Metric << std::endl;
   os << indent << "SumOfSquaredDifference: " << m_SumOfSquaredDifference << std::endl;
-  os << indent
-     << "NumberOfPixelsProcessed: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsProcessed)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumberOfPixelsProcessed", m_NumberOfPixelsProcessed);
   os << indent << "RMSChange: " << m_RMSChange << std::endl;
   os << indent << "SumOfSquaredChange: " << m_SumOfSquaredChange << std::endl;
 

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
@@ -20,6 +20,7 @@
 
 #include "itkMacro.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -52,27 +53,22 @@ SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplaceme
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent
-     << "FixedImageSpacing: " << static_cast<typename NumericTraits<SpacingType>::PrintType>(m_FixedImageSpacing)
-     << std::endl;
-  os << indent << "FixedImageOrigin: " << static_cast<typename NumericTraits<PointType>::PrintType>(m_FixedImageOrigin)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "FixedImageSpacing", m_FixedImageSpacing);
+  print_helper::PrintNumericTrait(os, indent, "FixedImageOrigin", m_FixedImageOrigin);
 
   os << indent << "Normalizer: " << m_Normalizer << std::endl;
 
   itkPrintSelfObjectMacro(FixedImageGradientCalculator);
   itkPrintSelfObjectMacro(MovingImageInterpolator);
 
-  os << indent << "TimeStep: " << static_cast<typename NumericTraits<TimeStepType>::PrintType>(m_TimeStep) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "TimeStep", m_TimeStep);
 
   os << indent << "DenominatorThreshold: " << m_DenominatorThreshold << std::endl;
   os << indent << "IntensityDifferenceThreshold: " << m_IntensityDifferenceThreshold << std::endl;
 
   os << indent << "Metric: " << m_Metric << std::endl;
   os << indent << "SumOfSquaredDifference: " << m_SumOfSquaredDifference << std::endl;
-  os << indent
-     << "NumberOfPixelsProcessed: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfPixelsProcessed)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumberOfPixelsProcessed", m_NumberOfPixelsProcessed);
   os << indent << "RMSChange: " << m_RMSChange << std::endl;
   os << indent << "SumOfSquaredChange: " << m_SumOfSquaredChange << std::endl;
 }

--- a/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkImageRegistrationMethodv4.hxx
@@ -1115,16 +1115,11 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
 
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "CurrentLevel: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_CurrentLevel) << std::endl;
-  os << indent << "NumberOfLevels: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfLevels)
-     << std::endl;
-  os << indent << "CurrentIteration: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_CurrentIteration)
-     << std::endl;
-  os << indent
-     << "CurrentMetricValue: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_CurrentMetricValue)
-     << std::endl;
-  os << indent << "CurrentConvergenceValue: "
-     << static_cast<typename NumericTraits<RealType>::PrintType>(m_CurrentConvergenceValue) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "CurrentLevel", m_CurrentLevel);
+  print_helper::PrintNumericTrait(os, indent, "NumberOfLevels", m_NumberOfLevels);
+  print_helper::PrintNumericTrait(os, indent, "CurrentIteration", m_CurrentIteration);
+  print_helper::PrintNumericTrait(os, indent, "CurrentMetricValue", m_CurrentMetricValue);
+  print_helper::PrintNumericTrait(os, indent, "CurrentConvergenceValue", m_CurrentConvergenceValue);
   itkPrintSelfBooleanMacro(IsConverged);
 
   os << indent << "FixedSmoothImages: " << m_FixedSmoothImages << std::endl;
@@ -1137,26 +1132,19 @@ ImageRegistrationMethodv4<TFixedImage, TMovingImage, TTransform, TVirtualImage, 
   os << indent << "FixedPointSets: " << m_FixedPointSets << std::endl;
   os << indent << "MovingPointSets: " << m_MovingPointSets << std::endl;
 
-  os << indent
-     << "NumberOfFixedObjects: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfFixedObjects)
-     << std::endl;
-  os << indent
-     << "NumberOfMovingObjects: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfMovingObjects)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumberOfFixedObjects", m_NumberOfFixedObjects);
+  print_helper::PrintNumericTrait(os, indent, "NumberOfMovingObjects", m_NumberOfMovingObjects);
 
   itkPrintSelfObjectMacro(Optimizer);
 
-  os << indent
-     << "OptimizerWeights: " << static_cast<typename NumericTraits<OptimizerWeightsType>::PrintType>(m_OptimizerWeights)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "OptimizerWeights", m_OptimizerWeights);
   itkPrintSelfBooleanMacro(OptimizerWeightsAreIdentity);
 
   itkPrintSelfObjectMacro(Metric);
 
   os << indent << "MetricSamplingStrategy: " << m_MetricSamplingStrategy << std::endl;
   os << indent << "MetricSamplingPercentagePerLevel: " << m_MetricSamplingPercentagePerLevel << std::endl;
-  os << indent << "NumberOfMetrics: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfMetrics)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumberOfMetrics", m_NumberOfMetrics);
   os << indent << "FirstImageMetricIndex: " << m_FirstImageMetricIndex << std::endl;
   os << indent << "ShrinkFactorsPerLevel: " << m_ShrinkFactorsPerLevel << std::endl;
   os << indent << "SmoothingSigmasPerLevel: " << m_SmoothingSigmasPerLevel << std::endl;

--- a/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkSyNImageRegistrationMethod.hxx
@@ -28,6 +28,7 @@
 #include "itkMultiplyImageFilter.h"
 #include "itkVectorNeighborhoodOperatorImageFilter.h"
 #include "itkWindowConvergenceMonitoringFunction.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -861,10 +862,8 @@ SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform, TVirtual
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "LearningRate: " << static_cast<typename NumericTraits<RealType>::PrintType>(this->m_LearningRate)
-     << std::endl;
-  os << indent << "ConvergenceThreshold: "
-     << static_cast<typename NumericTraits<RealType>::PrintType>(this->m_ConvergenceThreshold) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "LearningRate", this->m_LearningRate);
+  print_helper::PrintNumericTrait(os, indent, "ConvergenceThreshold", this->m_ConvergenceThreshold);
   os << indent << "ConvergenceWindowSize: " << this->m_ConvergenceWindowSize << std::endl;
 
   itkPrintSelfObjectMacro(MovingToMiddleTransform);
@@ -873,12 +872,10 @@ SyNImageRegistrationMethod<TFixedImage, TMovingImage, TOutputTransform, TVirtual
   os << indent << "NumberOfIterationsPerLevel: " << this->m_NumberOfIterationsPerLevel << std::endl;
   os << indent << "DownsampleImagesForMetricDerivatives: " << m_DownsampleImagesForMetricDerivatives << std::endl;
   os << indent << "AverageMidPointGradients: " << m_AverageMidPointGradients << std::endl;
-  os << indent << "GaussianSmoothingVarianceForTheUpdateField: "
-     << static_cast<typename NumericTraits<RealType>::PrintType>(this->m_GaussianSmoothingVarianceForTheUpdateField)
-     << std::endl;
-  os << indent << "GaussianSmoothingVarianceForTheTotalField: "
-     << static_cast<typename NumericTraits<RealType>::PrintType>(this->m_GaussianSmoothingVarianceForTheTotalField)
-     << std::endl;
+  print_helper::PrintNumericTrait(
+    os, indent, "GaussianSmoothingVarianceForTheUpdateField", this->m_GaussianSmoothingVarianceForTheUpdateField);
+  print_helper::PrintNumericTrait(
+    os, indent, "GaussianSmoothingVarianceForTheTotalField", this->m_GaussianSmoothingVarianceForTheTotalField);
 }
 
 } // end namespace itk

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingBSplineVelocityFieldImageRegistrationMethod.hxx
@@ -31,6 +31,7 @@
 #include "itkVectorMagnitudeImageFilter.h"
 #include "itkWindowConvergenceMonitoringFunction.h"
 #include "itkNeighborhoodAlgorithm.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -855,16 +856,11 @@ TimeVaryingBSplineVelocityFieldImageRegistrationMethod<TFixedImage,
 
   itkPrintSelfObjectMacro(IdentityDisplacementFieldTransform);
 
-  os << indent << "LearningRate: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_LearningRate)
-     << std::endl;
-  os << indent
-     << "ConvergenceThreshold: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_ConvergenceThreshold)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "LearningRate", m_LearningRate);
+  print_helper::PrintNumericTrait(os, indent, "ConvergenceThreshold", m_ConvergenceThreshold);
   os << indent << "ConvergenceWindowSize: " << m_ConvergenceWindowSize << std::endl;
   os << indent << "NumberOfIterationsPerLevel: " << m_NumberOfIterationsPerLevel << std::endl;
-  os << indent
-     << "NumberOfTimePointSamples: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfTimePointSamples)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumberOfTimePointSamples", m_NumberOfTimePointSamples);
   os << indent << "BoundaryWeight: " << m_BoundaryWeight << std::endl;
 }
 

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
@@ -28,6 +28,7 @@
 #include "itkStatisticsImageFilter.h"
 #include "itkVectorMagnitudeImageFilter.h"
 #include "itkWindowConvergenceMonitoringFunction.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -444,11 +445,8 @@ TimeVaryingVelocityFieldImageRegistrationMethodv4<TFixedImage,
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "LearningRate: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_LearningRate)
-     << std::endl;
-  os << indent
-     << "ConvergenceThreshold: " << static_cast<typename NumericTraits<RealType>::PrintType>(m_ConvergenceThreshold)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "LearningRate", m_LearningRate);
+  print_helper::PrintNumericTrait(os, indent, "ConvergenceThreshold", m_ConvergenceThreshold);
   os << indent << "ConvergenceWindowSize: " << m_ConvergenceWindowSize << std::endl;
   os << indent << "NumberOfIterationsPerLevel: " << m_NumberOfIterationsPerLevel << std::endl;
 }

--- a/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.hxx
@@ -19,6 +19,7 @@
 #define itkImageKmeansModelEstimator_hxx
 
 #include "itkMakeUniqueForOverwrite.h"
+#include "itkPrintHelper.h"
 
 
 namespace itk
@@ -53,13 +54,9 @@ ImageKmeansModelEstimator<TInputImage, TMembershipFunction>::PrintSelf(std::ostr
   os << indent << "OutputDistortion: " << m_OutputDistortion << std::endl;
   os << indent << "OutputNumberOfEmptyCells: " << m_OutputNumberOfEmptyCells << std::endl;
 
-  os << indent << "VectorDimension: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_VectorDimension)
-     << std::endl;
-  os << indent << "NumberOfCodewords: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfCodewords)
-     << std::endl;
-  os << indent
-     << "CurrentNumberOfCodewords: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_CurrentNumberOfCodewords)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "VectorDimension", m_VectorDimension);
+  print_helper::PrintNumericTrait(os, indent, "NumberOfCodewords", m_NumberOfCodewords);
+  print_helper::PrintNumericTrait(os, indent, "CurrentNumberOfCodewords", m_CurrentNumberOfCodewords);
 
   os << indent << "CodewordHistogram: " << m_CodewordHistogram << std::endl;
   os << indent << "CodewordDistortion: " << m_CodewordDistortion << std::endl;

--- a/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkImageRegionIterator.h"
 #include "itkNumericTraits.h"
 #include "itkObjectFactory.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -181,18 +182,12 @@ ThresholdMaximumConnectedComponentsImageFilter<TInputImage, TOutputImage>::Print
   itkPrintSelfObjectMacro(MinMaxCalculator);
 
   os << indent << "MinimumObjectSizeInPixels: " << m_MinimumObjectSizeInPixels << std::endl;
-  os << indent << "OutsideValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_OutsideValue)
-     << std::endl;
-  os << indent << "InsideValue: " << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_InsideValue)
-     << std::endl;
-  os << indent << "LowerBoundary: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_LowerBoundary)
-     << std::endl;
-  os << indent << "UpperBoundary: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_UpperBoundary)
-     << std::endl;
-  os << indent << "Threshold Value: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_ThresholdValue)
-     << std::endl;
-  os << indent << "NumberOfObjects: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfObjects)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "OutsideValue", m_OutsideValue);
+  print_helper::PrintNumericTrait(os, indent, "InsideValue", m_InsideValue);
+  print_helper::PrintNumericTrait(os, indent, "LowerBoundary", m_LowerBoundary);
+  print_helper::PrintNumericTrait(os, indent, "UpperBoundary", m_UpperBoundary);
+  print_helper::PrintNumericTrait(os, indent, "Threshold Value", m_ThresholdValue);
+  print_helper::PrintNumericTrait(os, indent, "NumberOfObjects", m_NumberOfObjects);
 }
 } // end namespace itk
 

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkRegionGrowImageFilter.hxx
@@ -19,6 +19,7 @@
 #define itkRegionGrowImageFilter_hxx
 
 
+#include "itkPrintHelper.h"
 namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
@@ -35,7 +36,7 @@ RegionGrowImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, I
   Superclass::PrintSelf(os, indent);
 
   os << indent << "MaximumNumberOfRegions: " << m_MaximumNumberOfRegions << std::endl;
-  os << indent << "GridSize: " << static_cast<typename NumericTraits<GridSizeType>::PrintType>(m_GridSize) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "GridSize", m_GridSize);
 }
 } // namespace itk
 

--- a/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
@@ -23,6 +23,7 @@
 #include "itkTotalProgressReporter.h"
 
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -147,8 +148,7 @@ LabelVotingImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, 
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "LabelForUndecidedPixels: "
-     << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(m_HasLabelForUndecidedPixels) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "LabelForUndecidedPixels", m_HasLabelForUndecidedPixels);
   itkPrintSelfBooleanMacro(HasLabelForUndecidedPixels);
   os << indent << "TotalLabelCount: " << m_TotalLabelCount << std::endl;
 }

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.hxx
@@ -26,6 +26,7 @@
 
 #include <vector>
 #include <algorithm>
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -157,12 +158,8 @@ VotingBinaryImageFilter<TInputImage, TOutput>::PrintSelf(std::ostream & os, Inde
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Radius: " << m_Radius << std::endl;
-  os << indent
-     << "Foreground value : " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
-  os << indent
-     << "Background value : " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Foreground value ", m_ForegroundValue);
+  print_helper::PrintNumericTrait(os, indent, "Background value ", m_BackgroundValue);
   os << indent << "Birth Threshold   : " << m_BirthThreshold << std::endl;
   os << indent << "Survival Threshold   : " << m_SurvivalThreshold << std::endl;
 }

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryIterativeHoleFillingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryIterativeHoleFillingImageFilter.hxx
@@ -27,6 +27,7 @@
 
 #include <vector>
 #include <algorithm>
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -94,12 +95,8 @@ VotingBinaryIterativeHoleFillingImageFilter<TInputImage>::PrintSelf(std::ostream
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "Radius: " << m_Radius << std::endl;
-  os << indent
-     << "Foreground value : " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_ForegroundValue)
-     << std::endl;
-  os << indent
-     << "Background value : " << static_cast<typename NumericTraits<InputPixelType>::PrintType>(m_BackgroundValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Foreground value ", m_ForegroundValue);
+  print_helper::PrintNumericTrait(os, indent, "Background value ", m_BackgroundValue);
   os << indent << "Maximum Number of Iterations : " << m_MaximumNumberOfIterations << std::endl;
   os << indent << "Current Number of Iterations : " << m_CurrentNumberOfIterations << std::endl;
   os << indent << "Majority Threshold           : " << m_MajorityThreshold << std::endl;

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
@@ -23,6 +23,7 @@
 #include "itkMath.h"
 
 #include <algorithm>
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -54,8 +55,7 @@ LevelSetNeighborhoodExtractor<TLevelSet>::PrintSelf(std::ostream & os, Indent in
   os << indent << "NarrowBandwidth: " << m_NarrowBandwidth << std::endl;
   os << indent << "InputNarrowBand: " << m_InputNarrowBand << std::endl;
   os << indent << "ImageRegion: " << m_ImageRegion << std::endl;
-  os << indent << "LargeValue: " << static_cast<typename NumericTraits<PixelType>::PrintType>(m_LargeValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "LargeValue", m_LargeValue);
   // ToDo
   // os << indent << "NodesUsed: " << m_NodesUsed << std::endl;
   itkPrintSelfBooleanMacro(LastPointIsInside);

--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -2426,8 +2426,7 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::PrintSelf(std
 
   os << indent << "Layers: " << m_Layers << std::endl;
 
-  os << indent << "NumberOfLayers: " << static_cast<NumericTraits<StatusType>::PrintType>(m_NumberOfLayers)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumberOfLayers", m_NumberOfLayers);
 
   itkPrintSelfObjectMacro(StatusImage);
   itkPrintSelfObjectMacro(OutputImage);
@@ -2437,16 +2436,14 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::PrintSelf(std
 
   itkPrintSelfObjectMacro(LayerNodeStore);
 
-  os << indent << "IsoSurfaceValue: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_IsoSurfaceValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "IsoSurfaceValue", m_IsoSurfaceValue);
 
   os << indent << "TimeStepList: " << m_TimeStepList << std::endl;
   os << indent << "ValidTimeStepList: " << m_ValidTimeStepList << std::endl;
 
-  os << indent << "TimeStep: " << static_cast<typename NumericTraits<TimeStepType>::PrintType>(m_TimeStep) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "TimeStep", m_TimeStep);
 
-  os << indent << "NumOfWorkUnits: " << static_cast<NumericTraits<ThreadIdType>::PrintType>(m_NumOfWorkUnits)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumOfWorkUnits", m_NumOfWorkUnits);
 
   os << indent << "SplitAxis: " << m_SplitAxis << std::endl;
   os << indent << "ZSize: " << m_ZSize << std::endl;

--- a/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkShapePriorSegmentationLevelSetFunction.hxx
@@ -19,6 +19,7 @@
 #define itkShapePriorSegmentationLevelSetFunction_hxx
 
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -37,9 +38,7 @@ ShapePriorSegmentationLevelSetFunction<TImageType, TFeatureImageType>::PrintSelf
 
   itkPrintSelfObjectMacro(ShapeFunction);
 
-  os << indent
-     << "ShapePriorWeight: " << static_cast<typename NumericTraits<ScalarValueType>::PrintType>(m_ShapePriorWeight)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ShapePriorWeight", m_ShapePriorWeight);
 }
 
 template <typename TImageType, typename TFeatureImageType>

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.hxx
@@ -75,7 +75,7 @@ SparseFieldCityBlockNeighborList<TNeighborhoodType>::Print(std::ostream & os, In
   os << "SparseFieldCityBlockNeighborList: " << std::endl;
 
   os << indent << "Size: " << m_Size << std::endl;
-  os << indent << "Radius: " << static_cast<typename NumericTraits<RadiusType>::PrintType>(m_Radius) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Radius", m_Radius);
   os << indent << "ArrayIndex: " << m_ArrayIndex << std::endl;
   os << indent << "NeighborhoodOffset: " << m_NeighborhoodOffset << std::endl;
   os << indent << "StrideTable: " << m_StrideTable << std::endl;
@@ -1095,10 +1095,8 @@ SparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostrea
   itkPrintSelfObjectMacro(StatusImage);
   itkPrintSelfObjectMacro(LayerNodeStore);
 
-  os << indent << "IsoSurfaceValue: " << static_cast<typename NumericTraits<ValueType>::PrintType>(m_IsoSurfaceValue)
-     << std::endl;
-  os << indent << "UpdateBuffer: " << static_cast<typename NumericTraits<UpdateBufferType>::PrintType>(m_UpdateBuffer)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "IsoSurfaceValue", m_IsoSurfaceValue);
+  print_helper::PrintNumericTrait(os, indent, "UpdateBuffer", m_UpdateBuffer);
   itkPrintSelfBooleanMacro(InterpolateSurfaceLocation);
 
   itkPrintSelfObjectMacro(InputImage);

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkMRFImageFilter.hxx
@@ -45,17 +45,10 @@ MRFImageFilter<TInputImage, TClassifiedImage>::PrintSelf(std::ostream & os, Inde
 
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "InputImageNeighborhoodRadius: "
-     << static_cast<typename NumericTraits<InputImageNeighborhoodRadiusType>::PrintType>(m_InputImageNeighborhoodRadius)
-     << std::endl;
-  os << indent << "LabelledImageNeighborhoodRadius: "
-     << static_cast<typename NumericTraits<LabelledImageNeighborhoodRadiusType>::PrintType>(
-          m_LabelledImageNeighborhoodRadius)
-     << std::endl;
-  os << indent << "LabelStatusImageNeighborhoodRadius: "
-     << static_cast<typename NumericTraits<LabelStatusImageNeighborhoodRadiusType>::PrintType>(
-          m_LabelStatusImageNeighborhoodRadius)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "InputImageNeighborhoodRadius", m_InputImageNeighborhoodRadius);
+  print_helper::PrintNumericTrait(os, indent, "LabelledImageNeighborhoodRadius", m_LabelledImageNeighborhoodRadius);
+  print_helper::PrintNumericTrait(
+    os, indent, "LabelStatusImageNeighborhoodRadius", m_LabelStatusImageNeighborhoodRadius);
 
   os << indent << "NumberOfClasses: " << m_NumberOfClasses << std::endl;
   os << indent << "MaximumNumberOfIterations: " << m_MaximumNumberOfIterations << std::endl;

--- a/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConfidenceConnectedImageFilter.hxx
@@ -88,13 +88,10 @@ ConfidenceConnectedImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostrea
   os << indent << "Seeds: " << m_Seeds << std::endl;
   os << indent << "Multiplier: " << m_Multiplier << std::endl;
   os << indent << "NumberOfIterations: " << m_NumberOfIterations << std::endl;
-  os << indent
-     << "ReplaceValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ReplaceValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ReplaceValue", m_ReplaceValue);
   os << indent << "InitialNeighborhoodRadius: " << m_InitialNeighborhoodRadius << std::endl;
-  os << indent << "Mean: " << static_cast<typename NumericTraits<InputRealType>::PrintType>(m_Mean) << std::endl;
-  os << indent << "Variance: " << static_cast<typename NumericTraits<InputRealType>::PrintType>(m_Variance)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Mean", m_Mean);
+  print_helper::PrintNumericTrait(os, indent, "Variance", m_Variance);
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Segmentation/RegionGrowing/include/itkConnectedThresholdImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkConnectedThresholdImageFilter.hxx
@@ -24,6 +24,7 @@
 
 #include "itkShapedFloodFilledImageFunctionConditionalIterator.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -280,13 +281,9 @@ void
 ConnectedThresholdImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   this->Superclass::PrintSelf(os, indent);
-  os << indent << "Upper: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(this->GetUpper())
-     << std::endl;
-  os << indent << "Lower: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(this->GetLower())
-     << std::endl;
-  os << indent
-     << "ReplaceValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ReplaceValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Upper", this->GetUpper());
+  print_helper::PrintNumericTrait(os, indent, "Lower", this->GetLower());
+  print_helper::PrintNumericTrait(os, indent, "ReplaceValue", m_ReplaceValue);
   os << indent << "Seeds: ";
   for (unsigned int i = 0; i < this->m_Seeds.size(); ++i)
   {

--- a/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
@@ -51,20 +51,13 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream 
   os << indent << "Seeds1: " << std::endl;
   os << indent << "Seeds2: " << std::endl;
 
-  os << indent << "Lower: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Lower)
-     << std::endl;
-  os << indent << "Upper: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Upper)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Lower", m_Lower);
+  print_helper::PrintNumericTrait(os, indent, "Upper", m_Upper);
 
-  os << indent
-     << "ReplaceValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ReplaceValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ReplaceValue", m_ReplaceValue);
 
-  os << indent
-     << "IsolatedValue: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_IsolatedValue)
-     << std::endl;
-  os << indent << "IsolatedValueTolerance: "
-     << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_IsolatedValueTolerance) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "IsolatedValue", m_IsolatedValue);
+  print_helper::PrintNumericTrait(os, indent, "IsolatedValueTolerance", m_IsolatedValueTolerance);
 
   itkPrintSelfBooleanMacro(FindUpperThreshold);
   itkPrintSelfBooleanMacro(ThresholdingFailed);

--- a/Modules/Segmentation/RegionGrowing/include/itkNeighborhoodConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkNeighborhoodConnectedImageFilter.hxx
@@ -71,13 +71,9 @@ NeighborhoodConnectedImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostr
   Superclass::PrintSelf(os, indent);
 
   os << indent << "Seeds: " << m_Seeds << std::endl;
-  os << indent << "Upper: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Upper)
-     << std::endl;
-  os << indent << "Lower: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Lower)
-     << std::endl;
-  os << indent
-     << "ReplaceValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ReplaceValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Upper", m_Upper);
+  print_helper::PrintNumericTrait(os, indent, "Lower", m_Lower);
+  print_helper::PrintNumericTrait(os, indent, "ReplaceValue", m_ReplaceValue);
   os << indent << "Radius: " << m_Radius << std::endl;
 }
 

--- a/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkVectorConfidenceConnectedImageFilter.hxx
@@ -51,9 +51,7 @@ VectorConfidenceConnectedImageFilter<TInputImage, TOutputImage>::PrintSelf(std::
   os << indent << "Seeds: " << m_Seeds << std::endl;
   os << indent << "Multiplier: " << m_Multiplier << std::endl;
   os << indent << "NumberOfIterations: " << m_NumberOfIterations << std::endl;
-  os << indent
-     << "ReplaceValue: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ReplaceValue)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ReplaceValue", m_ReplaceValue);
   os << indent << "InitialNeighborhoodRadius: " << m_InitialNeighborhoodRadius << std::endl;
 
   itkPrintSelfObjectMacro(ThresholdFunction);

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -23,6 +23,7 @@
 #include "vnl/vnl_sample.h"
 #include "itkMath.h"
 #include "itkMakeUniqueForOverwrite.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -1286,9 +1287,8 @@ VoronoiDiagram2DGenerator<TCoordinate>::PrintSelf(std::ostream & os, Indent inde
   Superclass::PrintSelf(os, indent);
 
   os << indent << "Number Of Seeds: " << m_NumberOfSeeds << std::endl;
-  os << indent << "VorBoundary: " << static_cast<typename NumericTraits<PointType>::PrintType>(m_VorBoundary)
-     << std::endl;
-  os << indent << "OutputVD: " << static_cast<typename NumericTraits<OutputType>::PrintType>(m_OutputVD) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "VorBoundary", m_VorBoundary);
+  print_helper::PrintNumericTrait(os, indent, "OutputVD", m_OutputVD);
 
   os << indent << "Pxmin: " << m_Pxmin << std::endl;
   os << indent << "Pxmax: " << m_Pxmax << std::endl;

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiSegmentationImageFilterBase.hxx
@@ -44,9 +44,9 @@ VoronoiSegmentationImageFilterBase<TInputImage, TOutputImage, TBinaryPriorImage>
 
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "Size: " << static_cast<typename NumericTraits<SizeType>::PrintType>(m_Size) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Size", m_Size);
   os << indent << "NumberOfSeeds: " << m_NumberOfSeeds << std::endl;
-  os << indent << "MinRegion: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_MinRegion) << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "MinRegion", m_MinRegion);
   os << indent << "Steps: " << m_Steps << std::endl;
   os << indent << "LastStepSeeds: " << m_LastStepSeeds << std::endl;
   os << indent << "NumberOfSeedsToAdded: " << m_NumberOfSeedsToAdded << std::endl;

--- a/Modules/Segmentation/Watersheds/include/itkIsolatedWatershedImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkIsolatedWatershedImageFilter.hxx
@@ -20,6 +20,7 @@
 
 #include "itkProgressReporter.h"
 #include "itkIterationReporter.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -181,12 +182,8 @@ IsolatedWatershedImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream 
   this->Superclass::PrintSelf(os, indent);
   os << indent << "Threshold: " << m_Threshold << std::endl;
   os << indent << "UpperValueLimit: " << m_UpperValueLimit << std::endl;
-  os << indent
-     << "ReplaceValue1: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ReplaceValue1)
-     << std::endl;
-  os << indent
-     << "ReplaceValue2: " << static_cast<typename NumericTraits<OutputImagePixelType>::PrintType>(m_ReplaceValue2)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "ReplaceValue1", m_ReplaceValue1);
+  print_helper::PrintNumericTrait(os, indent, "ReplaceValue2", m_ReplaceValue2);
   os << indent << "Seed1: " << m_Seed1 << std::endl;
   os << indent << "Seed2: " << m_Seed2 << std::endl;
   os << indent << "IsolatedValue: " << m_IsolatedValue << std::endl;

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedImageFilter.hxx
@@ -23,6 +23,7 @@
 #include "itkConnectedComponentImageFilter.h"
 #include "itkMorphologicalWatershedFromMarkersImageFilter.h"
 #include "itkNumericTraits.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -145,8 +146,7 @@ MorphologicalWatershedImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ost
 
   itkPrintSelfBooleanMacro(FullyConnected);
   os << indent << "MarkWatershedLine: " << m_MarkWatershedLine << std::endl;
-  os << indent << "Level: " << static_cast<typename NumericTraits<InputImagePixelType>::PrintType>(m_Level)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "Level", m_Level);
 }
 
 } // end namespace itk

--- a/Modules/Video/IO/include/itkVideoFileWriter.hxx
+++ b/Modules/Video/IO/include/itkVideoFileWriter.hxx
@@ -23,6 +23,7 @@
 #include "itkNumericTraits.h"
 #include "itkTemporalDataObject.h"
 #include "itkMath.h"
+#include "itkPrintHelper.h"
 
 namespace itk
 {
@@ -305,12 +306,10 @@ VideoFileWriter<TInputVideoStream>::PrintSelf(std::ostream & os, Indent indent) 
 
   os << indent << "OutputTemporalRegion: " << m_OutputTemporalRegion << std::endl;
 
-  os << indent << "FramesPerSecond: " << static_cast<NumericTraits<TemporalRatioType>::PrintType>(m_FramesPerSecond)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "FramesPerSecond", m_FramesPerSecond);
   os << indent << "FourCC: " << m_FourCC << std::endl;
   os << indent << "Dimensions: " << m_Dimensions << std::endl;
-  os << indent << "NumberOfComponents: " << static_cast<NumericTraits<SizeValueType>::PrintType>(m_NumberOfComponents)
-     << std::endl;
+  print_helper::PrintNumericTrait(os, indent, "NumberOfComponents", m_NumberOfComponents);
   os << indent << "ComponentType: " << m_ComponentType << std::endl;
 }
 


### PR DESCRIPTION
Replace the `os << indent << "Name: " << static_cast<typename NumericTraits<T>::PrintType>(this->m_Name) << std::endl;` boilerplate in 513 `PrintSelf` overrides across 221 files with `itk::print_helper::PrintNumericTrait(os, indent, "Name", this->m_Name);`. Supersedes #3909 (which proposed a macro).

<details>
<summary>How #3909's review concerns are resolved</summary>

| #3909 concern | Resolution |
|---|---|
| @N-Dekker: prefer named template over macro | Pure template function in `itk::print_helper`; no macro |
| @N-Dekker: take `os` and `indent` out as explicit params | They are explicit parameters |
| @N-Dekker: PR #3802 chained-`<<` co-location | Helper lives next to those overloads in `itkPrintHelper.h` |
| @issakomi: skip useless cast when types match | `if constexpr (std::is_same_v<T, NumericTraits<T>::PrintType>)` skips it |
| @issakomi: handle `std::complex<T>` (PrintType = Self) | Identity-cast branch covers it; unit-tested |
| WIP: no in-tree adoption | Commit 2 converts 513 sites |

</details>

<details>
<summary>Commits</summary>

1. `ENH:` Add `itk::print_helper::PrintNumericTrait` helper (helper + 6 tests for double / int / unsigned char / signed char / `complex<double>` / indented output)
2. `ENH:` Adopt `PrintNumericTrait` helper toolkit-wide (mechanical regex conversion; 1 chained-statement leftover left for follow-up — `Modules/Filtering/ImageFusion/include/itkLabelOverlayImageFilter.hxx:103`)

Co-authored with @jhlegarreta.

</details>

<details>
<summary>Local validation</summary>

- `pre-commit run --all-files`: clean
- Toolkit-wide build: 4448/4448 ninja targets in `build-python`
- `ctest -R PrintHelper`: 17/17 (incl. 6 new `PrintNumericTrait` cases)
- Cross-module sample (`ImageRegistrationMethodv4|MeanSquares|FastMarching|ImageStatistics|MultiResolution`): 63/63

</details>

<!--
provenance: claude-code session 2026-05-07
supersedes_pr: 3909
co_author: jhlegarreta
key_files:
  - Modules/Core/Common/include/itkPrintHelper.h (helper, forward-decl, ordering)
  - Modules/Core/Common/test/itkPrintHelperGTest.cxx (6 new tests)
  - 221 .h/.hxx/.cxx PrintSelf adopters across Modules/
chained-statement_residue: 1 (Modules/Filtering/ImageFusion/include/itkLabelOverlayImageFilter.hxx:103)
post_merge_action: close #3909 with link to this PR
-->

Closes #3909.
