### PR TITLE
COMP: Fix AppleClang CTAD test template-template parameter matching

### DIFF
--- a/Modules/Core/Common/test/itkNeighborhoodIteratorsGTest.cxx
+++ b/Modules/Core/Common/test/itkNeighborhoodIteratorsGTest.cxx
@@ -30,7 +30,7 @@
 
 namespace
 {
-template <template <typename> typename TIteratorTemplate, typename TImage>
+template <template <typename...> typename TIteratorTemplate, typename TImage>
 void
 CheckIteratorSupportsClassTemplateArgumentDeduction()
 {
@@ -42,7 +42,7 @@ CheckIteratorSupportsClassTemplateArgumentDeduction()
 }
 
 
-template <template <typename> typename TIteratorTemplate, typename TImage>
+template <template <typename...> typename TIteratorTemplate, typename TImage>
 void
 CheckConstIteratorSupportsClassTemplateArgumentDeduction()
 {
@@ -54,7 +54,7 @@ CheckConstIteratorSupportsClassTemplateArgumentDeduction()
 }
 
 
-template <template <typename> typename... TIteratorTemplate>
+template <template <typename...> typename... TIteratorTemplate>
 void
 CheckIteratorsSupportClassTemplateArgumentDeduction()
 {
@@ -63,7 +63,7 @@ CheckIteratorsSupportClassTemplateArgumentDeduction()
 }
 
 
-template <template <typename> typename... TIteratorTemplate>
+template <template <typename...> typename... TIteratorTemplate>
 void
 CheckConstIteratorsSupportClassTemplateArgumentDeduction()
 {


### PR DESCRIPTION
Fixes the AppleClang-dbg nightly build failures in
`itkNeighborhoodIteratorsGTest.cxx`: widen the CTAD test's
template-template parameters from `template <typename> typename` to
`template <typename...> typename` so iterators carrying a defaulted
second template parameter bind correctly.

<details>
<summary>Root cause</summary>

The `NeighborhoodIterators.SupportClassTemplateArgumentDeduction` test
(added in #6317, commit `b84dc9bd26`) declared its variadic
template-template parameter as `template <typename> typename...`. Four of
the five iterators it exercises — `ConstNeighborhoodIterator`,
`ConstShapedNeighborhoodIterator`, `NeighborhoodIterator`,
`ShapedNeighborhoodIterator` — are declared
`template <typename TImage, typename TBoundaryCondition = …>`. Older
AppleClang does not apply the P0522R0 relaxation by default, so a
two-parameter class template (even with the second parameter defaulted)
will not bind to a single-parameter template-template slot:

```
error: no matching function for call to
       'CheckConstIteratorsSupportClassTemplateArgumentDeduction'
```

Every `Mac1x-AppleClang-dbg` nightly failed with this error. Widening to
`template <typename...> typename` is strictly more permissive and accepts
all five iterators on GCC, Clang, AppleClang, and MSVC.
</details>

<details>
<summary>Local verification (macOS arm64, AppleClang)</summary>

- `ITKCommonGTestDriver` builds.
- `NeighborhoodIterators.SupportClassTemplateArgumentDeduction` passes.
- The new `template <typename...> typename` form compiles on AppleClang.

The exact failure reproduces only on the older AppleClang revisions on
the dashboards; the fix is verified to compile and is strictly more
permissive than the original.
</details>

<!--
provenance: claude-code session 2026-05-30, cdash-build-analysis triage
branch: fix-appleclang-ctad-neighborhood-iterators (hjmjohnson fork)
cdash: nightly 20260530-0100, Mac AppleClang-dbg builds
introduced_by: b84dc9bd26 (PR #6317)
file: Modules/Core/Common/test/itkNeighborhoodIteratorsGTest.cxx
-->
