### PR TITLE
COMP: CI check that the remote-module list stays in sync (#4786)

### DIFF
--- a/.github/workflows/remote-module-list.yml
+++ b/.github/workflows/remote-module-list.yml
@@ -1,0 +1,34 @@
+name: Remote module list
+
+# Verify that the generated remote-module documentation page is in sync with
+# its sources (Modules/Remote/*.remote.cmake and the classification file).
+# The generator is offline and deterministic, so a stale page means the author
+# edited a source without regenerating.
+
+on:
+  pull_request:
+    paths:
+      - 'Modules/Remote/*.remote.cmake'
+      - 'Documentation/remote_modules_classification.yaml'
+      - 'Documentation/docs/scientific_ecosystem/remote_modules.md'
+      - 'Utilities/Maintenance/GenerateRemoteModuleList.py'
+      - '.github/workflows/remote-module-list.yml'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: python -m pip install pyyaml
+      - name: Verify the remote-module list is up to date
+        run: |
+          python3 Utilities/Maintenance/GenerateRemoteModuleList.py --check \
+            || {
+              echo "::error::Documentation/docs/scientific_ecosystem/remote_modules.md is out of date." \
+                   "Run 'python3 Utilities/Maintenance/GenerateRemoteModuleList.py' and commit the result."
+              exit 1
+            }


### PR DESCRIPTION
Add a CI check that keeps the generated remote-module documentation page in sync with its sources, on top of the generator added in #6409 (now merged).

The generator is offline and deterministic, so the page can only drift when someone edits a `Modules/Remote/*.remote.cmake` file or the classification file without regenerating. This workflow runs `GenerateRemoteModuleList.py --check` on PRs touching those paths and fails with the exact regeneration command if the committed page is stale.

<details>
<summary>Why a PR check and not a scheduled regenerate job</summary>

The page depends only on in-repo files, so there is no external input for a periodic job to react to — a cron regenerate would always be a no-op. The PR-time check is the correct enforcement for the current offline design. A scheduled regenerate (and the bot PR it would open) becomes meaningful only once external data is introduced — the GitHub `itk-module` topic scrape and per-repo CI status badges planned for the next PR — so it is deferred to that change.

</details>

<details>
<summary>Validation</summary>

- In-sync tree: `--check` exits 0.
- Simulated source edit without regenerating: `--check` exits 1 with the regeneration instruction.
- No untrusted `github.event.*` input is interpolated into any `run:` step.

</details>

<!--
provenance: claude-code session 2026-06-09 (hjmjohnson)
issue: #4786 ; generator #6409 merged; rebased onto upstream/main (diff is now the single workflow file)
deferred_to_pr3: scheduled regenerate + bot PR, once GitHub-topic / CI-status external data is added
runner: ubuntu-latest (jhlegarreta review r3383554868 — offline Python job, no pinned version needed)
-->
