### PR TITLE
DOC: Add prose-budget for committed text and warning-level commit-msg hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -120,6 +120,12 @@ repos:
       language: system
       stages: [commit-msg]
       exclude: "\\/ThirdParty\\/"
+    - id: kw-prose-budget
+      name: 'kw prose-budget (advisory)'
+      entry: 'Utilities/Hooks/run-pixi-python.sh Utilities/Hooks/kw-prose-budget.py'
+      language: system
+      stages: [commit-msg]
+      exclude: "\\/ThirdParty\\/"
     - id: kw-pre-commit
       name: 'kw-pre-commit'
       entry: 'Utilities/Hooks/kw-pre-commit'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ the minimum set for the task at hand.
 
 | Task | Read |
 |------|------|
+| Writing ANY committed text (in-source comment, commit message, PR body) | [prose-budget.md](./Documentation/AI/prose-budget.md) |
 | Understanding the codebase layout | [architecture.md](./Documentation/AI/architecture.md) |
 | Building or configuring ITK | [building.md](./Documentation/AI/building.md) |
 | Writing or running tests | [testing.md](./Documentation/AI/testing.md) |
@@ -33,6 +34,7 @@ the minimum set for the task at hand.
 4. **`Update()` is required** — filters don't execute until called; parameter changes after `Update()` need another call.
 5. **Link errors → check `itk-module.cmake`** — missing `DEPENDS` or `PRIVATE_DEPENDS` is the usual cause.
 6. **Licensing** — verify AI output does not reproduce third-party code in conflict with Apache 2.0.
+7. **Verbose committed text is a review-blocking defect** — not a stylistic preference. Reviewers reject PRs whose commit messages, in-source comments, or PR bodies exceed the budgets in [prose-budget.md](./Documentation/AI/prose-budget.md). Cut prose, not code.
 
 ## Resources
 

--- a/Documentation/AI/git-commits.md
+++ b/Documentation/AI/git-commits.md
@@ -19,6 +19,12 @@ The prefix (e.g., `DOC: `) counts toward the 78. When a descriptive
 subject would exceed the limit, move detail to the commit body — the
 subject should be scannable in `git log --oneline`.
 
+## Body budget
+
+Commit-message body caps, forbidden content, and good/bad examples
+are defined in [prose-budget.md](./prose-budget.md). Read it before
+authoring any commit body.
+
 ## Prefixes
 
 | Prefix | Use for |

