### PR TITLE
DOC: Clear Doxygen documentation warnings (CDash Linux-Ubuntu-GCC-Doxygen)

### DIFF
--- a/Modules/Filtering/AnisotropicDiffusionLBR/itk-module.cmake
+++ b/Modules/Filtering/AnisotropicDiffusionLBR/itk-module.cmake
@@ -3,8 +3,8 @@ set(
   "This module provides coherence-enhancing (CED) and edge-enhancing
 (EED) anisotropic diffusion filters built on the
 Lattice-Basis-Reduction (LBR) stencil scheme by Jean-Marie Mirebeau.
-See the Doxygen on \\\\ref AnisotropicDiffusionLBRImageFilter and
-\\\\ref CoherenceEnhancingDiffusionImageFilter for the algorithm and
+See the Doxygen on \\\\ref itk::AnisotropicDiffusionLBRImageFilter and
+\\\\ref itk::CoherenceEnhancingDiffusionImageFilter for the algorithm and
 citations, and the module README for in-tree vs archived-upstream
 scope."
 )

--- a/Modules/Filtering/BoneEnhancement/include/itkKrcahEigenToMeasureParameterEstimationFilter.h
+++ b/Modules/Filtering/BoneEnhancement/include/itkKrcahEigenToMeasureParameterEstimationFilter.h
@@ -45,7 +45,7 @@ namespace itk
  * \f$ \gamma \f$. This is done to seperate parameter estimation from the unary
  * functor. The modification is very simple. If the average of the trace is
  * denoted \f$ T \f$ the new parameter becomes:
