### PR TITLE
ENH: Use latest version (v0.9.5) of setup-pixi GitHub action

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -34,7 +34,7 @@ jobs:
           cmake -E rename InsightToolkit-5.4.5/.ExternalData/CID ${{ github.workspace }}/.ExternalData/CID
 
       - name: Set up Pixi
-        uses: prefix-dev/setup-pixi@v0.8.1
+        uses: prefix-dev/setup-pixi@v0.9.5
 
       - name: Configure
         run: pixi run configure

--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -131,7 +131,7 @@ jobs:
             echo "ExternalData_OBJECT_STORES=${{ runner.temp }}/ExternalData" >> "$GITHUB_ENV"
 
         - name: Set up Pixi
-          uses: prefix-dev/setup-pixi@v0.8.1
+          uses: prefix-dev/setup-pixi@v0.9.5
 
         - name: Configure
           run: pixi run configure-ci


### PR DESCRIPTION
Avoids the following warning:

Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: prefix-dev/setup-pixi@v0.8.1. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
