### PR TITLE
BUG: Replace std::abs<double> with std::fabs to avoid ambiguity

### DIFF
--- a/Modules/Core/Transform/test/itkTransformGeometryImageFilterTest.cxx
+++ b/Modules/Core/Transform/test/itkTransformGeometryImageFilterTest.cxx
@@ -32,7 +32,7 @@
 inline bool
 Validate(double input, double desired, double tolerance)
 {
-  return std::abs<double>(input - desired) > tolerance * std::abs<double>(desired);
+  return std::fabs(input - desired) > tolerance * std::fabs(desired);
 }
 
 // Returns true if images are different


### PR DESCRIPTION
Backport of `40c64693e1` (main) to `release-5.4`.

`std::abs<double>(x)` is ill-formed for floating-point absolute value — only `<complex>`'s `abs` is a function template, so the explicit `<double>` argument discards the float/double/long-double overloads and the call becomes ambiguous on modern libc++/libstdc++. Replaces the two call sites in `itkTransformGeometryImageFilterTest` with `std::fabs`.

<details>
<summary>Verification</summary>

Built `ITKTransformTestDriver` and ran `itkTransformGeometryImageFilterTest` locally on `release-5.4` (macOS arm64, dual-precision FFTW): the driver now compiles (previously a hard compile error under libc++ full builds) and the test passes 1/1.
</details>

<!--
provenance: claude-code session 2026-05-25
cherry-pick: git cherry-pick -x 40c64693e183f76d0522b7e8a587689c05c83a17
author-preserved: Bradley Lowekamp
-->
