### PR TITLE
Class template argument deduction (CTAD) for Neighborhood Iterators

### DIFF
--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
@@ -108,7 +108,7 @@ public:
 
   /** Constructor which establishes the region size, neighborhood, and image
    * over which to walk. */
-  ConstNeighborhoodIterator(const SizeType & radius, const ImageType * ptr, const RegionType & region)
+  ConstNeighborhoodIterator(const SizeType & radius, const TImage * ptr, const RegionType & region)
   {
     this->Initialize(radius, ptr, region);
     for (DimensionValueType i = 0; i < Dimension; ++i)

--- a/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIterator.h
@@ -21,6 +21,8 @@
 #include <vector>
 #include <cstring>
 #include <iostream>
+#include <type_traits> // For remove_const_t.
+
 #include "itkImage.h"
 #include "itkNeighborhood.h"
 #include "itkMacro.h"
@@ -645,6 +647,12 @@ protected:
   /** Functor type used to access neighborhoods of pixel pointers */
   NeighborhoodAccessorFunctorType m_NeighborhoodAccessorFunctor{};
 };
+
+// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage>
+ConstNeighborhoodIterator(const typename TImage::SizeType &, SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ConstNeighborhoodIterator<std::remove_const_t<TImage>>;
+
 
 template <typename TImage>
 inline ConstNeighborhoodIterator<TImage>

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.h
@@ -98,7 +98,7 @@ public:
 
   /** Constructor which establishes the region size, neighborhood, and image
    * over which to walk. */
-  ConstNeighborhoodIteratorWithOnlyIndex(const SizeType & radius, const ImageType * ptr, const RegionType & region);
+  ConstNeighborhoodIteratorWithOnlyIndex(const SizeType & radius, const TImage * ptr, const RegionType & region);
 
   /** Standard itk print method */
   void

--- a/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.h
+++ b/Modules/Core/Common/include/itkConstNeighborhoodIteratorWithOnlyIndex.h
@@ -21,6 +21,8 @@
 #include <vector>
 #include <cstring>
 #include <iostream>
+#include <type_traits> // For remove_const_t.
+
 #include "itkImage.h"
 #include "itkNeighborhood.h"
 #include "itkMacro.h"
@@ -403,6 +405,14 @@ protected:
   /** Does the specified region need to worry about boundary conditions? */
   bool m_NeedToUseBoundaryCondition{ false };
 };
+
+// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage>
+ConstNeighborhoodIteratorWithOnlyIndex(const typename TImage::SizeType &,
+                                       SmartPointer<TImage>,
+                                       const typename TImage::RegionType &)
+  -> ConstNeighborhoodIteratorWithOnlyIndex<std::remove_const_t<TImage>>;
+
 
 template <typename TImage>
 inline ConstNeighborhoodIteratorWithOnlyIndex<TImage>

--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
@@ -20,6 +20,8 @@
 
 #include <vector>
 #include <list>
+#include <type_traits> // For remove_const_t.
+
 #include "itkNeighborhoodIterator.h"
 
 namespace itk
@@ -426,6 +428,14 @@ protected:
   bool          m_CenterIsActive{ false };
   IndexListType m_ActiveIndexList{};
 };
+
+// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage>
+ConstShapedNeighborhoodIterator(const typename TImage::SizeType &,
+                                SmartPointer<TImage>,
+                                const typename TImage::RegionType &)
+  -> ConstShapedNeighborhoodIterator<std::remove_const_t<TImage>>;
+
 } // namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkConstShapedNeighborhoodIterator.h
@@ -252,7 +252,7 @@ public:
 
   /** Constructor which establishes the region size, neighborhood, and image
    * over which to walk. */
-  ConstShapedNeighborhoodIterator(const SizeType & radius, const ImageType * ptr, const RegionType & region)
+  ConstShapedNeighborhoodIterator(const SizeType & radius, const TImage * ptr, const RegionType & region)
     : Superclass(radius, const_cast<ImageType *>(ptr), region)
   {}
 

--- a/Modules/Core/Common/include/itkNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodIterator.h
@@ -329,6 +329,12 @@ public:
     this->SetPixel(this->GetCenterNeighborhoodIndex() - this->GetStride(axis), v);
   }
 };
+
+// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage>
+NeighborhoodIterator(const typename TImage::SizeType &, SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> NeighborhoodIterator<TImage>;
+
 } // namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Modules/Core/Common/include/itkNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkNeighborhoodIterator.h
@@ -250,7 +250,7 @@ public:
 
   /** Constructor which establishes the region size, neighborhood, and image
    * over which to walk. */
-  NeighborhoodIterator(const SizeType & radius, ImageType * ptr, const RegionType & region)
+  NeighborhoodIterator(const SizeType & radius, TImage * ptr, const RegionType & region)
     : Superclass(radius, ptr, region)
   {}
 

--- a/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
@@ -220,7 +220,7 @@ public:
 
   /** Constructor which establishes the region size, neighborhood, and image
    * over which to walk. */
-  ShapedNeighborhoodIterator(const SizeType & radius, ImageType * ptr, const RegionType & region)
+  ShapedNeighborhoodIterator(const SizeType & radius, TImage * ptr, const RegionType & region)
     : Superclass(radius, ptr, region)
   {}
 

--- a/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
+++ b/Modules/Core/Common/include/itkShapedNeighborhoodIterator.h
@@ -275,6 +275,12 @@ protected:
 
   using typename Superclass::NeighborIndexType;
 };
