### PR TITLE
BUG: Fix VTKPolyDataMeshIO binary cell-data section scan (itkMeshFileReadWriteTestField)

### DIFF
--- a/Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIO.h
+++ b/Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIO.h
@@ -424,7 +424,7 @@ protected:
     while (!inputFile.eof())
     {
       std::getline(inputFile, line, '\n');
-      if (line.find("POINT_DATA") != std::string::npos)
+      if (line.find("CELL_DATA") != std::string::npos)
       {
         if (!inputFile.eof())
         {
@@ -432,7 +432,7 @@ protected:
         }
         else
         {
-          itkExceptionStringMacro("UnExpected end of line while trying to read POINT_DATA");
+          itkExceptionStringMacro("UnExpected end of line while trying to read CELL_DATA");
         }
 
         /** For scalars we have to read the next line of LOOKUP_TABLE */


### PR DESCRIPTION
Fixes `itkMeshFileReadWriteTestField` failing on the ARM64 CI legs. `VTKPolyDataMeshIO::ReadCellDataBufferAsBINARY` scanned for `POINT_DATA` instead of `CELL_DATA` (a copy/paste from the point-data reader), so binary meshes with a `CELL_DATA` section had their cell-data buffer left unread.

<details>
<summary>Root cause</summary>

The binary cell-data reader broke symmetry with its siblings:

| Reader | Section it scans |
|--------|------------------|
| `ReadPointDataBufferAsASCII/BINARY` | `POINT_DATA` ✓ |
| `ReadCellDataBufferAsASCII` | `CELL_DATA` ✓ |
| `ReadCellDataBufferAsBINARY` | **`POINT_DATA`** ✗ → should be `CELL_DATA` |

`ReadCellData` (`itkVTKPolyDataMeshIO.cxx`) opens the file **fresh from the start** and the reader fills `m_NumberOfCellPixels` cell values. The failing fixture `Input/gourd.vtk` is `BINARY` with a `CELL_DATA` + `FIELD` section and **no `POINT_DATA`**, so the scan never matched, the cell-data buffer was never read, and it was left **uninitialized**.

That explains why the failure is platform-dependent: the read returns whatever happened to be in the buffer, so it passes on some platforms (e.g. macOS locally) and fails consistently on ARM64.

</details>

<details>
<summary>Local validation</summary>

```
ninja ITKIOMeshVTKTestDriver
ctest -R "MeshVTK|itkMeshFileReadWrite|..."   # 20/20 pass (incl. 7 ITKIOMeshVTK)
pre-commit run --all-files                    # all hooks pass
```

The ARM64 *failure* itself is not reproducible on macOS — the symptom is an uninitialized read, so a passing local run can't confirm the original bug, only that the fix introduces no regression. First execution of the corrected path on ARM64 relies on CI.

</details>

<details>
<summary>Note on the VTK-5 cell-count suggestion (deliberately not included)</summary>

A separate suggestion proposed dropping the `- 1` in the VTK version-5 `numberOfVertices/Lines/Polygons - 1` cell counting in `ReadMeshInformation()`. That is **not** included here: VTK-5 `OFFSETS` arrays carry N+1 entries for N cells, so `count - 1` is plausibly correct, and changing it risks an off-by-one regression. It needs independent verification with a version-5 fixture and is out of scope for this targeted test fix.

</details>

<!--
provenance: claude-code session 2026-05-22
fix: Modules/IO/MeshVTK/include/itkVTKPolyDataMeshIO.h ReadCellDataBufferAsBINARY POINT_DATA->CELL_DATA (lines ~427/435)
root_cause: ReadCellData opens file fresh; cell buffer left uninitialized for binary CELL_DATA-only meshes
failing_test: itkMeshFileReadWriteTestField (ARM64 CI run 26294566770, test #1490)
fixture: Input/gourd.vtk = BINARY, CELL_DATA + FIELD, no POINT_DATA
excluded: itkVTKPolyDataMeshIO.cxx version-5 cell-count -1 change (unverified, possible off-by-one regression)
local_validation: macOS 20/20 mesh tests pass; arm64 failure not locally reproducible (uninitialized-read symptom)
-->
