### PR TITLE
COMP: Add ITKGoogleTest dep to RLEImage TEST_DEPENDS

### DIFF
--- a/Modules/Filtering/RLEImage/itk-module.cmake
+++ b/Modules/Filtering/RLEImage/itk-module.cmake
@@ -5,6 +5,7 @@ itk_module(
     ITKImageGrid
   TEST_DEPENDS
     ITKTestKernel
+    ITKGoogleTest
   EXCLUDE_FROM_DEFAULT
   DESCRIPTION "Run-length encoded memory compression scheme for an itk::Image."
 )


### PR DESCRIPTION
Fixes Ubuntu CMake configure error reported by @dzenanz where `RLEImageGTestDriver` could not resolve `GTest::gtest`.

`Modules/Filtering/RLEImage/test/CMakeLists.txt` calls `creategoogletestdriver()`, which links `GTest::gtest` / `GTest::gtest_main` — targets provided by the `ITKGoogleTest` third-party module. RLEImage's `itk-module.cmake` was missing `ITKGoogleTest` from `TEST_DEPENDS`. Other modules that use `creategoogletestdriver` (e.g. `Core/TestKernel`, `Core/Transform`, `Numerics/Statistics`) already declare this dependency.

<details>
<summary>Reported error</summary>

```
CMake Error at CMake/ITKModuleTest.cmake:281 (target_link_libraries):
  Target "RLEImageGTestDriver" links to:

    GTest::gtest

  but the target was not found.
Call Stack (most recent call first):
  Modules/Filtering/RLEImage/test/CMakeLists.txt:21 (creategoogletestdriver)
```
</details>
