### PR TITLE
WIP: Support non-standard JPEG precision (10/15-bit) in libjpeg-turbo

### DIFF
--- a/Modules/ThirdParty/JPEG/src/itkjpeg-turbo/jdapistd.c
+++ b/Modules/ThirdParty/JPEG/src/itkjpeg-turbo/jdapistd.c
@@ -314,7 +314,7 @@ _jpeg_read_scanlines(j_decompress_ptr cinfo, _JSAMPARRAY scanlines,
 #if BITS_IN_JSAMPLE != 16 || defined(D_LOSSLESS_SUPPORTED)
   JDIMENSION row_ctr;
 
-  if (cinfo->data_precision != BITS_IN_JSAMPLE)
+  if (cinfo->data_precision > BITS_IN_JSAMPLE)
     ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 
   if (cinfo->global_state != DSTATE_SCANNING)

--- a/Modules/ThirdParty/JPEG/src/itkjpeg-turbo/jdcolor.c
+++ b/Modules/ThirdParty/JPEG/src/itkjpeg-turbo/jdcolor.c
@@ -759,7 +759,7 @@ _jinit_color_deconverter(j_decompress_ptr cinfo)
   my_cconvert_ptr cconvert;
   int ci;
 
-  if (cinfo->data_precision != BITS_IN_JSAMPLE)
+  if (cinfo->data_precision > BITS_IN_JSAMPLE)
     ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 
   cconvert = (my_cconvert_ptr)

--- a/Modules/ThirdParty/JPEG/src/itkjpeg-turbo/jdlossls.c
+++ b/Modules/ThirdParty/JPEG/src/itkjpeg-turbo/jdlossls.c
@@ -57,12 +57,13 @@
 
 #define UNDIFFERENCE_1D(INITIAL_PREDICTOR) \
   int Ra; \
+  int precision_mask = (1 << cinfo->data_precision) - 1; \
   \
-  Ra = (*diff_buf++ + INITIAL_PREDICTOR) & 0xFFFF; \
+  Ra = (*diff_buf++ + INITIAL_PREDICTOR) & precision_mask; \
   *undiff_buf++ = Ra; \
   \
   while (--width) { \
-    Ra = (*diff_buf++ + PREDICTOR1) & 0xFFFF; \
+    Ra = (*diff_buf++ + PREDICTOR1) & precision_mask; \
     *undiff_buf++ = Ra; \
   }
 
@@ -78,21 +79,23 @@
  * interleaved image with Vi=1, for example), we must take care to buffer Rb/Rc
  * before writing the current reconstructed sample value into output_buf.
  *
- * The reconstructed sample is supposed to be calculated modulo 2^16, so we
- * logically AND the result with 0xFFFF.
+ * The reconstructed sample is supposed to be calculated modulo 2^P, where P
+ * is the data precision, so we logically AND the result with
+ * (1 << data_precision) - 1.
  */
 
 #define UNDIFFERENCE_2D(PREDICTOR) \
   int Ra, Rb, Rc; \
+  int precision_mask = (1 << cinfo->data_precision) - 1; \
   \
   Rb = *prev_row++; \
-  Ra = (*diff_buf++ + PREDICTOR2) & 0xFFFF; \
+  Ra = (*diff_buf++ + PREDICTOR2) & precision_mask; \
   *undiff_buf++ = Ra; \
   \
   while (--width) { \
     Rc = Rb; \
     Rb = *prev_row++; \
-    Ra = (*diff_buf++ + PREDICTOR) & 0xFFFF; \
+    Ra = (*diff_buf++ + PREDICTOR) & precision_mask; \
     *undiff_buf++ = Ra; \
   }
 

--- a/Modules/ThirdParty/JPEG/src/itkjpeg-turbo/jdmainct.c
+++ b/Modules/ThirdParty/JPEG/src/itkjpeg-turbo/jdmainct.c
@@ -431,7 +431,7 @@ _jinit_d_main_controller(j_decompress_ptr cinfo, boolean need_full_buffer)
   int ci, rgroup, ngroups;
   jpeg_component_info *compptr;
 
-  if (cinfo->data_precision != BITS_IN_JSAMPLE)
+  if (cinfo->data_precision > BITS_IN_JSAMPLE)
     ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 
   main_ptr = (my_main_ptr)

