### PR TITLE
COMP: Add line continuations to pixi task cmds for pixi 0.68 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,42 +33,42 @@ libopenblas = ">=0.3.30,<0.4"
 libgfortran5 = ">=15.2.0,<16"
 
 [tool.pixi.feature.cxx.tasks.configure]
-cmd = '''cmake
-  -Bbuild
-  -S.
-  -GNinja
-  -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo
+cmd = '''cmake \
+  -Bbuild \
+  -S. \
+  -GNinja \
+  -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
   -DBUILD_TESTING:BOOL=ON'''
 description = "Configure ITK"
 outputs = ["build/CMakeFiles/"]
 
 [tool.pixi.feature.cxx.tasks.configure-ci]
-cmd = '''cmake
-  -Bbuild
-  -S.
-  -GNinja
-  -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo
-  -DBUILD_TESTING:BOOL=ON
-  -DITK_USE_CCACHE:BOOL=ON
-  -DCMAKE_C_COMPILER_LAUNCHER:STRING=ccache
-  -DCMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache
-  -DModule_AnisotropicDiffusionLBR:BOOL=ON
-  -DModule_Cuberille:BOOL=ON
-  -DModule_Montage:BOOL=ON
-  -DModule_FastBilateral:BOOL=ON
-  -DModule_GenericLabelInterpolator:BOOL=ON
-  -DModule_IOMeshSTL:BOOL=ON
-  -DModule_LabelErodeDilate:BOOL=ON
-  -DModule_MeshNoise:BOOL=ON
-  -DModule_MGHIO:BOOL=ON
-  -DModule_PolarTransform:BOOL=ON
-  -DModule_SplitComponents:BOOL=ON
-  -DModule_IOMeshMZ3:BOOL=ON
-  -DModule_IOFDF:BOOL=ON
-  -DModule_MorphologicalContourInterpolation:BOOL=ON
-  -DModule_RLEImage:BOOL=ON
-  -DModule_SubdivisionQuadEdgeMeshFilter:BOOL=ON
-  -DITK_COMPUTER_MEMORY_SIZE:STRING=11
+cmd = '''cmake \
+  -Bbuild \
+  -S. \
+  -GNinja \
+  -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
+  -DBUILD_TESTING:BOOL=ON \
+  -DITK_USE_CCACHE:BOOL=ON \
+  -DCMAKE_C_COMPILER_LAUNCHER:STRING=ccache \
+  -DCMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache \
+  -DModule_AnisotropicDiffusionLBR:BOOL=ON \
+  -DModule_Cuberille:BOOL=ON \
+  -DModule_Montage:BOOL=ON \
+  -DModule_FastBilateral:BOOL=ON \
+  -DModule_GenericLabelInterpolator:BOOL=ON \
+  -DModule_IOMeshSTL:BOOL=ON \
+  -DModule_LabelErodeDilate:BOOL=ON \
+  -DModule_MeshNoise:BOOL=ON \
+  -DModule_MGHIO:BOOL=ON \
+  -DModule_PolarTransform:BOOL=ON \
+  -DModule_SplitComponents:BOOL=ON \
+  -DModule_IOMeshMZ3:BOOL=ON \
+  -DModule_IOFDF:BOOL=ON \
+  -DModule_MorphologicalContourInterpolation:BOOL=ON \
+  -DModule_RLEImage:BOOL=ON \
+  -DModule_SubdivisionQuadEdgeMeshFilter:BOOL=ON \
+  -DITK_COMPUTER_MEMORY_SIZE:STRING=11 \
   -DModule_StructuralSimilarity:BOOL=ON'''
 description = "Configure ITK for CI (with ccache compiler launcher)"
 outputs = ["build/CMakeFiles/"]
@@ -85,11 +85,11 @@ description = "Test ITK"
 depends-on = ["build"]
 
 [tool.pixi.feature.cxx.tasks.configure-debug]
-cmd = '''cmake
-  -Bbuild-debug
-  -S.
-  -GNinja
-  -DCMAKE_BUILD_TYPE:STRING=Debug
+cmd = '''cmake \
+  -Bbuild-debug \
+  -S. \
+  -GNinja \
+  -DCMAKE_BUILD_TYPE:STRING=Debug \
   -DBUILD_TESTING:BOOL=ON'''
 description = "Configure ITK - Debug"
 outputs = ["build-debug/CMakeFiles/"]
@@ -106,11 +106,11 @@ description = "Test ITK - Debug"
 depends-on = ["build-debug"]
 
 [tool.pixi.feature.cxx.tasks.configure-release]
-cmd = '''cmake
-  -Bbuild-release
-  -S.
-  -GNinja
-  -DCMAKE_BUILD_TYPE:STRING=Release
+cmd = '''cmake \
+  -Bbuild-release \
+  -S. \
+  -GNinja \
+  -DCMAKE_BUILD_TYPE:STRING=Release \
   -DBUILD_TESTING:BOOL=ON'''
 description = "Configure ITK - Release"
 outputs = ["build-release/CMakeFiles/"]
@@ -127,12 +127,12 @@ description = "Test ITK - Release"
 depends-on = ["build-release"]
 
 [tool.pixi.feature.python.tasks.configure-python]
