### PR TITLE
ENH: Register dormant tests (compiled but never run) toward >90% coverage

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -221,6 +221,36 @@ itk_add_test(
     itkFixedArrayTest2
 )
 itk_add_test(
+  NAME itkObjectStoreTest
+  COMMAND
+    ITKCommon1TestDriver
+    itkObjectStoreTest
+)
+itk_add_test(
+  NAME itkImageComputeOffsetAndIndexTest
+  COMMAND
+    ITKCommon1TestDriver
+    itkImageComputeOffsetAndIndexTest
+)
+itk_add_test(
+  NAME itkImageRegionExplicitTest
+  COMMAND
+    ITKCommon1TestDriver
+    itkImageRegionExplicitTest
+)
+itk_add_test(
+  NAME itkMetaProgrammingLibraryTest
+  COMMAND
+    ITKCommon2TestDriver
+    itkMetaProgrammingLibraryTest
+)
+itk_add_test(
+  NAME itkPromoteType
+  COMMAND
+    ITKCommon2TestDriver
+    itkPromoteType
+)
+itk_add_test(
   NAME itkSobelOperatorImageConvolutionHorizTest
   COMMAND
     ITKCommon1TestDriver

--- a/Modules/Filtering/ImageGrid/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageGrid/test/CMakeLists.txt
@@ -63,6 +63,22 @@ endif()
 createtestdriver(ITKImageGrid "${ITKImageGrid-Test_LIBRARIES}" "${ITKImageGridTests}")
 
 itk_add_test(
+  NAME itkOrientImageFilterTest
+  COMMAND
+    ITKImageGridTestDriver
+    itkOrientImageFilterTest
+    0
+)
+if(NOT ITK_FUTURE_LEGACY_REMOVE)
+  itk_add_test(
+    NAME itkOrientImageFilterTest2
+    COMMAND
+      ITKImageGridTestDriver
+      itkOrientImageFilterTest2
+  )
+endif()
+
+itk_add_test(
   NAME itkBasicArchitectureTest
   COMMAND
     ITKImageGridTestDriver

--- a/Modules/IO/JPEG2000/test/CMakeLists.txt
+++ b/Modules/IO/JPEG2000/test/CMakeLists.txt
@@ -26,6 +26,18 @@ itk_add_test(
     240
 )
 itk_add_test(
+  NAME itkJPEG2000ImageIOFactoryTest01
+  COMMAND
+    ITKIOJPEG2000TestDriver
+    itkJPEG2000ImageIOFactoryTest01
+)
+itk_add_test(
+  NAME itkJPEG2000ImageIOTest00
+  COMMAND
+    ITKIOJPEG2000TestDriver
+    itkJPEG2000ImageIOTest00
+)
+itk_add_test(
   NAME itkJPEG2000Test01
   COMMAND
     ITKIOJPEG2000TestDriver

--- a/Modules/Nonunit/IntegratedTest/test/CMakeLists.txt
+++ b/Modules/Nonunit/IntegratedTest/test/CMakeLists.txt
@@ -1,9 +1,9 @@
 itk_module_test()
 set(
   ITKIntegratedTestTests
-  itkFilterImageAddTest.cxx # missing itk_add_test() call
+  itkFilterImageAddTest.cxx
   itkNumericsPrintTest.cxx
-  itkReleaseDataFilterTest.cxx # missing itk_add_test() call
+  itkReleaseDataFilterTest.cxx
   itkStatisticsPrintTest.cxx
   itkCommonPrintTest.cxx
   itkIOPrintTest.cxx
@@ -13,6 +13,19 @@ set(
 )
 
 createtestdriver(ITKIntegratedTest "${ITKIntegratedTest-Test_LIBRARIES}" "${ITKIntegratedTestTests}")
+
+itk_add_test(
+  NAME itkFilterImageAddTest
+  COMMAND
+    ITKIntegratedTestTestDriver
+    itkFilterImageAddTest
+)
+itk_add_test(
+  NAME itkReleaseDataFilterTest
+  COMMAND
+    ITKIntegratedTestTestDriver
+    itkReleaseDataFilterTest
+)
 
 set(TEMP ${ITK_TEST_OUTPUT_DIR})
 

--- a/Modules/Segmentation/LevelSetsv4/test/CMakeLists.txt
+++ b/Modules/Segmentation/LevelSetsv4/test/CMakeLists.txt
@@ -73,14 +73,12 @@ itk_add_test(
   COMMAND
     ITKLevelSetsv4TestDriver
     itkLevelSetEquationChanAndVeseInternalTermTest
-    DATA{${ITK_DATA_ROOT}/Input/whiteSpot.png}
 )
 itk_add_test(
   NAME itkLevelSetsv4EquationTermContainerTest
   COMMAND
     ITKLevelSetsv4TestDriver
     itkLevelSetEquationTermContainerTest
-    DATA{${ITK_DATA_ROOT}/Input/whiteSpot.png}
 )
 itk_add_test(
   NAME itkLevelSetsv4DenseImageBaseTest

--- a/Modules/Segmentation/LevelSetsv4/test/CMakeLists.txt
+++ b/Modules/Segmentation/LevelSetsv4/test/CMakeLists.txt
@@ -69,6 +69,20 @@ itk_add_test(
     itkLevelSetEquationOverlapPenaltyTermTest
 )
 itk_add_test(
+  NAME itkLevelSetsv4EquationChanAndVeseInternalTermTest
+  COMMAND
+    ITKLevelSetsv4TestDriver
+    itkLevelSetEquationChanAndVeseInternalTermTest
+    DATA{${ITK_DATA_ROOT}/Input/whiteSpot.png}
+)
+itk_add_test(
+  NAME itkLevelSetsv4EquationTermContainerTest
+  COMMAND
+    ITKLevelSetsv4TestDriver
+    itkLevelSetEquationTermContainerTest
+    DATA{${ITK_DATA_ROOT}/Input/whiteSpot.png}
+)
+itk_add_test(
   NAME itkLevelSetsv4DenseImageBaseTest
   COMMAND
     ITKLevelSetsv4TestDriver

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseInternalTermTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationChanAndVeseInternalTermTest.cxx
@@ -22,19 +22,11 @@
 #include "itkLevelSetEquationChanAndVeseInternalTerm.h"
 #include "itkSinRegularizedHeavisideStepFunction.h"
 #include "itkBinaryImageToLevelSetImageAdaptor.h"
-#include "itkTestingMacros.h"
+#include <iostream>
 
 int
-itkLevelSetEquationChanAndVeseInternalTermTest(int argc, char * argv[])
+itkLevelSetEquationChanAndVeseInternalTermTest(int, char *[])
 {
-
-  if (argc < 2)
-  {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << "Program " << itkNameOfTestExecutableMacro(argv) << std::endl;
-    return EXIT_FAILURE;
-  }
-
   constexpr unsigned int Dimension{ 2 };
 
   using InputPixelType = unsigned short;

--- a/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermContainerTest.cxx
+++ b/Modules/Segmentation/LevelSetsv4/test/itkLevelSetEquationTermContainerTest.cxx
@@ -25,15 +25,8 @@
 #include "itkTestingMacros.h"
 
 int
-itkLevelSetEquationTermContainerTest(int argc, char * argv[])
+itkLevelSetEquationTermContainerTest(int, char *[])
 {
-  if (argc < 2)
-  {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << "Program " << itkNameOfTestExecutableMacro(argv) << std::endl;
-    return EXIT_FAILURE;
-  }
-
   constexpr unsigned int Dimension{ 2 };
 
   using InputPixelType = unsigned short;


### PR DESCRIPTION
Register 13 tests that were compiled into their module test drivers but never invoked by any `itk_add_test` — so they built, counted as present, but never ran and contributed no coverage. Motivated by pushing line coverage past 90% (CDash `itk-coverage` is at 89.51%); tracked in #6370.

`itkOrientImageFilter` was the motivating example: 0% coverage despite two existing test files, purely because neither was registered. All registered tests here were built and run locally (macOS arm64 Release) and pass.

<details>
<summary>What was registered (per commit)</summary>

| Module | Tests |
|--------|-------|
| Filtering/ImageGrid | `itkOrientImageFilterTest` (useImageDirection=0) + legacy `itkOrientImageFilterTest2` |
| Core/Common | `itkObjectStoreTest`, `itkImageComputeOffsetAndIndexTest`, `itkImageRegionExplicitTest`, `itkMetaProgrammingLibraryTest`, `itkPromoteType` |
| Nonunit/IntegratedTest | `itkFilterImageAddTest`, `itkReleaseDataFilterTest` (both had explicit `# missing itk_add_test() call` comments) |
| IO/JPEG2000 | `itkJPEG2000ImageIOFactoryTest01`, `itkJPEG2000ImageIOTest00` |
| Segmentation/LevelSetsv4 | `itkLevelSetEquationTermContainerTest`, `itkLevelSetEquationChanAndVeseInternalTermTest` |

The final commit also drops the unused `argc>=2` requirement from the two LevelSetsv4 tests (they never read any argument) and swaps an orphaned `itkTestingMacros.h` include for `<iostream>`.
</details>

<details>
<summary>Deliberately NOT registered (skipped)</summary>

- `itkOrientImageFilterTest` with `useImageDirection=1` — fails by design: that mode derives orientation from the (identity) image direction, overriding the explicit `SetGivenCoordinateOrientation(LSA)` the test's assertions rely on. The `UseImageDirection=true` path is covered by `itkOrientImageFilterTest2`.
- `itkLevelSetEquationTermBaseTest` / `itkLevelSetEquationRegionTermTest` — degenerate `{ return EXIT_SUCCESS; }` stubs that exercise zero product code; registering them would be misleading green coverage. Left dormant; tracked in #6370 to flesh out or remove.
- Tests that fail when run (`itkQuadEdgeMeshBasicLayerTest`, `itkLevelSetEquationChanAndVeseExternalTermTest`) or need fixtures/baselines (LabelMap statistics trio, JPEG2000 Test01/02/04, DCMTK, BridgeVXL). See #6370.
</details>

<details>
<summary>History verification</summary>

These are move/reorg oversights, not intentional removals: `git log -G` finds zero historical `itk_add_test` invocations for any of them, none have GoogleTest replacements, and IntegratedTest even annotated two with `# missing itk_add_test() call`. Root causes traced to `ENH: Refine modular tree layout` and `ENH: Move remaining tests out of ITK-IntegratedTest`.
</details>

<!--
provenance: claude-code session 2026-05-31
tracking_issue: #6370
motivation: push CDash itk-coverage past 90% (currently 89.51%)
review: /code-review max -- zero correctness/build defects; the misleading-no-op-coverage finding was resolved by NOT registering the two LevelSetsv4 stubs
local_test: macOS arm64 Release; all 13 registered tests pass; pre-commit --all-files exit 0
followups (see #6370 + .devlocal hints): flesh-out-or-delete the 2 LevelSets stubs; investigate the 2 failing dormant tests; fixture-based registrations
-->
