### PR TITLE
BUG: Restore eigen_internal export to ITK's main targets set (#6239)

### DIFF
--- a/Modules/ThirdParty/Eigen3/src/itkeigen/CMakeLists.txt
+++ b/Modules/ThirdParty/Eigen3/src/itkeigen/CMakeLists.txt
@@ -965,6 +965,12 @@ target_include_directories (eigen_internal SYSTEM INTERFACE
 
 # Export as title case Eigen
 set_target_properties (eigen_internal PROPERTIES EXPORT_NAME Eigen)
+# Register in ITK's main export set so find_package(ITK) resolves
+# eigen_internal as an IMPORTED target loaded from ITKTargets.cmake
+# (issue #6239: SimpleITK FetchContent + FIND_PACKAGE_ARGS fallback).
+install (TARGETS eigen_internal EXPORT ${ITK3P_INSTALL_EXPORT_NAME})
+# Also register in the standalone ITKInternalEigen3 export set used by
+# find_package(ITKInternalEigen3) consumers.
 install (TARGETS eigen_internal EXPORT ITKInternalEigen3Targets)
 
 set(EIGEN3_TARGETS_FILE ITKInternalEigen3Targets.cmake)


### PR DESCRIPTION
Restores `eigen_internal` to ITK's main `${ITK3P_INSTALL_EXPORT_NAME}` export set so `find_package(ITK)` resolves it for downstream consumers (closes #6239 — SimpleITK CI red since 2026-05-01).

**Scope note**: this addresses only the most immediate regression. The broader Eigen3 design questions (header-path policy #5952 vs #6225, symbol mangling, VNL→Eigen migration, the `_SYSTEM_INCLUDE_DIRS` asymmetry #6224) remain in the master tracking issue #6230 and are deliberately not touched here.

<details>
<summary>Root cause (issue #6239)</summary>

Commit [`64ddc666`](https://github.com/InsightSoftwareConsortium/ITK/commit/64ddc6660c82966f47cbf36ef25175a8792c7df0) (Eigen 5.0.1 vendored update, 2026-05-01) silently moved `eigen_internal` out of ITK's main `${ITK3P_INSTALL_EXPORT_NAME}` export set into a standalone `ITKInternalEigen3Targets`. Because `ITKConfig.cmake` only loads `ITKTargets.cmake`, downstream `find_package(ITK)` could no longer resolve `eigen_internal` and any consumer using FetchContent with `FIND_PACKAGE_ARGS` (SimpleITK's pattern) hit a target-collision cascade as CMake fell back to `add_subdirectory`.

The fix re-adds the install rule that registers `eigen_internal` in the main export set while keeping the standalone `ITKInternalEigen3Targets` install for `find_package(ITKInternalEigen3)` consumers. Both export sets now reference the same target — same pattern as every other ITK-vendored third party (NrrdIO, NIFTI, Expat, OpenJPEG, DICOMParser).

</details>

<details>
<summary>Local verification — SimpleITK before/after differential</summary>

Reproduced against latest SimpleITK upstream (`853c78a9`, 2026-05-09) using two parallel ITK installs at the same configuration (`ITK_BUILD_DEFAULT_MODULES=ON` + `Module_ITKIOTransformMINC=ON` + `Module_ITKReview=ON`, matching `SuperBuild/External_ITK.cmake`):

| | source | install prefix |
|---|---|---|
| baseline | upstream/main `7820bbcfb8` (no fix) | `~/src/ITK-eigen-baseline-install` |
| fix-applied | this PR's tip | `~/src/ITK-build-test-tree-eigen/install-fix` |

**Pre-flight: `eigen_internal` in installed `ITKTargets.cmake`**
```bash
$ grep -c 'add_library(ITK::eigen_internal' install-fix/lib/cmake/ITK-6.0/ITKTargets.cmake
1
$ grep -c 'add_library(ITK::eigen_internal' ITK-eigen-baseline-install/lib/cmake/ITK-6.0/ITKTargets.cmake
0
$ find ITK-eigen-baseline-install -name 'ITKInternalEigen3Targets*.cmake'
ITK-eigen-baseline-install/share/ITKInternalEigen3Targets.cmake     # orphan; not loaded by ITKConfig
```

**SimpleITK configure against each install:**
```bash
cmake -G Ninja -S ~/src/SimpleITK -B sitk-bld \
  -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DWRAP_DEFAULT=OFF \
  -DITK_DIR=<install>/lib/cmake/ITK-6.0
```

| | `find_package(ITK)` | FetchContent fallback (`_deps/itk-src/`) | Error cascade |
|---|---|---|---|
| baseline | FAILED | YES — materialized | `add_library cannot create target "itksys" because an imported target with the same name already exists` (exact #6239 cascade) |
| this PR | `-- ITK found via find_package()` | NO | unrelated SimpleITK codegen issues that reproduce on either ITK |

The fix resolves the export-set regression cleanly. Verification comment with full reproduction steps posted to this PR.

</details>

<details>
<summary>What remains for #6230</summary>

This PR does **not** address (deferred per #6230 design discussion 2026-05-07/09):

- **Q1 header-path policy** — keep `ITK_EIGEN(X)` for ITK internals; PRs #5952 (per-module wrappers) and #6225 (canonical `<Eigen/X>` migration) both pending design resolution.
- **Q2 symbol mangling** — current state (no mangling) preserved; @phcerdan and @blowekamp comments 2026-05-07 lean against, @thewtex pro.
- **Q3 `Eigen3::Eigen` consumer exposure** — emerging consensus is "no, use `ITK::ITKEigen3Module`" but no code change here.
- **Q4 SYSTEM include treatment** — #6224 unchanged; the architecturally-correct fix per blowekamp's 2026-05-07 comment is target-property propagation through `eigen_internal`, not `_SYSTEM_INCLUDE_DIRS` glue. Larger refactor.
- **System-Eigen CI matrix** — still manual per #6176.
- **CTest find_package smoke test** — would be the highest-leverage automated guard but requires new test infrastructure (no third-party module currently has its own `test/`); deferred to avoid precedent-setting in a regression-fix PR.
- **`UpdateFromUpstream.sh` overlay-patch checklist** — was prototyped in an earlier revision of this PR but removed per maintainer preference; documenting the no-mangling decision and the dual-export requirement belongs elsewhere.

</details>

<!--
provenance: claude-code session 2026-05-09
key_facts:
  - phase1_fix: Modules/ThirdParty/Eigen3/src/itkeigen/CMakeLists.txt:968-973 (added install line for ${ITK3P_INSTALL_EXPORT_NAME})
  - reproducer_dirs:
      fix_install:      ~/src/ITK-build-test-tree-eigen/install-fix/
      baseline_install: ~/src/ITK-eigen-baseline-install/
      fix_sitk_bld:     /tmp/sitk-fix-bld/
      baseline_sitk_bld: /tmp/sitk-baseline-bld/
  - verified_against_simpleitk_sha: 853c78a9 (2026-05-09 upstream/main)
  - design_tracking: #6230 (master), #5952 (per-module wrappers), #6225 (canonical-include), #6224 (SYSTEM include asymmetry)
post_merge_action: Verify SimpleITK CI green at open.cdash.org/builds/11263985 (or successor); coordinate with #6230 for the larger refactor.
-->
