### PR TITLE
BUG: Free XML_Parser on all exit paths in XMLReaderBase::parse()

### DIFF
--- a/Modules/IO/XML/src/itkXMLFile.cxx
+++ b/Modules/IO/XML/src/itkXMLFile.cxx
@@ -64,7 +64,8 @@ extern "C"
 void
 XMLReaderBase::parse()
 {
-  XML_Parser Parser = XML_ParserCreate(nullptr);
+  std::unique_ptr<XML_ParserStruct, decltype(&XML_ParserFree)> parserGuard(XML_ParserCreate(nullptr), XML_ParserFree);
+  XML_Parser                                                   Parser = parserGuard.get();
 
   XML_SetElementHandler(Parser, &itkXMLParserStartElement, &itkXMLParserEndElement);
 
@@ -109,7 +110,6 @@ XMLReaderBase::parse()
     exception.SetDescription(message.c_str());
     throw exception;
   }
-  XML_ParserFree(Parser);
 }
 
 void


### PR DESCRIPTION
Fix memory leak in `itk::XMLReaderBase::parse()` when XML parsing raises an exception.

<details>
<summary>Root cause</summary>

`XML_ParserCreate()` allocated the expat parser at the top of `parse()`, but `XML_ParserFree()` was only called on the normal return path. Element handlers (e.g., in `PolygonGroupSpatialObjectXMLFileReader`) can throw `itk::ExceptionObject` through `XML_Parse()`, bypassing the free call and leaking the parser and all its internal buffers.

The fix wraps the handle in `std::unique_ptr<XML_ParserStruct, decltype(&XML_ParserFree)>` so it is freed on every exit path.

</details>

<details>
<summary>AI assistance</summary>

- Tool: GitHub Copilot (Claude Sonnet 4.6)
- Role: identified root cause from CDash valgrind report, implemented RAII fix, verified with local valgrind run

Local verification: `valgrind --leak-check=full` on `itkPolygonGroupXMLMalformedTest` went from 2,192 bytes definitely lost / 11,800 indirectly lost to "All heap blocks were freed -- no leaks are possible."

</details>