### PR TITLE
BUG: Fix JPEG2000ImageIOFactory leak in factory test

### DIFF
--- a/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOFactoryTest01.cxx
+++ b/Modules/IO/JPEG2000/test/itkJPEG2000ImageIOFactoryTest01.cxx
@@ -32,7 +32,7 @@ itkJPEG2000ImageIOFactoryTest01(int /*argc */, char * /*argv*/[])
 
   std::cout << "ClassName = " << factory->GetNameOfClass() << std::endl;
 
-  const itk::JPEG2000ImageIOFactory::Pointer factory2 = itk::JPEG2000ImageIOFactory::FactoryNew();
+  const itk::JPEG2000ImageIOFactory::Pointer factory2 = itk::JPEG2000ImageIOFactory::New();
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Replace `FactoryNew()` with `New()` in the JPEG2000 factory test to eliminate a 429-byte valgrind-confirmed memory leak reported by nightly dynamic analysis.

<details>
<summary>Root cause</summary>

`FactoryNew()` returns a raw `JPEG2000ImageIOFactory*` with reference count 1 — `LightObject::LightObject()` always initialises `m_ReferenceCount` to 1. Assigning that pointer directly to a `SmartPointer` calls `Register()`, raising the count to 2. When the `SmartPointer` destructs it calls `UnRegister()` once, leaving the count at 1 and the object permanently unreachable.

`New()` (generated by `itkFactorylessNewMacro`) compensates by calling `rawPtr->UnRegister()` immediately after wrapping the pointer, so the returned `SmartPointer` owns the object at refcount 1 and frees it correctly on destruction. `FactoryNew()` is a raw-pointer API designed for the dynamic-loading `itkLoad` convention, not for direct `SmartPointer` assignment.

Valgrind confirmed: before fix, 429 bytes (128 direct + 301 indirect) definitely lost; after fix, `All heap blocks were freed -- no leaks are possible`.

</details>

<details>
<summary>AI assistance</summary>

- Tool: GitHub Copilot (Claude Sonnet 4.6)
- Role: fetched CDash report, traced reference-count lifecycle through `LightObject`, `SmartPointer`, and `itkFactorylessNewMacro`; identified the off-by-one in the initial refcount; proposed the one-line fix
- Fix reviewed and valgrind-verified locally before committing

</details>