### PR TITLE
ENH: Update libjpeg-turbo to 3.1.4

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -94,8 +94,8 @@ intended solely for clarification.
 The Modified (3-clause) BSD License
 ===================================
 
-Copyright (C)2009-2023 D. R. Commander.  All Rights Reserved.<br>
-Copyright (C)2015 Viktor Szathmáry.  All Rights Reserved.
+Copyright (C) 2009-2026 D. R. Commander.  All Rights Reserved.<br>
+Copyright (C) 2015 Viktor Szathmáry.  All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/Modules/ThirdParty/JPEG/UpdateFromUpstream.sh
+++ b/Modules/ThirdParty/JPEG/UpdateFromUpstream.sh
@@ -8,14 +8,14 @@ readonly name="jpeg-turbo"
 readonly ownership="libjpeg-turbo Upstream <kwrobot@kitware.com>"
 readonly subtree="Modules/ThirdParty/JPEG/src/itk$name"
 readonly repo="https://github.com/libjpeg-turbo/libjpeg-turbo.git"
-readonly tag="3.0.4"
+readonly tag="3.1.4"
 readonly exact_tree_match=false
 readonly paths="
-j*.c
-j*.h
-jconfig.h.in
-jconfigint.h.in
-jversion.h.in
+src/j*.c
+src/j*.h
+src/jconfig.h.in
+src/jconfigint.h.in
+src/jversion.h.in
 
 LICENSE.md
 README.ijg
@@ -25,6 +25,9 @@ README.md
 extract_source () {
     git_archive
     pushd "${extractdir}/${name}-reduced"
+    # libjpeg-turbo 3.1.0 and later use a src/ subdirectory relocate to top-level structure.
+    mv src/* .
+    rmdir src
     echo "* -whitespace" >> .gitattributes
     echo "README.md conflict-marker-size=8" >> .gitattributes
     popd

--- a/Modules/ThirdParty/JPEG/src/itkjpeg-turbo/CMakeLists.txt
+++ b/Modules/ThirdParty/JPEG/src/itkjpeg-turbo/CMakeLists.txt
@@ -1,3 +1,11 @@
+# ITK downstream fork of libjpeg-turbo's build system.
+# Builds the core libjpeg API as the library itkjpeg.
+# No SIMD, no TurboJPEG API, no tools.
+# Three compiled precision tiers (BITS_IN_JSAMPLE=8/12/16) cover:
+#   lossy DCT JPEG at 8 and 12 bits/sample;
+#   lossless JPEG at 2-16 bits/sample (2-8 via 8-bit objects,
+#   9-12 via 12-bit objects, 13-16 via 16-bit objects).
+
 set(JPEG16_SOURCES jcapistd.c jccolor.c jcdiffct.c jclossls.c jcmainct.c
         jcprepct.c jcsample.c jdapistd.c jdcolor.c jddiffct.c jdlossls.c jdmainct.c
         jdpostct.c jdsample.c jutils.c)
@@ -28,8 +36,9 @@ endif()
 set(BITS_IN_JSAMPLE 8)
 
 set(JPEG_LIB_VERSION 80)
-set(LIBJPEG_TURBO_VERSION "3.0.4")
-set(LIBJPEG_TURBO_VERSION_NUMBER "003000004")
+set(LIBJPEG_TURBO_VERSION "3.1.4")
+set(LIBJPEG_TURBO_VERSION_NUMBER "003001004")
+set(COPYRIGHT_YEAR "1991-2026")
 set(MEM_SRCDST_SUPPORTED 1)
 set(C_ARITH_CODING_SUPPORTED 1)
 set(D_ARITH_CODING_SUPPORTED 1)
@@ -73,6 +82,7 @@ else ()
   set(JPEG_SHARED_LIBS 0)
 endif ()
 
+set(VERSION "${LIBJPEG_TURBO_VERSION}")
 configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}${header_input_dir}/jconfig.h.in"
         "${CMAKE_CURRENT_BINARY_DIR}/jconfig.h")
@@ -83,6 +93,7 @@ set(headers
         jpeglib.h
         "${CMAKE_CURRENT_BINARY_DIR}/jconfig.h")
 
+include(CheckCSourceCompiles)
 include(CheckTypeSize)
 check_type_size("size_t" SIZE_T)
 
@@ -91,8 +102,16 @@ if(SIZE_T EQUAL UNSIGNED_LONG)
           HAVE_BUILTIN_CTZL)
 endif()
 
+if(NOT WIN32)
+  check_c_source_compiles(
+    "extern const int table[1]; const int __attribute__((visibility(\"hidden\"))) table[1] = { 0 }; int main(void) { return table[0]; }"
+    HIDDEN_WORKS)
+  if(HIDDEN_WORKS)
+    set(HIDDEN "__attribute__((visibility(\"hidden\")))") 
+  endif()
+endif()
+
 set(SIZEOF_SIZE_T "${SIZE_T}")
-set(VERSION "${LIBJPEG_TURBO_VERSION}")
 set(PACKAGE_NAME "itkjpeg")
 string(TIMESTAMP BUILD "%Y%m%d")
 

--- a/README.ijg
+++ b/README.ijg
@@ -36,16 +36,18 @@ TO DO               Plans for future IJG releases.
 Other documentation files in the distribution are:
 
 User documentation:
-  usage.txt         Usage instructions for cjpeg, djpeg, jpegtran,
-                    rdjpgcom, and wrjpgcom.
-  *.1               Unix-style man pages for programs (same info as usage.txt).
-  wizard.txt        Advanced usage instructions for JPEG wizards only.
-  change.log        Version-to-version change highlights.
+  doc/usage.txt         Usage instructions for cjpeg, djpeg, jpegtran,
+                        rdjpgcom, and wrjpgcom.
+  doc/*.1               Unix-style man pages for programs (same info as
+                        usage.txt).
+  doc/wizard.txt        Advanced usage instructions for JPEG wizards only.
+  doc/change.log        Version-to-version change highlights.
 Programmer and internal documentation:
-  libjpeg.txt       How to use the JPEG library in your own programs.
-  example.c         Sample code for calling the JPEG library.
-  structure.txt     Overview of the JPEG library's internal structure.
-  coderules.txt     Coding style rules --- please read if you contribute code.
+  doc/libjpeg.txt       How to use the JPEG library in your own programs.
+  src/example.c         Sample code for calling the JPEG library.
+  doc/structure.txt     Overview of the JPEG library's internal structure.
+  doc/coderules.txt     Coding style rules --- please read if you contribute
+                        code.
 
 Please read at least usage.txt.  Some information can also be found in the JPEG
 FAQ (Frequently Asked Questions) article.  See ARCHIVE LOCATIONS below to find

--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ JPEG images:
   generating planar YUV images and performing multiple simultaneous lossless
   transforms on an image.  The Java interface for libjpeg-turbo is written on
   top of the TurboJPEG API.  The TurboJPEG API is recommended for first-time
-  users of libjpeg-turbo.  Refer to [tjexample.c](tjexample.c) and
-  [TJExample.java](java/TJExample.java) for examples of its usage and to
+  users of libjpeg-turbo.  Refer to [tjcomp.c](src/tjcomp.c),
+  [tjdecomp.c](src/tjdecomp.c), [tjtran.c](src/tjtran.c),
+  [TJComp.java](java/TJComp.java), [TJDecomp.java](java/TJDecomp.java), and
+  [TJTran.java](java/TJTran.java) for examples of its usage and to
   <https://libjpeg-turbo.org/Documentation/Documentation> for API
   documentation.
 
@@ -80,8 +82,9 @@ JPEG images:
   more powerful.  The libjpeg API implementation in libjpeg-turbo is both
   API/ABI-compatible and mathematically compatible with libjpeg v6b.  It can
   also optionally be configured to be API/ABI-compatible with libjpeg v7 and v8
-  (see below.)  Refer to [cjpeg.c](cjpeg.c) and [djpeg.c](djpeg.c) for examples
-  of its usage and to [libjpeg.txt](libjpeg.txt) for API documentation.
+  (see below.)  Refer to [cjpeg.c](src/cjpeg.c) and [djpeg.c](src/djpeg.c) for
+  examples of its usage and to [libjpeg.txt](doc/libjpeg.txt) for API
+  documentation.
 
 There is no significant performance advantage to either API when both are used
 to perform similar operations.
@@ -133,9 +136,9 @@ extensions at compile time with:
 
     #ifdef JCS_ALPHA_EXTENSIONS
 
-[jcstest.c](jcstest.c), located in the libjpeg-turbo source tree, demonstrates
-how to check for the existence of the colorspace extensions at compile time and
-run time.
+[jcstest.c](src/jcstest.c), located in the libjpeg-turbo source tree,
+demonstrates how to check for the existence of the colorspace extensions at
+compile time and run time.
 
 libjpeg v7 and v8 API/ABI Emulation
 -----------------------------------
@@ -365,8 +368,11 @@ Memory Debugger Pitfalls
 
 Valgrind and Memory Sanitizer (MSan) can generate false positives
 (specifically, incorrect reports of uninitialized memory accesses) when used
-with libjpeg-turbo's SIMD extensions.  It is generally recommended that the
-SIMD extensions be disabled, either by passing an argument of `-DWITH_SIMD=0`
-to `cmake` when configuring the build or by setting the environment variable
-`JSIMD_FORCENONE` to `1` at run time, when testing libjpeg-turbo with Valgrind,
-MSan, or other memory debuggers.
+with libjpeg-turbo's SIMD extensions.  There are two ways to work around this
+when testing libjpeg-turbo with Valgrind, MSan, or other memory debuggers:
+
+1. Disable the SIMD extensions, either by passing an argument of
+   `-DWITH_SIMD=0` to `cmake` when configuring the build or by setting the
+   environment variable `JSIMD_FORCENONE` to `1` at run time.
+2. Define the `ZERO_BUFFERS` preprocessor macro (for instance, by adding
+   `-DZERO_BUFFERS=1` to `CMAKE_C_FLAGS`.)

--- a/jcapimin.c
+++ b/jcapimin.c
@@ -5,7 +5,7 @@
  * Copyright (C) 1994-1998, Thomas G. Lane.
  * Modified 2003-2010 by Guido Vollbeding.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2022, D. R. Commander.
+ * Copyright (C) 2022, 2024, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -194,19 +194,25 @@ jpeg_finish_compress(j_compress_ptr cinfo)
       /* We bypass the main controller and invoke coef controller directly;
        * all work is being done from the coefficient buffer.
        */
-      if (cinfo->data_precision == 16) {
+      if (cinfo->data_precision <= 8) {
+        if (cinfo->coef->compress_data == NULL)
+          ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+        if (!(*cinfo->coef->compress_data) (cinfo, (JSAMPIMAGE)NULL))
+          ERREXIT(cinfo, JERR_CANT_SUSPEND);
+      } else if (cinfo->data_precision <= 12) {
+        if (cinfo->coef->compress_data_12 == NULL)
+          ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+        if (!(*cinfo->coef->compress_data_12) (cinfo, (J12SAMPIMAGE)NULL))
+          ERREXIT(cinfo, JERR_CANT_SUSPEND);
+      } else {
 #ifdef C_LOSSLESS_SUPPORTED
+        if (cinfo->coef->compress_data_16 == NULL)
+          ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
         if (!(*cinfo->coef->compress_data_16) (cinfo, (J16SAMPIMAGE)NULL))
           ERREXIT(cinfo, JERR_CANT_SUSPEND);
 #else
         ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 #endif
-      } else if (cinfo->data_precision == 12) {
-        if (!(*cinfo->coef->compress_data_12) (cinfo, (J12SAMPIMAGE)NULL))
-          ERREXIT(cinfo, JERR_CANT_SUSPEND);
-      } else {
-        if (!(*cinfo->coef->compress_data) (cinfo, (JSAMPIMAGE)NULL))
-          ERREXIT(cinfo, JERR_CANT_SUSPEND);
       }
     }
     (*cinfo->master->finish_pass) (cinfo);

--- a/jccoefct.c
+++ b/jccoefct.c
@@ -4,7 +4,7 @@
  * This file was part of the Independent JPEG Group's software:
  * Copyright (C) 1994-1997, Thomas G. Lane.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2022, D. R. Commander.
+ * Copyright (C) 2022, 2024, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -414,6 +414,7 @@ _jinit_c_coef_controller(j_compress_ptr cinfo, boolean need_full_buffer)
   coef = (my_coef_ptr)
     (*cinfo->mem->alloc_small) ((j_common_ptr)cinfo, JPOOL_IMAGE,
                                 sizeof(my_coef_controller));
+  memset(coef, 0, sizeof(my_coef_controller));
   cinfo->coef = (struct jpeg_c_coef_controller *)coef;
   coef->pub.start_pass = start_pass_coef;
 

--- a/jcdctmgr.c
+++ b/jcdctmgr.c
@@ -6,7 +6,7 @@
  * libjpeg-turbo Modifications:
  * Copyright (C) 1999-2006, MIYASAKA Masaru.
  * Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
- * Copyright (C) 2011, 2014-2015, 2022, 2024, D. R. Commander.
+ * Copyright (C) 2011, 2014-2015, 2022, 2024, 2026, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -22,6 +22,9 @@
 #include "jdct.h"               /* Private declarations for DCT subsystem */
 #include "jsimddct.h"
 
+
+#if defined(DCT_ISLOW_SUPPORTED) || defined(DCT_IFAST_SUPPORTED) || \
+    defined(DCT_FLOAT_SUPPORTED)
 
 /* Private subobject for this module */
 
@@ -176,11 +179,17 @@ compute_reciprocal(UINT16 divisor, DCTELEM *dtbl)
   UDCTELEM c;
   int b, r;
 
-  if (divisor == 1) {
+  if (divisor <= 1) {
     /* divisor == 1 means unquantized, so these reciprocal/correction/shift
      * values will cause the C quantization algorithm to act like the
      * identity function.  Since only the C quantization algorithm is used in
      * these cases, the scale value is irrelevant.
+     *
+     * divisor == 0 can never happen in a normal program, because
+     * jpeg_add_quant_table() clamps values < 1.  However, a program could
+     * abuse the API by manually modifying the exposed quantization table just
+     * before calling jpeg_start_compress().  Thus, we effectively clamp
+     * values < 1 here as well, to avoid dividing by 0.
      */
     dtbl[DCTSIZE2 * 0] = (DCTELEM)1;                        /* reciprocal */
     dtbl[DCTSIZE2 * 1] = (DCTELEM)0;                        /* correction */
@@ -746,3 +755,6 @@ _jinit_forward_dct(j_compress_ptr cinfo)
 #endif
   }
 }
+
+#endif /* defined(DCT_ISLOW_SUPPORTED) || defined(DCT_IFAST_SUPPORTED) ||
+          defined(DCT_FLOAT_SUPPORTED) */

--- a/jcdiffct.c
+++ b/jcdiffct.c
@@ -6,7 +6,7 @@
  * Lossless JPEG Modifications:
  * Copyright (C) 1999, Ken Murchison.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2022, D. R. Commander.
+ * Copyright (C) 2022, 2024, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -345,6 +345,14 @@ _jinit_c_diff_controller(j_compress_ptr cinfo, boolean need_full_buffer)
   my_diff_ptr diff;
   int ci, row;
   jpeg_component_info *compptr;
+
+#if BITS_IN_JSAMPLE == 8
+  if (cinfo->data_precision > BITS_IN_JSAMPLE || cinfo->data_precision < 2)
+#else
+  if (cinfo->data_precision > BITS_IN_JSAMPLE ||
+      cinfo->data_precision < BITS_IN_JSAMPLE - 3)
+#endif
+    ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 
   diff = (my_diff_ptr)
     (*cinfo->mem->alloc_small) ((j_common_ptr)cinfo, JPOOL_IMAGE,

--- a/jchuff.c
+++ b/jchuff.c
@@ -6,7 +6,7 @@
  * Lossless JPEG Modifications:
  * Copyright (C) 1999, Ken Murchison.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2009-2011, 2014-2016, 2018-2024, D. R. Commander.
+ * Copyright (C) 2009-2011, 2014-2016, 2018-2026, D. R. Commander.
  * Copyright (C) 2015, Matthieu Darbois.
  * Copyright (C) 2018, Matthias Räncker.
  * Copyright (C) 2020, Arm Limited.
@@ -55,7 +55,8 @@ typedef size_t bit_buf_type;
  * retain the old Huffman encoder behavior when using the GAS implementation.
  */
 #if defined(WITH_SIMD) && !(defined(__arm__) || defined(__aarch64__) || \
-                            defined(_M_ARM) || defined(_M_ARM64))
+                            defined(_M_ARM) || defined(_M_ARM64) || \
+                            defined(_M_ARM64EC))
 typedef unsigned long long simd_bit_buf_type;
 #else
 typedef bit_buf_type simd_bit_buf_type;
