### PR TITLE
BUG: Remove redundant m_Threader shadow in MatchCardinalityImageToImageMetric

### DIFF
--- a/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkMatchCardinalityImageToImageMetric.h
@@ -130,7 +130,7 @@ public:
   MultiThreaderBase *
   GetMultiThreader()
   {
-    return m_Threader;
+    return this->m_Threader;
   }
 
 protected:
@@ -183,10 +183,6 @@ private:
   bool                       m_MeasureMatches{ true };
   std::vector<MeasureType>   m_ThreadMatches{};
   std::vector<SizeValueType> m_ThreadCounts{};
-
-  /** Support processing data in multiple threads. Used by subclasses
-   * (e.g., ImageSource). */
-  MultiThreaderBase::Pointer m_Threader{ MultiThreaderBase::New() };
 };
 } // end namespace itk
 


### PR DESCRIPTION
Remove `MatchCardinalityImageToImageMetric`'s redundant `m_Threader` shadow. The base `ImageToImageMetric` constructor already initializes its protected `m_Threader` to `MultiThreaderBase::New()` — identical to the subclass's intended default — so the subclass redeclaration served no purpose.

<details>
<summary>The shadow and why it was 100% redundant</summary>

`itkMatchCardinalityImageToImageMetric.h:189` declared (in `private:`):

```cpp
MultiThreaderBase::Pointer m_Threader{ MultiThreaderBase::New() };
```

`itkImageToImageMetric.h:632` declares (in `protected:`):

```cpp
MultiThreaderBase::Pointer m_Threader{};
```

The base's in-class init produces a null pointer, but the **base's constructor** (`itkImageToImageMetric.hxx`) initializes the field in its member-initializer list:

```cpp
: ...
, m_Threader(MultiThreaderBase::New())
```

So when a `MatchCardinalityImageToImageMetric` is constructed, the base constructor runs first and sets `m_Threader` to a fresh `MultiThreaderBase::New()`. Then the subclass's in-class init for its shadow runs and ALSO produces a fresh `New()`. Two threaders allocated; only the subclass's shadow is reachable via the subclass's `GetMultiThreader()`. The base's threader is orphaned.

</details>

<details>
<summary>The fix</summary>

1. Delete the `m_Threader` redeclaration in `MatchCardinalityImageToImageMetric`'s `private:` section.
2. Qualify the `GetMultiThreader()` accessor with `this->` so the lookup resolves to the inherited protected member: `return this->m_Threader;`.

No constructor change is needed because the base already initializes the field.

Net diff: 4 lines removed, 1 line modified.

</details>

<details>
<summary>Local verification</summary>

- `pre-commit run --all-files` passes.
- `ninja ITKRegistrationCommonHeaderTest1 ITKRegistrationCommonHeaderTest2` builds clean.
- `itkMatchCardinalityImageToImageMetricTest` CTest: pre-existing baseline failure on this machine (missing `Spots.png` ExternalData fixture) — verified to fail identically on `upstream/main` HEAD without my change. **Not a regression from this PR.**

No new GTest was added because the shadow removal is byte-equivalent (base ctor produces the same `New()` pointer the subclass's shadow used to allocate). The single existing public accessor (`GetMultiThreader`) is exercised by the existing test driver.

</details>

<!--
provenance: claude-code session 2026-05-11 / shadow-member sweep
related_pr: https://github.com/InsightSoftwareConsortium/ITK/pull/6254 https://github.com/InsightSoftwareConsortium/ITK/pull/6255 (sibling shadow-removal PRs)
discovery_path: shadow-member scan flagged 24 ITK classes; this was the cleanest "subclass redeclares + base ctor already does the work" case
abi_impact: instance shrinks by sizeof(MultiThreaderBase::Pointer) per `MatchCardinalityImageToImageMetric` instance; eliminates one redundant `MultiThreaderBase::New()` allocation per construction
preexisting_ctest_failure: itkMatchCardinalityImageToImageMetricTest fails on upstream/main HEAD with "Spots.png file not found" — ExternalData fixture issue, unrelated to this PR
-->
