### PR TITLE
BUG: Remove shadow declarations of NumberOfClasses in RGBGibbsPriorFilter

### DIFF
--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.h
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.h
@@ -130,45 +130,6 @@ public:
   void
   SetClassifier(typename ClassifierType::Pointer ptrToClassifier);
 
-  /** Set the number of classes. */
-  void
-  SetNumberOfClasses(const unsigned int numberOfClasses) override
-  {
-    itkDebugMacro("setting NumberOfClasses to " << numberOfClasses);
-    if (this->m_NumberOfClasses != numberOfClasses)
-    {
-      this->m_NumberOfClasses = numberOfClasses;
-      this->Modified();
-    }
-  }
-
-  /** Get the number of classes. */
-  [[nodiscard]] unsigned int
-  GetNumberOfClasses() const override
-  {
-    return this->m_NumberOfClasses;
-  }
-
-  /** Set/Get the number of iteration of the Iterated Conditional Mode
-   * (ICM) algorithm. A default value is set at 50 iterations. */
-  void
-  SetMaximumNumberOfIterations(const unsigned int numberOfIterations) override
-  {
-    itkDebugMacro("setting MaximumNumberOfIterations to " << numberOfIterations);
-    if (this->m_MaximumNumberOfIterations != numberOfIterations)
-    {
-      this->m_MaximumNumberOfIterations = numberOfIterations;
-      this->Modified();
-    }
-  }
-
-  /** Get the number of iterations of the Iterated Conditional Mode
-   * (ICM) algorithm. */
-  [[nodiscard]] unsigned int
-  GetMaximumNumberOfIterations() const override
-  {
-    return this->m_MaximumNumberOfIterations;
-  }
 
   /** Set/Get the threshold for the object size. */
   /** @ITKStartGrouping */
@@ -251,12 +212,6 @@ private:
 
   /** Output. */
   LabelledImageType m_LabelledImage{};
-
-  /** Number of classes that need to be classified. */
-  unsigned int m_NumberOfClasses{ 0 };
-
-  /** Maximum number of iterations. */
-  unsigned int m_MaximumNumberOfIterations{ 10 };
 
   typename ClassifierType::Pointer m_ClassifierPtr{};
 

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
@@ -41,6 +41,7 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::RGBGibbsPriorFilter()
 
 {
   m_StartPoint.Fill(0);
+  this->SetMaximumNumberOfIterations(10);
 }
 
 template <typename TInputImage, typename TClassifiedImage>
@@ -165,7 +166,7 @@ void
 RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::SetClassifier(typename ClassifierType::Pointer ptrToClassifier)
 {
   m_ClassifierPtr = ptrToClassifier;
-  m_ClassifierPtr->SetNumberOfClasses(m_NumberOfClasses);
+  m_ClassifierPtr->SetNumberOfClasses(this->GetNumberOfClasses());
 }
 
 template <typename TInputImage, typename TClassifiedImage>
