### PR TITLE
COMP: Replace dynamic DESCRIPTION in PolarTransform itk-module.cmake

### DIFF
--- a/Modules/Filtering/PolarTransform/itk-module.cmake
+++ b/Modules/Filtering/PolarTransform/itk-module.cmake
@@ -1,23 +1,11 @@
-# the top-level README is used for describing this module, just
-# re-used it for documentation here
-get_filename_component(MY_CURRENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-file(READ "${MY_CURRENT_DIR}/README.md" DOCUMENTATION)
-
-# itk_module() defines the module dependencies in PolarTransform
-# PolarTransform depends on ITKCommon
-# The testing module in PolarTransform depends on ITKTestKernel
-# and ITKMetaIO(besides PolarTransform and ITKCore)
-# By convention those modules outside of ITK are not prefixed with
-# ITK.
-
-# define the dependencies of the include module and the tests
 itk_module(
   PolarTransform
   COMPILE_DEPENDS
     ITKTransform
   TEST_DEPENDS
     ITKTestKernel
-  DESCRIPTION "${DOCUMENTATION}"
+  DESCRIPTION
+    "Forward and inverse Cartesian/polar coordinate transforms for itk::Image."
   EXCLUDE_FROM_DEFAULT
   ENABLE_SHARED
 )


### PR DESCRIPTION
Drop the `file(READ README.md DOCUMENTATION)` preamble in `Modules/Filtering/PolarTransform/itk-module.cmake` and use a static one-line `DESCRIPTION`. Silences 4 `Unknown argument` AUTHOR_WARNINGs on every configure.

<details>
<summary>Root cause</summary>

`itk_module()` is a CMake macro, so `${ARGN}` re-tokenizes its arguments and list-splits any embedded `;`. The PolarTransform `README.md` contains 4 semicolons, producing 4 spurious `CMake Warning (dev): Unknown argument [...]` messages from `CMake/ITKModuleMacros.cmake:111`.

</details>

<details>
<summary>Prior art</summary>

- PR #6220 (merged 2026-05-06) applied the same canonical fix to `RLEImage`, `SplitComponents`, `IOFDF`, `IOMeshMZ3`, `IOMeshSTL`. PolarTransform was ingested in parallel and slipped through.
- PR #6204 (v4 ingestion, WIP) bakes the prevention into `Utilities/Maintenance/RemoteModuleIngest/sanitize-history.py:patch_dynamic_description` so future ingests cannot reintroduce this regression.

</details>

<details>
<summary>Verification</summary>

- Reproduced the 4 warnings against `Modules/Filtering/PolarTransform/itk-module.cmake:14` via the CDash configure log.
- Confirmed the canonical fix matches PR #6220's diff shape exactly.
- `pre-commit run --all-files` passes on the post-amend tree.

</details>
