### PR TITLE
STYLE: Fix missing space after mangled name

### DIFF
--- a/Modules/IO/Meta/src/itkMetaImageIO.cxx
+++ b/Modules/IO/Meta/src/itkMetaImageIO.cxx
@@ -522,7 +522,7 @@ MetaImageIO::WriteImageInformation()
       // library, which results is an unreadable/corrupt file.
       itkWarningMacro("Unsupported or empty metaData item " << key << " of type "
                                                             << metaDict[key]->GetMetaDataObjectTypeName()
-                                                            << "found, won't be written to image file");
+                                                            << " found, won't be written to image file");
       // so this entry should be skipped.
       continue;
     }


### PR DESCRIPTION
E.g.
NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEfound
should be
NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE found
