### PR TITLE
BUG: Harden QuickView against small latent defects

### DIFF
--- a/Modules/Bridge/VtkGlue/include/QuickView.h
+++ b/Modules/Bridge/VtkGlue/include/QuickView.h
@@ -20,6 +20,7 @@
 
 #include <vector>
 #include <algorithm>
+#include <cctype>
 #include <string>
 
 #include <itkImage.h>
@@ -198,7 +199,10 @@ public:
   SetSnapshotExtension(const std::string & iExtension)
   {
     m_SnapshotExtension = iExtension;
-    std::transform(m_SnapshotExtension.begin(), m_SnapshotExtension.end(), m_SnapshotExtension.begin(), ::tolower);
+    std::transform(m_SnapshotExtension.begin(),
+                   m_SnapshotExtension.end(),
+                   m_SnapshotExtension.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
   }
 
   /** Set the number of columns, default 4.*/

--- a/Modules/Bridge/VtkGlue/src/QuickView.cxx
+++ b/Modules/Bridge/VtkGlue/src/QuickView.cxx
@@ -204,6 +204,10 @@ QuickView::Visualize(bool interact)
 {
   unsigned int rendererSize = this->m_ViewPortSize;
   unsigned int numberOfImages = this->Images.size() + this->RGBImages.size();
+  if (numberOfImages == 0)
+  {
+    return;
+  }
   unsigned int numberOfRows = (numberOfImages - 1) / this->m_NumberOfColumns + 1;
   unsigned int numberOfColumns = numberOfImages / (numberOfRows) + 1;
   if (numberOfColumns > numberOfImages)

--- a/Modules/Bridge/VtkGlue/src/QuickView.cxx
+++ b/Modules/Bridge/VtkGlue/src/QuickView.cxx
@@ -223,8 +223,6 @@ QuickView::Visualize(bool interact)
   interactor->SetRenderWindow(renderWindow);
 
   // Render all of the images
-  std::vector<double *> viewports;
-
   using ConnectorType = itk::ImageToVTKImageFilter<itk::Image<unsigned char, 2>>;
   using RGBConnectorType = itk::ImageToVTKImageFilter<itk::Image<itk::RGBPixel<unsigned char>, 2>>;
   std::vector<ConnectorType::Pointer>
@@ -247,7 +245,6 @@ QuickView::Visualize(bool interact)
                                (numberOfRows * rendererSize),
                              static_cast<double>(col + 1) * rendererSize / (numberOfColumns * rendererSize),
                              static_cast<double>(numberOfRows - row) * rendererSize / (numberOfRows * rendererSize) };
-      viewports.push_back(viewport);
 
       // Grayscale images
       if (i < this->Images.size())
@@ -267,7 +264,7 @@ QuickView::Visualize(bool interact)
         // Setup renderer
         vtkSmartPointer<vtkRenderer> renderer = vtkSmartPointer<vtkRenderer>::New();
         renderWindow->AddRenderer(renderer);
-        renderer->SetViewport(viewports[i]);
+        renderer->SetViewport(viewport);
         renderer->SetBackground(background);
         if (m_ShareCamera)
         {
@@ -326,7 +323,7 @@ QuickView::Visualize(bool interact)
         // Setup renderer
         vtkSmartPointer<vtkRenderer> renderer = vtkSmartPointer<vtkRenderer>::New();
         renderWindow->AddRenderer(renderer);
-        renderer->SetViewport(viewports[i]);
+        renderer->SetViewport(viewport);
         renderer->SetBackground(background);
         if (m_ShareCamera)
         {
@@ -372,7 +369,7 @@ QuickView::Visualize(bool interact)
         // Fill empty viewports
         vtkSmartPointer<vtkRenderer> renderer = vtkSmartPointer<vtkRenderer>::New();
         renderWindow->AddRenderer(renderer);
-        renderer->SetViewport(viewports[i]);
+        renderer->SetViewport(viewport);
         renderer->SetBackground(background);
         continue;
       }

--- a/Modules/Bridge/VtkGlue/src/QuickView.cxx
+++ b/Modules/Bridge/VtkGlue/src/QuickView.cxx
@@ -307,7 +307,7 @@ QuickView::Visualize(bool interact)
       // RGB Images
       else if (i >= this->Images.size() && i < numberOfImages)
       {
-        unsigned int              j = row * numberOfColumns + col - this->Images.size();
+        const size_t              j = i - this->Images.size();
         RGBConnectorType::Pointer connector = RGBConnectorType::New();
         RGBconnectors.push_back(connector);
         connector->SetInput(this->RGBImages[j].m_Image);


### PR DESCRIPTION
Hardens `QuickView` against four small latent defects found during a code review of the VtkGlue rendering path. All changes are output-neutral — `QuickViewTest` (incl. its baseline image `--compare`) passes locally before and after.

<details>
<summary>Defects addressed</summary>

| Commit | Defect |
|---|---|
| `BUG:` empty-set guard | `numberOfImages` is `unsigned`; `(numberOfImages - 1)` underflowed to a huge value when `Visualize()` was called with no images added, producing an enormous render-window size. Returns early when there is nothing to render. |
| `BUG:` viewport pointer | A `std::vector<double *>` stored the address of `viewport`, a `double[4]` local scoped to each loop iteration (UB-adjacent). The in-scope local is now passed directly to `SetViewport` and the vector is removed. |
| `COMP:` size_t index | The RGB-branch index subtracts `Images.size()` (`size_t`); it is now held as `size_t` to avoid narrowing to `unsigned int`. |
| `BUG:` locale-safe tolower | `SetSnapshotExtension` passed a possibly-negative `char` to `::tolower`, which is undefined behavior. Each character is cast to `unsigned char` before `std::tolower`. |

</details>

<details>
<summary>Validation</summary>

- Each commit passes the full pre-commit suite (clang-format, gersemi, kw-commit-msg); `pre-commit run --all-files` is clean on the final tree.
- Built `ITKVtkGlueTestDriver` and ran `QuickViewTest` on Linux (GCC, shared, Release, VTK 9.6, headless via xvfb): passes, including the baseline `--compare`, confirming rendered output is unchanged.

</details>

<details>
<summary>Scope notes</summary>

Deliberately excluded changes that would alter the rendered baseline (`numberOfColumns` layout math; snapshot path-separator and unknown-extension handling) or that are API/behavior changes warranting separate discussion (`explicit` constructors; test-coverage gaps).

These fixes are independent of the VS2026-shared `QuickViewTest` segfault observed on CDash, which a separate investigation attributes to the VS2026 preview toolchain rather than the QuickView source.

</details>

<!--
provenance: claude-code session 2026-05-26
base: InsightSoftwareConsortium/ITK@main
head: hjmjohnson:quickview-latent-hardening
files: Modules/Bridge/VtkGlue/include/QuickView.h, Modules/Bridge/VtkGlue/src/QuickView.cxx
local_test: QuickViewTest PASS (Linux GCC shared Release, VTK 9.6, xvfb), baseline --compare intact, pre-commit --all-files clean
not_related_to: VS2026-Shared-ReleaseTBB QuickViewTest segfault (toolchain issue, not source)
-->