@@ -683,8 +684,6 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::PrintSelf(std::ostream & os,
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "NumberOfClasses: " << m_NumberOfClasses << std::endl;
-  os << indent << "MaximumNumberOfIterations: " << m_MaximumNumberOfIterations << std::endl;
   os << indent << "ObjectThreshold: " << m_ObjectThreshold << std::endl;
   os << indent << "BoundaryGradient: " << m_BoundaryGradient << std::endl;
   os << indent << "CliqueWeight_1: " << m_CliqueWeight_1 << std::endl;

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/CMakeLists.txt
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/CMakeLists.txt
@@ -21,3 +21,11 @@ itk_add_test(
     ITKMarkovRandomFieldsClassifiersTestDriver
     itkRGBGibbsPriorFilterTest
 )
+
+set(ITKMarkovRandomFieldsClassifiersGTests itkRGBGibbsPriorFilterGTest.cxx)
+
+creategoogletestdriver(
+  ITKMarkovRandomFieldsClassifiers
+  "${ITKMarkovRandomFieldsClassifiers-Test_LIBRARIES}"
+  "${ITKMarkovRandomFieldsClassifiersGTests}"
+)

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkRGBGibbsPriorFilterGTest.cxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/test/itkRGBGibbsPriorFilterGTest.cxx
@@ -1,0 +1,104 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkGTest.h"
+#include "itkMRFImageFilter.h"
+#include "itkRGBGibbsPriorFilter.h"
+#include "itkImage.h"
+#include "itkVector.h"
+
+namespace
+{
+constexpr unsigned int NumberOfBands{ 1 };
+constexpr unsigned int ImageDimension{ 3 };
+using PixelType = itk::Vector<unsigned short, NumberOfBands>;
+using InputImageType = itk::Image<PixelType, ImageDimension>;
+using LabelImageType = itk::Image<unsigned short, ImageDimension>;
+using BaseFilterType = itk::MRFImageFilter<InputImageType, LabelImageType>;
+using GibbsFilterType = itk::RGBGibbsPriorFilter<InputImageType, LabelImageType>;
+} // namespace
+
+TEST(RGBGibbsPriorFilter, DefaultNumberOfClassesIsZero)
+{
+  auto filter = GibbsFilterType::New();
+  EXPECT_EQ(filter->GetNumberOfClasses(), 0u);
+}
+
+TEST(RGBGibbsPriorFilter, DefaultMaximumNumberOfIterationsIsTen)
+{
+  auto filter = GibbsFilterType::New();
+  EXPECT_EQ(filter->GetMaximumNumberOfIterations(), 10u);
+}
+
+TEST(MRFImageFilter, DefaultMaximumNumberOfIterationsIsFifty)
+{
+  auto filter = BaseFilterType::New();
+  EXPECT_EQ(filter->GetMaximumNumberOfIterations(), 50u);
+}
+
+TEST(RGBGibbsPriorFilter, SetGetNumberOfClassesViaSubclass)
+{
+  auto filter = GibbsFilterType::New();
+  filter->SetNumberOfClasses(7u);
+  EXPECT_EQ(filter->GetNumberOfClasses(), 7u);
+}
+
+TEST(RGBGibbsPriorFilter, SetGetMaximumNumberOfIterationsViaSubclass)
+{
+  auto filter = GibbsFilterType::New();
+  filter->SetMaximumNumberOfIterations(25u);
+  EXPECT_EQ(filter->GetMaximumNumberOfIterations(), 25u);
+}
+
+TEST(RGBGibbsPriorFilter, SetGetNumberOfClassesViaBasePointer)
+{
+  auto                   gibbs = GibbsFilterType::New();
+  const BaseFilterType * basePtr = gibbs;
+  BaseFilterType *       baseMutable = gibbs;
+  baseMutable->SetNumberOfClasses(5u);
+  EXPECT_EQ(basePtr->GetNumberOfClasses(), 5u);
+  EXPECT_EQ(gibbs->GetNumberOfClasses(), 5u);
+}
+
+TEST(RGBGibbsPriorFilter, SetGetMaximumNumberOfIterationsViaBasePointer)
+{
+  auto                   gibbs = GibbsFilterType::New();
+  const BaseFilterType * basePtr = gibbs;
+  BaseFilterType *       baseMutable = gibbs;
+  baseMutable->SetMaximumNumberOfIterations(33u);
+  EXPECT_EQ(basePtr->GetMaximumNumberOfIterations(), 33u);
+  EXPECT_EQ(gibbs->GetMaximumNumberOfIterations(), 33u);
+}
+
+TEST(RGBGibbsPriorFilter, ModifiedTimeAdvancesOnNumberOfClassesChange)
+{
+  auto filter = GibbsFilterType::New();
+  filter->SetNumberOfClasses(3u);
+  const auto t1 = filter->GetMTime();
+  filter->SetNumberOfClasses(4u);
+  EXPECT_GT(filter->GetMTime(), t1);
+}
+
+TEST(RGBGibbsPriorFilter, ModifiedTimeUnchangedOnIdenticalAssignment)
+{
+  auto filter = GibbsFilterType::New();
+  filter->SetNumberOfClasses(3u);
+  const auto t1 = filter->GetMTime();
+  filter->SetNumberOfClasses(3u);
+  EXPECT_EQ(filter->GetMTime(), t1);
+}


### PR DESCRIPTION
Remove `RGBGibbsPriorFilter`'s redeclarations of `m_NumberOfClasses` and `m_MaximumNumberOfIterations` that shadowed the inherited `MRFImageFilter` members, along with the 4 hand-written accessor overrides that existed only to redirect at the shadow. New GTest suite confirms zero observable API change (defaults, Set/Get via subclass and base pointer, MTime semantics).

<details>
<summary>The shadow and why it was wrong</summary>

`itkRGBGibbsPriorFilter.h` declared:

```cpp
unsigned int m_NumberOfClasses{ 0 };        // shadows MRFImageFilter::m_NumberOfClasses (also 0)
unsigned int m_MaximumNumberOfIterations{ 10 };  // shadows MRFImageFilter::m_MaximumNumberOfIterations (default 50)
```

And four hand-written accessor overrides whose only purpose was to direct `this->m_*` at the subclass shadow rather than the inherited base member:

```cpp
void SetNumberOfClasses(const unsigned int numberOfClasses) override { ... }
unsigned int GetNumberOfClasses() const override { ... }
void SetMaximumNumberOfIterations(const unsigned int numberOfIterations) override { ... }
unsigned int GetMaximumNumberOfIterations() const override { ... }
```

Virtual dispatch through the base pointer made the shadow work correctly for `Set`/`Get` callers, but the design carried real costs:

- Every instance held two orphaned 8-byte fields (the inherited base members were never read or written, because `RGBGibbsPriorFilter::GenerateData()` is a complete override that never calls `Superclass::GenerateData()`).
- Any future `MRFImageFilter` method that read `m_NumberOfClasses` or `m_MaximumNumberOfIterations` directly would silently see stale defaults for `RGBGibbsPriorFilter` instances — a regression hazard hidden by virtual dispatch.
- `m_NumberOfClasses{0}` in both classes meant one of the shadows was purely accidental — only the `MaximumNumberOfIterations` shadow served the design goal of changing the default from 50 to 10.

</details>

<details>
<summary>The fix</summary>

1. **Delete the 4 redundant accessor overrides** in `itkRGBGibbsPriorFilter.h`. The inherited `MRFImageFilter::SetNumberOfClasses` and friends (declared via `itkVirtualSetMacro` / `itkGetConstMacro`) now operate on the single inherited member.
2. **Delete the shadow member declarations** in `itkRGBGibbsPriorFilter.h`.
3. **Preserve the subclass-specific default** `MaximumNumberOfIterations = 10` (vs base default `50`) by calling the inherited setter from the `RGBGibbsPriorFilter` constructor: `this->SetMaximumNumberOfIterations(10);`. `m_NumberOfClasses` default `0` matches the base, so no constructor work is needed.
4. **Drop 2 redundant `PrintSelf` lines** that re-printed `NumberOfClasses` and `MaximumNumberOfIterations` already emitted by `Superclass::PrintSelf`.
5. **Switch the one direct-field reference in `.hxx`** (`m_ClassifierPtr->SetNumberOfClasses(m_NumberOfClasses);`) to `this->GetNumberOfClasses()` — the inherited member is private in the base, so the public accessor is the right entry point.

Net diff: −43 lines in the header/hxx, +2 lines.

</details>

<details>
<summary>Test methodology — characterize-then-refactor</summary>

A new `itkRGBGibbsPriorFilterGTest.cxx` was added **before** the fix and committed first, so the test suite establishes the observable API contract independent of the code change. The fix commit is then verified non-regressive against that suite.

The 9 GTests cover:

- `RGBGibbsPriorFilter.DefaultNumberOfClassesIsZero` — default `0`
- `RGBGibbsPriorFilter.DefaultMaximumNumberOfIterationsIsTen` — default `10` (the subclass-specific value)
- `MRFImageFilter.DefaultMaximumNumberOfIterationsIsFifty` — base default `50` (documents the contract difference)
- `RGBGibbsPriorFilter.SetGetNumberOfClassesViaSubclass`
- `RGBGibbsPriorFilter.SetGetMaximumNumberOfIterationsViaSubclass`
- `RGBGibbsPriorFilter.SetGetNumberOfClassesViaBasePointer` — verifies virtual dispatch through `MRFImageFilter*`
- `RGBGibbsPriorFilter.SetGetMaximumNumberOfIterationsViaBasePointer` — same
- `RGBGibbsPriorFilter.ModifiedTimeAdvancesOnNumberOfClassesChange` — `MTime` advances when the value changes
- `RGBGibbsPriorFilter.ModifiedTimeUnchangedOnIdenticalAssignment` — `MTime` unchanged on no-op assignment

All 9 pass on the pre-fix tree (commit 1) and the post-fix tree (commit 2). The pre-existing `itkRGBGibbsPriorFilterTest` image-pipeline CTest also continues to pass — `RGBGibbsPriorFilter::GenerateData()` now operates on the inherited fields end-to-end.

</details>

<details>
<summary>Local verification</summary>

- `pre-commit run --all-files` clean on both commits.
- Full ITK ninja build: 0 real errors (the only failures are pre-existing KWStyle ExternalProject SDK issues unrelated to this PR).
- `ctest -R "MarkovRandomFields|RGBGibbs|MRFImageFilter"`: 13/13 pass (9 new GTests + 2 framework + 2 existing CTests).
- Broader `ctest -R Segmentation`: all pass except `itkVectorThresholdSegmentationLevelSetImageFilter`, which is in `Modules/Segmentation/LevelSets/` and has zero file-level dependency on either of the modified files (verified via `grep -rln "MRFImageFilter\\|RGBGibbsPriorFilter" Modules/Segmentation/LevelSets/` → no matches). Pre-existing baseline-PNG drift unrelated to this PR.

</details>

<!--
provenance: claude-code session 2026-05-11
related_pr: https://github.com/InsightSoftwareConsortium/ITK/pull/6253 (motivating macro work; this PR does NOT depend on #6253 — the fix is self-contained)
discovery_path: while analyzing the 49 hand-written accessor overrides in ITK as part of PR #6253 follow-up, three sites matched the macro-generated body pattern exactly; two (RGBGibbsPriorFilter::SetNumberOfClasses, SetMaximumNumberOfIterations) turned out to exist only because of shadow member declarations
hint_file: .devlocal/hints/rgbgibbs-shadow-member-bug.md
test_first: commit 6a99058d7e adds tests against current (broken) impl, all 9 pass — establishes the observable contract
fix_second: commit 619446c4ba removes shadow + redundant overrides, all 9 still pass
abi_impact: same vtable shape; SetNumberOfClasses/SetMaximumNumberOfIterations are no longer overridden by the subclass (they're inherited from MRFImageFilter), so the subclass vtable has 4 fewer slots and is 32 bytes smaller per instantiation on 64-bit
-->
