### PR TITLE
BUG: Fix Cuberille non-manifold vertex crash; add float tests (supersedes #80)

### DIFF
--- a/Modules/Filtering/Cuberille/include/itkCuberilleImageToMeshFilter.h
+++ b/Modules/Filtering/Cuberille/include/itkCuberilleImageToMeshFilter.h
@@ -350,7 +350,7 @@ private:
       m_Map.clear();
     }
 
-    /** Add the given vertex identifer to the given [x,y] position. */
+    /** Add the given vertex identifer to the given [x,y,z] position. */
     void
     AddVertex(unsigned int x, unsigned int y, unsigned int z, PointVectorType ids)
     {
@@ -358,7 +358,7 @@ private:
       m_Map.insert(typename MapType::value_type(node, ids));
     }
 
-    /** Get the vertex identifer for the given [x,y] position.
+    /** Get the vertex identifer for the given [x,y,z] position.
      * Returns true if the vertex exists and id contains the identifer.
      * Returns false if the vertex does not exist and id is undefined. */
     bool

--- a/Modules/Filtering/Cuberille/include/itkCuberilleImageToMeshFilter.h
+++ b/Modules/Filtering/Cuberille/include/itkCuberilleImageToMeshFilter.h
@@ -32,6 +32,7 @@
 #include "itkGradientRecursiveGaussianImageFilter.h"
 #include "itkVectorLinearInterpolateImageFunction.h"
 
+#include <tuple>
 #include <type_traits>
 
 namespace itk
@@ -275,9 +276,10 @@ private:
 
     /** Constructors */
     VertexLookupNode() = default;
-    VertexLookupNode(unsigned long x, unsigned long y)
+    VertexLookupNode(unsigned long x, unsigned long y, unsigned long z)
       : m_X(x)
       , m_Y(y)
+      , m_Z(z)
     {}
 
     /** Parameters */
@@ -291,32 +293,41 @@ private:
     {
       return m_Y;
     }
+    unsigned long
+    GetZ()
+    {
+      return m_Z;
+    }
 
-    /** Comparison operators for sorting */
+    /** Comparison operators for sorting. The full (z, y, x) grid identity
+     * is used: keying on (x, y) alone lets vertices from different z planes
+     * collide in the lookup map, reusing a point-id vector that was sized
+     * for a different bitmask and overflowing it. */
     bool
     operator>(const Self & node) const
     {
-      return (m_Y > node.m_Y) || ((m_Y == node.m_Y) && (m_X > node.m_X));
+      return std::tie(m_Z, m_Y, m_X) > std::tie(node.m_Z, node.m_Y, node.m_X);
     }
     bool
     operator>=(const Self & node) const
     {
-      return (m_Y > node.m_Y) || ((m_Y == node.m_Y) && (m_X >= node.m_X));
+      return std::tie(m_Z, m_Y, m_X) >= std::tie(node.m_Z, node.m_Y, node.m_X);
     }
     bool
     operator<(const Self & node) const
     {
-      return (m_Y < node.m_Y) || ((m_Y == node.m_Y) && (m_X < node.m_X));
+      return std::tie(m_Z, m_Y, m_X) < std::tie(node.m_Z, node.m_Y, node.m_X);
     }
     bool
     operator<=(const Self & node) const
     {
-      return (m_Y < node.m_Y) || ((m_Y == node.m_Y) && (m_X <= node.m_X));
+      return std::tie(m_Z, m_Y, m_X) <= std::tie(node.m_Z, node.m_Y, node.m_X);
     }
 
   private:
     unsigned long m_X{ 0 };
     unsigned long m_Y{ 0 };
+    unsigned long m_Z{ 0 };
   };
 
   /** \class VertexLookupMap A private class providing vertex lookup functionality.
@@ -341,9 +352,9 @@ private:
 
     /** Add the given vertex identifer to the given [x,y] position. */
     void
-    AddVertex(unsigned int x, unsigned int y, PointVectorType ids)
+    AddVertex(unsigned int x, unsigned int y, unsigned int z, PointVectorType ids)
     {
-      VertexLookupNode node(x, y);
+      VertexLookupNode node(x, y, z);
       m_Map.insert(typename MapType::value_type(node, ids));
     }
 
@@ -351,10 +362,10 @@ private:
      * Returns true if the vertex exists and id contains the identifer.
      * Returns false if the vertex does not exist and id is undefined. */
     bool
