### PR TITLE
BUG: Remove redundant m_InputImage shadow in AntiAliasBinaryImageFilter

### DIFF
--- a/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.h
+++ b/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.h
@@ -177,8 +177,6 @@ private:
   BinaryValueType m_LowerBinaryValue{};
 
   typename CurvatureFunctionType::Pointer m_CurvatureFunction{};
-
-  const TInputImage * m_InputImage{};
 };
 } // end namespace itk
 

--- a/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.hxx
+++ b/Modules/Filtering/AntiAlias/include/itkAntiAliasBinaryImageFilter.hxx
@@ -30,7 +30,6 @@ AntiAliasBinaryImageFilter<TInputImage, TOutputImage>::AntiAliasBinaryImageFilte
   : m_UpperBinaryValue(NumericTraits<BinaryValueType>::OneValue())
   , m_LowerBinaryValue(BinaryValueType{})
   , m_CurvatureFunction(CurvatureFunctionType::New())
-  , m_InputImage(nullptr)
 {
   this->SetDifferenceFunction(m_CurvatureFunction);
 
@@ -64,7 +63,7 @@ AntiAliasBinaryImageFilter<TInputImage, TOutputImage>::CalculateUpdateValue(cons
 {
   // This method introduces the constraint on the flow of the surface.
 
-  const BinaryValueType binary_val = m_InputImage->GetPixel(idx);
+  const BinaryValueType binary_val = this->m_InputImage->GetPixel(idx);
   const ValueType       new_value = value + dt * change;
 
   if (Math::ExactlyEquals(binary_val, m_UpperBinaryValue))
@@ -87,13 +86,13 @@ AntiAliasBinaryImageFilter<TInputImage, TOutputImage>::GenerateData()
                     << "  This value can be set by calling SetNumberOfLayers(n) on this filter.");
   }
 
-  m_InputImage = this->GetInput();
+  this->m_InputImage = this->GetInput();
 
   // Find the minimum and maximum of the input image and use these values to
   // set m_UpperBinaryValue, m_LowerBinaryValue, and m_IsoSurfaceValue in the
   // parent class.
   auto minmax = itk::MinimumMaximumImageCalculator<InputImageType>::New();
-  minmax->SetImage(m_InputImage);
+  minmax->SetImage(this->m_InputImage);
   minmax->ComputeMinimum();
   minmax->ComputeMaximum();
 
@@ -113,7 +112,7 @@ AntiAliasBinaryImageFilter<TInputImage, TOutputImage>::GenerateData()
   Superclass::GenerateData();
 
   // Release the pointer
-  m_InputImage = nullptr;
+  this->m_InputImage = nullptr;
 }
 
 template <typename TInputImage, typename TOutputImage>
@@ -124,8 +123,6 @@ AntiAliasBinaryImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & 
 
   print_helper::PrintNumericTrait(os, indent, "UpperBinaryValue", m_UpperBinaryValue);
   print_helper::PrintNumericTrait(os, indent, "LowerBinaryValue", m_LowerBinaryValue);
-
-  itkPrintSelfObjectMacro(InputImage);
 }
 } // end namespace itk
 


### PR DESCRIPTION
Remove `AntiAliasBinaryImageFilter`'s redundant `m_InputImage` shadow. The base `SparseFieldLevelSetImageFilter` declares the protected member `const InputImageType * m_InputImage{}` (where `InputImageType = TInputImage`) with the same null default. The subclass's algorithm already manages the field identically to the base — removing the shadow consolidates them onto one inherited member.

<details>
<summary>The shadow and why it was redundant</summary>

Subclass (`itkAntiAliasBinaryImageFilter.h:181`):
```cpp
const TInputImage * m_InputImage{};
```

Base (`itkSparseFieldLevelSetImageFilter.h:523`, in `protected:`):
```cpp
const InputImageType * m_InputImage{};
```

The base aliases `InputImageType = TInputImage` at line 262, so the two types are identical. Both default to null. The subclass's `GenerateData`:

```cpp
this->m_InputImage = this->GetInput();  // line 89
// ... use m_InputImage ...
Superclass::GenerateData();              // line 112 — base does m_InputImage = GetInput() too
this->m_InputImage = nullptr;            // line 115
```

Before this PR, the subclass's shadow and the base's member hold the same value (both set to `GetInput()`) but live in separate storage. After this PR, they share one storage; the base's redundant `m_InputImage = GetInput()` inside `Superclass::GenerateData()` becomes a harmless self-store.

</details>

<details>
<summary>The fix</summary>

1. Delete `m_InputImage` declaration in `itkAntiAliasBinaryImageFilter.h:181`.
2. Drop the constructor's `m_InputImage(nullptr)` member-initializer entry (the inherited field is already null-initialized).
3. Qualify the subclass `.hxx` references with `this->` so the unqualified-template-name lookup resolves to the inherited member (`this->m_InputImage` at lines 66, 89, 95, 115).

Net diff: 4 lines added (`this->` qualifications), 7 lines removed.

</details>

<details>
<summary>Local verification</summary>

- `pre-commit run --all-files` passes.
- `ninja ITKAntiAliasHeaderTest1`: builds clean.
- `ctest -R AntiAlias`: 3/3 pass, including `itkAntiAliasBinaryImageFilterTest` (image-baseline integration test).

</details>

<!--
provenance: claude-code session 2026-05-11 / shadow-member sweep
related_pr: https://github.com/InsightSoftwareConsortium/ITK/pull/6254 https://github.com/InsightSoftwareConsortium/ITK/pull/6255 https://github.com/InsightSoftwareConsortium/ITK/pull/6256 https://github.com/InsightSoftwareConsortium/ITK/pull/6257 (sibling shadow-removal PRs)
discovery_path: shadow-member scan flagged 24 ITK classes; this was one of the actively-used cases requiring type-alias verification before fix
abi_impact: instance shrinks by sizeof(const TInputImage *) per AntiAliasBinaryImageFilter instance
-->