-cmd = '''cmake
-  -Bbuild-python
-  -S.
-  -GNinja
-  -DITK_WRAP_PYTHON:BOOL=ON
-  -DCMAKE_BUILD_TYPE:STRING=Release
+cmd = '''cmake \
+  -Bbuild-python \
+  -S. \
+  -GNinja \
+  -DITK_WRAP_PYTHON:BOOL=ON \
+  -DCMAKE_BUILD_TYPE:STRING=Release \
   -DBUILD_TESTING:BOOL=ON'''
 description = "Configure ITK Python"
 outputs = ["build-python/CMakeFiles/"]
@@ -155,12 +155,12 @@ description = "Run a Python executable with the development ITK Python package"
 depends-on = ["build-python"]
 
 [tool.pixi.feature.python.tasks.configure-debug-python]
-cmd = '''cmake
-  -Bbuild-debug-python
-  -S.
-  -GNinja
-  -DITK_WRAP_PYTHON:BOOL=ON
-  -DCMAKE_BUILD_TYPE:STRING=Debug
+cmd = '''cmake \
+  -Bbuild-debug-python \
+  -S. \
+  -GNinja \
+  -DITK_WRAP_PYTHON:BOOL=ON \
+  -DCMAKE_BUILD_TYPE:STRING=Debug \
   -DBUILD_TESTING:BOOL=ON'''
 description = "Configure ITK Python - Debug"
 outputs = ["build-debug-python/CMakeFiles/"]


### PR DESCRIPTION
Add backslash line continuations to all multi-line `cmd` blocks in
`pyproject.toml` so pixi tasks still execute as a single shell command
under pixi 0.68+. **Unblocks Pixi-Cxx CI on every open ITK PR.**

<details>
<summary>Root cause (pixi 0.68 behavior change)</summary>

pixi 0.68.0 was released 2026-05-08 and shipped
[prefix-dev/pixi#5957](https://github.com/prefix-dev/pixi/pull/5957),
which changes how multi-line TOML `cmd` blocks are interpreted.

Before 0.68 (deno_task_shell collapsed bare newlines to whitespace):

```toml
[tasks.configure-ci]
cmd = '''cmake
  -Bbuild
  -S.
  ...'''
```

executed as `cmake -Bbuild -S. ...` — a single cmake invocation.

After 0.68 (pixi joins non-empty, non-comment lines with `&&` before
parsing), the same TOML executes as `cmake && -Bbuild && -S. && ...`.
`cmake` runs first with **no arguments**, prints its Usage banner;
the next statement tries to execute `-Bbuild` as a command, fails
with `command not found`, and the task exits 127.

Per the pixi PR description, *"Backslash line continuations are
merged"* — so adding a trailing ` \` on each non-final line
restores the legacy single-command semantics on pixi 0.68+ and is
a no-op on earlier versions.

</details>

<details>
<summary>Affected ITK CI shape</summary>

The `prefix-dev/setup-pixi@v0.8.1` action used by ITK's `.github/workflows/pixi.yml`
does not pin a `pixi-version`, so it pulls the latest release. Yesterday
runs got 0.67.2 (working); today's runs got 0.68.0 (broken).

| Pixi-Cxx job | Yesterday (0.67.2) | Today (0.68.0) |
|---|---|---|
| `Pixi-Cxx (ubuntu-22.04)` | ✅ pass | ❌ fail (1m22s, exit 127) |
| `Pixi-Cxx (macos-15)` | ✅ pass | ❌ fail (1m10s, exit 127) |
| `Pixi-Cxx (windows-2022)` | ✅ pass | ❌ fail (1m11s, exit 127) |

Confirmed by re-running PR #6234 today: same code that passed
yesterday now fails with the same `Usage` / `-Bbuild: command not
found` / `Available tasks:` signature. Same applies to PR #6235
and any open PR whose latest CI run fired today.

</details>

<details>
<summary>What this PR changes</summary>

Adds a trailing ` \` to every non-final, non-empty, non-already-`&&`-terminated
line of every multi-line `cmd` in `pyproject.toml`. Six tasks are
touched:

- `configure`
- `configure-ci`
- `configure-debug`
- `configure-release`
- `configure-python`
- `configure-debug-python`

The two `python-exe` tasks already terminate their first line with
`&&` (so per pixi 0.68's *"lines already ending in a shell control
operator (`&&`, `||`, `|`, `;`, `&`) aren't double-separated"* rule
they continue to work unmodified).

53 insertions / 53 deletions; no semantic change beyond restoring
the previous single-command execution model.

</details>

<details>
<summary>Local validation</summary>

- `python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"`: parses cleanly
- `pre-commit run --all-files`: clean
- Behavior under pre-0.68 pixi: backslash continuations have always been merged by deno_task_shell, so this change is a no-op on the previous version

</details>

<!--
provenance: claude-code session 2026-05-08
root_cause_pr: prefix-dev/pixi#5957 (released in pixi 0.68.0 on 2026-05-08)
affected_action: prefix-dev/setup-pixi@v0.8.1 (does not pin pixi-version)
mechanical_transform: regex insert ' \\' suffix on every non-final, non-blank, non-shell-op-terminated line of every multi-line cmd ''' block
unblocks_prs:
  - 6235 (ingest AdaptiveDenoising)
  - 6234 (PrintNumericTrait toolkit-wide)
  - 6233 (vnl protected ivars)
  - 6227 (ObjectToObjectMultiMetricv4 wrap)
  - 6222 (SingleMultiThreader)
  - all other open PRs whose CI fires after 2026-05-08 0.68.0 release
-->
