### PR TITLE
COMP: Pin DCMTK charset-conversion backend, disabling external iconv

### DIFF
--- a/Modules/ThirdParty/DCMTK/CMakeLists.txt
+++ b/Modules/ThirdParty/DCMTK/CMakeLists.txt
@@ -7,8 +7,22 @@ set(ITKDCMTK_NO_SRC 1)
 
 include(CMakeParseArguments)
 
+# oficonv is the fixed data backend; ICU and external iconv are mutually exclusive add-ons.
+set(
+  CHARSET_CONVERSION_ARGS
+  -DDCMTK_ENABLE_BUILTIN_OFICONV_DATA:BOOL=${DCMTK_ENABLE_BUILTIN_OFICONV_DATA}
+)
 if(DCMTK_USE_ICU)
   option(ITK_USE_SYSTEM_ICU "Use an installed version of ICU" OFF)
+  # ICU backend for both system and in-tree ICU; external iconv stays off.
+  list(
+    APPEND
+    CHARSET_CONVERSION_ARGS
+    -DDCMTK_WITH_STDLIBC_ICONV:BOOL=OFF
+    -DDCMTK_WITH_ICU:BOOL=ON
+    -DDCMTK_WITH_ICONV:BOOL=OFF
+    -DDCMTK_ENABLE_CHARSET_CONVERSION:STRING=ICU
+  )
   if(NOT ITK_USE_SYSTEM_ICU)
     set(ITKDCMTK_PREREQS ${ITKDCMTK_BINARY_DIR}/DCMTK_Prereqs)
     set(ITKDCMTK_ICU_LIBRARIES)
@@ -81,13 +95,7 @@ if(DCMTK_USE_ICU)
     else()
       set(ICU_ROOT_DIR ${ITKDCMTK_PREREQS})
     endif()
