### PR TITLE
ENH: Restore itkYvvBenchmark3D with ITKTestingData CID content-link

### DIFF
--- a/Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/test/CMakeLists.txt
+++ b/Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/test/CMakeLists.txt
@@ -62,6 +62,17 @@ itk_add_test(
 )
 
 itk_add_test(
+  NAME itkYvvBenchmark3D
+  COMMAND
+    ${itk-module}TestDriver
+    itkYvvBenchmark
+    DATA{Input/256x256x64.tif}
+    3
+    12.0
+    2
+)
+
+itk_add_test(
   NAME itkYvvWhiteImageTest2D
   COMMAND
     ${itk-module}TestDriver

--- a/Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/test/Input/256x256x64.tif.cid
+++ b/Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/test/Input/256x256x64.tif.cid
@@ -1,0 +1,1 @@
+bafkreihivrgyltvbk7qsdgxvuknyikkfnxijm6wgya66zi5zzjmyiei3da


### PR DESCRIPTION
Restores the `itkYvvBenchmark3D` test that was dropped in commit c2940bf7d1 (part of PR #6243) because the input fixture `256x256x64.tif` was not yet published. The fixture has since been published in ITKTestingData PR #49 (merged) under CID `bafkreihivrgyltvbk7qsdgxvuknyikkfnxijm6wgya66zi5zzjmyiei3da`, so the test can now resolve `DATA{Input/256x256x64.tif}` via ExternalData.

<details>
<summary>Test plan</summary>

- [x] Configured local build with `Module_SmoothingRecursiveYvvGaussianFilter=ON` (the module is `EXCLUDE_FROM_DEFAULT`).
- [x] Built `SmoothingRecursiveYvvGaussianFilterTestDriver` — clean link.
- [x] Triggered ExternalData fetch — blob (4.0 MiB) downloaded and symlinked to `ITK_DATA_CACHE/CID/bafkreihivr…`.
- [x] Ran `ctest -R '^itkYvvBenchmark3D$'` — **passed in 0.21s**.
- [x] `pre-commit run --all-files` clean on post-commit tree.

</details>

<details>
<summary>What this PR changes</summary>

Two-file change (+12 / -0):

- `Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/test/Input/256x256x64.tif.cid` — new content-link file with the ITKTestingData CID.
- `Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/test/CMakeLists.txt` — restores the `itk_add_test(NAME itkYvvBenchmark3D …)` block, invoking `itkYvvBenchmark` with `size=3`, `sigma=12.0`, `iterations=2` on the 256×256×64 input.

The drop in c2940bf7d1 retained 3D coverage via `itkYvvWhiteImageTest3D` and the GPU 3D filter test; this PR adds back the benchmark variant that exercises the recursive Yvv-Gaussian filter on a real medical-imaging-shaped volume.

</details>

<!--
provenance: claude-code session 2026-05-13
branch: restore-itkYvvBenchmark3D
base: upstream/main
fixture: 256x256x64.tif, 4.0 MiB, sha256=e8ac4d85cea157e1219af5a29b8429456dd0967ac6c03deca3b9ca5984111b18
cid: bafkreihivrgyltvbk7qsdgxvuknyikkfnxijm6wgya66zi5zzjmyiei3da
itktestingdata_pr: https://github.com/InsightSoftwareConsortium/ITKTestingData/pull/49 (merged)
supersedes_drop: c2940bf7d1
local_test: ctest -R '^itkYvvBenchmark3D$' -> Passed 0.21s
pre_commit: pre-commit run --all-files -> all hooks Passed
-->
