### PR TITLE
COMP: Forward-declare itk::Indent in itkPrintHelper.h

### DIFF
--- a/Modules/Core/Common/include/itkPrintHelper.h
+++ b/Modules/Core/Common/include/itkPrintHelper.h
@@ -38,6 +38,8 @@ namespace itk
 // sites already #include "itkNumericTraits.h" directly or transitively.
 template <typename T>
 class NumericTraits;
+// Same circular-include guard as NumericTraits<T> above.
+class Indent;
 } // namespace itk
 
 namespace itk::print_helper


### PR DESCRIPTION
Fix the common-mode compile error in `itkPrintHelper.h` that breaks **8+ Nightly / Expected Nightly platforms** (Mac11/12/13/14/15/26.x, Windows VS2022 Debug, Ubuntu gcc11 TBB-Debug, Valgrind, Coverage) with the same shape `CE=1 / TF=0 / TN=~2660` — one compile error in `ITKCommon` blocks the entire test grid.

<details>
<summary>Root cause</summary>

`itkPrintHelper.h:97` uses an unqualified `Indent` in a parameter declaration:

```cpp
namespace itk::print_helper
{
template <typename T>
inline void
PrintNumericTrait(std::ostream & os, const Indent & indent, ...)
```

`itkPrintHelper.h` is included from `itkMacro.h`, which is itself included from `itkIndent.h`. When `itkIndent.h` is the include-chain entry point (the common case for any header that streams an `Indent`), the recursive inclusion of `itkIndent.h` from `itkPrintHelper.h`'s prologue is a header-guard no-op — `class itk::Indent` has not yet been declared when `itkPrintHelper.h`'s body is parsed.

Stricter toolchain configurations reject this:

```
itkPrintHelper.h:97:44: error: unknown type name 'Indent'
```

Local builds against ITK's pixi-managed Clang tolerate it; the failures only surface on Apple Clang dbg / ASanUBSan / TSan / ClangMain, MSVC 2022 Static-Debug, gcc 11.4 TBB-Debug, valgrind, and coverage builds.

</details>

<details>
<summary>Fix</summary>

Mirror the existing `NumericTraits` forward declaration a few lines above, adding `class Indent;` inside the `namespace itk { ... }` block. Every `PrintNumericTrait()` call site already `#include`s `itkIndent.h` directly or transitively (they need the full definition to stream `os << indent`), so the forward declaration is sufficient for parameter-list parsing and the template instantiates against the full definition at every call site.

</details>

<details>
<summary>Affected builds on the 2026-05-11 dashboard</summary>

| Build | Status |
|---|---|
| Mac11.x-AppleClang-dbg | CE=1 TN=2660 |
| Mac12.x-AppleClang-dbg-arm64 | CE=1 TN=2707 |
| Mac13.x-AppleClang-dbg-Universal | CE=1 TN=2660 |
| Mac14.x-AppleClang-dbg-Universal | CE=1 TN=2660 |
| Mac15.x-AppleClang-dbg-ASanUBSan | CE=1 TN=2660 |
| Mac26.x-ClangMain-dbg-arm64 | CE=1 TN=2666 |
| Mac26.x-AppleClang-dbg-TSan | CE=1 TN=2452 |
| Windows11-VS2022-Static-DebugTBB | CE=2 TN=2604 |
| Ubuntu-22.04-gcc11.4-TBB-Debug | CE=1 TN=2598 |
| itk-valgrind | CE=1 TF=2785 |
| itk-coverage | CE=1 TN=2866 |

</details>

<!--
provenance: claude-code session 2026-05-11
root_cause: circular include — itkIndent.h → itkMacro.h → itkPrintHelper.h, header-guard no-op leaves itk::Indent undeclared
related_commits:
  introduced_by: 0e3ce94622 ENH: Add itk::print_helper::PrintNumericTrait helper (2026-05-08)
fix: forward-declare class Indent in namespace itk inside itkPrintHelper.h
verification: local build (pixi Clang) + local build (Apple Clang 26.4) both pass after fix
-->