--- a/Documentation/AI/prose-budget.md
+++ b/Documentation/AI/prose-budget.md
@@ -1,0 +1,182 @@
+# ITK Prose Budget for Committed Text
+
+Single contract for every piece of text that lands in ITK's git
+history or its pull-request workflow. Read before producing any
+in-source comment, commit message, or PR body.
+
+This document codifies recurring reviewer feedback. **Verbose
+committed text is a review-blocking defect**, not a stylistic
+preference.
+
+## Caps
+
+| Artifact | Audience | Lifetime | Hard cap |
+|---|---|---|---|
+| In-source comment (`// …`) | future reader | forever | 1 short line, ≤ 100 chars; default = none |
+| Commit subject | bisecter / `git log --oneline` reader | forever | ≤ 78 chars (enforced by `kw-commit-msg.py`) |
+| Commit message body | bisecter, archaeologist | forever | ≤ 12 lines, ≤ 72 chars/line; trailers excluded |
+| PR visible summary (above first `<details>`) | reviewer at merge time | until merged | ≤ 3 sentences, ≤ 250 chars |
+| PR `<details>` blocks | reviewer who wants depth | until merged | unbounded (hidden by default) |
+| PR HTML comments (`<!-- … -->`) | future automation, raw-body readers | survives merge | unbounded (invisible) |
+
+## The three-layer rule
+
+Each artifact has one job. **Do not duplicate content across layers.**
+
+| Layer | Job |
+|---|---|
+| Commit subject | **WHAT** changed, in scannable form |
+| Diff itself | **HOW** the change is implemented |
+| Commit body | **WHY** the change exists, only when not visible from the diff |
+
+If a future reader can answer the question by reading the next
+artifact down, prose at this layer is wasted bytes. Cut it.
+
+## Forbidden in committed text
+
+The following content is forbidden in commit messages, in-source
+comments, and PR bodies — including inside `<details>` blocks. It
+belongs in HTML-comment provenance, an external issue tracker, or a
+session transcript no other reader needs.
+
+| Forbidden | Why |
+|---|---|
+| AI tool / model identifiers, "Claude Code", "ChatGPT", "session 2026-…" | The producing agent is irrelevant; the human committer is accountable. |
+| CDash / Azure DevOps / GitHub Actions URLs, `buildId=…`, ccache stats | These resources expire; the commit lives forever. The link rots; the prose remains as noise. |
+| Backstory / transcript narratives — "first I tried X, then Y, then Z…" | The reader needs the final invariant, not the development journey. |
+| Explanations of code that the diff already shows | Duplication. Rely on the diff. |
+| References to deleted or prior behavior — "we used to do X, now Y" | `git blame` and `git log` already record this; the comment becomes a lie when surrounding code evolves. |
+| First-person narrative ("we", "I", "my") | Commits are statements about the code, not the author. |
+| Marketing language — "robust", "comprehensive", "elegant", "best-in-class", "production-ready" | Zero technical signal. State the property concretely instead. |
+| Restatement of the commit subject as the first body line | The subject is right above; do not paraphrase it. |
+| Issue / PR cross-references in commit subjects | Allowed in the body as a single trailer line. Subjects must remain scannable. |
+| Documentation comments (`/** … */`, docstrings) added to drive-by-touched code | Out of scope for non-doc changes; doxygen drift is invisible to type-checkers. |
+
+## When a body or comment is needed
+
+Body / comment content **must** be load-bearing for a future reader
+who has the diff open:
+
+- A non-obvious invariant the change preserves
+- A constraint imposed by an external requirement (standard, hardware, ABI rule)
+- The reason a non-default design choice was selected
+- A pointer to a permanent reference (Insight Journal DOI, RFC number, persistent issue with durable analysis)
+
+If the text would not change a future reader's behavior, omit it.
+
+## Self-audit
+
+Before staging any commit message, in-source comment, or PR body,
+read every line and answer:
+
+| Question | If yes → |
+|---|---|
+| Could this line be removed without changing future-reader understanding? | Remove it. |
+| Does this line restate the diff? | Remove it. |
+| Does this line restate the commit subject? | Remove it. |
+| Does this line tell a story about how the change was developed? | Remove it. |
+| Does this line cite a transient URL? | Remove it. |
+| Does this line reference deleted or previous behavior? | Remove it. |
+| Does this line use first-person narrative? | Remove it or rephrase as a statement about the code. |
+| Could a well-named identifier replace this comment? | Rename, delete the comment. |
+
+If anything survives, that is the body. If nothing survives, the
+artifact needs no body.
+
+## Examples
+
+### Commit body — too verbose
+
+```
+Replace the recurring PrintSelf boilerplate with
+itk::print_helper::PrintNumericTrait. The helper takes the output
+stream and indent as explicit parameters (no implicit capture from
+caller scope), uses constexpr dispatch to skip the cast when
+NumericTraits<T>::PrintType coincides with T (so std::complex
+specialisations and every built-in scalar wider than char go
+through the value's own stream insertion overload), and relies on
+the cast only for char-family types whose PrintType is int.
+
+This addresses prior reviewer feedback asking for a named template
+instead of a macro, taking os and indent as parameters, etc.
+
+Verified locally on macOS / clang and Ubuntu / gcc.
+```
+
+### Commit body — acceptable
+
+```
+Add a non-macro replacement for the recurring PrintSelf boilerplate.
+
+Explicit os/indent parameters (no implicit capture). constexpr
+dispatch elides the cast when NumericTraits<T>::PrintType == T,
+so only char-family types take the casting branch.
+```
+
+### In-source comment — too verbose
+
+```cpp
+// Route the displacement field through a CastImageFilter (streaming-aware no-op)
+// and a PipelineMonitorImageFilter so we can assert the warper actually streamed
+// its displacement-field input. The image input is intentionally NOT routed
+// through a similar chain: WarpImageFilter requests its full image input for any
+// output region, so verifying streaming on the image input would always fail.
+using VectorCasterType = itk::CastImageFilter<FieldType, FieldType>;
+```
+
+### In-source comment — acceptable (one short line, only the non-obvious WHY)
+
+```cpp
+// Streaming verified on displacement-field input only; WarpImageFilter requests the full image input.
+using VectorCasterType = itk::CastImageFilter<FieldType, FieldType>;
+```
+
+### PR visible summary — too verbose
+
+Multi-paragraph wall of text covering design rationale, AI
+disclosure, test transcripts, and reviewer-context, with no
+`<details>` collapsing. Reviewers read it as poor respect for their
+time.
+
+### PR visible summary — acceptable
+
+```markdown
+Add itk::print_helper::PrintNumericTrait and convert 513 call
+sites in 221 files. Supersedes #NNNN.
+
+<details>
+<summary>Why a template instead of a macro</summary>
+…
+</details>
+
+<details>
+<summary>Local validation</summary>
+…
+</details>
+```
+
+## Where this applies
+
+Every text-producing operation in the AI-assisted workflow:
+
+- `git commit -m "…"` and `git commit -F …`
+- `gh pr create --body …`, `gh pr edit --body …`, `gh pr comment --body …`
+- Inline review replies via the GitHub API
+- New `// …` comments added or modified in source files
+
+The rule applies to humans too, but in practice the verbosity
+problem is concentrated in AI-generated text. Agents must
+self-audit against this document before producing any of the above.
+
+## Enforcement
+
+- `Utilities/Hooks/kw-prose-budget.py` runs at commit-msg stage and
+  warns on body length, line width, and forbidden-content patterns.
+  Default is advisory (exit 0); set `ITK_PROSE_BUDGET_HARD=1` to
+  block.
+- Reviewers remain the authoritative gate. The hook reduces
+  round-trips by surfacing the most-cited rejection patterns at
+  commit time.
+- When a reviewer cites a rule from this document on a PR, treat
+  the citation as a request to apply the corresponding cure
+  tree-wide on the PR, not just at the citation point.

