### PR TITLE
COMP: Build Pixi-Cxx CI as Release to enable Windows ccache

### DIFF
--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -140,7 +140,7 @@ jobs:
           run: |
             echo "****** df -h /  -- pre build"
             df -h /
-            pixi run --skip-deps build
+            pixi run --skip-deps build-ci
             echo "****** df -h /  -- post build"
             df -h /
 
@@ -160,7 +160,7 @@ jobs:
             df -h /
 
         - name: Test
-          run: pixi run --skip-deps test
+          run: pixi run --skip-deps test-ci
 
         - name: Disk space reporting AFTER (optimize free-disk-space)
           run: |

--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -34,6 +34,7 @@ jobs:
       runs-on: ${{ matrix.os }}
       timeout-minutes: 0
       strategy:
+        fail-fast: false
         matrix:
           os: [ubuntu-22.04, windows-2022, macos-15]
       steps:

--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -137,6 +137,9 @@ jobs:
         - name: Configure
           run: pixi run configure-ci
 
+        - name: Fetch ExternalData
+          run: pixi run --skip-deps build-external-data-ci
+
         - name: Build
           run: |
             echo "****** df -h /  -- pre build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,11 @@ cmd = "ctest -j3 --test-dir build"
 description = "Test ITK"
 depends-on = ["build"]
 
+[tool.pixi.feature.cxx.tasks.build-external-data-ci]
+cmd = "cmake --build build --target ITKData"
+description = "Fetch ITK ExternalData for CI (fails fast on download errors)"
+depends-on = ["configure-ci"]
+
 [tool.pixi.feature.cxx.tasks.build-ci]
 cmd = "cmake --build build"
 description = "Build ITK for CI"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,17 @@ cmd = "ctest -j3 --test-dir build"
 description = "Test ITK"
 depends-on = ["build"]
 
+[tool.pixi.feature.cxx.tasks.build-ci]
+cmd = "cmake --build build"
+description = "Build ITK for CI"
+outputs = ["build/lib/**"]
+depends-on = ["configure-ci"]
+
+[tool.pixi.feature.cxx.tasks.test-ci]
+cmd = "ctest -j3 --test-dir build"
+description = "Test ITK for CI"
+depends-on = ["build-ci"]
+
 [tool.pixi.feature.cxx.tasks.configure-debug]
 cmd = '''cmake \
   -Bbuild-debug \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ cmd = '''cmake \
   -Bbuild \
   -S. \
   -GNinja \
-  -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
+  -DCMAKE_BUILD_TYPE:STRING=Release \
   -DBUILD_TESTING:BOOL=ON \
   -DITK_USE_CCACHE:BOOL=ON \
   -DCMAKE_C_COMPILER_LAUNCHER:STRING=ccache \


### PR DESCRIPTION
Build the Pixi-Cxx CI legs as `Release` instead of `RelWithDebInfo`, and add dedicated `build-ci`/`test-ci` pixi tasks so CI's build/test chain depends on `configure-ci` (Release + ccache) rather than the local-dev `configure` (RelWithDebInfo). Motivated by ccache being effectively useless on the Windows MSVC leg today.

<details>
<summary>ccache rationale — Windows is ~1% cacheable today</summary>

The compiler-launcher plumbing (install, restore/save, `CMAKE_CXX_COMPILER_LAUNCHER=ccache`) is identical across all three OS legs, but `RelWithDebInfo` adds MSVC `/Zi` (separate-PDB debug info), which ccache cannot cache. Measured on a recent `main` Pixi-Cxx run:

| OS | Cacheable calls | Notes |
|----|----------------|-------|
| windows-2022 | **48 / 4492 (1.07%)** | 98.93% uncacheable — ccache provides ~no benefit |
| ubuntu-22.04 | ~100% | 99.85% hit rate |
| macos | 4510 / 4510 (100%) | 99.87% hit rate |

`Release` omits `/Zi`, so Windows compilations become cacheable like Linux/macOS. `/O2` is unchanged, so generated code is equivalent; only debug info is dropped. CDash/Azure debug coverage is unaffected — the Azure ITK.Linux leg already builds Debug for assert()/debug-codepath coverage.

</details>

<details>
<summary>Disk rationale — expected Windows .obj/.pdb size reduction</summary>

Because `/O2` is identical in both configs, the entire object-size delta is the CodeView debug info `/Zi` writes into each `.obj` (`.debug$S` symbols, `.debug$T` type records). For ITK's extremely template-dense code, `.debug$T` dominates (one set of type records per distinct instantiation).

Expected on the Windows leg:

- **`.obj` ~60–75% smaller** (Release object ≈ ¼–⅖ of the RelWithDebInfo object; ITK's template density puts it toward the upper end).
- **`.pdb` files eliminated entirely** — compiler `vc*.pdb` + linker `.pdb`, often as large as the objects themselves. The existing post-build cleanup (#6324) only deletes `.obj`/`.lib`; it never touched PDBs, so this is additional headroom.
- **Static `.lib` shrink proportionally** (cxx CI config is static).

These are estimates from MSVC behavior, not yet a measurement; the cleanup step can be instrumented to report exact bytes if a hard number is wanted.

</details>

<details>
<summary>Why the build-ci / test-ci tasks</summary>

`build`/`test` depend on the local-dev `configure` (RelWithDebInfo), so CI relied on `--skip-deps` to keep the explicitly-run `configure-ci` (Release) build type from being clobbered. Adding `build-ci` (depends-on `configure-ci`) and `test-ci` (depends-on `build-ci`) makes the CI dependency chain resolve to Release + ccache by construction. The bare `configure`/`build`/`test` tasks keep `RelWithDebInfo` for local development (symbols preserved). `--skip-deps` is retained in the workflow for step isolation: the post-build disk-cleanup step deletes intermediates between Build and Test, so Test must not attempt a relink.

</details>

<details>
<summary>Local validation</summary>

Rebased on latest `main`; `pixi run configure-ci` then `pixi run --skip-deps build-ci` on macOS:

```
CMAKE_BUILD_TYPE=Release, CMAKE_CXX_COMPILER_LAUNCHER=ccache, ITK_USE_CCACHE=ON
4506 translation units compiled (core ITK + enabled remote modules)
ccache: 4504/4506 cacheable (99.96%)   # the Release-is-cacheable thesis, on macOS
pre-commit run --all-files: all hooks pass
```

</details>

<!--
provenance: claude-code session 2026-05-22
branch: comp/pixi-ci-release-not-relwithdebinfo (hjmjohnson fork)
files: pyproject.toml (configure-ci -> Release; add build-ci/test-ci),
       .github/workflows/pixi.yml (build-ci/test-ci)
data_source: main Pixi-Cxx run 26284498039 (windows 48/4492 cacheable; ubuntu/macos ~100%)
obj_estimate: 60-75% smaller .obj on Windows; PDBs eliminated; from MSVC /Zi CodeView behavior, not measured
local_repo_left: ITK-build-test-tree detached at branch tip; Modules/Remote/* clones removed per user
-->