@@ -946,7 +947,10 @@ GLOBAL(void)
 jpeg_gen_optimal_table(j_compress_ptr cinfo, JHUFF_TBL *htbl, long freq[])
 {
 #define MAX_CLEN  32            /* assumed maximum initial code length */
-  UINT8 bits[MAX_CLEN + 1];     /* bits[k] = # of symbols with code length k */
+  /* The array length is MAX_CLEN + 2 rather than MAX_CLEN + 1 to work around a
+   * -Wstringop-overflow false positive with GCC 12 and later.
+   */
+  UINT8 bits[MAX_CLEN + 2];     /* bits[k] = # of symbols with code length k */
   int bit_pos[MAX_CLEN + 1];    /* # of symbols with smaller code length */
   int codesize[257];            /* codesize[k] = code length of symbol k */
   int nz_index[257];            /* index of nonzero symbol in the original freq

--- a/jcinit.c
+++ b/jcinit.c
@@ -6,7 +6,7 @@
  * Lossless JPEG Modifications:
  * Copyright (C) 1999, Ken Murchison.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2020, 2022, D. R. Commander.
+ * Copyright (C) 2020, 2022, 2024, 2026, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -40,7 +40,16 @@ jinit_compress_master(j_compress_ptr cinfo)
 
   /* Preprocessing */
   if (!cinfo->raw_data_in) {
-    if (cinfo->data_precision == 16) {
+    if (cinfo->data_precision <= 8) {
+      jinit_color_converter(cinfo);
+      jinit_downsampler(cinfo);
+      jinit_c_prep_controller(cinfo, FALSE /* never need full buffer here */);
+    } else if (cinfo->data_precision <= 12) {
+      j12init_color_converter(cinfo);
+      j12init_downsampler(cinfo);
+      j12init_c_prep_controller(cinfo,
+                                FALSE /* never need full buffer here */);
+    } else {
 #ifdef C_LOSSLESS_SUPPORTED
       j16init_color_converter(cinfo);
       j16init_downsampler(cinfo);
@@ -49,27 +58,18 @@ jinit_compress_master(j_compress_ptr cinfo)
 #else
       ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 #endif
-    } else if (cinfo->data_precision == 12) {
-      j12init_color_converter(cinfo);
-      j12init_downsampler(cinfo);
-      j12init_c_prep_controller(cinfo,
-                                FALSE /* never need full buffer here */);
-    } else {
-      jinit_color_converter(cinfo);
-      jinit_downsampler(cinfo);
-      jinit_c_prep_controller(cinfo, FALSE /* never need full buffer here */);
     }
   }
 
   if (cinfo->master->lossless) {
 #ifdef C_LOSSLESS_SUPPORTED
     /* Prediction, sample differencing, and point transform */
-    if (cinfo->data_precision == 16)
-      j16init_lossless_compressor(cinfo);
-    else if (cinfo->data_precision == 12)
+    if (cinfo->data_precision <= 8)
+      jinit_lossless_compressor(cinfo);
+    else if (cinfo->data_precision <= 12)
       j12init_lossless_compressor(cinfo);
     else
-      jinit_lossless_compressor(cinfo);
+      j16init_lossless_compressor(cinfo);
     /* Entropy encoding: either Huffman or arithmetic coding. */
     if (cinfo->arith_code) {
       ERREXIT(cinfo, JERR_ARITH_NOTIMPL);
@@ -78,26 +78,28 @@ jinit_compress_master(j_compress_ptr cinfo)
     }
 
     /* Need a full-image difference buffer in any multi-pass mode. */
-    if (cinfo->data_precision == 16)
-      j16init_c_diff_controller(cinfo, (boolean)(cinfo->num_scans > 1 ||
-                                                 cinfo->optimize_coding));
-    else if (cinfo->data_precision == 12)
+    if (cinfo->data_precision <= 8)
+      jinit_c_diff_controller(cinfo, (boolean)(cinfo->num_scans > 1 ||
+                                               cinfo->optimize_coding));
+    else if (cinfo->data_precision <= 12)
       j12init_c_diff_controller(cinfo, (boolean)(cinfo->num_scans > 1 ||
                                                  cinfo->optimize_coding));
     else
-      jinit_c_diff_controller(cinfo, (boolean)(cinfo->num_scans > 1 ||
-                                               cinfo->optimize_coding));
+      j16init_c_diff_controller(cinfo, (boolean)(cinfo->num_scans > 1 ||
+                                                 cinfo->optimize_coding));
 #else
     ERREXIT(cinfo, JERR_NOT_COMPILED);
 #endif
   } else {
-    if (cinfo->data_precision == 16)
-      ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+#if defined(DCT_ISLOW_SUPPORTED) || defined(DCT_IFAST_SUPPORTED) || \
+    defined(DCT_FLOAT_SUPPORTED)
     /* Forward DCT */
-    if (cinfo->data_precision == 12)
+    if (cinfo->data_precision == 8)
+      jinit_forward_dct(cinfo);
+    else if (cinfo->data_precision == 12)
       j12init_forward_dct(cinfo);
     else
-      jinit_forward_dct(cinfo);
+      ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
     /* Entropy encoding: either Huffman or arithmetic coding. */
     if (cinfo->arith_code) {
 #ifdef C_ARITH_CODING_SUPPORTED
@@ -123,18 +125,21 @@ jinit_compress_master(j_compress_ptr cinfo)
     else
       jinit_c_coef_controller(cinfo, (boolean)(cinfo->num_scans > 1 ||
                                                cinfo->optimize_coding));
+#else
+    ERREXIT(cinfo, JERR_NOT_COMPILED);
+#endif
   }
 
-  if (cinfo->data_precision == 16)
+  if (cinfo->data_precision <= 8)
+    jinit_c_main_controller(cinfo, FALSE /* never need full buffer here */);
+  else if (cinfo->data_precision <= 12)
+    j12init_c_main_controller(cinfo, FALSE /* never need full buffer here */);
+  else
 #ifdef C_LOSSLESS_SUPPORTED
     j16init_c_main_controller(cinfo, FALSE /* never need full buffer here */);
 #else
     ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 #endif
-  else if (cinfo->data_precision == 12)
-    j12init_c_main_controller(cinfo, FALSE /* never need full buffer here */);
-  else
-    jinit_c_main_controller(cinfo, FALSE /* never need full buffer here */);
 
   jinit_marker_writer(cinfo);
 

--- a/jclhuff.c
+++ b/jclhuff.c
@@ -6,7 +6,7 @@
  * Lossless JPEG Modifications:
  * Copyright (C) 1999, Ken Murchison.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2022, D. R. Commander.
+ * Copyright (C) 2022, 2026, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -190,7 +190,9 @@ start_pass_lhuff(j_compress_ptr cinfo, boolean gather_statistics)
         entropy->input_ptr_index[sampn] = ptrn;
         /* Precalculate which tables to use for each sample */
         entropy->cur_tbls[sampn] = entropy->derived_tbls[compptr->dc_tbl_no];
+#ifdef ENTROPY_OPT_SUPPORTED
         entropy->cur_counts[sampn] = entropy->count_ptrs[compptr->dc_tbl_no];
+#endif
       }
     }
   }

--- a/jclossls.c
+++ b/jclossls.c
@@ -6,7 +6,7 @@
  * Lossless JPEG Modifications:
  * Copyright (C) 1999, Ken Murchison.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2022, D. R. Commander.
+ * Copyright (C) 2022, 2024, 2026, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -228,6 +228,9 @@ jpeg_difference_first_row(j_compress_ptr cinfo, int ci,
     case 7:
       losslessc->predict_difference[ci] = jpeg_difference7;
       break;
+    default:
+      ERREXIT4(cinfo, JERR_BAD_PROGRESSION,
+               cinfo->Ss, cinfo->Se, cinfo->Ah, cinfo->Al);
     }
   }
 }
@@ -307,6 +310,14 @@ GLOBAL(void)
 _jinit_lossless_compressor(j_compress_ptr cinfo)
 {
   lossless_comp_ptr losslessc;
+
+#if BITS_IN_JSAMPLE == 8
+  if (cinfo->data_precision > BITS_IN_JSAMPLE || cinfo->data_precision < 2)
+#else
+  if (cinfo->data_precision > BITS_IN_JSAMPLE ||
+      cinfo->data_precision < BITS_IN_JSAMPLE - 3)
+#endif
+    ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 
   /* Create subobject in permanent pool */
   losslessc = (lossless_comp_ptr)

--- a/jcmainct.c
+++ b/jcmainct.c
@@ -6,7 +6,7 @@
  * Lossless JPEG Modifications:
  * Copyright (C) 1999, Ken Murchison.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2022, D. R. Commander.
+ * Copyright (C) 2022, 2024, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -140,12 +140,26 @@ _jinit_c_main_controller(j_compress_ptr cinfo, boolean need_full_buffer)
   jpeg_component_info *compptr;
   int data_unit = cinfo->master->lossless ? 1 : DCTSIZE;
 
-  if (cinfo->data_precision != BITS_IN_JSAMPLE)
-    ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+#ifdef C_LOSSLESS_SUPPORTED
+  if (cinfo->master->lossless) {
+#if BITS_IN_JSAMPLE == 8
+    if (cinfo->data_precision > BITS_IN_JSAMPLE || cinfo->data_precision < 2)
+#else
+    if (cinfo->data_precision > BITS_IN_JSAMPLE ||
+        cinfo->data_precision < BITS_IN_JSAMPLE - 3)
+#endif
+      ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+  } else
+#endif
+  {
+    if (cinfo->data_precision != BITS_IN_JSAMPLE)
+      ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+  }
 
   main_ptr = (my_main_ptr)
     (*cinfo->mem->alloc_small) ((j_common_ptr)cinfo, JPOOL_IMAGE,
                                 sizeof(my_main_controller));
+  memset(main_ptr, 0, sizeof(my_main_controller));
   cinfo->main = (struct jpeg_c_main_controller *)main_ptr;
   main_ptr->pub.start_pass = start_pass_main;
 

--- a/jcmaster.c
+++ b/jcmaster.c
@@ -7,7 +7,7 @@
  * Lossless JPEG Modifications:
  * Copyright (C) 1999, Ken Murchison.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2010, 2016, 2018, 2022-2024, D. R. Commander.
+ * Copyright (C) 2010, 2016, 2018, 2022-2024, 2026, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -190,13 +190,19 @@ initial_setup(j_compress_ptr cinfo, boolean transcode_only)
   if ((long)jd_samplesperrow != samplesperrow)
     ERREXIT(cinfo, JERR_WIDTH_OVERFLOW);
 
+  /* Lossy JPEG images must have 8 or 12 bits per sample.  Lossless JPEG images
+   * can have 2 to 16 bits per sample.
+   */
 #ifdef C_LOSSLESS_SUPPORTED
-  if (cinfo->data_precision != 8 && cinfo->data_precision != 12 &&
-      cinfo->data_precision != 16)
-#else
-  if (cinfo->data_precision != 8 && cinfo->data_precision != 12)
+  if (cinfo->master->lossless) {
+    if (cinfo->data_precision < 2 || cinfo->data_precision > 16)
+      ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+  } else
 #endif
-    ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+  {
+    if (cinfo->data_precision != 8 && cinfo->data_precision != 12)
+      ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+  }
 
   /* Check that number of components won't exceed internal array sizes */
   if (cinfo->num_components > MAX_COMPONENTS)
@@ -270,11 +276,11 @@ validate_script(j_compress_ptr cinfo)
  */
 {
   const jpeg_scan_info *scanptr;
-  int scanno, ncomps, ci, coefi, thisi;
+  int scanno, ncomps, ci, thisi;
   int Ss, Se, Ah, Al;
   boolean component_sent[MAX_COMPONENTS];
 #ifdef C_PROGRESSIVE_SUPPORTED
-  int *last_bitpos_ptr;
+  int coefi, *last_bitpos_ptr;
   int last_bitpos[MAX_COMPONENTS][DCTSIZE2];
   /* -1 until that coefficient has been seen; then last Al for it */
 #endif
@@ -613,8 +619,8 @@ prepare_for_pass(j_compress_ptr cinfo)
      */
     master->pass_type = output_pass;
     master->pass_number++;
-#endif
     FALLTHROUGH                 /*FALLTHROUGH*/
+#endif
   case output_pass:
     /* Do a data-output pass. */
     /* We need not repeat per-scan setup if prior optimization pass did it. */
@@ -731,6 +737,7 @@ jinit_c_master_control(j_compress_ptr cinfo, boolean transcode_only)
     cinfo->num_scans = 1;
   }
 
+#ifdef C_LOSSLESS_SUPPORTED
   /* Disable smoothing and subsampling in lossless mode, since those are lossy
    * algorithms.  Set the JPEG colorspace to the input colorspace.  Disable raw
    * (downsampled) data input, because it isn't particularly useful without
@@ -747,6 +754,7 @@ jinit_c_master_control(j_compress_ptr cinfo, boolean transcode_only)
          ci++, compptr++)
       compptr->h_samp_factor = compptr->v_samp_factor = 1;
   }
+#endif
 
   /* Validate parameters, determine derived values */
   initial_setup(cinfo, transcode_only);

--- a/jcparam.c
+++ b/jcparam.c
@@ -7,7 +7,7 @@
  * Lossless JPEG Modifications:
  * Copyright (C) 1999, Ken Murchison.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2009-2011, 2018, 2023, D. R. Commander.
+ * Copyright (C) 2009-2011, 2018, 2023-2024, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -220,6 +220,9 @@ jpeg_set_defaults(j_compress_ptr cinfo)
   cinfo->scan_info = NULL;
   cinfo->num_scans = 0;
 
+  /* Default is lossy output */
+  cinfo->master->lossless = FALSE;
+
   /* Expect normal source image, not raw downsampled data */
   cinfo->raw_data_in = FALSE;
 
@@ -297,9 +300,11 @@ jpeg_default_colorspace(j_compress_ptr cinfo)
   case JCS_EXT_BGRA:
   case JCS_EXT_ABGR:
   case JCS_EXT_ARGB:
+#ifdef C_LOSSLESS_SUPPORTED
     if (cinfo->master->lossless)
       jpeg_set_colorspace(cinfo, JCS_RGB);
     else
+#endif
       jpeg_set_colorspace(cinfo, JCS_YCbCr);
     break;
   case JCS_YCbCr:
@@ -479,10 +484,12 @@ jpeg_simple_progression(j_compress_ptr cinfo)
   if (cinfo->global_state != CSTATE_START)
     ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
 
+#ifdef C_LOSSLESS_SUPPORTED
   if (cinfo->master->lossless) {
     cinfo->master->lossless = FALSE;
     jpeg_default_colorspace(cinfo);
   }
+#endif
 
   /* Figure space needed for script.  Calculation must match code below! */
   if (ncomps == 3 && cinfo->jpeg_color_space == JCS_YCbCr) {

--- a/jcphuff.c
+++ b/jcphuff.c
@@ -217,7 +217,7 @@ start_pass_phuff(j_compress_ptr cinfo, boolean gather_statistics)
       if (entropy->bit_buffer == NULL)
         entropy->bit_buffer = (char *)
           (*cinfo->mem->alloc_small) ((j_common_ptr)cinfo, JPOOL_IMAGE,
-                                      MAX_CORR_BITS * sizeof(char));
+                                      MAX_CORR_BITS);
     }
   }
   if (gather_statistics)