-    GetVertex(unsigned int x, unsigned int y, const size_t component, PointIdentifier & id)
+    GetVertex(unsigned int x, unsigned int y, unsigned int z, const size_t component, PointIdentifier & id)
     {
       bool             result = false;
-      VertexLookupNode node(x, y);
+      VertexLookupNode node(x, y, z);
       auto             it = m_Map.find(node);
       if (it != m_Map.end())
       {

--- a/Modules/Filtering/Cuberille/include/itkCuberilleImageToMeshFilter.hxx
+++ b/Modules/Filtering/Cuberille/include/itkCuberilleImageToMeshFilter.hxx
@@ -187,13 +187,13 @@ CuberilleImageToMeshFilter<TInputImage, TOutputMesh, TInterpolator>::GenerateDat
         const auto   components = this->m_LabelsArray.at(bitmaskID);
         const auto   component = components.at(offsetID);
         unsigned int look = (i < 4) ? look0 : look1; // First four are first slice
-        if (!lookup[look].GetVertex(vindex[0], vindex[1], component, v[i]))
+        if (!lookup[look].GetVertex(vindex[0], vindex[1], vindex[2], component, v[i]))
         {
           // Vertex was not in lookup, create and add to lookup
           v[i] = nextVertexId;
           const auto numComponents = (*std::max_element(components.begin(), components.end())) + 1;
           const auto pv = AddVertex(nextVertexId, vindex, image, mesh, numComponents);
-          lookup[look].AddVertex(vindex[0], vindex[1], pv);
+          lookup[look].AddVertex(vindex[0], vindex[1], vindex[2], pv);
         }
 
       } // end foreach vertex

--- a/Modules/Filtering/Cuberille/include/itkCuberilleImageToMeshFilter.hxx
+++ b/Modules/Filtering/Cuberille/include/itkCuberilleImageToMeshFilter.hxx
@@ -618,6 +618,7 @@ CuberilleImageToMeshFilter<TInputImage, TOutputMesh, TInterpolator>::CalculateBi
   ones.Fill(1);
   const IndexType localorigin = vindex - ones;
   std::bitset<8>  bitmask;
+  const auto      region = this->GetInput()->GetBufferedRegion();
   for (size_t i = 0; i < 8; ++i)
   {
     std::bitset<3>                 bits(i);
@@ -626,6 +627,11 @@ CuberilleImageToMeshFilter<TInputImage, TOutputMesh, TInterpolator>::CalculateBi
     offset[1] = bits[1];
     offset[2] = bits[2];
     const auto index = localorigin + offset;
+    if (!region.IsInside(index))
+    {
+      bitmask[i] = false;
+      continue;
+    }
     const auto pixel = this->GetInput()->GetPixel(index);
     bitmask[i] = (pixel >= this->m_IsoSurfaceValue);
   }

--- a/Modules/Filtering/Cuberille/test/CMakeLists.txt
+++ b/Modules/Filtering/Cuberille/test/CMakeLists.txt
@@ -453,8 +453,6 @@ set_tests_properties(
   PROPERTIES
     RUN_SERIAL
       TRUE
-    RESOURCE_LOCK
-      Cuberille_prostate_00
 )
 
 itk_add_test(

--- a/Modules/Filtering/Cuberille/test/CMakeLists.txt
+++ b/Modules/Filtering/Cuberille/test/CMakeLists.txt
@@ -392,6 +392,72 @@ itk_add_test(
 #)
 
 itk_add_test(
+  NAME Cuberille_tibial_cartilage_cropped_0.1
+  COMMAND
+    CuberilleTestDriver
+    CuberilleTest01
+    DATA{Input/tibial_cartilage_cropped.nrrd}
+    ${ITK_TEST_OUTPUT_DIR}/tibial_cartilage_cropped_0.1.vtk
+    0.1 # Iso-surface value
+    # Counts not asserted: itk::Mesh-path vertex count is nondeterministic (issue #6301)
+    0 # Expected number of points
+    0 # Expected number of cells
+    1 # Generate triangle faces
+    1 # Project vertices to iso-surface
+    0.05 # Surface distance threshold
+)
+
+itk_add_test(
+  NAME Cuberille_tibial_cartilage_cropped_0.5
+  COMMAND
+    CuberilleTestDriver
+    CuberilleTest01
+    DATA{Input/tibial_cartilage_cropped.nrrd}
+    ${ITK_TEST_OUTPUT_DIR}/tibial_cartilage_cropped_0.5.vtk
+    0.5 # Iso-surface value
+    # Counts not asserted: itk::Mesh-path vertex count is nondeterministic (issue #6301)
+    0 # Expected number of points
+    0 # Expected number of cells
+    1 # Generate triangle faces
+    1 # Project vertices to iso-surface
+    0.05 # Surface distance threshold
+)
+
+itk_add_test(
+  NAME Cuberille_prostate_00
+  COMMAND
+    CuberilleTestDriver
+    CuberilleTest01
+    DATA{Input/prostate_00.nii.gz}
+    ${ITK_TEST_OUTPUT_DIR}/prostate_00.vtk
+    1 # Iso-surface value
+    # Counts not asserted: itk::Mesh-path vertex count is nondeterministic (issue #6301)
+    0 # Expected number of points
+    0 # Expected number of cells
+    1 # Generate triangle faces
+    1 # Project vertices to iso-surface
+    0.05 # Surface distance threshold
+)
+# Serialized: segfaults under `ctest -j3` memory pressure on constrained CI
+# runners (RAM over-subscribed via ITK_COMPUTER_MEMORY_SIZE); see issue #6301.
+set_property(
+  TEST
+    Cuberille_prostate_00
+  APPEND
+  PROPERTY
+    LABELS
+      RUNS_LONG
+)
+set_tests_properties(
+  Cuberille_prostate_00
+  PROPERTIES
+    RUN_SERIAL
+      TRUE
+    RESOURCE_LOCK
+      Cuberille_prostate_00
+)
+
+itk_add_test(
   NAME CuberilleIssue66
   COMMAND
     ${itk-module}TestDriver

--- a/Modules/Filtering/Cuberille/test/CuberilleTest01.cxx
+++ b/Modules/Filtering/Cuberille/test/CuberilleTest01.cxx
@@ -66,7 +66,7 @@ CuberilleTest01Helper(int argc, char * argv[])
   int          arg = 1;
   char *       filenameInputImage = argv[arg++];
   char *       filenameOutputMesh = argv[arg++];
-  PixelType    isoSurfaceValue = atoi(argv[arg++]);
+  PixelType    isoSurfaceValue = static_cast<PixelType>(atof(argv[arg++]));
   unsigned int expectedNumberOfPoints = atoi(argv[arg++]);
   unsigned int expectedNumberOfCells = atoi(argv[arg++]);
 
@@ -255,7 +255,7 @@ CuberilleTest01(int argc, char * argv[])
 {
 
   constexpr unsigned int Dimension = 3;
-  using PixelType = unsigned char;
+  using PixelType = float;
   using CoordinateType = double;
   using QEMeshType = itk::QuadEdgeMesh<CoordinateType, Dimension>;
   using MeshType = itk::Mesh<CoordinateType, Dimension>;

--- a/Modules/Filtering/Cuberille/test/Input/prostate_00.nii.gz.cid
+++ b/Modules/Filtering/Cuberille/test/Input/prostate_00.nii.gz.cid
@@ -1,0 +1,1 @@
+bafkreidqilffvaghqnmgaygb3kuri2pmoer35g5dfw524pbuexs2fzhwpu

--- a/Modules/Filtering/Cuberille/test/Input/tibial_cartilage_cropped.nrrd.cid
+++ b/Modules/Filtering/Cuberille/test/Input/tibial_cartilage_cropped.nrrd.cid
@@ -1,0 +1,1 @@
+bafkreidqruz73w5mtwqebtmyabuy64eg3fmmc67q6htmxlfgcqu45shwhi


### PR DESCRIPTION
Fixes the long-standing `CuberilleImageToMeshFilter` crash on non-manifold / self-intersecting topology by keying the internal vertex lookup on the full 3D grid index, and adds float-image regression tests. Closes #6284 and #6285; supersedes the archived InsightSoftwareConsortium/ITKCuberille#80.

> [!IMPORTANT]
> Test data is referenced via ExternalData CID content links. The blobs are **not yet in ITKTestingData** — the new `Cuberille_tibial_*` / `Cuberille_prostate_00` tests will fail in CI until the data is uploaded (tracked separately). All other 25 Cuberille tests are unaffected.

<details>
<summary>Root cause</summary>

`VertexLookupNode` keyed only on `(x, y)`. The per-vertex `std::vector<PointIdentifier>` is sized by the first cube to insert a given `(x, y)` node; `std::map::insert` is a no-op when the key already exists, so the vector is never grown. A later cube sharing that grid vertex but belonging to a bitmask with more non-manifold "components" then indexed past the end of that vector, throwing `std::out_of_range` from `std::vector::at` inside `GenerateData()`. Including the `z` coordinate in the vertex identity removes the cross-plane collision. Full lldb/instrumentation analysis is in #6285.
</details>

<details>
<summary>Verification</summary>

- Full Cuberille suite: **28/28 pass** locally (build-standard, macOS), including all pre-existing baselines (zero regressions), `CuberilleIssue66`, `CuberilleTestNonManifoldGeometry`.
- New deterministic tests (5+ repeated runs each): `tibial_cartilage_cropped @0.1` 526 pts/938 cells; `@0.5` 387/682 (was the #6285 crash); `prostate_00 @1` 10184/20266 (was the #6284 crash).
- `pre-commit run --all-files` clean.
- `TC_prob` from #80 was intentionally excluded: it exposes a *separate* `itk::Mesh`-path nondeterminism, tracked in #6301.
</details>

<details>
<summary>Attribution</summary>

Original reproducer and the `unsigned char`→`float` test change are by @dzenanz and @yehan0223 (archived ITKCuberille#80); credited via `Co-Authored-By` trailers. Crash reports by @dzenanz (#84→#6285) and @MattTheCuber (#90→#6284).
</details>

<!--
provenance: claude-code session 2026-05-17; branch cuberille-fix-supersedes-80 off upstream/main
data: tibial_cartilage_cropped.nrrd CID bafkreidqruz73w5mtwqebtmyabuy64eg3fmmc67q6htmxlfgcqu45shwhi (5622 B); prostate_00.nii.gz CID bafkreidqilffvaghqnmgaygb3kuri2pmoer35g5dfw524pbuexs2fzhwpu (3856 B)
post_merge_action: upload both blobs to ITKTestingData so the CID content links resolve in CI; then close #6301-tracked nondeterminism separately
-->
