### PR TITLE
BUG: Throw instead of hang on a non-closing QuadEdge ring

### DIFF
--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h
@@ -19,6 +19,7 @@
 #define itkQuadEdgeMeshBaseIterator_h
 
 #include "itkMacro.h"
+#include "itkIntTypes.h"
 
 // -------------------------------------------------------------------------
 #define itkQEDefineIteratorMethodsMacro(Op)                                                                        \
@@ -104,6 +105,8 @@ public:
       m_Iterator = r.m_Iterator;
       m_OpType = r.m_OpType;
       m_Start = r.m_Start;
+      m_NumberOfSteps = r.m_NumberOfSteps;
+      m_MaximumNumberOfSteps = r.m_MaximumNumberOfSteps;
     }
     return *this;
   }
@@ -129,6 +132,22 @@ public:
     return m_Start;
   }
 
+  /** Maximum number of steps before iteration is judged non-terminating.
+   * A valid Onext / Lnext / Sym / ... ring returns to the start edge, so it
+   * always terminates well below the (deliberately huge) default. A malformed
+   * (non-closing) ring would otherwise loop forever; the iterator throws once
+   * this bound is crossed. See InsightSoftwareConsortium/ITK#6372. */
+  void
+  SetMaximumNumberOfSteps(itk::SizeValueType maxSteps)
+  {
+    m_MaximumNumberOfSteps = maxSteps;
+  }
+  [[nodiscard]] itk::SizeValueType
+  GetMaximumNumberOfSteps() const
+  {
+    return m_MaximumNumberOfSteps;
+  }
+
   /** Iteration methods. */
   bool
   operator==(const Self & r) const
@@ -146,6 +165,7 @@ public:
     {
       this->GoToNext();
       m_Start = !(m_Iterator == m_StartEdge);
+      this->CheckRingClosure();
     }
 
     return *this;
@@ -158,11 +178,24 @@ public:
     {
       this->GoToNext();
       m_Start = !(m_Iterator == m_StartEdge);
+      this->CheckRingClosure();
     }
     return *this;
   }
 
 protected:
+  void
+  CheckRingClosure()
+  {
+    if (m_Start && ++m_NumberOfSteps > m_MaximumNumberOfSteps)
+    {
+      itkGenericExceptionMacro("QuadEdgeMesh ring iterator took more than "
+                               << m_MaximumNumberOfSteps
+                               << " steps without returning to its start edge; the underlying quad-edge ring does "
+                                  "not close (malformed/inconsistent connectivity).");
+    }
+  }
+
   /** Method that should do all the iteration work. */
   virtual void
   GoToNext()
@@ -214,10 +247,12 @@ protected:
   }
 
 protected:
-  QuadEdgeType * m_StartEdge{}; /**< Start edge */
-  QuadEdgeType * m_Iterator{};  /**< Current iteration position */
-  int            m_OpType{};    /**< Operation type */
-  bool           m_Start{};     /**< Indicates iteration has just started */
+  QuadEdgeType *     m_StartEdge{};                       /**< Start edge */
+  QuadEdgeType *     m_Iterator{};                        /**< Current iteration position */
+  int                m_OpType{};                          /**< Operation type */
+  bool               m_Start{};                           /**< Indicates iteration has just started */
+  itk::SizeValueType m_NumberOfSteps{};                   /**< Steps taken; guards against non-closing rings */
+  itk::SizeValueType m_MaximumNumberOfSteps{ 100000000 }; /**< Non-closing-ring guard threshold (1e8) */
 };
 
 /**

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshBasicLayerTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshBasicLayerTest.cxx
@@ -19,6 +19,7 @@
 // Program test for the basic QE layer.
 #include <iostream>
 #include "itkGeometricalQuadEdge.h"
+#include "itkTestingMacros.h"
 
 class itkQuadEdgeMeshBasicLayerTestHelper
 {
@@ -27,7 +28,7 @@ public:
   using DualType = PrimalType::DualType;
 
   static PrimalType *
-  MakeQuadEdges()
+  MakeQuadEdges(bool degenerateDual = false)
   {
     auto * e1 = new PrimalType();
     auto * e2 = new DualType();
@@ -42,17 +43,71 @@ public:
     e1->SetOnext(e1);
     e2->SetOnext(e4);
     e3->SetOnext(e3);
-    e4->SetOnext(e2); // dual quadrants form the e2<->e4 2-cycle (Guibas-Stolfi MakeEdge)
+    // dual quadrants form the e2<->e4 2-cycle (Guibas-Stolfi MakeEdge); the
+    // degenerate self-loop is kept available to build a non-closing ring.
+    e4->SetOnext(degenerateDual ? e4 : e2);
 
     return e1;
   }
 };
 
+namespace
+{
+using PrimalType = itkQuadEdgeMeshBasicLayerTestHelper::PrimalType;
+
+// Free five quad-edges; each owns a four-element Rot ring.
+void
+FreeQuadEdges(PrimalType * e[5])
+{
+  for (int i = 0; i < 5; ++i)
+  {
+    delete e[i]->GetRot()->GetRot()->GetRot();
+    delete e[i]->GetRot()->GetRot();
+    delete e[i]->GetRot();
+    delete e[i];
+  }
+}
+
+// Build the two-triangle structure with the degenerate dual init (the historical
+// bug). The caller owns the five edges and must free them with FreeQuadEdges().
+void
+BuildDegenerateLnextRing(PrimalType * e[5])
+{
+  for (int i = 0; i < 5; ++i)
+  {
+    e[i] = itkQuadEdgeMeshBasicLayerTestHelper::MakeQuadEdges(true);
+  }
+  const int org[5] = { 0, 1, 2, 3, 0 };
+  const int dest[5] = { 1, 2, 3, 0, 2 };
+  for (int i = 0; i < 5; ++i)
+  {
+    e[i]->SetOrigin(org[i]);
+    e[i]->SetDestination(dest[i]);
+  }
+  e[0]->Splice(e[4]);
+  e[4]->Splice(e[3]->GetSym());
+  e[1]->Splice(e[0]->GetSym());
+  e[2]->Splice(e[4]->GetSym());
+  e[4]->GetSym()->Splice(e[1]->GetSym());
+  e[3]->Splice(e[2]->GetSym());
+}
+
+// Fully traverse a left-face ring; the iterator guard throws if it never
+// closes. See InsightSoftwareConsortium/ITK#6372.
+void
+TraverseLnextRing(PrimalType * start)
+{
+  auto it = start->BeginGeomLnext();
+  it.SetMaximumNumberOfSteps(1000);
+  for (; it != start->EndGeomLnext(); ++it)
+  {
+  }
+}
+} // namespace
+
 int
 itkQuadEdgeMeshBasicLayerTest(int, char *[])
 {
-  using PrimalType = itkQuadEdgeMeshBasicLayerTestHelper::PrimalType;
-
   PrimalType * e[5];
 
   //////////////////////////////////////////////////////////
@@ -229,14 +284,15 @@ itkQuadEdgeMeshBasicLayerTest(int, char *[])
   }
   std::cout << "Passed" << std::endl;
 
-  // Free the five quad-edges; each owns a four-element Rot ring.
-  for (auto & i : e)
-  {
-    delete i->GetRot()->GetRot()->GetRot();
-    delete i->GetRot()->GetRot();
-    delete i->GetRot();
-    delete i;
-  }
+  //////////////////////////////////////////////////////////
+  std::cout << "Testing non-closing-ring guard... " << std::endl;
+  PrimalType * degenerate[5];
+  BuildDegenerateLnextRing(degenerate);
+  ITK_TRY_EXPECT_EXCEPTION(TraverseLnextRing(degenerate[0]));
+  FreeQuadEdges(degenerate);
+  std::cout << "Passed" << std::endl;
+
+  FreeQuadEdges(e);
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Resolves #6372.

Adds the iterator loop-guard so the QuadEdgeMesh geometric ring iterators (`BeginGeomLnext`/`Onext`/`Sym`/…) **throw** an `itk::ExceptionObject` on a non-closing ring instead of looping forever, and extends `itkQuadEdgeMeshBasicLayerTest` with coverage that proves it. Rebased onto `main` after #6374 merged — now a single guard commit.

<details>
<summary>Root cause</summary>

`QuadEdgeMeshBaseIterator::operator++` terminates only when the iterator returns to its start edge:

```cpp
this->GoToNext();
m_Start = !(m_Iterator == m_StartEdge);   // stays true forever if the ring never closes
```

So `for (it = e->BeginGeomLnext(); it != e->EndGeomLnext(); ++it)` never reaches the end iterator on a non-closing ring → infinite hang, the worst failure mode for malformed input.

</details>

<details>
<summary>What this adds</summary>

**`itkQuadEdgeMeshBaseIterator.h`** — `operator++` now calls `CheckRingClosure()`, which increments a per-iterator step counter and throws once it exceeds `m_MaximumNumberOfSteps` (default **1e8**; no consistent-mesh ring approaches it). Settable via `SetMaximumNumberOfSteps` — a tuning knob, and it lets the test verify the throw in microseconds instead of spinning to 1e8.

- Single chokepoint: the derived `QuadEdgeMeshIterator`/`QuadEdgeMeshIteratorGeom` do **not** override `operator++`, so guarding the base covers every geom ring iterator. `operator==` intentionally ignores the counters, so valid rings still terminate by edge identity at their natural length.

**`itkQuadEdgeMeshBasicLayerTest.cxx`** — adds an `ITK_TRY_EXPECT_EXCEPTION` that deliberately rebuilds the structure with a degenerate dual init (via a `degenerateDual` flag on the helper) and confirms the guard throws while traversing its non-closing `Lnext` ring. The degenerate edges are freed after the macro catches the exception, so the test stays leak-clean (`leaks --atExit`: 0 leaks).

</details>

<details>
<summary>Validation</summary>

| Check | Result |
|---|---|
| `itkQuadEdgeMeshBasicLayerTest` (all rings + guard) | Passed — exception caught with exact diagnostic |
| Full `ITKQuadEdgeMesh` label suite | 90/90 passed |
| `pre-commit run --all-files` | clean |

Re-validated on the post-rebase tip (single guard commit on `upstream/main`): clean build + link, test passes.

</details>

<details>
<summary>Performance impact of the guard</summary>

Negligible — **well under 1%**. The added per-`++` work is one increment + one L1-resident load + one compare + one always-predicted branch (~1–2 cycles on already-hot iterator data). It rides on top of a per-step baseline that is dozens of cycles: a virtual `GoToNext()` dispatch, a `dynamic_cast` (RTTI) in the `GetLnext`/`Onext` accessor, the out-of-line `QuadEdge::GetLnext()`, and pointer-chasing through the quad-edge graph. The iterator grew 16 bytes (two `SizeValueType`) in the existing cache line.

</details>

<!--
provenance: claude-code session 2026-06-01 (gh-triage-pr)
issue: #6372 (resolves)
stacked_on: #6374 (MERGED 2026-06-01) — rebased onto upstream/main, base commits dropped
branch: quadedge-noclosing-ring-guard (origin/hjmjohnson)
head: 4b976d0bb4 (single guard commit on upstream/main 06172c1ec4)
files:
  Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshBaseIterator.h (operator++ / CheckRingClosure / SetMaximumNumberOfSteps)
  Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshBasicLayerTest.cxx (+ degenerateDual flag + guard EXPECT_THROW)
ci_note: prior macOS.Python build 15598 link-failed ("Undefined symbols x86_64") against the OLD stacked base
  with a reused/stale s-build object tree; #6374 (build 15597, immediately prior) passed. Clean single-commit
  rebase + fresh CI run is the definitive check. Linux build+link+test re-verified locally post-rebase.
local_validation: itkQuadEdgeMeshBasicLayerTest pass; pre-commit --all-files clean
-->