- *  \f{
+ *  \f{eqnarray*}{
  *      \gamma &=& 0.25 \cdot T
  *  \f}
  *

--- a/Modules/Filtering/BoneEnhancement/include/itkKrcahPreprocessingImageToImageFilter.h
+++ b/Modules/Filtering/BoneEnhancement/include/itkKrcahPreprocessingImageToImageFilter.h
@@ -32,8 +32,8 @@ namespace itk
  *
  * This filters performs an unsharp filter as defined by Krcah
  * et al. The unsharp filter is defined by:
- *  \f{
- *      J = I+k*(I-(I*G))
+ *  \f{eqnarray*}{
+ *      J &=& I+k*(I-(I*G))
  *  \f}
  *
  * Where \f$ k \f$ is a scaling constant set to 5 and the Guassian

--- a/Modules/Filtering/FixedPointInverseDisplacementField/include/itkFixedPointInverseDisplacementFieldImageFilter.h
+++ b/Modules/Filtering/FixedPointInverseDisplacementField/include/itkFixedPointInverseDisplacementFieldImageFilter.h
@@ -50,7 +50,6 @@ Medical Physics, vol. 35, issue 1, p. 81
  *
  * \author Marcel Lüthi, Computer Science Department, University of Basel
  *
- * \ingroup ImageToImageFilter
  * \ingroup FixedPointInverseDisplacementField
  */
 

--- a/Modules/Filtering/GenericLabelInterpolator/itk-module.cmake
+++ b/Modules/Filtering/GenericLabelInterpolator/itk-module.cmake
@@ -6,7 +6,7 @@ independently with any underlying ordinary image interpolator and
 returns the label with the highest interpolated value at each
 point.  Generalizes the Gaussian-only behavior of
 itkLabelImageGaussianInterpolateImageFunction.  See the Doxygen on
-\\\\ref LabelImageGenericInterpolateImageFunction for the algorithm
+\\\\ref itk::LabelImageGenericInterpolateImageFunction for the algorithm
 and the Insight Journal article (Schaerer, Roche, Belaroussi, 2014,
 https://hdl.handle.net/10380/3506) for derivation, and the module
 README for in-tree vs archived-upstream scope."

--- a/Modules/Filtering/IsotropicWavelets/include/itkRieszRotationMatrix.h
+++ b/Modules/Filtering/IsotropicWavelets/include/itkRieszRotationMatrix.h
@@ -78,12 +78,13 @@ public:
 
   /**
    * Multi-index notation
-   * S[n = (n1,...,nd)][m = (m1,...,md)]
    *
-   * S[n = (n1,...,nd)][m = (m1,...,md)] =
-   *  sqrt(\frac{m!}{n!}) \sum_{|k1| = n1} \cdots \sum_{|kd| = nd}
-   *  \delta_{k1 + k2 + k3, m} x
-   *  \\frac{n!}{k1! \cdots kd!} r_1^{k_1} \cdots r_d^{k_d}
+   * \f[
+   *  S[n = (n_1, \cdots, n_d)][m = (m_1, \cdots, m_d)] =
+   *  \sqrt{\frac{m!}{n!}} \sum_{|k_1| = n_1} \cdots \sum_{|k_d| = n_d}
+   *  \delta_{k_1 + \cdots + k_d, m} x
+   *  \frac{n!}{k_1! \cdots k_d!} r_1^{k_1} \cdots r_d^{k_d}
+   * \f]
    *
    * The indices are ordered in descending order:
    * For example, for order = 2:

--- a/Modules/Filtering/MinimalPathExtraction/include/itkArrivalFunctionToPathFilter.h
+++ b/Modules/Filtering/MinimalPathExtraction/include/itkArrivalFunctionToPathFilter.h
@@ -137,8 +137,6 @@ private:
  *
  * \author Dan Mueller, Queensland University of Technology, dan.muel[at]gmail.com
  *
- * \ingroup ImageToPathFilters
- *
  * \ingroup MinimalPathExtraction
  */
 template <typename TInputImage, typename TOutputPath = PolyLineParametricPath<TInputImage::ImageDimension>>

--- a/Modules/Filtering/MinimalPathExtraction/include/itkSpeedFunctionToPathFilter.h
+++ b/Modules/Filtering/MinimalPathExtraction/include/itkSpeedFunctionToPathFilter.h
@@ -61,8 +61,6 @@ namespace itk
  * \author Dan Mueller, Queensland University of Technology, dan.muel[at]gmail.com
  *
  * \sa ArrivalFunctionToPathFilter
- * \ingroup ImageToPathFilters
- *
  * \ingroup MinimalPathExtraction
  */
 template <typename TInputImage, typename TOutputPath = PolyLineParametricPath<TInputImage::ImageDimension>>

--- a/Modules/Filtering/ParabolicMorphology/include/itkMorphSDTHelperImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkMorphSDTHelperImageFilter.h
@@ -30,7 +30,7 @@ namespace itk
  *
  * \ingroup ParabolicMorphology
  *
- * \ingroup IntensityImageFilters  Multithreaded
+ * \ingroup IntensityImageFilters  MultiThreaded
  */
 namespace Function
 {

--- a/Modules/Filtering/PolarTransform/include/itkCartesianToPolarTransform.h
+++ b/Modules/Filtering/PolarTransform/include/itkCartesianToPolarTransform.h
@@ -50,7 +50,7 @@ namespace itk
  * \author Jakub Bican, Department of Image Processing, Institute of Information Theory and Automation, Academy of
  * Sciences of the Czech Republic.
  *
- * \ingroup Transforms
+ * \ingroup GeometricTransform
  * \ingroup PolarTransform
  */
 template <typename TParametersValueType = double, // Data type for scalars (float or double)

--- a/Modules/Filtering/PolarTransform/include/itkPolarToCartesianTransform.h
+++ b/Modules/Filtering/PolarTransform/include/itkPolarToCartesianTransform.h
@@ -48,7 +48,7 @@ namespace itk
  * \author Jakub Bican, Department of Image Processing, Institute of Information Theory and Automation, Academy of
  * Sciences of the Czech Republic.
  *
- * \ingroup Transforms
+ * \ingroup GeometricTransform
  * \ingroup PolarTransform
  */
 template <typename TParametersValueType = double, // Data type for scalars (float or double)

--- a/Modules/IO/IOMeshSTL/include/itkSTLMeshIO.h
+++ b/Modules/IO/IOMeshSTL/include/itkSTLMeshIO.h
@@ -55,8 +55,8 @@ public:
   /**-------- This part of the interfaces deals with reading data. ----- */
 
   /** Determine if the file can be read with this MeshIO implementation.
-   * \param FileNameToRead The name of the file to test for reading.
-   * \post Sets classes MeshIOBase::m_FileName variable to be FileNameToWrite
+   * \param fileName The name of the file to test for reading.
+   * \post Sets classes MeshIOBase::m_FileName variable to be fileName
    * \return Returns true if this MeshIO can read the file specified.
    */
   bool
@@ -96,8 +96,8 @@ public:
 
   /*-------- This part of the interfaces deals with writing data. ----- */
   /** Determine if the file can be written with this MeshIO implementation.
-   * \param FileNameToWrite The name of the file to test for writing.
-   * \post Sets classes MeshIOBase::m_FileName variable to be FileNameToWrite
+   * \param fileName The name of the file to test for writing.
+   * \post Sets classes MeshIOBase::m_FileName variable to be fileName
    * \return Returns true if this MeshIO can write the file specified.
    */
   bool

--- a/Modules/IO/IOMeshSWC/include/itkSWCMeshIO.h
+++ b/Modules/IO/IOMeshSWC/include/itkSWCMeshIO.h
@@ -84,8 +84,8 @@ public:
   /*-------- This part of the interfaces deals with reading data. ----- */
 
   /** Determine if the file can be read with this MeshIO implementation.
-   * \param FileNameToRead The name of the file to test for reading.
-   * \post Sets classes MeshIOBase::m_FileName variable to be FileNameToWrite
+   * \param fileName The name of the file to test for reading.
+   * \post Sets classes MeshIOBase::m_FileName variable to be fileName
    * \return Returns true if this MeshIO can read the file specified.
    */
   bool
@@ -111,8 +111,8 @@ public:
   /*-------- This part of the interfaces deals with writing data. ----- */
 
   /** Determine if the file can be written with this MeshIO implementation.
-   * \param FileNameToWrite The name of the file to test for writing.
-   * \post Sets classes MeshIOBase::m_FileName variable to be FileNameToWrite
+   * \param fileName The name of the file to test for writing.
+   * \post Sets classes MeshIOBase::m_FileName variable to be fileName
    * \return Returns true if this MeshIO can write the file specified.
    */
   bool

--- a/Modules/IO/MGHIO/include/itkMGHImageIO.h
+++ b/Modules/IO/MGHIO/include/itkMGHImageIO.h
@@ -56,7 +56,7 @@ public:
 
   /** Determine if the file can be read with this ImageIO implementation.
    * \param FileNameToRead The name of the file to test for reading.
-   * \post Sets classes ImageIOBase::m_FileName variable to be FileNameToWrite
+   * \post Sets classes ImageIOBase::m_FileName variable to be FileNameToRead
    * \return Returns true if this ImageIO can read the file specified.
    */
   bool
@@ -73,8 +73,8 @@ public:
   /*-------- This part of the interfaces deals with writing data. ----- */
 
   /** Determine if the file can be written with this ImageIO implementation.
-   * \param FileNameToWrite The name of the file to test for writing.
-   * \post Sets classes ImageIOBase::m_FileName variable to be FileNameToWrite
+   * \param name The name of the file to test for writing.
+   * \post Sets classes ImageIOBase::m_FileName variable to be name
    * \return Returns true if this ImageIO can write the file specified.
    */
   bool

--- a/Modules/Registration/Montage/itk-module.cmake
+++ b/Modules/Registration/Montage/itk-module.cmake
@@ -3,8 +3,8 @@ set(
   "This module provides Montage: mosaic-stitching and 3D
 reconstruction of large datasets from a collection of partially
 overlapping 2D slices via phase-correlation image registration.
-Core pieces are \\\\ref PhaseCorrelationImageRegistrationMethod,
-\\\\ref TileMontage, and \\\\ref TileMergeImageFilter.
+Core pieces are \\\\ref itk::PhaseCorrelationImageRegistrationMethod,
+\\\\ref itk::TileMontage, and \\\\ref itk::TileMergeImageFilter.
 See the module README for in-tree vs archived-upstream scope."
 )
 

--- a/Modules/Registration/RANSAC/include/itkRANSAC.h
+++ b/Modules/Registration/RANSAC/include/itkRANSAC.h
@@ -94,7 +94,7 @@ public:
    * Set/Get the number of threads used by the RANSAC implementation.
    *
    * @param numberOfThreads Number of threads the algorithm uses. Valid values
-   *                        are in [1, #cores].
+   *                        are in [1, \#cores].
    */
   void
   SetNumberOfThreads(unsigned int numberOfThreads);
@@ -163,7 +163,7 @@ public:
 protected:
   /**
    * Construct an instance of the RANSAC algorithm. The number of threads used
-   * in the computation is 1, valid values are in [1, #cores].
+   * in the computation is 1, valid values are in [1, \#cores].
    *
    */
   RANSAC();

--- a/Modules/Registration/VariationalRegistration/include/itkContinuousBorderWarpImageFilter.h
+++ b/Modules/Registration/VariationalRegistration/include/itkContinuousBorderWarpImageFilter.h
@@ -46,7 +46,7 @@ namespace itk
  *  and displacement field type all have the same number of dimensions.
  *
  *  \ingroup VariationalRegistration
- *  \ingroup GeometricTransforms
+ *  \ingroup GeometricTransform
  *  \ingroup MultiThreaded
  *
  *  \note This class was developed with funding from the German Research

--- a/Modules/Segmentation/GrowCut/include/FibHeap.h
+++ b/Modules/Segmentation/GrowCut/include/FibHeap.h
@@ -161,7 +161,7 @@ public:
 // FibHeap class can then be used to Insert(), ExtractMin(), etc.,
 // instances of FibHeapNode class.
 
-/// \ingroup Slicer_QtModules_Segmentations
+/// \ingroup GrowCut
 
 class GrowCut_EXPORT FibHeap
 {

--- a/Utilities/Doxygen/DoxygenConfig.cmake
+++ b/Utilities/Doxygen/DoxygenConfig.cmake
@@ -16,6 +16,7 @@ set(DOXYGEN_NUM_PROC_THREADS "0")
 set(
   DOXYGEN_ALIASES
   "starteraliasnotused=@par not used"
+  "doxygen{1}=\\ref \\1"
   "sphinx=\\par ITK Sphinx Examples: ^^ \\li <a href=\\\"https://itk.org/ITKExamples\\\">All ITK Sphinx Examples</a> ^^"
   "sphinxexample{2}=\\li <a href=\\\"https://itk.org/ITKExamples/src/\\1/Documentation.html\\\">\\2</a> ^^"
   "endsphinx=^^ ^^ ^^"
@@ -209,7 +210,7 @@ set(
 )
 set(DOXYGEN_GRAPHICAL_HIERARCHY "NO")
 set(DOXYGEN_DOT_IMAGE_FORMAT "svg")
-set(DOXYGEN_DOT_GRAPH_MAX_NODES "250")
+set(DOXYGEN_DOT_GRAPH_MAX_NODES "300")
 set(DOXYGEN_INTERACTIVE_SVG "YES")
 set(DOXYGEN_DOT_MULTI_TARGETS "YES")
 set(


### PR DESCRIPTION
Clears the Doxygen documentation warnings reported on the nightly `Linux-Ubuntu-GCC-Doxygen` dashboard (CDash build 11328394), and the same warning classes in remote modules that build did not enable. Five focused commits, one per warning class, to ease review.

<details>
<summary>What was fixed</summary>

| Commit | Warning class | Examples |
|---|---|---|
| `DOC: Fix @param names …` | `@param` name does not match the signature | MGHIO/STLMeshIO/SWCMeshIO `CanReadFile`/`CanWriteFile` (`FileNameToRead`→`fileName`, etc.); `\post` text updated to match |
| `DOC: Fix non-existing \ingroup …` | `Found non-existing group … for @ingroup` | `Multithreaded`→`MultiThreaded`, `GeometricTransforms`/`Transforms`→`GeometricTransform`, `Slicer_QtModules_Segmentations`→`GrowCut`; dropped undefined `ImageToImageFilter`/`ImageToPathFilters` |
| `DOC: Qualify class \ref … itk::` | `unable to resolve reference … for \ref` | module `DESCRIPTION` `\ref` to classes generate global-scope group pages; qualified with `itk::` (AnisotropicDiffusionLBR, GenericLabelInterpolator, Montage) |
| `DOC: Fix malformed Doxygen formula and link commands` | `Found unknown command` / `explicit link request … could not be resolved` | bare `\f{`→`\f{eqnarray*}{` (BoneEnhancement), LaTeX wrapped in `\f[ … \f]` (IsotropicWavelets), `#cores`→`\#cores` (RANSAC) |
| `COMP: Define \doxygen alias and raise DOT node limit` | unknown `\doxygen` command; inheritance graph not generated | added the `\doxygen{}` alias to `DoxygenConfig.cmake`; `DOT_GRAPH_MAX_NODES` 250→300 |

</details>

<details>
<summary>Validation</summary>

Built the `Documentation` target locally (Doxygen 1.13.2) before/after. Source-located Doxygen warnings: **63 → 0**. The CDash build-11328394 set is fully cleared. The only warnings remaining in the local run are 20 `ExternalData "not readable"` notices from Montage test data not downloaded on the workstation — these do not appear on CDash (where the data is present) and are not source-fixable.

`pre-commit run --all-files` is clean.

</details>

<!--
provenance: claude-code session 2026-06-06
branch: fix-doxygen-warnings (5 commits off upstream/main 3609b55578)
target_build: CDash 11328394 (Linux-Ubuntu-GCC-Doxygen, 20260606-0100-Nightly)
validation: cmake --build build --target Documentation; source warnings 63->0; pre-commit --all-files clean
local_only: ITK_USE_FFTWD/FFTWF were enabled in the local build cache to exercise FFT-dependent modules during doc testing; pyproject.toml intentionally NOT changed
remaining: 20 ExternalData "not readable" warnings are environmental (Montage test data not fetched locally); absent on CDash
-->