--- a/Modules/ThirdParty/JPEG/src/itkjpeg-turbo/jdmaster.c
+++ b/Modules/ThirdParty/JPEG/src/itkjpeg-turbo/jdmaster.c
@@ -422,7 +422,7 @@ prepare_range_limit_table(j_decompress_ptr cinfo)
 #endif
   int i;
 
-  if (cinfo->data_precision == 16) {
+  if (cinfo->data_precision > 12) {
 #ifdef D_LOSSLESS_SUPPORTED
     table16 = (J16SAMPLE *)
       (*cinfo->mem->alloc_small) ((j_common_ptr)cinfo, JPOOL_IMAGE,
@@ -449,7 +449,7 @@ prepare_range_limit_table(j_decompress_ptr cinfo)
 #else
     ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 #endif
-  } else if (cinfo->data_precision == 12) {
+  } else if (cinfo->data_precision > 8) {
     table12 = (J12SAMPLE *)
       (*cinfo->mem->alloc_small) ((j_common_ptr)cinfo, JPOOL_IMAGE,
                   (5 * (MAXJ12SAMPLE + 1) + CENTERJ12SAMPLE) *
@@ -615,14 +615,14 @@ master_selection(j_decompress_ptr cinfo)
       ERREXIT(cinfo, JERR_NOT_COMPILED);
 #endif
     } else {
-      if (cinfo->data_precision == 16) {
+      if (cinfo->data_precision > 12) {
 #ifdef D_LOSSLESS_SUPPORTED
         j16init_color_deconverter(cinfo);
         j16init_upsampler(cinfo);
 #else
         ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 #endif
-      } else if (cinfo->data_precision == 12) {
+      } else if (cinfo->data_precision > 8) {
         j12init_color_deconverter(cinfo);
         j12init_upsampler(cinfo);
       } else {
@@ -630,13 +630,13 @@ master_selection(j_decompress_ptr cinfo)
         jinit_upsampler(cinfo);
       }
     }
-    if (cinfo->data_precision == 16)
+    if (cinfo->data_precision > 12)
 #ifdef D_LOSSLESS_SUPPORTED
       j16init_d_post_controller(cinfo, cinfo->enable_2pass_quant);
 #else
       ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 #endif
-    else if (cinfo->data_precision == 12)
+    else if (cinfo->data_precision > 8)
       j12init_d_post_controller(cinfo, cinfo->enable_2pass_quant);
     else
       jinit_d_post_controller(cinfo, cinfo->enable_2pass_quant);
@@ -647,9 +647,9 @@ master_selection(j_decompress_ptr cinfo)
     /* Prediction, sample undifferencing, point transform, and sample size
      * scaling
      */
-    if (cinfo->data_precision == 16)
+    if (cinfo->data_precision > 12)
       j16init_lossless_decompressor(cinfo);
-    else if (cinfo->data_precision == 12)
+    else if (cinfo->data_precision > 8)
       j12init_lossless_decompressor(cinfo);
     else
       jinit_lossless_decompressor(cinfo);
@@ -663,9 +663,9 @@ master_selection(j_decompress_ptr cinfo)
     /* Initialize principal buffer controllers. */
     use_c_buffer = cinfo->inputctl->has_multiple_scans ||
                    cinfo->buffered_image;
-    if (cinfo->data_precision == 16)
+    if (cinfo->data_precision > 12)
       j16init_d_diff_controller(cinfo, use_c_buffer);
-    else if (cinfo->data_precision == 12)
+    else if (cinfo->data_precision > 8)
       j12init_d_diff_controller(cinfo, use_c_buffer);
     else
       jinit_d_diff_controller(cinfo, use_c_buffer);
@@ -673,7 +673,7 @@ master_selection(j_decompress_ptr cinfo)
     ERREXIT(cinfo, JERR_NOT_COMPILED);
 #endif
   } else {
-    if (cinfo->data_precision == 16)
+    if (cinfo->data_precision > 12)
       ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
     /* Inverse DCT */
     if (cinfo->data_precision == 12)
@@ -708,14 +708,14 @@ master_selection(j_decompress_ptr cinfo)
   }
 
   if (!cinfo->raw_data_out) {
-    if (cinfo->data_precision == 16)
+    if (cinfo->data_precision > 12)
 #ifdef D_LOSSLESS_SUPPORTED
       j16init_d_main_controller(cinfo,
                                 FALSE /* never need full buffer here */);
 #else
       ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 #endif
-    else if (cinfo->data_precision == 12)
+    else if (cinfo->data_precision > 8)
       j12init_d_main_controller(cinfo,
                                 FALSE /* never need full buffer here */);
     else

--- a/Modules/ThirdParty/JPEG/src/itkjpeg-turbo/jdpostct.c
+++ b/Modules/ThirdParty/JPEG/src/itkjpeg-turbo/jdpostct.c
@@ -267,7 +267,7 @@ _jinit_d_post_controller(j_decompress_ptr cinfo, boolean need_full_buffer)
 {
   my_post_ptr post;
 
-  if (cinfo->data_precision != BITS_IN_JSAMPLE)
+  if (cinfo->data_precision > BITS_IN_JSAMPLE)
     ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 
   post = (my_post_ptr)

--- a/Modules/ThirdParty/JPEG/src/itkjpeg-turbo/jdsample.c
+++ b/Modules/ThirdParty/JPEG/src/itkjpeg-turbo/jdsample.c
@@ -421,7 +421,7 @@ _jinit_upsampler(j_decompress_ptr cinfo)
   boolean need_buffer, do_fancy;
   int h_in_group, v_in_group, h_out_group, v_out_group;
 
-  if (cinfo->data_precision != BITS_IN_JSAMPLE)
+  if (cinfo->data_precision > BITS_IN_JSAMPLE)
     ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 
   if (!cinfo->master->jinit_upsampler_no_alloc) {


### PR DESCRIPTION
## Summary

**WIP** — Support for non-standard bit-depth (10, 15-bit) JPEG Lossless decoding in libjpeg-turbo.

### Motivation

GDCM conformance test suite includes DICOM files with non-standard JPEG Lossless precision:
- **10-bit**: RG2_JPLL, RG3_JPLL, XA1_JPLL (radiography, angiography)
- **15-bit**: RG1_JPLL, gdcm-JPEG-LossLessThoravision.dcm

Standard libjpeg-turbo only dispatches on exact bit-depth matches (8, 12, 16 via BITS_IN_JSAMPLE). Non-standard depths fail with "Invalid data precision".

### Changes

**File**: `Modules/ThirdParty/JPEG/src/itkjpeg-turbo/`

1. **jdmaster.c**: Range-based dispatch
   - `prepare_range_limit_table`: `> 12` instead of exact check
   - Lossless init block: `> 12` (j16 path) vs `<= 12` (j12 path)
   - Post-processing: `> 12` → j16, else j12
   - DCT path: Error on `data_precision > 12` (DCT doesn't support 10/15-bit)

2. **jdlossls.c**: Precision-aware undifferencing
   - `UNDIFFERENCE_1D`, `UNDIFFERENCE_2D`: `& ((1 << data_precision) - 1)` instead of `& 0xFFFF`
   - Correct modulo-2^P wrapping for all precision values

3. **jdapistd.c**, **jdcolor.c**, **jdmainct.c**, **jdpostct.c**, **jdsample.c**: 
   - Init guards: `> BITS_IN_JSAMPLE` instead of `!=`

### Test Results

**5 previously failing files now pass:**
- ✓ RG1_JPLL (15-bit, MONOCHROME1)
- ✓ RG2_JPLL (10-bit, MONOCHROME2)
- ✓ RG3_JPLL (10-bit, MONOCHROME1)
- ✓ XA1_JPLL (10-bit, MONOCHROME2)
- ✓ gdcm-JPEG-LossLessThoravision.dcm (15-bit)

**Maintains compatibility:** All 16 standard bit-depth files (8, 12, 16) continue to pass.

### Dependencies

This PR is complementary to **PR #6382** (GDCM multi-fragment JPEG fix). Together they enable robust handling of non-standard precision JPEG Lossless DICOM images.

### Status

- **WIP** — Ready for community review; not yet targeting merge
- Requires testing across additional platforms
- Consider backport strategy for stable releases