### PR TITLE
BUG: Honor StopOptimization from IterationEvent in v4 optimizers

### DIFF
--- a/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkExhaustiveOptimizerv4.hxx
@@ -134,6 +134,10 @@ ExhaustiveOptimizerv4<TInternalComputationValueType>::ResumeWalking()
                                << "@ index " << this->GetCurrentIndex() << " value is " << m_CurrentValue;
 
     this->InvokeEvent(IterationEvent());
+    if (m_Stop)
+    {
+      break;
+    }
     this->AdvanceOneStep();
     this->m_CurrentIteration++;
   }

--- a/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.hxx
@@ -257,6 +257,13 @@ OnePlusOneEvolutionaryOptimizerv4<TInternalComputationValueType>::StartOptimizat
     }
 
     this->InvokeEvent(IterationEvent());
+    if (m_Stop)
+    {
+      m_StopConditionDescription.str("");
+      m_StopConditionDescription << this->GetNameOfClass() << ": "
+                                 << "StopOptimization() called";
+      break;
+    }
     itkDebugMacro("Current position: " << this->GetCurrentPosition());
   }
   if (this->m_CurrentIteration >= m_MaximumIteration)

--- a/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
@@ -498,6 +498,12 @@ PowellOptimizerv4<TInternalComputationValueType>::StartOptimization(bool /* doOn
     }
 
     this->InvokeEvent(IterationEvent());
+    if (m_Stop)
+    {
+      m_StopConditionDescription << "StopOptimization() called";
+      this->InvokeEvent(EndEvent());
+      return;
+    }
   }
 
   m_StopConditionDescription << "Maximum number of iterations exceeded. "


### PR DESCRIPTION
## Summary

Add an immediate `m_Stop` check after `InvokeEvent(IterationEvent())` in `ExhaustiveOptimizerv4`, `PowellOptimizerv4`, and `OnePlusOneEvolutionaryOptimizerv4`.

Previously these optimizers would continue advancing after an observer called `StopOptimization()` (or `StopWalking()`) during `IterationEvent`, making it impossible to halt from a callback.

This is the companion change to #6196 (commit cf929f2ca7) which added the same pattern to the `GradientDescentOptimizerv4` family.

## Behavior Table

After this PR, all v4 optimizers that support stopping now behave consistently when `StopOptimization()` is called from an `IterationEvent` observer:

| Optimizer | Stop Method | Stops Before Next Step | `GetCurrentIteration()` at stop |
|---|---|---|---|
| ConjugateGradientLineSearch | `StopOptimization()` | ✓ (via #6196) | iteration where stop was called |
| GradientDescent | `StopOptimization()` | ✓ (via #6196) | iteration where stop was called |
| GradientDescentLineSearch | `StopOptimization()` | ✓ (via #6196) | iteration where stop was called |
| RegularStepGradientDescent | `StopOptimization()` | ✓ (via #6196) | iteration where stop was called |
| **ExhaustiveOptimizerv4** | `StopWalking()` | ✓ **(this PR)** | iteration where stop was called |
| **PowellOptimizerv4** | `StopOptimization()` | ✓ **(this PR)** | iteration where stop was called |
| **OnePlusOneEvolutionaryOptimizerv4** | `StopOptimization()` | ✓ **(this PR)** | iteration where stop was called |

## References

- ITK PR #6196 — Gradient descent family fix (commit cf929f2ca7)
- SimpleITK test exercising all stoppable optimizers: [`Testing/Unit/sitkImageRegistrationMethodTests.cxx` — `StopRegistration`](https://github.com/SimpleITK/SimpleITK/blob/v2.4.0/Testing/Unit/sitkImageRegistrationMethodTests.cxx#L1098)
