### PR TITLE
WIP: Validate PR #6322 dashboard cleanup on Azure CI

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
@@ -60,7 +60,7 @@ jobs:
         displayName: 'Install dependencies'
 
       - script: |
-          git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
+          git clone -b dashboard-cleanup-objects-before-test --single-branch https://github.com/hjmjohnson/ITK.git ITK-dashboard
         workingDirectory: $(Agent.BuildDirectory)
         displayName: 'Download dashboard script'
 

--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -66,7 +66,7 @@ jobs:
 
     - bash: |
         set -x
-        git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
+        git clone -b dashboard-cleanup-objects-before-test --single-branch https://github.com/hjmjohnson/ITK.git ITK-dashboard
       workingDirectory: $(Agent.BuildDirectory)
       displayName: 'Download dashboard script'
 

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -67,7 +67,7 @@ jobs:
 
     - bash: |
         set -x
-        git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
+        git clone -b dashboard-cleanup-objects-before-test --single-branch https://github.com/hjmjohnson/ITK.git ITK-dashboard
       workingDirectory: $(Agent.BuildDirectory)
       displayName: 'Download dashboard script'
 

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -75,7 +75,7 @@ jobs:
 
     - bash: |
         set -x
-        git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
+        git clone -b dashboard-cleanup-objects-before-test --single-branch https://github.com/hjmjohnson/ITK.git ITK-dashboard
       workingDirectory: $(Agent.BuildDirectory)
       displayName: 'Download dashboard script'
 

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -61,7 +61,7 @@ jobs:
       displayName: 'Install dependencies'
 
     - script: |
-        git clone -b dashboard --single-branch https://github.com/InsightSoftwareConsortium/ITK.git ITK-dashboard
+        git clone -b dashboard-cleanup-objects-before-test --single-branch https://github.com/hjmjohnson/ITK.git ITK-dashboard
       workingDirectory: $(Agent.BuildDirectory)
       displayName: 'Download dashboard script'
 


### PR DESCRIPTION
**DO NOT MERGE.** End-to-end validation rig for PR #6322 (the `itk_common.cmake` post-build/pre-test cleanup change).

The Azure pipelines clone the dashboard helper script from `InsightSoftwareConsortium/ITK#dashboard` in their "Download dashboard script" step. With #6322 still on the dashboard branch of my fork, Azure CI on a regular `main` PR would not exercise it. This WIP retargets that clone in every Azure YAML to `hjmjohnson/ITK#dashboard-cleanup-objects-before-test`, so the Azure pipelines on this PR's HEAD run with the modified `itk_common.cmake`.

<details>
<summary>What to look at in CI output</summary>

In each Azure pipeline log, between the `Build` and `Test` sections, look for the new collapsible fold:

```
##[group]Free build-tree object files
Removing N object/archive files from /.../ITK-build
##[endgroup]
```

When the fold is present, the cleanup matched files and removed them. When absent on a Windows MSVC pipeline, that's expected: this build either had no `.o`/`.a`/`.obj`/`.lib` to remove (e.g. partially-failed build) or the cleanup skipped due to `dashboard_continuous`/`dashboard_do_coverage`.

</details>

<details>
<summary>Cleanup checklist</summary>

When PR #6322 merges to upstream's `dashboard` branch:

1. Close this WIP PR (or revert the single commit).
2. Confirm the next Azure run uses `upstream/dashboard` again.

</details>

<!--
provenance: end-to-end test rig for PR #6322, 2026-05-21
fork_branch: hjmjohnson/dashboard-cleanup-objects-before-test
upstream_branch: dashboard
post_merge_action: close this PR after #6322 merges to upstream/dashboard
related_prs: 6322 (the dashboard-side change being validated)
-->
