### PR TITLE
COMP: Fix -Wshadow-field on ITKGDCMSeriesTestData::m_TempDir

### DIFF
--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -147,10 +147,14 @@ jobs:
         - name: Free disk space after build
           shell: bash
           run: |
-            # Remove object files and static libraries (not needed for testing)
-            find build -type f -name "*.o" -delete
-            find build -type f -name "*.a" -delete
+            # Remove compiler intermediates not needed for testing. Scope by path:
+            # .obj/.lib also name Wavefront-mesh and Makefile test data, so match
+            # only compiled objects in intermediate dirs (CMakeFiles/ for Ninja,
+            # *.dir/ for Visual Studio) and archives under lib/.
+            find build -type f \( -path '*/CMakeFiles/*' -o -path '*.dir/*' \) \( -name "*.o" -o -name "*.obj" \) -delete
+            find build/lib -type f \( -name "*.a" -o -name "*.lib" \) -delete 2>/dev/null || true
             # Trim ccache to stay within CCACHE_MAXSIZE and remove orphaned entries
+            ccache --evict-older-than 1d 2>/dev/null || true
             ccache --cleanup 2>/dev/null || true
             echo "****** df -h /  -- post cleanup"
             df -h /

--- a/Modules/IO/GDCM/test/itkGDCMImageIOGTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIOGTest.cxx
@@ -64,23 +64,23 @@ public:
   SetUp() override
   {
     // CTest runs each TEST_F in a separate process and may run them
-    // concurrently.  Suffix m_TempDir with the running test name so each
-    // process owns its own scratch directory; otherwise one test's
-    // TearDown races with another test's body.
+    // concurrently.  Suffix the scratch directory with the running test
+    // name so each process owns its own scratch directory; otherwise one
+    // test's TearDown races with another test's body.
     const auto * info = ::testing::UnitTest::GetInstance()->current_test_info();
-    m_TempDir = std::string(TOSTRING(ITK_TEST_OUTPUT_DIR)) + "/ITKGDCMSeriesTestData_" + info->name();
-    itksys::SystemTools::MakeDirectory(m_TempDir);
+    m_SeriesTempDir = std::string(TOSTRING(ITK_TEST_OUTPUT_DIR)) + "/ITKGDCMSeriesTestData_" + info->name();
+    itksys::SystemTools::MakeDirectory(m_SeriesTempDir);
     CreateTestDicomSeries();
   }
 
   void
   TearDown() override
   {
-    itksys::SystemTools::RemoveADirectory(m_TempDir);
+    itksys::SystemTools::RemoveADirectory(m_SeriesTempDir);
   }
 
 protected:
-  std::string              m_TempDir;
+  std::string              m_SeriesTempDir;
   std::vector<std::string> m_DicomFiles;
 
 
@@ -142,7 +142,7 @@ private:
       itk::EncapsulateMetaData<std::string>(dict, "0008|0020", "20240101");        // StudyDate
       itk::EncapsulateMetaData<std::string>(dict, "0008|0030", "120000");          // StudyTime
 
-      const std::string filename = m_TempDir + "/slice_" + std::to_string(i + 1) + ".dcm";
+      const std::string filename = m_SeriesTempDir + "/slice_" + std::to_string(i + 1) + ".dcm";
       writer->SetFileName(filename);
       writer->SetInput(image);
       writer->Update();
@@ -232,7 +232,7 @@ TEST_F(ITKGDCMSeriesTestData, CreateAndReadTestSeries)
   // Read the series using GDCMSeriesFileNames
   using NamesGeneratorType = itk::GDCMSeriesFileNames;
   auto namesGenerator = NamesGeneratorType::New();
-  namesGenerator->SetDirectory(m_TempDir);
+  namesGenerator->SetDirectory(m_SeriesTempDir);
   namesGenerator->SetUseSeriesDetails(true);
 
   std::vector<std::string> fileNames = namesGenerator->GetInputFileNames();


### PR DESCRIPTION
> **Stacked on #6324** — this branch is rebased on top of `followup/pixi-windows-artifacts-and-ccache-evict`. The `.github/workflows/pixi.yml` change in the diff belongs to #6324 and will drop out once that PR merges. The only change owned by this PR is the GDCM test rename below.

Fixes the one real `-Wshadow-field` warning on CDash build [11292903](https://open.cdash.org/builds/11292903/build) (`Mac14.x-AppleClang-dbg-Universal`).

`ITKGDCMSeriesTestData::m_TempDir` shadowed the same-named `const std::string` member inherited from the `ITKGDCMImageIO` fixture base; the two scratch directories are independent (`"ITKGDCMImageIO"` vs per-test `"ITKGDCMSeriesTestData_<name>"`). Renamed the derived-class member to `m_SeriesTempDir`.

<details>
<summary>Local verification</summary>

```
ninja ITKGDCMImageIOGTestDriver        # clean, no warnings
ctest -R ITKGDCMSeriesTestData         # 4/4 pass:
   ITKGDCMSeriesTestData.ReadSlicesReverseOrder    ✓
   ITKGDCMSeriesTestData.CreateAndReadTestSeries   ✓
   ITKGDCMSeriesTestData.ReadSeriesTopToBottom     ✓
   ITKGDCMSeriesTestData.ReadSeriesBottomToTop     ✓
pre-commit run --all-files             # all hooks pass
```

</details>

<!--
provenance: cdash build 11292903, Mac14.x-AppleClang-dbg-Universal, 2026-05-21
file: Modules/IO/GDCM/test/itkGDCMImageIOGTest.cxx
warning: -Wshadow-field at line 83 (shadows base const member at line 51)
stacked_on: PR #6324 (followup/pixi-windows-artifacts-and-ccache-evict)
post_merge_action: after #6324 merges, rebase this onto upstream/main; pixi.yml drops from diff
-->
