### PR TITLE
COMP: Add <cstdint> include to RANSAC nanoflann.hpp for uint32_t

### DIFF
--- a/Modules/Registration/RANSAC/include/nanoflann.hpp
+++ b/Modules/Registration/RANSAC/include/nanoflann.hpp
@@ -48,6 +48,7 @@
 #include <array>
 #include <cassert>
 #include <cmath>   // for abs()
+#include <cstdint> // for uint32_t
 #include <cstdlib> // for abs()
 #include <functional>
 #include <istream>


### PR DESCRIPTION
Add the missing `<cstdint>` include to the RANSAC module's vendored `nanoflann.hpp` so `uint32_t` resolves on toolchains that no longer include it transitively.

<details>
<summary>Failure trace</summary>

```
nanoflann.hpp:392: error: 'uint32_t' does not name a type
note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
```

Surfaced building `main` with the pixi `cxx` environment (conda-forge GCC + libstdc++, which no longer pulls in `<cstdint>` transitively). `RANSACHeaderTest1` was the first failing unit. A full `pixi run build-ci` is green with the include added (3139/3139 objects, RANSAC test compiles and `RANSACTestDriver` links).
</details>

<details>
<summary>Note on upstream nanoflann</summary>

`nanoflann.hpp` is vendored from `jlblancoc/nanoflann`; this patches ITK's in-tree copy. The same one-line fix could be sent upstream so it survives a future re-vendor.
</details>

<!--
provenance: claude-code session 2026-06-06
commit: a18601a853 (COMP: Add <cstdint> include to RANSAC nanoflann.hpp for uint32_t)
file: Modules/Registration/RANSAC/include/nanoflann.hpp (added "#include <cstdint> // for uint32_t" between <cmath> and <cstdlib>)
validation: full pixi run build-ci green (0 FAILED, 3139/3139); pre-commit run --all-files clean
base: upstream/main 3609b55578
-->
