### PR TITLE
COMP: Use DirectionType in Jacobian det test for float space precision

### DIFF
--- a/Modules/Filtering/DisplacementField/test/itkDisplacementFieldJacobianDeterminantFilterTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkDisplacementFieldJacobianDeterminantFilterTest.cxx
@@ -169,8 +169,8 @@ TestDisplacementJacobianDeterminantValue()
   auto displacementFieldPermuted = permute->GetOutput();
 
   // Adjust direction to match permutation
-  itk::Matrix<double, 2, 2> origDir = displacementField->GetDirection();
-  itk::Matrix<double, 2, 2> newDirPermute;
+  FieldType::DirectionType origDir = displacementField->GetDirection();
+  FieldType::DirectionType newDirPermute;
   newDirPermute[0][0] = origDir[1][0];
   newDirPermute[0][1] = origDir[1][1];
   newDirPermute[1][0] = origDir[0][0];
@@ -196,11 +196,11 @@ TestDisplacementJacobianDeterminantValue()
   auto displacementFieldFlip = flip->GetOutput();
 
   // Adjust direction to compensate flip
-  itk::Matrix<double, 2, 2> flipMat;
+  FieldType::DirectionType flipMat;
   flipMat.SetIdentity();
   flipMat[0][0] = -1.0;
 
-  itk::Matrix<double, 2, 2> newDirFlip = flipMat * displacementField->GetDirection();
+  FieldType::DirectionType newDirFlip = flipMat * displacementField->GetDirection();
 
   displacementFieldFlip->SetDirection(newDirFlip);
 


### PR DESCRIPTION
Fixes the single-precision (`ITK_USE_FLOAT_SPACE_PRECISION`) nightly
build failure in `itkDisplacementFieldJacobianDeterminantFilterTest.cxx`:
use `FieldType::DirectionType` instead of a hardcoded
`itk::Matrix<double, 2, 2>` for the direction matrices.

<details>
<summary>Root cause</summary>

The test constructed its direction matrices as `itk::Matrix<double, 2, 2>`
and assigned them from `GetDirection()` / to `SetDirection()`. Under
`ITK_USE_FLOAT_SPACE_PRECISION` the image direction type is
`Matrix<float, 2, 2>`, which has no implicit conversion to/from
`Matrix<double, 2, 2>`:

```
error: no viable conversion from 'const Matrix<SpacePrecisionType, …>'
       to 'Matrix<double, …>'
```

(MSVC: `C2440` at lines 172/179/203/205). The `Windows11-VS22x64-
RelWithDebInfo-Favorite-Remotes` nightly builds with single space
precision and failed there. Using `FieldType::DirectionType` makes the
matrices follow the configured space precision, so the test compiles in
both single- and double-precision configurations.
</details>

<details>
<summary>Local verification (macOS arm64, AppleClang)</summary>

Reproduced and fixed the exact dashboard failure locally:

- **Old code, float precision** (`-DITK_USE_FLOAT_SPACE_PRECISION`): the
  precise CDash errors reproduce at lines 172, 179, 203, 205.
- **New code, float precision:** 0 errors.
- **New code, double precision:** `ITKDisplacementFieldTestDriver` builds
  and `itkDisplacementFieldJacobianDeterminantFilterTest` passes.
</details>

<!--
provenance: claude-code session 2026-05-30, cdash-build-analysis triage
branch: fix-float-space-precision-jacobian-det-test (hjmjohnson fork)
cdash: nightly 20260530-0100, Windows VS22 Favorite-Remotes (float space precision)
introduced_by: 612f2cec49 (Philip Cook)
file: Modules/Filtering/DisplacementField/test/itkDisplacementFieldJacobianDeterminantFilterTest.cxx
-->