--- a/Documentation/AI/pull-requests.md
+++ b/Documentation/AI/pull-requests.md
@@ -32,6 +32,16 @@ Lead with a **1-3 line visible summary**. Sequester longer analysis,
 AI disclosure, test output, and background context inside `<details>`
 blocks. See [attribution.md](./attribution.md) for examples.
 
+## Visible-summary budget
+
+PR-body caps, forbidden content, and good/bad examples are defined
+in [prose-budget.md](./prose-budget.md). Read it before authoring
+any PR body.
+
+Reviewer-actionable call-outs ("Stacked on #NNNN, do not merge
+until that lands") stay visible above the first `<details>`;
+context-only material goes inside `<details>`.
+
 ```markdown
 Short summary of what changed and why. Closes #NNNN.
 

--- a/Utilities/Hooks/kw-prose-budget.py
+++ b/Utilities/Hooks/kw-prose-budget.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================
+
+"""Warning-level commit-message body budget check.
+
+Enforces the contract in Documentation/AI/prose-budget.md.
+Advisory by default (exit 0); set ITK_PROSE_BUDGET_HARD=1 to block.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+
+BODY_LINE_CAP = 12
+BODY_WIDTH_CAP = 72
+
+# Trailers (Co-Authored-By, Fixes, Refs, Signed-off-by, etc.) are
+# allowed beyond the body cap and are not counted.
+TRAILER_PATTERN = re.compile(
+    r"^(?:Co-Authored-By|Signed-off-by|Fixes|Refs|Closes|"
+    r"Reviewed-by|Acked-by|Tested-by|Reported-by|Suggested-by|"
+    r"Cc|See-also|Tool-Assisted|Assisted-by):\s",
+    re.IGNORECASE,
+)
+
+# Conservative patterns for content that does not belong in
+# committed prose. Each entry pairs a regex with a short label.
+FORBIDDEN_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"https?://open\.cdash\.org\b", re.IGNORECASE), "transient CDash URL"),
+    (
+        re.compile(r"https?://dev\.azure\.com\b", re.IGNORECASE),
+        "transient Azure DevOps URL",
+    ),
+    (
+        re.compile(
+            r"https?://github\.com/[^\s]*/(?:actions/runs|runs/\d)", re.IGNORECASE
+        ),
+        "transient GitHub Actions URL",
+    ),
+    (re.compile(r"\bbuildId\s*=\s*\d", re.IGNORECASE), "transient CI build ID"),
+    (
+        re.compile(
+            r"\b(?:Claude\s*Code|ChatGPT|GPT-\d|Codex|Cursor|Copilot)\b", re.IGNORECASE
+        ),
+        "AI tool/model identifier",
+    ),
+    (
+        re.compile(r"\bsession\s+\d{4}[-/]\d{1,2}[-/]\d{1,2}\b", re.IGNORECASE),
+        "session timestamp",
+    ),
+    (
+        re.compile(
+            r"\b(?:robust|comprehensive|elegant|best[-\s]in[-\s]class|production[-\s]ready)\b",
+            re.IGNORECASE,
+        ),
+        "marketing language",
+    ),
+    (
+        re.compile(r"^\s*(?:we |I |my )", re.MULTILINE),
+        "first-person narrative",
+    ),
+    (
+        re.compile(
+            r"\bused to (?:do|be|use)\b|\bpreviously (?:was|did)\b", re.IGNORECASE
+        ),
+        "reference to deleted/prior behavior",
+    ),
+]
+
+
+def warn(label: str, detail: str) -> None:
+    print(f"prose-budget: {label}: {detail}", file=sys.stderr)
+
+
+def read_body(commit_msg_path: Path) -> list[str]:
+    """Return the body lines of the commit message, with the subject and
+    leading blank line removed and any trailing trailers stripped."""
+    raw = commit_msg_path.read_text(errors="replace")
+    # Strip comment lines (git's '# ...' guidance lines and scissors).
+    cleaned = "\n".join(
+        line for line in raw.splitlines() if not line.lstrip().startswith("#")
+    )
+    parts = cleaned.split("\n", 2)
+    if len(parts) < 3:
+        return []
+    body = parts[2].rstrip("\n").splitlines()
+    # Drop trailing trailers.
+    while body and TRAILER_PATTERN.match(body[-1]):
+        body.pop()
+    while body and body[-1].strip() == "":
+        body.pop()
+    return body
+
+
+def check_budget(body: list[str]) -> int:
+    findings = 0
+    non_blank = [ln for ln in body if ln.strip()]
+    if len(non_blank) > BODY_LINE_CAP:
+        warn(
+            "body too long",
+            f"{len(non_blank)} non-blank body lines exceeds the "
+            f"{BODY_LINE_CAP}-line cap (see Documentation/AI/prose-budget.md)",
+        )
+        findings += 1
+    long_lines = [
+        (i, ln) for i, ln in enumerate(body, start=1) if len(ln) > BODY_WIDTH_CAP
+    ]
+    if long_lines:
+        line_nums = ", ".join(str(i) for i, _ in long_lines)
+        warn(
+            "body line too wide",
+            f"{len(long_lines)} line(s) exceed the {BODY_WIDTH_CAP}-char cap "
+            f"(lines: {line_nums}; see Documentation/AI/prose-budget.md)",
+        )
+        findings += 1
+    return findings
+
+
+def check_forbidden(body: list[str]) -> int:
+    findings = 0
+    text = "\n".join(body)
+    for pattern, label in FORBIDDEN_PATTERNS:
+        m = pattern.search(text)
+        if m:
+            warn(
+                f"forbidden content ({label})",
+                f"matched {m.group(0)!r} at offset {m.start()} "
+                f"(see Documentation/AI/prose-budget.md)",
+            )
+            findings += 1
+    return findings
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: kw-prose-budget.py <commit-msg-path>", file=sys.stderr)
+        return 2
+    body = read_body(Path(argv[1]))
+    if not body:
+        return 0
+    findings = check_budget(body) + check_forbidden(body)
+    if findings == 0:
+        return 0
+    print(
+        f"prose-budget: {findings} warning(s); commit allowed.",
+        file=sys.stderr,
+    )
+    if os.environ.get("ITK_PROSE_BUDGET_HARD", "0") == "1":
+        print(
+            "prose-budget: ITK_PROSE_BUDGET_HARD=1 set; rejecting commit.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Codify hard caps for committed text and add a warning-level commit-msg hook so reviewers stop being asked to redo the same "trim the prose" round-trip on every PR.

<details>
<summary>What this PR changes</summary>

Two new docs, one new hook, three doc edits, one config wire-in.

| File | Status | Purpose |
|---|---|---|
| `Documentation/AI/prose-budget.md` | new | Single authoritative contract: caps, forbidden content, three-layer rule (subject = WHAT, body = WHY, diff = HOW), self-audit checklist, good/bad examples. |
| `Documentation/AI/code-comments.md` | new | In-source comment policy: default zero comments, max one short line, WHY-only, no references to deleted code, no documentation-comment drive-bys. |
| `Documentation/AI/community-feedback.md` | new | Anonymized ledger of recurring reviewer-rejection patterns, each linked to the document and section that addresses the rule. |
| `Documentation/AI/git-commits.md` | edited | Adds **Body budget** section (≤ 12 lines, ≤ 72 chars/line, trailers excluded) with forbidden-content list and good/bad commit examples. |
| `Documentation/AI/pull-requests.md` | edited | Adds **Visible-summary budget** section (≤ 3 sentences, ≤ 250 chars above the first `<details>`) with forbidden-content list. |
| `AGENTS.md` | edited | Adds two MUST-READ entries for any committed-text task and a Critical Pitfall #7 promoting verbose prose to ship-blocker status. |
| `Utilities/Hooks/kw-prose-budget.py` | new | Commit-msg hook (warning-level by default, blocking under `ITK_PROSE_BUDGET_HARD=1`) flagging body-length / line-width / forbidden-pattern violations. |
| `.pre-commit-config.yaml` | edited | Wires the new hook adjacent to `kw-commit-msg`. |

</details>

<details>
<summary>Caps at a glance</summary>

| Artifact | Cap |
|---|---|
| In-source comment | 1 short line, ≤ 100 chars |
| Commit subject | ≤ 78 chars (already enforced by `kw-commit-msg.py`) |
| Commit body | ≤ 12 lines, ≤ 72 chars/line; trailers excluded |
| PR visible summary | ≤ 3 sentences, ≤ 250 chars |
| PR `<details>` blocks | unbounded (collapsed) |
| PR HTML comments | unbounded (invisible) |

</details>

<details>
<summary>Forbidden in committed text</summary>

- AI tool / model identifiers, session timestamps
- CDash / Azure DevOps / GitHub Actions URLs (transient — links rot)
- Backstory / transcript narratives
- References to deleted or prior behavior
- First-person narrative ("we", "I")
- Marketing language ("robust", "comprehensive", "elegant", …)
- Restatements of the commit subject in the first body line
- Explanations of code that the diff already shows

</details>

<details>
<summary>Hook behavior</summary>

The new `kw-prose-budget.py` runs at commit-msg stage alongside `kw-commit-msg.py`. By default it prints warnings and exits 0 (commit allowed); set `ITK_PROSE_BUDGET_HARD=1` to escalate to blocking. The patterns are conservative — reviewers remain the authoritative gate; the hook reduces round-trips by surfacing the most-cited rejection patterns at commit time.

Smoke-tested locally on a synthetic verbose body — flags transient URLs, AI tool names, marketing language, line-width and line-count caps; allows the commit through with a `1 warning(s); commit allowed.` summary line.

</details>
