### PR TITLE
ENH: Remove eigen_internal; export ITKInternalEigen3_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -815,39 +815,15 @@ message(STATUS "")
 ################################ ITK ##########################################
 ###############################################################################
 
-
-# Caller from ITK needs to pass to this project in itkExternal_Eigen3:
-# CMAKE_INSTALL_PREFIX: install prefix, make sure is an absolute path.
-# CMAKE_INSTALL_INCLUDEDIR: Location where headers files are installed: ${ITK_INSTALL_INCLUDE_DIR}
-# CMAKE_INSTALL_DATADIR: Location to install Targets and Config files: ${ITK_INSTALL_PACKAGE_DIR}/Modules
-# (optionally) ITK_USE_EIGEN_MPL2_ONLY (OFF by default)
-
-option(ITK_USE_EIGEN_MPL2_ONLY "Set compile definition EIGEN_MPL2_ONLY for ITKInternalEigen3." OFF)
-mark_as_advanced(ITK_USE_EIGEN_MPL2_ONLY)
-
-include(GNUInstallDirs)
-# Variables CMAKE_INSTALL_X are handled by GNUInstallDirs
-set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}")
-set(CMAKEPACKAGE_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}")
-
-
-
 include (CMakePackageConfigHelpers)
 
-######################### eigen_external #####################################
-
-# eigen_external can be reused for third-parties and modules, generates a
-# regular Eigen3Targets.cmake and Eigen3Config.cmake, and find_package(Eigen3) can be used to find it
-# It will point to the internal Eigen of ITK, without using #include itkeigen/Eigen/X headers but regular Eigen/X
-# The only modification to upstream is the INSTALL_INTERFACE, where itkeigen is appended.
-# Imported target support
-
+# eigen_external: INTERFACE target exporting Eigen3Config.cmake for find_package(Eigen3 CONFIG).
 add_library (eigen_external INTERFACE)
 
 target_compile_definitions (eigen_external INTERFACE ${EIGEN_DEFINITIONS})
 target_include_directories (eigen_external INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}/itkeigen>
+  $<INSTALL_INTERFACE:${ITK3P_INSTALL_INCLUDE_DIR}/itkeigen>
   )
 
 # Export as title case Eigen
@@ -859,7 +835,7 @@ set(EIGEN3_TARGETS_FILE Eigen3Targets.cmake)
 configure_package_config_file (
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Eigen3Config.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/Eigen3Config.cmake
-  INSTALL_DESTINATION ${CMAKEPACKAGE_INSTALL_DIR}
+  INSTALL_DESTINATION ${ITK3P_INSTALL_DATADIR}
   NO_CHECK_REQUIRED_COMPONENTS_MACRO # Eigen does not provide components
   )
 # Remove CMAKE_SIZEOF_VOID_P from Eigen3ConfigVersion.cmake since Eigen does
@@ -881,42 +857,14 @@ export (TARGETS eigen_external NAMESPACE Eigen3:: FILE Eigen3Targets.cmake)
 # CMake even if it has not been installed to a standard directory.
 # export (PACKAGE Eigen3)
 
-install (EXPORT Eigen3Targets NAMESPACE Eigen3:: DESTINATION ${CMAKEPACKAGE_INSTALL_DIR})
+install (EXPORT Eigen3Targets NAMESPACE Eigen3:: DESTINATION ${ITK3P_INSTALL_DATADIR})
 
 install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/Eigen3Config.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/Eigen3ConfigVersion.cmake
-  DESTINATION ${CMAKEPACKAGE_INSTALL_DIR} )
+  DESTINATION ${ITK3P_INSTALL_DATADIR} )
 
 # Install files (used for both eigen_external and eigen_internal)
 install(
   DIRECTORY   "${CMAKE_CURRENT_SOURCE_DIR}/Eigen/"
   DESTINATION "${ITK3P_INSTALL_INCLUDE_DIR}/itkeigen/Eigen"
   PATTERN "*.txt" EXCLUDE)
