### PR TITLE
COMP: Fix warning: loop variable 'image' creates a copy

### DIFF
--- a/Modules/Filtering/Cuberille/test/CuberilleTest_Issue66.cxx
+++ b/Modules/Filtering/Cuberille/test/CuberilleTest_Issue66.cxx
@@ -112,7 +112,7 @@ int
 CuberilleTest_Issue66(int, char *[])
 {
   int countFailed = 0;
-  for (const auto image : { case1(), case2() })
+  for (const auto & image : { case1(), case2() })
   {
 
     const auto extract = TExtract::New();


### PR DESCRIPTION
Full message was:
```log
[2089/2102] Building CXX object Modules/Remote/Cuberille/test/CMakeFiles/CuberilleTestDriver.dir/CuberilleTest_Issue66.cxx.o 
/.../ITK/Modules/Remote/Cuberille/test/CuberilleTest_Issue66.cxx: In function 'int CuberilleTest_Issue66(int, char**)': 
/.../ITK/Modules/Remote/Cuberille/test/CuberilleTest_Issue66.cxx:115:19: warning: loop variable 'image' creates a copy from type 'const itk::SmartPointer<itk::Image<unsigned char, 3> >' [-Wrange-loop-construct]
  115 |   for (const auto image : { case1(), case2() })
      |                   ^~~~~
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