--- a/jcprepct.c
+++ b/jcprepct.c
@@ -6,7 +6,7 @@
  * Lossless JPEG Modifications:
  * Copyright (C) 1999, Ken Murchison.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2022, D. R. Commander.
+ * Copyright (C) 2022, 2024, 2026, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -38,21 +38,21 @@
 
 
 /*
- * For the simple (no-context-row) case, we just need to buffer one
- * row group's worth of pixels for the downsampling step.  At the bottom of
- * the image, we pad to a full row group by replicating the last pixel row.
- * The downsampler's last output row is then replicated if needed to pad
- * out to a full iMCU row.
+ * For the simple (no-context-row) case, we just need to buffer one row group's
+ * worth of components for the downsampling step.  At the bottom of the image,
+ * we pad to a full row group by replicating the last component row(s).  The
+ * downsampler's last output row is then replicated if needed to pad out to a
+ * full iMCU row.
  *
  * When providing context rows, we must buffer three row groups' worth of
- * pixels.  Three row groups are physically allocated, but the row pointer
+ * components.  Three row groups are physically allocated, but the row pointer
  * arrays are made five row groups high, with the extra pointers above and
  * below "wrapping around" to point to the last and first real row groups.
- * This allows the downsampler to access the proper context rows.
- * At the top and bottom of the image, we create dummy context rows by
- * copying the first or last real pixel row.  This copying could be avoided
- * by pointer hacking as is done in jdmainct.c, but it doesn't seem worth the
- * trouble on the compression side.
+ * This allows the downsampler to access the proper context rows.  At the top
+ * and bottom of the image, we create dummy context rows by copying the first
+ * or last real component row(s).  This copying could be avoided by pointer
+ * hacking, as is done in jdmainct.c, but it doesn't seem worth the trouble on
+ * the compression side.
  */
 
 
@@ -324,8 +324,21 @@ _jinit_c_prep_controller(j_compress_ptr cinfo, boolean need_full_buffer)
   jpeg_component_info *compptr;
   int data_unit = cinfo->master->lossless ? 1 : DCTSIZE;
 
-  if (cinfo->data_precision != BITS_IN_JSAMPLE)
-    ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+#ifdef C_LOSSLESS_SUPPORTED
+  if (cinfo->master->lossless) {
+#if BITS_IN_JSAMPLE == 8
+    if (cinfo->data_precision > BITS_IN_JSAMPLE || cinfo->data_precision < 2)
+#else
+    if (cinfo->data_precision > BITS_IN_JSAMPLE ||
+        cinfo->data_precision < BITS_IN_JSAMPLE - 3)
+#endif
+      ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+  } else
+#endif
+  {
+    if (cinfo->data_precision != BITS_IN_JSAMPLE)
+      ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+  }
 
   if (need_full_buffer)         /* safety check */
     ERREXIT(cinfo, JERR_BAD_BUFFER_MODE);

--- a/jcsample.c
+++ b/jcsample.c
@@ -8,16 +8,16 @@
  * libjpeg-turbo Modifications:
  * Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
  * Copyright (C) 2014, MIPS Technologies, Inc., California.
- * Copyright (C) 2015, 2019, 2022, D. R. Commander.
+ * Copyright (C) 2015, 2019, 2022, 2024, 2026, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
  * This file contains downsampling routines.
  *
- * Downsampling input data is counted in "row groups".  A row group
- * is defined to be max_v_samp_factor pixel rows of each component,
- * from which the downsampler produces v_samp_factor sample rows.
- * A single row group is processed in each call to the downsampler module.
+ * Downsampling input data is counted in "row groups".  A row group is defined
+ * to be max_v_samp_factor rows of each component, from which the downsampler
+ * produces v_samp_factor sample rows.  A single row group is processed in each
+ * call to the downsampler module.
  *
  * The downsampler is responsible for edge-expansion of its output data
  * to fill an integral number of DCT blocks horizontally.  The source buffer
@@ -26,29 +26,29 @@
  * The caller (the prep controller) is responsible for vertical padding.
  *
  * The downsampler may request "context rows" by setting need_context_rows
- * during startup.  In this case, the input arrays will contain at least
- * one row group's worth of pixels above and below the passed-in data;
- * the caller will create dummy rows at image top and bottom by replicating
- * the first or last real pixel row.
+ * during startup.  In this case, the input arrays will contain at least one
+ * row group's worth of components above and below the passed-in data; the
+ * caller will create dummy rows at image top and bottom by replicating the
+ * first or last real component row(s).
  *
  * An excellent reference for image resampling is
  *   Digital Image Warping, George Wolberg, 1990.
  *   Pub. by IEEE Computer Society Press, Los Alamitos, CA. ISBN 0-8186-8944-7.
  *
  * The downsampling algorithm used here is a simple average of the source
- * pixels covered by the output pixel.  The hi-falutin sampling literature
- * refers to this as a "box filter".  In general the characteristics of a box
- * filter are not very good, but for the specific cases we normally use (1:1
- * and 2:1 ratios) the box is equivalent to a "triangle filter" which is not
- * nearly so bad.  If you intend to use other sampling ratios, you'd be well
- * advised to improve this code.
+ * components covered by the output sample.  The hi-falutin sampling literature
+ * refers to this as a "box filter".  In general, the characteristics of a box
+ * filter are not very good.  However, for the specific cases we normally use
+ * (1:1 and 2:1 ratios), the box is equivalent to a "triangle filter", which is
+ * not nearly so bad.  If you intend to use other sampling ratios, you'd be
+ * well advised to improve this code.
  *
  * A simple input-smoothing capability is provided.  This is mainly intended