-
-######################### eigen_internal #####################################
-
-# eigen_internal is the Eigen used internally in ITK if ITK_USE_SYSTEM_EIGEN is not set.
-
-# Imported target support
-add_library (eigen_internal INTERFACE)
-add_library (ITKInternalEigen3::Eigen ALIAS eigen_internal)
-# Because the header-only nature of Eigen3, EIGEN_MPL2_ONLY definition could be leaked outside ITK.
-# This would wrongly enforce EIGEN_MPL2_ONLY to other libraries using Eigen.
-# We wrap this definition in ITK_USE_EIGEN_MPL2_ONLY, and only enabling it internally in the dashboards and CI,
-# to avoid introducing GPL code from Eigen3 internally in ITK.
-
-if(ITK_USE_EIGEN_MPL2_ONLY)
-  target_compile_definitions (eigen_internal INTERFACE "EIGEN_MPL2_ONLY")
-endif()
-
-# BUILD: go one directory before to localize the headers:
-#   #include <itkeigen/Eigen/x>
-# INSTALL: headers require pre-prend itkeigen/Eigen/X.
-target_include_directories (eigen_internal SYSTEM INTERFACE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${ITK3P_INSTALL_INCLUDE_DIR}/itkeigen>;"
-  )
-
-# Export as title case Eigen
-install (TARGETS eigen_internal EXPORT ${ITK3P_INSTALL_EXPORT_NAME})
-

--- a/Modules/ThirdParty/Eigen3/CMakeLists.txt
+++ b/Modules/ThirdParty/Eigen3/CMakeLists.txt
@@ -10,7 +10,7 @@ mark_as_advanced(ITK_USE_SYSTEM_EIGEN)
 
 option(
   ITK_USE_EIGEN_MPL2_ONLY
-  "Set compile definition EIGEN_MPL2_ONLY for eigen_internal."
+  "Set compile definition EIGEN_MPL2_ONLY when using internal Eigen."
   OFF
 )
 mark_as_advanced(ITK_USE_EIGEN_MPL2_ONLY)
@@ -54,18 +54,38 @@ if(ITK_USE_SYSTEM_EIGEN)
 "
   )
 else()
