### PR TITLE
ENH: Install openjpeg.h to subdir path expected by itk_openjpeg.h

### DIFF
--- a/Modules/ThirdParty/OpenJPEG/src/openjpeg/src/lib/openjp2/CMakeLists.txt
+++ b/Modules/ThirdParty/OpenJPEG/src/openjpeg/src/lib/openjp2/CMakeLists.txt
@@ -121,12 +121,12 @@ install(TARGETS ${INSTALL_LIBS}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Libraries
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Libraries
 )
-# --ITK]]
 
 # Install includes files
 install(FILES openjpeg.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${OPENJPEG_INSTALL_SUBDIR} COMPONENT Headers
 )
+# --ITK]]
 
 # -- ITK Begin
 # Apply user-defined properties to the library target.
@@ -146,6 +146,11 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/openjpeg_mangle.h
   ${CMAKE_CURRENT_BINARY_DIR}/opj_config.h
   DESTINATION ${ITK3P_INSTALL_INCLUDE_DIR}
+  COMPONENT Development
+)
+install(FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/openjpeg.h
+  DESTINATION ${ITK3P_INSTALL_INCLUDE_DIR}/openjpeg/src/lib/openjp2
   COMPONENT Development
 )
 #-- ITK End


### PR DESCRIPTION
Install `openjpeg.h` to `openjpeg/src/lib/openjp2/` within `ITK3P_INSTALL_INCLUDE_DIR` so the path matches the `#include <openjpeg/src/lib/openjp2/openjpeg.h>` directive in `itk_openjpeg.h.in` when using the install tree.

<details>
<summary>AI assistance</summary>

GitHub Copilot identified the mismatch between the include path in `itk_openjpeg.h.in` and the flat install location; user verified the fix and staged the change before committing.

</details>