### PR TITLE
BUG: Give racing test outputs unique names to avoid parallel collisions

### DIFF
--- a/Modules/Filtering/IsotropicWavelets/test/CMakeLists.txt
+++ b/Modules/Filtering/IsotropicWavelets/test/CMakeLists.txt
@@ -423,7 +423,7 @@ itk_add_test(
   COMMAND
     IsotropicWaveletsTestDriver
     itkIsotropicWaveletFrequencyFunctionTest
-    ${ITK_TEST_OUTPUT_DIR}/profileMotherWavelet
+    ${ITK_TEST_OUTPUT_DIR}/profileMotherWaveletHeld
     "unused"
     1
     "Held"
@@ -434,7 +434,7 @@ itk_add_test(
   COMMAND
     IsotropicWaveletsTestDriver
     itkIsotropicWaveletFrequencyFunctionTest
-    ${ITK_TEST_OUTPUT_DIR}/profileMotherWavelet
+    ${ITK_TEST_OUTPUT_DIR}/profileMotherWaveletShannon
     "unused"
     1
     "Shannon"
@@ -445,7 +445,7 @@ itk_add_test(
   COMMAND
     IsotropicWaveletsTestDriver
     itkIsotropicWaveletFrequencyFunctionTest
-    ${ITK_TEST_OUTPUT_DIR}/profileMotherWavelet
+    ${ITK_TEST_OUTPUT_DIR}/profileMotherWaveletSimoncelli
     "unused"
     1
     "Simoncelli"
@@ -456,7 +456,7 @@ itk_add_test(
   COMMAND
     IsotropicWaveletsTestDriver
     itkIsotropicWaveletFrequencyFunctionTest
-    ${ITK_TEST_OUTPUT_DIR}/profileMotherWavelet
+    ${ITK_TEST_OUTPUT_DIR}/profileMotherWaveletVow
     "unused"
     1
     "Vow"
@@ -613,10 +613,10 @@ itk_add_test(
     IsotropicWaveletsTestDriver
     # --compare
     # DATA{Baseline/vol11-16_16_16_output_expected.nrrd}
-    # ${ITK_TEST_OUTPUT_DIR}/vol11-16_16_16_L2_B2_S2.nrrd
+    # ${ITK_TEST_OUTPUT_DIR}/vol11-16_16_16_L2_B2_S2_SpatialDomain.nrrd
     itkWaveletCoeffsSpatialDomainImageFilterTest
     DATA{Input/vol11-16_16_16.nrrd}
-    ${ITK_TEST_OUTPUT_DIR}/vol11-16_16_16.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/vol11-16_16_16_SpatialDomain.nrrd
     2
     2
     Simoncelli

--- a/Modules/Filtering/LabelMap/test/CMakeLists.txt
+++ b/Modules/Filtering/LabelMap/test/CMakeLists.txt
@@ -378,7 +378,7 @@ itk_add_test(
     ITKLabelMapTestDriver
     itkBinaryImageToLabelMapFilterTest2
     DATA{${ITK_DATA_ROOT}/Input/BinaryImage1Row.bmp}
-    ${ITK_TEST_OUTPUT_DIR}/LabelImage1Row.bmp
+    ${ITK_TEST_OUTPUT_DIR}/LabelImage1Row_Test7.bmp
     255
     0
     1

--- a/Modules/IO/DCMTK/test/CMakeLists.txt
+++ b/Modules/IO/DCMTK/test/CMakeLists.txt
@@ -173,7 +173,7 @@ itk_add_test(
     ITKIODCMTKTestDriver
     itkDCMTKSeriesReadImageWrite
     DATA{${ITK_DATA_ROOT}/Input/DicomDirectionsTest/,REGEX:1020_[0-9]+.dcm}
-    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKSeriesReadImageWrite.vtk
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKDirCosinesTest.vtk
     0
     0
     0

--- a/Modules/IO/ImageBase/test/CMakeLists.txt
+++ b/Modules/IO/ImageBase/test/CMakeLists.txt
@@ -920,7 +920,7 @@ itk_add_test(
   COMMAND
     ITKIOImageBaseTestDriver
     itkReadWriteImageWithDictionaryTest
-    ${ITK_TEST_OUTPUT_DIR}/test.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkReadWriteImageWithDictionaryTest1.mha
 )
 itk_add_test(
   NAME itkVectorImageReadWriteTest

--- a/Modules/IO/MeshVTK/test/CMakeLists.txt
+++ b/Modules/IO/MeshVTK/test/CMakeLists.txt
@@ -163,7 +163,7 @@ itk_add_test(
     ITKIOMeshVTKTestDriver
     itkVTKPolyDataMeshIOTest
     DATA{Baseline/fibers.vtk}
-    ${ITK_TEST_OUTPUT_DIR}/fibers_b.vtk
+    ${ITK_TEST_OUTPUT_DIR}/fibers_b_VTKPolyDataMeshIO.vtk
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mha}
     ${ITK_TEST_OUTPUT_DIR}/binary2binaryvtk2mhaHeadMRVolume.mha
     0

--- a/Modules/IO/NIFTI/test/CMakeLists.txt
+++ b/Modules/IO/NIFTI/test/CMakeLists.txt
@@ -96,7 +96,7 @@ itk_add_test(
   COMMAND
     ITKIONIFTITestDriver
     itkNiftiImageIOTest
-    ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOLittleEndianCompressedTest.nii.gz
+    ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOLittleEndianTest.nii.gz
     itkNiftiIOLittleEndian
     DATA{${ITK_DATA_ROOT}/Input/LittleEndian.hdr,LittleEndian.mhd,LittleEndian.img}
 )

--- a/Modules/Numerics/FEM/test/CMakeLists.txt
+++ b/Modules/Numerics/FEM/test/CMakeLists.txt
@@ -463,7 +463,7 @@ itk_add_test(
     ITKFEMTestDriver
     itkFEMElement2DC0LinearQuadrilateralStrainItpackTest
     DATA{Input/2DC0LinearQuadrilateralStrainTest.meta}
-    ${ITK_TEST_OUTPUT_DIR}/2DC0LinearQuadrilateralStrainTestWrite.meta
+    ${ITK_TEST_OUTPUT_DIR}/2DC0LinearQuadrilateralStrainItpackTestWrite.meta
 )
 
 itk_add_test(

--- a/Modules/Numerics/Statistics/test/CMakeLists.txt
+++ b/Modules/Numerics/Statistics/test/CMakeLists.txt
@@ -929,7 +929,7 @@ itk_add_test(
     ITKStatisticsTestDriver
     itkImageToHistogramFilterTest2
     DATA{${ITK_DATA_ROOT}/Input/VisibleWomanEyeSlice.png}
-    ${ITK_TEST_OUTPUT_DIR}/itkImageToHistogramFilterTest2.txt
+    ${ITK_TEST_OUTPUT_DIR}/itkImageToHistogramFilterTest2_Auto.txt
     1
 )
 itk_add_test(

--- a/Modules/Registration/Common/test/RegistrationITKv3/test/CMakeLists.txt
+++ b/Modules/Registration/Common/test/RegistrationITKv3/test/CMakeLists.txt
@@ -62,8 +62,8 @@ itk_add_test(
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceShifted13x17y.png
     ${TEMP}/ImageRegistration4Test2.png
     0
-    ${TEMP}/ImageRegistration4BeforeTest.png
-    ${TEMP}/ImageRegistration4AfterTest.png
+    ${TEMP}/ImageRegistration4BeforeTest2.png
+    ${TEMP}/ImageRegistration4AfterTest2.png
     24
     10000
     0

--- a/Modules/Registration/GPUPDEDeformable/test/CMakeLists.txt
+++ b/Modules/Registration/GPUPDEDeformable/test/CMakeLists.txt
@@ -32,7 +32,7 @@ if(ITK_USE_GPU)
       50 # number of iterations
       DATA{Input/LenaFix.png}
       DATA{Input/LenaMov.png}
-      ${ITK_TEST_OUTPUT_DIR}/gpuDemonsRegistrationTest2D.mha
+      ${ITK_TEST_OUTPUT_DIR}/gpuDemonsRegistrationTest3D.mha
   )
 
   itk_add_test(

--- a/Modules/Video/BridgeOpenCV/test/CMakeLists.txt
+++ b/Modules/Video/BridgeOpenCV/test/CMakeLists.txt
@@ -93,7 +93,7 @@ itk_add_test(
     # Video Input:
     DATA{Input/inde-circulation_short.avi}
     # Output:
-    ${ITK_TEST_OUTPUT_DIR}/OpenCVVideoIOTest_Out.avi
+    ${ITK_TEST_OUTPUT_DIR}/OpenCVVideoIOFactoryTest_Out.avi
     # Webcam Number:
     0
 )

--- a/Modules/Video/BridgeVXL/test/CMakeLists.txt
+++ b/Modules/Video/BridgeVXL/test/CMakeLists.txt
@@ -37,7 +37,7 @@ itk_add_test(
     # Video Input:
     DATA{Input/inde-circulation.avi}
     # Output:
-    ${ITK_TEST_OUTPUT_DIR}/VXLVideoIOTest_Out.avi
+    ${ITK_TEST_OUTPUT_DIR}/VXLVideoIOFactoryTest_Out.avi
     # Webcam Number:
     0
 )


### PR DESCRIPTION
Several independent tests wrote the **same** `${ITK_TEST_OUTPUT_DIR}` file, so a parallel `ctest -j` run could let one test clobber another's output (flaky failures, corrupted comparison inputs). Give each test a distinct output name so no two unrelated tests share a writable path.

<details>
<summary>Renamed outputs (one side of each colliding pair)</summary>

| Module | Output → unique name |
|---|---|
| IsotropicWavelets | `profileMotherWavelet` → `…{Held,Shannon,Simoncelli,Vow}`; SpatialDomain coeffs → `…_SpatialDomain` |
| LabelMap | `LabelImage1Row.bmp` → `LabelImage1Row_Test7.bmp` (Test7) |
| DCMTK | `itkDCMTKSeriesReadImageWrite.vtk` → `itkDCMTKDirCosinesTest.vtk` (DirCosines) |
| NIFTI | `…CompressedTest.nii.gz` → `itkNiftiIOLittleEndianTest.nii.gz` (non-compressed test) |
| ImageBase | `test.mha` → `itkReadWriteImageWithDictionaryTest1.mha` |
| MeshVTK | `fibers_b.vtk` → `fibers_b_VTKPolyDataMeshIO.vtk` |
| FEM | `…StrainTestWrite.meta` → `…StrainItpackTestWrite.meta` (Itpack) |
| Statistics | `itkImageToHistogramFilterTest2.txt` → `…Test2_Auto.txt` |
| Registration (ITKv3) | `ImageRegistration4{Before,After}Test.png` → `…Test2.png` (Test2) |
| GPUPDEDeformable | `gpuDemonsRegistrationTest2D.mha` → `…Test3D.mha` (Dim3; the 2D name was wrong) |
| Video OpenCV / VXL | `…Test_Out.avi` → `…FactoryTest_Out.avi` (factory tests) |

Only writable `${ITK_TEST_OUTPUT_DIR}`/`${TEMP}` output args were changed; no `DATA{...}` inputs or baselines were touched.
</details>

<details>
<summary>How the collisions were found</summary>

A parser over all 221 `test/CMakeLists.txt` (2719 `itk_add_test` invocations) grouped every `${ITK_TEST_OUTPUT_DIR}`/`${TEMP}` output by the tests that write it, then flagged any literal output path owned by more than one test name. 13 genuine write-write collisions were found and renamed here. Cases where a file is intentionally shared (one test writes, another reads) were left alone — those are already serialized in ITK via `DEPENDS`/`FIXTURES` (ImageNoise PSNR, IOScanco read-written, JPEG2000, KdTree plots, BSplineWarping), and a few apparent collisions are false positives (shared output *prefix* with unique per-band suffixes, or filenames made unique by format extension). After this change the detector reports zero unprotected write-write collisions.
</details>

<!--
provenance: claude-code session 2026-06-06
branch: fix-test-output-races (1 commit off upstream/main)
method: deterministic CMake parser; 221 files, 2719 tests, 1716 distinct outputs; 13 write-write races renamed
verified: DATA{} untouched; detector clean post-change; pre-commit run --all-files clean
followup: a gated (ITK_REMOVE_TEST_FILES_ON_SUCCESS) per-test cleanup change is parked on local branch fix-test-cleanup-on-success, intentionally NOT in this PR
-->
