### PR TITLE
BUG: Remove obsolete BUILD_EXAMPLES cache restore in VNL

### DIFF
--- a/Modules/ThirdParty/VNL/src/CMakeLists.txt
+++ b/Modules/ThirdParty/VNL/src/CMakeLists.txt
@@ -20,16 +20,6 @@ set(BUILD_DOCUMENTATION OFF)
 
 add_subdirectory(vxl)
 
-# The variable type of BUILD_EXAMPLES changed to INTERNAL type in VXL.
-# Retrive the variable type to CACHE.
-set(
-  BUILD_EXAMPLES
-  ${BUILD_EXAMPLES}
-  CACHE BOOL
-  "Build the examples from the ITK Software Guide."
-  FORCE
-)
-
 foreach(
   lib
   itkvcl


### PR DESCRIPTION
Remove the `set(BUILD_EXAMPLES ... CACHE BOOL ...)` block from `Modules/ThirdParty/VNL/src/CMakeLists.txt`. VXL no longer modifies this variable, making the workaround dead code that can interfere with FetchContent consumers.

<details>
<summary>Root cause / design rationale</summary>

The block was originally added because VXL historically changed the cache type of `BUILD_EXAMPLES` to `INTERNAL`. The workaround restored it to `BOOL`. With `FORCE`, it also overwrote the value — breaking projects that embed ITK via `FetchContent` and pre-set `BUILD_EXAMPLES`.

Current VXL uses `VXL_BUILD_EXAMPLES` exclusively and never writes to `BUILD_EXAMPLES`. Confirmed by searching the vendored VXL source: no `set(BUILD_EXAMPLES ...)` or `INTERNAL` type change exists. The entire block is dead code.

Discovered via SimpleITK PR InsightSoftwareConsortium/SimpleITK#2599 where `BUILD_EXAMPLES=ON` was being silently overwritten.

</details>

<details>
<summary>AI assistance</summary>

- Tool: GitHub Copilot (Claude Opus 4.6)
- Role: verified VXL source no longer touches BUILD_EXAMPLES, applied removal

</details>
