### PR TITLE
STYLE: Replace deprecated iterator GetIndex() with ComputeIndex()

### DIFF
--- a/Modules/Filtering/MorphologicalContourInterpolation/include/itkMorphologicalContourInterpolator.hxx
+++ b/Modules/Filtering/MorphologicalContourInterpolation/include/itkMorphologicalContourInterpolator.hxx
@@ -876,7 +876,7 @@ MorphologicalContourInterpolator<TImage>::Interpolate1toN(int                   
       auto                       res = std::find(jRegionIds.begin(), jRegionIds.end(), jVal);
       if (res != jRegionIds.end())
       {
-        blobs[res - jRegionIds.begin()]->SetPixel(maskIt.GetIndex(), true);
+        blobs[res - jRegionIds.begin()]->SetPixel(maskIt.ComputeIndex(), true);
         belongInit.Set(res - jRegionIds.begin() + 1);
       }
     }

--- a/Modules/Filtering/RLEImage/include/itkRLEImageConstIterator.h
+++ b/Modules/Filtering/RLEImage/include/itkRLEImageConstIterator.h
@@ -265,7 +265,7 @@ public:
     IndexType indR(m_Image->GetBufferedRegion().GetIndex());
 
     indR[0] += m_Index0;
-    typename BufferType::IndexType bufInd = m_BI.GetIndex();
+    typename BufferType::IndexType bufInd = m_BI.ComputeIndex();
     for (IndexValueType i = 1; i < VImageDimension; i++)
     {
       indR[i] = bufInd[i - 1];

--- a/Modules/Filtering/RLEImage/test/itkRLEImageAlgorithmCopyGTest.cxx
+++ b/Modules/Filtering/RLEImage/test/itkRLEImageAlgorithmCopyGTest.cxx
@@ -57,7 +57,7 @@ TEST(RLEImageAlgorithmCopy, FromRLEToImage)
 
   for (itk::ImageRegionConstIterator<ImageType> it(dst, region); !it.IsAtEnd(); ++it)
   {
-    ASSERT_EQ(it.Get(), 7) << "Mismatch at " << it.GetIndex();
+    ASSERT_EQ(it.Get(), 7) << "Mismatch at " << it.ComputeIndex();
   }
 }
 

--- a/Modules/Filtering/RLEImage/test/itkRLEImageScanlineIteratorTest1.cxx
+++ b/Modules/Filtering/RLEImage/test/itkRLEImageScanlineIteratorTest1.cxx
@@ -171,7 +171,7 @@ itkRLEImageScanlineIteratorTest1(int, char *[])
     {
       while (!createImageIterator.IsAtEndOfLine())
       {
-        if (createImageIterator.GetIndex()[0] == 0)
+        if (createImageIterator.ComputeIndex()[0] == 0)
         {
           createImageIterator.Set(0);
         }


### PR DESCRIPTION
Clears ~280 nightly `-Wdeprecated-declarations` / `C4996` warnings (the
two largest non-ThirdParty warning buckets) by replacing deprecated
iterator `GetIndex()` calls with `ComputeIndex()` in `RLEImage` and
`MorphologicalContourInterpolation`.

<details>
<summary>Root cause</summary>

`itk::ImageConstIterator::GetIndex()` is `ITK_FUTURE_DEPRECATED` in favor
of `ComputeIndex()`. Four call sites invoke it on no-index iterators
(`ImageRegionConstIterator`, `ImageRegionIterator`, `ImageScanlineIterator`),
each instantiated across many translation units, producing ~175 `C4996`
(MSVC) and ~106 `-Wdeprecated-declarations` (GCC/Clang) nightly warnings:

- `itkRLEImageConstIterator.h` — `m_BI.GetIndex()` (buffer iterator)
- `itkMorphologicalContourInterpolator.hxx:879` — `maskIt.GetIndex()`
- `itkRLEImageScanlineIteratorTest1.cxx:174` — `createImageIterator.GetIndex()`
- `itkRLEImageAlgorithmCopyGTest.cxx:60` — `it.GetIndex()`
</details>

<details>
<summary>Scope note — what was deliberately left unchanged</summary>

`ImageRegionConstIteratorWithIndex` provides its own non-deprecated
`GetIndex()`, so those call sites (`itkMorphologicalContourInterpolator.hxx`
lines 526/920/933/948/977) are untouched. The RLE-specialized
`ImageRegionConstIterator<RLEImage>` at `itkRLEImageAlgorithmCopyGTest.cxx:82`
is likewise left as-is. This matches exactly which sites CDash flagged.
</details>

<details>
<summary>Local verification (macOS arm64, AppleClang)</summary>

- `RLEImageTestDriver`, `RLEImageGTestDriver`,
  `MorphologicalContourInterpolationTestDriver` build with **0**
  deprecation warnings.
- `ctest -R "RLEImage|MorphologicalContourInterp"`: 50/50 pass.
</details>

<!--
provenance: claude-code session 2026-05-30, cdash-build-analysis triage
branch: fix-deprecated-getindex-computeindex (hjmjohnson fork)
cdash: nightly 20260530-0100; C4996 (175) + -Wdeprecated-declarations (106)
replacement: itk::ImageConstIterator::GetIndex() -> ComputeIndex()
files: itkRLEImageConstIterator.h, itkMorphologicalContourInterpolator.hxx, itkRLEImageScanlineIteratorTest1.cxx, itkRLEImageAlgorithmCopyGTest.cxx
-->
