### PR TITLE
WIP: CI test windows-2025-vs2026

### DIFF
--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -35,7 +35,7 @@ jobs:
       timeout-minutes: 0
       strategy:
         matrix:
-          os: [ubuntu-22.04, windows-2022, macos-15]
+          os: [ubuntu-22.04, windows-2025-vs2026, macos-15]
       steps:
         - name: Checkout
           uses: actions/checkout@v5

--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -131,7 +131,7 @@ jobs:
             echo "ExternalData_OBJECT_STORES=${{ runner.temp }}/ExternalData" >> "$GITHUB_ENV"
 
         - name: Set up Pixi
-          uses: prefix-dev/setup-pixi@v0.8.1
+          uses: prefix-dev/setup-pixi@v0.9.5
 
         - name: Configure
           run: pixi run configure-ci


### PR DESCRIPTION
DO NOT MERGE: testing `windows-2025-vs2026` OS. [Background](https://github.blog/changelog/2026-02-05-github-actions-early-february-2026-updates/#windows-server-2025-with-visual-studio-2026-image-now-available-for-github-hosted-runners).