### PR TITLE
COMP: Declare ITKGoogleTest TEST_DEPENDS for all modules with gtest drivers

### DIFF
--- a/Modules/Core/Common/itk-module.cmake
+++ b/Modules/Core/Common/itk-module.cmake
@@ -26,6 +26,7 @@ itk_module(
   COMPILE_DEPENDS
     ITKKWSys
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKMesh
     ITKImageIntensity

--- a/Modules/Core/ImageAdaptors/itk-module.cmake
+++ b/Modules/Core/ImageAdaptors/itk-module.cmake
@@ -12,6 +12,7 @@ itk_module(
   COMPILE_DEPENDS
     ITKCommon
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKCommon
   DESCRIPTION "${DOCUMENTATION}"

--- a/Modules/Core/ImageFunction/itk-module.cmake
+++ b/Modules/Core/ImageFunction/itk-module.cmake
@@ -16,6 +16,7 @@ itk_module(
     ITKTransform
     ITKStatistics
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
   DESCRIPTION "${DOCUMENTATION}"
 )

--- a/Modules/Core/QuadEdgeMesh/itk-module.cmake
+++ b/Modules/Core/QuadEdgeMesh/itk-module.cmake
@@ -79,6 +79,7 @@ itk_module(
     ITKCommon
     ITKMesh
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKMesh
   DESCRIPTION "${DOCUMENTATION}"

--- a/Modules/Core/SpatialObjects/itk-module.cmake
+++ b/Modules/Core/SpatialObjects/itk-module.cmake
@@ -19,6 +19,7 @@ itk_module(
     ITKMetaIO
     ITKMesh
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKMetaIO
     ITKMesh

--- a/Modules/Filtering/AnisotropicDiffusionLBR/itk-module.cmake
+++ b/Modules/Filtering/AnisotropicDiffusionLBR/itk-module.cmake
@@ -17,6 +17,7 @@ itk_module(
     ITKImageGradient
   TEST_DEPENDS
     ITKTestKernel
+    ITKGoogleTest
   DESCRIPTION "${DOCUMENTATION}"
   EXCLUDE_FROM_DEFAULT
   # Header only library, no ENABLE_SHARED

--- a/Modules/Filtering/DiffusionTensorImage/itk-module.cmake
+++ b/Modules/Filtering/DiffusionTensorImage/itk-module.cmake
@@ -11,6 +11,7 @@ itk_module(
   DEPENDS
     ITKSpatialObjects
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKImageFeature
   DESCRIPTION "${DOCUMENTATION}"

--- a/Modules/Filtering/DistanceMap/itk-module.cmake
+++ b/Modules/Filtering/DistanceMap/itk-module.cmake
@@ -12,6 +12,7 @@ itk_module(
     ITKImageLabel
     ITKNarrowBand
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
   DESCRIPTION "${DOCUMENTATION}"
 )

--- a/Modules/Filtering/FFT/itk-module.cmake
+++ b/Modules/Filtering/FFT/itk-module.cmake
@@ -22,6 +22,7 @@ itk_module(
   COMPILE_DEPENDS
     ITKImageGrid
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKImageCompare
     ITKImageIntensity

--- a/Modules/Filtering/ImageFeature/itk-module.cmake
+++ b/Modules/Filtering/ImageFeature/itk-module.cmake
@@ -18,6 +18,7 @@ itk_module(
     ITKMesh
     ITKImageStatistics
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKThresholding
   DESCRIPTION "${DOCUMENTATION}"

--- a/Modules/Filtering/ImageFilterBase/itk-module.cmake
+++ b/Modules/Filtering/ImageFilterBase/itk-module.cmake
@@ -13,6 +13,7 @@ itk_module(
   COMPILE_DEPENDS
     ITKCommon
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKImageIntensity
   DESCRIPTION "${DOCUMENTATION}"

--- a/Modules/Filtering/ImageFrequency/itk-module.cmake
+++ b/Modules/Filtering/ImageFrequency/itk-module.cmake
@@ -16,6 +16,7 @@ itk_module(
   DEPENDS
     ITKCommon
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKImageIntensity
     ITKFFT

--- a/Modules/Filtering/ImageGradient/itk-module.cmake
+++ b/Modules/Filtering/ImageGradient/itk-module.cmake
@@ -13,6 +13,7 @@ itk_module(
   COMPILE_DEPENDS
     ITKImageAdaptors
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
   DESCRIPTION "${DOCUMENTATION}"
 )

--- a/Modules/Filtering/ImageGrid/itk-module.cmake
+++ b/Modules/Filtering/ImageGrid/itk-module.cmake
@@ -11,6 +11,7 @@ itk_module(
   COMPILE_DEPENDS
     ITKImageFunction
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKSmoothing
     ITKImageSources

--- a/Modules/Filtering/ImageStatistics/itk-module.cmake
+++ b/Modules/Filtering/ImageStatistics/itk-module.cmake
@@ -15,6 +15,7 @@ itk_module(
     ITKSpatialObjects
     ITKImageCompose
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKIOGDCM
     ITKIOMeta

--- a/Modules/Filtering/MathematicalMorphology/itk-module.cmake
+++ b/Modules/Filtering/MathematicalMorphology/itk-module.cmake
@@ -17,6 +17,7 @@ itk_module(
     ITKThresholding
     ITKConnectedComponents
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
   DESCRIPTION "${DOCUMENTATION}"
 )

--- a/Modules/Filtering/Smoothing/itk-module.cmake
+++ b/Modules/Filtering/Smoothing/itk-module.cmake
@@ -14,6 +14,7 @@ itk_module(
     ITKImageFunction
     ITKImageSources
   TEST_DEPENDS
+    ITKGoogleTest
     ITKConvolution
     ITKTestKernel
   DESCRIPTION "${DOCUMENTATION}"

--- a/Modules/IO/GDCM/itk-module.cmake
+++ b/Modules/IO/GDCM/itk-module.cmake
@@ -14,6 +14,7 @@ itk_module(
   PRIVATE_DEPENDS
     ITKGDCM
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKGDCM
     ITKImageIntensity

--- a/Modules/IO/IOMeshSWC/itk-module.cmake
+++ b/Modules/IO/IOMeshSWC/itk-module.cmake
@@ -15,6 +15,7 @@ itk_module(
     ITKIOMeshBase
   TEST_DEPENDS
     ITKTestKernel
+    ITKGoogleTest
   DESCRIPTION
     "Read and write meshes from SWC files, a format for representing neuron morphology."
   EXCLUDE_FROM_DEFAULT

--- a/Modules/IO/ImageBase/itk-module.cmake
+++ b/Modules/IO/ImageBase/itk-module.cmake
@@ -16,6 +16,7 @@ itk_module(
   DEPENDS
     ITKCommon
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKIOGDCM
     ITKIOMeta

--- a/Modules/IO/MeshVTK/itk-module.cmake
+++ b/Modules/IO/MeshVTK/itk-module.cmake
@@ -14,6 +14,7 @@ itk_module(
   COMPILE_DEPENDS
     ITKMesh
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKQuadEdgeMesh
   FACTORY_NAMES

--- a/Modules/IO/TIFF/itk-module.cmake
+++ b/Modules/IO/TIFF/itk-module.cmake
@@ -12,6 +12,7 @@ itk_module(
   PRIVATE_DEPENDS
     ITKTIFF
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
   FACTORY_NAMES
     ImageIO::TIFF

--- a/Modules/IO/TransformMatlab/itk-module.cmake
+++ b/Modules/IO/TransformMatlab/itk-module.cmake
@@ -10,6 +10,7 @@ itk_module(
   DEPENDS
     ITKIOTransformBase
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
   FACTORY_NAMES
     TransformIO::Matlab

--- a/Modules/IO/VTK/itk-module.cmake
+++ b/Modules/IO/VTK/itk-module.cmake
@@ -14,6 +14,7 @@ itk_module(
     ITKExpat
     ITKZLIB
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKImageSources
     ITKZLIB

--- a/Modules/Numerics/Optimizersv4/itk-module.cmake
+++ b/Modules/Numerics/Optimizersv4/itk-module.cmake
@@ -18,6 +18,7 @@ itk_module(
     ITKImageGrid
     ITKDisplacementField
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKMetricsv4
   DESCRIPTION "${DOCUMENTATION}"

--- a/Modules/Numerics/Statistics/itk-module.cmake
+++ b/Modules/Numerics/Statistics/itk-module.cmake
@@ -15,6 +15,7 @@ itk_module(
     ITKCommon
     ITKNetlib
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKImageIntensity
     ITKImageCompose

--- a/Modules/Registration/Common/itk-module.cmake
+++ b/Modules/Registration/Common/itk-module.cmake
@@ -39,6 +39,7 @@ itk_module(
     ITKDisplacementField
     ITKStatistics
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKDistanceMap
     ITKImageSources

--- a/Modules/Registration/FPFH/itk-module.cmake
+++ b/Modules/Registration/FPFH/itk-module.cmake
@@ -18,6 +18,7 @@ itk_module(
     ITKTestKernel
     ITKMetaIO
     ITKIOMeshBase
+    ITKGoogleTest
   DESCRIPTION
     "Fast Point Feature Histogram (FPFH) descriptors for point-set registration."
   EXCLUDE_FROM_DEFAULT

--- a/Modules/Segmentation/ConnectedComponents/itk-module.cmake
+++ b/Modules/Segmentation/ConnectedComponents/itk-module.cmake
@@ -14,6 +14,7 @@ itk_module(
     ITKImageGrid
     ITKImageLabel
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
   DESCRIPTION "${DOCUMENTATION}"
 )

--- a/Modules/Segmentation/DeformableMesh/itk-module.cmake
+++ b/Modules/Segmentation/DeformableMesh/itk-module.cmake
@@ -14,6 +14,7 @@ itk_module(
     ITKImageFeature
     ITKAnisotropicSmoothing
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
   DESCRIPTION "${DOCUMENTATION}"
 )

--- a/Modules/Segmentation/LevelSets/itk-module.cmake
+++ b/Modules/Segmentation/LevelSets/itk-module.cmake
@@ -24,6 +24,7 @@ itk_module(
   COMPILE_DEPENDS
     ITKIOImageBase
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
   DESCRIPTION "${DOCUMENTATION}"
 )

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/itk-module.cmake
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/itk-module.cmake
@@ -13,6 +13,7 @@ itk_module(
     ITKStatistics
     ITKClassifiers
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
   DESCRIPTION "${DOCUMENTATION}"
 )

--- a/Modules/Segmentation/SignedDistanceFunction/itk-module.cmake
+++ b/Modules/Segmentation/SignedDistanceFunction/itk-module.cmake
@@ -11,6 +11,7 @@ itk_module(
   DEPENDS
     ITKImageFunction
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
   DESCRIPTION "${DOCUMENTATION}"
 )


### PR DESCRIPTION
Modules that call `creategoogletestdriver` (which links `GTest::gtest`) must declare `ITKGoogleTest` in `TEST_DEPENDS`, or they fail at configure with "Target ... GTest::gtest ... not found" whenever `ITKGoogleTest` isn't otherwise enabled. Reported by @dzenanz for AnisotropicDiffusionLBR; an audit found the same omission in two more ingested modules and across many core modules.

This PR adds the missing `ITKGoogleTest` dependency:
- **Reachable bug** (3 `EXCLUDE_FROM_DEFAULT` ingested modules, one commit each): `AnisotropicDiffusionLBR`, `IOMeshSWC`, `Fpfh`.
- **Hygiene** (one commit): 30 core default-on modules that relied on `ITKGoogleTest` being present transitively.

<details>
<summary>Why this was latent / why CI didn't catch it</summary>

Full default builds enable `ITKGoogleTest` (core modules use it), so `GTest::gtest` exists and a missing declaration is masked. The failure surfaces only when a module is enabled without `ITKGoogleTest` otherwise present — e.g. `ITK_BUILD_DEFAULT_MODULES=OFF` with just an opt-in module, which is the a-la-carte path the `EXCLUDE_FROM_DEFAULT` ingested modules are meant to support. The 30 core modules were never broken in practice, but the explicit dependency is correct and makes minimal/partial configurations robust.

</details>

<details>
<summary>Commits</summary>

1. `COMP: Add ITKGoogleTest dependency to AnisotropicDiffusionLBR tests`
2. `COMP: Add ITKGoogleTest dependency to IOMeshSWC tests`
3. `COMP: Add ITKGoogleTest dependency to Fpfh tests`
4. `COMP: Declare ITKGoogleTest dependency across remaining gtest-driver modules` (30 core modules)

</details>

<details>
<summary>Local validation</summary>

Minimal config (`ITK_BUILD_DEFAULT_MODULES=OFF`, `BUILD_TESTING=ON`, Ninja, internal Eigen3):
- Base `upstream/main`: configure fails for the three ingested modules at the exact `creategoogletestdriver` lines (`GTest::gtest` not found).
- This branch: configure exits 0; `AnisotropicDiffusionLBRGTestDriver`, `IOMeshSWCGTestDriver`, `FpfhGTestDriver` all build and link.

Default config (full module set): reconfigure after the hygiene commit exits 0 with no dependency cycle (`ITKGoogleTest` has empty `DEPENDS`). `pre-commit run --all-files` passes.

</details>

<!--
provenance: claude-code session 2026-06-05
reported_by: dzenanz (email) - AnisotropicDiffusionLBRGTestDriver links GTest::gtest, target not found
root_cause: creategoogletestdriver needs ITKGoogleTest in TEST_DEPENDS
scope: 3 EXCLUDE_FROM_DEFAULT ingested modules (reachable bug) + 30 core default-on modules (hygiene)
validated: minimal ITK_BUILD_DEFAULT_MODULES=OFF build base-fails/branch-passes; default reconfigure exit 0 no cycle
-->