+
+// Deduction guide for class template argument deduction (CTAD).
+template <typename TImage>
+ShapedNeighborhoodIterator(const typename TImage::SizeType &, SmartPointer<TImage>, const typename TImage::RegionType &)
+  -> ShapedNeighborhoodIterator<TImage>;
+
 } // namespace itk
 
 #endif

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -1437,6 +1437,7 @@ set(
   itkMinimumMaximumImageCalculatorGTest.cxx
   itkModifiedTimeGTest.cxx
   itkNeighborhoodAllocatorGTest.cxx
+  itkNeighborhoodIteratorsGTest.cxx
   itkNumberToStringGTest.cxx
   itkNumericLocaleGTest.cxx
   itkObjectFactoryBaseGTest.cxx

--- a/Modules/Core/Common/test/itkImageIteratorsGTest.cxx
+++ b/Modules/Core/Common/test/itkImageIteratorsGTest.cxx
@@ -148,6 +148,7 @@ void
 CheckConstIteratorsSupportClassTemplateArgumentDeduction()
 {
   (CheckConstIteratorSupportsClassTemplateArgumentDeduction<TIteratorTemplate, itk::Image<int>>(), ...);
+  (CheckConstIteratorSupportsClassTemplateArgumentDeduction<TIteratorTemplate, itk::Image<double, 3>>(), ...);
 }
 } // namespace
 

--- a/Modules/Core/Common/test/itkNeighborhoodIteratorsGTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodIteratorsGTest.cxx
@@ -1,0 +1,89 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header files to be tested:
+#include "itkConstNeighborhoodIterator.h"
+#include "itkConstNeighborhoodIteratorWithOnlyIndex.h"
+#include "itkConstShapedNeighborhoodIterator.h"
+#include "itkNeighborhoodIterator.h"
+#include "itkShapedNeighborhoodIterator.h"
+
+#include "itkImage.h"
+#include <gtest/gtest.h>
+#include <type_traits> // For is_same_v.
+
+
+namespace
+{
+template <template <typename> typename TIteratorTemplate, typename TImage>
+void
+CheckIteratorSupportsClassTemplateArgumentDeduction()
+{
+  using SizeType = typename TImage::SizeType;
+  using RegionType = typename TImage::RegionType;
+  using PointerType = typename TImage::Pointer;
+  static_assert(std::is_same_v<decltype(TIteratorTemplate(SizeType{}, PointerType{}, RegionType{})),
+                               decltype(TIteratorTemplate<TImage>(SizeType{}, PointerType{}, RegionType{}))>);
+}
+
+
+template <template <typename> typename TIteratorTemplate, typename TImage>
+void
+CheckConstIteratorSupportsClassTemplateArgumentDeduction()
+{
+  using SizeType = typename TImage::SizeType;
+  using RegionType = typename TImage::RegionType;
+  using ConstPointerType = typename TImage::ConstPointer;
+  static_assert(std::is_same_v<decltype(TIteratorTemplate(SizeType{}, ConstPointerType{}, RegionType{})),
+                               decltype(TIteratorTemplate<TImage>(SizeType{}, ConstPointerType{}, RegionType{}))>);
+}
+
+
+template <template <typename> typename... TIteratorTemplate>
+void
+CheckIteratorsSupportClassTemplateArgumentDeduction()
+{
+  (CheckIteratorSupportsClassTemplateArgumentDeduction<TIteratorTemplate, itk::Image<int>>(), ...);
+  (CheckIteratorSupportsClassTemplateArgumentDeduction<TIteratorTemplate, itk::Image<double, 3>>(), ...);
+}
+
+
+template <template <typename> typename... TIteratorTemplate>
+void
+CheckConstIteratorsSupportClassTemplateArgumentDeduction()
+{
+  (CheckConstIteratorSupportsClassTemplateArgumentDeduction<TIteratorTemplate, itk::Image<int>>(), ...);
+  (CheckConstIteratorSupportsClassTemplateArgumentDeduction<TIteratorTemplate, itk::Image<double, 3>>(), ...);
+}
+} // namespace
+
+
+// Checks that the iterator class templates support class template argument deduction (CTAD), when constructed by
+// `IteratorTemplate(radius, ptr, region)`, with `ptr` being a `SmartPointer` to an image.
+TEST(NeighborhoodIterators, SupportClassTemplateArgumentDeduction)
+{
+  CheckIteratorsSupportClassTemplateArgumentDeduction<itk::ConstNeighborhoodIterator,
+                                                      itk::ConstNeighborhoodIteratorWithOnlyIndex,
+                                                      itk::ConstShapedNeighborhoodIterator,
+                                                      itk::NeighborhoodIterator,
+                                                      itk::ShapedNeighborhoodIterator>();
+
+  CheckConstIteratorsSupportClassTemplateArgumentDeduction<itk::ConstNeighborhoodIterator,
+                                                           itk::ConstNeighborhoodIteratorWithOnlyIndex,
+                                                           itk::ConstShapedNeighborhoodIterator>();
+}


### PR DESCRIPTION
Added support for class template argument deduction (CTAD) to ITK's "traditional" Neighborhood Iterators:
```
  - ConstNeighborhoodIterator
  - ConstNeighborhoodIteratorWithOnlyIndex
  - ConstShapedNeighborhoodIterator
  - NeighborhoodIterator
  - ShapedNeighborhoodIterator
```

- Follow-up to pull request #5845