### PR TITLE
Fix missing examples for Montage and MorphologicalContourInterp.

### DIFF
--- a/Modules/Filtering/MorphologicalContourInterpolation/CMakeLists.txt
+++ b/Modules/Filtering/MorphologicalContourInterpolation/CMakeLists.txt
@@ -1,5 +1,3 @@
 project(MorphologicalContourInterpolation)
 
 itk_module_impl()
-
-itk_module_examples()

--- a/Modules/Registration/Montage/CMakeLists.txt
+++ b/Modules/Registration/Montage/CMakeLists.txt
@@ -1,37 +1,5 @@
-if(CMAKE_CXX_STANDARD EQUAL "98")
-  message(
-    FATAL_ERROR
-    "CMAKE_CXX_STANDARD:STRING=98 is not supported in ITK version 5 and greater."
-  )
-endif()
-
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17) # Supported values are ``17``, ``20``, and ``23``.
-endif()
-if(NOT CMAKE_CXX_STANDARD_REQUIRED)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
-if(NOT CMAKE_CXX_EXTENSIONS)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-
 project(Montage)
 
 set(Montage_LIBRARIES Montage)
 
-# Suppress warnings about potentially uninstantiated static members
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  include(CheckCXXCompilerFlag)
-  check_cxx_compiler_flag(
-    "-Wno-undefined-var-template"
-    COMPILER_HAS_NO_UNDEFINED_VAR_TEMPLATE
-  )
-  if(COMPILER_HAS_NO_UNDEFINED_VAR_TEMPLATE)
-    set(CMAKE_CXX_FLAGS "-Wno-undefined-var-template ${CMAKE_CXX_FLAGS}")
-  endif()
-endif()
-
-set(ITK_DIR ${CMAKE_BINARY_DIR})
 itk_module_impl()
-
-itk_module_examples()


### PR DESCRIPTION
The [error message](https://open.cdash.org/builds/11276006/configure) was:
```log
CMake Error at CMake/ITKModuleMacros.cmake:656 (add_subdirectory):
  add_subdirectory given source "examples" which is not an existing
  directory.
Call Stack (most recent call first):
  Modules/Registration/Montage/CMakeLists.txt:37 (itk_module_examples)

CMake Error at CMake/ITKModuleMacros.cmake:656 (add_subdirectory):
  add_subdirectory given source "examples" which is not an existing
  directory.
Call Stack (most recent call first):
  Modules/Filtering/MorphologicalContourInterpolation/CMakeLists.txt:5 (itk_module_examples)
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
