### PR TITLE
COMP: Extend Pixi-Cxx post-build cleanup to MSVC artifacts (followup #6322)

### DIFF
--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -147,10 +147,14 @@ jobs:
         - name: Free disk space after build
           shell: bash
           run: |
-            # Remove object files and static libraries (not needed for testing)
-            find build -type f -name "*.o" -delete
-            find build -type f -name "*.a" -delete
+            # Remove compiler intermediates not needed for testing. Scope by path:
+            # .obj/.lib also name Wavefront-mesh and Makefile test data, so match
+            # only compiled objects in intermediate dirs (CMakeFiles/ for Ninja,
+            # *.dir/ for Visual Studio) and archives under lib/.
+            find build -type f \( -path '*/CMakeFiles/*' -o -path '*.dir/*' \) \( -name "*.o" -o -name "*.obj" \) -delete
+            find build/lib -type f \( -name "*.a" -o -name "*.lib" \) -delete 2>/dev/null || true
             # Trim ccache to stay within CCACHE_MAXSIZE and remove orphaned entries
+            ccache --evict-older-than 1d 2>/dev/null || true
             ccache --cleanup 2>/dev/null || true
             echo "****** df -h /  -- post cleanup"
             df -h /


### PR DESCRIPTION
Follow-up to #6322 (merged): widens the Pixi-Cxx workflow's post-build cleanup to also delete MSVC `*.obj`/`*.lib` artifacts and runs `ccache --evict-older-than 1d` before `--cleanup` so the windows-2022 runner gets the same disk relief that #6322 gave dashboard-script clients via `itk_common.cmake`.

<details>
<summary>Why a separate workflow change is needed</summary>

PR #6322 added the equivalent `*.o`/`*.a` cleanup to `itk_common.cmake` between `ctest_build` and `ctest_test`. That helps Azure DevOps / CircleCI / custom nightly clients that drive CTest via `ctest -S dashboard.cmake`.

The `ITK.Pixi` workflow runs cmake + ctest directly (no dashboard script — `pixi run configure-ci` then `cmake --build build` then `ctest -j3 --test-dir build`), so it does not pick up the `itk_common.cmake` cleanup hook. It has its own inline "Free disk space after build" step that already handled POSIX object files. This PR widens that step to also cover Windows MSVC artifacts and adds the older-than-1d ccache eviction that #6322 introduced for dashboard clients.

</details>

<details>
<summary>Diff</summary>

```diff
- find build -type f -name "*.o" -delete
- find build -type f -name "*.a" -delete
+ find build -type f -regex '.*\.\(o\|a\|obj\|lib\)$' -delete
  # Trim ccache to stay within CCACHE_MAXSIZE and remove orphaned entries
+ ccache --evict-older-than 1d 2>/dev/null ||true
  ccache --cleanup 2>/dev/null || true
```

</details>

<!--
provenance: followup to merged #6322 (ENH: Drop *.o/*.a between ctest_build and ctest_test)
motivating_failure: PR #6318 Pixi-Cxx ubuntu-22.04 hit 98% disk; windows-2022 never benefited from the existing find -name "*.o" because MSVC emits *.obj/*.lib
verification: pre-commit run --all-files clean
-->
