### PR TITLE
COMP: Bound displacement-component loops by the pixel vector length

### DIFF
--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
@@ -287,6 +287,7 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::DynamicThreadedG
   PointType                    point{};
   DisplacementType             displacement{};
   NumericTraits<DisplacementType>::SetLength(displacement, ImageDimension);
+  const unsigned int numberOfDisplacementComponents = NumericTraits<DisplacementType>::GetLength(displacement);
   static_assert(PointType::Dimension == ImageDimension, "ERROR: Point type and ImageDimension must be the same!");
   if (this->m_DefFieldSameInformation)
   {
@@ -303,7 +304,7 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::DynamicThreadedG
       displacement = fieldIt.Get();
 
       // compute the required input image point
-      for (unsigned int j = 0; j < ImageDimension; ++j)
+      for (unsigned int j = 0; j < numberOfDisplacementComponents; ++j)
       {
         point[j] += displacement[j];
       }
@@ -333,7 +334,7 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::DynamicThreadedG
 
       this->EvaluateDisplacementAtPhysicalPoint(point, fieldPtr, displacement);
       // compute the required input image point
-      for (unsigned int j = 0; j < ImageDimension; ++j)
+      for (unsigned int j = 0; j < numberOfDisplacementComponents; ++j)
       {
         point[j] += displacement[j];
       }

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
@@ -172,8 +172,10 @@ ESMDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Co
 {
   auto *    globalData = (GlobalDataStruct *)gd;
   PixelType update{};
-  IndexType FirstIndex = this->GetFixedImage()->GetLargestPossibleRegion().GetIndex();
-  IndexType LastIndex = this->GetFixedImage()->GetLargestPossibleRegion().GetIndex() +
+  NumericTraits<PixelType>::SetLength(update, ImageDimension);
+  const unsigned int numberOfUpdateComponents = NumericTraits<PixelType>::GetLength(update);
+  IndexType          FirstIndex = this->GetFixedImage()->GetLargestPossibleRegion().GetIndex();
+  IndexType          LastIndex = this->GetFixedImage()->GetLargestPossibleRegion().GetIndex() +
                         this->GetFixedImage()->GetLargestPossibleRegion().GetSize();
 
   const IndexType index = it.GetIndex();
@@ -325,7 +327,7 @@ ESMDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Co
   {
     PointType mappedPoint{};
     this->GetFixedImage()->TransformIndexToPhysicalPoint(index, mappedPoint);
-    for (unsigned int j = 0; j < ImageDimension; ++j)
+    for (unsigned int j = 0; j < numberOfUpdateComponents; ++j)
     {
       mappedPoint[j] += it.GetCenterPixel()[j];
     }
@@ -365,7 +367,7 @@ ESMDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Co
     {
       const double factor = 2.0 * speedValue / denom;
 
-      for (unsigned int j = 0; j < ImageDimension; ++j)
+      for (unsigned int j = 0; j < numberOfUpdateComponents; ++j)
       {
         update[j] = factor * usedGradientTimes2[j];
       }


### PR DESCRIPTION
Clears the GCC `-Waggressive-loop-optimizations` nightly warnings in
`WarpImageFilter` and `ESMDemonsRegistrationFunction` by bounding the
displacement-component loops with the pixel vector's actual length
instead of the compile-time `ImageDimension`.

<details>
<summary>Root cause</summary>

GCC reported *"iteration 2 invokes undefined behavior"* at
`itkWarpImageFilter.hxx:308,338` and
`itkESMDemonsRegistrationFunction.hxx:330,370`. Each loop indexed the
displacement / update vector with `j < ImageDimension`. The
displacement-field pixel type can be a fixed-size vector shorter than
`ImageDimension` for instantiations that are compiled (e.g. via Python
wrapping) but rejected at runtime by the existing dimension guard
(`WarpImageFilter::VerifyInputInformation`). Because `ImageDimension` is
a compile-time constant, GCC unrolls the loop and proves an
out-of-bounds access on those instantiations.

Bounding the loops with `NumericTraits<>::GetLength()` of the vector
removes the provable overrun (GCC can no longer prove a fixed trip count
that exceeds the array). This reuses the idiom already present in
`WarpImageFilter::EvaluateDisplacementAtPhysicalPoint`. In every valid
instantiation the vector length equals `ImageDimension`, so behavior is
unchanged.

Both sites now call `SetLength(vec, ImageDimension)` before `GetLength`,
symmetric with the existing `WarpImageFilter` code: a no-op for the
fixed-size vectors used in practice, but it prevents a default-constructed
`VariableLengthVector` from reporting length 0 and silently skipping the
loops.
</details>

<details>
<summary>Local verification</summary>

- `ITKImageGridTestDriver`, `ITKPDEDeformableRegistrationTestDriver` build clean.
- `ctest -R "Warp|ESMDemons|Demons|PDEDeformable"`: 29/29 pass.
- `pre-commit run --all-files`: exit 0.

The warning is GCC-only and cannot reproduce on local AppleClang/Linux-clang;
the runtime-length bound provably eliminates GCC's ability to prove the
overrun. Relying on Linux GCC CI for first observation of the warning's
removal.
</details>

<!--
provenance: claude-code cdash triage; rebased + greptile-P2 fix via gh-triage-pr
branch: fix-aggressive-loop-optimizations-displacement-bounds (hjmjohnson fork)
head: d9c468f406 (single COMP commit on upstream/main 06172c1ec4)
cdash: latest nightly Ubuntu gcc11.4 builds (-Waggressive-loop-optimizations)
files: itkWarpImageFilter.hxx (308,338), itkESMDemonsRegistrationFunction.hxx (330,370)
idiom_reference: WarpImageFilter::EvaluateDisplacementAtPhysicalPoint line 255
greptile_p2: ESMDemons now calls SetLength(update, ImageDimension) before GetLength (symmetric w/ WarpImageFilter) — resolved
sibling_prs: #6364, #6365, #6366 (same nightly triage)
deferred: -Wnrvo, -Wallocator-wrappers, -Wlifetime-safety-* (Clang-trunk heuristics, not churned)
-->