- * for cleaning up color-dithered GIF input files (if you find it inadequate,
+ * for cleaning up color-dithered GIF input files.  (If you find it inadequate,
  * we suggest using an external filtering program such as pnmconvol).  When
- * enabled, each input pixel P is replaced by a weighted sum of itself and its
- * eight neighbors.  P's weight is 1-8*SF and each neighbor's weight is SF,
- * where SF = (smoothing_factor / 1024).
+ * enabled, each input component C is replaced by a weighted sum of itself and
+ * its eight neighbors.  C's weight is 1-8*SF, and each neighbor's weight is
+ * SF, where SF = (smoothing_factor / 1024).
  * Currently, smoothing is only supported for 2h2v sampling factors.
  */
 
@@ -142,7 +142,7 @@ sep_downsample(j_compress_ptr cinfo, _JSAMPIMAGE input_buf,
 
 
 /*
- * Downsample pixel values of a single component.
+ * Downsample components from a single plane.
  * One row group is processed per call.
  * This version handles arbitrary integral sampling ratios, without smoothing.
  * Note that this version is not actually used for customary sampling ratios.
@@ -191,7 +191,7 @@ int_downsample(j_compress_ptr cinfo, jpeg_component_info *compptr,
 
 
 /*
- * Downsample pixel values of a single component.
+ * Downsample components from a single plane.
  * This version handles the special case of a full-size component,
  * without smoothing.
  */
@@ -212,7 +212,7 @@ fullsize_downsample(j_compress_ptr cinfo, jpeg_component_info *compptr,
 
 
 /*
- * Downsample pixel values of a single component.
+ * Downsample components from a single plane.
  * This version handles the common case of 2:1 horizontal and 1:1 vertical,
  * without smoothing.
  *
@@ -255,7 +255,7 @@ h2v1_downsample(j_compress_ptr cinfo, jpeg_component_info *compptr,
 
 
 /*
- * Downsample pixel values of a single component.
+ * Downsample components from a single plane.
  * This version handles the standard case of 2:1 horizontal and 2:1 vertical,
  * without smoothing.
  */
@@ -298,7 +298,7 @@ h2v2_downsample(j_compress_ptr cinfo, jpeg_component_info *compptr,
 #ifdef INPUT_SMOOTHING_SUPPORTED
 
 /*
- * Downsample pixel values of a single component.
+ * Downsample components from a single plane.
  * This version handles the standard case of 2:1 horizontal and 2:1 vertical,
  * with smoothing.  One row of context is required.
  */
@@ -321,17 +321,17 @@ h2v2_smooth_downsample(j_compress_ptr cinfo, jpeg_component_info *compptr,
   expand_right_edge(input_data - 1, cinfo->max_v_samp_factor + 2,
                     cinfo->image_width, output_cols * 2);
 
-  /* We don't bother to form the individual "smoothed" input pixel values;
+  /* We don't bother to form the individual "smoothed" input component values;
    * we can directly compute the output which is the average of the four
-   * smoothed values.  Each of the four member pixels contributes a fraction
-   * (1-8*SF) to its own smoothed image and a fraction SF to each of the three
-   * other smoothed pixels, therefore a total fraction (1-5*SF)/4 to the final
-   * output.  The four corner-adjacent neighbor pixels contribute a fraction
-   * SF to just one smoothed pixel, or SF/4 to the final output; while the
-   * eight edge-adjacent neighbors contribute SF to each of two smoothed
-   * pixels, or SF/2 overall.  In order to use integer arithmetic, these
-   * factors are scaled by 2^16 = 65536.
-   * Also recall that SF = smoothing_factor / 1024.
+   * smoothed values.  Each of the four member components contributes a
+   * fraction (1-8*SF) to its own smoothed image and a fraction SF to each of
+   * the three other smoothed components, therefore a total fraction (1-5*SF)/4
+   * to the final output.  The four corner-adjacent neighbor components
+   * contribute a fraction SF to just one smoothed component, or SF/4 to the
+   * final output; while the eight edge-adjacent neighbors contribute SF to
+   * each of two smoothed components, or SF/2 overall.  In order to use integer
+   * arithmetic, these factors are scaled by 2^16 = 65536.  Also recall that
+   * SF = smoothing_factor / 1024.
    */
 
   memberscale = 16384 - cinfo->smoothing_factor * 80; /* scaled (1-5*SF)/4 */
@@ -356,9 +356,9 @@ h2v2_smooth_downsample(j_compress_ptr cinfo, jpeg_component_info *compptr,
     inptr0 += 2;  inptr1 += 2;  above_ptr += 2;  below_ptr += 2;
 
     for (colctr = output_cols - 2; colctr > 0; colctr--) {
-      /* sum of pixels directly mapped to this output element */
+      /* sum of components directly mapped to this output element */
       membersum = inptr0[0] + inptr0[1] + inptr1[0] + inptr1[1];
-      /* sum of edge-neighbor pixels */
+      /* sum of edge-neighbor components */
       neighsum = above_ptr[0] + above_ptr[1] + below_ptr[0] + below_ptr[1] +
                  inptr0[-1] + inptr0[2] + inptr1[-1] + inptr1[2];
       /* The edge-neighbors count twice as much as corner-neighbors */
@@ -387,7 +387,7 @@ h2v2_smooth_downsample(j_compress_ptr cinfo, jpeg_component_info *compptr,
 
 
 /*
- * Downsample pixel values of a single component.
+ * Downsample components from a single plane.
  * This version handles the special case of a full-size component,
  * with smoothing.  One row of context is required.
  */
@@ -411,10 +411,10 @@ fullsize_smooth_downsample(j_compress_ptr cinfo, jpeg_component_info *compptr,
   expand_right_edge(input_data - 1, cinfo->max_v_samp_factor + 2,
                     cinfo->image_width, output_cols);
 
-  /* Each of the eight neighbor pixels contributes a fraction SF to the
-   * smoothed pixel, while the main pixel contributes (1-8*SF).  In order
-   * to use integer arithmetic, these factors are multiplied by 2^16 = 65536.
-   * Also recall that SF = smoothing_factor / 1024.
+  /* Each of the eight neighbor components contributes a fraction SF to the
+   * smoothed component, while the main component contributes (1-8*SF).  In
+   * order to use integer arithmetic, these factors are multiplied by
+   * 2^16 = 65536.  Also recall that SF = smoothing_factor / 1024.
    */
 
   memberscale = 65536L - cinfo->smoothing_factor * 512L; /* scaled 1-8*SF */
@@ -468,10 +468,25 @@ _jinit_downsampler(j_compress_ptr cinfo)
   my_downsample_ptr downsample;
   int ci;
   jpeg_component_info *compptr;
+#ifdef INPUT_SMOOTHING_SUPPORTED
   boolean smoothok = TRUE;
+#endif
 
-  if (cinfo->data_precision != BITS_IN_JSAMPLE)
-    ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+#ifdef C_LOSSLESS_SUPPORTED
+  if (cinfo->master->lossless) {
+#if BITS_IN_JSAMPLE == 8
+    if (cinfo->data_precision > BITS_IN_JSAMPLE || cinfo->data_precision < 2)
+#else
+    if (cinfo->data_precision > BITS_IN_JSAMPLE ||
+        cinfo->data_precision < BITS_IN_JSAMPLE - 3)
+#endif
+      ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+  } else
+#endif
+  {
+    if (cinfo->data_precision != BITS_IN_JSAMPLE)
+      ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+  }
 
   downsample = (my_downsample_ptr)
     (*cinfo->mem->alloc_small) ((j_common_ptr)cinfo, JPOOL_IMAGE,
@@ -498,7 +513,9 @@ _jinit_downsampler(j_compress_ptr cinfo)
         downsample->methods[ci] = fullsize_downsample;
     } else if (compptr->h_samp_factor * 2 == cinfo->max_h_samp_factor &&
                compptr->v_samp_factor == cinfo->max_v_samp_factor) {
+#ifdef INPUT_SMOOTHING_SUPPORTED
       smoothok = FALSE;
+#endif
 #ifdef WITH_SIMD
       if (jsimd_can_h2v1_downsample())
         downsample->methods[ci] = jsimd_h2v1_downsample;
@@ -528,7 +545,9 @@ _jinit_downsampler(j_compress_ptr cinfo)
       }
     } else if ((cinfo->max_h_samp_factor % compptr->h_samp_factor) == 0 &&
                (cinfo->max_v_samp_factor % compptr->v_samp_factor) == 0) {
+#ifdef INPUT_SMOOTHING_SUPPORTED
       smoothok = FALSE;
+#endif
       downsample->methods[ci] = int_downsample;
     } else
       ERREXIT(cinfo, JERR_FRACT_SAMPLE_NOTIMPL);

--- a/jcstest.c
+++ b/jcstest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2011 D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2011, 2025 D. R. Commander.  All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -30,8 +30,8 @@
    capabilities of libjpeg-turbo at both compile time and run time. */
 
 #include <stdio.h>
-#include <jpeglib.h>
-#include <jerror.h>
+#include "jpeglib.h"
+#include "jerror.h"
 #include <setjmp.h>
 
 #ifndef JCS_EXTENSIONS

--- a/jdapimin.c
+++ b/jdapimin.c
@@ -161,17 +161,21 @@ default_decompress_parms(j_decompress_ptr cinfo)
       int cid2 = cinfo->comp_info[2].component_id;
 
       if (cid0 == 1 && cid1 == 2 && cid2 == 3) {
+#ifdef D_LOSSLESS_SUPPORTED
         if (cinfo->master->lossless)
           cinfo->jpeg_color_space = JCS_RGB; /* assume RGB w/out marker */
         else
+#endif
           cinfo->jpeg_color_space = JCS_YCbCr; /* assume JFIF w/out marker */
       } else if (cid0 == 82 && cid1 == 71 && cid2 == 66)
         cinfo->jpeg_color_space = JCS_RGB; /* ASCII 'R', 'G', 'B' */
       else {
         TRACEMS3(cinfo, 1, JTRC_UNKNOWN_IDS, cid0, cid1, cid2);
+#ifdef D_LOSSLESS_SUPPORTED
         if (cinfo->master->lossless)
           cinfo->jpeg_color_space = JCS_RGB; /* assume it's RGB */
         else
+#endif
           cinfo->jpeg_color_space = JCS_YCbCr; /* assume it's YCbCr */
       }
     }

--- a/jdapistd.c
+++ b/jdapistd.c
@@ -4,7 +4,7 @@
  * This file was part of the Independent JPEG Group's software:
  * Copyright (C) 1994-1996, Thomas G. Lane.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2010, 2015-2020, 2022-2024, D. R. Commander.
+ * Copyright (C) 2010, 2015-2020, 2022-2026, D. R. Commander.
  * Copyright (C) 2015, Google, Inc.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
@@ -128,20 +128,28 @@ output_pass_setup(j_decompress_ptr cinfo)
       }
       /* Process some data */
       last_scanline = cinfo->output_scanline;
-#ifdef D_LOSSLESS_SUPPORTED
-      if (cinfo->data_precision == 16)
-        (*cinfo->main->process_data_16) (cinfo, (J16SAMPARRAY)NULL,
-                                         &cinfo->output_scanline,
-                                         (JDIMENSION)0);
-      else
-#endif
-      if (cinfo->data_precision == 12)
+      if (cinfo->data_precision <= 8) {
+        if (cinfo->main->process_data == NULL)
+          ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+        (*cinfo->main->process_data) (cinfo, (JSAMPARRAY)NULL,
+                                      &cinfo->output_scanline, (JDIMENSION)0);
+      } else if (cinfo->data_precision <= 12) {
+        if (cinfo->main->process_data_12 == NULL)
+          ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
         (*cinfo->main->process_data_12) (cinfo, (J12SAMPARRAY)NULL,
                                          &cinfo->output_scanline,
                                          (JDIMENSION)0);
-      else
-        (*cinfo->main->process_data) (cinfo, (JSAMPARRAY)NULL,
-                                      &cinfo->output_scanline, (JDIMENSION)0);
+      } else {
+#ifdef D_LOSSLESS_SUPPORTED
+        if (cinfo->main->process_data_16 == NULL)
+          ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+        (*cinfo->main->process_data_16) (cinfo, (J16SAMPARRAY)NULL,
+                                         &cinfo->output_scanline,
+                                         (JDIMENSION)0);
+#else
+        ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+#endif
+      }
       if (cinfo->output_scanline == last_scanline)
         return FALSE;           /* No progress made, must suspend */
     }
@@ -314,8 +322,21 @@ _jpeg_read_scanlines(j_decompress_ptr cinfo, _JSAMPARRAY scanlines,
 #if BITS_IN_JSAMPLE != 16 || defined(D_LOSSLESS_SUPPORTED)
   JDIMENSION row_ctr;
 
-  if (cinfo->data_precision != BITS_IN_JSAMPLE)
-    ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+#ifdef D_LOSSLESS_SUPPORTED
+  if (cinfo->master->lossless) {
+#if BITS_IN_JSAMPLE == 8
+    if (cinfo->data_precision > BITS_IN_JSAMPLE || cinfo->data_precision < 2)
+#else
+    if (cinfo->data_precision > BITS_IN_JSAMPLE ||
+        cinfo->data_precision < BITS_IN_JSAMPLE - 3)
+#endif
+      ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+  } else
+#endif
+  {
+    if (cinfo->data_precision != BITS_IN_JSAMPLE)
+      ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+  }
 
   if (cinfo->global_state != DSTATE_SCANNING)
     ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
@@ -333,6 +354,8 @@ _jpeg_read_scanlines(j_decompress_ptr cinfo, _JSAMPARRAY scanlines,
 
   /* Process some data */
   row_ctr = 0;
+  if (cinfo->main->_process_data == NULL)
+    ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
   (*cinfo->main->_process_data) (cinfo, scanlines, &row_ctr, max_lines);
   cinfo->output_scanline += row_ctr;
   return row_ctr;
@@ -385,7 +408,11 @@ read_and_discard_scanlines(j_decompress_ptr cinfo, JDIMENSION num_lines)
   void (*color_quantize) (j_decompress_ptr cinfo, _JSAMPARRAY input_buf,
                           _JSAMPARRAY output_buf, int num_rows) = NULL;
 
-  if (cinfo->cconvert && cinfo->cconvert->_color_convert) {
+  if (cinfo->cconvert &&
+#ifdef UPSAMPLE_MERGING_SUPPORTED
+      !master->using_merged_upsample &&
+#endif
+      cinfo->cconvert->_color_convert) {
     color_convert = cinfo->cconvert->_color_convert;
     cinfo->cconvert->_color_convert = noop_convert;
     /* This just prevents UBSan from complaining about adding 0 to a NULL
@@ -394,7 +421,8 @@ read_and_discard_scanlines(j_decompress_ptr cinfo, JDIMENSION num_lines)
     scanlines = &dummy_row;
   }
 
-  if (cinfo->cquantize && cinfo->cquantize->_color_quantize) {
+  if (cinfo->quantize_colors && cinfo->cquantize &&
+      cinfo->cquantize->_color_quantize) {
     color_quantize = cinfo->cquantize->_color_quantize;
     cinfo->cquantize->_color_quantize = noop_quantize;
   }
@@ -679,6 +707,8 @@ _jpeg_read_raw_data(j_decompress_ptr cinfo, _JSAMPIMAGE data,
     ERREXIT(cinfo, JERR_BUFFER_SIZE);
 
   /* Decompress directly into user's buffer. */
+  if (cinfo->coef->_decompress_data == NULL)
+    ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
   if (!(*cinfo->coef->_decompress_data) (cinfo, data))
     return 0;                   /* suspension forced, can do nothing more */
 

--- a/jdatadst-tj.c
+++ b/jdatadst-tj.c
@@ -5,7 +5,7 @@
  * Copyright (C) 1994-1996, Thomas G. Lane.
  * Modified 2009-2012 by Guido Vollbeding.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2011, 2014, 2016, 2019, 2022-2023, D. R. Commander.
+ * Copyright (C) 2011, 2014, 2016, 2019, 2022-2023, 2025-2026, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -181,7 +181,7 @@ jpeg_mem_dest_tj(j_compress_ptr cinfo, unsigned char **outbuffer,
   dest->outsize = outsize;
   dest->alloc = alloc;
 
-  if (*outbuffer == NULL || *outsize == 0) {
+  if (*outbuffer == NULL || (*outsize == 0 && !reused)) {
     if (alloc) {
       /* Allocate initial buffer */
       dest->newbuffer = *outbuffer = (unsigned char *)MALLOC(OUTPUT_BUF_SIZE);
@@ -190,7 +190,8 @@ jpeg_mem_dest_tj(j_compress_ptr cinfo, unsigned char **outbuffer,
       *outsize = OUTPUT_BUF_SIZE;
     } else
       ERREXIT(cinfo, JERR_BUFFER_SIZE);
-  }
+  } else
+    dest->newbuffer = *outbuffer;
 
   dest->pub.next_output_byte = dest->buffer = *outbuffer;
   if (!reused)

--- a/jdcoefct.c
+++ b/jdcoefct.c
@@ -5,7 +5,7 @@
  * Copyright (C) 1994-1997, Thomas G. Lane.
  * libjpeg-turbo Modifications:
  * Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
- * Copyright (C) 2010, 2015-2016, 2019-2020, 2022-2023, D. R. Commander.
+ * Copyright (C) 2010, 2015-2016, 2019-2020, 2022-2024, D. R. Commander.
  * Copyright (C) 2015, 2020, Google, Inc.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
@@ -824,6 +824,7 @@ _jinit_d_coef_controller(j_decompress_ptr cinfo, boolean need_full_buffer)
   coef = (my_coef_ptr)
     (*cinfo->mem->alloc_small) ((j_common_ptr)cinfo, JPOOL_IMAGE,
                                 sizeof(my_coef_controller));
+  memset(coef, 0, sizeof(my_coef_controller));
   cinfo->coef = (struct jpeg_d_coef_controller *)coef;
   coef->pub.start_input_pass = start_input_pass;
   coef->pub.start_output_pass = start_output_pass;

--- a/jddctmgr.c
+++ b/jddctmgr.c
@@ -6,7 +6,7 @@
  * Modified 2002-2010 by Guido Vollbeding.
  * libjpeg-turbo Modifications:
  * Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
- * Copyright (C) 2010, 2015, 2022, D. R. Commander.
+ * Copyright (C) 2010, 2015, 2022, 2026, D. R. Commander.
  * Copyright (C) 2013, MIPS Technologies, Inc., California.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
@@ -28,6 +28,9 @@
 #include "jsimddct.h"
 #include "jpegapicomp.h"
 
+
+#if defined(DCT_ISLOW_SUPPORTED) || defined(DCT_IFAST_SUPPORTED) || \
+    defined(DCT_FLOAT_SUPPORTED)
 
 /*
  * The decompressor input side (jdinput.c) saves away the appropriate
@@ -363,3 +366,6 @@ _jinit_inverse_dct(j_decompress_ptr cinfo)
     idct->cur_method[ci] = -1;
   }
 }
+
+#endif /* defined(DCT_ISLOW_SUPPORTED) || defined(DCT_IFAST_SUPPORTED) ||
+          defined(DCT_FLOAT_SUPPORTED) */

--- a/jddiffct.c
+++ b/jddiffct.c
@@ -6,7 +6,7 @@
  * Lossless JPEG Modifications:
  * Copyright (C) 1999, Ken Murchison.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2022, D. R. Commander.
+ * Copyright (C) 2022, 2024, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -349,6 +349,14 @@ _jinit_d_diff_controller(j_decompress_ptr cinfo, boolean need_full_buffer)
   my_diff_ptr diff;
   int ci;
   jpeg_component_info *compptr;
+
+#if BITS_IN_JSAMPLE == 8
+  if (cinfo->data_precision > BITS_IN_JSAMPLE || cinfo->data_precision < 2)
+#else
+  if (cinfo->data_precision > BITS_IN_JSAMPLE ||
+      cinfo->data_precision < BITS_IN_JSAMPLE - 3)
+#endif
+    ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 
   diff = (my_diff_ptr)
     (*cinfo->mem->alloc_small) ((j_common_ptr)cinfo, JPOOL_IMAGE,

--- a/jdlossls.c
+++ b/jdlossls.c
@@ -6,7 +6,7 @@
  * Lossless JPEG Modifications:
  * Copyright (C) 1999, Ken Murchison.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2022, D. R. Commander.
+ * Copyright (C) 2022, 2024, 2026, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -206,6 +206,9 @@ jpeg_undifference_first_row(j_decompress_ptr cinfo, int comp_index,
   case 7:
     losslessd->predict_undifference[comp_index] = jpeg_undifference7;
     break;
+  default:
+    ERREXIT4(cinfo, JERR_BAD_PROGRESSION,
+             cinfo->Ss, cinfo->Se, cinfo->Ah, cinfo->Al);
   }
 }
 
@@ -277,6 +280,14 @@ GLOBAL(void)
 _jinit_lossless_decompressor(j_decompress_ptr cinfo)
 {
   lossless_decomp_ptr losslessd;
+
+#if BITS_IN_JSAMPLE == 8
+  if (cinfo->data_precision > BITS_IN_JSAMPLE || cinfo->data_precision < 2)
+#else
+  if (cinfo->data_precision > BITS_IN_JSAMPLE ||
+      cinfo->data_precision < BITS_IN_JSAMPLE - 3)
+#endif
+    ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 
   /* Create subobject in permanent pool */
   losslessd = (lossless_decomp_ptr)

--- a/jdmainct.c
+++ b/jdmainct.c
@@ -4,7 +4,7 @@
  * This file was part of the Independent JPEG Group's software:
  * Copyright (C) 1994-1996, Thomas G. Lane.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2010, 2016, 2022, D. R. Commander.
+ * Copyright (C) 2010, 2016, 2022, 2024, 2026, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -36,8 +36,8 @@
  * chosen such that these numbers are integers.  In practice DCT_scaled_size
  * values will likely be powers of two, so we actually have the stronger
  * condition that DCT_scaled_size / min_DCT_scaled_size is an integer.)
- * Upsampling will typically produce max_v_samp_factor pixel rows from each
- * row group (times any additional scale factor that the upsampler is
+ * Upsampling will typically produce max_v_samp_factor rows of each component
+ * from each row group (times any additional scale factor that the upsampler is
  * applying).
  *
  * The coefficient or difference controller will deliver data to us one iMCU
@@ -431,12 +431,26 @@ _jinit_d_main_controller(j_decompress_ptr cinfo, boolean need_full_buffer)
   int ci, rgroup, ngroups;
   jpeg_component_info *compptr;
 
-  if (cinfo->data_precision != BITS_IN_JSAMPLE)
-    ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+#ifdef D_LOSSLESS_SUPPORTED
+  if (cinfo->master->lossless) {
+#if BITS_IN_JSAMPLE == 8
+    if (cinfo->data_precision > BITS_IN_JSAMPLE || cinfo->data_precision < 2)
+#else
+    if (cinfo->data_precision > BITS_IN_JSAMPLE ||
+        cinfo->data_precision < BITS_IN_JSAMPLE - 3)
+#endif
+      ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+  } else
+#endif
+  {
+    if (cinfo->data_precision != BITS_IN_JSAMPLE)
+      ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+  }
 
   main_ptr = (my_main_ptr)
     (*cinfo->mem->alloc_small) ((j_common_ptr)cinfo, JPOOL_IMAGE,
                                 sizeof(my_main_controller));
+  memset(main_ptr, 0, sizeof(my_main_controller));
   cinfo->main = (struct jpeg_d_main_controller *)main_ptr;
   main_ptr->pub.start_pass = start_pass_main;
 

--- a/jdmaster.c
+++ b/jdmaster.c
@@ -7,7 +7,7 @@
  * Lossless JPEG Modifications:
  * Copyright (C) 1999, Ken Murchison.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2009-2011, 2016, 2019, 2022-2023, D. R. Commander.
+ * Copyright (C) 2009-2011, 2016, 2019, 2022-2024, 2026, D. R. Commander.
  * Copyright (C) 2013, Linaro Limited.
  * Copyright (C) 2015, Google, Inc.
  * For conditions of distribution and use, see the accompanying README.ijg
@@ -422,7 +422,50 @@ prepare_range_limit_table(j_decompress_ptr cinfo)
 #endif
   int i;
 
-  if (cinfo->data_precision == 16) {
+  if (cinfo->data_precision <= 8) {
+    table = (JSAMPLE *)
+      (*cinfo->mem->alloc_small) ((j_common_ptr)cinfo, JPOOL_IMAGE,
+                  (5 * (MAXJSAMPLE + 1) + CENTERJSAMPLE) * sizeof(JSAMPLE));
+    table += (MAXJSAMPLE + 1);  /* allow negative subscripts of simple table */
+    cinfo->sample_range_limit = table;
+    /* First segment of "simple" table: limit[x] = 0 for x < 0 */
+    memset(table - (MAXJSAMPLE + 1), 0, (MAXJSAMPLE + 1) * sizeof(JSAMPLE));
+    /* Main part of "simple" table: limit[x] = x */
+    for (i = 0; i <= MAXJSAMPLE; i++)
+      table[i] = (JSAMPLE)i;
+    table += CENTERJSAMPLE;     /* Point to where post-IDCT table starts */
+    /* End of simple table, rest of first half of post-IDCT table */
+    for (i = CENTERJSAMPLE; i < 2 * (MAXJSAMPLE + 1); i++)
+      table[i] = MAXJSAMPLE;
+    /* Second half of post-IDCT table */
+    memset(table + (2 * (MAXJSAMPLE + 1)), 0,
+           (2 * (MAXJSAMPLE + 1) - CENTERJSAMPLE) * sizeof(JSAMPLE));
+    memcpy(table + (4 * (MAXJSAMPLE + 1) - CENTERJSAMPLE),
+           cinfo->sample_range_limit, CENTERJSAMPLE * sizeof(JSAMPLE));
+  } else if (cinfo->data_precision <= 12) {
+    table12 = (J12SAMPLE *)
+      (*cinfo->mem->alloc_small) ((j_common_ptr)cinfo, JPOOL_IMAGE,
+                  (5 * (MAXJ12SAMPLE + 1) + CENTERJ12SAMPLE) *
+                  sizeof(J12SAMPLE));
+    table12 += (MAXJ12SAMPLE + 1);  /* allow negative subscripts of simple
+                                       table */
+    cinfo->sample_range_limit = (JSAMPLE *)table12;
+    /* First segment of "simple" table: limit[x] = 0 for x < 0 */
+    memset(table12 - (MAXJ12SAMPLE + 1), 0,
+           (MAXJ12SAMPLE + 1) * sizeof(J12SAMPLE));
+    /* Main part of "simple" table: limit[x] = x */
+    for (i = 0; i <= MAXJ12SAMPLE; i++)
+      table12[i] = (J12SAMPLE)i;
+    table12 += CENTERJ12SAMPLE; /* Point to where post-IDCT table starts */
+    /* End of simple table, rest of first half of post-IDCT table */
+    for (i = CENTERJ12SAMPLE; i < 2 * (MAXJ12SAMPLE + 1); i++)
+      table12[i] = MAXJ12SAMPLE;
+    /* Second half of post-IDCT table */
+    memset(table12 + (2 * (MAXJ12SAMPLE + 1)), 0,
+           (2 * (MAXJ12SAMPLE + 1) - CENTERJ12SAMPLE) * sizeof(J12SAMPLE));
+    memcpy(table12 + (4 * (MAXJ12SAMPLE + 1) - CENTERJ12SAMPLE),
+           cinfo->sample_range_limit, CENTERJ12SAMPLE * sizeof(J12SAMPLE));
+  } else {
 #ifdef D_LOSSLESS_SUPPORTED
     table16 = (J16SAMPLE *)
       (*cinfo->mem->alloc_small) ((j_common_ptr)cinfo, JPOOL_IMAGE,
@@ -449,49 +492,6 @@ prepare_range_limit_table(j_decompress_ptr cinfo)
 #else
     ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 #endif
-  } else if (cinfo->data_precision == 12) {
-    table12 = (J12SAMPLE *)
-      (*cinfo->mem->alloc_small) ((j_common_ptr)cinfo, JPOOL_IMAGE,
-                  (5 * (MAXJ12SAMPLE + 1) + CENTERJ12SAMPLE) *
-                  sizeof(J12SAMPLE));
-    table12 += (MAXJ12SAMPLE + 1);  /* allow negative subscripts of simple
-                                       table */
-    cinfo->sample_range_limit = (JSAMPLE *)table12;
-    /* First segment of "simple" table: limit[x] = 0 for x < 0 */
-    memset(table12 - (MAXJ12SAMPLE + 1), 0,
-           (MAXJ12SAMPLE + 1) * sizeof(J12SAMPLE));
-    /* Main part of "simple" table: limit[x] = x */
-    for (i = 0; i <= MAXJ12SAMPLE; i++)
-      table12[i] = (J12SAMPLE)i;
-    table12 += CENTERJ12SAMPLE; /* Point to where post-IDCT table starts */
-    /* End of simple table, rest of first half of post-IDCT table */
-    for (i = CENTERJ12SAMPLE; i < 2 * (MAXJ12SAMPLE + 1); i++)
-      table12[i] = MAXJ12SAMPLE;
-    /* Second half of post-IDCT table */
-    memset(table12 + (2 * (MAXJ12SAMPLE + 1)), 0,
-           (2 * (MAXJ12SAMPLE + 1) - CENTERJ12SAMPLE) * sizeof(J12SAMPLE));
-    memcpy(table12 + (4 * (MAXJ12SAMPLE + 1) - CENTERJ12SAMPLE),
-           cinfo->sample_range_limit, CENTERJ12SAMPLE * sizeof(J12SAMPLE));
-  } else {
-    table = (JSAMPLE *)
-      (*cinfo->mem->alloc_small) ((j_common_ptr)cinfo, JPOOL_IMAGE,
-                  (5 * (MAXJSAMPLE + 1) + CENTERJSAMPLE) * sizeof(JSAMPLE));
-    table += (MAXJSAMPLE + 1);  /* allow negative subscripts of simple table */
-    cinfo->sample_range_limit = table;
-    /* First segment of "simple" table: limit[x] = 0 for x < 0 */
-    memset(table - (MAXJSAMPLE + 1), 0, (MAXJSAMPLE + 1) * sizeof(JSAMPLE));
-    /* Main part of "simple" table: limit[x] = x */
-    for (i = 0; i <= MAXJSAMPLE; i++)
-      table[i] = (JSAMPLE)i;
-    table += CENTERJSAMPLE;     /* Point to where post-IDCT table starts */
-    /* End of simple table, rest of first half of post-IDCT table */
-    for (i = CENTERJSAMPLE; i < 2 * (MAXJSAMPLE + 1); i++)
-      table[i] = MAXJSAMPLE;
-    /* Second half of post-IDCT table */
-    memset(table + (2 * (MAXJSAMPLE + 1)), 0,
-           (2 * (MAXJSAMPLE + 1) - CENTERJSAMPLE) * sizeof(JSAMPLE));
-    memcpy(table + (4 * (MAXJSAMPLE + 1) - CENTERJSAMPLE),
-           cinfo->sample_range_limit, CENTERJSAMPLE * sizeof(JSAMPLE));
   }
 }
 
@@ -521,10 +521,12 @@ master_selection(j_decompress_ptr cinfo)
    * particularly useful without subsampling and has not been tested in
    * lossless mode.
    */
+#ifdef D_LOSSLESS_SUPPORTED
   if (cinfo->master->lossless) {
     cinfo->raw_data_out = FALSE;
     cinfo->scale_num = cinfo->scale_denom = 1;
   }
+#endif
 
   /* Initialize dimensions and other stuff */
   jpeg_calc_output_dimensions(cinfo);
@@ -570,12 +572,12 @@ master_selection(j_decompress_ptr cinfo)
 
     if (cinfo->enable_1pass_quant) {
 #ifdef QUANT_1PASS_SUPPORTED
-      if (cinfo->data_precision == 16)
-        ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+      if (cinfo->data_precision == 8)
+        jinit_1pass_quantizer(cinfo);
       else if (cinfo->data_precision == 12)
         j12init_1pass_quantizer(cinfo);
       else
-        jinit_1pass_quantizer(cinfo);
+        ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
       master->quantizer_1pass = cinfo->cquantize;
 #else
       ERREXIT(cinfo, JERR_NOT_COMPILED);
@@ -585,12 +587,12 @@ master_selection(j_decompress_ptr cinfo)
     /* We use the 2-pass code to map to external colormaps. */
     if (cinfo->enable_2pass_quant || cinfo->enable_external_quant) {
 #ifdef QUANT_2PASS_SUPPORTED
-      if (cinfo->data_precision == 16)
-        ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+      if (cinfo->data_precision == 8)
+        jinit_2pass_quantizer(cinfo);
       else if (cinfo->data_precision == 12)
         j12init_2pass_quantizer(cinfo);
       else
-        jinit_2pass_quantizer(cinfo);
+        ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
       master->quantizer_2pass = cinfo->cquantize;
 #else
       ERREXIT(cinfo, JERR_NOT_COMPILED);
@@ -605,41 +607,41 @@ master_selection(j_decompress_ptr cinfo)
   if (!cinfo->raw_data_out) {
     if (master->using_merged_upsample) {
 #ifdef UPSAMPLE_MERGING_SUPPORTED
-      if (cinfo->data_precision == 16)
-        ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+      if (cinfo->data_precision == 8)
+        jinit_merged_upsampler(cinfo); /* does color conversion too */
       else if (cinfo->data_precision == 12)
         j12init_merged_upsampler(cinfo); /* does color conversion too */
       else
-        jinit_merged_upsampler(cinfo); /* does color conversion too */
+        ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 #else
       ERREXIT(cinfo, JERR_NOT_COMPILED);
 #endif
     } else {
-      if (cinfo->data_precision == 16) {
+      if (cinfo->data_precision <= 8) {
+        jinit_color_deconverter(cinfo);
+        jinit_upsampler(cinfo);
+      } else if (cinfo->data_precision <= 12) {
+        j12init_color_deconverter(cinfo);
+        j12init_upsampler(cinfo);
+      } else {
 #ifdef D_LOSSLESS_SUPPORTED
         j16init_color_deconverter(cinfo);
         j16init_upsampler(cinfo);
 #else
         ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 #endif
-      } else if (cinfo->data_precision == 12) {
-        j12init_color_deconverter(cinfo);
-        j12init_upsampler(cinfo);
-      } else {
-        jinit_color_deconverter(cinfo);
-        jinit_upsampler(cinfo);
       }
     }
-    if (cinfo->data_precision == 16)
+    if (cinfo->data_precision <= 8)
+      jinit_d_post_controller(cinfo, cinfo->enable_2pass_quant);
+    else if (cinfo->data_precision <= 12)
+      j12init_d_post_controller(cinfo, cinfo->enable_2pass_quant);
+    else
 #ifdef D_LOSSLESS_SUPPORTED
       j16init_d_post_controller(cinfo, cinfo->enable_2pass_quant);
 #else
       ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 #endif
-    else if (cinfo->data_precision == 12)
-      j12init_d_post_controller(cinfo, cinfo->enable_2pass_quant);
-    else
-      jinit_d_post_controller(cinfo, cinfo->enable_2pass_quant);
   }
 
   if (cinfo->master->lossless) {
@@ -647,12 +649,12 @@ master_selection(j_decompress_ptr cinfo)
     /* Prediction, sample undifferencing, point transform, and sample size
      * scaling
      */
-    if (cinfo->data_precision == 16)
-      j16init_lossless_decompressor(cinfo);
-    else if (cinfo->data_precision == 12)
+    if (cinfo->data_precision <= 8)
+      jinit_lossless_decompressor(cinfo);
+    else if (cinfo->data_precision <= 12)
       j12init_lossless_decompressor(cinfo);
     else
-      jinit_lossless_decompressor(cinfo);
+      j16init_lossless_decompressor(cinfo);
     /* Entropy decoding: either Huffman or arithmetic coding. */
     if (cinfo->arith_code) {
       ERREXIT(cinfo, JERR_ARITH_NOTIMPL);
@@ -663,23 +665,25 @@ master_selection(j_decompress_ptr cinfo)
     /* Initialize principal buffer controllers. */
     use_c_buffer = cinfo->inputctl->has_multiple_scans ||
                    cinfo->buffered_image;
-    if (cinfo->data_precision == 16)
-      j16init_d_diff_controller(cinfo, use_c_buffer);
-    else if (cinfo->data_precision == 12)
+    if (cinfo->data_precision <= 8)
+      jinit_d_diff_controller(cinfo, use_c_buffer);
+    else if (cinfo->data_precision <= 12)
       j12init_d_diff_controller(cinfo, use_c_buffer);
     else
-      jinit_d_diff_controller(cinfo, use_c_buffer);
+      j16init_d_diff_controller(cinfo, use_c_buffer);
 #else
     ERREXIT(cinfo, JERR_NOT_COMPILED);
 #endif
   } else {
-    if (cinfo->data_precision == 16)
-      ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+#if defined(DCT_ISLOW_SUPPORTED) || defined(DCT_IFAST_SUPPORTED) || \
+    defined(DCT_FLOAT_SUPPORTED)
     /* Inverse DCT */
-    if (cinfo->data_precision == 12)
+    if (cinfo->data_precision == 8)
+      jinit_inverse_dct(cinfo);
+    else if (cinfo->data_precision == 12)
       j12init_inverse_dct(cinfo);
     else
-      jinit_inverse_dct(cinfo);
+      ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
     /* Entropy decoding: either Huffman or arithmetic coding. */
     if (cinfo->arith_code) {
 #ifdef D_ARITH_CODING_SUPPORTED
@@ -705,21 +709,24 @@ master_selection(j_decompress_ptr cinfo)
       j12init_d_coef_controller(cinfo, use_c_buffer);
     else
       jinit_d_coef_controller(cinfo, use_c_buffer);
+#else
+    ERREXIT(cinfo, JERR_NOT_COMPILED);
+#endif
   }
 
   if (!cinfo->raw_data_out) {
-    if (cinfo->data_precision == 16)
+    if (cinfo->data_precision <= 8)
+      jinit_d_main_controller(cinfo, FALSE /* never need full buffer here */);
+    else if (cinfo->data_precision <= 12)
+      j12init_d_main_controller(cinfo,
+                                FALSE /* never need full buffer here */);
+    else
 #ifdef D_LOSSLESS_SUPPORTED
       j16init_d_main_controller(cinfo,
                                 FALSE /* never need full buffer here */);
 #else
       ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 #endif
-    else if (cinfo->data_precision == 12)
-      j12init_d_main_controller(cinfo,
-                                FALSE /* never need full buffer here */);
-    else
-      jinit_d_main_controller(cinfo, FALSE /* never need full buffer here */);
   }
 
   /* We can now tell the memory manager to allocate virtual arrays. */

--- a/jdpostct.c
+++ b/jdpostct.c
@@ -4,7 +4,7 @@
  * This file was part of the Independent JPEG Group's software:
  * Copyright (C) 1994-1996, Thomas G. Lane.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2022-2023, D. R. Commander.
+ * Copyright (C) 2022-2024, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -267,8 +267,21 @@ _jinit_d_post_controller(j_decompress_ptr cinfo, boolean need_full_buffer)
 {
   my_post_ptr post;
 
-  if (cinfo->data_precision != BITS_IN_JSAMPLE)
-    ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+#ifdef D_LOSSLESS_SUPPORTED
+  if (cinfo->master->lossless) {
+#if BITS_IN_JSAMPLE == 8
+    if (cinfo->data_precision > BITS_IN_JSAMPLE || cinfo->data_precision < 2)
+#else
+    if (cinfo->data_precision > BITS_IN_JSAMPLE ||
+        cinfo->data_precision < BITS_IN_JSAMPLE - 3)
+#endif
+      ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+  } else
+#endif
+  {
+    if (cinfo->data_precision != BITS_IN_JSAMPLE)
+      ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+  }
 
   post = (my_post_ptr)
     (*cinfo->mem->alloc_small) ((j_common_ptr)cinfo, JPOOL_IMAGE,

--- a/jdsample.c
+++ b/jdsample.c
@@ -5,7 +5,7 @@
  * Copyright (C) 1991-1996, Thomas G. Lane.
  * libjpeg-turbo Modifications:
  * Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
- * Copyright (C) 2010, 2015-2016, 2022, D. R. Commander.
+ * Copyright (C) 2010, 2015-2016, 2022, 2024-2026, D. R. Commander.
  * Copyright (C) 2014, MIPS Technologies, Inc., California.
  * Copyright (C) 2015, Google, Inc.
  * Copyright (C) 2019-2020, Arm Limited.
@@ -14,11 +14,11 @@
  *
  * This file contains upsampling routines.
  *
- * Upsampling input data is counted in "row groups".  A row group
- * is defined to be (v_samp_factor * DCT_scaled_size / min_DCT_scaled_size)
- * sample rows of each component.  Upsampling will normally produce
- * max_v_samp_factor pixel rows from each row group (but this could vary
- * if the upsampler is applying a scale factor of its own).
+ * Upsampling input data is counted in "row groups".  A row group is defined to
+ * be (v_samp_factor * DCT_scaled_size / min_DCT_scaled_size) sample rows of
+ * each component.  Upsampling will normally produce max_v_samp_factor rows of
+ * each component from each row group (but this could vary if the upsampler is
+ * applying a scale factor of its own).
  *
  * An excellent reference for image resampling is
  *   Digital Image Warping, George Wolberg, 1990.
@@ -113,8 +113,8 @@ sep_upsample(j_decompress_ptr cinfo, _JSAMPIMAGE input_buf,
 
 
 /*
- * These are the routines invoked by sep_upsample to upsample pixel values
- * of a single component.  One row group is processed per call.
+ * These are the routines invoked by sep_upsample to upsample values of a
+ * single component.  One row group is processed per call.
  */
 
 
@@ -148,13 +148,13 @@ noop_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
 
 /*
  * This version handles any integral sampling ratios.
- * This is not used for typical JPEG files, so it need not be fast.
- * Nor, for that matter, is it particularly accurate: the algorithm is
- * simple replication of the input pixel onto the corresponding output
- * pixels.  The hi-falutin sampling literature refers to this as a
- * "box filter".  A box filter tends to introduce visible artifacts,
- * so if you are actually going to use 3:1 or 4:1 sampling ratios
- * you would be well advised to improve this code.
+ * This is not used for typical JPEG files, so it need not be fast.  Nor, for
+ * that matter, is it particularly accurate: the algorithm is simple
+ * replication of the input sample onto the corresponding output components.
+ * The hi-falutin sampling literature refers to this as a "box filter".  A box
+ * filter tends to introduce visible artifacts, so if you are actually going to
+ * use 3:1 or 4:1 sampling ratios you would be well advised to improve this
+ * code.
  */
 
 METHODDEF(void)
@@ -260,10 +260,10 @@ h2v2_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
 /*
  * Fancy processing for the common case of 2:1 horizontal and 1:1 vertical.
  *
- * The upsampling algorithm is linear interpolation between pixel centers,
- * also known as a "triangle filter".  This is a good compromise between
- * speed and visual quality.  The centers of the output pixels are 1/4 and 3/4
- * of the way between input pixel centers.
+ * The upsampling algorithm is linear interpolation between component centers,
+ * also known as a "triangle filter".  This is a good compromise between speed
+ * and visual quality.  The centers of the output components are 1/4 and 3/4 of
+ * the way between input component centers.
  *
  * A note about the "bias" calculations: when rounding fractional values to
  * integer, we do not want to always round 0.5 up to the next integer.
@@ -291,7 +291,7 @@ h2v1_fancy_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
     *outptr++ = (_JSAMPLE)((invalue * 3 + inptr[0] + 2) >> 2);
 
     for (colctr = compptr->downsampled_width - 2; colctr > 0; colctr--) {
-      /* General case: 3/4 * nearer pixel + 1/4 * further pixel */
+      /* General case: 3/4 * nearer component + 1/4 * further component */
       invalue = (*inptr++) * 3;
       *outptr++ = (_JSAMPLE)((invalue + inptr[-2] + 1) >> 2);
       *outptr++ = (_JSAMPLE)((invalue + inptr[0] + 2) >> 2);
@@ -391,8 +391,9 @@ h2v2_fancy_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
       lastcolsum = thiscolsum;  thiscolsum = nextcolsum;
 
       for (colctr = compptr->downsampled_width - 2; colctr > 0; colctr--) {
-        /* General case: 3/4 * nearer pixel + 1/4 * further pixel in each */
-        /* dimension, thus 9/16, 3/16, 3/16, 1/16 overall */
+        /* General case: 3/4 * nearer component + 1/4 * further component in
+         * each dimension, thus 9/16, 3/16, 3/16, 1/16 overall
+         */
         nextcolsum = (*inptr0++) * 3 + (*inptr1++);
         *outptr++ = (_JSAMPLE)((thiscolsum * 3 + lastcolsum + 8) >> 4);
         *outptr++ = (_JSAMPLE)((thiscolsum * 3 + nextcolsum + 7) >> 4);
@@ -421,8 +422,21 @@ _jinit_upsampler(j_decompress_ptr cinfo)
   boolean need_buffer, do_fancy;
   int h_in_group, v_in_group, h_out_group, v_out_group;
 
-  if (cinfo->data_precision != BITS_IN_JSAMPLE)
-    ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+#ifdef D_LOSSLESS_SUPPORTED
+  if (cinfo->master->lossless) {
+#if BITS_IN_JSAMPLE == 8
+    if (cinfo->data_precision > BITS_IN_JSAMPLE || cinfo->data_precision < 2)
+#else
+    if (cinfo->data_precision > BITS_IN_JSAMPLE ||
+        cinfo->data_precision < BITS_IN_JSAMPLE - 3)
+#endif
+      ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+  } else
+#endif
+  {
+    if (cinfo->data_precision != BITS_IN_JSAMPLE)
+      ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
+  }
 
   if (!cinfo->master->jinit_upsampler_no_alloc) {
     upsample = (my_upsample_ptr)
@@ -449,7 +463,7 @@ _jinit_upsampler(j_decompress_ptr cinfo)
   for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
        ci++, compptr++) {
     /* Compute size of an "input group" after IDCT scaling.  This many samples
-     * are to be converted to max_h_samp_factor * max_v_samp_factor pixels.
+     * are to be converted to max_h_samp_factor * max_v_samp_factor components.
      */
     h_in_group = (compptr->h_samp_factor * compptr->_DCT_scaled_size) /
                  cinfo->_min_DCT_scaled_size;
@@ -488,7 +502,8 @@ _jinit_upsampler(j_decompress_ptr cinfo)
                v_in_group * 2 == v_out_group && do_fancy) {
       /* Non-fancy upsampling is handled by the generic method */
 #if defined(WITH_SIMD) && (defined(__arm__) || defined(__aarch64__) || \
-                           defined(_M_ARM) || defined(_M_ARM64))
+                           defined(_M_ARM) || defined(_M_ARM64) || \
+                           defined(_M_ARM64EC))
       if (jsimd_can_h1v2_fancy_upsample())
         upsample->methods[ci] = jsimd_h1v2_fancy_upsample;
       else

--- a/jdsample.h
+++ b/jdsample.h
@@ -4,7 +4,7 @@
  * This file was part of the Independent JPEG Group's software:
  * Copyright (C) 1991-1996, Thomas G. Lane.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2022, D. R. Commander.
+ * Copyright (C) 2022, 2026, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  */
@@ -43,7 +43,7 @@ typedef struct {
   /* Height of an input row group for each component. */
   int rowgroup_height[MAX_COMPONENTS];
 
-  /* These arrays save pixel expansion factors so that int_expand need not
+  /* These arrays save component expansion factors so that int_expand need not
    * recompute them each time.  They are unused for other upsampling methods.
    */
   UINT8 h_expand[MAX_COMPONENTS];

--- a/jidctint.c
+++ b/jidctint.c
@@ -5,7 +5,7 @@
  * Copyright (C) 1991-1998, Thomas G. Lane.
  * Modification developed 2002-2018 by Guido Vollbeding.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2015, 2020, 2022, D. R. Commander.
+ * Copyright (C) 2015, 2020, 2022, 2026, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -30,7 +30,7 @@
  *
  * We also provide IDCT routines with various output sample block sizes for
  * direct resolution reduction or enlargement without additional resampling:
- * NxN (N=1...16) pixels for one 8x8 input DCT block.
+ * NxN (N=1...16) samples for one 8x8 input DCT block.
  *
  * For N<8 we simply take the corresponding low-frequency coefficients of
  * the 8x8 input DCT block and apply an NxN point IDCT on the sub-block

--- a/jidctred.c
+++ b/jidctred.c
@@ -4,12 +4,12 @@
  * This file was part of the Independent JPEG Group's software:
  * Copyright (C) 1994-1998, Thomas G. Lane.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2015, 2022, D. R. Commander.
+ * Copyright (C) 2015, 2022, 2026, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
  * This file contains inverse-DCT routines that produce reduced-size output:
- * either 4x4, 2x2, or 1x1 pixels from an 8x8 DCT block.
+ * either 4x4, 2x2, or 1x1 samples from an 8x8 DCT block.
  *
  * The implementation is based on the Loeffler, Ligtenberg and Moschytz (LL&M)
  * algorithm used in jidctint.c.  We simply replace each 8-to-8 1-D IDCT step
@@ -397,7 +397,7 @@ _jpeg_idct_1x1(j_decompress_ptr cinfo, jpeg_component_info *compptr,
   SHIFT_TEMPS
 
   /* We hardly need an inverse DCT routine for this: just take the
-   * average pixel value, which is one-eighth of the DC coefficient.
+   * average sample value, which is one-eighth of the DC coefficient.
    */
   quantptr = (ISLOW_MULT_TYPE *)compptr->dct_table;
   dcval = DEQUANTIZE(coef_block[0], quantptr[0]);

--- a/jmemmgr.c
+++ b/jmemmgr.c
@@ -4,7 +4,7 @@
  * This file was part of the Independent JPEG Group's software:
  * Copyright (C) 1991-1997, Thomas G. Lane.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2016, 2021-2022, D. R. Commander.
+ * Copyright (C) 2016, 2021-2022, 2024, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -156,8 +156,9 @@ typedef my_memory_mgr *my_mem_ptr;
 
 struct jvirt_sarray_control {
   JSAMPARRAY mem_buffer;        /* => the in-memory buffer (if
-                                   cinfo->data_precision is 12, then this is
-                                   actually a J12SAMPARRAY) */
+                                   cinfo->data_precision > 8, then this is
+                                   actually a J12SAMPARRAY or a
+                                   J16SAMPARRAY) */
   JDIMENSION rows_in_array;     /* total virtual array height */
   JDIMENSION samplesperrow;     /* width of array (and of memory buffer) */
   JDIMENSION maxaccess;         /* max rows accessed by access_virt_sarray */
@@ -449,8 +450,8 @@ alloc_sarray(j_common_ptr cinfo, int pool_id, JDIMENSION samplesperrow,
   int data_precision = cinfo->is_decompressor ?
                         ((j_decompress_ptr)cinfo)->data_precision :
                         ((j_compress_ptr)cinfo)->data_precision;
-  size_t sample_size = data_precision == 16 ?
-                       sizeof(J16SAMPLE) : (data_precision == 12 ?
+  size_t sample_size = data_precision > 12 ?
+                       sizeof(J16SAMPLE) : (data_precision > 8 ?
                                             sizeof(J12SAMPLE) :
                                             sizeof(JSAMPLE));
 
@@ -477,7 +478,44 @@ alloc_sarray(j_common_ptr cinfo, int pool_id, JDIMENSION samplesperrow,
     rowsperchunk = numrows;
   mem->last_rowsperchunk = rowsperchunk;
 
-  if (data_precision == 16) {
+  if (data_precision <= 8) {
+    /* Get space for row pointers (small object) */
+    result = (JSAMPARRAY)alloc_small(cinfo, pool_id,
+                                     (size_t)(numrows * sizeof(JSAMPROW)));
+
+    /* Get the rows themselves (large objects) */
+    currow = 0;
+    while (currow < numrows) {
+      rowsperchunk = MIN(rowsperchunk, numrows - currow);
+      workspace = (JSAMPROW)alloc_large(cinfo, pool_id,
+        (size_t)((size_t)rowsperchunk * (size_t)samplesperrow * sample_size));
+      for (i = rowsperchunk; i > 0; i--) {
+        result[currow++] = workspace;
+        workspace += samplesperrow;
+      }
+    }
+
+    return result;
+  } else if (data_precision <= 12) {
+    /* Get space for row pointers (small object) */
+    result12 = (J12SAMPARRAY)alloc_small(cinfo, pool_id,
+                                         (size_t)(numrows *
+                                                  sizeof(J12SAMPROW)));
+
+    /* Get the rows themselves (large objects) */
+    currow = 0;
+    while (currow < numrows) {
+      rowsperchunk = MIN(rowsperchunk, numrows - currow);
+      workspace12 = (J12SAMPROW)alloc_large(cinfo, pool_id,
+        (size_t)((size_t)rowsperchunk * (size_t)samplesperrow * sample_size));
+      for (i = rowsperchunk; i > 0; i--) {
+        result12[currow++] = workspace12;
+        workspace12 += samplesperrow;
+      }
+    }
+
+    return (JSAMPARRAY)result12;
+  } else {
 #if defined(C_LOSSLESS_SUPPORTED) || defined(D_LOSSLESS_SUPPORTED)
     /* Get space for row pointers (small object) */
     result16 = (J16SAMPARRAY)alloc_small(cinfo, pool_id,
@@ -501,43 +539,6 @@ alloc_sarray(j_common_ptr cinfo, int pool_id, JDIMENSION samplesperrow,
     ERREXIT1(cinfo, JERR_BAD_PRECISION, data_precision);
     return NULL;
 #endif
-  } else if (data_precision == 12) {
-    /* Get space for row pointers (small object) */
-    result12 = (J12SAMPARRAY)alloc_small(cinfo, pool_id,
-                                         (size_t)(numrows *
-                                                  sizeof(J12SAMPROW)));
-
-    /* Get the rows themselves (large objects) */
-    currow = 0;
-    while (currow < numrows) {
-      rowsperchunk = MIN(rowsperchunk, numrows - currow);
-      workspace12 = (J12SAMPROW)alloc_large(cinfo, pool_id,
-        (size_t)((size_t)rowsperchunk * (size_t)samplesperrow * sample_size));
-      for (i = rowsperchunk; i > 0; i--) {
-        result12[currow++] = workspace12;
-        workspace12 += samplesperrow;
-      }
-    }
-
-    return (JSAMPARRAY)result12;
-  } else {
-    /* Get space for row pointers (small object) */
-    result = (JSAMPARRAY)alloc_small(cinfo, pool_id,
-                                     (size_t)(numrows * sizeof(JSAMPROW)));
-
-    /* Get the rows themselves (large objects) */
-    currow = 0;
-    while (currow < numrows) {
-      rowsperchunk = MIN(rowsperchunk, numrows - currow);
-      workspace = (JSAMPROW)alloc_large(cinfo, pool_id,
-        (size_t)((size_t)rowsperchunk * (size_t)samplesperrow * sample_size));
-      for (i = rowsperchunk; i > 0; i--) {
-        result[currow++] = workspace;
-        workspace += samplesperrow;
-      }
-    }
-
-    return result;
   }
 }
 
@@ -703,8 +704,8 @@ realize_virt_arrays(j_common_ptr cinfo)
   int data_precision = cinfo->is_decompressor ?
                         ((j_decompress_ptr)cinfo)->data_precision :
                         ((j_compress_ptr)cinfo)->data_precision;
-  size_t sample_size = data_precision == 16 ?
-                       sizeof(J16SAMPLE) : (data_precision == 12 ?
+  size_t sample_size = data_precision > 12 ?
+                       sizeof(J16SAMPLE) : (data_precision > 8 ?
                                             sizeof(J12SAMPLE) :
                                             sizeof(JSAMPLE));
 
@@ -716,11 +717,11 @@ realize_virt_arrays(j_common_ptr cinfo)
   maximum_space = 0;
   for (sptr = mem->virt_sarray_list; sptr != NULL; sptr = sptr->next) {
     if (sptr->mem_buffer == NULL) { /* if not realized yet */
-      size_t new_space = (long)sptr->rows_in_array *
-                         (long)sptr->samplesperrow * sample_size;
+      size_t new_space = (size_t)sptr->rows_in_array *
+                         (size_t)sptr->samplesperrow * sample_size;
 
-      space_per_minheight += (long)sptr->maxaccess *
-                             (long)sptr->samplesperrow * sample_size;
+      space_per_minheight += (size_t)sptr->maxaccess *
+                             (size_t)sptr->samplesperrow * sample_size;
       if (SIZE_MAX - maximum_space < new_space)
         out_of_memory(cinfo, 10);
       maximum_space += new_space;
@@ -728,11 +729,11 @@ realize_virt_arrays(j_common_ptr cinfo)
   }
   for (bptr = mem->virt_barray_list; bptr != NULL; bptr = bptr->next) {
     if (bptr->mem_buffer == NULL) { /* if not realized yet */
-      size_t new_space = (long)bptr->rows_in_array *
-                         (long)bptr->blocksperrow * sizeof(JBLOCK);
+      size_t new_space = (size_t)bptr->rows_in_array *
+                         (size_t)bptr->blocksperrow * sizeof(JBLOCK);
 
-      space_per_minheight += (long)bptr->maxaccess *
-                             (long)bptr->blocksperrow * sizeof(JBLOCK);
+      space_per_minheight += (size_t)bptr->maxaccess *
+                             (size_t)bptr->blocksperrow * sizeof(JBLOCK);
       if (SIZE_MAX - maximum_space < new_space)
         out_of_memory(cinfo, 11);
       maximum_space += new_space;
@@ -773,9 +774,9 @@ realize_virt_arrays(j_common_ptr cinfo)
         /* It doesn't fit in memory, create backing store. */
         sptr->rows_in_mem = (JDIMENSION)(max_minheights * sptr->maxaccess);
         jpeg_open_backing_store(cinfo, &sptr->b_s_info,
-                                (long)sptr->rows_in_array *
-                                (long)sptr->samplesperrow *
-                                (long)sample_size);
+                                (long)((size_t)sptr->rows_in_array *
+                                       (size_t)sptr->samplesperrow *
+                                       sample_size));
         sptr->b_s_open = TRUE;
       }
       sptr->mem_buffer = alloc_sarray(cinfo, JPOOL_IMAGE,
@@ -797,9 +798,9 @@ realize_virt_arrays(j_common_ptr cinfo)
         /* It doesn't fit in memory, create backing store. */
         bptr->rows_in_mem = (JDIMENSION)(max_minheights * bptr->maxaccess);
         jpeg_open_backing_store(cinfo, &bptr->b_s_info,
-                                (long)bptr->rows_in_array *
-                                (long)bptr->blocksperrow *
-                                (long)sizeof(JBLOCK));
+                                (long)((size_t)bptr->rows_in_array *
+                                       (size_t)bptr->blocksperrow *
+                                       sizeof(JBLOCK)));
         bptr->b_s_open = TRUE;
       }
       bptr->mem_buffer = alloc_barray(cinfo, JPOOL_IMAGE,
@@ -821,8 +822,8 @@ do_sarray_io(j_common_ptr cinfo, jvirt_sarray_ptr ptr, boolean writing)
   int data_precision = cinfo->is_decompressor ?
                         ((j_decompress_ptr)cinfo)->data_precision :
                         ((j_compress_ptr)cinfo)->data_precision;
-  size_t sample_size = data_precision == 16 ?
-                       sizeof(J16SAMPLE) : (data_precision == 12 ?
+  size_t sample_size = data_precision > 12 ?
+                       sizeof(J16SAMPLE) : (data_precision > 8 ?
                                             sizeof(J12SAMPLE) :
                                             sizeof(JSAMPLE));
 
@@ -840,7 +841,27 @@ do_sarray_io(j_common_ptr cinfo, jvirt_sarray_ptr ptr, boolean writing)
     if (rows <= 0)              /* this chunk might be past end of file! */
       break;
     byte_count = rows * bytesperrow;
-    if (data_precision == 16) {
+    if (data_precision <= 8) {
+      if (writing)
+        (*ptr->b_s_info.write_backing_store) (cinfo, &ptr->b_s_info,
+                                              (void *)ptr->mem_buffer[i],
+                                              file_offset, byte_count);
+      else
+        (*ptr->b_s_info.read_backing_store) (cinfo, &ptr->b_s_info,
+                                             (void *)ptr->mem_buffer[i],
+                                             file_offset, byte_count);
+    } else if (data_precision <= 12) {
+      J12SAMPARRAY mem_buffer12 = (J12SAMPARRAY)ptr->mem_buffer;
+
+      if (writing)
+        (*ptr->b_s_info.write_backing_store) (cinfo, &ptr->b_s_info,
+                                              (void *)mem_buffer12[i],
+                                              file_offset, byte_count);
+      else
+        (*ptr->b_s_info.read_backing_store) (cinfo, &ptr->b_s_info,
+                                             (void *)mem_buffer12[i],
+                                             file_offset, byte_count);
+    } else {
 #if defined(C_LOSSLESS_SUPPORTED) || defined(D_LOSSLESS_SUPPORTED)
       J16SAMPARRAY mem_buffer16 = (J16SAMPARRAY)ptr->mem_buffer;
 
@@ -855,26 +876,6 @@ do_sarray_io(j_common_ptr cinfo, jvirt_sarray_ptr ptr, boolean writing)
 #else
       ERREXIT1(cinfo, JERR_BAD_PRECISION, data_precision);
 #endif
-    } else if (data_precision == 12) {
-      J12SAMPARRAY mem_buffer12 = (J12SAMPARRAY)ptr->mem_buffer;
-
-      if (writing)
-        (*ptr->b_s_info.write_backing_store) (cinfo, &ptr->b_s_info,
-                                              (void *)mem_buffer12[i],
-                                              file_offset, byte_count);
-      else
-        (*ptr->b_s_info.read_backing_store) (cinfo, &ptr->b_s_info,
-                                             (void *)mem_buffer12[i],
-                                             file_offset, byte_count);
-    } else {
-      if (writing)
-        (*ptr->b_s_info.write_backing_store) (cinfo, &ptr->b_s_info,
-                                              (void *)ptr->mem_buffer[i],
-                                              file_offset, byte_count);
-      else
-        (*ptr->b_s_info.read_backing_store) (cinfo, &ptr->b_s_info,
-                                             (void *)ptr->mem_buffer[i],
-                                             file_offset, byte_count);
     }
     file_offset += byte_count;
   }
@@ -926,8 +927,8 @@ access_virt_sarray(j_common_ptr cinfo, jvirt_sarray_ptr ptr,
   int data_precision = cinfo->is_decompressor ?
                         ((j_decompress_ptr)cinfo)->data_precision :
                         ((j_compress_ptr)cinfo)->data_precision;
-  size_t sample_size = data_precision == 16 ?
-                       sizeof(J16SAMPLE) : (data_precision == 12 ?
+  size_t sample_size = data_precision > 12 ?
+                       sizeof(J16SAMPLE) : (data_precision > 8 ?
                                             sizeof(J12SAMPLE) :
                                             sizeof(JSAMPLE));
 

--- a/jmorecfg.h
+++ b/jmorecfg.h
@@ -7,7 +7,8 @@
  * Lossless JPEG Modifications:
  * Copyright (C) 1999, Ken Murchison.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2009, 2011, 2014-2015, 2018, 2020, 2022, D. R. Commander.
+ * Copyright (C) 2009, 2011, 2014-2015, 2018, 2020, 2022, 2026,
+ *           D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -241,7 +242,9 @@ typedef int boolean;
 /* Encoder capability options: */
 
 #define C_MULTISCAN_FILES_SUPPORTED /* Multiple-scan JPEG files? */
-#define C_PROGRESSIVE_SUPPORTED     /* Progressive JPEG? (Requires MULTISCAN)*/
+#define C_PROGRESSIVE_SUPPORTED     /* Progressive JPEG?  (Requires
+                                       C_MULTISCAN_FILES_SUPPORTED and
+                                       ENTROPY_OPT_SUPPORTED) */
 #define C_LOSSLESS_SUPPORTED        /* Lossless JPEG? */
 #define ENTROPY_OPT_SUPPORTED       /* Optimization of entropy coding parms? */
 /* Note: if you selected 12-bit data precision, it is dangerous to turn off
@@ -249,21 +252,22 @@ typedef int boolean;
  * precision, so jchuff.c normally uses entropy optimization to compute
  * usable tables for higher precision.  If you don't want to do optimization,
  * you'll have to supply different default Huffman tables.
- * The exact same statements apply for progressive and lossless JPEG:
- * the default tables don't work for progressive mode or lossless mode.
- * (This may get fixed, however.)
+ * The exact same statements apply for lossless JPEG: the default tables don't
+ * work for lossless mode.  (This may get fixed, however.)
  */
 #define INPUT_SMOOTHING_SUPPORTED   /* Input image smoothing option? */
 
 /* Decoder capability options: */
 
 #define D_MULTISCAN_FILES_SUPPORTED /* Multiple-scan JPEG files? */
-#define D_PROGRESSIVE_SUPPORTED     /* Progressive JPEG? (Requires MULTISCAN)*/
-#define D_LOSSLESS_SUPPORTED        /* Lossless JPEG? */
+#define D_PROGRESSIVE_SUPPORTED     /* Progressive JPEG?  (Requires
+                                       D_MULTISCAN_FILES_SUPPORTED) */
+#define D_LOSSLESS_SUPPORTED        /* Lossless JPEG?  (Requires
+                                       D_MULTISCAN_FILES_SUPPORTED) */
 #define SAVE_MARKERS_SUPPORTED      /* jpeg_save_markers() needed? */
 #define BLOCK_SMOOTHING_SUPPORTED   /* Block smoothing? (Progressive only) */
-#define IDCT_SCALING_SUPPORTED      /* Output rescaling via IDCT? */
-#undef  UPSAMPLE_SCALING_SUPPORTED  /* Output rescaling at upsample stage? */
+#define IDCT_SCALING_SUPPORTED      /* Output rescaling via IDCT?  (Requires
+                                       DCT_ISLOW_SUPPORTED) */
 #define UPSAMPLE_MERGING_SUPPORTED  /* Fast path for sloppy upsampling? */
 #define QUANT_1PASS_SUPPORTED       /* 1-pass color quantization? */
 #define QUANT_2PASS_SUPPORTED       /* 2-pass color quantization? */

--- a/jpeg_nbits.c
+++ b/jpeg_nbits.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, D. R. Commander.
+ * Copyright (C) 2024-2025, D. R. Commander.
  *
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
@@ -17,7 +17,7 @@
  * encoders can reuse jpeg_nbits_table from the SSE2 baseline Huffman encoder.
  */
 #if (defined(__x86_64__) || defined(__i386__) || defined(_M_IX86) || \
-     defined(_M_X64)) && defined(WITH_SIMD)
+     (defined(_M_X64) && !defined(_M_ARM64EC))) && defined(WITH_SIMD)
 #undef INCLUDE_JPEG_NBITS_TABLE
 #endif
 

--- a/jpeg_nbits.h
+++ b/jpeg_nbits.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014, 2021, 2024, D. R. Commander.
+ * Copyright (C) 2014, 2021, 2024-2025, D. R. Commander.
  * Copyright (C) 2014, Olle Liljenzin.
  * Copyright (C) 2020, Arm Limited.
  *
@@ -23,7 +23,7 @@
 
 /* NOTE: Both GCC and Clang define __GNUC__ */
 #if (defined(__GNUC__) && (defined(__arm__) || defined(__aarch64__))) || \
-    defined(_M_ARM) || defined(_M_ARM64)
+    defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #if !defined(__thumb__) || defined(__thumb2__)
 #define USE_CLZ_INTRINSIC
 #endif

--- a/jpeglib.h
+++ b/jpeglib.h
@@ -86,22 +86,26 @@ extern "C" {
 /* Data structures for images (arrays of samples and of DCT coefficients).
  */
 
-typedef JSAMPLE *JSAMPROW;      /* ptr to one image row of pixel samples. */
-typedef JSAMPROW *JSAMPARRAY;   /* ptr to some rows (a 2-D sample array) */
-typedef JSAMPARRAY *JSAMPIMAGE; /* a 3-D sample array: top index is color */
+typedef JSAMPLE *JSAMPROW;      /* ptr to one image row of pixel samples with
+                                   2-bit through 8-bit data precision. */
+typedef JSAMPROW *JSAMPARRAY;   /* ptr to some JSAMPLE rows (a 2-D JSAMPLE
+                                   array) */
+typedef JSAMPARRAY *JSAMPIMAGE; /* a 3-D JSAMPLE array: top index is color */
 
-typedef J12SAMPLE *J12SAMPROW;      /* ptr to one image row of 12-bit pixel
-                                       samples. */
-typedef J12SAMPROW *J12SAMPARRAY;   /* ptr to some 12-bit sample rows (a 2-D
-                                       12-bit sample array) */
-typedef J12SAMPARRAY *J12SAMPIMAGE; /* a 3-D 12-bit sample array: top index is
+typedef J12SAMPLE *J12SAMPROW;      /* ptr to one image row of pixel samples
+                                       with 9-bit through 12-bit data
+                                       precision. */
+typedef J12SAMPROW *J12SAMPARRAY;   /* ptr to some J12SAMPLE rows (a 2-D
+                                       J12SAMPLE array) */
+typedef J12SAMPARRAY *J12SAMPIMAGE; /* a 3-D J12SAMPLE array: top index is
                                        color */
 
-typedef J16SAMPLE *J16SAMPROW;      /* ptr to one image row of 16-bit pixel
-                                       samples. */
-typedef J16SAMPROW *J16SAMPARRAY;   /* ptr to some 16-bit sample rows (a 2-D
-                                       16-bit sample array) */
-typedef J16SAMPARRAY *J16SAMPIMAGE; /* a 3-D 16-bit sample array: top index is
+typedef J16SAMPLE *J16SAMPROW;      /* ptr to one image row of pixel samples
+                                       with 13-bit through 16-bit data
+                                       precision. */
+typedef J16SAMPROW *J16SAMPARRAY;   /* ptr to some J16SAMPLE rows (a 2-D
+                                       J16SAMPLE array) */
+typedef J16SAMPARRAY *J16SAMPIMAGE; /* a 3-D J16SAMPLE array: top index is
                                        color */
 
 typedef JCOEF JBLOCK[DCTSIZE2]; /* one block of coefficients */
@@ -708,11 +712,12 @@ struct jpeg_decompress_struct {
    */
 
   JSAMPLE *sample_range_limit;  /* table for fast range-limiting
-                                   If data_precision is 12 or 16, then this is
-                                   actually a J12SAMPLE pointer or a J16SAMPLE
-                                   pointer, so callers must type-cast it in
-                                   order to read 12-bit or 16-bit samples from
-                                   the array. */
+                                   If data_precision is 9 to 12, then this is
+                                   actually a J12SAMPLE pointer, and if
+                                   data_precision is 13 to 16, then this is
+                                   actually a J16SAMPLE pointer, so callers
+                                   must type-cast it in order to read samples
+                                   from the array. */
 
   /*
    * These fields are valid during any one scan.

--- a/jpegtran.c
+++ b/jpegtran.c
@@ -4,7 +4,7 @@
  * This file was part of the Independent JPEG Group's software:
  * Copyright (C) 1995-2019, Thomas G. Lane, Guido Vollbeding.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2010, 2014, 2017, 2019-2022, 2024, D. R. Commander.
+ * Copyright (C) 2010, 2014, 2017, 2019-2022, 2024, 2026, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -37,7 +37,9 @@ static const char *progname;    /* program name for error messages */
 static char *icc_filename;      /* for -icc switch */
 static JDIMENSION max_scans;    /* for -maxscans switch */
 static char *outfilename;       /* for -outfile switch */
+#if TRANSFORMS_SUPPORTED
 static char *dropfilename;      /* for -drop switch */
+#endif
 static boolean report;          /* for -report switch */
 static boolean strict;          /* for -strict switch */
 static JCOPY_OPTION copyoption; /* -copy switch */
@@ -74,8 +76,6 @@ usage(void)
   fprintf(stderr, "  -grayscale     Reduce to grayscale (omit color data)\n");
   fprintf(stderr, "  -perfect       Fail if there is non-transformable edge blocks\n");
   fprintf(stderr, "  -rotate [90|180|270]         Rotate image (degrees clockwise)\n");
-#endif
-#if TRANSFORMS_SUPPORTED
   fprintf(stderr, "  -transpose     Transpose image\n");
   fprintf(stderr, "  -transverse    Transverse transpose image\n");
   fprintf(stderr, "  -trim          Drop non-transformable edge blocks\n");
@@ -140,11 +140,17 @@ parse_switches(j_compress_ptr cinfo, int argc, char **argv,
 {
   int argn;
   char *arg;
+#ifdef C_PROGRESSIVE_SUPPORTED
   boolean simple_progressive;
+#endif
+#ifdef C_MULTISCAN_FILES_SUPPORTED
   char *scansarg = NULL;        /* saves -scans parm if any */
+#endif
 
   /* Set up default JPEG parameters. */
+#ifdef C_PROGRESSIVE_SUPPORTED
   simple_progressive = FALSE;
+#endif
   icc_filename = NULL;
   max_scans = 0;
   outfilename = NULL;

--- a/jsamplecomp.h
+++ b/jsamplecomp.h
@@ -93,7 +93,6 @@
 
 /* Image I/O functions (cdjpeg.h) */
 #ifdef C_LOSSLESS_SUPPORTED
-#define _jinit_read_gif  j16init_read_gif
 #define _jinit_read_ppm  j16init_read_ppm
 #endif
 
@@ -209,7 +208,6 @@
 #define _buffer  buffer12
 
 /* Image I/O functions (cdjpeg.h) */
-#define _jinit_read_gif  j12init_read_gif
 #define _jinit_write_gif  j12init_write_gif
 #define _jinit_read_ppm  j12init_read_ppm
 #define _jinit_write_ppm  j12init_write_ppm
@@ -324,7 +322,6 @@
 #define _buffer  buffer
 
 /* Image I/O functions (cdjpeg.h) */
-#define _jinit_read_gif  jinit_read_gif
 #define _jinit_write_gif  jinit_write_gif
 #define _jinit_read_ppm  jinit_read_ppm
 #define _jinit_write_ppm  jinit_write_ppm

--- a/jstdhuff.c
+++ b/jstdhuff.c
@@ -4,7 +4,7 @@
  * This file was part of the Independent JPEG Group's software:
  * Copyright (C) 1991-1998, Thomas G. Lane.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2013, 2022, D. R. Commander.
+ * Copyright (C) 2013, 2022, 2024, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -25,7 +25,7 @@ add_huff_table(j_common_ptr cinfo, JHUFF_TBL **htblptr, const UINT8 *bits,
 
   if (*htblptr == NULL)
     *htblptr = jpeg_alloc_huff_table(cinfo);
-  else
+  else if (cinfo->is_decompressor)
     return;
 
   /* Copy the number-of-symbols-of-each-code-length counts */

--- a/jversion.h.in
+++ b/jversion.h.in
@@ -4,7 +4,7 @@
  * This file was part of the Independent JPEG Group's software:
  * Copyright (C) 1991-2020, Thomas G. Lane, Guido Vollbeding.
  * libjpeg-turbo Modifications:
- * Copyright (C) 2010, 2012-2024, D. R. Commander.
+ * Copyright (C) 2010, 2012-2026, D. R. Commander.
  * For conditions of distribution and use, see the accompanying README.ijg
  * file.
  *
@@ -37,11 +37,11 @@
  */
 
 #define JCOPYRIGHT1 \
-  "Copyright (C) 2009-2024 D. R. Commander\n" \
+  "Copyright (C) 2009-2026 D. R. Commander\n" \
+  "Copyright (C) 2015-2016, 2018, 2022 Matthieu Darbois\n" \
+  "Copyright (C) 2019-2021 Arm Limited\n" \
   "Copyright (C) 2015, 2020 Google, Inc.\n" \
-  "Copyright (C) 2019-2020 Arm Limited\n" \
-  "Copyright (C) 2015-2016, 2018 Matthieu Darbois\n" \
-  "Copyright (C) 2011-2016 Siarhei Siamashka\n" \
+  "Copyright (C) 2011, 2014, 2016 Siarhei Siamashka\n" \
   "Copyright (C) 2015 Intel Corporation\n"
 #define JCOPYRIGHT2 \
   "Copyright (C) 2013-2014 Linaro Limited\n" \


### PR DESCRIPTION
Update the vendored libjpeg-turbo third-party library from the previous import to 3.1.4.

Upstream release: https://github.com/libjpeg-turbo/libjpeg-turbo/releases/tag/3.1.4
Upstream changelog: https://github.com/libjpeg-turbo/libjpeg-turbo/blob/3.1.4/ChangeLog.md


All 35 JPEG-related tests pass locally with this update.

Generated with the `update-third-party` skill.


Closes #6386
Relates to #6380