### PR TITLE
ENH: Drop *.o/*.a between ctest_build and ctest_test

### DIFF
--- a/itk_common.cmake
+++ b/itk_common.cmake
@@ -36,6 +36,12 @@
 #   dashboard_do_coverage     = True to enable coverage (ex: gcov)
 #   dashboard_do_memcheck     = True to enable memcheck (ex: valgrind)
 #   dashboard_no_clean        = True to skip build tree wipeout
+#   dashboard_keep_objects    = True to skip the post-build delete of
+#                               *.o / *.a / *.obj / *.lib intermediates
+#                               (default: removed before tests to free
+#                               disk; auto-skipped when
+#                               dashboard_do_coverage or
+#                               dashboard_continuous is set)
 #   dashboard_no_update       = True to skip source tree update
 #   CTEST_UPDATE_COMMAND      = path to git command-line client
 #   CTEST_BUILD_FLAGS         = build tool arguments (ex: -j2)
@@ -544,6 +550,29 @@ while(NOT dashboard_done)
     # without having to expand the build section.
     ci_report_build_diagnostics(
       "${CTEST_BINARY_DIRECTORY}" "${build_warnings}" "${build_errors}")
+
+    # Drop intermediates between build and test to free disk on tight CI runners.
+    # Skipped under coverage (gcov needs .gcno colocated with .o) and continuous
+    # mode (incremental relinking next iteration would force a full rebuild).
+    if(NOT dashboard_do_coverage
+       AND NOT dashboard_continuous
+       AND NOT dashboard_keep_objects)
+      file(GLOB_RECURSE _dashboard_object_files
+           LIST_DIRECTORIES FALSE
+           "${CTEST_BINARY_DIRECTORY}/*.o"
+           "${CTEST_BINARY_DIRECTORY}/*.a"
+           "${CTEST_BINARY_DIRECTORY}/*.obj"
+           "${CTEST_BINARY_DIRECTORY}/*.lib")
+      list(LENGTH _dashboard_object_files _dashboard_object_count)
+      if(_dashboard_object_count GREATER 0)
+        ci_section_start("cleanup_objects_${_dashboard_iteration}" "Free build-tree object files")
+        message("Removing ${_dashboard_object_count} object/archive files from ${CTEST_BINARY_DIRECTORY}")
+        file(REMOVE ${_dashboard_object_files})
+        ci_section_end("cleanup_objects_${_dashboard_iteration}")
+      endif()
+      unset(_dashboard_object_files)
+      unset(_dashboard_object_count)
+    endif()
 
     ci_section_start("test_${_dashboard_iteration}" "Test")
     if(COMMAND dashboard_hook_test)


### PR DESCRIPTION
Adds an automatic post-build, pre-test cleanup step to `itk_common.cmake` that deletes intermediate `*.o` and `*.a` files from `CTEST_BINARY_DIRECTORY` between `ctest_build` and `ctest_test`. Free disk for the test phase on size-constrained CI runners (the GitHub Actions Ubuntu 22.04 runner has ~73 GiB root with ~2 GiB free immediately post-build; tests can hit "No space left on device" before they get a chance to run).

<details>
<summary>What this does</summary>

Just after `ctest_build` returns and before `ctest_test` is called, the script removes every `*.o` and `*.a` under `CTEST_BINARY_DIRECTORY`. The linked executables and shared libraries are already complete at this point; the intermediates aren't needed by `ctest_test`, `ctest_memcheck`, or `ctest_submit`.

Two opt-outs:
- **`dashboard_do_coverage`** — automatic skip. `gcov` needs the `.gcno` note files colocated with the corresponding `.o` files in the build tree.
- **`dashboard_keep_objects`** — new per-client opt-out, e.g. for clients that re-link incrementally between dashboard iterations.

The step is wrapped in a CI fold (`ci_section_start` / `ci_section_end` "Free build-tree object files") so it appears next to the build and test sections in the GitHub Actions log.

</details>

<details>
<summary>Motivating CI failure</summary>

From PR #6318's `Pixi-Cxx (ubuntu-22.04)` job:

```
****** df -h /  -- post build
/dev/root        73G   71G  2.0G  98% /
****** df -h /  -- post cleanup
/dev/root        73G   63G   11G  87% /
...
System.IO.IOException: No space left on device :
  '/home/runner/actions-runner/cached/2.334.0/_diag/Worker_20260521-171155-utc.log'
```

The GitHub Actions workflow has been working around this by running `find build -type f -name "*.o" -delete` + `find build -type f -name "*.a" -delete` in a dedicated "Free disk space after build" step (see `.github/workflows/itk.pixi.yml`). This PR moves that same logic into the canonical dashboard script so it applies to every consumer of `itk_common.cmake` (Azure, CircleCI, Jenkins, custom nightly clients) — not just GitHub Actions.

</details>

<!--
provenance: PR #6318 ubuntu-22.04 disk-pressure failure, 2026-05-21
fix_locality: itk_common.cmake, single addition between ctest_build and ctest_test calls.
opt_outs: dashboard_do_coverage (auto), dashboard_keep_objects (manual).
ci_fold_label: "Free build-tree object files".
-->