-    set(
-      CHARSET_CONVERSION_ARGS
-      -DDCMTK_WITH_STDLIBC_ICONV:BOOL=OFF
-      -DDCMTK_WITH_ICU:BOOL=ON
-      -DDCMTK_ENABLE_CHARSET_CONVERSION:STRING=ICU
-      -DICU_ROOT:PATH=${ICU_ROOT_DIR}
-    )
+    list(APPEND CHARSET_CONVERSION_ARGS -DICU_ROOT:PATH=${ICU_ROOT_DIR})
     itk_download_attempt_check(icu)
     ExternalProject_Add(
       icu
@@ -109,7 +117,13 @@ if(DCMTK_USE_ICU)
     set(ICU_DEPENDENCY icu)
   endif()
 else()
-  set(CHARSET_CONVERSION_ARGS -DDCMTK_WITH_ICU:BOOL=OFF)
+  # Built-in oficonv only; disable ICU and external iconv for a deterministic backend.
+  list(
+    APPEND
+    CHARSET_CONVERSION_ARGS
+    -DDCMTK_WITH_ICU:BOOL=OFF
+    -DDCMTK_WITH_ICONV:BOOL=OFF
+  )
 endif()
 
 set(
@@ -480,7 +494,6 @@ endforeach()
       -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
       -DCMAKE_INSTALL_LIBDIR:PATH=${CMAKE_INSTALL_LIBDIR}
       -DCMAKE_INSTALL_BINDIR:PATH=${CMAKE_INSTALL_BINDIR}
-      -DDCMTK_ENABLE_BUILTIN_OFICONV_DATA:BOOL=${DCMTK_ENABLE_BUILTIN_OFICONV_DATA}
       ${CHARSET_CONVERSION_ARGS}
     DEPENDS
       ${JPEG_DEPENDENCY}


### PR DESCRIPTION
Pin DCMTK's charset-conversion backend so it is fixed by ITK (built-in oficonv), not auto-discovered from the build environment, and co-locate the related options. Fixes a macOS arm64 conda/pixi configure abort where DCMTK's external-iconv probe links the SDK libiconv against the conda `iconv.h`. Config-only change to `Modules/ThirdParty/DCMTK/CMakeLists.txt`.

<details>
<summary>Why / root cause</summary>

DCMTK auto-enables `DCMTK_WITH_ICONV` when it finds an external libiconv, which then runs an iconv try-compile during configure. In a conda/pixi toolchain the conda `iconv.h` (which `#define`s `iconv → libiconv`) gets paired with the macOS SDK libiconv at link time, so the probe fails with undefined `_libiconv*` symbols and configure aborts on macOS arm64.

ITK already selects the built-in oficonv backend via `DCMTK_ENABLE_BUILTIN_OFICONV_DATA=ON`, so external libiconv is never the actual converter. Previously `DCMTK_WITH_ICONV` was left to DCMTK's auto-detection — the configured backend silently depended on whether a libiconv was discoverable in the environment. This PR sets `DCMTK_WITH_ICONV:BOOL=OFF` explicitly on every path (no-ICU, in-tree ICU, and system ICU), so the build is reproducible instead of environment-sensitive.
</details>

<details>
<summary>Failure trace (macOS arm64, pixi cxx env)</summary>

```
Undefined symbols for architecture arm64:
  "_libiconv", referenced from: _main in iconv.cc.o
  "_libiconv_open", ...
  "_libiconv_close", ...
ld: symbol(s) not found for architecture arm64
CMake/GenerateDCMTKConfigure.cmake:1029 (message)  ← analyze_iconv_flags()
```

`analyze_iconv_flags()` only runs `if(DCMTK_WITH_ICONV OR DCMTK_WITH_STDLIBC_ICONV)`; with `DCMTK_WITH_ICONV=OFF` the doomed probe is skipped entirely.
</details>

<details>
<summary>Co-location / readability</summary>

The interrelated options are assembled in one `CHARSET_CONVERSION_ARGS` variable so their relationship is visible in one place:
- `DCMTK_ENABLE_BUILTIN_OFICONV_DATA` — always-on data backend (seeded before the branch).
- ICU branch: `DCMTK_WITH_ICU=ON`, `DCMTK_WITH_ICONV=OFF`, `DCMTK_WITH_STDLIBC_ICONV=OFF`, `DCMTK_ENABLE_CHARSET_CONVERSION=ICU` — applied to **both** the in-tree and `ITK_USE_SYSTEM_ICU=ON` sub-paths; only `-DICU_ROOT` is scoped to the in-tree build.
- no-ICU branch: `DCMTK_WITH_ICU=OFF`, `DCMTK_WITH_ICONV=OFF`.

The standalone `-DDCMTK_ENABLE_BUILTIN_OFICONV_DATA` at the `ExternalProject_Add` call site is removed (now carried by `CHARSET_CONVERSION_ARGS`).
</details>

<details>
<summary>Validation</summary>

- macOS arm64 / pixi cxx env: `pixi run build-ci` now completes (exit 0); the full ITKDCMTK + IOTransformDCMTK module set builds and all test drivers link.
- Cross-platform safe: on Linux/Windows the external-iconv probe currently *succeeds* but its result is unused (oficonv is the converter), so pinning it off changes the configured backend nowhere — it only removes environment sensitivity.
</details>

<!--
provenance: claude-code session 2026-06-06 (hjmjohnson); gh-triage-pr #6407
root_cause: DCMTK auto-set DCMTK_WITH_ICONV=ON from conda libiconv; iconv try-compile linked SDK libiconv (no _libiconv*) against conda header (renames to libiconv*)
fix: explicit DCMTK_WITH_ICONV:BOOL=OFF on all paths; co-locate oficonv/ICU/iconv in CHARSET_CONVERSION_ARGS
triage_fixups_b875592: addressed 3 greptile P2 findings — two prose-budget comment trims (lines ~10 and ~122) + lifted common ICU-backend flags out of if(NOT ITK_USE_SYSTEM_ICU) so the system-ICU sub-path also disables external iconv (the gap greptile flagged at line 120)
guard: GenerateDCMTKConfigure.cmake analyze_iconv_flags gated on DCMTK_WITH_ICONV
-->
