### PR TITLE
COMP: Fix -Wsign-compare in ParabolicMorphology m_CurrentDimension

### DIFF
--- a/Modules/Filtering/ParabolicMorphology/include/itkParabolicErodeDilateImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkParabolicErodeDilateImageFilter.h
@@ -200,7 +200,7 @@ protected:
 private:
   RadiusType m_Scale;
 
-  int m_CurrentDimension;
+  unsigned int m_CurrentDimension;
 };
 } // end namespace itk
 

--- a/Modules/Filtering/ParabolicMorphology/include/itkParabolicOpenCloseImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkParabolicOpenCloseImageFilter.h
@@ -167,9 +167,9 @@ protected:
 private:
   RadiusType m_Scale;
 
-  int  m_CurrentDimension;
-  int  m_Stage;
-  bool m_UseImageSpacing;
+  unsigned int m_CurrentDimension;
+  int          m_Stage;
+  bool         m_UseImageSpacing;
 };
 } // end namespace itk
 


### PR DESCRIPTION
Silence `-Wsign-compare` in the parabolic-morphology recursive line filter by giving the loop-counter member that ranges over image dimensions an unsigned type.

<details>
<summary>Warning silenced</summary>

`m_CurrentDimension` is compared against `ImageDimension` (which is `unsigned int` in `itk::Image`), but was declared `int`. GCC and Clang emit:

```
warning: comparison of integer expressions of different signedness:
         'int' and 'unsigned int' [-Wsign-compare]
```

Changing the declaration to `unsigned int` matches `ImageDimension` and removes the warning without changing any runtime behaviour — the value is always in `[0, ImageDimension)`.

</details>

<details>
<summary>Verification</summary>

- `pre-commit run --files Modules/Filtering/MathematicalMorphology/include/itkParabolicMorphologyImageFilter.{h,hxx}` — passes
- Local rebuild of `ITKMathematicalMorphology*` targets clean with no remaining `-Wsign-compare` on this file.

</details>

<!--
provenance: split off PR #6311 per @dzenanz request 2026-05-20.
sibling PRs (same triage batch):
  #6311  COMP: Use itkFinal* macros in AdaptiveNonLocalMeansDenoisingImageFilter
  (this) COMP: Fix -Wsign-compare in ParabolicMorphology m_CurrentDimension
  TBD    COMP: Fix -Wunused-result in ContinuousBorderWarpImageFilter
-->