-  set(ITKEigen3_LIBRARIES eigen_internal)
-  # Two include directories are required so both ITK's own
-  # ITK_EIGEN(X) macro convention <itkeigen/Eigen/X> and the upstream
-  # Eigen convention <Eigen/X> resolve.  ITK code rooted at
-  # ${ITKEigen3_SOURCE_DIR}/src uses the macro form; external
-  # consumers (proxTV, anything else that includes Eigen the
-  # standard way) need the parent of <Eigen/X>, which is
-  # ${ITKEigen3_SOURCE_DIR}/src/itkeigen.
+  # Eigen3 is header-only, so no library linking is required.
+  # The ITK_EIGEN(X) macro handles header inclusion with the "itkeigen/Eigen/" prefix.
+
+  # Re-using internal Eigen3 in another project:
+  # A downstream project can re-use ITK's vendored Eigen3 via the exported
+  # Eigen3Config.cmake without depending on the ITK_EIGEN() macro.
+  #
+  #   find_package(ITK)
+  #   if(DEFINED ITKInternalEigen3_DIR)
+  #     set(Eigen3_DIR ${ITKInternalEigen3_DIR})
+  #   endif()
+  #   find_package(Eigen3 REQUIRED CONFIG)
+  #   add_executable(main main.cpp)
+  #   target_link_libraries(main PUBLIC ITK::ITKCommonModule Eigen3::Eigen)
+  #
+  # Then the project can include Eigen headers directly:
+  #   #include <Eigen/Eigenvalues>
+
+  set(ITKEigen3_LIBRARIES "")
+  set(ITKEigen3_INCLUDE_DIRS ${ITKEigen3_SOURCE_DIR}/src)
+
   set(
-    ITKEigen3_INCLUDE_DIRS
-    ${ITKEigen3_SOURCE_DIR}/src
-    ${ITKEigen3_SOURCE_DIR}/src/itkeigen
+    ITKEigen3_EXPORT_CODE_INSTALL
+    "
+set(ITKInternalEigen3_DIR \"\${ITK_MODULES_DIR}\")
+"
+  )
+  set(
+    ITKEigen3_EXPORT_CODE_BUILD
+    "
+set(ITKInternalEigen3_DIR \"${ITKEigen3_BINARY_DIR}/src/itkeigen\")
+"
   )
 endif()
 

--- a/Modules/ThirdParty/Eigen3/UpdateFromUpstream.sh
+++ b/Modules/ThirdParty/Eigen3/UpdateFromUpstream.sh
@@ -9,7 +9,7 @@ readonly ownership="Eigen Upstream <kwrobot@kitware.com>"
 readonly subtree="Modules/ThirdParty/Eigen3/src/itkeigen"
 readonly exact_tree_match=false
 readonly repo="https://github.com/InsightSoftwareConsortium/eigen"
-readonly tag="for/itk-5.0.1-v3"
+readonly tag="for/itk-eigen-5.0.1-bc3b39870"
 readonly paths="
 Eigen/AccelerateSupport
 Eigen/Cholesky

--- a/Modules/ThirdParty/Eigen3/src/CMakeLists.txt
+++ b/Modules/ThirdParty/Eigen3/src/CMakeLists.txt
@@ -2,5 +2,8 @@ set(ITK3P_INSTALL_EXPORT_NAME "${ITKEigen3-targets}")
 set(ITK3P_INSTALL_INCLUDE_DIR "${ITKEigen3_INSTALL_INCLUDE_DIR}")
 set(ITK3P_INSTALL_RUNTIME_DIR "${ITKEigen3_INSTALL_RUNTIME_DIR}")
 
+# Install Eigen3Config.cmake alongside other ITK module files,
+# matching the path expected by ITKInternalEigen3_DIR.
+set(ITK3P_INSTALL_DATADIR "${ITK_INSTALL_PACKAGE_DIR}/Modules")
+
 add_subdirectory(itkeigen)
-itk_module_target(eigen_internal NO_INSTALL)

--- a/Modules/ThirdParty/Eigen3/src/itk_eigen.h.in
+++ b/Modules/ThirdParty/Eigen3/src/itk_eigen.h.in
@@ -29,32 +29,6 @@
  *  ITK_EIGEN(SparseCholesky)
  */
 
-/* Re-using internal Eigen3 in other project:
- * A project can re-use the internal Eigen3, not dealing with this header
- * nor with the ITK_EIGEN macro (intended for internal usage only).
- *
-\code{.cmake}
-find_package(ITK REQUIRED COMPONENTS
-  ITKCommon
-  ITKEigen3
-  )
-include(${ITK_USE_FILE})
-if(DEFINED ITKInternalEigen3_DIR)
-  set(Eigen3_DIR ${ITKInternalEigen3_DIR})
-endif()
-message(STATUS "From ITK: Eigen3_DIR: ${Eigen3_DIR}")
-find_package(Eigen3 REQUIRED CONFIG)
-add_executable(main main.cpp)
-target_link_libraries(main PUBLIC ${ITK_LIBRARIES})
-target_link_libraries(main PUBLIC Eigen3::Eigen)
-\endcode
- *
- * Then, the user can use Eigen3 as usual:
- * #include "Eigen/Eigenvalues"
- * This is intended to facilitate bridging third party libraries and algorithms
- * which currently use Eigen3 internally.
- * For an example check the module: https://github.com/phcerdan/ITKTotalVariation
- */
 
 /* Helper macro to stringify
  * dev: If not stringified, the macro cannot be used twice in the same header. */


### PR DESCRIPTION
Remove the `eigen_internal` CMake target and replace it with exported
`ITKInternalEigen3_DIR` pointing to the vendored `Eigen3Config.cmake`.

<details>
<summary>Design rationale</summary>

All ITK-internal Eigen includes go through the `ITK_EIGEN(X)` macro in
`itk_eigen.h`, which resolves to `itkeigen/Eigen/X`. The `eigen_internal`
INTERFACE target existed to provide a second include root (`src/itkeigen`)
so that `<Eigen/X>` worked alongside `<itkeigen/Eigen/X>`. With the macro
enforcing the `itkeigen/` prefix for internal code, that second root is
unnecessary.

Downstream projects that need `<Eigen/X>` can use the exported
`Eigen3Config.cmake` via `ITKInternalEigen3_DIR`, which is now set in
the `ITKEigen3` module's export code for both build and install trees.
`Eigen3Config.cmake` is installed alongside other ITK module files
(`${ITK_INSTALL_PACKAGE_DIR}/Modules`) to match the path that
`ITK_MODULES_DIR` exposes at find-time.

`EIGEN_MPL2_ONLY` is not propagated to external consumers via
`Eigen3::Eigen`; it remains an ITK-internal enforcement only, applied
through `itk_eigen.h` when `ITK_USE_EIGEN_MPL2_ONLY` is ON.

The `WIP:` second commit removes stale standalone-project boilerplate
from `itkeigen/CMakeLists.txt` that predates the `add_subdirectory`
integration and needs verification before promoting.

</details>

<details>
<summary>AI assistance</summary>

GitHub Copilot assisted with design, implementation, and commit authoring.
Changes were reviewed, tested locally with `ninja install`, and verified
by inspecting installed paths in the build tree.

</details>