### PR TITLE
COMP: Fix PrintNumericTrait build error in debug mode

### DIFF
--- a/Modules/Core/Common/include/itkIndent.h
+++ b/Modules/Core/Common/include/itkIndent.h
@@ -89,4 +89,8 @@ private:
 };
 } // end namespace itk
 
+#ifndef NDEBUG
+#  include "itkPrintHelper.h" // for itkDebugMacro ostream operator<<
+#endif
+
 #endif

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -48,7 +48,6 @@
 #include <cstdlib>
 #ifndef NDEBUG
 #  include <cassert>
-#  include "itkPrintHelper.h" // for ostream operator<<std::vector<T>
 #endif
 
 #include <sstream>

--- a/Modules/Core/Common/include/itkPrintHelper.h
+++ b/Modules/Core/Common/include/itkPrintHelper.h
@@ -31,15 +31,10 @@
 
 namespace itk
 {
-// Forward declaration so itkPrintHelper.h can be safely included from
-// itkMacro.h without re-entering itkNumericTraits.h (which itself uses
-// macros defined later in itkMacro.h).  Every PrintNumericTrait() call
-// site needs the full NumericTraits<T> specialization in scope, but those
-// sites already #include "itkNumericTraits.h" directly or transitively.
+// Forward declaration; call sites must have the full NumericTraits<T>
+// specialization in scope via #include "itkNumericTraits.h".
 template <typename T>
 class NumericTraits;
-// Same circular-include guard as NumericTraits<T> above.
-class Indent;
 } // namespace itk
 
 namespace itk::print_helper


### PR DESCRIPTION
Move `itkPrintHelper.h` include from `itkMacro.h` to the bottom of `itkIndent.h`, fixing a build error in debug mode.

<details>
<summary>Root cause</summary>

`itkIndent.h` includes `itkMacro.h`, which inside `#ifndef NDEBUG` re-included `itkPrintHelper.h` before `class Indent` was fully declared. `PrintNumericTrait`'s `os << indent` then failed to resolve `operator<<(ostream, const Indent &)`:

```
itkPrintHelper.h:101: error: no match for 'operator<<'
  (operand types are 'std::ostream' and 'const itk::Indent')
```

Moving the include to the bottom of `itkIndent.h` ensures `itkPrintHelper.h` always sees the complete class and its `operator<<`. The now-redundant `class Indent;` forward declaration in `itkPrintHelper.h` is also removed.

</details>

<details>
<summary>AI assistance</summary>

GitHub Copilot (Claude Sonnet 4.6) identified the circular include chain and proposed this fix. Verified locally by building `ITKCommon` with the `debug` CMake preset (GCC 13, `-DCMAKE_BUILD_TYPE=Debug`).

</details>