### PR TITLE
COMP: Update vendored DCMTK to 3.7.0 and standardize the DCMTK fork

### DIFF
--- a/Documentation/Maintenance/ThirdPartyForkConventions.md
+++ b/Documentation/Maintenance/ThirdPartyForkConventions.md
@@ -1,0 +1,46 @@
+# Third-Party Fork Conventions
+
+Several ITK third-party dependencies are vendored from a fork hosted under the
+[InsightSoftwareConsortium](https://github.com/InsightSoftwareConsortium)
+organization (for example
+[eigen](https://github.com/InsightSoftwareConsortium/eigen) and
+[DCMTK](https://github.com/InsightSoftwareConsortium/DCMTK)). Each fork carries
+a small overlay of ITK-specific patches on top of an upstream release.
+
+To keep these forks predictable and self-documenting, all ITK forks follow one
+convention.
+
+## Default branch: `welcome`
+
+The default branch of every fork is an orphan branch named `welcome` containing
+only a `README.md`. That README describes the upstream source, the branch
+naming convention, and the step-by-step workflow for producing the next update.
+Because GitHub renders the default branch's README on the repository landing
+page, a visitor immediately sees how the fork is maintained instead of a stale
+upstream description.
+
+## Branch naming: `for/itk-<project>-<version>-<sha7>`
+
+Each overlay branch is named `for/itk-<project>-<version>-<sha7>` where:
+
+- `<project>` is the forked project (e.g. `eigen`, `dcmtk`),
+- `<version>` is the upstream release the overlay is built on (e.g. `3.7.0`),
+- `<sha7>` is the 7-character commit hash of that upstream release tag.
+
+For example, `for/itk-dcmtk-3.7.0-ccfd10b` carries the ITK overlay on top of
+upstream DCMTK tag `DCMTK-3.7.0` (commit `ccfd10b`). Older non-conforming
+branches are retained for historical reference but are no longer the update
+target.
+
+## Pinning the fork in ITK
+
+ITK pins a specific overlay commit, not a branch name, so the build is
+reproducible:
+
+- `eigen` is consumed through `Modules/ThirdParty/Eigen3/UpdateFromUpstream.sh`.
+- `DCMTK` is pinned by `DCMTK_GIT_TAG` in
+  `Modules/ThirdParty/DCMTK/DCMTKGitTag.cmake`.
+
+When updating, the per-fork `welcome` branch is the authoritative, current
+description of the procedure; follow it, then update the corresponding pin in
+ITK and refresh the patch-list comment.

--- a/Modules/IO/DCMTK/test/CMakeLists.txt
+++ b/Modules/IO/DCMTK/test/CMakeLists.txt
@@ -41,8 +41,6 @@ if(NOT ITK_USE_SYSTEM_DCMTK)
     dcmjpeg
     dcmjpls
     dcmnet
-    dcmwlm
-    dcmrt
     dcmiod
     dcmfg
     dcmseg

--- a/Modules/ThirdParty/DCMTK/CMakeLists.txt
+++ b/Modules/ThirdParty/DCMTK/CMakeLists.txt
@@ -123,8 +123,6 @@ set(
   dcmjpeg
   dcmjpls
   dcmnet
-  dcmwlm
-  dcmrt
   dcmiod
   dcmfg
   dcmseg

--- a/Modules/ThirdParty/DCMTK/DCMTKGitTag.cmake
+++ b/Modules/ThirdParty/DCMTK/DCMTKGitTag.cmake
@@ -4,7 +4,7 @@ set(
   DCMTK_GIT_REPOSITORY
   "https://github.com/InsightSoftwareConsortium/DCMTK.git"
 )
-# 2024.03.11 patched
+# DCMTK-3.7.0 patched
 # Patch list:
 
 #Francois Budin (1):
@@ -16,10 +16,24 @@ set(
 #Jean-Christophe Fillion-Robin (1):
 #COMP: Set 3rd party package CMake variables only if needed
 
-#Matt McCormick (1):
-#Support CMAKE_CROSSCOMPILING_EMULATOR # pushed upstream in https://github.com/DCMTK/dcmtk/pull/94
+#Matt McCormick (7):
+#COMP: Avoid dcmjpeg use of setjmp with WASI
+#COMP: Enable dcmjpeg, dcmjpls to support plastimatch
+#COMP: Add missing oflog libraries for native unix
+#COMP: Update __cxa_allocate_exception for WASI-SDK 22
+#COMP: Do not try to make mmap calls with wasi
+#COMP: Add WASI exception shim
+#COMP: Do not use non-type template argument -1 in variadic template
 
-#Shreeraj Jadhav (1):
-#ENH: Replace HTML_HYPERLINK_PREFIX_FOR_CGI with std::string argument
+#Shreeraj Jadhav (9):
+#COMP: enable dcmfg for dcmqi seg object read-write
+#COMP: Fixes for wasi compiler errors after enabling dcmpstat
+#COMP: Enable dcmpstat to support GSPS/CSPS IODs
+#COMP: disable use of log4cplus::tistringstream
+#COMP: add fixes for Emscripten linker errors
+#COMP: Enable dcm2pdf, fix WIN32 build
+#COMP: disable unneeded tests and apps
+#COMP: fix WASI compiler errors
+#COMP: fix missing <csetjmp> header issue
 
-set(DCMTK_GIT_TAG "8197ee21a2e17be65b72508dca9a91d4d60725aa") # 20240311_DCMTK_PATCHES_FOR_ITK-1
+set(DCMTK_GIT_TAG "2f645cb91b603ccc674857ea05b9822a8a899675") # for/itk-dcmtk-3.7.0-ccfd10b

--- a/Modules/ThirdParty/DCMTK/README.md
+++ b/Modules/ThirdParty/DCMTK/README.md
@@ -2,3 +2,10 @@ To build new Windows ICU packages, see [MSVCBuildICU](https://github.com/Insight
 
 It should have no trouble building a version of DCMTK libraries linkable to
 ITK.
+
+The vendored DCMTK source is pinned by `DCMTK_GIT_TAG` in
+[`DCMTKGitTag.cmake`](DCMTKGitTag.cmake), which references a
+`for/itk-dcmtk-*` branch of the
+[InsightSoftwareConsortium/DCMTK](https://github.com/InsightSoftwareConsortium/DCMTK)
+fork. The fork's `welcome` branch documents the update workflow; see also
+[Third-Party Fork Conventions](../../../Documentation/Maintenance/ThirdPartyForkConventions.md).


### PR DESCRIPTION
Update the vendored DCMTK ExternalProject pin to **DCMTK-3.7.0** on the standardized fork branch [`for/itk-dcmtk-3.7.0-ccfd10b`](https://github.com/InsightSoftwareConsortium/DCMTK/tree/for/itk-dcmtk-3.7.0-ccfd10b). Also standardizes the DCMTK fork to the eigen/Slicer convention (orphan `welcome` default + `for/itk-...` naming) and documents it in ITK core docs (addresses @blowekamp's review).

Built and tested locally — all DCMTK and GDCM tests pass (details below).

<details>
<summary>Local build & test results (macOS arm64, Release, Clang)</summary>

Built in a worktree with `Module_ITKIODCMTK=ON`, `ITK_USE_SYSTEM_DCMTK=OFF` (all unrelated Remote modules disabled):

- **DCMTK ExternalProject (3.7.0 + ITK patches):** all 29 DCMTK libraries compiled.
- **`ITKDCMTK` + `ITKIODCMTK`:** built, 0 errors, 0 ITK-side warnings.
- **`ITKIODCMTK` test label:** 24/24 passed.
- **`GDCM` tests (shares JPEG/PNG/TIFF/ZLIB):** 65/65 passed — confirms codec libraries are undisturbed.

The branch repoint from `1158255a` to `2f645cb9` is a content-preserving rebase reword (`WIP:` → `COMP:`); `git diff` between the two tips is empty, so these results carry over unchanged.

**Not exercised locally:** Linux, Windows/MSVC, and the WASI/Emscripten path. Several carried 3.7.0 patches are WASM-specific and rely on CI for first execution.
</details>

<details>
<summary>DCMTK fork standardization (review follow-up)</summary>

- DCMTK fork default branch → orphan **`welcome`** (single `README.md` documenting source, naming, and update workflow), modeled on the eigen fork.
- Adopted one naming convention, **`for/itk-<project>-<version>-<sha7>`**; the 3.7.0 overlay is `for/itk-dcmtk-3.7.0-ccfd10b`. Legacy `YYYYMMDD_*` branches retained.
- The carried `WIP:` patch reworded to `COMP:` on the new branch (Matt McCormick authorship preserved, tree byte-identical).
- Documented cross-fork in `Documentation/Maintenance/ThirdPartyForkConventions.md` (+ DCMTK module README pointer).
</details>

<details>
<summary>Relationship to #5537</summary>

PR #5537 (draft, `DCMTK_USE_FIND_PACKAGE=ON`) attempted to make DCMTK consume ITK's PNG/ZLIB/TIFF via standard `find_package`. With this 3.7.0 update DCMTK already links **ITK's** codec libraries through the carried patch stack, so the goal of #5537 is achieved. This PR does not touch that mechanism; whether #5537 is closed as superseded or re-scoped is left to the maintainers.
</details>

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

<!--
provenance: claude-code session, gh-triage-pr (rebased on upstream/main 06172c1ec4)
pr_head: 4035f30c48 (2 commits: COMP repoint + DOC conventions)
change: Modules/ThirdParty/DCMTK/DCMTKGitTag.cmake tag -> 2f645cb91b603ccc674857ea05b9822a8a899675 (for/itk-dcmtk-3.7.0-ccfd10b)
dcmtk_fork: default_branch welcome; for/itk-dcmtk-3.7.0-ccfd10b is reword (WIP->COMP) of old 1158255a, tree-identical
docs: Documentation/Maintenance/ThirdPartyForkConventions.md (new); Modules/ThirdParty/DCMTK/README.md pointer
local_tests: ITKIODCMTK 24/24, GDCM 65/65; macOS arm64 Release Clang; tree-identical to prior validated tip
related_pr: #5537 (possibly superseded; not modified)
review: blowekamp welcome/naming/docs request addressed; greptile P2 (WIP prefix) resolved
-->
