### PR TITLE
BUG: Spare test fixtures from dashboard post-build cleanup (#6322 regression)

### DIFF
--- a/itk_common.cmake
+++ b/itk_common.cmake
@@ -557,12 +557,21 @@ while(NOT dashboard_done)
     if(NOT dashboard_do_coverage
        AND NOT dashboard_continuous
        AND NOT dashboard_keep_objects)
-      file(GLOB_RECURSE _dashboard_object_files
+      # Scope by path: .obj also names Wavefront mesh fixtures and .lib names a
+      # Makefile template, so match compiled objects only in compiler intermediate
+      # dirs (CMakeFiles/ for Ninja/Makefiles, <target>.dir/ for Visual Studio) and
+      # archives only under lib/ to avoid deleting test data before ctest_test.
+      file(GLOB_RECURSE _dashboard_compiled_objects
            LIST_DIRECTORIES FALSE
            "${CTEST_BINARY_DIRECTORY}/*.o"
+           "${CTEST_BINARY_DIRECTORY}/*.obj")
+      list(FILTER _dashboard_compiled_objects INCLUDE REGEX "/CMakeFiles/|\\.dir/")
+      file(GLOB_RECURSE _dashboard_archives
+           LIST_DIRECTORIES FALSE
            "${CTEST_BINARY_DIRECTORY}/*.a"
-           "${CTEST_BINARY_DIRECTORY}/*.obj"
            "${CTEST_BINARY_DIRECTORY}/*.lib")
+      list(FILTER _dashboard_archives INCLUDE REGEX "/lib/")
+      set(_dashboard_object_files ${_dashboard_compiled_objects} ${_dashboard_archives})
       list(LENGTH _dashboard_object_files _dashboard_object_count)
       if(_dashboard_object_count GREATER 0)
         ci_section_start("cleanup_objects_${_dashboard_iteration}" "Free build-tree object files")
@@ -572,6 +581,8 @@ while(NOT dashboard_done)
       endif()
       unset(_dashboard_object_files)
       unset(_dashboard_object_count)
+      unset(_dashboard_compiled_objects)
+      unset(_dashboard_archives)
     endif()
 
     ci_section_start("test_${_dashboard_iteration}" "Test")


### PR DESCRIPTION
Fixes a regression from #6322: the post-build cleanup deletes Wavefront `.obj` mesh fixtures and a DCMTK `Makefile.lib` before `ctest_test`, breaking `itkOBJMeshIOTest1/2` and `itkMeshFileReadWriteOBJ*` on every dashboard client (ARMBUILD, Azure ITK.* pipelines). **Targets the `dashboard` branch** — this is live on all PR CI right now.

<details>
<summary>Root cause</summary>

#6322 added a post-build, pre-test cleanup in `itk_common.cmake`:

```cmake
file(GLOB_RECURSE _dashboard_object_files LIST_DIRECTORIES FALSE
     "${CTEST_BINARY_DIRECTORY}/*.o" "${CTEST_BINARY_DIRECTORY}/*.a"
     "${CTEST_BINARY_DIRECTORY}/*.obj" "${CTEST_BINARY_DIRECTORY}/*.lib")
file(REMOVE ${_dashboard_object_files})
```

`*.obj` and `*.lib` are overloaded extensions:
- `*.obj` — MSVC compiled object **and** Wavefront mesh (`ITKIOMeshOBJ` `Baseline/bunny.obj`, `box.obj`; `Cuberille` `mesh.obj`).
- `*.lib` — MSVC static/import lib **and** `Modules/ThirdParty/DCMTK/.../config/templates/Makefile.lib`.

`GLOB_RECURSE` descends into `build/ExternalData/`, so the mesh fixtures were deleted between `ctest_build` and `ctest_test`:

```
Read file .../build/ExternalData/Modules/IO/MeshOBJ/test/Baseline/bunny.obj failed
itkOBJMeshIOTest1 / itkOBJMeshIOTest2 / itkMeshFileReadWriteOBJTest ***Failed
```

The `*.o`/`*.a` parts were harmless (no test data uses those extensions); only the `*.obj`/`*.lib` additions collided.

</details>

<details>
<summary>The fix</summary>

Scope the deletion by path — compiled objects always live under `CMakeFiles/`, archives under `lib/`, on every platform:

```cmake
file(GLOB_RECURSE _objs ... "*.o" "*.obj")
list(FILTER _objs INCLUDE REGEX "/CMakeFiles/")
file(GLOB_RECURSE _arch ... "*.a" "*.lib")
list(FILTER _arch INCLUDE REGEX "/lib/")
```

Verified against a real configured ITK build tree:
- 5579 compiled objects + 148 archives still removed (disk savings preserved).
- All 7 `*.obj` mesh fixtures and the DCMTK `Makefile.lib` spared.

</details>

<!--
provenance: claude-code 2026-05-21; found while triaging #6324 (the Pixi-workflow analogue of this same cleanup)
base_branch: dashboard (NOT main) — dashboard-script CI clones this branch at runtime via `git clone -b dashboard`
regressing_pr: #6322 (merged to dashboard 2026-05-21)
symptom: itkOBJMeshIOTest1/2 + itkMeshFileReadWriteOBJ* fail reading deleted bunny.obj on all dashboard CI
verification: cmake -P simulation against build-standard tree; 5579 objs/148 archives removed, 7 .obj + Makefile.lib spared
related: #6324 applies the identical path-scoping fix to .github/workflows/pixi.yml
-->
