### PR TITLE
COMP: Fail configure on orphaned remote-module source clones

### DIFF
--- a/CMake/itkCheckForOrphanedRemoteModules.cmake
+++ b/CMake/itkCheckForOrphanedRemoteModules.cmake
@@ -1,0 +1,52 @@
+#
+# Detect remote-module clones left in the source tree without a controlling
+# <name>.remote.cmake. Such orphans are discovered by the module DAG glob and
+# break the build, commonly after a module is ingested into ITK core.
+function(itk_check_for_orphaned_remote_modules)
+  set(_remote_dir "${ITK_SOURCE_DIR}/Modules/Remote")
+  file(GLOB _entries CONFIGURE_DEPENDS "${_remote_dir}/*")
+
+  set(_orphans)
+  foreach(_entry ${_entries})
+    if(NOT IS_DIRECTORY "${_entry}")
+      continue()
+    endif()
+    get_filename_component(_name "${_entry}" NAME)
+    if(_name STREQUAL "Deprecated")
+      continue()
+    endif()
+    if(
+      NOT
+        EXISTS
+          "${_remote_dir}/${_name}.remote.cmake"
+      AND
+        NOT
+          EXISTS
+            "${_remote_dir}/Deprecated/${_name}.remote.cmake"
+    )
+      list(APPEND _orphans "${_entry}")
+    endif()
+  endforeach()
+
+  if(_orphans)
+    set(_rm_lines)
+    foreach(_orphan ${_orphans})
+      if(CMAKE_HOST_WIN32)
+        string(APPEND _rm_lines "    rmdir /s /q \"${_orphan}\"\n")
+      else()
+        string(APPEND _rm_lines "    rm -rf \"${_orphan}\"\n")
+      endif()
+    endforeach()
+    message(
+      FATAL_ERROR
+      "Stale (orphaned) remote-module source directories detected.\n"
+      "These were fetched into the source tree but no longer have a "
+      "controlling <name>.remote.cmake (the module was likely ingested into "
+      "ITK core). They are picked up by the module dependency scan and will "
+      "break the build. Delete them and re-configure:\n\n"
+      "${_rm_lines}"
+    )
+  endif()
+endfunction()
+
+itk_check_for_orphaned_remote_modules()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -769,6 +769,11 @@ if(BUILD_TESTING OR ITK_BUILD_DOCUMENTATION OR ITK_WRAP_PYTHON)
 endif()
 
 #----------------------------------------------------------------------
+# Fail early on stale remote-module clones left without a controlling
+# .remote.cmake (e.g. after ingestion into core).
+include(itkCheckForOrphanedRemoteModules)
+
+#----------------------------------------------------------------------
 # Make sure remote modules are downloaded before sorting out the module
 # dependencies.
 add_subdirectory(Modules/Remote)


### PR DESCRIPTION
Configuring ITK after a remote module is ingested into core (or its `.remote.cmake` controller is otherwise removed) breaks with confusing missing-header errors, because the leftover fetched clone in `Modules/Remote/<name>/` is still discovered by the module-dependency glob. This adds an early configure-time guard that detects such orphans and stops with the exact paths to delete. Fixes #6376.

<details>
<summary>Root cause</summary>

Remote modules are `git clone`d into the source tree at `${ITK_SOURCE_DIR}/Modules/Remote/<name>/`, controlled by a checked-in `<name>.remote.cmake`. `itk_module_load_dag` (CMake/ITKModuleEnablement.cmake) does `GLOB_RECURSE "*/*/*/itk-module.cmake"`, which matches `Modules/Remote/<name>/itk-module.cmake` even after the controller file is gone. The orphaned clone is then added as a live module, colliding with the ingested core copy — e.g. `itkMGHImageIOFactory.h: No such file or directory` in #6376.
</details>

<details>
<summary>Detection and behavior</summary>

`CMake/itkCheckForOrphanedRemoteModules.cmake` scans the immediate children of `Modules/Remote/`. Any directory (other than `Deprecated`) lacking a controlling `<name>.remote.cmake` (or `Deprecated/<name>.remote.cmake`) is an orphan. If any are found, configuration stops with `FATAL_ERROR` listing copy-paste `rm -rf` lines. Included from the top-level `CMakeLists.txt` immediately before `add_subdirectory(Modules/Remote)` so it fires before the module-DAG glob runs.
</details>

<details>
<summary>Local validation</summary>

Verified via `cmake -P` in isolation:
- Clean ITK source tree (no orphans) → no error.
- Fake tree with `Modules/Remote/FakeOrphan/itk-module.cmake` and no controller → `FATAL_ERROR` listing exactly that path.
- A legitimately fetched module (directory + matching `.remote.cmake`) → correctly not flagged.
</details>

<!--
provenance: claude-code session 2026-06-02
issue: 6376 (MGHIO ingest left stale Modules/Remote/MGHIO clone)
files: CMake/itkCheckForOrphanedRemoteModules.cmake (new), CMakeLists.txt (include before add_subdirectory(Modules/Remote))
scope: source-tree orphans only; build-tree staleness and NRRD explicitly out of scope per author
-->
