### PR TITLE
COMP: Auto-remove transient single-owner test outputs in itk_add_test

### DIFF
--- a/CMake/ITKModuleTest.cmake
+++ b/CMake/ITKModuleTest.cmake
@@ -101,21 +101,29 @@ endfunction()
 # to the value of its containing module.
 #
 function(itk_add_test)
+  # Optional ITK_REMOVE_TEMPORARY_TEST_FILES <file>... lists the transient
+  # outputs to remove after the test.  It is the only parsed keyword, so it
+  # must appear LAST: every argument following it is consumed as a file to
+  # remove.  Arguments preceding it form the add_test specification.
+  cmake_parse_arguments(_iat "" "" "ITK_REMOVE_TEMPORARY_TEST_FILES" ${ARGN})
+  set(_iat_args ${_iat_UNPARSED_ARGUMENTS})
+
   # Add tests with data in the ITKData group.
   ExternalData_Add_Test(
     ITKData
-    ${ARGN}
+    ${_iat_args}
   )
 
-  if("NAME" STREQUAL "${ARGV0}")
-    set(_iat_testname ${ARGV1})
+  list(GET _iat_args 0 _iat_arg0)
+  if("NAME" STREQUAL "${_iat_arg0}")
+    list(GET _iat_args 1 _iat_testname)
   else()
-    set(_iat_testname ${ARGV0})
+    set(_iat_testname ${_iat_arg0})
   endif()
 
   if(itk-module)
     set(_label ${itk-module})
-    if(TARGET ${itk-module}-all AND "${ARGN}" MATCHES "DATA{")
+    if(TARGET ${itk-module}-all AND "${_iat_args}" MATCHES "DATA{")
       add_dependencies(${itk-module}-all ITKData)
     endif()
   else()
@@ -129,6 +137,13 @@ function(itk_add_test)
       LABELS
         ${_label}
   )
+
+  if(_iat_ITK_REMOVE_TEMPORARY_TEST_FILES)
+    itk_add_file_test_cleanup(
+      ${_iat_testname}
+      ${_iat_ITK_REMOVE_TEMPORARY_TEST_FILES}
+    )
+  endif()
 endfunction()
 
 #-----------------------------------------------------------------------------
@@ -343,15 +358,19 @@ function(itk_memcheck_ignore)
 endfunction()
 
 #-----------------------------------------------------------------------------
-# Option to automatically remove large test output files after completion.
-# BigIO write-read tests can produce multi-gigabyte temporary files
-# that exhaust disk space on CI runners and local builds.
+# Removing transient test outputs is the default behavior: each wired test
+# gets a companion cleanup test that deletes its ${ITK_TEST_OUTPUT_DIR}
+# outputs, which otherwise accumulate (BigIO write-read tests alone produce
+# multi-gigabyte files that exhaust disk on CI runners and local builds).
+# Cleanup runs unconditionally after the test (pass, fail, or skip); a
+# developer who needs to inspect outputs must opt out by configuring with
+# -DITK_REMOVE_TEMPORARY_TEST_FILES=OFF, which retains all test outputs.
 option(
-  ITK_REMOVE_TEST_FILES_ON_SUCCESS
-  "Remove large test output files after test completion. Set OFF to retain files for debugging."
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+  "Remove transient test outputs after each test (default ON; removed even on failure). Set OFF to retain all outputs for debugging."
   ON
 )
-mark_as_advanced(ITK_REMOVE_TEST_FILES_ON_SUCCESS)
+mark_as_advanced(ITK_REMOVE_TEMPORARY_TEST_FILES)
 
 #-----------------------------------------------------------------------------
 # itk_add_file_test_cleanup(<test_name> <output_file> [<output_file2> ...])
@@ -363,7 +382,7 @@ mark_as_advanced(ITK_REMOVE_TEST_FILES_ON_SUCCESS)
 # NOTE: Per CMake documentation, FIXTURES_CLEANUP tests execute
 # unconditionally after their fixture — they run regardless of whether the
 # SETUP test passed, failed, or was skipped.  To retain output files for
-# debugging after a failure, set ITK_REMOVE_TEST_FILES_ON_SUCCESS=OFF.
+# debugging after a failure, set ITK_REMOVE_TEMPORARY_TEST_FILES=OFF.
 #
 # NOTE: In a full unfiltered run all tests (including *_cleanup variants)
 # are in the active set and fixture ordering is respected.  When rerunning
@@ -371,11 +390,11 @@ mark_as_advanced(ITK_REMOVE_TEST_FILES_ON_SUCCESS)
 # the *_cleanup test does not match; omit the anchors (ctest -R <test_name>)
 # so both the main test and its cleanup are selected.
 #
-# When ITK_REMOVE_TEST_FILES_ON_SUCCESS is OFF, no cleanup test is added
+# When ITK_REMOVE_TEMPORARY_TEST_FILES is OFF, no cleanup test is added
 # and the output files are retained for manual inspection.
 #
 function(itk_add_file_test_cleanup TEST_NAME)
-  if(NOT ITK_REMOVE_TEST_FILES_ON_SUCCESS)
+  if(NOT ITK_REMOVE_TEMPORARY_TEST_FILES)
     return()
   endif()
 
@@ -389,31 +408,24 @@ function(itk_add_file_test_cleanup TEST_NAME)
         ${FIXTURE_NAME}
   )
 
-  # Build the removal command for all output files
-  set(RM_ARGS "")
-  foreach(OUTPUT_FILE ${ARGN})
-    # For .mhd files, also remove the companion .raw/.zraw
-    get_filename_component(EXT "${OUTPUT_FILE}" LAST_EXT)
-    get_filename_component(BASE_NAME "${OUTPUT_FILE}" NAME_WLE)
-    get_filename_component(DIR "${OUTPUT_FILE}" DIRECTORY)
-    list(APPEND RM_ARGS "${OUTPUT_FILE}")
-    if("${EXT}" STREQUAL ".mhd")
-      list(APPEND RM_ARGS "${DIR}/${BASE_NAME}.raw")
-      list(APPEND RM_ARGS "${DIR}/${BASE_NAME}.zraw")
-    endif()
-  endforeach()
+  # The developer supplies the exact files and glob patterns to remove.  Each
+  # entry is forwarded verbatim; itkRemoveTestFiles.cmake expands patterns at
+  # test time and removes only the matching files (never directories).
+  set(RM_ARGS ${ARGN})
 
-  add_test(
-    NAME ${TEST_NAME}_cleanup
-    COMMAND
-      ${CMAKE_COMMAND} -E rm -f ${RM_ARGS}
-  )
-  set_tests_properties(
-    ${TEST_NAME}_cleanup
-    PROPERTIES
-      FIXTURES_CLEANUP
-        ${FIXTURE_NAME}
-      LABELS
-        "CLEANUP"
-  )
+  if(RM_ARGS)
+    add_test(
+      NAME ${TEST_NAME}_cleanup
+      COMMAND
+        ${CMAKE_COMMAND} -P ${ITK_CMAKE_DIR}/itkRemoveTestFiles.cmake ${RM_ARGS}
+    )
+    set_tests_properties(
+      ${TEST_NAME}_cleanup
+      PROPERTIES
+        FIXTURES_CLEANUP
+          ${FIXTURE_NAME}
+        LABELS
+          "CLEANUP"
+    )
+  endif()
 endfunction()

--- a/CMake/itkRemoveTestFiles.cmake
+++ b/CMake/itkRemoveTestFiles.cmake
@@ -1,0 +1,50 @@
+# Remove transient test output files matching the given path patterns.
+#
+# Invoked as a fixture cleanup command:
+#   cmake -P itkRemoveTestFiles.cmake <pattern> [<pattern> ...]
+#
+# Each pattern is expanded with file(GLOB) at test time and only the matching
+# regular files are removed.  Directories are never removed, so an unintended
+# pattern can delete individual files but can never recurse into a tree.
+#
+# A pattern may contain a single brace set "{a,b,c}" listing the extensions a
+# test actually writes for a shared stem, e.g. "foo.{mhd,raw}" expands to
+# "foo.mhd" and "foo.raw" before globbing.
+if(CMAKE_ARGC LESS 4)
+  return()
+endif()
+
+# Expand one "{a,b,c}" brace set in PATTERN into OUT_VAR (a list).
+function(_itk_expand_braces PATTERN OUT_VAR)
+  string(FIND "${PATTERN}" "{" _open)
+  string(FIND "${PATTERN}" "}" _close)
+  if(_open EQUAL -1 OR _close EQUAL -1 OR _close LESS _open)
+    set(${OUT_VAR} "${PATTERN}" PARENT_SCOPE)
+    return()
+  endif()
+  string(SUBSTRING "${PATTERN}" 0 ${_open} _prefix)
+  math(EXPR _glen "${_close} - ${_open} - 1")
+  math(EXPR _gstart "${_open} + 1")
+  string(SUBSTRING "${PATTERN}" ${_gstart} ${_glen} _group)
+  math(EXPR _sstart "${_close} + 1")
+  string(SUBSTRING "${PATTERN}" ${_sstart} -1 _suffix)
+  string(REPLACE "," ";" _opts "${_group}")
+  set(_result "")
+  foreach(_o IN LISTS _opts)
+    list(APPEND _result "${_prefix}${_o}${_suffix}")
+  endforeach()
+  set(${OUT_VAR} "${_result}" PARENT_SCOPE)
+endfunction()
+
+math(EXPR _last "${CMAKE_ARGC} - 1")
+foreach(_i RANGE 3 ${_last})
+  _itk_expand_braces("${CMAKE_ARGV${_i}}" _patterns)
+  foreach(_pat IN LISTS _patterns)
+    file(GLOB _matches "${_pat}")
+    foreach(_match IN LISTS _matches)
+      if(NOT IS_DIRECTORY "${_match}")
+        file(REMOVE "${_match}")
+      endif()
+    endforeach()
+  endforeach()
+endforeach()

--- a/CMake/stubs/itk_add_test.cmake
+++ b/CMake/stubs/itk_add_test.cmake
@@ -12,7 +12,7 @@ function(itk_add_test)
     ARG
     "COMMAND_EXPAND_LISTS"
     "NAME;WORKING_DIRECTORY"
-    "COMMAND;CONFIGURATIONS"
+    "COMMAND;CONFIGURATIONS;ITK_REMOVE_TEMPORARY_TEST_FILES"
   )
 
   # This is a stub function to assist code formatting

--- a/Modules/Bridge/VtkGlue/test/CMakeLists.txt
+++ b/Modules/Bridge/VtkGlue/test/CMakeLists.txt
@@ -82,6 +82,8 @@ if(NOT VTK_RENDERING_BACKEND STREQUAL "None")
       QuickViewTest
       DATA{${ITK_DATA_ROOT}/Input/peppers.png}
       ${ITK_TEST_OUTPUT_DIR}
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/QuickViewTest0.png
   )
   set_property(
     TEST

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -172,6 +172,8 @@ itk_add_test(
     ${TEMP}/itkColorTableTest1.txt
     itkColorTableTest
     8
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkColorTableTest1.txt
 )
 set_tests_properties(
   itkColorTableTest1
@@ -187,6 +189,8 @@ itk_add_test(
     ${TEMP}/itkColorTableTest2.txt
     itkColorTableTest
     16
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkColorTableTest2.txt
 )
 set_tests_properties(
   itkColorTableTest2
@@ -207,6 +211,8 @@ itk_add_test(
   COMMAND
     ITKCommon1TestDriver
     itkMultipleLogOutputTest
+    ${TEMP}/test_multi.txt
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${TEMP}/test_multi.txt
 )
 itk_add_test(
@@ -256,6 +262,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/sf4.png}
     0
     ${ITK_TEST_OUTPUT_DIR}/itkSobelOperatorImageConvolutionHorizTest.tiff
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSobelOperatorImageConvolutionHorizTest.tiff
 )
 itk_add_test(
   NAME itkSobelOperatorImageFilterHorizTest
@@ -268,6 +276,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/sf4.png}
     0
     ${ITK_TEST_OUTPUT_DIR}/itkSobelOperatorImageFilterHorizTest.tiff
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSobelOperatorImageFilterHorizTest.tiff
 )
 itk_add_test(
   NAME itkSobelOperatorImageConvolutionVertTest
@@ -279,6 +289,8 @@ itk_add_test(
     itkSobelOperatorImageConvolutionTest
     DATA{${ITK_DATA_ROOT}/Input/sf4.png}
     1
+    ${ITK_TEST_OUTPUT_DIR}/itkSobelOperatorImageConvolutionVertTest.tiff
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkSobelOperatorImageConvolutionVertTest.tiff
 )
 
@@ -294,6 +306,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/circle.png}
     1
     ${ITK_TEST_OUTPUT_DIR}/itkSobelOperatorImageConvolutionVertCircleTest.tiff
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSobelOperatorImageConvolutionVertCircleTest.tiff
 )
 
 itk_add_test(
@@ -307,6 +321,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/sf4.png}
     1
     ${ITK_TEST_OUTPUT_DIR}/itkSobelOperatorImageFilterVertTest.tiff
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSobelOperatorImageFilterVertTest.tiff
 )
 
 itk_add_test(
@@ -316,6 +332,8 @@ itk_add_test(
     --redirectOutput
     ${TEMP}/itkConstNeighborhoodIteratorTest.txt
     itkConstNeighborhoodIteratorTest
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkConstNeighborhoodIteratorTest.txt
 )
 set_tests_properties(
   itkConstNeighborhoodIteratorTest
@@ -331,6 +349,8 @@ itk_add_test(
     --redirectOutput
     ${TEMP}/itkShapedNeighborhoodIteratorTest.txt
     itkShapedNeighborhoodIteratorTest
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkShapedNeighborhoodIteratorTest.txt
 )
 set_tests_properties(
   itkShapedNeighborhoodIteratorTest
@@ -431,6 +451,8 @@ itk_add_test(
     itkImageDuplicatorTest2
     DATA{${ITK_DATA_ROOT}/Input/vol-raw-big.nrrd}
     ${ITK_TEST_OUTPUT_DIR}/vol-raw-big-dup2.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/vol-raw-big-dup2.nrrd
 )
 itk_add_test(
   NAME itkImageIteratorsForwardBackwardTest
@@ -455,6 +477,8 @@ itk_add_test(
   COMMAND
     ITKCommon1TestDriver
     itkImageRandomIteratorTest2
+    ${ITK_TEST_OUTPUT_DIR}/itkImageRandomIteratorTest2Output.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkImageRandomIteratorTest2Output.mha
 )
 itk_add_test(
@@ -488,12 +512,16 @@ itk_add_test(
     ITKCommon1TestDriver
     itkLoggerTest
     ${TEMP}/test_logger.txt
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/test_logger.txt
 )
 itk_add_test(
   NAME itkLoggerOutputTest
   COMMAND
     ITKCommon2TestDriver
     itkLoggerOutputTest
+    ${TEMP}/test_loggerOutput.txt
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${TEMP}/test_loggerOutput.txt
 )
 itk_add_test(
@@ -502,12 +530,16 @@ itk_add_test(
     ITKCommon2TestDriver
     itkLoggerManagerTest
     ${TEMP}/test_LoggerManager.txt
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/test_LoggerManager.txt
 )
 itk_add_test(
   NAME itkLoggerThreadWrapperTest
   COMMAND
     ITKCommon2TestDriver
     itkLoggerThreadWrapperTest
+    ${TEMP}/test_LoggerThreadWrapper.txt
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${TEMP}/test_LoggerThreadWrapper.txt
 )
 itk_add_test(
@@ -561,6 +593,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkPointSetToImageFilterTest1.png
     itkPointSetToImageFilterTest1
     ${ITK_TEST_OUTPUT_DIR}/itkPointSetToImageFilterTest1.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPointSetToImageFilterTest1.png
 )
 itk_add_test(
   NAME itkPointSetToImageFilterTest2
@@ -571,6 +605,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkPointSetToImageFilterTest2.mha
     itkPointSetToImageFilterTest2
     DATA{${ITK_DATA_ROOT}/Input/VascularTreePointSet.txt}
+    ${ITK_TEST_OUTPUT_DIR}/itkPointSetToImageFilterTest2.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkPointSetToImageFilterTest2.mha
 )
 itk_add_test(
@@ -977,6 +1013,8 @@ itk_add_test(
     --redirectOutput
     ${TEMP}/itkSliceIteratorTest.txt
     itkSliceIteratorTest
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkSliceIteratorTest.txt
 )
 set_tests_properties(
   itkSliceIteratorTest
@@ -996,12 +1034,16 @@ itk_add_test(
     ITKCommon2TestDriver
     itkStdStreamLogOutputTest
     ${TEMP}/testStreamLogOutput.txt
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/testStreamLogOutput.txt
 )
 itk_add_test(
   NAME itkThreadLoggerTest
   COMMAND
     ITKCommon2TestDriver
     itkThreadLoggerTest
+    ${TEMP}/test_threadLogger.txt
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${TEMP}/test_threadLogger.txt
 )
 itk_add_test(
@@ -1022,12 +1064,16 @@ itk_add_test(
     ITKCommon1TestDriver
     itkSymmetricSecondRankTensorImageReadTest
     ${ITK_TEST_OUTPUT_DIR}/testSymmetricTensor.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/testSymmetricTensor.nrrd
 )
 itk_add_test(
   NAME itkSymmetricSecondRankTensorImageWriteReadTest
   COMMAND
     ITKCommon1TestDriver
     itkSymmetricSecondRankTensorImageWriteReadTest
+    ${ITK_TEST_OUTPUT_DIR}/testSymmetricTensorWriteRead.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/testSymmetricTensorWriteRead.mha
 )
 itk_add_test(
@@ -1071,6 +1117,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/CellsFluorescence1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkStreamingImageFilterTest3_1.png
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkStreamingImageFilterTest3_1.png
 )
 itk_add_test(
   NAME itkStreamingImageFilterTest3_2
@@ -1083,6 +1131,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/CellsFluorescence1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkStreamingImageFilterTest3_2.png
     1000
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkStreamingImageFilterTest3_2.png
 )
 itk_add_test(
   NAME itkVariableLengthVectorTest
@@ -1285,6 +1335,8 @@ itk_add_test(
     ITKCommon2TestDriver
     itkXMLFileOutputWindowTest
     ${ITK_TEST_OUTPUT_DIR}/itkXMLFileOutputWindowTest.xml
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkXMLFileOutputWindowTest.xml
 )
 
 itk_add_test(
@@ -1295,6 +1347,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkXMLFilterWatcherTest.txt
     itkXMLFilterWatcherTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkXMLFilterWatcherTest.txt
 )
 
 if(ITK_BUILD_SHARED_LIBS AND ITK_DYNAMIC_LOADING)

--- a/Modules/Core/ImageAdaptors/test/CMakeLists.txt
+++ b/Modules/Core/ImageAdaptors/test/CMakeLists.txt
@@ -29,6 +29,9 @@ itk_add_test(
     itkVectorImageTest
     ${ITK_TEST_OUTPUT_DIR}/VectorImage.nrrd
     ${ITK_TEST_OUTPUT_DIR}/VectorImage.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/VectorImage.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/VectorImage.{mhd,raw}
 )
 itk_add_test(
   NAME itkComplexConjugateImageAdaptorTest

--- a/Modules/Core/Mesh/test/CMakeLists.txt
+++ b/Modules/Core/Mesh/test/CMakeLists.txt
@@ -144,12 +144,16 @@ itk_add_test(
     ITKMeshTestDriver
     itkTriangleMeshToBinaryImageFilterTest
     ${ITK_TEST_OUTPUT_DIR}/itkTriangleMeshToBinaryImageFilterTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTriangleMeshToBinaryImageFilterTest.mha
 )
 itk_add_test(
   NAME itkTriangleMeshToBinaryImageFilterTest1
   COMMAND
     ITKMeshTestDriver
     itkTriangleMeshToBinaryImageFilterTest1
+    ${ITK_TEST_OUTPUT_DIR}/itkTriangleMeshToBinaryImageFilterTest1.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkTriangleMeshToBinaryImageFilterTest1.mha
 )
 itk_add_test(
@@ -164,6 +168,9 @@ itk_add_test(
     --compareIntensityTolerance
     0
     itkTriangleMeshToBinaryImageFilterTest2
+    ${ITK_TEST_OUTPUT_DIR}/itkTriangleMeshToBinaryImageFilterTest2.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTriangleMeshToBinaryImageFilterTest2.txt
     ${ITK_TEST_OUTPUT_DIR}/itkTriangleMeshToBinaryImageFilterTest2.mha
 )
 set_tests_properties(
@@ -188,6 +195,8 @@ itk_add_test(
     0.01
     0.01
     0.01
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTriangleMeshToBinaryImageFilterTest3.mha
 )
 itk_add_test(
   NAME itkTriangleMeshToBinaryImageFilterTest4
@@ -205,6 +214,8 @@ itk_add_test(
     0.01
     0.01
     0.01
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTriangleMeshToBinaryImageFilterTest4.mha
 )
 itk_add_test(
   NAME itkTriangleMeshToSimplexMeshFilterTest
@@ -358,12 +369,16 @@ itk_add_test(
     ITKMeshTestDriver
     itkVTKPolyDataWriterTest01
     ${ITK_TEST_OUTPUT_DIR}/VTKPolyDataWriterTest01.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/VTKPolyDataWriterTest01.vtk
 )
 itk_add_test(
   NAME itkVTKPolyDataWriterTest02
   COMMAND
     ITKMeshTestDriver
     itkVTKPolyDataWriterTest02
+    ${ITK_TEST_OUTPUT_DIR}/VTKPolyDataWriterTest02.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/VTKPolyDataWriterTest02.vtk
 )
 itk_add_test(
@@ -399,6 +414,8 @@ itk_add_test(
     ITKMeshTestDriver
     itkMeshFstreamTest
     ${ITK_TEST_OUTPUT_DIR}/testMeshFstream.txt
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/testMeshFstream.txt
 )
 itk_add_test(
   NAME itkMeshSourceGraftOutputTest
@@ -412,6 +429,8 @@ itk_add_test(
     ITKMeshTestDriver
     itkMeshSpatialObjectIOTest
     ${ITK_TEST_OUTPUT_DIR}/metameshIOTest.txt
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/metameshIOTest.txt
 )
 itk_add_test(
   NAME itkMeshSpatialObjectIOTest1
@@ -420,6 +439,8 @@ itk_add_test(
     itkMeshSpatialObjectIOTest
     ${ITK_TEST_OUTPUT_DIR}/metameshIOTest1.txt
     binary
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/metameshIOTest1.txt
 )
 itk_add_test(
   NAME itkMeshSpatialObjectIOTest2
@@ -428,6 +449,8 @@ itk_add_test(
     itkMeshSpatialObjectIOTest
     ${ITK_TEST_OUTPUT_DIR}/metameshIOTest2.txt
     DATA{${ITK_DATA_ROOT}/Input/metamesh.txt}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/metameshIOTest2.txt
 )
 itk_add_test(
   NAME itkParametricSpaceToImageSpaceMeshFilterTest

--- a/Modules/Core/MultipleImageIterator/test/CMakeLists.txt
+++ b/Modules/Core/MultipleImageIterator/test/CMakeLists.txt
@@ -16,4 +16,6 @@ itk_add_test(
     DATA{img1.png}
     DATA{img2.png}
     DATA{img3.png}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/randOut.nrrd
 )

--- a/Modules/Core/QuadEdgeMesh/test/CMakeLists.txt
+++ b/Modules/Core/QuadEdgeMesh/test/CMakeLists.txt
@@ -82,6 +82,8 @@ itk_add_test(
     ITKQuadEdgeMeshTestDriver
     itkQuadEdgeMeshScalarDataVTKPolyDataWriterTest1
     ${ITK_TEST_OUTPUT_DIR}/sphere.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/sphere.vtk
 )
 itk_add_test(
   NAME itkQuadEdgeTest1
@@ -262,6 +264,8 @@ itk_add_test(
     ITKQuadEdgeMeshTestDriver
     itkVTKPolyDataIOQuadEdgeMeshTest
     DATA{${ITK_DATA_ROOT}/Input/genusZeroSurface01.vtk}
+    ${ITK_TEST_OUTPUT_DIR}/VTKPolyDataIOTest.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/VTKPolyDataIOTest.vtk
 )
 itk_add_test(

--- a/Modules/Core/SpatialObjects/test/CMakeLists.txt
+++ b/Modules/Core/SpatialObjects/test/CMakeLists.txt
@@ -124,12 +124,16 @@ itk_add_test(
     ITKSpatialObjectsTestDriver
     itkMetaArrowConverterTest
     ${ITK_TEST_OUTPUT_DIR}/MetaArrowConverterTestFile.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/MetaArrowConverterTestFile.mha
 )
 itk_add_test(
   NAME itkMetaGaussianConverterTest
   COMMAND
     ITKSpatialObjectsTestDriver
     itkMetaGaussianConverterTest
+    ${ITK_TEST_OUTPUT_DIR}/MetaGaussianConverterTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/MetaGaussianConverterTest.mha
 )
 itk_add_test(
@@ -165,6 +169,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/BoxSpatialObjectTest.png
     itkBoxSpatialObjectTest
     ${ITK_TEST_OUTPUT_DIR}/BoxSpatialObjectTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/BoxSpatialObjectTest.png
 )
 itk_add_test(
   NAME itkGaussianSpatialObjectTest
@@ -190,6 +196,8 @@ itk_add_test(
     itkPolygonSpatialObjectIsInsideInObjectSpaceTest
     DATA{Input/PolygonContourPoints.csv}
     DATA{Baseline/itkPolygonSpatialObjectIsInsideInObjectSpaceTest.mha}
+    ${ITK_TEST_OUTPUT_DIR}/itkPolygonSpatialObjectIsInsideInObjectSpaceTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkPolygonSpatialObjectIsInsideInObjectSpaceTest.mha
 )
 itk_add_test(
@@ -221,6 +229,8 @@ itk_add_test(
   COMMAND
     ITKSpatialObjectsTestDriver
     itkNewMetaObjectTypeTest
+    ${ITK_TEST_OUTPUT_DIR}/NewMetaObjectType.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/NewMetaObjectType.meta
 )
 

--- a/Modules/Core/TestKernel/test/CMakeLists.txt
+++ b/Modules/Core/TestKernel/test/CMakeLists.txt
@@ -28,6 +28,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkRandomImageSourceValuesTest.mha
     itkRandomImageSourceValuesTest
     ${ITK_TEST_OUTPUT_DIR}/itkRandomImageSourceValuesTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkRandomImageSourceValuesTest.mha
 )
 
 itk_add_test(

--- a/Modules/Core/Transform/test/CMakeLists.txt
+++ b/Modules/Core/Transform/test/CMakeLists.txt
@@ -209,6 +209,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest2PixelCentered.png
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest2DeformationFieldPixelCentered.mhd
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest2PixelCentered.png
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest2DeformationFieldPixelCentered.{mhd,raw}
 )
 itk_add_test(
   NAME itkBSplineDeformableTransformTest3
@@ -224,6 +227,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest3PixelCentered.png
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest3DeformationFieldPixelCentered.mhd
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest3PixelCentered.png
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest3DeformationFieldPixelCentered.{mhd,raw}
 )
 itk_add_test(
   NAME itkBSplineDeformableTransformTest4
@@ -239,6 +245,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest4PixelCentered.png
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest4DeformationFieldPixelCentered.mhd
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest4PixelCentered.png
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest4DeformationFieldPixelCentered.{mhd,raw}
 )
 itk_add_test(
   NAME itkBSplineDeformableTransformTest5
@@ -254,6 +263,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest5PixelCentered.png
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest5DeformationFieldPixelCentered.mhd
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest5PixelCentered.png
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest5DeformationFieldPixelCentered.{mhd,raw}
 )
 itk_add_test(
   NAME itkBSplineDeformableTransformTest6
@@ -269,6 +281,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest6PixelCentered.png
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest6DeformationFieldPixelCentered.mhd
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest6PixelCentered.png
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest6DeformationFieldPixelCentered.{mhd,raw}
 )
 itk_add_test(
   NAME itkBSplineDeformableTransformTest7
@@ -284,6 +299,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest7PixelCentered.png
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest7DeformationFieldPixelCentered.mhd
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest7PixelCentered.png
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineDeformableTransformTest7DeformationFieldPixelCentered.{mhd,raw}
 )
 
 ## Tests for ITKv4 version of BSplineTransforms
@@ -307,6 +325,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest2PixelCentered.png
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest2DeformationFieldPixelCentered.mhd
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest2PixelCentered.png
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest2DeformationFieldPixelCentered.{mhd,raw}
 )
 itk_add_test(
   NAME itkBSplineTransformTest3
@@ -322,6 +343,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest3PixelCentered.png
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest3DeformationFieldPixelCentered.mhd
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest3PixelCentered.png
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest3DeformationFieldPixelCentered.{mhd,raw}
 )
 itk_add_test(
   NAME itkBSplineTransformTest4
@@ -337,6 +361,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest4PixelCentered.png
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest4DeformationFieldPixelCentered.mhd
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest4PixelCentered.png
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest4DeformationFieldPixelCentered.{mhd,raw}
 )
 itk_add_test(
   NAME itkBSplineTransformTest5
@@ -352,6 +379,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest5PixelCentered.png
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest5DeformationFieldPixelCentered.mhd
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest5PixelCentered.png
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest5DeformationFieldPixelCentered.{mhd,raw}
 )
 itk_add_test(
   NAME itkBSplineTransformTest6
@@ -367,6 +397,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest6PixelCentered.png
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest6DeformationFieldPixelCentered.mhd
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest6PixelCentered.png
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest6DeformationFieldPixelCentered.{mhd,raw}
 )
 itk_add_test(
   NAME itkBSplineTransformTest7
@@ -382,6 +415,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest7PixelCentered.png
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest7DeformationFieldPixelCentered.mhd
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest7PixelCentered.png
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformTest7DeformationFieldPixelCentered.{mhd,raw}
 )
 itk_add_test(
   NAME itkBSplineTransformInitializerTest1
@@ -393,6 +429,9 @@ itk_add_test(
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceBorder20.png
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformInitializerTest1.png
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformInitializerTest1DeformationField.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformInitializerTest1.png
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineTransformInitializerTest1DeformationField.{mhd,raw}
 )
 itk_add_test(
   NAME itkBSplineTransformInitializerTest2
@@ -466,6 +505,8 @@ itk_add_test(
     itkTransformGeometryImageFilterTest
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensity3Slices.mha
     DATA{Baseline/BrainProtonDensity3SlicesHardened.mha}
+    ${ITK_TEST_OUTPUT_DIR}/BrainProtonDensity3SlicesHardened.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/BrainProtonDensity3SlicesHardened.mha
 )
 

--- a/Modules/Filtering/AdaptiveDenoising/test/CMakeLists.txt
+++ b/Modules/Filtering/AdaptiveDenoising/test/CMakeLists.txt
@@ -15,6 +15,8 @@ itk_add_test(
     DATA{Input/r16slice.nrrd}
     ${ITK_TEST_OUTPUT_DIR}/r16denoised_pearson_correlation.nrrd
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/r16denoised_pearson_correlation.nrrd
 )
 
 itk_add_test(
@@ -28,4 +30,6 @@ itk_add_test(
     DATA{Input/r16slice.nrrd}
     ${ITK_TEST_OUTPUT_DIR}/r16denoised_mean_squares.nrrd
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/r16denoised_mean_squares.nrrd
 )

--- a/Modules/Filtering/AnisotropicSmoothing/test/CMakeLists.txt
+++ b/Modules/Filtering/AnisotropicSmoothing/test/CMakeLists.txt
@@ -44,4 +44,6 @@ itk_add_test(
     itkGradientAnisotropicDiffusionImageFilterTest2
     DATA{${ITK_DATA_ROOT}/Input/cake_easy.png}
     ${ITK_TEST_OUTPUT_DIR}/GradientAnisotropicDiffusionImageFilterTest2.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/GradientAnisotropicDiffusionImageFilterTest2.png
 )

--- a/Modules/Filtering/AntiAlias/test/CMakeLists.txt
+++ b/Modules/Filtering/AntiAlias/test/CMakeLists.txt
@@ -12,4 +12,6 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkAntiAliasBinaryImageFilterTest.mha
     itkAntiAliasBinaryImageFilterTest
     ${ITK_TEST_OUTPUT_DIR}/itkAntiAliasBinaryImageFilterTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkAntiAliasBinaryImageFilterTest.mha
 )

--- a/Modules/Filtering/BSplineGradient/test/CMakeLists.txt
+++ b/Modules/Filtering/BSplineGradient/test/CMakeLists.txt
@@ -17,6 +17,8 @@ itk_add_test(
     itkImageToImageOfVectorsFilterTest
     DATA{Input/foot.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkImageToImageOfVectorsFilterTestOutput.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkImageToImageOfVectorsFilterTestOutput.mha
 )
 
 itk_add_test(
@@ -25,6 +27,8 @@ itk_add_test(
     BSplineGradientTestDriver
     itkBSplineScatteredDataPointSetToGradientImageFilterTest
     DATA{Input/foot.mha}
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineScatteredDataPointSetToGradientImageFilterTestGradientMagnitudeOutput.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineScatteredDataPointSetToGradientImageFilterTestGradientMagnitudeOutput.mha
 )
 
@@ -35,6 +39,8 @@ itk_add_test(
     itkBSplineApproximationGradientImageFilterTest
     DATA{Input/foot.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineApproximationGradientImageFilterTest
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineApproximationGradientImageFilterTestGradient*.mha
 )
 
 itk_add_test(
@@ -43,5 +49,7 @@ itk_add_test(
     BSplineGradientTestDriver
     itkBSplineGradientImageFilterTest
     DATA{Input/foot.mha}
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineGradientImageFilterTestGradientMagnitude.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineGradientImageFilterTestGradientMagnitude.mha
 )

--- a/Modules/Filtering/BiasCorrection/test/CMakeLists.txt
+++ b/Modules/Filtering/BiasCorrection/test/CMakeLists.txt
@@ -32,6 +32,8 @@ itk_add_test(
     20x20 # number of iterations
     none # mask
     200 # spline distance
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/N4ControlPoints_2D.nii.gz
 )
 itk_add_test(
   NAME itkN4BiasFieldCorrectionImageFilterTest2
@@ -48,6 +50,8 @@ itk_add_test(
     10x10x10 # number of iterations
     none # mask
     150 # spline distance
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/N4ControlPoints_3D_Test2.nii.gz
 )
 
 itk_add_test(
@@ -66,4 +70,6 @@ itk_add_test(
     none # mask
     150 # spline distance
     1 # mask label
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/N4ControlPoints_3D_Test3.nii.gz
 )

--- a/Modules/Filtering/BinaryMathematicalMorphology/test/CMakeLists.txt
+++ b/Modules/Filtering/BinaryMathematicalMorphology/test/CMakeLists.txt
@@ -37,6 +37,8 @@ itk_add_test(
     0
     255
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryClosingByReconstructionImageFilterTest.png
 )
 itk_add_test(
   NAME itkBinaryDilateImageFilterTest
@@ -64,6 +66,8 @@ itk_add_test(
     0
     0
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryDilateImageFilterTest-100-0-0.png
 )
 itk_add_test(
   NAME itkBinaryDilateImageFilterTest-100-0-1
@@ -79,6 +83,8 @@ itk_add_test(
     0
     1
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryDilateImageFilterTest-100-0-1.png
 )
 itk_add_test(
   NAME itkBinaryDilateImageFilterTest-100-150-0
@@ -94,6 +100,8 @@ itk_add_test(
     150
     0
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryDilateImageFilterTest-100-150-0.png
 )
 itk_add_test(
   NAME itkBinaryDilateImageFilterTest-100-150-1
@@ -109,6 +117,8 @@ itk_add_test(
     150
     1
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryDilateImageFilterTest-100-150-1.png
 )
 itk_add_test(
   NAME itkBinaryDilateImageFilterTest-200-0-0
@@ -124,6 +134,8 @@ itk_add_test(
     0
     0
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryDilateImageFilterTest-200-0-0.png
 )
 itk_add_test(
   NAME itkBinaryDilateImageFilterTest-200-0-1
@@ -139,6 +151,8 @@ itk_add_test(
     0
     1
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryDilateImageFilterTest-200-0-1.png
 )
 itk_add_test(
   NAME itkBinaryDilateImageFilterTest-200-150-0
@@ -154,6 +168,8 @@ itk_add_test(
     150
     0
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryDilateImageFilterTest-200-150-0.png
 )
 itk_add_test(
   NAME itkBinaryDilateImageFilterTest-200-150-1
@@ -169,6 +185,8 @@ itk_add_test(
     150
     1
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryDilateImageFilterTest-200-150-1.png
 )
 itk_add_test(
   NAME itkBinaryErodeImageFilterTest
@@ -190,6 +208,8 @@ itk_add_test(
     0
     0
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryErodeImageFilterTest-100-0-0.png
 )
 itk_add_test(
   NAME itkBinaryErodeImageFilterTest-100-0-1
@@ -205,6 +225,8 @@ itk_add_test(
     0
     1
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryErodeImageFilterTest-100-0-1.png
 )
 itk_add_test(
   NAME itkBinaryErodeImageFilterTest-100-150-0
@@ -220,6 +242,8 @@ itk_add_test(
     150
     0
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryErodeImageFilterTest-100-150-0.png
 )
 itk_add_test(
   NAME itkBinaryErodeImageFilterTest-100-150-1
@@ -235,6 +259,8 @@ itk_add_test(
     150
     1
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryErodeImageFilterTest-100-150-1.png
 )
 itk_add_test(
   NAME itkBinaryErodeImageFilterTest-200-0-0
@@ -250,6 +276,8 @@ itk_add_test(
     0
     0
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryErodeImageFilterTest-200-0-0.png
 )
 itk_add_test(
   NAME itkBinaryErodeImageFilterTest-200-0-1
@@ -265,6 +293,8 @@ itk_add_test(
     0
     1
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryErodeImageFilterTest-200-0-1.png
 )
 itk_add_test(
   NAME itkBinaryErodeImageFilterTest-200-150-0
@@ -280,6 +310,8 @@ itk_add_test(
     150
     0
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryErodeImageFilterTest-200-150-0.png
 )
 itk_add_test(
   NAME itkBinaryErodeImageFilterTest-200-150-1
@@ -295,6 +327,8 @@ itk_add_test(
     150
     1
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryErodeImageFilterTest-200-150-1.png
 )
 itk_add_test(
   NAME itkBinaryMorphologicalClosingImageFilterTest
@@ -309,6 +343,8 @@ itk_add_test(
     40
     1
     200
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryMorphologicalClosingImageFilterTest.png
 )
 itk_add_test(
   NAME itkBinaryMorphologicalClosingImageFilterTestUnsafe
@@ -323,6 +359,8 @@ itk_add_test(
     40
     0
     200
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryMorphologicalClosingImageFilterTestUnsafe.png
 )
 itk_add_test(
   NAME itkBinaryMorphologicalOpeningImageFilterTest
@@ -337,6 +375,8 @@ itk_add_test(
     8
     150
     200
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryMorphologicalOpeningImageFilterTest.png
 )
 itk_add_test(
   NAME itkBinaryOpeningByReconstructionImageFilterTest
@@ -352,6 +392,8 @@ itk_add_test(
     0
     255
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryOpeningByReconstructionImageFilterTest.png
 )
 itk_add_test(
   NAME itkBinaryThinningImageFilterTest
@@ -362,5 +404,7 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/BinaryThinningImageFilterTest.png
     itkBinaryThinningImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/Shapes.png}
+    ${ITK_TEST_OUTPUT_DIR}/BinaryThinningImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/BinaryThinningImageFilterTest.png
 )

--- a/Modules/Filtering/BoneMorphometry/test/CMakeLists.txt
+++ b/Modules/Filtering/BoneMorphometry/test/CMakeLists.txt
@@ -29,6 +29,8 @@ itk_add_test(
     DATA{Input/Scan_CBCT_13R.nrrd}
     DATA{Input/SegmC_CBCT_13R.nrrd}
     ${ITK_TEST_OUTPUT_DIR}/resultTestFilterInstantiation.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultTestFilterInstantiation.nrrd
 )
 
 itk_add_test(
@@ -41,5 +43,7 @@ itk_add_test(
     ReplaceFeatureMapNanInfImageFilterInstantiationTest
     DATA{Input/Scan_CBCT_13R.nrrd}
     DATA{Input/SegmC_CBCT_13R.nrrd}
+    ${ITK_TEST_OUTPUT_DIR}/resultTestReplaceFeatureMapNanInfImageFilter.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/resultTestReplaceFeatureMapNanInfImageFilter.nrrd
 )

--- a/Modules/Filtering/Colormap/test/CMakeLists.txt
+++ b/Modules/Filtering/Colormap/test/CMakeLists.txt
@@ -28,6 +28,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_red.png
     red
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_red.png
 )
 itk_add_test(
   NAME RGBColormapTest_green
@@ -41,6 +43,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_green.png
     green
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_green.png
 )
 itk_add_test(
   NAME RGBColormapTest_blue
@@ -54,6 +58,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_blue.png
     blue
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_blue.png
 )
 itk_add_test(
   NAME RGBColormapTest_hot
@@ -67,6 +73,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_hot.png
     hot
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_hot.png
 )
 itk_add_test(
   NAME RGBColormapTest_cool
@@ -80,6 +88,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_cool.png
     cool
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_cool.png
 )
 itk_add_test(
   NAME RGBColormapTest_spring
@@ -93,6 +103,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_spring.png
     spring
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_spring.png
 )
 itk_add_test(
   NAME RGBColormapTest_summer
@@ -106,6 +118,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_summer.png
     summer
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_summer.png
 )
 itk_add_test(
   NAME RGBColormapTest_autumn
@@ -119,6 +133,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_autumn.png
     autumn
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_autumn.png
 )
 itk_add_test(
   NAME RGBColormapTest_winter
@@ -132,6 +148,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_winter.png
     winter
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_winter.png
 )
 itk_add_test(
   NAME RGBColormapTest_copper
@@ -145,6 +163,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_copper.png
     copper
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_copper.png
 )
 itk_add_test(
   NAME RGBColormapTest_hsv
@@ -158,6 +178,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_hsv.png
     hsv
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_hsv.png
 )
 itk_add_test(
   NAME RGBColormapTest_jet
@@ -171,6 +193,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_jet.png
     jet
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_jet.png
 )
 itk_add_test(
   NAME RGBColormapTest_overunder
@@ -184,4 +208,6 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_overunder.png
     overunder
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_overunder.png
 )

--- a/Modules/Filtering/Convolution/test/CMakeLists.txt
+++ b/Modules/Filtering/Convolution/test/CMakeLists.txt
@@ -27,6 +27,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     DATA{${ITK_DATA_ROOT}/Input/sobel_x.nii.gz}
     ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterTestSobelX.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterTestSobelX.nrrd
 )
 itk_add_test(
   NAME itkConvolutionImageFilterTestSobelY
@@ -38,6 +40,8 @@ itk_add_test(
     itkConvolutionImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     DATA{${ITK_DATA_ROOT}/Input/sobel_y.nii.gz}
+    ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterTestSobelY.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterTestSobelY.nrrd
 )
 itk_add_test(
@@ -53,6 +57,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterTest4x4Mean.png
     1
     SAME
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterTest4x4Mean.png
 )
 itk_add_test(
   NAME itkConvolutionImageFilterTest4x5Mean
@@ -67,6 +73,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterTest4x5Mean.png
     1
     SAME
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterTest4x5Mean.png
 )
 itk_add_test(
   NAME itkConvolutionImageFilterTest5x5Mean
@@ -81,6 +89,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterTest5x5Mean.png
     1
     SAME
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterTest5x5Mean.png
 )
 itk_add_test(
   NAME itkConvolutionImageFilterTest4x4MeanValidRegion
@@ -95,6 +105,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterTest4x4MeanValidRegion.png
     1
     VALID
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterTest4x4MeanValidRegion.png
 )
 itk_add_test(
   NAME itkConvolutionImageFilterTest4x5MeanValidRegion
@@ -109,6 +121,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterTest4x5MeanValidRegion.png
     1
     VALID
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterTest4x5MeanValidRegion.png
 )
 itk_add_test(
   NAME itkConvolutionImageFilterTest5x5MeanValidRegion
@@ -123,6 +137,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterTest5x5MeanValidRegion.png
     1
     VALID
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterTest5x5MeanValidRegion.png
 )
 itk_add_test(
   NAME itkConvolutionImageFilterDeltaFunctionTest
@@ -133,6 +149,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterDeltaFunctionTest.png
     itkConvolutionImageFilterDeltaFunctionTest
     DATA{${ITK_DATA_ROOT}/Input/level.png}
+    ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterDeltaFunctionTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterDeltaFunctionTest.png
 )
 
@@ -148,6 +166,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     DATA{${ITK_DATA_ROOT}/Input/sobel_x.nii.gz}
     ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterTestSobelX.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterTestSobelX.nrrd
 )
 itk_add_test(
   NAME itkFFTConvolutionImageFilterTestSobelY
@@ -159,6 +179,8 @@ itk_add_test(
     itkFFTConvolutionImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     DATA{${ITK_DATA_ROOT}/Input/sobel_y.nii.gz}
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterTestSobelY.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterTestSobelY.nrrd
 )
 itk_add_test(
@@ -176,6 +198,8 @@ itk_add_test(
     0
     SAME
     PERIODIC
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterTestSobelYPeriodic.nrrd
 )
 itk_add_test(
   NAME itkFFTConvolutionImageFilterTestSobelXConstant
@@ -192,6 +216,8 @@ itk_add_test(
     0
     SAME
     CONSTANT
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterTestSobelXConstant.nrrd
 )
 itk_add_test(
   NAME itkFFTConvolutionImageFilterTestSobelXZeroFluxNeumann
@@ -208,6 +234,8 @@ itk_add_test(
     0
     VALID
     ZEROFLUXNEUMANN
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterTestSobelXZeroFluxNeumann.nrrd
 )
 itk_add_test(
   NAME itkFFTConvolutionImageFilterTest4x4Mean
@@ -222,6 +250,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterTest4x4Mean.png
     1
     SAME
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterTest4x4Mean.png
 )
 itk_add_test(
   NAME itkFFTConvolutionImageFilterTest4x5Mean
@@ -236,6 +266,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterTest4x5Mean.png
     1
     SAME
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterTest4x5Mean.png
 )
 itk_add_test(
   NAME itkFFTConvolutionImageFilterTest5x5Mean
@@ -250,6 +282,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterTest5x5Mean.png
     1
     SAME
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterTest5x5Mean.png
 )
 itk_add_test(
   NAME itkFFTConvolutionImageFilterTest4x4MeanValidRegion
@@ -264,6 +298,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterTest4x4MeanValidRegion.png
     1
     VALID
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterTest4x4MeanValidRegion.png
 )
 itk_add_test(
   NAME itkFFTConvolutionImageFilterTest4x5MeanValidRegion
@@ -278,6 +314,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterTest4x5MeanValidRegion.png
     1
     VALID
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterTest4x5MeanValidRegion.png
 )
 itk_add_test(
   NAME itkFFTConvolutionImageFilterTest5x5MeanValidRegion
@@ -292,6 +330,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterTest5x5MeanValidRegion.png
     1
     VALID
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterTest5x5MeanValidRegion.png
 )
 itk_add_test(
   NAME itkFFTConvolutionImageFilterDeltaFunctionTest
@@ -304,6 +344,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/level.png}
     ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterDeltaFunctionTest.png
     5
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterDeltaFunctionTest.png
 )
 
 # NCC tests
@@ -317,6 +359,8 @@ itk_add_test(
     itkNormalizedCorrelationImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/sf4.png}
     DATA{${ITK_DATA_ROOT}/Input/circle.png}
+    ${ITK_TEST_OUTPUT_DIR}/NormalizedCorrelationImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/NormalizedCorrelationImageFilterTest.png
 )
 
@@ -336,6 +380,8 @@ itk_add_test(
     0.1
     DATA{Input/FixedRectangleMask1.png}
     DATA{Input/MovingRectanglesMask.png}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMaskedFFTNormalizedCorrelationImageFilterTest1.png
 )
 itk_add_test(
   NAME itkMaskedFFTNormalizedCorrelationImageFilterTest2
@@ -351,6 +397,8 @@ itk_add_test(
     0.1
     DATA{Input/FixedRectangleMask2.png}
     DATA{Input/MovingRectanglesMask.png}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMaskedFFTNormalizedCorrelationImageFilterTest2.png
 )
 itk_add_test(
   NAME itkMaskedFFTNormalizedCorrelationImageFilterTest3
@@ -366,6 +414,8 @@ itk_add_test(
     0.1
     DATA{Input/FixedRectangleMask3.png}
     DATA{Input/MovingRectanglesMask.png}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMaskedFFTNormalizedCorrelationImageFilterTest3.png
 )
 # Test with different size images
 itk_add_test(
@@ -381,6 +431,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkMaskedFFTNormalizedCorrelationImageFilterTest4.png
     0.1
     DATA{Input/FixedRectangleMask3.png}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMaskedFFTNormalizedCorrelationImageFilterTest4.png
 )
 # Test with not passing the fixed mask or moving mask.
 # Also test with requiring no minimum overlapping pixels. This leads to more noise on the borders.
@@ -396,6 +448,8 @@ itk_add_test(
     DATA{Input/MovingRectangles.png}
     ${ITK_TEST_OUTPUT_DIR}/itkMaskedFFTNormalizedCorrelationImageFilterTest5.png
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMaskedFFTNormalizedCorrelationImageFilterTest5.png
 )
 # Test with not passing the moving mask. This should be the same as Test3 since the moving mask was set to all ones.
 itk_add_test(
@@ -411,6 +465,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkMaskedFFTNormalizedCorrelationImageFilterTest6.png
     0.1
     DATA{Input/FixedRectangleMask3.png}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMaskedFFTNormalizedCorrelationImageFilterTest6.png
 )
 
 # Standard FFT NCC tests
@@ -432,6 +488,8 @@ itk_add_test(
     DATA{Input/MovingRectangles.png}
     ${ITK_TEST_OUTPUT_DIR}/itkFFTNormalizedCorrelationImageFilterTest1.png
     0.1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTNormalizedCorrelationImageFilterTest1.png
 )
 itk_add_test(
   NAME itkFFTNormalizedCorrelationImageFilterTest2
@@ -445,6 +503,8 @@ itk_add_test(
     DATA{Input/MovingRectangles.png}
     ${ITK_TEST_OUTPUT_DIR}/itkFFTNormalizedCorrelationImageFilterTest2.png
     0.1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTNormalizedCorrelationImageFilterTest2.png
 )
 itk_add_test(
   NAME itkFFTNormalizedCorrelationImageFilterTest3
@@ -458,6 +518,8 @@ itk_add_test(
     DATA{Input/MovingRectangles.png}
     ${ITK_TEST_OUTPUT_DIR}/itkFFTNormalizedCorrelationImageFilterTest3.png
     0.1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTNormalizedCorrelationImageFilterTest3.png
 )
 # Test with different size images
 itk_add_test(
@@ -472,6 +534,8 @@ itk_add_test(
     DATA{Input/MovingRectanglesCropped.png}
     ${ITK_TEST_OUTPUT_DIR}/itkFFTNormalizedCorrelationImageFilterTest4.png
     0.1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTNormalizedCorrelationImageFilterTest4.png
 )
 # Test NCC of the original fixed and moving images, without masking the fixed image first.
 # The result should be the same as Test5 of MaskedFFTNormalizedCorrelation
@@ -487,6 +551,8 @@ itk_add_test(
     DATA{Input/MovingRectangles.png}
     ${ITK_TEST_OUTPUT_DIR}/itkFFTNormalizedCorrelationImageFilterTest5.png
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTNormalizedCorrelationImageFilterTest5.png
 )
 # Test with subregion
 itk_add_test(
@@ -507,6 +573,8 @@ itk_add_test(
     0
     same
     DATA{${ITK_DATA_ROOT}/Input/sobel_y.nii.gz}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterSubregionTestOutput.mha
 )
 itk_add_test(
   NAME itkFFTConvolutionImageFilterSubregionTest
@@ -526,6 +594,8 @@ itk_add_test(
     0
     same
     DATA{${ITK_DATA_ROOT}/Input/sobel_y.nii.gz}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterSubregionTestOutput.mha
 )
 itk_add_test(
   NAME itkConvolutionImageFilterSubregionTest2
@@ -545,6 +615,8 @@ itk_add_test(
     0
     same
   # with inline Gaussian kernel
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterSubregionTestOutput2.mha
 )
 itk_add_test(
   NAME itkFFTConvolutionImageFilterSubregionTest2
@@ -564,6 +636,8 @@ itk_add_test(
     0
     same
   # with inline Gaussian kernel
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterSubregionTestOutput2.mha
 )
 itk_add_test(
   NAME itkFFTConvolutionImageFilterSubregionValidTest
@@ -583,6 +657,8 @@ itk_add_test(
     0
     valid
   # with inline Gaussian kernel
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterSubregionValidTestOutput.mha
 )
 itk_add_test(
   NAME itkFFTConvolutionImageFilterSubregionNormalizeTest
@@ -602,6 +678,8 @@ itk_add_test(
     1
     same
   # with inline Gaussian kernel
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterSubregionNormalizeTestOutput.mha
 )
 itk_add_test(
   NAME itkConvolutionImageFilterStreamingTest
@@ -618,6 +696,8 @@ itk_add_test(
     75
     150
     150
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterStreamingTestOutput.mha
 )
 itk_add_test(
   NAME itkFFTConvolutionImageFilterStreamingTest
@@ -634,6 +714,8 @@ itk_add_test(
     75
     150
     150
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterStreamingTestOutput.mha
 )
 itk_add_test(
   NAME itkConvolutionImageFilterStreamingValidTest
@@ -651,6 +733,8 @@ itk_add_test(
     150
     150
     valid # use only valid input region (no pad for kernel)
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkConvolutionImageFilterStreamingValidTestOutput.mha
 )
 itk_add_test(
   NAME itkFFTConvolutionImageFilterStreamingValidTest
@@ -668,4 +752,6 @@ itk_add_test(
     150
     150
     valid # use only valid input region (no pad for kernel)
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterStreamingValidTestOutput.mha
 )

--- a/Modules/Filtering/Cuberille/test/CMakeLists.txt
+++ b/Modules/Filtering/Cuberille/test/CMakeLists.txt
@@ -30,6 +30,8 @@ itk_add_test(
     0.24 # Step length
     0.95 # Step length relaxation factor
     100 # Maximum number of steps
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/blob0-01.vtk
 )
 
 itk_add_test(
@@ -48,6 +50,8 @@ itk_add_test(
     0.24 # Step length
     0.95 # Step length relaxation factor
     100 # Maximum number of steps
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/blob1-01.vtk
 )
 
 itk_add_test(
@@ -66,6 +70,8 @@ itk_add_test(
     0.24 # Step length
     0.95 # Step length relaxation factor
     100 # Maximum number of steps
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/blob2-01.vtk
 )
 
 itk_add_test(
@@ -84,6 +90,8 @@ itk_add_test(
     0.24 # Step length
     0.95 # Step length relaxation factor
     100 # Maximum number of steps
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/blob3-01.vtk
 )
 
 itk_add_test(
@@ -102,6 +110,8 @@ itk_add_test(
     0.24 # Step length
     0.95 # Step length relaxation factor
     100 # Maximum number of steps
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/blob4-01.vtk
 )
 
 itk_add_test(
@@ -120,6 +130,8 @@ itk_add_test(
     0.24 # Step length
     0.95 # Step length relaxation factor
     200 # Maximum number of steps
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/marschnerlobb-01.vtk
 )
 
 itk_add_test(
@@ -138,6 +150,8 @@ itk_add_test(
     0.24 # Step length
     0.95 # Step length relaxation factor
     100 # Maximum number of steps
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/fuel-01.vtk
 )
 
 itk_add_test(
@@ -156,6 +170,8 @@ itk_add_test(
     0.24 # Step length
     0.95 # Step length relaxation factor
     100 # Maximum number of steps
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/fuel-02.vtk
 )
 
 itk_add_test(
@@ -174,6 +190,8 @@ itk_add_test(
     0.24 # Step length
     0.95 # Step length relaxation factor
     100 # Maximum number of steps
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/fuel-03.vtk
 )
 
 itk_add_test(
@@ -192,6 +210,8 @@ itk_add_test(
     0.24 # Step length
     0.95 # Step length relaxation factor
     100 # Maximum number of steps
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/hydrogenAtom-01.vtk
 )
 
 itk_add_test(
@@ -210,6 +230,8 @@ itk_add_test(
     0.24 # Step length
     0.95 # Step length relaxation factor
     100 # Maximum number of steps
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/neghip-01.vtk
 )
 
 itk_add_test(
@@ -228,6 +250,8 @@ itk_add_test(
     0.24 # Step length
     0.95 # Step length relaxation factor
     100 # Maximum number of steps
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/neghip-02.vtk
 )
 
 itk_add_test(
@@ -246,6 +270,8 @@ itk_add_test(
     0.24 # Step length
     0.95 # Step length relaxation factor
     100 # Maximum number of steps
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/neghip-03.vtk
 )
 
 itk_add_test(
@@ -264,6 +290,8 @@ itk_add_test(
     0.24 # Step length
     0.95 # Step length relaxation factor
     100 # Maximum number of steps
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/nucleon-01.vtk
 )
 
 itk_add_test(
@@ -282,6 +310,8 @@ itk_add_test(
     0.24 # Step length
     0.95 # Step length relaxation factor
     100 # Maximum number of steps
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/nucleon-02.vtk
 )
 
 itk_add_test(
@@ -300,6 +330,8 @@ itk_add_test(
     0.24 # Step length
     0.95 # Step length relaxation factor
     100 # Maximum number of steps
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/nucleon-03.vtk
 )
 
 itk_add_test(
@@ -318,6 +350,8 @@ itk_add_test(
     0.24 # Step length
     0.95 # Step length relaxation factor
     100 # Maximum number of steps
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/silicium-01.vtk
 )
 
 itk_add_test(
@@ -336,6 +370,8 @@ itk_add_test(
     0.24 # Step length
     0.95 # Step length relaxation factor
     100 # Maximum number of steps
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/silicium-02.vtk
 )
 
 itk_add_test(
@@ -354,6 +390,8 @@ itk_add_test(
     0.24 # Step length
     0.95 # Step length relaxation factor
     100 # Maximum number of steps
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/silicium-03.vtk
 )
 
 #add_test(
@@ -405,6 +443,8 @@ itk_add_test(
     1 # Generate triangle faces
     1 # Project vertices to iso-surface
     0.05 # Surface distance threshold
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/tibial_cartilage_cropped_0.1.vtk
 )
 
 itk_add_test(
@@ -421,6 +461,8 @@ itk_add_test(
     1 # Generate triangle faces
     1 # Project vertices to iso-surface
     0.05 # Surface distance threshold
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/tibial_cartilage_cropped_0.5.vtk
 )
 
 itk_add_test(
@@ -437,6 +479,8 @@ itk_add_test(
     1 # Generate triangle faces
     1 # Project vertices to iso-surface
     0.05 # Surface distance threshold
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/prostate_00.vtk
 )
 # Serialized: segfaults under `ctest -j3` memory pressure on constrained CI
 # runners (RAM over-subscribed via ITK_COMPUTER_MEMORY_SIZE); see issue #6301.

--- a/Modules/Filtering/CurvatureFlow/test/CMakeLists.txt
+++ b/Modules/Filtering/CurvatureFlow/test/CMakeLists.txt
@@ -19,4 +19,6 @@ itk_add_test(
     ITKCurvatureFlowTestDriver
     itkCurvatureFlowTest
     ${ITK_TEST_OUTPUT_DIR}/itkCurvatureFlowTest.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkCurvatureFlowTest.vtk
 )

--- a/Modules/Filtering/Deconvolution/test/CMakeLists.txt
+++ b/Modules/Filtering/Deconvolution/test/CMakeLists.txt
@@ -32,6 +32,8 @@ itk_add_test(
     DATA{Input/itkDeconvolutionImageFilterTestKernel.png}
     ${ITK_TEST_OUTPUT_DIR}/itkRichardsonLucyDeconvolutionImageFilterGaussianKernelTest.nrrd
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkRichardsonLucyDeconvolutionImageFilterGaussianKernelTest.nrrd
 )
 itk_add_test(
   NAME itkRichardsonLucyDeconvolutionImageFilterIrregularKernelTest
@@ -45,6 +47,8 @@ itk_add_test(
     DATA{Input/itkDeconvolutionImageFilterTestKernelIrregular.tif}
     ${ITK_TEST_OUTPUT_DIR}/itkRichardsonLucyDeconvolutionImageFilterIrregularKernelTest.nrrd
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkRichardsonLucyDeconvolutionImageFilterIrregularKernelTest.nrrd
 )
 itk_add_test(
   NAME itkRichardsonLucyDeconvolutionImageFilterNonNullImageOriginTest
@@ -58,6 +62,8 @@ itk_add_test(
     DATA{Input/itkDeconvolutionImageFilterTestKernel.png}
     ${ITK_TEST_OUTPUT_DIR}/itkRichardsonLucyDeconvolutionImageFilterNonNullImageOriginTest.nrrd
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkRichardsonLucyDeconvolutionImageFilterNonNullImageOriginTest.nrrd
 )
 itk_add_test(
   NAME itkLandweberDeconvolutionImageFilterGaussianKernelTest
@@ -72,6 +78,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkLandweberDeconvolutionImageFilterGaussianKernelTest.nrrd
     1
     2.0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLandweberDeconvolutionImageFilterGaussianKernelTest.nrrd
 )
 itk_add_test(
   NAME itkLandweberDeconvolutionImageFilterIrregularKernelTest
@@ -86,6 +94,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkLandweberDeconvolutionImageFilterIrregularKernelTest.nrrd
     1
     2.0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLandweberDeconvolutionImageFilterIrregularKernelTest.nrrd
 )
 itk_add_test(
   NAME itkProjectedLandweberDeconvolutionImageFilterGaussianKernelTest
@@ -100,6 +110,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkProjectedLandweberDeconvolutionImageFilterGaussianKernelTest.nrrd
     1
     2.0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkProjectedLandweberDeconvolutionImageFilterGaussianKernelTest.nrrd
 )
 itk_add_test(
   NAME itkProjectedLandweberDeconvolutionImageFilterIrregularKernelTest
@@ -114,6 +126,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkProjectedLandweberDeconvolutionImageFilterIrregularKernelTest.nrrd
     1
     2.0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkProjectedLandweberDeconvolutionImageFilterIrregularKernelTest.nrrd
 )
 itk_add_test(
   NAME itkInverseDeconvolutionImageFilterGaussianKernelTest
@@ -127,6 +141,8 @@ itk_add_test(
     DATA{Input/itkDeconvolutionImageFilterTestKernel.png}
     ${ITK_TEST_OUTPUT_DIR}/itkInverseDeconvolutionImageFilterGaussianKernelTest.nrrd
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkInverseDeconvolutionImageFilterGaussianKernelTest.nrrd
 )
 itk_add_test(
   NAME itkInverseDeconvolutionImageFilterIrregularKernelTest
@@ -140,6 +156,8 @@ itk_add_test(
     DATA{Input/itkDeconvolutionImageFilterTestKernelIrregular.tif}
     ${ITK_TEST_OUTPUT_DIR}/itkInverseDeconvolutionImageFilterIrregularKernelTest.nrrd
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkInverseDeconvolutionImageFilterIrregularKernelTest.nrrd
 )
 itk_add_test(
   NAME itkTikhonovDeconvolutionImageFilterGaussianKernelTest
@@ -153,6 +171,8 @@ itk_add_test(
     DATA{Input/itkDeconvolutionImageFilterTestKernel.png}
     ${ITK_TEST_OUTPUT_DIR}/itkTikhonovDeconvolutionImageFilterGaussianKernelTest.nrrd
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTikhonovDeconvolutionImageFilterGaussianKernelTest.nrrd
 )
 itk_add_test(
   NAME itkTikhonovDeconvolutionImageFilterIrregularKernelTest
@@ -166,6 +186,8 @@ itk_add_test(
     DATA{Input/itkDeconvolutionImageFilterTestKernelIrregular.tif}
     ${ITK_TEST_OUTPUT_DIR}/itkTikhonovDeconvolutionImageFilterIrregularKernelTest.nrrd
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTikhonovDeconvolutionImageFilterIrregularKernelTest.nrrd
 )
 itk_add_test(
   NAME itkWienerDeconvolutionImageFilterGaussianKernelTest
@@ -179,6 +201,8 @@ itk_add_test(
     DATA{Input/itkDeconvolutionImageFilterTestKernel.png}
     ${ITK_TEST_OUTPUT_DIR}/itkWienerDeconvolutionImageFilterGaussianKernelTest.nrrd
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkWienerDeconvolutionImageFilterGaussianKernelTest.nrrd
 )
 itk_add_test(
   NAME itkWienerDeconvolutionImageFilterIrregularKernelTest
@@ -192,6 +216,8 @@ itk_add_test(
     DATA{Input/itkDeconvolutionImageFilterTestKernelIrregular.tif}
     ${ITK_TEST_OUTPUT_DIR}/itkWienerDeconvolutionImageFilterIrregularKernelTest.nrrd
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkWienerDeconvolutionImageFilterIrregularKernelTest.nrrd
 )
 itk_add_test(
   NAME itkParametricBlindLeastSquaresDeconvolutionImageFilterTest
@@ -206,5 +232,8 @@ itk_add_test(
     1
     1
     0.5
+    ${ITK_TEST_OUTPUT_DIR}/itkParametricBlindLeastSquaresDeconvolutionImageFilterTestInput.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkParametricBlindLeastSquaresDeconvolutionImageFilterTest.nrrd
     ${ITK_TEST_OUTPUT_DIR}/itkParametricBlindLeastSquaresDeconvolutionImageFilterTestInput.nrrd
 )

--- a/Modules/Filtering/Denoising/test/CMakeLists.txt
+++ b/Modules/Filtering/Denoising/test/CMakeLists.txt
@@ -18,6 +18,8 @@ itk_add_test(
     DATA{Input/noisy_checkerboard.mha}
     ${ITK_TEST_OUTPUT_DIR}/PatchBasedDenoisingImageFilterDefaultTest.mha
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/PatchBasedDenoisingImageFilterDefaultTest.mha
 )
 itk_add_test(
   NAME itkPatchBasedDenoisingImageFilterTest0
@@ -41,6 +43,8 @@ itk_add_test(
     2
     2
     200
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/PatchBasedDenoisingImageFilterTest0.mha
 )
 itk_add_test(
   NAME itkPatchBasedDenoisingImageFilterTestGaussian
@@ -68,6 +72,8 @@ itk_add_test(
     1
     GAUSSIAN
     0.1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/PatchBasedDenoisingImageFilterTestGaussian.mha
 )
 itk_add_test(
   NAME itkPatchBasedDenoisingImageFilterTestRician
@@ -95,6 +101,8 @@ itk_add_test(
     1
     RICIAN
     0.1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/PatchBasedDenoisingImageFilterTestRician.mha
 )
 itk_add_test(
   NAME itkPatchBasedDenoisingImageFilterTestPoisson
@@ -122,6 +130,8 @@ itk_add_test(
     1
     POISSON
     0.1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/PatchBasedDenoisingImageFilterTestPoisson.mha
 )
 # Extra tolerance for Tensors. The alternative EigenValues-computation of this class is faster,
 # but numerically unstable. The extra tolerance covers the difference between 64 and 32 bits machines.
@@ -147,4 +157,6 @@ itk_add_test(
     100
     0
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/PatchBasedDenoisingImageFilterTestTensors.nrrd
 )

--- a/Modules/Filtering/DisplacementField/test/CMakeLists.txt
+++ b/Modules/Filtering/DisplacementField/test/CMakeLists.txt
@@ -44,6 +44,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkIterativeInverseDisplacementFieldImageFilterTest.mha
     5
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkIterativeInverseDisplacementFieldImageFilterTest.mha
 )
 itk_add_test(
   NAME itkLandmarkDisplacementFieldSourceTest
@@ -52,12 +54,17 @@ itk_add_test(
     itkLandmarkDisplacementFieldSourceTest
     ${ITK_TEST_OUTPUT_DIR}/itkLandmarkDisplacementFieldSourceTestLandmarks.txt
     ${ITK_TEST_OUTPUT_DIR}/itkLandmarkDisplacementFieldSourceTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLandmarkDisplacementFieldSourceTestLandmarks.txt
+    ${ITK_TEST_OUTPUT_DIR}/itkLandmarkDisplacementFieldSourceTest.mha
 )
 itk_add_test(
   NAME itkInverseDisplacementFieldImageFilterTest
   COMMAND
     ITKDisplacementFieldTestDriver
     itkInverseDisplacementFieldImageFilterTest
+    ${ITK_TEST_OUTPUT_DIR}/itkInverseDisplacementFieldImageFilterTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkInverseDisplacementFieldImageFilterTest.mha
 )
 itk_add_test(
@@ -145,6 +152,8 @@ itk_add_test(
     itkTransformToDisplacementFieldFilterTest
     Affine
     ${ITK_TEST_OUTPUT_DIR}/itkTransformToDisplacementFieldFilterTestField01.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTransformToDisplacementFieldFilterTestField01.mha
 )
 itk_add_test(
   NAME itkTransformToDisplacementFieldFilterTest02
@@ -157,6 +166,8 @@ itk_add_test(
     BSpline
     ${ITK_TEST_OUTPUT_DIR}/itkTransformToDisplacementFieldFilterTestField02.mha
     DATA{${ITK_DATA_ROOT}/Input/parametersBSpline.txt}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTransformToDisplacementFieldFilterTestField02.mha
 )
 itk_add_test(
   NAME itkTransformToDisplacementFieldFilterTest03
@@ -171,6 +182,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/transformedImage.nii
     ${ITK_TEST_OUTPUT_DIR}/warpedImage.nii
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/transformedImage.nii
+    ${ITK_TEST_OUTPUT_DIR}/warpedImage.nii
 )
 itk_add_test(
   NAME itkDisplacementFieldTransformCloneTest

--- a/Modules/Filtering/DistanceMap/test/CMakeLists.txt
+++ b/Modules/Filtering/DistanceMap/test/CMakeLists.txt
@@ -26,6 +26,8 @@ itk_add_test(
     0
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDanielssonDistanceMapImageFilterTest1.{mhd,zraw}
 )
 itk_add_test(
   NAME itkDanielssonDistanceMapImageFilterTest2
@@ -37,6 +39,8 @@ itk_add_test(
     itkDanielssonDistanceMapImageFilterTest2
     DATA{${ITK_DATA_ROOT}/Input/BinaryImageWithVariousShapes01.png}
     ${ITK_TEST_OUTPUT_DIR}/itkDanielssonDistanceMapImageFilterTest2.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDanielssonDistanceMapImageFilterTest2.png
 )
 itk_add_test(
   NAME itkDirectedHausdorffDistanceImageFilterTest
@@ -44,6 +48,8 @@ itk_add_test(
     ITKDistanceMapTestDriver
     itkDirectedHausdorffDistanceImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/BinaryImageWithVariousShapes01.png}
+    ${ITK_TEST_OUTPUT_DIR}/itkDirectedHausdorffDistanceImageFilterTest2.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkDirectedHausdorffDistanceImageFilterTest2.png
 )
 itk_add_test(
@@ -63,6 +69,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/BinaryImageWithVariousShapes01.png}
     ${ITK_TEST_OUTPUT_DIR}/itkSignedDanielssonDistanceMapImageFilterTest1.mhd
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSignedDanielssonDistanceMapImageFilterTest1.{mhd,zraw}
 )
 itk_add_test(
   NAME itkSignedDanielssonDistanceMapImageFilterTest2
@@ -73,6 +81,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkSignedDanielssonDistanceMapImageFilterTest2.mha
     itkSignedDanielssonDistanceMapImageFilterTest2
     DATA{${ITK_DATA_ROOT}/Input/BinaryImageWithVariousShapes01.png}
+    ${ITK_TEST_OUTPUT_DIR}/itkSignedDanielssonDistanceMapImageFilterTest2.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkSignedDanielssonDistanceMapImageFilterTest2.mha
 )
 # Test the distance filter on a 3D volume.
@@ -88,6 +98,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/BinarySquare3D.mhd,BinarySquare3D.zraw}
     ${ITK_TEST_OUTPUT_DIR}/itkSignedDanielssonDistanceMapImageFilterTest3D.mhd
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSignedDanielssonDistanceMapImageFilterTest3D.{mhd,zraw}
 )
 # Test the distance filter on a 4D volume.
 # The middle 3D volume of the output 4D volume should be exactly the same as the
@@ -104,6 +116,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/BinarySquare4D.mhd,BinarySquare4D.zraw}
     ${ITK_TEST_OUTPUT_DIR}/itkSignedDanielssonDistanceMapImageFilterTest4D.mhd
     4
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSignedDanielssonDistanceMapImageFilterTest4D.{mhd,zraw}
 )
 
 itk_add_test(
@@ -117,6 +131,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/SquareBinary201.png}
     ${ITK_TEST_OUTPUT_DIR}/itkSignedMaurerDistanceMapImageFilterTest1.mhd
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSignedMaurerDistanceMapImageFilterTest1.{mhd,zraw}
 )
 itk_add_test(
   NAME itkSignedMaurerDistanceMapImageFilterTest2
@@ -129,6 +145,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/BrainSliceBinary.png}
     ${ITK_TEST_OUTPUT_DIR}/itkSignedMaurerDistanceMapImageFilterTest2.mhd
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSignedMaurerDistanceMapImageFilterTest2.{mhd,zraw}
 )
 itk_add_test(
   NAME itkSignedMaurerDistanceMapImageFilterTest3
@@ -141,6 +159,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/LungSliceBinary.png}
     ${ITK_TEST_OUTPUT_DIR}/itkSignedMaurerDistanceMapImageFilterTest3.mhd
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSignedMaurerDistanceMapImageFilterTest3.{mhd,zraw}
 )
 # Test the distance filter on a 3D volume.
 itk_add_test(
@@ -154,6 +174,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/BinarySquare3D.mhd,BinarySquare3D.zraw}
     ${ITK_TEST_OUTPUT_DIR}/itkSignedMaurerDistanceMapImageFilterTest3D.mhd
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSignedMaurerDistanceMapImageFilterTest3D.{mhd,zraw}
 )
 # Test the distance filter on a 4D volume.
 # The middle 3D volume of the output 4D volume should be exactly the same as the
@@ -169,6 +191,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/BinarySquare4D.mhd,BinarySquare4D.zraw}
     ${ITK_TEST_OUTPUT_DIR}/itkSignedMaurerDistanceMapImageFilterTest4D.mhd
     4
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSignedMaurerDistanceMapImageFilterTest4D.{mhd,zraw}
 )
 
 itk_add_test(
@@ -184,6 +208,8 @@ itk_add_test(
     itkApproximateSignedDistanceMapImageFilterTest
     100
     ${ITK_TEST_OUTPUT_DIR}/itkApproximateSignedDistanceMapImageFilterTest0.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkApproximateSignedDistanceMapImageFilterTest0.mha
 )
 itk_add_test(
   NAME itkApproximateSignedDistanceMapImageFilterTest1
@@ -195,6 +221,8 @@ itk_add_test(
     itkApproximateSignedDistanceMapImageFilterTest
     1
     ${ITK_TEST_OUTPUT_DIR}/itkApproximateSignedDistanceMapImageFilterTest1.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkApproximateSignedDistanceMapImageFilterTest1.{mhd,raw}
 )
 set(
   ITKDistanceMapGTests

--- a/Modules/Filtering/FFT/test/CMakeLists.txt
+++ b/Modules/Filtering/FFT/test/CMakeLists.txt
@@ -53,6 +53,8 @@ itk_add_test(
     --redirectOutput
     ${TEMP}/itkVnlFFTTest.txt
     itkVnlFFTTest
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkVnlFFTTest.txt
 )
 set_tests_properties(
   itkVnlFFTTest
@@ -68,6 +70,8 @@ itk_add_test(
     --redirectOutput
     ${TEMP}/itkVnlRealFFTTest.txt
     itkVnlRealFFTTest
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkVnlRealFFTTest.txt
 )
 set_tests_properties(
   itkVnlRealFFTTest
@@ -159,6 +163,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/BrainSliceBinary.png}
     ${ITK_TEST_OUTPUT_DIR}/itkFFTShiftImageFilterTest0.png
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTShiftImageFilterTest0.png
 )
 itk_add_test(
   NAME itkFFTShiftImageFilterTestOdd1
@@ -171,6 +177,8 @@ itk_add_test(
     DATA{Baseline/itkFFTShiftImageFilterTest0.png}
     ${ITK_TEST_OUTPUT_DIR}/itkFFTShiftImageFilterTest1.png
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTShiftImageFilterTest1.png
 )
 itk_add_test(
   NAME itkFFTShiftImageFilterTestEven0
@@ -183,6 +191,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkFFTShiftImageFilterTestEven0.png
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTShiftImageFilterTestEven0.png
 )
 itk_add_test(
   NAME itkFFTShiftImageFilterTestEven1
@@ -195,6 +205,8 @@ itk_add_test(
     DATA{Baseline/itkFFTShiftImageFilterTestEven0.png}
     ${ITK_TEST_OUTPUT_DIR}/itkFFTShiftImageFilterTestEven1.png
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTShiftImageFilterTestEven1.png
 )
 itk_add_test(
   NAME itkHalfToFullHermitianImageFilterTestEvenEven
@@ -286,6 +298,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkComplexToComplexFFTImageFilter2DFloatTest.mha
     float
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkComplexToComplexFFTImageFilter2DFloatTest.mha
 )
 # The data contained in ${ITK_DATA_ROOT}/Input/DicomSeries/
 # is required by mri3D.mhd:
@@ -312,6 +326,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/mri3D.mhd}
     ${ITK_TEST_OUTPUT_DIR}/itkComplexToComplexFFTImageFilter3DFloatTest.mha
     float
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkComplexToComplexFFTImageFilter3DFloatTest.mha
 )
 itk_add_test(
   NAME itkComplexToComplexFFTImageFilter2DDoubleTest
@@ -324,6 +340,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkComplexToComplexFFTImageFilter2DDoubleTest.mha
     double
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkComplexToComplexFFTImageFilter2DDoubleTest.mha
 )
 itk_add_test(
   NAME itkComplexToComplexFFTImageFilter3DDoubleTest
@@ -336,6 +354,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/mri3D.mhd}
     ${ITK_TEST_OUTPUT_DIR}/itkComplexToComplexFFTImageFilter3DDoubleTest.mha
     double
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkComplexToComplexFFTImageFilter3DDoubleTest.mha
 )
 
 itk_add_test(
@@ -349,6 +369,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkVnlComplexToComplexFFTImageFilter2DFloatTest.mha
     float
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkVnlComplexToComplexFFTImageFilter2DFloatTest.mha
 )
 itk_add_test(
   NAME itkVnlComplexToComplexFFTImageFilter3DFloatTest
@@ -361,6 +383,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/mri3D.mhd}
     ${ITK_TEST_OUTPUT_DIR}/itkVnlComplexToComplexFFTImageFilter3DFloatTest.mha
     float
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkVnlComplexToComplexFFTImageFilter3DFloatTest.mha
 )
 itk_add_test(
   NAME itkVnlComplexToComplexFFTImageFilter2DDoubleTest
@@ -373,6 +397,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkVnlComplexToComplexFFTImageFilter2DDoubleTest.mha
     double
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkVnlComplexToComplexFFTImageFilter2DDoubleTest.mha
 )
 itk_add_test(
   NAME itkVnlComplexToComplexFFTImageFilter3DDoubleTest
@@ -385,6 +411,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/mri3D.mhd}
     ${ITK_TEST_OUTPUT_DIR}/itkVnlComplexToComplexFFTImageFilter3DDoubleTest.mha
     double
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkVnlComplexToComplexFFTImageFilter3DDoubleTest.mha
 )
 
 if(ITK_USE_FFTWF)
@@ -399,6 +427,8 @@ if(ITK_USE_FFTWF)
       DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
       ${ITK_TEST_OUTPUT_DIR}/itkFFTWComplexToComplexFFTImageFilter2DFloatTest.mha
       float
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/itkFFTWComplexToComplexFFTImageFilter2DFloatTest.mha
   )
   itk_add_test(
     NAME itkFFTWComplexToComplexFFTImageFilter3DFloatTest
@@ -411,6 +441,8 @@ if(ITK_USE_FFTWF)
       DATA{${ITK_DATA_ROOT}/Input/mri3D.mhd}
       ${ITK_TEST_OUTPUT_DIR}/itkFFTWComplexToComplexFFTImageFilter3DFloatTest.mha
       float
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/itkFFTWComplexToComplexFFTImageFilter3DFloatTest.mha
   )
 endif()
 if(ITK_USE_FFTWD)
@@ -425,6 +457,8 @@ if(ITK_USE_FFTWD)
       DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
       ${ITK_TEST_OUTPUT_DIR}/itkFFTWComplexToComplexFFTImageFilter2DDoubleTest.mha
       double
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/itkFFTWComplexToComplexFFTImageFilter2DDoubleTest.mha
   )
   itk_add_test(
     NAME itkFFTWComplexToComplexFFTImageFilter3DDoubleTest
@@ -437,6 +471,8 @@ if(ITK_USE_FFTWD)
       DATA{${ITK_DATA_ROOT}/Input/mri3D.mhd}
       ${ITK_TEST_OUTPUT_DIR}/itkFFTWComplexToComplexFFTImageFilter3DDoubleTest.mha
       double
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/itkFFTWComplexToComplexFFTImageFilter3DDoubleTest.mha
   )
 endif()
 
@@ -484,6 +520,8 @@ itk_add_test(
     DATA{Input/itkForward1DFFTImageFilterTestBaselineRealFull.mhd}
     DATA{Input/itkForward1DFFTImageFilterTestBaselineImaginaryFull.mhd}
     ${ITK_TEST_OUTPUT_DIR}/itkComplexToComplex1DFFTImageFilterTestOutput.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkComplexToComplex1DFFTImageFilterTestOutput.mha
 )
 # use a forward fft, then inverse fft for this instead because of the FullMatrix
 # issue
@@ -496,6 +534,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkFFT1DImageFilterTestOutput.mha
     itkFFT1DImageFilterTest
     DATA{Input/TreeBarkTexture.png}
+    ${ITK_TEST_OUTPUT_DIR}/itkFFT1DImageFilterTestOutput.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkFFT1DImageFilterTestOutput.mha
 )
 itk_add_test(
@@ -510,6 +550,8 @@ itk_add_test(
     DATA{Input/itkForward1DFFTImageFilterTestBaselineImaginaryFull.mhd,itkForward1DFFTImageFilterTestBaselineImaginaryFull.raw}
     ${ITK_TEST_OUTPUT_DIR}/itkVnlComplexToComplex1DFFTImageFilterTestOutput.mhd
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkVnlComplexToComplex1DFFTImageFilterTestOutput.{mhd,raw}
 )
 itk_add_test(
   NAME itkVnlForward1DFFTImageFilterTest
@@ -525,6 +567,9 @@ itk_add_test(
     DATA{Input/TreeBarkTexture.png}
     ${ITK_TEST_OUTPUT_DIR}/itkVnlForward1DFFTImageFilterTestOutput
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkVnlForward1DFFTImageFilterTestOutputReal.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkVnlForward1DFFTImageFilterTestOutputImaginary.mha
 )
 itk_add_test(
   NAME itkVnlInverse1DFFTImageFilterTest
@@ -538,6 +583,8 @@ itk_add_test(
     DATA{Input/itkForward1DFFTImageFilterTestBaselineImaginaryFull.mhd,itkForward1DFFTImageFilterTestBaselineImaginaryFull.raw}
     ${ITK_TEST_OUTPUT_DIR}/itkVnlInverse1DFFTImageFilterTestOutput.mhd
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkVnlInverse1DFFTImageFilterTestOutput.{mhd,raw}
 )
 itk_add_test(
   NAME itkVnlFFT1DImageFilterTest
@@ -550,6 +597,8 @@ itk_add_test(
     DATA{Input/TreeBarkTexture.png}
     ${ITK_TEST_OUTPUT_DIR}/itkVnlFFT1DImageFilterTestOutput.mha
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkVnlFFT1DImageFilterTestOutput.mha
 )
 
 if(ITK_USE_FFTWF OR ITK_USE_FFTWD)
@@ -567,6 +616,9 @@ if(ITK_USE_FFTWF OR ITK_USE_FFTWD)
       DATA{Input/TreeBarkTexture.png}
       ${ITK_TEST_OUTPUT_DIR}/itkFFTWForward1DFFTImageFilterTestOutput
       2
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/itkFFTWForward1DFFTImageFilterTestOutputReal.mha
+      ${ITK_TEST_OUTPUT_DIR}/itkFFTWForward1DFFTImageFilterTestOutputImaginary.mha
   )
   itk_add_test(
     NAME itkFFTWInverse1DFFTImageFilterTest
@@ -580,6 +632,8 @@ if(ITK_USE_FFTWF OR ITK_USE_FFTWD)
       DATA{Input/itkForward1DFFTImageFilterTestBaselineImaginaryFull.mhd,itkForward1DFFTImageFilterTestBaselineImaginaryFull.raw}
       ${ITK_TEST_OUTPUT_DIR}/itkFFTWInverse1DFFTImageFilterTestOutput.mha
       2
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/itkFFTWInverse1DFFTImageFilterTestOutput.mha
   )
   itk_add_test(
     NAME itkFFTWComplexToComplex1DFFTImageFilterTest
@@ -593,6 +647,8 @@ if(ITK_USE_FFTWF OR ITK_USE_FFTWD)
       DATA{Input/itkForward1DFFTImageFilterTestBaselineImaginaryFull.mhd}
       ${ITK_TEST_OUTPUT_DIR}/itkFFTWComplexToComplex1DFFTImageFilterTestOutput.mha
       2
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/itkFFTWComplexToComplex1DFFTImageFilterTestOutput.mha
   )
   itk_add_test(
     NAME itkFFTW1DImageFilterTest
@@ -605,6 +661,8 @@ if(ITK_USE_FFTWF OR ITK_USE_FFTWD)
       DATA{Input/TreeBarkTexture.png}
       ${ITK_TEST_OUTPUT_DIR}/itkFFTW1DImageFilterTestOutput.mha
       2
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/itkFFTW1DImageFilterTestOutput.mha
   )
 endif()
 

--- a/Modules/Filtering/FastBilateral/test/CMakeLists.txt
+++ b/Modules/Filtering/FastBilateral/test/CMakeLists.txt
@@ -18,6 +18,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkFastBilateralImageFilterTestOutput.mha
     itkFastBilateralImageFilterTest
     ${ITK_TEST_OUTPUT_DIR}/itkFastBilateralImageFilterTestOutput.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFastBilateralImageFilterTestOutput.mha
 )
 
 itk_add_test(
@@ -30,6 +32,8 @@ itk_add_test(
     itkFastBilateralImageFilterTest2
     DATA{Input/cake_easy.png}
     ${ITK_TEST_OUTPUT_DIR}/itkFastBilateralImageFilterTest2Output.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFastBilateralImageFilterTest2Output.png
 )
 
 itk_add_test(
@@ -41,5 +45,7 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkFastBilateralImageFilterTest3Output.png
     itkFastBilateralImageFilterTest3
     DATA{Input/cake_easy.png}
+    ${ITK_TEST_OUTPUT_DIR}/itkFastBilateralImageFilterTest3Output.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkFastBilateralImageFilterTest3Output.png
 )

--- a/Modules/Filtering/FastMarching/test/CMakeLists.txt
+++ b/Modules/Filtering/FastMarching/test/CMakeLists.txt
@@ -186,6 +186,8 @@ itk_add_test(
     DATA{Baseline/BrainProtonDensitySlice_singleSeed.nii.gz}
     150
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/test_Brain2D_singleSeed_NoTopo.nii.gz
 )
 
 itk_add_test(
@@ -202,6 +204,8 @@ itk_add_test(
     DATA{Baseline/BrainProtonDensitySlice_singleSeed.nii.gz}
     150
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/test_Brain2D_singleSeed_StrictTopo.nii.gz
 )
 
 itk_add_test(
@@ -218,6 +222,8 @@ itk_add_test(
     DATA{Baseline/BrainProtonDensitySlice_singleSeed.nii.gz}
     150
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/test_Brain2D_singleSeed_NoHandlesTopo.nii.gz
 )
 
 itk_add_test(
@@ -234,6 +240,8 @@ itk_add_test(
     DATA{Baseline/BrainProtonDensitySlice_multipleSeeds.nii.gz}
     150
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/test_Brain2D_multipleSeeds_NoTopo.nii.gz
 )
 
 itk_add_test(
@@ -250,6 +258,8 @@ itk_add_test(
     DATA{Baseline/BrainProtonDensitySlice_multipleSeeds.nii.gz}
     150
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/test_Brain2D_multipleSeeds_StrictTopo.nii.gz
 )
 
 itk_add_test(
@@ -266,6 +276,8 @@ itk_add_test(
     DATA{Baseline/BrainProtonDensitySlice_multipleSeeds.nii.gz}
     150
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/test_Brain2D_multipleSeeds_NoHandlesTopo.nii.gz
 )
 
 # ************************************************************************
@@ -284,6 +296,8 @@ itk_add_test(
     DATA{Baseline/torus_multipleSeeds.nii.gz}
     150
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/test_torus_multipleSeeds_NoTopo.nii.gz
 )
 
 itk_add_test(
@@ -300,6 +314,8 @@ itk_add_test(
     DATA{Baseline/torus_multipleSeeds.nii.gz}
     150
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/test_torus_multipleSeeds_StrictTopo.nii.gz
 )
 
 itk_add_test(
@@ -316,6 +332,8 @@ itk_add_test(
     DATA{Baseline/torus_multipleSeeds.nii.gz}
     150
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/test_torus_multipleSeeds_NoHandlesTopo.nii.gz
 )
 
 itk_add_test(
@@ -332,6 +350,8 @@ itk_add_test(
     DATA{Baseline/wm_multipleSeeds.nii.gz}
     150
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/test_wm_multipleSeeds_NoTopo.nii.gz
 )
 set_property(
   TEST
@@ -356,6 +376,8 @@ itk_add_test(
     DATA{Baseline/wm_multipleSeeds.nii.gz}
     150
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/test_wm_multipleSeeds_StrictTopo.nii.gz
 )
 set_property(
   TEST
@@ -380,6 +402,8 @@ itk_add_test(
     DATA{Baseline/wm_multipleSeeds.nii.gz}
     150
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/test_wm_multipleSeeds_NoHandlesTopo.nii.gz
 )
 set_property(
   TEST

--- a/Modules/Filtering/GPUAnisotropicSmoothing/test/CMakeLists.txt
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/test/CMakeLists.txt
@@ -18,6 +18,8 @@ if(ITK_USE_GPU)
       DATA{Input/BrainProtonDensitySlice.png}
       ${ITK_TEST_OUTPUT_DIR}/gpuGradientAnisotropicDiffusionImageFilterTest2D.mha
       2
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/gpuGradientAnisotropicDiffusionImageFilterTest2D.mha
   )
 
   itk_add_test(
@@ -28,5 +30,7 @@ if(ITK_USE_GPU)
       DATA{Input/HeadMRVolume.mha}
       ${ITK_TEST_OUTPUT_DIR}/gpuGradientAnisotropicDiffusionImageFilterTest3D.mha
       3
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/gpuGradientAnisotropicDiffusionImageFilterTest3D.mha
   )
 endif()

--- a/Modules/Filtering/GPUImageFilterBase/test/CMakeLists.txt
+++ b/Modules/Filtering/GPUImageFilterBase/test/CMakeLists.txt
@@ -13,6 +13,8 @@ if(ITK_USE_GPU)
       DATA{Input/BrainProtonDensitySlice.png}
       ${ITK_TEST_OUTPUT_DIR}/gpuNeighborhoodOperatorImageFilterTest2D.mha
       2
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/gpuNeighborhoodOperatorImageFilterTest2D.mha
   )
 
   itk_add_test(
@@ -23,5 +25,7 @@ if(ITK_USE_GPU)
       DATA{Input/HeadMRVolume.mha}
       ${ITK_TEST_OUTPUT_DIR}/gpuNeighborhoodOperatorImageFilterTest3D.mha
       3
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/gpuNeighborhoodOperatorImageFilterTest3D.mha
   )
 endif()

--- a/Modules/Filtering/GPUSmoothing/test/CMakeLists.txt
+++ b/Modules/Filtering/GPUSmoothing/test/CMakeLists.txt
@@ -20,6 +20,8 @@ if(ITK_USE_GPU)
       DATA{Input/BrainProtonDensitySlice.png}
       ${ITK_TEST_OUTPUT_DIR}/gpuMeanImageFilterTest2D.png
       2
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/gpuMeanImageFilterTest2D.png
   )
 
   itk_add_test(
@@ -33,6 +35,8 @@ if(ITK_USE_GPU)
       DATA{Input/HeadMRVolume.mha}
       ${ITK_TEST_OUTPUT_DIR}/gpuMeanImageFilterTest3D.mha
       3
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/gpuMeanImageFilterTest3D.mha
   )
 
   itk_add_test(
@@ -43,6 +47,8 @@ if(ITK_USE_GPU)
       DATA{Input/BrainProtonDensitySlice.png}
       ${ITK_TEST_OUTPUT_DIR}/gpuGradientDiscreteGaussianImageFilterTest2D.mha
       2
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/gpuGradientDiscreteGaussianImageFilterTest2D.mha
   )
 
   itk_add_test(
@@ -53,5 +59,7 @@ if(ITK_USE_GPU)
       DATA{Input/HeadMRVolume.mha}
       ${ITK_TEST_OUTPUT_DIR}/gpuGradientDiscreteGaussianImageFilterTest3D.mha
       3
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/gpuGradientDiscreteGaussianImageFilterTest3D.mha
   )
 endif()

--- a/Modules/Filtering/GPUThresholding/test/CMakeLists.txt
+++ b/Modules/Filtering/GPUThresholding/test/CMakeLists.txt
@@ -18,6 +18,8 @@ if(ITK_USE_GPU)
       ${ITK_SOURCE_DIR}/Examples/Data/BrainProtonDensitySlice.png
       ${ITK_TEST_OUTPUT_DIR}/gpuImageFilterTest2D.png
       2
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/gpuImageFilterTest2D.png
   )
   itk_add_test(
     NAME itkGPUImageFilterTest3D
@@ -27,6 +29,8 @@ if(ITK_USE_GPU)
       ${ITK_SOURCE_DIR}/Examples/Data/BrainProtonDensitySlice.png
       ${ITK_TEST_OUTPUT_DIR}/gpuImageFilterTest3D.png
       3
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/gpuImageFilterTest3D.png
   )
 
   #
@@ -44,6 +48,8 @@ if(ITK_USE_GPU)
       ${ITK_SOURCE_DIR}/Examples/Data/BrainProtonDensitySlice.png
       ${ITK_TEST_OUTPUT_DIR}/gpuBinaryThresholdImageFilterTest2D.mha
       2
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/gpuBinaryThresholdImageFilterTest2D.mha
   )
 
   itk_add_test(
@@ -54,5 +60,7 @@ if(ITK_USE_GPU)
       ${ITK_SOURCE_DIR}/Examples/Data/BrainProtonDensitySlice.png
       ${ITK_TEST_OUTPUT_DIR}/gpuBinaryThresholdImageFilterTest3D.mha
       3
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/gpuBinaryThresholdImageFilterTest3D.mha
   )
 endif()

--- a/Modules/Filtering/GenericLabelInterpolator/test/CMakeLists.txt
+++ b/Modules/Filtering/GenericLabelInterpolator/test/CMakeLists.txt
@@ -15,4 +15,6 @@ itk_add_test(
     DATA{Input/classification_s4.mha}
     ${ITK_TEST_OUTPUT_DIR}/
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/gl_gaussian_3.mha
 )

--- a/Modules/Filtering/HigherOrderAccurateGradient/test/CMakeLists.txt
+++ b/Modules/Filtering/HigherOrderAccurateGradient/test/CMakeLists.txt
@@ -18,6 +18,10 @@ itk_add_test(
     itkHigherOrderAccurateGradientImageFilterTest
     DATA{Input/foot.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkHigherOrderAccurateGradientImageFilterTest
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHigherOrderAccurateGradientImageFilterTest_Accuracy1_Magnitude.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkHigherOrderAccurateGradientImageFilterTest_GradientImageFilter_Magnitude.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkHigherOrderAccurateGradientImageFilterTest_*_Magnitude.mha
 )
 
 itk_add_test(
@@ -33,4 +37,10 @@ itk_add_test(
     itkHigherOrderAccurateDerivativeImageFilterTest
     DATA{Input/foot.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkHigherOrderAccurateDerivativeImageFilterTest
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHigherOrderAccurateDerivativeImageFilterTest_Accuracy1_Direction0.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkHigherOrderAccurateDerivativeImageFilterTest_DerivativeImageFilter_Direction0.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkHigherOrderAccurateDerivativeImageFilterTest_Accuracy1_Direction1.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkHigherOrderAccurateDerivativeImageFilterTest_DerivativeImageFilter_Direction1.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkHigherOrderAccurateDerivativeImageFilterTest_*_Direction[01].mha
 )

--- a/Modules/Filtering/ImageCompare/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageCompare/test/CMakeLists.txt
@@ -34,6 +34,8 @@ itk_add_test(
     277faa96444775070dcc8f6be2d71eb2
     itkCheckerBoardImageFilterTest
     ${ITK_TEST_OUTPUT_DIR}/itkCheckerBoardImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkCheckerBoardImageFilterTest.png
 )
 itk_add_test(
   NAME itkConstrainedValueDifferenceImageFilterTest
@@ -43,6 +45,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkConstrainedValueDifferenceImageFilterTest.png
     87028680dd2bbc12f57b141f7272d295
     itkConstrainedValueDifferenceImageFilterTest
+    ${ITK_TEST_OUTPUT_DIR}/itkConstrainedValueDifferenceImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkConstrainedValueDifferenceImageFilterTest.png
 )
 itk_add_test(
@@ -68,6 +72,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/STAPLE2.png}
     DATA{${ITK_DATA_ROOT}/Input/STAPLE3.png}
     DATA{${ITK_DATA_ROOT}/Input/STAPLE4.png}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/STAPLEImageFilterTest.mha
 )
 itk_add_test(
   NAME itkTestingComparisonImageFilterTest
@@ -88,6 +94,8 @@ itk_add_test(
     66
     16.2999
     26846
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTestingComparisonImageFilterTest.png
 )
 itk_add_test(
   NAME itkImageFileReaderIOToRequestedRegionMismatchTest

--- a/Modules/Filtering/ImageCompose/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageCompose/test/CMakeLists.txt
@@ -74,6 +74,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/SpotsInverted.png}
     DATA{${ITK_DATA_ROOT}/Input/SpotsInverted.png}
     ${ITK_TEST_OUTPUT_DIR}/ImageToVectorImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ImageToVectorImageFilterTest.png
 )
 itk_add_test(
   NAME itkImageReadRealAndImaginaryWriteComplexTest
@@ -82,6 +84,8 @@ itk_add_test(
     itkImageReadRealAndImaginaryWriteComplexTest
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySlice.png
     ${ITK_EXAMPLE_DATA_ROOT}/BrainT1Slice.png
+    ${ITK_TEST_OUTPUT_DIR}/itkBrainSliceComplex.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkBrainSliceComplex.mha
 )
 itk_add_test(
@@ -94,6 +98,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/Number2inText.png}
     DATA{${ITK_DATA_ROOT}/Input/Number3inText.png}
     DATA{${ITK_DATA_ROOT}/Input/IntensityRamp64.png}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkComposeRGBAImageFilterTestOutput.png
 )
 itk_add_test(
   NAME itkJoinSeriesImageFilterTest
@@ -110,6 +116,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkJoinSeriesImageFilterStreamingTest.mha
     itkJoinSeriesImageFilterStreamingTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mhd,HeadMRVolume.raw}
+    ${ITK_TEST_OUTPUT_DIR}/itkJoinSeriesImageFilterStreamingTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkJoinSeriesImageFilterStreamingTest.mha
 )
 itk_add_test(

--- a/Modules/Filtering/ImageFeature/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageFeature/test/CMakeLists.txt
@@ -54,6 +54,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkLaplacianImageFilterTest.png
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLaplacianImageFilterTest.png
 )
 itk_add_test(
   NAME itkLaplacianImageFilterWithSpacingTest
@@ -66,6 +68,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkLaplacianImageFilterWithSpacingTest.png
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLaplacianImageFilterWithSpacingTest.png
 )
 itk_add_test(
   NAME itkSobelEdgeDetectionImageFilterTest
@@ -76,6 +80,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkSobelEdgeDetectionImageFilterTest.png
     itkSobelEdgeDetectionImageFilterTest
     DATA{Input/Swirled.png}
+    ${ITK_TEST_OUTPUT_DIR}/itkSobelEdgeDetectionImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkSobelEdgeDetectionImageFilterTest.png
 )
 itk_add_test(
@@ -97,6 +103,8 @@ itk_add_test(
     uchar
     DATA{Input/Swirled.png}
     ${TEMP}/SwirledUSM_Defaults.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/SwirledUSM_Defaults.png
 )
 itk_add_test(
   NAME itkUnsharpMaskImageFilterTest_DefaultsFloat
@@ -110,6 +118,8 @@ itk_add_test(
     itkUnsharpMaskImageFilterTest
     float
     DATA{Input/Swirled.png}
+    ${TEMP}/SwirledUSM_Defaults.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${TEMP}/SwirledUSM_Defaults.nrrd
 )
 itk_add_test(
@@ -128,6 +138,8 @@ itk_add_test(
     3.0
     3.0
     15
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/SwirledUSM_3-3-15.nrrd.nrrd
 )
 itk_add_test(
   NAME itkHessian3DToVesselnessMeasureImageFilterTest
@@ -152,6 +164,8 @@ itk_add_test(
     ${TEMP}/itkHessianToObjectnessMeasureImageFilterTestOutput.mha
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkHessianToObjectnessMeasureImageFilterTestOutput.mha
 )
 itk_add_test(
   NAME itkHessianToObjectnessMeasureImageFilterTest2
@@ -167,6 +181,8 @@ itk_add_test(
     ${TEMP}/itkHessianToObjectnessMeasureImageFilterTestOutput2.mha
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkHessianToObjectnessMeasureImageFilterTestOutput2.mha
 )
 itk_add_test(
   NAME itkHessianRecursiveGaussianFilterScaleSpaceTest
@@ -184,6 +200,8 @@ itk_add_test(
     itkHessianRecursiveGaussianFilterTest
     2.5
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkHessianRecursiveGaussianFilterTest.txt
 )
 set_tests_properties(
   itkHessianRecursiveGaussianFilterTest
@@ -214,6 +232,8 @@ itk_add_test(
     itkCannyEdgeDetectionImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkCannyEdgeDetectionImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkCannyEdgeDetectionImageFilterTest.png
 )
 itk_add_test(
   NAME itkBilateralImageFilterTest
@@ -231,6 +251,8 @@ itk_add_test(
     itkBilateralImageFilterTest2
     DATA{${ITK_DATA_ROOT}/Input/cake_easy.png}
     ${ITK_TEST_OUTPUT_DIR}/BilateralImageFilterTest2.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/BilateralImageFilterTest2.png
 )
 itk_add_test(
   NAME itkBilateralImageFilterTest3
@@ -241,6 +263,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/BilateralImageFilterTest3.png
     itkBilateralImageFilterTest3
     DATA{${ITK_DATA_ROOT}/Input/cake_easy.png}
+    ${ITK_TEST_OUTPUT_DIR}/BilateralImageFilterTest3.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/BilateralImageFilterTest3.png
 )
 itk_add_test(
@@ -258,6 +282,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/SimpleContourExtractorImageFilterTest.png
     itkSimpleContourExtractorImageFilterTest
     DATA{${ITK_DATA_ROOT}/Baseline/BasicFilters/BinaryThresholdImageFilterTest2.png}
+    ${ITK_TEST_OUTPUT_DIR}/SimpleContourExtractorImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/SimpleContourExtractorImageFilterTest.png
 )
 itk_add_test(
@@ -277,6 +303,9 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkCannyEdgeDetectionImageFilterTest2_A.png
     ${ITK_TEST_OUTPUT_DIR}/itkCannyEdgeDetectionImageFilterTest2_B.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkCannyEdgeDetectionImageFilterTest2_A.png
+    ${ITK_TEST_OUTPUT_DIR}/itkCannyEdgeDetectionImageFilterTest2_B.png
 )
 itk_add_test(
   NAME itkDerivativeImageFilterTest1x
@@ -291,6 +320,8 @@ itk_add_test(
     1
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDerivativeImageFilterTest1x.png
 )
 itk_add_test(
   NAME itkDerivativeImageFilterTest1y
@@ -305,6 +336,8 @@ itk_add_test(
     1
     1
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDerivativeImageFilterTest1y.png
 )
 itk_add_test(
   NAME itkDerivativeImageFilterTest2x
@@ -319,6 +352,8 @@ itk_add_test(
     2
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDerivativeImageFilterTest2x.png
 )
 itk_add_test(
   NAME itkDerivativeImageFilterTest2y
@@ -333,6 +368,8 @@ itk_add_test(
     2
     1
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDerivativeImageFilterTest2y.png
 )
 itk_add_test(
   NAME itkLaplacianRecursiveGaussianImageFilterTest
@@ -343,6 +380,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/LaplacianRecursiveGaussianImageFilterTest.png
     itkLaplacianRecursiveGaussianImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
+    ${ITK_TEST_OUTPUT_DIR}/LaplacianRecursiveGaussianImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/LaplacianRecursiveGaussianImageFilterTest.png
 )
 itk_add_test(
@@ -356,6 +395,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/sf4.png}
     ${ITK_TEST_OUTPUT_DIR}/itkLaplacianSharpeningImageFilterTest.png
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLaplacianSharpeningImageFilterTest.png
 )
 itk_add_test(
   NAME itkMaskFeaturePointSelectionFilterTest
@@ -371,6 +412,8 @@ itk_add_test(
     2
     0
     0.01
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMaskFeaturePointSelectionFilterTest.mha
 )
 itk_add_test(
   NAME itkMaskFeaturePointSelectionFilterTestTensors
@@ -386,6 +429,8 @@ itk_add_test(
     2
     1
     0.01
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMaskFeaturePointSelectionFilterTestTensors.mha
 )
 itk_add_test(
   NAME itkMaskFeaturePointSelectionFilterTestMask
@@ -402,6 +447,8 @@ itk_add_test(
     1
     0.01
     DATA{Input/HeadMRVolumeMaskImage.mha}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMaskFeaturePointSelectionFilterTestMask.mha
 )
 itk_add_test(
   NAME itkDiscreteGaussianDerivativeImageFilterScaleSpaceTest
@@ -422,6 +469,8 @@ itk_add_test(
     0
     1
     3.0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDiscreteGaussianDerivativeImageFilterTest01.png
 )
 itk_add_test(
   NAME itkDiscreteGaussianDerivativeImageFilterTest10
@@ -436,6 +485,8 @@ itk_add_test(
     1
     0
     3.0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDiscreteGaussianDerivativeImageFilterTest10.png
 )
 itk_add_test(
   NAME itkDiscreteGaussianDerivativeImageFilterTest11
@@ -450,6 +501,8 @@ itk_add_test(
     1
     1
     3.0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDiscreteGaussianDerivativeImageFilterTest11.png
 )
 itk_add_test(
   NAME itkDiscreteGaussianDerivativeImageFilterTest20
@@ -464,6 +517,8 @@ itk_add_test(
     2
     0
     3.0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDiscreteGaussianDerivativeImageFilterTest20.png
 )
 itk_add_test(
   NAME itkDiscreteGaussianDerivativeImageFilterTest02
@@ -478,6 +533,8 @@ itk_add_test(
     0
     2
     3.0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDiscreteGaussianDerivativeImageFilterTest02.png
 )
 itk_add_test(
   NAME itkDiscreteGaussianDerivativeImageFilterTest21
@@ -492,6 +549,8 @@ itk_add_test(
     2
     1
     3.0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDiscreteGaussianDerivativeImageFilterTest21.png
 )
 itk_add_test(
   NAME itkDiscreteGaussianDerivativeImageFilterTest12
@@ -506,6 +565,8 @@ itk_add_test(
     1
     2
     3.0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDiscreteGaussianDerivativeImageFilterTest12.png
 )
 itk_add_test(
   NAME itkDiscreteGaussianDerivativeImageFilterTest30
@@ -520,6 +581,8 @@ itk_add_test(
     3
     0
     3.0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDiscreteGaussianDerivativeImageFilterTest30.png
 )
 itk_add_test(
   NAME itkDiscreteGaussianDerivativeImageFilterTest03
@@ -534,6 +597,8 @@ itk_add_test(
     0
     3
     3.0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDiscreteGaussianDerivativeImageFilterTest03.png
 )
 itk_add_test(
   NAME itkMultiScaleHessianBasedMeasureImageFilterTest
@@ -551,6 +616,10 @@ itk_add_test(
     10
     1
     0
+    ${ITK_TEST_OUTPUT_DIR}/itkMultiScaleHessianBasedMeasureImageFilterTestEnhancedOutput2.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMultiScaleHessianBasedMeasureImageFilterTestEnhancedOutput.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkMultiScaleHessianBasedMeasureImageFilterTestScalesOutput.mha
     ${ITK_TEST_OUTPUT_DIR}/itkMultiScaleHessianBasedMeasureImageFilterTestEnhancedOutput2.mha
 )
 

--- a/Modules/Filtering/ImageFilterBase/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageFilterBase/test/CMakeLists.txt
@@ -52,6 +52,8 @@ itk_add_test(
     itkMaskNeighborhoodOperatorImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/MaskNeighborhoodOperatorImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/MaskNeighborhoodOperatorImageFilterTest.png
 )
 itk_add_test(
   NAME itkCastImageFilterTest

--- a/Modules/Filtering/ImageFusion/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageFusion/test/CMakeLists.txt
@@ -27,6 +27,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1Label.png}
     0.0
     ${ITK_TEST_OUTPUT_DIR}/cthead1-0_0Overlay.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-0_0Overlay.png
 )
 itk_add_test(
   NAME itkLabelOverlayImageFilterTest-Opacity-0_1
@@ -39,6 +41,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     DATA{${ITK_DATA_ROOT}/Input/cthead1Label.png}
     0.1
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-0_1Overlay.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/cthead1-0_1Overlay.png
 )
 itk_add_test(
@@ -53,6 +57,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1Label.png}
     0.2
     ${ITK_TEST_OUTPUT_DIR}/cthead1-0_2Overlay.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-0_2Overlay.png
 )
 itk_add_test(
   NAME itkLabelOverlayImageFilterTest-Opacity-0_3
@@ -65,6 +71,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     DATA{${ITK_DATA_ROOT}/Input/cthead1Label.png}
     0.3
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-0_3Overlay.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/cthead1-0_3Overlay.png
 )
 itk_add_test(
@@ -79,6 +87,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1Label.png}
     0.4
     ${ITK_TEST_OUTPUT_DIR}/cthead1-0_4Overlay.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-0_4Overlay.png
 )
 itk_add_test(
   NAME itkLabelOverlayImageFilterTest-Opacity-0_5
@@ -91,6 +101,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     DATA{${ITK_DATA_ROOT}/Input/cthead1Label.png}
     0.5
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-0_5Overlay.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/cthead1-0_5Overlay.png
 )
 itk_add_test(
@@ -105,6 +117,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1Label.png}
     0.6
     ${ITK_TEST_OUTPUT_DIR}/cthead1-0_6Overlay.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-0_6Overlay.png
 )
 itk_add_test(
   NAME itkLabelOverlayImageFilterTest-Opacity-0_7
@@ -117,6 +131,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     DATA{${ITK_DATA_ROOT}/Input/cthead1Label.png}
     0.7
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-0_7Overlay.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/cthead1-0_7Overlay.png
 )
 itk_add_test(
@@ -131,6 +147,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1Label.png}
     0.8
     ${ITK_TEST_OUTPUT_DIR}/cthead1-0_8Overlay.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-0_8Overlay.png
 )
 itk_add_test(
   NAME itkLabelOverlayImageFilterTest-Opacity-0_9
@@ -143,6 +161,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     DATA{${ITK_DATA_ROOT}/Input/cthead1Label.png}
     0.9
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-0_9Overlay.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/cthead1-0_9Overlay.png
 )
 itk_add_test(
@@ -157,6 +177,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1Label.png}
     1.0
     ${ITK_TEST_OUTPUT_DIR}/cthead1-1_0Overlay.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-1_0Overlay.png
 )
 itk_add_test(
   NAME itkLabelToRGBImageFilterTest
@@ -167,6 +189,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/cthead1Label-color.png
     itkLabelToRGBImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1Label.png}
+    ${ITK_TEST_OUTPUT_DIR}/cthead1Label-color.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/cthead1Label-color.png
 )
 itk_add_test(
@@ -179,6 +203,8 @@ itk_add_test(
     itkLabelMapToRGBImageFilterTest1
     DATA{${ITK_DATA_ROOT}/Input/SpotsLabeled.png}
     ${ITK_TEST_OUTPUT_DIR}/itkLabelMapToRGBImageFilterTest1.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapToRGBImageFilterTest1.png
 )
 itk_add_test(
   NAME itkLabelMapToRGBImageFilterTest2
@@ -189,6 +215,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkLabelMapToRGBImageFilterTest2.png
     itkLabelMapToRGBImageFilterTest2
     DATA{${ITK_DATA_ROOT}/Input/SpotsLabeled.png}
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapToRGBImageFilterTest2.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkLabelMapToRGBImageFilterTest2.png
 )
 itk_add_test(
@@ -208,6 +236,8 @@ itk_add_test(
     10
     1
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapContourOverlayImageFilterTest0.png
 )
 itk_add_test(
   NAME itkLabelMapContourOverlayImageFilterTest1
@@ -226,6 +256,8 @@ itk_add_test(
     15
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapContourOverlayImageFilterTest1.png
 )
 itk_add_test(
   NAME itkLabelMapContourOverlayImageFilterTest2
@@ -244,6 +276,8 @@ itk_add_test(
     12
     1
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapContourOverlayImageFilterTest2.png
 )
 itk_add_test(
   NAME itkLabelMapContourOverlayImageFilterTest3
@@ -261,6 +295,8 @@ itk_add_test(
     3
     12
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapContourOverlayImageFilterTest3.png
 )
 itk_add_test(
   NAME itkLabelMapContourOverlayImageFilterTest4
@@ -278,6 +314,8 @@ itk_add_test(
     2
     15
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapContourOverlayImageFilterTest4.png
 )
 
 itk_add_test(
@@ -292,6 +330,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkLabelMapOverlayImageFilterTest1.png
     0.3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapOverlayImageFilterTest1.png
 )
 itk_add_test(
   NAME itkLabelMapOverlayImageFilterTest2
@@ -305,6 +345,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkLabelMapOverlayImageFilterTest2.png
     0.3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapOverlayImageFilterTest2.png
 )
 itk_add_test(
   NAME itkLabelMapOverlayImageFilterTest3
@@ -318,6 +360,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkLabelMapOverlayImageFilterTest3.png
     0.3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapOverlayImageFilterTest3.png
 )
 
 set(ITKImageFusionGTests itkScalarToRGBPixelFunctorGTest.cxx)

--- a/Modules/Filtering/ImageGradient/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageGradient/test/CMakeLists.txt
@@ -36,6 +36,8 @@ itk_add_test(
     itkGradientImageFilterTest2
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/GradientMagnitudeImageFilterTest2.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/GradientMagnitudeImageFilterTest2.mha
 )
 
 itk_add_test(
@@ -52,6 +54,8 @@ itk_add_test(
     1.0
     1.0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/VectorGradientMagnitudeImageFilterTest1a.png
 )
 itk_add_test(
   NAME itkVectorGradientMagnitudeImageFilterTest1b
@@ -67,6 +71,8 @@ itk_add_test(
     1.0
     1.0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/VectorGradientMagnitudeImageFilterTest1b.png
 )
 itk_add_test(
   NAME itkVectorGradientMagnitudeImageFilterTest2
@@ -80,6 +86,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/VectorGradientMagnitudeImageFilterTest2.png
     0
     5
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/VectorGradientMagnitudeImageFilterTest2.png
 )
 itk_add_test(
   NAME itkVectorGradientMagnitudeImageFilterTest2b
@@ -93,6 +101,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/VectorGradientMagnitudeImageFilterTest2b.png
     1
     5
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/VectorGradientMagnitudeImageFilterTest2b.png
 )
 itk_add_test(
   NAME itkGradientMagnitudeImageFilterTest1
@@ -116,6 +126,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/VHFColor.mhd,VHFColor.raw}
     ${ITK_TEST_OUTPUT_DIR}/VectorGradientMagnitudeImageFilterTest3.mha
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/VectorGradientMagnitudeImageFilterTest3.mha
 )
 itk_add_test(
   NAME itkGradientMagnitudeRecursiveGaussianFilterTest
@@ -167,6 +179,14 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkGradientRecursiveGaussianFilterTest3e.nii.gz
     ${ITK_TEST_OUTPUT_DIR}/itkGradientRecursiveGaussianFilterTest3f.nii.gz
     ${ITK_TEST_OUTPUT_DIR}/itkGradientRecursiveGaussianFilterTest3g.nii.gz
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGradientRecursiveGaussianFilterTest3a.nii.gz
+    ${ITK_TEST_OUTPUT_DIR}/itkGradientRecursiveGaussianFilterTest3b.nii.gz
+    ${ITK_TEST_OUTPUT_DIR}/itkGradientRecursiveGaussianFilterTest3c.nii.gz
+    ${ITK_TEST_OUTPUT_DIR}/itkGradientRecursiveGaussianFilterTest3d.nii.gz
+    ${ITK_TEST_OUTPUT_DIR}/itkGradientRecursiveGaussianFilterTest3e.nii.gz
+    ${ITK_TEST_OUTPUT_DIR}/itkGradientRecursiveGaussianFilterTest3f.nii.gz
+    ${ITK_TEST_OUTPUT_DIR}/itkGradientRecursiveGaussianFilterTest3g.nii.gz
 )
 
 itk_add_test(
@@ -178,6 +198,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkGradientRecursiveGaussianFilterTest4.mha
     itkGradientRecursiveGaussianFilterTest4
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
+    ${ITK_TEST_OUTPUT_DIR}/itkGradientRecursiveGaussianFilterTest4.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkGradientRecursiveGaussianFilterTest4.mha
 )
 

--- a/Modules/Filtering/ImageGrid/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageGrid/test/CMakeLists.txt
@@ -106,6 +106,8 @@ itk_add_test(
     itkBSplineScatteredDataPointSetToImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/cake_easy.png}
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineScatteredDataPointSetToImageFilterTest01.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineScatteredDataPointSetToImageFilterTest01.mha
 )
 itk_add_test(
   NAME itkBSplineScatteredDataPointSetToImageFilterTest02
@@ -115,6 +117,8 @@ itk_add_test(
     DATA{Baseline/itkBSplineScatteredDataPointSetToImageFilterTest02.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineScatteredDataPointSetToImageFilterTest02.mha
     itkBSplineScatteredDataPointSetToImageFilterTest2
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineScatteredDataPointSetToImageFilterTest02.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineScatteredDataPointSetToImageFilterTest02.mha
 )
 itk_add_test(
@@ -126,6 +130,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineScatteredDataPointSetToImageFilterTest03.mha
     itkBSplineScatteredDataPointSetToImageFilterTest3
     DATA{${ITK_DATA_ROOT}/Input/BSplineScatteredApproximationDataPointsInput.txt}
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineScatteredDataPointSetToImageFilterTest03.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineScatteredDataPointSetToImageFilterTest03.mha
 )
 itk_add_test(
@@ -143,6 +149,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineScatteredDataPointSetToImageFilterTest05_magnitude.png
     itkBSplineScatteredDataPointSetToImageFilterTest5
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineScatteredDataPointSetToImageFilterTest05_magnitude.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineScatteredDataPointSetToImageFilterTest05_magnitude.png
 )
 itk_add_test(
   NAME itkBSplineControlPointImageFilterTest1
@@ -156,6 +164,9 @@ itk_add_test(
     DATA{Baseline/N4ControlPoints_2D.nii.gz}
     ${ITK_TEST_OUTPUT_DIR}/N4ControlPoints_2D_output.nii.gz
     ${ITK_TEST_OUTPUT_DIR}/N4ControlPoints_2D_outputRefined.nii.gz
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/N4ControlPoints_2D_output.nii.gz
+    ${ITK_TEST_OUTPUT_DIR}/N4ControlPoints_2D_outputRefined.nii.gz
 )
 itk_add_test(
   NAME itkBSplineControlPointImageFilterTest2
@@ -167,6 +178,9 @@ itk_add_test(
     itkBSplineControlPointImageFilterTest
     3
     DATA{Baseline/N4ControlPoints_3D.nii.gz}
+    ${ITK_TEST_OUTPUT_DIR}/N4ControlPoints_3D_output.nii.gz
+    ${ITK_TEST_OUTPUT_DIR}/N4ControlPoints_3D_outputRefined.nii.gz
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/N4ControlPoints_3D_output.nii.gz
     ${ITK_TEST_OUTPUT_DIR}/N4ControlPoints_3D_outputRefined.nii.gz
 )
@@ -327,6 +341,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mhd,HeadMRVolume.raw}
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineUpsampleImageFilterTest1.mha
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineUpsampleImageFilterTest1.mha
 )
 
 itk_add_test(
@@ -336,6 +352,8 @@ itk_add_test(
     --redirectOutput
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineResampleImageFilterTest
     itkBSplineResampleImageFilterTest
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineResampleImageFilterTest
 )
 set_tests_properties(
   itkBSplineResampleImageFilterTest
@@ -358,6 +376,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mhd,HeadMRVolume.raw}
     ${ITK_TEST_OUTPUT_DIR}/itkBSplineDownsampleImageFilterTest1.mha
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBSplineDownsampleImageFilterTest1.mha
 )
 itk_add_test(
   NAME itkTileImageFilterTest
@@ -386,6 +406,9 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/smooth_circle.png}
     DATA{${ITK_DATA_ROOT}/Input/smooth_square.png}
     ${ITK_TEST_OUTPUT_DIR}/TileImageFilterTest%d.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/TileImageFilterTest4.png
+    ${ITK_TEST_OUTPUT_DIR}/TileImageFilterTest%d.png
 )
 itk_add_test(
   NAME itkInterpolateImageFilterTest
@@ -403,6 +426,8 @@ itk_add_test(
     itkPasteImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     DATA{${ITK_DATA_ROOT}/Input/cake_easy.png}
+    ${ITK_TEST_OUTPUT_DIR}/PasteImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/PasteImageFilterTest.png
 )
 itk_add_test(
@@ -449,6 +474,8 @@ itk_add_test(
     1.0
     11
     7
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/SwirledMirrored_0-11-7.nrrd
 )
 itk_add_test(
   NAME itkMirrorPadWithExponentialDecayTestFloat
@@ -464,6 +491,8 @@ itk_add_test(
     0.75
     11
     7
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/SwirledMirroredFloat_0.75-11-7.nrrd
 )
 itk_add_test(
   NAME itkMirrorPadWithExponentialDecayTestUChar
@@ -479,6 +508,8 @@ itk_add_test(
     0.75
     11
     7
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/SwirledMirroredUChar_0.75-11-7.nrrd
 )
 itk_add_test(
   NAME itkResampleImageTest
@@ -511,6 +542,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2dUseRefImageOff.png
     0
     0.8
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2aUseRefImageOff.png
+    ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2bUseRefImageOff.png
+    ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2cUseRefImageOff.png
+    ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2dUseRefImageOff.png
 )
 itk_add_test(
   NAME itkResampleImageTest2UseRefImageOn
@@ -536,6 +572,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2cUseRefImageOn.png
     ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2dUseRefImageOn.png
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2aUseRefImageOn.png
+    ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2bUseRefImageOn.png
+    ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2cUseRefImageOn.png
+    ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2dUseRefImageOn.png
 )
 itk_add_test(
   NAME itkResampleImageTest2Streaming
@@ -560,6 +601,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2bStreaming.mha
     ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2cStreaming.mha
     ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2dStreaming.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2aStreaming.mha
+    ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2bStreaming.mha
+    ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2cStreaming.mha
+    ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest2dStreaming.mha
 )
 itk_add_test(
   NAME itkResampleImageTest3
@@ -570,6 +616,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest3.png
     itkResampleImageTest3
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
+    ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest3.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest3.png
 )
 itk_add_test(
@@ -588,6 +636,8 @@ itk_add_test(
     itkResampleImageTest5
     10
     ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest5.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest5.png
 )
 itk_add_test(
   NAME itkResampleImageTest6
@@ -598,6 +648,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest6.png
     itkResampleImageTest6
     10
+    ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest6.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/ResampleImageTest6.png
 )
 itk_add_test(
@@ -631,6 +683,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cake_easy.png}
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/PushPopTileImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/PushPopTileImageFilterTest.png
 )
 itk_add_test(
   NAME itkShrinkImageStreamingTest
@@ -658,6 +712,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mhd,HeadMRVolume.raw}
     ${ITK_TEST_OUTPUT_DIR}/itkSliceBySliceImageFilterDimension0Test.mha
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSliceBySliceImageFilterDimension0Test.mha
 )
 itk_add_test(
   NAME itkSliceBySliceImageFilterDimension1Test
@@ -667,6 +723,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mhd,HeadMRVolume.raw}
     ${ITK_TEST_OUTPUT_DIR}/itkSliceBySliceImageFilterDimension1Test.mha
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSliceBySliceImageFilterDimension1Test.mha
 )
 itk_add_test(
   NAME itkSliceBySliceImageFilterDimension2Test
@@ -676,6 +734,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mhd,HeadMRVolume.raw}
     ${ITK_TEST_OUTPUT_DIR}/itkSliceBySliceImageFilterDimension2Test.mha
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSliceBySliceImageFilterDimension2Test.mha
 )
 itk_add_test(
   NAME itkPadImageFilterTest

--- a/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
@@ -147,6 +147,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/RGBTestImage.tif}
     ${ITK_TEST_OUTPUT_DIR}/itkVectorIndexSelectionCastImageFilterTest1.mha
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkVectorIndexSelectionCastImageFilterTest1.mha
 )
 itk_add_test(
   NAME itkVectorIndexSelectionCastImageFilterTest2
@@ -159,6 +161,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/RGBTestImage.tif}
     ${ITK_TEST_OUTPUT_DIR}/itkVectorIndexSelectionCastImageFilterTest2.mha
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkVectorIndexSelectionCastImageFilterTest2.mha
 )
 itk_add_test(
   NAME itkVectorIndexSelectionCastImageFilterTest3
@@ -171,6 +175,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/RGBTestImage.tif}
     ${ITK_TEST_OUTPUT_DIR}/itkVectorIndexSelectionCastImageFilterTest3.mha
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkVectorIndexSelectionCastImageFilterTest3.mha
 )
 itk_add_test(
   NAME itkInvertIntensityImageFilterTest
@@ -181,6 +187,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/InvertIntensityImageFilterTest.png
     itkInvertIntensityImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
+    ${ITK_TEST_OUTPUT_DIR}/InvertIntensityImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/InvertIntensityImageFilterTest.png
 )
 itk_add_test(
@@ -197,6 +205,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkSymmetricEigenAnalysisImageFilterTestOrderByValue.png
     1
     ${ITK_TEST_OUTPUT_DIR}/itkSymmetricEigenAnalysisFixedDimensionImageFilterTestOrderByValue.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSymmetricEigenAnalysisImageFilterTestOrderByValue.png
+    ${ITK_TEST_OUTPUT_DIR}/itkSymmetricEigenAnalysisFixedDimensionImageFilterTestOrderByValue.png
 )
 itk_add_test(
   NAME itkSymmetricEigenAnalysisImageFilterTestOrderByMagnitude
@@ -211,6 +222,9 @@ itk_add_test(
     itkSymmetricEigenAnalysisImageFilterTest
     ${ITK_TEST_OUTPUT_DIR}/itkSymmetricEigenAnalysisImageFilterTestOrderByMagnitude.png
     2
+    ${ITK_TEST_OUTPUT_DIR}/itkSymmetricEigenAnalysisFixedDimensionImageFilterTestOrderByMagnitude.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSymmetricEigenAnalysisImageFilterTestOrderByMagnitude.png
     ${ITK_TEST_OUTPUT_DIR}/itkSymmetricEigenAnalysisFixedDimensionImageFilterTestOrderByMagnitude.png
 )
 # FixedDimension (with Eigen3) orders by value by default.
@@ -227,6 +241,9 @@ itk_add_test(
     itkSymmetricEigenAnalysisImageFilterTest
     ${ITK_TEST_OUTPUT_DIR}/itkSymmetricEigenAnalysisImageFilterTestDoNotOrder.png
     3
+    ${ITK_TEST_OUTPUT_DIR}/itkSymmetricEigenAnalysisFixedDimensionImageFilterTestDoNotOrder.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSymmetricEigenAnalysisImageFilterTestDoNotOrder.png
     ${ITK_TEST_OUTPUT_DIR}/itkSymmetricEigenAnalysisFixedDimensionImageFilterTestDoNotOrder.png
 )
 itk_add_test(
@@ -249,6 +266,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkAndImageFilterTest.png
     93d46ee3d5e0c157e2b2d27977ae4d0f
     itkAndImageFilterTest
+    ${ITK_TEST_OUTPUT_DIR}/itkAndImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkAndImageFilterTest.png
 )
 itk_add_test(
@@ -278,6 +297,8 @@ itk_add_test(
     6ef609d089e93e2eed8f089f75bc67fb
     itkConstrainedValueAdditionImageFilterTest
     ${ITK_TEST_OUTPUT_DIR}/itkConstrainedValueAdditionImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkConstrainedValueAdditionImageFilterTest.png
 )
 itk_add_test(
   NAME itkAtanImageFilterAndAdaptorTest
@@ -303,6 +324,8 @@ itk_add_test(
     ITKImageIntensityTestDriver
     itkAddImageFilterTest2
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mha}
+    ${TEMP}/itkAddImageFilterTest2.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${TEMP}/itkAddImageFilterTest2.mha
 )
 itk_add_test(
@@ -338,6 +361,8 @@ itk_add_test(
     --redirectOutput
     ${TEMP}/itkNormalizeImageFilterTest.txt
     itkNormalizeImageFilterTest
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkNormalizeImageFilterTest.txt
 )
 set_tests_properties(
   itkNormalizeImageFilterTest
@@ -379,6 +404,8 @@ itk_add_test(
     7f199e1363c4b754eb03cf4d0ba8d343
     itkTernaryMagnitudeImageFilterTest
     ${ITK_TEST_OUTPUT_DIR}/itkTernaryMagnitudeImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTernaryMagnitudeImageFilterTest.png
 )
 itk_add_test(
   NAME itkMaximumImageFilterTest
@@ -400,6 +427,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Baseline/BasicFilters/MatrixIndexSelectionImageFilterTest.png}
     ${ITK_TEST_OUTPUT_DIR}/MatrixIndexSelectionImageFilterTest.png
     itkMatrixIndexSelectionImageFilterTest
+    ${ITK_TEST_OUTPUT_DIR}/MatrixIndexSelectionImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/MatrixIndexSelectionImageFilterTest.png
 )
 itk_add_test(
@@ -509,6 +538,8 @@ itk_add_test(
     817d6d96c1c07cb12bfc200134aa57ba
     itkOrImageFilterTest
     ${ITK_TEST_OUTPUT_DIR}/itkOrImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkOrImageFilterTest.png
 )
 itk_add_test(
   NAME itkRGBToLuminanceImageFilterAndAdaptorTest.cxx
@@ -524,6 +555,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkXorImageFilterTest.png
     3b5b9852567ef7618aac7f5f2d74ef74
     itkXorImageFilterTest
+    ${ITK_TEST_OUTPUT_DIR}/itkXorImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkXorImageFilterTest.png
 )
 itk_add_test(
@@ -557,6 +590,8 @@ itk_add_test(
     itkPolylineMask2DImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkPolylineMask2DImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPolylineMask2DImageFilterTest.png
 )
 itk_add_test(
   NAME itkPolylineMaskImageFilterTest
@@ -566,6 +601,8 @@ itk_add_test(
     DATA{Baseline/PolylineMaskImageFilterTest.mha}
     ${ITK_TEST_OUTPUT_DIR}/PolylineMaskImageFilterTest.mha
     itkPolylineMaskImageFilterTest
+    ${ITK_TEST_OUTPUT_DIR}/PolylineMaskImageFilterTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/PolylineMaskImageFilterTest.mha
 )
 itk_add_test(
@@ -578,6 +615,8 @@ itk_add_test(
     itkPromoteDimensionImageTest
     DATA{${ITK_DATA_ROOT}/Input/VisibleWomanEyeSlice.png}
     ${ITK_TEST_OUTPUT_DIR}/PromoteDimensionImageTest.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/PromoteDimensionImageTest.{mhd,raw}
 )
 itk_add_test(
   NAME itkModulusImageFilterTest
@@ -588,6 +627,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/ModulusImageFilterTest.png
     itkModulusImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/Spots.png}
+    ${ITK_TEST_OUTPUT_DIR}/ModulusImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/ModulusImageFilterTest.png
 )
 itk_add_test(
@@ -625,6 +666,8 @@ itk_add_test(
     DATA{Input/itkBrainSliceComplexMagnitude.mha}
     DATA{Input/itkBrainSliceComplexPhase.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkMagnitudeAndPhaseToComplexImageFilterTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMagnitudeAndPhaseToComplexImageFilterTest.mha
 )
 itk_add_test(
   NAME itkDiscreteHessianGaussianImageFunctionTest
@@ -639,6 +682,8 @@ itk_add_test(
     2.0
     0.01
     32
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDiscreteHessianGaussianImageFunctionTest.mha
 )
 itk_add_test(
   NAME itkDiscreteGradientMagnitudeGaussianImageFunctionTest01
@@ -655,6 +700,8 @@ itk_add_test(
     32
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDiscreteGradientMagnitudeGaussianImageFunctionTest01.png
 )
 itk_add_test(
   NAME itkDiscreteGradientMagnitudeGaussianImageFunctionTest02
@@ -671,6 +718,8 @@ itk_add_test(
     64
     1
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDiscreteGradientMagnitudeGaussianImageFunctionTest02.png
 )
 itk_add_test(
   NAME itkDiscreteGradientMagnitudeGaussianImageFunctionTestUseImageSpacingOff
@@ -687,6 +736,8 @@ itk_add_test(
     64
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDiscreteGradientMagnitudeGaussianImageFunctionTestUseImageSpacingOff.png
 )
 itk_add_test(
   NAME itkDiscreteGaussianDerivativeImageFunctionTest01
@@ -703,6 +754,8 @@ itk_add_test(
     0.01
     32
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDiscreteGaussianDerivativeImageFunctionTest01.png
 )
 itk_add_test(
   NAME itkDiscreteGaussianDerivativeImageFunctionTest02
@@ -719,6 +772,8 @@ itk_add_test(
     0.03
     16
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDiscreteGaussianDerivativeImageFunctionTest02.png
 )
 
 set(

--- a/Modules/Filtering/ImageLabel/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageLabel/test/CMakeLists.txt
@@ -23,6 +23,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkLabelContourImageFilterTest0.png
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelContourImageFilterTest0.png
 )
 itk_add_test(
   NAME itkLabelContourImageFilterTest1
@@ -36,6 +38,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkLabelContourImageFilterTest1.png
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelContourImageFilterTest1.png
 )
 itk_add_test(
   NAME itkBinaryContourImageFilterTest0
@@ -50,6 +54,8 @@ itk_add_test(
     0
     200
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryContourImageFilterTest0.png
 )
 itk_add_test(
   NAME itkBinaryContourImageFilterTest1
@@ -64,4 +70,6 @@ itk_add_test(
     1
     200
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryContourImageFilterTest1.png
 )

--- a/Modules/Filtering/ImageSources/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageSources/test/CMakeLists.txt
@@ -24,6 +24,8 @@ itk_add_test(
     itkGaborImageSourceTest
     ${ITK_TEST_OUTPUT_DIR}/GaborImageSourceTest0.mha
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/GaborImageSourceTest0.mha
 )
 itk_add_test(
   NAME itkGaborImageSourceTest1
@@ -35,6 +37,8 @@ itk_add_test(
     itkGaborImageSourceTest
     ${ITK_TEST_OUTPUT_DIR}/GaborImageSourceTest1.mha
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/GaborImageSourceTest1.mha
 )
 itk_add_test(
   NAME itkGaussianImageSourceTest1
@@ -46,6 +50,8 @@ itk_add_test(
     itkGaussianImageSourceTest
     ${ITK_TEST_OUTPUT_DIR}/itkGaussianImageSourceTest1.nrrd
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGaussianImageSourceTest1.nrrd
 )
 itk_add_test(
   NAME itkGaussianImageSourceTest2
@@ -57,6 +63,8 @@ itk_add_test(
     itkGaussianImageSourceTest
     ${ITK_TEST_OUTPUT_DIR}/itkGaussianImageSourceTest2.nrrd
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGaussianImageSourceTest2.nrrd
 )
 itk_add_test(
   NAME itkGridImageSourceTest1
@@ -77,6 +85,8 @@ itk_add_test(
     0
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGridImageSourceTest1.{nhdr,raw}
 )
 itk_add_test(
   NAME itkGridImageSourceTest2
@@ -97,6 +107,8 @@ itk_add_test(
     0
     1
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGridImageSourceTest2.{nhdr,raw}
 )
 itk_add_test(
   NAME itkGridImageSourceTest3
@@ -117,6 +129,8 @@ itk_add_test(
     1
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGridImageSourceTest3.{nhdr,raw}
 )
 itk_add_test(
   NAME itkGridImageSourceTest4
@@ -137,6 +151,8 @@ itk_add_test(
     0
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGridImageSourceTest4.{nhdr,raw}
 )
 itk_add_test(
   NAME itkGridImageSourceTest5
@@ -147,6 +163,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkGridImageSourceTest5.mha
     itkGridImageSourceTest2
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
+    ${ITK_TEST_OUTPUT_DIR}/itkGridImageSourceTest5.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkGridImageSourceTest5.mha
 )
 itk_add_test(
@@ -159,6 +177,8 @@ itk_add_test(
     itkPhysicalPointImageSourceTest
     ${ITK_TEST_OUTPUT_DIR}/itkPhysicalPointImageSourceTest0.mha
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPhysicalPointImageSourceTest0.mha
 )
 itk_add_test(
   NAME itkPhysicalPointImageSourceTest1
@@ -171,6 +191,8 @@ itk_add_test(
     itkPhysicalPointImageSourceTest
     ${ITK_TEST_OUTPUT_DIR}/itkPhysicalPointImageSourceTest1.mha
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPhysicalPointImageSourceTest1.mha
 )
 itk_add_test(
   NAME itkPhysicalPointImageSourceTest2
@@ -182,6 +204,8 @@ itk_add_test(
     itkPhysicalPointImageSourceTest
     ${ITK_TEST_OUTPUT_DIR}/itkPhysicalPointImageSourceTest2.mha
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPhysicalPointImageSourceTest2.mha
 )
 itk_add_test(
   NAME itkPhysicalPointImageSourceTest3
@@ -194,6 +218,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkPhysicalPointImageSourceTest3.mha
     3
     0.0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPhysicalPointImageSourceTest3.mha
 )
 itk_add_test(
   NAME itkPhysicalPointImageSourceTest4
@@ -208,4 +234,6 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkPhysicalPointImageSourceTest4.nrrd
     3
     0.785398163
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPhysicalPointImageSourceTest4.nrrd
 )

--- a/Modules/Filtering/ImageStatistics/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageStatistics/test/CMakeLists.txt
@@ -93,6 +93,8 @@ itk_add_test(
     itkSumProjectionImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mhd,HeadMRVolume.raw}
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeSumProjection.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeSumProjection.tif
 )
 itk_add_test(
   NAME itkStandardDeviationProjectionImageFilterTest
@@ -103,6 +105,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeStandardDeviationProjection.tif
     itkStandardDeviationProjectionImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mhd,HeadMRVolume.raw}
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeStandardDeviationProjection.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeStandardDeviationProjection.tif
 )
 itk_add_test(
@@ -143,6 +147,8 @@ itk_add_test(
     0
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolumeWithDirection.mhd,HeadMRVolume.raw}
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeMaximumProjection0.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeMaximumProjection0.mha
 )
 itk_add_test(
   NAME itkMaximumProjectionImageFilterTest2_2
@@ -154,6 +160,8 @@ itk_add_test(
     itkMaximumProjectionImageFilterTest2
     1
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolumeWithDirection.mhd,HeadMRVolume.raw}
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeMaximumProjection1.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeMaximumProjection1.mha
 )
 itk_add_test(
@@ -167,6 +175,8 @@ itk_add_test(
     0
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolumeWithDirection.mhd,HeadMRVolume.raw}
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeMaximumProjection2D0.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeMaximumProjection2D0.mha
 )
 itk_add_test(
   NAME itkMaximumProjectionImageFilterTest3_2
@@ -178,6 +188,8 @@ itk_add_test(
     itkMaximumProjectionImageFilterTest3
     1
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolumeWithDirection.mhd,HeadMRVolume.raw}
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeMaximumProjection2D1.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeMaximumProjection2D1.tif
 )
 itk_add_test(
@@ -191,6 +203,8 @@ itk_add_test(
     2
     DATA{${ITK_DATA_ROOT}/Input/VHFColor.mhd,VHFColor.mhd.raw}
     ${ITK_TEST_OUTPUT_DIR}/VHFColorMaximumProjection2D1.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/VHFColorMaximumProjection2D1.tif
 )
 
 itk_add_test(
@@ -203,6 +217,8 @@ itk_add_test(
     itkMinimumProjectionImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mhd,HeadMRVolume.raw}
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeMinimumProjection.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeMinimumProjection.tif
 )
 itk_add_test(
   NAME itkMeanProjectionImageFilterTest
@@ -213,6 +229,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeMeanProjection.tif
     itkMeanProjectionImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mhd,HeadMRVolume.raw}
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeMeanProjection.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeMeanProjection.tif
 )
 itk_add_test(
@@ -231,6 +249,8 @@ itk_add_test(
     itkMaximumProjectionImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mhd,HeadMRVolume.raw}
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeMaximumProjection.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeMaximumProjection.tif
 )
 itk_add_test(
   NAME itkMedianProjectionImageFilterTest
@@ -242,6 +262,8 @@ itk_add_test(
     itkMedianProjectionImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mhd,HeadMRVolume.raw}
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeMedianProjection.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeMedianProjection.tif
 )
 itk_add_test(
   NAME itkHistogramToEntropyImageFilterTest1
@@ -250,6 +272,8 @@ itk_add_test(
     itkHistogramToEntropyImageFilterTest1
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkHistogramToEntropyImageFilterTest1.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHistogramToEntropyImageFilterTest1.{mhd,raw}
 )
 itk_add_test(
   NAME itkHistogramToEntropyImageFilterTest2
@@ -259,6 +283,8 @@ itk_add_test(
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySlice.png
     ${ITK_EXAMPLE_DATA_ROOT}/BrainT1Slice.png
     ${ITK_TEST_OUTPUT_DIR}/itkHistogramToEntropyImageFilterTest2.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHistogramToEntropyImageFilterTest2.{mhd,raw}
 )
 itk_add_test(
   NAME itkHistogramToIntensityImageFilterTest1
@@ -267,6 +293,8 @@ itk_add_test(
     itkHistogramToIntensityImageFilterTest1
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkHistogramToIntensityImageFilterTest1.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHistogramToIntensityImageFilterTest1.{mhd,raw}
 )
 itk_add_test(
   NAME itkHistogramToIntensityImageFilterTest2
@@ -276,6 +304,8 @@ itk_add_test(
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySlice.png
     ${ITK_EXAMPLE_DATA_ROOT}/BrainT1Slice.png
     ${ITK_TEST_OUTPUT_DIR}/itkHistogramToIntensityImageFilterTest2.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHistogramToIntensityImageFilterTest2.{mhd,raw}
 )
 itk_add_test(
   NAME itkHistogramToLogProbabilityImageFilterTest1
@@ -284,6 +314,8 @@ itk_add_test(
     itkHistogramToLogProbabilityImageFilterTest1
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkHistogramToLogProbabilityImageFilterTest1.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHistogramToLogProbabilityImageFilterTest1.{mhd,raw}
 )
 itk_add_test(
   NAME itkHistogramToLogProbabilityImageFilterTest2
@@ -293,6 +325,8 @@ itk_add_test(
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySlice.png
     ${ITK_EXAMPLE_DATA_ROOT}/BrainT1Slice.png
     ${ITK_TEST_OUTPUT_DIR}/itkHistogramToLogProbabilityImageFilterTest2.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHistogramToLogProbabilityImageFilterTest2.{mhd,raw}
 )
 itk_add_test(
   NAME itkHistogramToProbabilityImageFilterTest1
@@ -301,6 +335,8 @@ itk_add_test(
     itkHistogramToProbabilityImageFilterTest1
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkHistogramToProbabilityImageFilterTest1.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHistogramToProbabilityImageFilterTest1.{mhd,raw}
 )
 itk_add_test(
   NAME itkHistogramToProbabilityImageFilterTest2
@@ -310,6 +346,8 @@ itk_add_test(
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySlice.png
     ${ITK_EXAMPLE_DATA_ROOT}/BrainT1Slice.png
     ${ITK_TEST_OUTPUT_DIR}/itkHistogramToProbabilityImageFilterTest2.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHistogramToProbabilityImageFilterTest2.{mhd,raw}
 )
 
 itk_add_test(
@@ -321,6 +359,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/AccumulateImageFilterTest.png
     itkAccumulateImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/DicomSeries/,REGEX:Image[0-9]+.dcm}
+    ${ITK_TEST_OUTPUT_DIR}/AccumulateImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/AccumulateImageFilterTest.png
 )
 itk_add_test(
@@ -336,6 +376,8 @@ itk_add_test(
     10
     0.5
     0.5
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/AdaptiveHistogramEqualizationImageFilterTest.png
 )
 itk_add_test(
   NAME itkAdaptiveHistogramEqualizationImageFilterTest2
@@ -350,6 +392,8 @@ itk_add_test(
     10
     1.0
     0.25
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/AdaptiveHistogramEqualizationImageFilterTest2.png
 )
 itk_add_test(
   NAME itkGetAverageSliceImageFilterTest
@@ -362,6 +406,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/DicomSeries/,REGEX:Image[0-9]+.dcm}
     ${ITK_TEST_OUTPUT_DIR}/GetAverageSliceImageFilterTest.png
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/GetAverageSliceImageFilterTest.png
 )
 itk_add_test(
   NAME itkBinaryProjectionImageFilterTest1
@@ -375,6 +421,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeBinaryProjection100.tif
     100
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeBinaryProjection100.tif
 )
 itk_add_test(
   NAME itkBinaryProjectionImageFilterTest2
@@ -388,6 +436,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeBinaryProjection200.tif
     200
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeBinaryProjection200.tif
 )
 itk_add_test(
   NAME itkProjectionImageFilterTest1
@@ -401,6 +451,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeProjection100.tif
     100
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeProjection100.tif
 )
 
 itk_add_test(

--- a/Modules/Filtering/IsotropicWavelets/test/CMakeLists.txt
+++ b/Modules/Filtering/IsotropicWavelets/test/CMakeLists.txt
@@ -107,6 +107,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkWaveletFrequencyFilterBankGeneratorTest1.tiff
     1
     "Held"
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkWaveletFrequencyFilterBankGeneratorTest1.tiff
 )
 itk_add_test(
   NAME itkWaveletFrequencyFilterBankGeneratorTest2
@@ -117,6 +119,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkWaveletFrequencyFilterBankGeneratorTest2.tiff
     2
     "Held"
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkWaveletFrequencyFilterBankGeneratorTest2.tiff
 )
 # 2D:
 # DISABLED: checkershadow_Lch_512x512.tiff is orphaned (404 from gh-pages,
@@ -169,6 +173,8 @@ itk_add_test(
     DATA{Input/collagen_64x64x16.tiff}
     ${ITK_TEST_OUTPUT_DIR}/itkRieszFrequencyFilterBankGeneratorTest1.tiff
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkRieszFrequencyFilterBankGeneratorTest1.tiff
 )
 itk_add_test(
   NAME itkRieszFrequencyFilterBankGeneratorTest2
@@ -178,6 +184,8 @@ itk_add_test(
     DATA{Input/collagen_64x64x16.tiff}
     ${ITK_TEST_OUTPUT_DIR}/itkRieszFrequencyFilterBankGeneratorTest2.tiff
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkRieszFrequencyFilterBankGeneratorTest2.tiff
 )
 # Riesz Steerable framework
 itk_add_test(
@@ -202,6 +210,8 @@ itk_add_test(
     itkMonogenicSignalFrequencyImageFilterTest
     DATA{Input/collagen_32x32x16.tiff}
     ${ITK_TEST_OUTPUT_DIR}/itkMonogenicSignalFrequencyImageFilterTest.tiff
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMonogenicSignalFrequencyImageFilterTest.tiff
 )
 
 itk_add_test(
@@ -216,6 +226,8 @@ itk_add_test(
     10044.513
     5020.3013
     20085.115
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPhaseAnalysisSoftThresholdImageFilterTest.tiff
 )
 # StructureTensor
 itk_add_test(
@@ -243,6 +255,8 @@ itk_add_test(
     1
     1
     "Vow"
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkWaveletFrequencyForwardTest.tiff
 )
 
 # DISABLED: checkershadow_Lch_512x512.tiff is orphaned (404 from gh-pages,
@@ -264,6 +278,8 @@ itk_add_test(
     2
     1
     "Simoncelli"
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkWaveletFrequencyForwardUndecimatedTest.tiff
 )
 
 #Wavelet Inverse
@@ -280,6 +296,8 @@ itk_add_test(
     1
     1
     "Held"
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkWaveletFrequencyInverseTest.tiff
 )
 
 itk_add_test(
@@ -295,6 +313,8 @@ itk_add_test(
     2
     5
     "Held"
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkWaveletFrequencyInverseTestMultiLevelMultiBand.tiff
 )
 # Wavelet Inverse Undecimated
 itk_add_test(
@@ -312,6 +332,8 @@ itk_add_test(
     "Held"
     "noFilterBankPyramid"
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkWaveletFrequencyInverseUndecimatedTest.tiff
 )
 #2D
 # DISABLED: checkershadow_Lch_512x512.tiff is orphaned (404 from gh-pages,
@@ -364,6 +386,8 @@ itk_add_test(
     1
     Apply
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkStructureTensorWithGeneralizedRieszTest.tiff
 )
 # DISABLED: checkershadow_Lch_512x512.tiff is orphaned (404 from gh-pages,
 # Girder, and itk.org). TODO: re-enable when a replacement baseline is
@@ -386,6 +410,8 @@ itk_add_test(
     ${DefaultWavelet}
     3
     Apply
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkRieszWaveletPhaseAnalysisTest.tiff
 )
 itk_add_test(
   NAME itkRieszWaveletPhaseAnalysisTestMultiLevelMultiBand
@@ -399,6 +425,8 @@ itk_add_test(
     ${DefaultWavelet}
     3
     Apply
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkRieszWaveletPhaseAnalysisTestMultiLevelMultiBand.tiff
 )
 ###
 # DISABLED: checkershadow_Lch_512x512.tiff is orphaned (404 from gh-pages,
@@ -428,6 +456,8 @@ itk_add_test(
     1
     "Held"
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/profileMotherWaveletHeld_*
 )
 itk_add_test(
   NAME itkIsotropicWaveletFrequencyFunctionShannonTest
@@ -439,6 +469,8 @@ itk_add_test(
     1
     "Shannon"
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/profileMotherWaveletShannon_*
 )
 itk_add_test(
   NAME itkIsotropicWaveletFrequencyFunctionSimoncelliTest
@@ -450,6 +482,8 @@ itk_add_test(
     1
     "Simoncelli"
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/profileMotherWaveletSimoncelli_*
 )
 itk_add_test(
   NAME itkIsotropicWaveletFrequencyFunctionVowTest
@@ -461,6 +495,8 @@ itk_add_test(
     1
     "Vow"
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/profileMotherWaveletVow_*
 )
 
 itk_add_test(
@@ -543,6 +579,8 @@ itk_add_test(
     DATA{Input/collagen_32x32x16.tiff}
     ${ITK_TEST_OUTPUT_DIR}/itkFrequencyExpandAndShrinkTest3D.tiff
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFrequencyExpandAndShrinkTest3D.tiff
 )
 ## Even input
 #Expand
@@ -556,6 +594,8 @@ itk_add_test(
     itkFrequencyExpandTest
     DATA{Input/collagen_32x32x16.tiff}
     ${ITK_TEST_OUTPUT_DIR}/itkFrequencyExpandEvenTest.tiff
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFrequencyExpandEvenTest.tiff
 )
 ##Shrink
 itk_add_test(
@@ -567,6 +607,8 @@ itk_add_test(
     #   ${ITK_TEST_OUTPUT_DIR}/itkFrequencyShrinkEvenTest.tiff
     itkFrequencyShrinkTest
     DATA{Input/collagen_32x32x16.tiff}
+    ${ITK_TEST_OUTPUT_DIR}/itkFrequencyShrinkEvenTest.tiff
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkFrequencyShrinkEvenTest.tiff
 )
 # DISABLED: checkershadow_Lch_512x512.tiff is orphaned (404 from gh-pages,
@@ -605,6 +647,9 @@ itk_add_test(
     Simoncelli
     3
     NoApply
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/vol11-16_16_16_L2_B2_S2.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/vol11-16_16_16.nrrd
 )
 ## WaveletCoeffsSpatialDomain
 itk_add_test(
@@ -621,6 +666,8 @@ itk_add_test(
     2
     Simoncelli
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/vol11-16_16_16_SpatialDomain.nrrd
 )
 
 ## Odd input
@@ -640,6 +687,8 @@ if(ITK_USE_FFTWF OR ITK_USE_FFTWD)
       itkFrequencyExpandTest
       DATA{Input/collagen_21x21x9.tiff}
       ${ITK_TEST_OUTPUT_DIR}/itkFrequencyExpandOddTest.tiff
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/itkFrequencyExpandOddTest.tiff
   )
   #Shrink
   itk_add_test(
@@ -648,6 +697,8 @@ if(ITK_USE_FFTWF OR ITK_USE_FFTWD)
       IsotropicWaveletsTestDriver
       itkFrequencyShrinkTest
       DATA{Input/collagen_21x21x9.tiff}
+      ${ITK_TEST_OUTPUT_DIR}/itkFrequencyShrinkOddTest.tiff
+    ITK_REMOVE_TEMPORARY_TEST_FILES
       ${ITK_TEST_OUTPUT_DIR}/itkFrequencyShrinkOddTest.tiff
   )
   list(

--- a/Modules/Filtering/LabelErodeDilate/test/CMakeLists.txt
+++ b/Modules/Filtering/LabelErodeDilate/test/CMakeLists.txt
@@ -19,6 +19,8 @@ itk_add_test(
     DATA{Input/axial.png}
     5
     ${ITK_TEST_OUTPUT_DIR}/axialdilate5.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/axialdilate5.png
 )
 
 itk_add_test(
@@ -31,6 +33,8 @@ itk_add_test(
     itkLabelSetDilateTest
     DATA{Input/HarvardOxford-cort-maxprob-thr50-1mm.nii.gz}
     5
+    ${ITK_TEST_OUTPUT_DIR}/cortdilate_5.nii.gz
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/cortdilate_5.nii.gz
 )
 
@@ -45,6 +49,8 @@ itk_add_test(
     DATA{Input/dot.nii.gz}
     41
     ${ITK_TEST_OUTPUT_DIR}/dotdilate_41.nii.gz
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/dotdilate_41.nii.gz
 )
 
 itk_add_test(
@@ -57,6 +63,8 @@ itk_add_test(
     itkLabelSetErodeTest
     DATA{Input/axial.png}
     3
+    ${ITK_TEST_OUTPUT_DIR}/axialerode3.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/axialerode3.png
 )
 
@@ -71,6 +79,8 @@ itk_add_test(
     DATA{Input/HarvardOxford-cort-maxprob-thr50-1mm.nii.gz}
     3
     ${ITK_TEST_OUTPUT_DIR}/corterode_3.nii.gz
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/corterode_3.nii.gz
 )
 
 itk_add_test(
@@ -83,5 +93,7 @@ itk_add_test(
     itkLabelSetErodeTest
     DATA{Input/hole.nii.gz}
     41
+    ${ITK_TEST_OUTPUT_DIR}/holeerode_41.nii.gz
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/holeerode_41.nii.gz
 )

--- a/Modules/Filtering/LabelMap/test/CMakeLists.txt
+++ b/Modules/Filtering/LabelMap/test/CMakeLists.txt
@@ -88,6 +88,8 @@ itk_add_test(
     itkAggregateLabelMapFilterTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1Label.png}
     ${ITK_TEST_OUTPUT_DIR}/cthead1-labelAggregate.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-labelAggregate.mha
 )
 itk_add_test(
   NAME itkAttributeKeepNObjectsLabelMapFilterTest0
@@ -101,6 +103,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkAttributeKeepNObjectsLabelMapFilterTest0.png
     2
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkAttributeKeepNObjectsLabelMapFilterTest0.png
 )
 itk_add_test(
   NAME itkAttributeKeepNObjectsLabelMapFilterTest1
@@ -114,6 +118,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkAttributeKeepNObjectsLabelMapFilterTest1.png
     2
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkAttributeKeepNObjectsLabelMapFilterTest1.png
 )
 itk_add_test(
   NAME itkAttributeLabelObjectAccessorsTest1
@@ -135,6 +141,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkAttributeOpeningLabelMapFilterTest0.png
     2
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkAttributeOpeningLabelMapFilterTest0.png
 )
 itk_add_test(
   NAME itkAttributeOpeningLabelMapFilterTest1
@@ -148,6 +156,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkAttributeOpeningLabelMapFilterTest1.png
     2
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkAttributeOpeningLabelMapFilterTest1.png
 )
 itk_add_test(
   NAME itkAttributePositionLabelMapFilterTest1
@@ -158,6 +168,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkAttributePositionLabelMapFilterTest1.png
     itkAttributePositionLabelMapFilterTest1
     DATA{${ITK_DATA_ROOT}/Input/SpotsLabeled.png}
+    ${ITK_TEST_OUTPUT_DIR}/itkAttributePositionLabelMapFilterTest1.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkAttributePositionLabelMapFilterTest1.png
 )
 itk_add_test(
@@ -171,6 +183,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1Label.png}
     ${ITK_TEST_OUTPUT_DIR}/itkAttributeRelabelLabelMapFilterTest0.png
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkAttributeRelabelLabelMapFilterTest0.png
 )
 itk_add_test(
   NAME itkAttributeRelabelLabelMapFilterTest1
@@ -183,6 +197,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1Label.png}
     ${ITK_TEST_OUTPUT_DIR}/itkAttributeRelabelLabelMapFilterTest1.png
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkAttributeRelabelLabelMapFilterTest1.png
 )
 itk_add_test(
   NAME itkAttributeUniqueLabelMapFilterTest0
@@ -195,6 +211,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/SpotsLabeled.png}
     ${ITK_TEST_OUTPUT_DIR}/itkAttributeUniqueLabelMapFilterTest0.png
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkAttributeUniqueLabelMapFilterTest0.png
 )
 itk_add_test(
   NAME itkAttributeUniqueLabelMapFilterTest1
@@ -207,6 +225,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/SpotsLabeled.png}
     ${ITK_TEST_OUTPUT_DIR}/itkAttributeUniqueLabelMapFilterTest1.png
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkAttributeUniqueLabelMapFilterTest1.png
 )
 itk_add_test(
   NAME itkAutoCropLabelMapFilterTest1
@@ -221,6 +241,8 @@ itk_add_test(
     176
     4
     4
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-label-autocrop.mha
 )
 itk_add_test(
   NAME itkBinaryFillholeImageFilterTest1
@@ -234,6 +256,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBinaryFillholeImageFilterTest1.png
     1
     255
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryFillholeImageFilterTest1.png
 )
 itk_add_test(
   NAME itkBinaryFillholeImageFilterTest3D_0
@@ -247,6 +271,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBinaryFillholeImageFilterTest3D_0.nrrd
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryFillholeImageFilterTest3D_0.nrrd
 )
 itk_add_test(
   NAME itkBinaryFillholeImageFilterTest3D_1
@@ -260,6 +286,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBinaryFillholeImageFilterTest3D_1.nrrd
     1
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryFillholeImageFilterTest3D_1.nrrd
 )
 itk_add_test(
   NAME itkBinaryGrindPeakImageFilterTest1
@@ -274,6 +302,8 @@ itk_add_test(
     1
     255
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryGrindPeakImageFilterTest1.png
 )
 itk_add_test(
   NAME itkBinaryGrindPeakImageFilterTest2
@@ -288,6 +318,8 @@ itk_add_test(
     0
     255
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryGrindPeakImageFilterTest2.png
 )
 itk_add_test(
   NAME itkBinaryImageToLabelMapFilterTest1
@@ -303,6 +335,8 @@ itk_add_test(
     255
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-labeled.mha
 )
 itk_add_test(
   NAME itkBinaryImageToLabelMapFilterTest2
@@ -318,6 +352,8 @@ itk_add_test(
     255
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/connected0lines-0.png
 )
 itk_add_test(
   NAME itkBinaryImageToLabelMapFilterTest3
@@ -333,6 +369,8 @@ itk_add_test(
     255
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/connected0lines-1.png
 )
 itk_add_test(
   NAME itkBinaryImageToLabelMapFilterTest4
@@ -345,6 +383,8 @@ itk_add_test(
     255
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/tooManyObjects.png
 )
 itk_add_test(
   NAME itkBinaryImageToLabelMapFilterTest5
@@ -360,6 +400,8 @@ itk_add_test(
     255
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/nonConnected3DLines-0.tif
 )
 itk_add_test(
   NAME itkBinaryImageToLabelMapFilterTest6
@@ -371,6 +413,8 @@ itk_add_test(
     255
     0
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/LabelImage1Row.bmp
 )
 itk_add_test(
   NAME itkBinaryImageToLabelMapFilterTest7
@@ -382,6 +426,8 @@ itk_add_test(
     255
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/LabelImage1Row_Test7.bmp
 )
 itk_add_test(
   NAME itkBinaryImageToShapeLabelMapFilterTest1
@@ -399,6 +445,8 @@ itk_add_test(
     1
     1
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/Spots-binaryimage-to-shapelabel.mha
 )
 itk_add_test(
   NAME itkBinaryImageToStatisticsLabelMapFilterTest1
@@ -418,6 +466,8 @@ itk_add_test(
     1
     1
     128
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/Spots-binaryimage-to-statisticslabel.mha
 )
 itk_add_test(
   NAME itkBinaryNotImageFilterTest
@@ -429,6 +479,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBinaryNotImageFilterTest.png
     255
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryNotImageFilterTest.png
 )
 itk_add_test(
   NAME itkBinaryReconstructionByDilationImageFilterTest
@@ -444,6 +496,8 @@ itk_add_test(
     255
     100
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryReconstructionByDilationImageFilterTest.png
 )
 itk_add_test(
   NAME itkBinaryReconstructionByErosionImageFilterTest
@@ -459,6 +513,8 @@ itk_add_test(
     0
     255
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryReconstructionByErosionImageFilterTest.png
 )
 itk_add_test(
   NAME itkBinaryReconstructionLabelMapFilterTest
@@ -472,6 +528,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1-markers.png}
     ${ITK_TEST_OUTPUT_DIR}/itkBinaryReconstructionLabelMapFilterTest.png
     94
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryReconstructionLabelMapFilterTest.png
 )
 itk_add_test(
   NAME itkBinaryShapeKeepNObjectsImageFilterTest1
@@ -489,6 +547,8 @@ itk_add_test(
     0
     1
     Label
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryShapeKeepNObjectsImageFilterTest1.png
 )
 itk_add_test(
   NAME itkBinaryShapeOpeningImageFilterTest1
@@ -506,6 +566,8 @@ itk_add_test(
     1
     1
     100
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-binary-shape-opening.mha
 )
 itk_add_test(
   NAME itkBinaryStatisticsKeepNObjectsImageFilterTest1
@@ -524,6 +586,8 @@ itk_add_test(
     0
     0
     200
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryStatisticsKeepNObjectsImageFilterTest1.png
 )
 itk_add_test(
   NAME itkBinaryStatisticsOpeningImageFilterTest1
@@ -542,6 +606,8 @@ itk_add_test(
     0
     0
     202
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBinaryStatisticsOpeningImageFilterTest1.png
 )
 itk_add_test(
   NAME itkChangeLabelLabelMapFilterTest1
@@ -559,6 +625,8 @@ itk_add_test(
     163
     176
     176
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-label-changed.mha
 )
 itk_add_test(
   NAME itkChangeLabelLabelMapFilterTest2
@@ -576,6 +644,8 @@ itk_add_test(
     50
     92
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-label-changed2.mha
 )
 itk_add_test(
   NAME itkChangeLabelLabelMapFilterTest3
@@ -589,6 +659,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/cthead1-label-changed3.png
     0
     94
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-label-changed3.png
 )
 itk_add_test(
   NAME itkChangeRegionLabelMapFilterTest1
@@ -604,6 +676,8 @@ itk_add_test(
     100
     120
     150
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-label-changeregion.mha
 )
 itk_add_test(
   NAME itkConvertLabelMapFilterTest1
@@ -615,6 +689,8 @@ itk_add_test(
     itkConvertLabelMapFilterTest1
     DATA{${ITK_DATA_ROOT}/Input/cthead1Label.png}
     ${ITK_TEST_OUTPUT_DIR}/cthead1-convert.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-convert.png
 )
 itk_add_test(
   NAME itkConvertLabelMapFilterTest2
@@ -625,6 +701,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/cthead1-convert-short.png
     itkConvertLabelMapFilterTest2
     DATA{${ITK_DATA_ROOT}/Input/cthead1Label.png}
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-convert-short.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/cthead1-convert-short.png
 )
 itk_add_test(
@@ -639,6 +717,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/cthead1-label-crop.mha
     40
     50
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-label-crop.mha
 )
 itk_add_test(
   NAME itkLabelImageToLabelMapFilterTest
@@ -659,6 +739,8 @@ itk_add_test(
     90
     1
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/simple-label-to-shapelabelmap.mha
 )
 itk_add_test(
   NAME itkLabelImageToStatisticsLabelMapFilterTest1
@@ -676,6 +758,8 @@ itk_add_test(
     1
     1
     256
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/Spots-labelimage-to-statisticslabel.png
 )
 itk_add_test(
   NAME itkLabelMapFilterTest
@@ -699,6 +783,8 @@ itk_add_test(
     0
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTest-0-0-0.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTestCrop-0-0-0-0
@@ -716,6 +802,8 @@ itk_add_test(
     0
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTestCrop-0-0-0-0.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTestCrop-0-0-0-10
@@ -733,6 +821,8 @@ itk_add_test(
     0
     1
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTestCrop-0-0-0-10.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTest-0-0-1
@@ -750,6 +840,8 @@ itk_add_test(
     1
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTest-0-0-1.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTestCrop-0-0-1-0
@@ -767,6 +859,8 @@ itk_add_test(
     1
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTestCrop-0-0-1-0.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTestCrop-0-0-1-10
@@ -784,6 +878,8 @@ itk_add_test(
     1
     1
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTestCrop-0-0-1-10.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTest-0-1-0
@@ -801,6 +897,8 @@ itk_add_test(
     0
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTest-0-1-0.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTestCrop-0-1-0-0
@@ -818,6 +916,8 @@ itk_add_test(
     0
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTestCrop-0-1-0-0.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTestCrop-0-1-0-10
@@ -835,6 +935,8 @@ itk_add_test(
     0
     1
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTestCrop-0-1-0-10.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTest-0-1-1
@@ -852,6 +954,8 @@ itk_add_test(
     1
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTest-0-1-1.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTestCrop-0-1-1-0
@@ -869,6 +973,8 @@ itk_add_test(
     1
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTestCrop-0-1-1-0.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTestCrop-0-1-1-10
@@ -886,6 +992,8 @@ itk_add_test(
     1
     1
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTestCrop-0-1-1-10.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTest-100-0-0
@@ -903,6 +1011,8 @@ itk_add_test(
     0
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTest-100-0-0.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTestCrop-100-0-0-0
@@ -920,6 +1030,8 @@ itk_add_test(
     0
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTestCrop-100-0-0-0.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTestCrop-100-0-0-10
@@ -937,6 +1049,8 @@ itk_add_test(
     0
     1
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTestCrop-100-0-0-10.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTest-100-0-1
@@ -954,6 +1068,8 @@ itk_add_test(
     1
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTest-100-0-1.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTestCrop-100-0-1-0
@@ -971,6 +1087,8 @@ itk_add_test(
     1
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTestCrop-100-0-1-0.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTestCrop-100-0-1-10
@@ -988,6 +1106,8 @@ itk_add_test(
     1
     1
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTestCrop-100-0-1-10.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTest-100-1-0
@@ -1005,6 +1125,8 @@ itk_add_test(
     0
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTest-100-1-0.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTestCrop-100-1-0-0
@@ -1022,6 +1144,8 @@ itk_add_test(
     0
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTestCrop-100-1-0-0.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTestCrop-100-1-0-10
@@ -1039,6 +1163,8 @@ itk_add_test(
     0
     1
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTestCrop-100-1-0-10.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTest-100-1-1
@@ -1056,6 +1182,8 @@ itk_add_test(
     1
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTest-100-1-1.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTestCrop-100-1-1-0
@@ -1073,6 +1201,8 @@ itk_add_test(
     1
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTestCrop-100-1-1-0.png
 )
 itk_add_test(
   NAME itkLabelMapMaskImageFilterTestCrop-100-1-1-10
@@ -1090,6 +1220,8 @@ itk_add_test(
     1
     1
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapMaskImageFilterTestCrop-100-1-1-10.png
 )
 itk_add_test(
   NAME itkLabelMapTest
@@ -1113,6 +1245,8 @@ itk_add_test(
     itkLabelMapToAttributeImageFilterTest1
     DATA{${ITK_DATA_ROOT}/Input/SpotsLabeled.png}
     ${ITK_TEST_OUTPUT_DIR}/itkLabelMapToAttributeImageFilterTest1.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelMapToAttributeImageFilterTest1.png
 )
 itk_add_test(
   NAME itkLabelMapToBinaryImageFilterTest1
@@ -1126,6 +1260,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/cthead1-label-binary.mha
     255
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-label-binary.mha
 )
 itk_add_test(
   NAME itkLabelMapToLabelImageFilterTest
@@ -1163,6 +1299,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkLabelSelectionLabelMapFilterTest0.png
     0
     94
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelSelectionLabelMapFilterTest0.png
 )
 itk_add_test(
   NAME itkLabelSelectionLabelMapFilterTest1
@@ -1176,6 +1314,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkLabelSelectionLabelMapFilterTest1.png
     1
     94
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelSelectionLabelMapFilterTest1.png
 )
 itk_add_test(
   NAME itkLabelShapeKeepNObjectsImageFilterTest1
@@ -1191,6 +1331,8 @@ itk_add_test(
     1
     0
     Label
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelShapeKeepNObjectsImageFilterTest1.png
 )
 itk_add_test(
   NAME itkLabelShapeOpeningImageFilterTest1
@@ -1206,6 +1348,8 @@ itk_add_test(
     4000
     0
     100
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelShapeOpeningImageFilterTest1.png
 )
 itk_add_test(
   NAME itkLabelStatisticsKeepNObjectsImageFilterTest1
@@ -1222,6 +1366,8 @@ itk_add_test(
     7
     0
     203
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelStatisticsKeepNObjectsImageFilterTest1.png
 )
 itk_add_test(
   NAME itkLabelStatisticsOpeningImageFilterTest1
@@ -1238,6 +1384,8 @@ itk_add_test(
     98
     0
     Label
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelStatisticsOpeningImageFilterTest1.png
 )
 itk_add_test(
   NAME itkLabelUniqueLabelMapFilterTest0
@@ -1250,6 +1398,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/SpotsLabeled.png}
     ${ITK_TEST_OUTPUT_DIR}/itkLabelUniqueLabelMapFilterTest0.png
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelUniqueLabelMapFilterTest0.png
 )
 itk_add_test(
   NAME itkLabelUniqueLabelMapFilterTest1
@@ -1262,6 +1412,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/SpotsLabeled.png}
     ${ITK_TEST_OUTPUT_DIR}/itkLabelUniqueLabelMapFilterTest1.png
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelUniqueLabelMapFilterTest1.png
 )
 itk_add_test(
   NAME itkMergeLabelMapFilterTest1a
@@ -1278,6 +1430,8 @@ itk_add_test(
     50
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/simple-label-merge-keep.mha
 )
 itk_add_test(
   NAME itkMergeLabelMapFilterTest1b
@@ -1294,6 +1448,8 @@ itk_add_test(
     50
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/simple-label-merge-aggregate.mha
 )
 itk_add_test(
   NAME itkMergeLabelMapFilterTest1c
@@ -1310,6 +1466,8 @@ itk_add_test(
     50
     2
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/simple-label-merge-pack.mha
 )
 itk_add_test(
   NAME itkMergeLabelMapFilterTest1d
@@ -1323,6 +1481,8 @@ itk_add_test(
     50
     3
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/thisFileShouldNotExist.mha
 )
 itk_add_test(
   NAME itkMergeLabelMapFilterTest1e
@@ -1339,6 +1499,8 @@ itk_add_test(
     50
     3
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/simple-label-merge-strict.mha
 )
 itk_add_test(
   NAME itkMergeLabelMapFilterTest1f
@@ -1352,6 +1514,8 @@ itk_add_test(
     50
     10
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/simple-label-merge-wrong.mha
 )
 itk_add_test(
   NAME itkObjectByObjectLabelMapFilterTest0
@@ -1366,6 +1530,8 @@ itk_add_test(
     0
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkObjectByObjectLabelMapFilterTest0.png
 )
 itk_add_test(
   NAME itkObjectByObjectLabelMapFilterTest1
@@ -1380,6 +1546,8 @@ itk_add_test(
     1
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkObjectByObjectLabelMapFilterTest1.png
 )
 itk_add_test(
   NAME itkPadLabelMapFilterTest1
@@ -1393,6 +1561,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/cthead1-label-pad.mha
     40
     50
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-label-pad.mha
 )
 itk_add_test(
   NAME itkRegionFromReferenceLabelMapFilterTest1
@@ -1405,6 +1575,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1Label.png}
     DATA{${ITK_DATA_ROOT}/Input/circle.png}
     ${ITK_TEST_OUTPUT_DIR}/cthead1-label-regionreference.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-label-regionreference.mha
 )
 itk_add_test(
   NAME itkRelabelLabelMapFilterTest1
@@ -1415,6 +1587,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/cthead1-label-relabeled.mha
     itkRelabelLabelMapFilterTest1
     DATA{${ITK_DATA_ROOT}/Input/cthead1Label.png}
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-label-relabeled.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/cthead1-label-relabeled.mha
 )
 itk_add_test(
@@ -1430,6 +1604,8 @@ itk_add_test(
     0
     0
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-shape-keep-n-objects.mha
 )
 itk_add_test(
   NAME itkShapeLabelObjectAccessorsTest1
@@ -1451,6 +1627,8 @@ itk_add_test(
     140
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-shape-opening.mha
 )
 itk_add_test(
   NAME itkShapePositionLabelMapFilterTest1
@@ -1463,6 +1641,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/SpotsLabeled.png}
     ${ITK_TEST_OUTPUT_DIR}/itkShapePositionLabelMapFilterTest1.png
     Centroid
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkShapePositionLabelMapFilterTest1.png
 )
 itk_add_test(
   NAME itkShapeRelabelLabelMapFilterTest1
@@ -1476,6 +1656,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/cthead1-shape-relabel-labelmap.mha
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-shape-relabel-labelmap.mha
 )
 itk_add_test(
   NAME itkShapeUniqueLabelMapFilterTest1
@@ -1489,6 +1671,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/cthead1-shape-unique-labelmap.mha
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-shape-unique-labelmap.mha
 )
 itk_add_test(
   NAME itkShiftScaleLabelMapFilterTest1
@@ -1503,6 +1687,8 @@ itk_add_test(
     10
     0.5
     true
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1-label-shiftscaled.mha
 )
 itk_add_test(
   NAME itkStatisticsPositionLabelMapFilterTest1
@@ -1516,6 +1702,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/SpotsLabeled.png}
     ${ITK_TEST_OUTPUT_DIR}/itkStatisticsPositionLabelMapFilterTest1.png
     CenterOfGravity
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkStatisticsPositionLabelMapFilterTest1.png
 )
 itk_add_test(
   NAME itkShapeRelabelImageFilterTest1
@@ -1530,6 +1718,8 @@ itk_add_test(
     255
     0
     Label
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkShapeRelabelImageFilterTest1.png
 )
 itk_add_test(
   NAME itkStatisticsRelabelImageFilterTest1
@@ -1545,6 +1735,8 @@ itk_add_test(
     0
     0
     202
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkStatisticsRelabelImageFilterTest1.png
 )
 itk_add_test(
   NAME itkAutoCropLabelMapFilterTest2
@@ -1562,6 +1754,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkAutoCropLabelMapFilterTest2-163.png
     92
     163
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkAutoCropLabelMapFilterTest2-92.png
+    ${ITK_TEST_OUTPUT_DIR}/itkAutoCropLabelMapFilterTest2-163.png
 )
 itk_add_test(
   NAME itkStatisticsUniqueLabelMapFilterTest1
@@ -1576,6 +1771,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkStatisticsUniqueLabelMapFilterTest1.png
     0
     100
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkStatisticsUniqueLabelMapFilterTest1.png
 )
 itk_add_test(
   NAME itkStatisticsUniqueLabelMapFilterTest2
@@ -1592,6 +1789,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkStatisticsUniqueLabelMapFilterTest2.png
     1
     100
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkStatisticsUniqueLabelMapFilterTest2.png
 )
 
 set(

--- a/Modules/Filtering/MathematicalMorphology/test/CMakeLists.txt
+++ b/Modules/Filtering/MathematicalMorphology/test/CMakeLists.txt
@@ -88,6 +88,9 @@ itk_add_test(
     0
     0
     ${ITK_TEST_OUTPUT_DIR}/ClosingByReconstructionImageFilterTestSubtract.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ClosingByReconstructionImageFilterTest.png
+    ${ITK_TEST_OUTPUT_DIR}/ClosingByReconstructionImageFilterTestSubtract.png
 )
 itk_add_test(
   NAME itkClosingByReconstructionImageFilterTest2
@@ -102,6 +105,9 @@ itk_add_test(
     4
     1
     0
+    ${ITK_TEST_OUTPUT_DIR}/ClosingByReconstructionImageFilterTestSubtract2.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ClosingByReconstructionImageFilterTest2.png
     ${ITK_TEST_OUTPUT_DIR}/ClosingByReconstructionImageFilterTestSubtract2.png
 )
 itk_add_test(
@@ -118,6 +124,9 @@ itk_add_test(
     1
     1
     ${ITK_TEST_OUTPUT_DIR}/ClosingByReconstructionImageFilterTestSubtractFullyConnected.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ClosingByReconstructionImageFilterTestFullyConnected.png
+    ${ITK_TEST_OUTPUT_DIR}/ClosingByReconstructionImageFilterTestSubtractFullyConnected.png
 )
 itk_add_test(
   NAME itkFlatStructuringElementTest
@@ -126,6 +135,8 @@ itk_add_test(
     --redirectOutput
     ${ITK_TEST_OUTPUT_DIR}/itkFlatStructuringElementTest.txt
     itkFlatStructuringElementTest
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFlatStructuringElementTest.txt
 )
 set_tests_properties(
   itkFlatStructuringElementTest
@@ -144,6 +155,8 @@ itk_add_test(
     itkFlatStructuringElementTest2
     DATA{Baseline/FlatStructuringElementImageTest.png}
     ${ITK_TEST_OUTPUT_DIR}/FlatStructuringElementImageTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/FlatStructuringElementImageTest.png
 )
 
 itk_add_test(
@@ -158,6 +171,8 @@ itk_add_test(
     10
     4
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/FlatStructuringPoly4.png
 )
 itk_add_test(
   NAME itkFlatStructuringElementTest3_2
@@ -171,6 +186,8 @@ itk_add_test(
     10
     6
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/FlatStructuringPoly6.png
 )
 
 itk_add_test(
@@ -186,6 +203,8 @@ itk_add_test(
     174
     214
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/GrayscaleConnectedClosingImageFilterTest.png
 )
 itk_add_test(
   NAME itkGrayscaleConnectedClosingImageFilterTest2
@@ -200,6 +219,8 @@ itk_add_test(
     150
     169
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/GrayscaleConnectedClosingImageFilterTest2.png
 )
 itk_add_test(
   NAME itkGrayscaleConnectedOpeningImageFilterTest
@@ -214,6 +235,8 @@ itk_add_test(
     174
     214
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/GrayscaleConnectedOpeningImageFilterTest.png
 )
 itk_add_test(
   NAME itkGrayscaleConnectedOpeningImageFilterTest2
@@ -228,6 +251,8 @@ itk_add_test(
     150
     169
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/GrayscaleConnectedOpeningImageFilterTest2.png
 )
 itk_add_test(
   NAME itkGrayscaleFillholeImageFilterTestFullyConnectedOff
@@ -240,6 +265,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleFillholeImageFilterTestFullyConnectedOff.png
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleFillholeImageFilterTestFullyConnectedOff.png
 )
 itk_add_test(
   NAME itkGrayscaleFillholeImageFilterTestFullyConnectedOn
@@ -252,6 +279,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleFillholeImageFilterTestFullyConnectedOn.png
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleFillholeImageFilterTestFullyConnectedOn.png
 )
 itk_add_test(
   NAME itkGrayscaleFunctionDilateImageFilterTest
@@ -262,6 +291,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleFunctionDilateImageFilterTest.mha
     itkGrayscaleFunctionDilateImageFilterTest
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleFunctionDilateImageFilterTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleFunctionDilateImageFilterTest.mha
 )
 itk_add_test(
   NAME itkGrayscaleFunctionErodeImageFilterTest
@@ -271,6 +302,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Baseline/BasicFilters/itkGrayscaleFunctionErodeImageFilterTest.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleFunctionErodeImageFilterTest.mha
     itkGrayscaleFunctionErodeImageFilterTest
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleFunctionErodeImageFilterTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleFunctionErodeImageFilterTest.mha
 )
 itk_add_test(
@@ -284,6 +317,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/GrayscaleMorphologicalClosingImageFilterTest.png
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/GrayscaleMorphologicalClosingImageFilterTest.png
 )
 itk_add_test(
   NAME itkGrayscaleMorphologicalOpeningImageFilterTest
@@ -296,6 +331,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/GrayscaleMorphologicalOpeningImageFilterTest.png
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/GrayscaleMorphologicalOpeningImageFilterTest.png
 )
 itk_add_test(
   NAME itkGrayscaleGeodesicErodeDilateImageFilterTest
@@ -310,6 +347,8 @@ itk_add_test(
     35
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleGeodesicErodeDilateImageFilterTest.png
 )
 itk_add_test(
   NAME itkGrayscaleGrindPeakImageFilterTest
@@ -322,6 +361,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleGrindPeakImageFilterTest.png
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleGrindPeakImageFilterTest.png
 )
 itk_add_test(
   NAME itkHConcaveImageFilterTestFullyConnectedOff
@@ -335,6 +376,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkHConcaveImageFilterTestFullyConnectedOff.png
     2000
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHConcaveImageFilterTestFullyConnectedOff.png
 )
 itk_add_test(
   NAME itkHConcaveImageFilterTestFullyConnectedOn
@@ -348,6 +391,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkHConcaveImageFilterTestFullyConnectedOn.png
     2000
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHConcaveImageFilterTestFullyConnectedOn.png
 )
 itk_add_test(
   NAME itkHConvexImageFilterTestFullyConnectedOff
@@ -361,6 +406,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkHConvexImageFilterTestFullyConnectedOff.png
     2000
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHConvexImageFilterTestFullyConnectedOff.png
 )
 itk_add_test(
   NAME itkHConvexImageFilterTestFullyConnectedOn
@@ -374,6 +421,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkHConvexImageFilterTestFullyConnectedOn.png
     2000
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHConvexImageFilterTestFullyConnectedOn.png
 )
 itk_add_test(
   NAME itkHConvexConcaveImageFilterTest
@@ -386,6 +435,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/HConvexConcaveImageFilterTest.png
     50
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HConvexConcaveImageFilterTest.png
 )
 itk_add_test(
   NAME itkHMaximaImageFilterTestFullyConnectedOff
@@ -399,6 +450,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkHMaximaImageFilterTestFullyConnectedOff.png
     2000
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHMaximaImageFilterTestFullyConnectedOff.png
 )
 itk_add_test(
   NAME itkHMaximaImageFilterTestFullyConnectedOn
@@ -412,6 +465,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkHMaximaImageFilterTestFullyConnectedOn.png
     2000
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHMaximaImageFilterTestFullyConnectedOn.png
 )
 itk_add_test(
   NAME itkHMinimaImageFilterTestFullyConnectedOff
@@ -425,6 +480,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkHMinimaImageFilterTestFullyConnectedOff.png
     2000
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHMinimaImageFilterTestFullyConnectedOff.png
 )
 itk_add_test(
   NAME itkHMinimaImageFilterTestFullyConnectedOn
@@ -438,6 +495,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkHMinimaImageFilterTestFullyConnectedOn.png
     2000
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHMinimaImageFilterTestFullyConnectedOn.png
 )
 itk_add_test(
   NAME itkHMaximaMinimaImageFilterTest
@@ -450,6 +509,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cake_easy.png}
     ${ITK_TEST_OUTPUT_DIR}/HMaximaMinimaImageFilterTest.png
     35
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HMaximaMinimaImageFilterTest.png
 )
 itk_add_test(
   NAME itkHMaximaMinimaImageFilterTest2
@@ -462,6 +523,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cake_hard.png}
     ${ITK_TEST_OUTPUT_DIR}/HMaximaMinimaImageFilterTest2.png
     35
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HMaximaMinimaImageFilterTest2.png
 )
 itk_add_test(
   NAME itkMorphologicalGradientImageFilterTest
@@ -473,6 +536,8 @@ itk_add_test(
     itkMorphologicalGradientImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/MorphologicalGradientImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/MorphologicalGradientImageFilterTest.png
 )
 itk_add_test(
   NAME itkMorphologicalGradientImageFilterTest2
@@ -483,6 +548,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/MorphologicalGradientImageFilterTest2.png
     itkMorphologicalGradientImageFilterTest2
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
+    ${ITK_TEST_OUTPUT_DIR}/MorphologicalGradientImageFilterTest2.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/MorphologicalGradientImageFilterTest2.png
 )
 itk_add_test(
@@ -505,6 +572,9 @@ itk_add_test(
     0
     0
     ${ITK_TEST_OUTPUT_DIR}/OpeningByReconstructionImageFilterTestSubtract.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/OpeningByReconstructionImageFilterTest.png
+    ${ITK_TEST_OUTPUT_DIR}/OpeningByReconstructionImageFilterTestSubtract.png
 )
 itk_add_test(
   NAME itkOpeningByReconstructionImageFilterTest2
@@ -520,6 +590,9 @@ itk_add_test(
     1
     0
     ${ITK_TEST_OUTPUT_DIR}/OpeningByReconstructionImageFilterTestSubtract2.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/OpeningByReconstructionImageFilterTest2.png
+    ${ITK_TEST_OUTPUT_DIR}/OpeningByReconstructionImageFilterTestSubtract2.png
 )
 itk_add_test(
   NAME itkOpeningByReconstructionImageFilterTestFullyConnected
@@ -534,6 +607,9 @@ itk_add_test(
     4
     1
     1
+    ${ITK_TEST_OUTPUT_DIR}/OpeningByReconstructionImageFilterTestSubtractFullyConnected.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/OpeningByReconstructionImageFilterTestFullyConnected.png
     ${ITK_TEST_OUTPUT_DIR}/OpeningByReconstructionImageFilterTestSubtractFullyConnected.png
 )
 itk_add_test(
@@ -553,6 +629,9 @@ itk_add_test(
     0.5
     0.5
     ${ITK_TEST_OUTPUT_DIR}/OpeningByReconstructionImageFilterTestSubtractNoInput.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/OpeningByReconstructionImageFilterTestNoInput.png
+    ${ITK_TEST_OUTPUT_DIR}/OpeningByReconstructionImageFilterTestSubtractNoInput.png
 )
 itk_add_test(
   NAME itkOpeningByReconstructionImageFilterTestNoInput2
@@ -571,6 +650,9 @@ itk_add_test(
     0.5
     0.5
     ${ITK_TEST_OUTPUT_DIR}/OpeningByReconstructionImageFilterTestSubtractNoInput2.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/OpeningByReconstructionImageFilterTestNoInput2.png
+    ${ITK_TEST_OUTPUT_DIR}/OpeningByReconstructionImageFilterTestSubtractNoInput2.png
 )
 itk_add_test(
   NAME itkDoubleThresholdImageFilterTest
@@ -587,6 +669,8 @@ itk_add_test(
     255
     255
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/DoubleThresholdImageFilterTest.png
 )
 itk_add_test(
   NAME itkDoubleThresholdImageFilterTest2
@@ -603,6 +687,8 @@ itk_add_test(
     164
     180
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/DoubleThresholdImageFilterTest2.png
 )
 itk_add_test(
   NAME itkRemoveBoundaryObjectsTest
@@ -614,6 +700,8 @@ itk_add_test(
     itkRemoveBoundaryObjectsTest
     DATA{${ITK_DATA_ROOT}/Input/Spots.png}
     ${ITK_TEST_OUTPUT_DIR}/RemoveBoundaryObjectsTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RemoveBoundaryObjectsTest.png
 )
 itk_add_test(
   NAME itkRemoveBoundaryObjectsTest2
@@ -624,6 +712,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RemoveBoundaryObjectsTest2.png
     itkRemoveBoundaryObjectsTest2
     DATA{${ITK_DATA_ROOT}/Input/SpotsInverted.png}
+    ${ITK_TEST_OUTPUT_DIR}/RemoveBoundaryObjectsTest2.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/RemoveBoundaryObjectsTest2.png
 )
 itk_add_test(
@@ -647,6 +737,8 @@ itk_add_test(
     1
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBlackTopHatImageFilterTest.png
 )
 itk_add_test(
   NAME itkWhiteTopHatImageFilterTest
@@ -663,6 +755,8 @@ itk_add_test(
     1
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkWhiteTopHatImageFilterTest.png
 )
 itk_add_test(
   NAME itkGrayscaleMorphologicalClosingImageFilterTest2
@@ -685,6 +779,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalClosingImageFilterTest2VHGW.png
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalClosingImageFilterTest2Anchor.png
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalClosingImageFilterTest2Basic.png
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalClosingImageFilterTest2Histo.png
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalClosingImageFilterTest2VHGW.png
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalClosingImageFilterTest2Anchor.png
 )
 itk_add_test(
   NAME itkGrayscaleMorphologicalClosingImageFilterTest2SafeBorder
@@ -707,6 +806,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalClosingImageFilterTest2VHGWSafeBorder.png
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalClosingImageFilterTest2AnchorSafeBorder.png
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalClosingImageFilterTest2BasicSafeBorder.png
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalClosingImageFilterTest2HistoSafeBorder.png
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalClosingImageFilterTest2VHGWSafeBorder.png
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalClosingImageFilterTest2AnchorSafeBorder.png
 )
 itk_add_test(
   NAME itkGrayscaleMorphologicalOpeningImageFilterTest2
@@ -729,6 +833,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalOpeningImageFilterTest2VHGW.png
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalOpeningImageFilterTest2Anchor.png
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalOpeningImageFilterTest2Basic.png
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalOpeningImageFilterTest2Histo.png
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalOpeningImageFilterTest2VHGW.png
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalOpeningImageFilterTest2Anchor.png
 )
 itk_add_test(
   NAME itkGrayscaleMorphologicalOpeningImageFilterTest2SafeBorder
@@ -751,6 +860,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalOpeningImageFilterTest2VHGWSafeBorder.png
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalOpeningImageFilterTest2AnchorSafeBorder.png
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalOpeningImageFilterTest2BasicSafeBorder.png
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalOpeningImageFilterTest2HistoSafeBorder.png
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalOpeningImageFilterTest2VHGWSafeBorder.png
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleMorphologicalOpeningImageFilterTest2AnchorSafeBorder.png
 )
 itk_add_test(
   NAME itkGrayscaleDilateImageFilterTest
@@ -771,6 +885,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleDilateImageFilterTestHisto.png
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleDilateImageFilterTestVHGW.png
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleDilateImageFilterTestAnchor.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleDilateImageFilterTestBasic.png
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleDilateImageFilterTestHisto.png
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleDilateImageFilterTestVHGW.png
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleDilateImageFilterTestAnchor.png
 )
 itk_add_test(
   NAME itkGrayscaleErodeImageFilterTest
@@ -787,6 +906,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleErodeImageFilterTestAnchor.png
     itkGrayscaleErodeImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleErodeImageFilterTestBasic.png
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleErodeImageFilterTestHisto.png
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleErodeImageFilterTestVHGW.png
+    ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleErodeImageFilterTestAnchor.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleErodeImageFilterTestBasic.png
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleErodeImageFilterTestHisto.png
     ${ITK_TEST_OUTPUT_DIR}/itkGrayscaleErodeImageFilterTestVHGW.png
@@ -813,6 +937,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalClosingImageFilterTestVHGW.png
     ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalClosingImageFilterTestAnchor.png
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalClosingImageFilterTestBasic.png
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalClosingImageFilterTestHisto.png
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalClosingImageFilterTestVHGW.png
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalClosingImageFilterTestAnchor.png
 )
 itk_add_test(
   NAME itkMapGrayscaleMorphologicalClosingImageFilterTestSafeBorder
@@ -834,6 +963,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalClosingImageFilterTestVHGWSafeBorder.png
     ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalClosingImageFilterTestAnchorSafeBorder.png
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalClosingImageFilterTestBasicSafeBorder.png
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalClosingImageFilterTestHistoSafeBorder.png
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalClosingImageFilterTestVHGWSafeBorder.png
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalClosingImageFilterTestAnchorSafeBorder.png
 )
 itk_add_test(
   NAME itkMapGrayscaleMorphologicalOpeningImageFilterTest
@@ -855,6 +989,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalOpeningImageFilterTestVHGW.png
     ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalOpeningImageFilterTestAnchor.png
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalOpeningImageFilterTestBasic.png
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalOpeningImageFilterTestHisto.png
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalOpeningImageFilterTestVHGW.png
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalOpeningImageFilterTestAnchor.png
 )
 itk_add_test(
   NAME itkMapGrayscaleMorphologicalOpeningImageFilterTestSafeBorder
@@ -876,6 +1015,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalOpeningImageFilterTestVHGWSafeBorder.png
     ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalOpeningImageFilterTestAnchorSafeBorder.png
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalOpeningImageFilterTestBasicSafeBorder.png
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalOpeningImageFilterTestHistoSafeBorder.png
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalOpeningImageFilterTestVHGWSafeBorder.png
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleMorphologicalOpeningImageFilterTestAnchorSafeBorder.png
 )
 
 itk_add_test(
@@ -893,6 +1037,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleDilateImageFilterTestAnchor.png
     itkMapGrayscaleDilateImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleDilateImageFilterTestBasic.png
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleDilateImageFilterTestHisto.png
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleDilateImageFilterTestVHGW.png
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleDilateImageFilterTestAnchor.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleDilateImageFilterTestBasic.png
     ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleDilateImageFilterTestHisto.png
     ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleDilateImageFilterTestVHGW.png
@@ -917,6 +1066,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleErodeImageFilterTestHisto.png
     ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleErodeImageFilterTestVHGW.png
     ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleErodeImageFilterTestAnchor.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleErodeImageFilterTestBasic.png
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleErodeImageFilterTestHisto.png
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleErodeImageFilterTestVHGW.png
+    ${ITK_TEST_OUTPUT_DIR}/itkMapGrayscaleErodeImageFilterTestAnchor.png
 )
 itk_add_test(
   NAME itkRegionalMinimaImageFilterTest1
@@ -932,6 +1086,9 @@ itk_add_test(
     2
     1
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1RegionalMinimal1.png
+    ${ITK_TEST_OUTPUT_DIR}/cthead1RegionalMinimal-ref1.png
 )
 itk_add_test(
   NAME itkRegionalMinimaImageFilterTest2
@@ -947,6 +1104,9 @@ itk_add_test(
     2
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1RegionalMinimal2.png
+    ${ITK_TEST_OUTPUT_DIR}/cthead1RegionalMinimal-ref2.png
 )
 
 itk_add_test(
@@ -963,6 +1123,9 @@ itk_add_test(
     2
     1
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1RegionalMaximal1.png
+    ${ITK_TEST_OUTPUT_DIR}/cthead1RegionalMaximal-ref1.png
 )
 itk_add_test(
   NAME itkRegionalMaximaImageFilterTest2
@@ -978,6 +1141,9 @@ itk_add_test(
     2
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1RegionalMaximal2.png
+    ${ITK_TEST_OUTPUT_DIR}/cthead1RegionalMaximal-ref2.png
 )
 
 itk_add_test(
@@ -992,6 +1158,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/cthead1ValuedRegionalMaximal.png
     ${ITK_TEST_OUTPUT_DIR}/cthead1ValuedRegionalMaximal-ref.png
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1ValuedRegionalMaximal.png
+    ${ITK_TEST_OUTPUT_DIR}/cthead1ValuedRegionalMaximal-ref.png
 )
 itk_add_test(
   NAME itkValuedRegionalMaximaImageFilterTest2
@@ -1005,6 +1174,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/cthead1ValuedRegionalMaximal2.png
     ${ITK_TEST_OUTPUT_DIR}/cthead1ValuedRegionalMaximal-ref2.png
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1ValuedRegionalMaximal2.png
+    ${ITK_TEST_OUTPUT_DIR}/cthead1ValuedRegionalMaximal-ref2.png
 )
 itk_add_test(
   NAME itkValuedRegionalMinimaImageFilterTest
@@ -1018,6 +1190,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/cthead1ValuedRegionalMinimal.png
     ${ITK_TEST_OUTPUT_DIR}/cthead1ValuedRegionalMinimal-ref.png
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1ValuedRegionalMinimal.png
+    ${ITK_TEST_OUTPUT_DIR}/cthead1ValuedRegionalMinimal-ref.png
 )
 itk_add_test(
   NAME itkValuedRegionalMinimaImageFilterTest2
@@ -1031,6 +1206,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/cthead1ValuedRegionalMinimal2.png
     ${ITK_TEST_OUTPUT_DIR}/cthead1ValuedRegionalMinimal-ref2.png
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1ValuedRegionalMinimal2.png
+    ${ITK_TEST_OUTPUT_DIR}/cthead1ValuedRegionalMinimal-ref2.png
 )
 itk_add_test(
   NAME itkMapMaskedRankImageFilterTest3
@@ -1044,6 +1222,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1-mask.png}
     ${ITK_TEST_OUTPUT_DIR}/itkMapMaskedRankImageFilter3.png
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMapMaskedRankImageFilter3.png
 )
 itk_add_test(
   NAME itkMapMaskedRankImageFilterTest10
@@ -1057,6 +1237,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1-mask.png}
     ${ITK_TEST_OUTPUT_DIR}/itkMapMaskedRankImageFilter10.png
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMapMaskedRankImageFilter10.png
 )
 itk_add_test(
   NAME itkMapRankImageFilterTest3
@@ -1069,6 +1251,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkMapRankImageFilter3.png
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMapRankImageFilter3.png
 )
 itk_add_test(
   NAME itkMapRankImageFilterTest10
@@ -1081,6 +1265,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkMapRankImageFilter10.png
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMapRankImageFilter10.png
 )
 itk_add_test(
   NAME itkMaskedRankImageFilterTest3
@@ -1094,6 +1280,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1-mask.png}
     ${ITK_TEST_OUTPUT_DIR}/itkMaskedRankImageFilter3.png
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMaskedRankImageFilter3.png
 )
 itk_add_test(
   NAME itkMaskedRankImageFilterTest10
@@ -1107,6 +1295,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1-mask.png}
     ${ITK_TEST_OUTPUT_DIR}/itkMaskedRankImageFilter10.png
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMaskedRankImageFilter10.png
 )
 itk_add_test(
   NAME itkRankImageFilterTest3
@@ -1119,6 +1309,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkRankImageFilter3.png
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkRankImageFilter3.png
 )
 itk_add_test(
   NAME itkRankImageFilterTest10
@@ -1131,6 +1323,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkRankImageFilter10.png
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkRankImageFilter10.png
 )
 itk_add_test(
   NAME itkVanHerkGilWermanErodeDilateImageFilterTest

--- a/Modules/Filtering/MeshToPolyData/test/CMakeLists.txt
+++ b/Modules/Filtering/MeshToPolyData/test/CMakeLists.txt
@@ -19,6 +19,8 @@ itk_add_test(
     itkMeshToPolyDataFilterTest
     DATA{Input/cow.vtk}
     ${ITK_TEST_OUTPUT_DIR}/itkMeshToPolyDataFilterTest.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMeshToPolyDataFilterTest.vtk
 )
 
 itk_add_test(
@@ -48,6 +50,8 @@ itk_add_test(
     MeshToPolyDataTestDriver
     itkImageToPointSetFilterTest
     DATA{Input/foot.mha}
+    ${ITK_TEST_OUTPUT_DIR}/itkImageToPointSetFilterTestOutput.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkImageToPointSetFilterTestOutput.vtk
 )
 

--- a/Modules/Filtering/Path/test/CMakeLists.txt
+++ b/Modules/Filtering/Path/test/CMakeLists.txt
@@ -94,6 +94,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/ExtractOrthogonalSwath2DImageFilterTest.png
     itkExtractOrthogonalSwath2DImageFilterTest
     ${ITK_TEST_OUTPUT_DIR}/ExtractOrthogonalSwath2DImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ExtractOrthogonalSwath2DImageFilterTest.png
 )
 itk_add_test(
   NAME itkOrthogonalSwath2DPathFilterTest

--- a/Modules/Filtering/PhaseSymmetry/test/CMakeLists.txt
+++ b/Modules/Filtering/PhaseSymmetry/test/CMakeLists.txt
@@ -21,6 +21,8 @@ itk_add_test(
     itkPhaseSymmetryImageFilterTest
     DATA{Input/HeartUltrasound.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkPhaseSymmetryImageFilterTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPhaseSymmetryImageFilterTest.mha
 )
 
 itk_add_test(
@@ -36,6 +38,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkButterworthFilterFreqImageSourceTestOutput.mha
     ${ITK_TEST_OUTPUT_DIR}/itkButterworthFilterFreqImageSourceTestInputFFT.mha
     ${ITK_TEST_OUTPUT_DIR}/itkButterworthFilterFreqImageSourceTestOutputFFT.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkButterworthFilterFreqImageSourceTestFilter.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkButterworthFilterFreqImageSourceTestOutput.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkButterworthFilterFreqImageSourceTestInputFFT.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkButterworthFilterFreqImageSourceTestOutputFFT.mha
 )
 
 itk_add_test(
@@ -47,6 +54,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkLogGaborFreqImageSourceTestFilter.mha
     itkLogGaborFreqImageSourceTest
     DATA{Input/SinusoidImage.mha}
+    ${ITK_TEST_OUTPUT_DIR}/itkLogGaborFreqImageSourceTestFilter.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkLogGaborFreqImageSourceTestOutput.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkLogGaborFreqImageSourceTestInputFFT.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkLogGaborFreqImageSourceTestOutputFFT.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkLogGaborFreqImageSourceTestFilter.mha
     ${ITK_TEST_OUTPUT_DIR}/itkLogGaborFreqImageSourceTestOutput.mha
     ${ITK_TEST_OUTPUT_DIR}/itkLogGaborFreqImageSourceTestInputFFT.mha
@@ -73,4 +85,6 @@ itk_add_test(
     0.1
     0.2
     0.2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSinusoidImageSourceTest.mha
 )

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/CMakeLists.txt
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/CMakeLists.txt
@@ -38,6 +38,8 @@ itk_add_test(
     0
     0
     ${TEMP}/border00.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/border00.vtk
 )
 
 itk_add_test(
@@ -48,6 +50,8 @@ itk_add_test(
     DATA{${INPUTDATA}/mushroom.vtk}
     0
     1
+    ${TEMP}/border01.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${TEMP}/border01.vtk
 )
 
@@ -60,6 +64,8 @@ itk_add_test(
     1
     0
     ${TEMP}/border10.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/border10.vtk
 )
 
 itk_add_test(
@@ -70,6 +76,8 @@ itk_add_test(
     DATA{${INPUTDATA}/mushroom.vtk}
     1
     1
+    ${TEMP}/border11.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${TEMP}/border11.vtk
 )
 
@@ -96,6 +104,8 @@ itk_add_test(
     DATA{${INPUTDATA}/mushroom.vtk}
     20
     ${TEMP}/temp_SquaredEdgeLengthDecimationResult1.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/temp_SquaredEdgeLengthDecimationResult1.vtk
 )
 
 itk_add_test(
@@ -108,6 +118,8 @@ itk_add_test(
     0.1
     0
     ${TEMP}/temp_SmoothResult0.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/temp_SmoothResult0.vtk
 )
 
 itk_add_test(
@@ -119,6 +131,8 @@ itk_add_test(
     10
     0.1
     1
+    ${TEMP}/temp_SmoothResult1.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${TEMP}/temp_SmoothResult1.vtk
 )
 
@@ -146,6 +160,8 @@ itk_add_test(
     itkDelaunayConformingQuadEdgeMeshFilterTest
     DATA{${INPUTDATA}/mushroom.vtk}
     ${TEMP}/mushroom_delaunay.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/mushroom_delaunay.vtk
 )
 itk_add_test(
   NAME itkCleanQuadEdgeMeshFilterTest
@@ -154,6 +170,8 @@ itk_add_test(
     itkCleanQuadEdgeMeshFilterTest
     DATA{${INPUTDATA}/mushroom.vtk}
     0.1
+    ${TEMP}/temp_CleanResult1.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${TEMP}/temp_CleanResult1.vtk
 )
 itk_add_test(
@@ -170,6 +188,8 @@ itk_add_test(
     DATA{${INPUTDATA}/mushroom.vtk}
     100
     ${TEMP}/temp_QuadricDecimationResult1.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/temp_QuadricDecimationResult1.vtk
 )
 itk_add_test(
   NAME itkQuadEdgeMeshQuadricDecimationTetrahedronTest
@@ -178,6 +198,8 @@ itk_add_test(
     itkQuadricDecimationQuadEdgeMeshFilterTest
     DATA{${INPUTDATA}/tetrahedron.vtk}
     2
+    ${TEMP}/temp_QuadricDecimationTetrahedron.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${TEMP}/temp_QuadricDecimationTetrahedron.vtk
 )
 itk_add_test(
@@ -197,6 +219,8 @@ itk_add_test(
   COMMAND
     ITKQuadEdgeMeshFilteringTestDriver
     itkRegularSphereQuadEdgeMeshSourceTest
+    ${ITK_TEST_OUTPUT_DIR}/itkRegularSphereMeshQuadEdgeMeshSourceTest.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkRegularSphereMeshQuadEdgeMeshSourceTest.vtk
 )
 itk_add_test(

--- a/Modules/Filtering/Smoothing/test/CMakeLists.txt
+++ b/Modules/Filtering/Smoothing/test/CMakeLists.txt
@@ -31,6 +31,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkBoxMeanImageFilter3.png
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBoxMeanImageFilter3.png
 )
 itk_add_test(
   NAME itkBoxMeanImageFilterTest10
@@ -43,6 +45,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkBoxMeanImageFilter10.png
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBoxMeanImageFilter10.png
 )
 itk_add_test(
   NAME itkBoxSigmaImageFilterTest3
@@ -55,6 +59,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkBoxSigmaImageFilter3.png
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBoxSigmaImageFilter3.png
 )
 itk_add_test(
   NAME itkBoxSigmaImageFilterTest10
@@ -67,6 +73,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkBoxSigmaImageFilter10.png
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBoxSigmaImageFilter10.png
 )
 itk_add_test(
   NAME itkDiscreteGaussianImageFilterTest2
@@ -81,6 +89,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/RGBTestImage.tif}
     ${ITK_TEST_OUTPUT_DIR}/DiscreteGaussianImageFilterTest2_OutputA.mha
     1.870829
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/DiscreteGaussianImageFilterTest2_OutputA.mha
 )
 itk_add_test(
   NAME itkSmoothingRecursiveGaussianImageFilterTestNormalizeScalesOn
@@ -94,6 +104,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkSmoothingRecursiveGaussianImageFilterTestNormalizeScalesOn.png
     1
     2.5
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSmoothingRecursiveGaussianImageFilterTestNormalizeScalesOn.png
 )
 itk_add_test(
   NAME itkSmoothingRecursiveGaussianImageFilterOnVectorImageTest
@@ -150,6 +162,8 @@ itk_add_test(
     3.5
     0.05
     35
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/DiscreteGaussianImageFilterComparisonTestOutput.mha
 )
 itk_add_test(
   NAME itkFFTDiscreteGaussianImageFilter2DComparisonTest
@@ -167,6 +181,8 @@ itk_add_test(
     35
     2
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/FFTDiscreteGaussianImageFilterComparisonTestOutput.mha
 )
 itk_add_test(
   NAME itkDiscreteGaussianImageFilter3DComparisonTest
@@ -183,6 +199,8 @@ itk_add_test(
     5.0
     0.03
     25
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/DiscreteGaussianImageFilter3DComparisonTestOutput.mha
 )
 itk_add_test(
   NAME itkFFTDiscreteGaussianImageFilter3DComparisonTest
@@ -200,6 +218,8 @@ itk_add_test(
     25
     3
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/FFTDiscreteGaussianImageFilter3DComparisonTestOutput.mha
 )
 # Compare results on images with adjusted origin and spacing
 itk_add_test(
@@ -218,6 +238,8 @@ itk_add_test(
     0.03
     31
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/DiscreteGaussianImageFilterNonunitImageComparisonTestOutput.mha
 )
 itk_add_test(
   NAME itkFFTDiscreteGaussianImageFilterNonunitImageComparisonTest
@@ -235,6 +257,8 @@ itk_add_test(
     31
     2
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/FFTDiscreteGaussianImageFilterNonunitImageComparisonTestOutput.mha
 )
 # Comparing results of lower-dimensionality smoothing
 itk_add_test(
@@ -253,6 +277,8 @@ itk_add_test(
     0.02
     31
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/DiscreteGaussianImageFilter3DComparisonTestOutput2.mha
 )
 itk_add_test(
   NAME itkFFTDiscreteGaussianImageFilter3DComparisonTest2
@@ -270,6 +296,8 @@ itk_add_test(
     31
     2
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/FFTDiscreteGaussianImageFilter3DComparisonTestOutput2.mha
 )
 # Test smoothing with GaussianImageSource
 itk_add_test(
@@ -288,6 +316,8 @@ itk_add_test(
     35
     2
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/FFTDiscreteGaussianImageFilterTestImageSourceOutput.mha
 )
 itk_add_test(
   NAME itkFFTDiscreteGaussianImageFilterKernelDimensionalityTest
@@ -305,6 +335,8 @@ itk_add_test(
     11
     1
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/FFTDiscreteGaussianImageFilterTestKernelDimensionalityOutput.mha
 )
 itk_add_test(
   NAME itkFFTDiscreteGaussianImageFilter3DImageSourceTest
@@ -322,6 +354,8 @@ itk_add_test(
     25
     3
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/FFTDiscreteGaussianImageFilter3DImageSourceTestOutput.mha
 )
 itk_add_test(
   NAME itkFFTDiscreteGaussianImageFilterFactoryTest

--- a/Modules/Filtering/Strain/test/CMakeLists.txt
+++ b/Modules/Filtering/Strain/test/CMakeLists.txt
@@ -21,6 +21,9 @@ itk_add_test(
     DATA{Input/LineLoadDisplacement.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterTest
     "INFINITESIMAL"
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterTestOutput.vtk
+    ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterTestComponent*.mha
 )
 
 itk_add_test(
@@ -34,6 +37,9 @@ itk_add_test(
     DATA{Input/LineLoadDisplacement.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterLagrangianTest
     "GREENLAGRANGIAN"
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterLagrangianTestOutput.vtk
+    ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterLagrangianTestComponent*.mha
 )
 
 itk_add_test(
@@ -47,6 +53,9 @@ itk_add_test(
     DATA{Input/LineLoadDisplacement.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterEulerianTest
     "EULERIANALMANSI"
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterEulerianTestOutput.vtk
+    ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterEulerianTestComponent*.mha
 )
 
 itk_add_test(
@@ -59,6 +68,9 @@ itk_add_test(
     itkStrainImageFilterDoGTest
     DATA{Input/LineLoadDisplacement.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterDoGTest
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterDoGTestOutput.vtk
+    ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterDoGTestComponent*.mha
 )
 
 itk_add_test(
@@ -71,6 +83,9 @@ itk_add_test(
     itkStrainImageFilterRecursiveGaussianTest
     DATA{Input/LineLoadDisplacement.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterRecursiveGaussianTest
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterRecursiveGaussianTestOutput.vtk
+    ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterRecursiveGaussianTestComponent*.mha
 )
 
 # BSplineTransform has not yet implemented
@@ -95,6 +110,10 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestInfinitesimalAffine.mha
     ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestInfinitesimalAffineToDisplacementField.mha
     ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestInfinitesimalAffineToDisplacementFieldStrain.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestInfinitesimalAffine.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestInfinitesimalAffineToDisplacementFieldStrain.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestInfinitesimalAffineToDisplacementField.mha
 )
 
 itk_add_test(
@@ -110,6 +129,10 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestGreenLagrangianAffine.mha
     ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestGreenLagrangianAffineToDisplacementField.mha
     ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestGreenLagrangianAffineToDisplacementFieldStrain.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestGreenLagrangianAffine.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestGreenLagrangianAffineToDisplacementFieldStrain.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestGreenLagrangianAffineToDisplacementField.mha
 )
 
 itk_add_test(
@@ -125,6 +148,10 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestEulerianAlmansiAffine.mha
     ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestEulerianAlmansiAffineToDisplacementField.mha
     ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestEulerianAlmansiAffineToDisplacementFieldStrain.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestEulerianAlmansiAffine.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestEulerianAlmansiAffineToDisplacementFieldStrain.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestEulerianAlmansiAffineToDisplacementField.mha
 )
 
 itk_add_test(
@@ -140,6 +167,10 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestInfinitesimalSimilarity.mha
     ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestInfinitesimalSimilarityToDisplacementField.mha
     ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestInfinitesimalSimilarityToDisplacementFieldStrain.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestInfinitesimalSimilarity.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestInfinitesimalSimilarityToDisplacementFieldStrain.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestInfinitesimalSimilarityToDisplacementField.mha
 )
 
 itk_add_test(
@@ -155,6 +186,10 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestGreenLagrangianSimilarity.mha
     ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestGreenLagrangianSimilarityToDisplacementField.mha
     ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestGreenLagrangianSimilarityToDisplacementFieldStrain.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestGreenLagrangianSimilarity.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestGreenLagrangianSimilarityToDisplacementFieldStrain.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestGreenLagrangianSimilarityToDisplacementField.mha
 )
 
 itk_add_test(
@@ -170,4 +205,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestEulerianAlmansiSimilarity.mha
     ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestEulerianAlmansiSimilarityToDisplacementField.mha
     ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestEulerianAlmansiSimilarityToDisplacementFieldStrain.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestEulerianAlmansiSimilarity.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestEulerianAlmansiSimilarityToDisplacementFieldStrain.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkTransformToStrainFilterTestEulerianAlmansiSimilarityToDisplacementField.mha
 )

--- a/Modules/Filtering/TextureFeatures/test/CMakeLists.txt
+++ b/Modules/Filtering/TextureFeatures/test/CMakeLists.txt
@@ -44,6 +44,8 @@ itk_add_test(
     0
     0.7
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultTestWithoutMask1.nrrd
 )
 
 itk_add_test(
@@ -62,6 +64,8 @@ itk_add_test(
     0
     1.25
     4
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultTestWithoutMask2.nrrd
 )
 
 itk_add_test(
@@ -80,6 +84,8 @@ itk_add_test(
     0
     1.8
     6
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultTestWithoutMask3.nrrd
 )
 
 itk_add_test(
@@ -99,6 +105,8 @@ itk_add_test(
     0
     0.7
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImage1.nrrd
 )
 
 itk_add_test(
@@ -118,6 +126,8 @@ itk_add_test(
     0
     1.25
     4
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImage2.nrrd
 )
 
 itk_add_test(
@@ -137,6 +147,8 @@ itk_add_test(
     0
     0.7
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultPartialImage1.nrrd
 )
 
 itk_add_test(
@@ -156,6 +168,8 @@ itk_add_test(
     0
     1.25
     4
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultPartialImage2.nrrd
 )
 
 itk_add_test(
@@ -175,6 +189,8 @@ itk_add_test(
     0
     0.7
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultWholeImage.nrrd
 )
 
 itk_add_test(
@@ -221,6 +237,17 @@ itk_add_test(
     0
     1.25
     4
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultSeparateFeatures_1.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultSeparateFeatures_2.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultSeparateFeatures_3.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultSeparateFeatures_4.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultSeparateFeatures_5.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultSeparateFeatures_6.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultSeparateFeatures_7.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultSeparateFeatures_8.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultSeparateFeatures_9.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultSeparateFeatures_0.nrrd
 )
 
 itk_add_test(
@@ -267,6 +294,17 @@ itk_add_test(
     0
     1.25
     4
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImageSeparateFeatures_1.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImageSeparateFeatures_2.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImageSeparateFeatures_3.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImageSeparateFeatures_4.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImageSeparateFeatures_5.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImageSeparateFeatures_6.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImageSeparateFeatures_7.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImageSeparateFeatures_8.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImageSeparateFeatures_9.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImageSeparateFeatures_0.nrrd
 )
 
 itk_add_test(
@@ -292,6 +330,8 @@ itk_add_test(
     0
     4200
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultTestWithoutMask4.nrrd
 )
 
 itk_add_test(
@@ -308,6 +348,8 @@ itk_add_test(
     0
     4200
     4
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultTestWithoutMask5.nrrd
 )
 
 itk_add_test(
@@ -324,6 +366,8 @@ itk_add_test(
     0
     4200
     6
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultTestWithoutMask6.nrrd
 )
 
 itk_add_test(
@@ -341,6 +385,8 @@ itk_add_test(
     0
     4200
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImage3.nrrd
 )
 
 itk_add_test(
@@ -358,6 +404,8 @@ itk_add_test(
     0
     4200
     4
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImage4.nrrd
 )
 
 itk_add_test(
@@ -375,6 +423,8 @@ itk_add_test(
     0
     4200
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultPartialImage3.nrrd
 )
 
 itk_add_test(
@@ -392,6 +442,8 @@ itk_add_test(
     0
     4200
     4
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultPartialImage4.nrrd
 )
 
 itk_add_test(
@@ -409,6 +461,8 @@ itk_add_test(
     0
     4200
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultWholeImage2.nrrd
 )
 
 itk_add_test(
@@ -447,6 +501,15 @@ itk_add_test(
     0
     4200
     4
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultSeparateFeatures_11.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultSeparateFeatures_12.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultSeparateFeatures_13.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultSeparateFeatures_14.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultSeparateFeatures_15.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultSeparateFeatures_16.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultSeparateFeatures_17.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultSeparateFeatures_18.nrrd
 )
 
 itk_add_test(
@@ -485,6 +548,15 @@ itk_add_test(
     0
     4200
     4
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImageSeparateFeatures_11.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImageSeparateFeatures_12.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImageSeparateFeatures_13.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImageSeparateFeatures_14.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImageSeparateFeatures_15.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImageSeparateFeatures_16.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImageSeparateFeatures_17.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/resultVectorImageSeparateFeatures_18.nrrd
 )
 
 itk_add_test(
@@ -495,6 +567,8 @@ itk_add_test(
     DATA{Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkTextureFeatureImageFilterTest1.mha
     5
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTextureFeatureImageFilterTest1.mha
 )
 
 if(NOT "${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR}" VERSION_LESS "4.13")

--- a/Modules/Filtering/Thickness3D/test/CMakeLists.txt
+++ b/Modules/Filtering/Thickness3D/test/CMakeLists.txt
@@ -21,6 +21,8 @@ itk_add_test(
     itkBinaryThinningImageFilter3DTest
     DATA{Input/input.tiff}
     ${ITK_TEST_OUTPUT_DIR}/skeleton.tiff
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/skeleton.tiff
 )
 
 itk_add_test(
@@ -32,5 +34,7 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/medial_thickness.tiff
     itkMedialThicknessImageFilter3DTest
     DATA{Input/input.tiff}
+    ${ITK_TEST_OUTPUT_DIR}/medial_thickness.tiff
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/medial_thickness.tiff
 )

--- a/Modules/Filtering/Thresholding/test/CMakeLists.txt
+++ b/Modules/Filtering/Thresholding/test/CMakeLists.txt
@@ -64,6 +64,8 @@ itk_add_test(
     2
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkOtsuMultipleThresholdsImageFilterTest.png
 )
 
 itk_add_test(
@@ -111,6 +113,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     DATA{${ITK_DATA_ROOT}/Input/DicomSeries/Image0076.dcm}
     ${ITK_TEST_OUTPUT_DIR}/BinaryThresholdImageFilterTest2.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/BinaryThresholdImageFilterTest2.png
 )
 itk_add_test(
   NAME itkBinaryThresholdProjectionImageFilterTest
@@ -125,6 +129,8 @@ itk_add_test(
     100
     255
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeBinaryThresholdProjection.png
 )
 itk_add_test(
   NAME itkBinaryThresholdSpatialFunctionTest
@@ -146,6 +152,8 @@ itk_add_test(
     256
     1
     19
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHuangThresholdImageFilterTest.png
 )
 itk_add_test(
   NAME itkHuangThresholdImageFilterTestNoAutoMinMax
@@ -160,6 +168,8 @@ itk_add_test(
     32
     0
     -31744
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHuangThresholdImageFilterTestNoAutoMinMax.png
 )
 
 itk_add_test(
@@ -176,6 +186,8 @@ itk_add_test(
     1
     255
     239
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHuangMaskedThresholdImageFilterTest.png
 )
 
 itk_add_test(
@@ -193,6 +205,8 @@ itk_add_test(
     1000
     1
     76
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkIntermodesThresholdImageFilterTest.png
 )
 itk_add_test(
   NAME itkIntermodesThresholdImageFilterTestNoInterMode
@@ -209,6 +223,8 @@ itk_add_test(
     2000
     0
     75
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkIntermodesThresholdImageFilterTestNoInterMode.png
 )
 #itk_add_test(NAME itkIntermodesThresholdImageFilterTestNoAutoMinMax
 #      COMMAND ITKThresholdingTestDriver
@@ -232,6 +248,8 @@ itk_add_test(
     1000
     1
     97
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkIntermodesMaskedThresholdImageFilterTest.png
 )
 
 itk_add_test(
@@ -247,6 +265,8 @@ itk_add_test(
     256
     1
     85
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkIsoDataThresholdImageFilterTest.png
 )
 itk_add_test(
   NAME itkIsoDataThresholdImageFilterTestNoAutoMinMax
@@ -261,6 +281,8 @@ itk_add_test(
     32
     0
     1023
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkIsoDataThresholdImageFilterTestNoAutoMinMax.png
 )
 
 itk_add_test(
@@ -277,6 +299,8 @@ itk_add_test(
     1
     255
     114
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkIsoDataMaskedThresholdImageFilterTest.png
 )
 
 itk_add_test(
@@ -292,6 +316,8 @@ itk_add_test(
     256
     1
     32
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkKittlerIllingworthThresholdImageFilterTest.png
 )
 itk_add_test(
   NAME itkKittlerIllingworthThresholdImageFilterTestNoAutoMinMax
@@ -306,6 +332,8 @@ itk_add_test(
     32
     0
     1023
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkKittlerIllingworthThresholdImageFilterTestNoAutoMinMax.png
 )
 
 itk_add_test(
@@ -322,6 +350,8 @@ itk_add_test(
     1
     255
     254
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkKittlerIllingworthMaskedThresholdImageFilterTest.png
 )
 
 itk_add_test(
@@ -337,6 +367,8 @@ itk_add_test(
     256
     1
     54
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLiThresholdImageFilterTest.png
 )
 itk_add_test(
   NAME itkLiThresholdImageFilterTestNoAutoMinMax
@@ -351,6 +383,8 @@ itk_add_test(
     32
     0
     1023
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLiThresholdImageFilterTestNoAutoMinMax.png
 )
 
 itk_add_test(
@@ -367,6 +401,8 @@ itk_add_test(
     1
     255
     177
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLiMaskedThresholdImageFilterTest.png
 )
 
 itk_add_test(
@@ -382,6 +418,8 @@ itk_add_test(
     256
     1
     140
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMaximumEntropyThresholdImageFilterTest.png
 )
 itk_add_test(
   NAME itkMaximumEntropyThresholdImageFilterTestNoAutoMinMax
@@ -396,6 +434,8 @@ itk_add_test(
     32
     0
     -31744
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMaximumEntropyThresholdImageFilterTestNoAutoMinMax.png
 )
 
 itk_add_test(
@@ -412,6 +452,8 @@ itk_add_test(
     1
     255
     118
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMaximumEntropyMaskedThresholdImageFilterTest.png
 )
 
 itk_add_test(
@@ -427,6 +469,8 @@ itk_add_test(
     256
     1
     133
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMomentsThresholdImageFilterTest.png
 )
 itk_add_test(
   NAME itkMomentsThresholdImageFilterTestNoAutoMinMax
@@ -441,6 +485,8 @@ itk_add_test(
     32
     0
     -31744
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMomentsThresholdImageFilterTestNoAutoMinMax.png
 )
 
 itk_add_test(
@@ -457,6 +503,8 @@ itk_add_test(
     1
     255
     139
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMomentsMaskedThresholdImageFilterTest.png
 )
 
 itk_add_test(
@@ -473,6 +521,8 @@ itk_add_test(
     1
     84
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkOtsuThresholdImageFilterTest.png
 )
 itk_add_test(
   NAME itkOtsuThresholdImageFilterTestFlipInsideOut
@@ -488,6 +538,8 @@ itk_add_test(
     1
     84
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkOtsuThresholdImageFilterTestFlipInsideOut.png
 )
 itk_add_test(
   NAME itkOtsuThresholdImageFilterTestNoAutoMinMax
@@ -503,6 +555,8 @@ itk_add_test(
     0
     -30720
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkOtsuThresholdImageFilterTestNoAutoMinMax.png
 )
 
 # With one threshold, the OtsuMultipleThresholdsImageFilter should give the same result as the OtsuThresholdImageFilter.
@@ -521,6 +575,8 @@ itk_add_test(
     256
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkOtsuMultipleThresholdsImageFilterTest2.png
 )
 
 # Test the algorithm on an image with a small dark region.
@@ -539,6 +595,8 @@ itk_add_test(
     2
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkOtsuMultipleThresholdsImageFilterTest3.png
 )
 
 # Test the valley emphasis algorithm on an image with a small dark region.
@@ -556,6 +614,8 @@ itk_add_test(
     1
     2
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkOtsuMultipleThresholdsImageFilterTest4.png
 )
 
 itk_add_test(
@@ -571,6 +631,8 @@ itk_add_test(
     128
     2
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkOtsuMultipleThresholdsImageFilterTest5.png
 )
 
 itk_add_test(
@@ -588,6 +650,8 @@ itk_add_test(
     0
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkOtsuMultipleThresholdsImageFilterTest6.png
 )
 set_tests_properties(
   itkOtsuMultipleThresholdsImageFilterTest6
@@ -614,6 +678,8 @@ itk_add_test(
     1
     255
     184
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkOtsuMaskedThresholdImageFilterTest.png
 )
 
 itk_add_test(
@@ -629,6 +695,8 @@ itk_add_test(
     256
     1
     51
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkRenyiEntropyThresholdImageFilterTest.png
 )
 itk_add_test(
   NAME itkRenyiEntropyThresholdImageFilterTestNoAutoMinMax
@@ -643,6 +711,8 @@ itk_add_test(
     32
     0
     -31744
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkRenyiEntropyThresholdImageFilterTestNoAutoMinMax.png
 )
 
 itk_add_test(
@@ -659,6 +729,8 @@ itk_add_test(
     1
     255
     118
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkRenyiEntropyMaskedThresholdImageFilterTest.png
 )
 
 itk_add_test(
@@ -674,6 +746,8 @@ itk_add_test(
     256
     1
     133
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkShanbhagThresholdImageFilterTest.png
 )
 itk_add_test(
   NAME itkShanbhagThresholdImageFilterTestNoAutoMinMax
@@ -688,6 +762,8 @@ itk_add_test(
     32
     0
     -31744
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkShanbhagThresholdImageFilterTestNoAutoMinMax.png
 )
 
 itk_add_test(
@@ -704,6 +780,8 @@ itk_add_test(
     1
     255
     55
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkShanbhagMaskedThresholdImageFilterTest.png
 )
 
 itk_add_test(
@@ -719,6 +797,8 @@ itk_add_test(
     256
     1
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTriangleThresholdImageFilterTest.png
 )
 itk_add_test(
   NAME itkTriangleThresholdImageFilterTestNoAutoMinMax
@@ -733,6 +813,8 @@ itk_add_test(
     32
     0
     3071
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTriangleThresholdImageFilterTestNoAutoMinMax.png
 )
 
 itk_add_test(
@@ -749,6 +831,8 @@ itk_add_test(
     1
     255
     254
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTriangleMaskedThresholdImageFilterTest.png
 )
 
 itk_add_test(
@@ -764,6 +848,8 @@ itk_add_test(
     256
     1
     26
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkYenThresholdImageFilterTest.png
 )
 itk_add_test(
   NAME itkYenThresholdImageFilterTestNoAutoMinMax
@@ -778,6 +864,8 @@ itk_add_test(
     32
     0
     -31744
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkYenThresholdImageFilterTestNoAutoMinMax.png
 )
 
 itk_add_test(
@@ -794,6 +882,8 @@ itk_add_test(
     1
     255
     118
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkYenMaskedThresholdImageFilterTest.png
 )
 
 itk_add_test(
@@ -809,6 +899,8 @@ itk_add_test(
     256
     1
     30771
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkHuangThresholdImageFilterTestShort.png
 )
 
 itk_add_test(
@@ -826,6 +918,8 @@ itk_add_test(
     1000
     1
     14251
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkIntermodesThresholdImageFilterTestShort.png
 )
 
 itk_add_test(
@@ -841,6 +935,8 @@ itk_add_test(
     256
     1
     15044
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkIsoDataThresholdImageFilterTestShort.png
 )
 
 itk_add_test(
@@ -856,6 +952,8 @@ itk_add_test(
     256
     1
     31168
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkKittlerIllingworthThresholdImageFilterTestShort.png
 )
 
 itk_add_test(
@@ -871,6 +969,8 @@ itk_add_test(
     256
     1
     26939
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLiThresholdImageFilterTestShort.png
 )
 
 itk_add_test(
@@ -886,6 +986,8 @@ itk_add_test(
     256
     1
     22181
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMaximumEntropyThresholdImageFilterTestShort.png
 )
 
 itk_add_test(
@@ -901,6 +1003,8 @@ itk_add_test(
     256
     1
     23238
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMomentsThresholdImageFilterTestShort.png
 )
 
 itk_add_test(
@@ -917,6 +1021,8 @@ itk_add_test(
     1
     14516
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkOtsuThresholdImageFilterTestShort.png
 )
 
 itk_add_test(
@@ -932,6 +1038,8 @@ itk_add_test(
     256
     1
     22181
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkRenyiEntropyThresholdImageFilterTestShort.png
 )
 
 itk_add_test(
@@ -947,6 +1055,8 @@ itk_add_test(
     256
     1
     28921
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkShanbhagThresholdImageFilterTestShort.png
 )
 
 itk_add_test(
@@ -962,6 +1072,8 @@ itk_add_test(
     256
     1
     22313
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTriangleThresholdImageFilterTestShort.png
 )
 
 itk_add_test(
@@ -977,6 +1089,8 @@ itk_add_test(
     256
     1
     22181
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkYenThresholdImageFilterTestShort.png
 )
 
 itk_add_test(
@@ -1017,6 +1131,8 @@ itk_add_test(
     3.5
     2
     69
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkKappaSigmaThresholdImageFilterTest01.png
 )
 
 itk_add_test(
@@ -1033,4 +1149,6 @@ itk_add_test(
     3.0
     2
     92
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkKappaSigmaThresholdImageFilterTest02.png
 )

--- a/Modules/Filtering/TotalVariation/test/CMakeLists.txt
+++ b/Modules/Filtering/TotalVariation/test/CMakeLists.txt
@@ -14,4 +14,7 @@ itk_add_test(
     itkProxTVImageFilterTest
     ${ITK_TEST_OUTPUT_DIR}/itkProxTVImageFilterTestOutput2D.mha
     ${ITK_TEST_OUTPUT_DIR}/itkProxTVImageFilterTestOutput3D.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkProxTVImageFilterTestOutput2D.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkProxTVImageFilterTestOutput3D.mha
 )

--- a/Modules/IO/BMP/test/CMakeLists.txt
+++ b/Modules/IO/BMP/test/CMakeLists.txt
@@ -24,6 +24,8 @@ itk_add_test(
     itkBMPImageIOTest2
     DATA{${ITK_DATA_ROOT}/Input/smallRGBA.bmp}
     ${ITK_TEST_OUTPUT_DIR}/smallRGBA.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/smallRGBA.mha
 )
 itk_add_test(
   NAME itkBMPImageIOTest6
@@ -34,6 +36,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/smallRGBA.bmp
     itkBMPImageIOTest2
     DATA{${ITK_DATA_ROOT}/Input/smallRGBA.bmp}
+    ${ITK_TEST_OUTPUT_DIR}/smallRGBA.bmp
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/smallRGBA.bmp
 )
 itk_add_test(
@@ -46,6 +50,8 @@ itk_add_test(
     itkBMPImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.bmp}
     ${ITK_TEST_OUTPUT_DIR}/cthead1.bmp
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1.bmp
 )
 itk_add_test(
   NAME itkBMPImageIOTest2
@@ -56,6 +62,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/cthead254x254.bmp
     itkBMPImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/cthead254x254.bmp}
+    ${ITK_TEST_OUTPUT_DIR}/cthead254x254.bmp
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/cthead254x254.bmp
 )
 itk_add_test(
@@ -68,6 +76,8 @@ itk_add_test(
     itkBMPImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/image_grayscale.bmp}
     ${ITK_TEST_OUTPUT_DIR}/image_grayscale.bmp
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/image_grayscale.bmp
 )
 itk_add_test(
   NAME itkBMPImageIOTest4
@@ -78,6 +88,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/image_color.bmp
     itkBMPImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/image_color.bmp}
+    ${ITK_TEST_OUTPUT_DIR}/image_color.bmp
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/image_color.bmp
 )
 itk_add_test(
@@ -117,6 +129,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBMPImageIOTestPaletteExpanded.bmp
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBMPImageIOTestPaletteExpanded.bmp
 )
 itk_add_test(
   NAME itkBMPImageIOTestPaletteNotExpanded
@@ -130,6 +144,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBMPImageIOTestPaletteNotExpanded.bmp
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBMPImageIOTestPaletteNotExpanded.bmp
 )
 itk_add_test(
   NAME itkBMPImageIOTestPaletteNotExpandedGrey
@@ -143,6 +159,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBMPImageIOTestPaletteNotExpandedGrey.bmp
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBMPImageIOTestPaletteNotExpandedGrey.bmp
 )
 
 itk_add_test(

--- a/Modules/IO/BioRad/test/CMakeLists.txt
+++ b/Modules/IO/BioRad/test/CMakeLists.txt
@@ -13,4 +13,6 @@ itk_add_test(
     itkBioRadImageIOTest
     DATA{Input/biorad.pic}
     ${ITK_TEST_OUTPUT_DIR}/biorad_new.pic
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/biorad_new.pic
 )

--- a/Modules/IO/Bruker/test/CMakeLists.txt
+++ b/Modules/IO/Bruker/test/CMakeLists.txt
@@ -19,6 +19,8 @@ itk_add_test(
     itkBrukerImageTest
     DATA{Input/PV6.0_FLASH/pdata/1/2dseq}
     ${ITK_TEST_OUTPUT_DIR}/PV6.0_FLASH_INT16.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/PV6.0_FLASH_INT16.mha
 )
 
 itk_add_test(
@@ -30,6 +32,8 @@ itk_add_test(
     DATA{Baseline/PV6.0_FLASH_UINT8.mha}
     itkBrukerImageTest
     DATA{Input/PV6.0_FLASH/pdata/2/2dseq}
+    ${ITK_TEST_OUTPUT_DIR}/PV6.0_FLASH_UINT8.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/PV6.0_FLASH_UINT8.mha
 )
 
@@ -43,6 +47,8 @@ itk_add_test(
     itkBrukerImageTest
     DATA{Input/PV6.0_FLASH/pdata/2/2dseq}
     ${ITK_TEST_OUTPUT_DIR}/PV6.0_FLASH_FLOAT32.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/PV6.0_FLASH_FLOAT32.mha
 )
 
 itk_add_test(
@@ -54,5 +60,7 @@ itk_add_test(
     DATA{Baseline/PV5.1_FSE_INT16.mha}
     itkBrukerImageTest
     DATA{Input/PV5.1_FSE/pdata/1/2dseq}
+    ${ITK_TEST_OUTPUT_DIR}/PV5.1_FSE_INT16.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/PV5.1_FSE_INT16.mha
 )

--- a/Modules/IO/CSV/test/CMakeLists.txt
+++ b/Modules/IO/CSV/test/CMakeLists.txt
@@ -23,11 +23,15 @@ itk_add_test(
     ITKIOCSVTestDriver
     itkCSVNumericObjectFileWriterTest
     ${TEMP}/NumericObjectToCSVFileWriterOutput.csv
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/NumericObjectToCSVFileWriterOutput.csv
 )
 itk_add_test(
   NAME itkCSVArray2DFileReaderWriterTest
   COMMAND
     ITKIOCSVTestDriver
     itkCSVArray2DFileReaderWriterTest
+    ${TEMP}/csvFileArray2DReaderWriterTestOutput.csv
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${TEMP}/csvFileArray2DReaderWriterTestOutput.csv
 )

--- a/Modules/IO/DCMTK/test/CMakeLists.txt
+++ b/Modules/IO/DCMTK/test/CMakeLists.txt
@@ -79,6 +79,8 @@ itk_add_test(
     itkDCMTKGetDicomTagsTest
     DATA{${ITK_DATA_ROOT}/Input/DicomSeries/Image0075.dcm}
     ${ITK_TEST_OUTPUT_DIR}/DICOMTags.txt
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/DICOMTags.txt
 )
 
 itk_add_test(
@@ -98,6 +100,10 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest.dcm
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest.png
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKRescaleImageIOTest.dcm
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest.dcm
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest.png
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKRescaleImageIOTest.dcm
 )
 
 itk_add_test(
@@ -106,6 +112,10 @@ itk_add_test(
     ITKIODCMTKTestDriver
     itkDCMTKImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/itkGDCMImageIOTest.dcm}
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest2.dcm
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest2.png
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKRescaleImageIOTest2.dcm
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest2.dcm
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest2.png
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKRescaleImageIOTest2.dcm
@@ -120,6 +130,10 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest3.dcm
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest3.png
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKRescaleImageIOTest3.dcm
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest3.dcm
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest3.png
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKRescaleImageIOTest3.dcm
 )
 
 itk_add_test(
@@ -128,6 +142,10 @@ itk_add_test(
     ITKIODCMTKTestDriver
     itkDCMTKImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/itkGDCMImageIOTest3.dcm}
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest4.dcm
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest4.png
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKRescaleImageIOTest4.dcm
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest4.dcm
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest4.png
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKRescaleImageIOTest4.dcm
@@ -142,6 +160,10 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest5.dcm
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest5.png
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKRescaleImageIOTest5.dcm
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest5.dcm
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest5.png
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKRescaleImageIOTest5.dcm
 )
 
 itk_add_test(
@@ -150,6 +172,10 @@ itk_add_test(
     ITKIODCMTKTestDriver
     itkDCMTKImageIOTest
     DATA{Input/no_preamble.dcm}
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest6.dcm
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest6.png
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKRescaleImageIOTest6.dcm
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest6.dcm
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKImageIOTest6.png
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKRescaleImageIOTest6.dcm
@@ -165,6 +191,8 @@ itk_add_test(
     0
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKSeriesReadImageWrite.vtk
 )
 
 itk_add_test(
@@ -177,6 +205,8 @@ itk_add_test(
     0
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKDirCosinesTest.vtk
 )
 
 set_property(
@@ -199,6 +229,8 @@ itk_add_test(
     0.85939
     1.60016
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKSeriesStreamReadImageWrite1.{mhd,raw}
 )
 
 itk_add_test(
@@ -216,6 +248,8 @@ itk_add_test(
     0
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKSeriesImageOrientationWrite1.mha
 )
 
 itk_add_test(
@@ -233,6 +267,8 @@ itk_add_test(
     itkDCMTKMultiFrame4DTest
     DATA{${ITK_DATA_ROOT}/Input/Philips_4D_DICOM.dcm}
     ${ITK_TEST_OUTPUT_DIR}/Philips_4D_DICOM.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/Philips_4D_DICOM.nrrd
 )
 
 itk_add_test(
@@ -247,6 +283,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKNonSquare.nii.gz
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKNonSquare.nii.gz
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKNonSquareRescale.dcm
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKNonSquare.nii.gz
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKNonSquareRescale.dcm
 )
 
 itk_add_test(
@@ -259,6 +298,8 @@ itk_add_test(
     itkDCMTKRGBImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/RGBDicomTest.dcm}
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKColorImage.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKColorImage.png
 )
 
 itk_add_test(
@@ -270,6 +311,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKColorImageSpatialMetadata.nrrd
     itkDCMTKRGBImageIOTest
     DATA{Input/visible-male-rgb-slice.dcm}
+    ${ITK_TEST_OUTPUT_DIR}/itkDCMTKColorImageSpatialMetadata.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkDCMTKColorImageSpatialMetadata.nrrd
 )
 

--- a/Modules/IO/GDCM/test/CMakeLists.txt
+++ b/Modules/IO/GDCM/test/CMakeLists.txt
@@ -42,6 +42,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest.mha
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTestRescaled.dcm
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTestRescaled.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTestRescaled.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest.dcm
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTestRescaled.dcm
 )
 itk_add_test(
   NAME itkGDCMImageIOTest2
@@ -59,6 +64,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest2.mha
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest2Rescaled.dcm
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest2Rescaled.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest2.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest2Rescaled.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest2.dcm
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest2Rescaled.dcm
 )
 itk_add_test(
   NAME itkGDCMImageIOTest3
@@ -76,6 +86,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest3.mha
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest3Rescaled.dcm
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest3Rescaled.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest3.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest3Rescaled.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest3.dcm
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest3Rescaled.dcm
 )
 itk_add_test(
   NAME itkGDCMImageIOTest4
@@ -93,6 +108,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest4.mha
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest4Rescaled.dcm
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest4Rescaled.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest4.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest4Rescaled.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest4.dcm
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest4Rescaled.dcm
 )
 itk_add_test(
   NAME itkGDCMImageIOSecondaryCaptureSpacingTest
@@ -107,6 +127,11 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOSecondaryCaptureSpacingTest.mha
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOSecondaryCaptureSpacingTestRescaled.dcm
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOSecondaryCaptureSpacingTestRescaled.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOSecondaryCaptureSpacingTest.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOSecondaryCaptureSpacingTest.dcm
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOSecondaryCaptureSpacingTestRescaled.dcm
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOSecondaryCaptureSpacingTestRescaled.mha
 )
 itk_add_test(
   NAME itkGDCMImageIOTest5
@@ -115,6 +140,8 @@ itk_add_test(
     itkGDCMImageIOTest2
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mhd,HeadMRVolume.raw}
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest5
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest5-*.dcm
 )
 
 itk_add_test(
@@ -132,6 +159,8 @@ itk_add_test(
     0
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMSeriesStreamReadImageWriteTest1.{mhd,raw}
 )
 
 set_property(
@@ -158,6 +187,8 @@ itk_add_test(
     0
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMSeriesStreamReadImageWriteTest2.{mhd,raw}
 )
 
 set_property(
@@ -188,6 +219,9 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageReadSeriesWriteTest
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageReadSeriesWriteTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageReadSeriesWriteTest.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageReadSeriesWriteTest/image*.dcm
 )
 
 itk_add_test(
@@ -248,6 +282,8 @@ itk_add_test(
     # https://discourse.slicer.org/t/dicom-multiframe-support/4806/9
     DATA{Input/LegacyMultiFrame.dcm}
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMLegacyMultiFrameTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMLegacyMultiFrameTest.mha
 )
 
 itk_add_test(
@@ -279,6 +315,8 @@ itk_add_test(
     DATA{Input/030658_001.dcm}
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTestIntToUint.mha
     scalar
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTestIntToUint.mha
 )
 
 itk_add_test(
@@ -300,6 +338,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/RGBDicomTest.dcm}
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageReadWriteTest_RGB.mha
     rgb
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageReadWriteTest_RGB.mha
 )
 
 itk_add_test(
@@ -313,6 +353,8 @@ itk_add_test(
     DATA{Input/visible-male-rgb-slice.dcm}
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageReadWriteTest_SC_RGB.nrrd
     rgb
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageReadWriteTest_SC_RGB.nrrd
 )
 
 itk_add_test(
@@ -326,6 +368,8 @@ itk_add_test(
     DATA{Input/US1_J2KI.dcm}
     ${ITK_TEST_OUTPUT_DIR}/itkGDCM_ComplianceTestRGB_JPEG2000ICT.mha
     rgb
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCM_ComplianceTestRGB_JPEG2000ICT.mha
 )
 
 itk_add_test(
@@ -339,6 +383,8 @@ itk_add_test(
     DATA{Input/US1_J2KR.dcm}
     ${ITK_TEST_OUTPUT_DIR}/itkGDCM_ComplianceTestRGB_JPEG2000RCT.mha
     rgb
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCM_ComplianceTestRGB_JPEG2000RCT.mha
 )
 
 itk_add_test(
@@ -356,6 +402,8 @@ itk_add_test(
     DATA{Input/JPEGBaseline1DicomTest.dcm}
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageReadWriteTest_JPEGBaseline1.mha
     rgb
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageReadWriteTest_JPEGBaseline1.mha
 )
 itk_add_test(
   NAME itkGDCMImageReadWriteTest_MultiFrameMRIZSpacing
@@ -368,6 +416,8 @@ itk_add_test(
     DATA{Input/MultiFrameMRIZSpacing.dcm}
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageReadWriteTest_MultiFrameMRIZSpacing.mha
     scalar
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageReadWriteTest_MultiFrameMRIZSpacing.mha
 )
 
 itk_add_test(
@@ -382,6 +432,8 @@ itk_add_test(
     DATA{Input/itkGDCMImageIOTest3_mono1.dcm}
     ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest3_mono1.mha
     scalar
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGDCMImageIOTest3_mono1.mha
 )
 
 itk_add_test(
@@ -395,6 +447,8 @@ itk_add_test(
     DATA{Input/single-bit.dcm}
     ${ITK_TEST_OUTPUT_DIR}/single-bit.mha
     scalar
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/single-bit.mha
 )
 
 itk_add_test(
@@ -408,6 +462,8 @@ itk_add_test(
     DATA{Input/preamble.dcm}
     ${ITK_TEST_OUTPUT_DIR}/preamble.mha
     scalar
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/preamble.mha
 )
 
 itk_add_test(
@@ -421,6 +477,8 @@ itk_add_test(
     DATA{Input/no_preamble.dcm}
     ${ITK_TEST_OUTPUT_DIR}/no_preamble.mha
     scalar
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/no_preamble.mha
 )
 
 function(AddComplianceTest fileName)

--- a/Modules/IO/GE/test/CMakeLists.txt
+++ b/Modules/IO/GE/test/CMakeLists.txt
@@ -18,6 +18,8 @@ itk_add_test(
     GE4
     DATA{${ITK_DATA_ROOT}/Input/test_ge4/19771.002.001,REGEX:19771\\.002\\.00[1-6]}
     ${ITK_TEST_OUTPUT_DIR}/19771.002.001.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/19771.002.001.mha
 )
 itk_add_test(
   NAME itkGE5
@@ -34,6 +36,8 @@ itk_add_test(
     GE5
     DATA{${ITK_DATA_ROOT}/Input/test_ge5/113766.003.001,REGEX:113766\\.003\\.00[1-6]}
     ${ITK_TEST_OUTPUT_DIR}/113766.003.001.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/113766.003.001.mha
 )
 itk_add_test(
   NAME itkGE5Test2
@@ -47,6 +51,8 @@ itk_add_test(
     true
     GE5
     DATA{Input/c_vf1122.fre}
+    ${ITK_TEST_OUTPUT_DIR}/c_vf1122.fre.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/c_vf1122.fre.mha
 )
 itk_add_test(
@@ -62,6 +68,8 @@ itk_add_test(
     GE5
     DATA{Input/c_vf1123.fre}
     ${ITK_TEST_OUTPUT_DIR}/c_vf1123.fre.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/c_vf1123.fre.mha
 )
 itk_add_test(
   NAME itkGE5Test4
@@ -75,6 +83,8 @@ itk_add_test(
     true
     GE5
     DATA{Input/c_vf1210.fre}
+    ${ITK_TEST_OUTPUT_DIR}/c_vf1210.fre.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/c_vf1210.fre.mha
 )
 itk_add_test(
@@ -90,6 +100,8 @@ itk_add_test(
     GE5
     DATA{Input/c_vf1211.fre}
     ${ITK_TEST_OUTPUT_DIR}/c_vf1211.fre.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/c_vf1211.fre.mha
 )
 itk_add_test(
   NAME itkGEAdw
@@ -104,6 +116,8 @@ itk_add_test(
     GEAdw
     DATA{${ITK_DATA_ROOT}/Input/test_geadw/I.001,REGEX:I\\.00[1-6]}
     ${ITK_TEST_OUTPUT_DIR}/I.001.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/I.001.mha
 )
 itk_add_test(
   NAME itkSiemens
@@ -117,6 +131,8 @@ itk_add_test(
     true
     Siemens
     DATA{${ITK_DATA_ROOT}/Input/test_siemens/3868-2-100.ima,REGEX:3868-2-10[0-5]\\.ima}
+    ${ITK_TEST_OUTPUT_DIR}/3868-2-100.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/3868-2-100.mha
 )
 itk_add_test(

--- a/Modules/IO/GIPL/test/CMakeLists.txt
+++ b/Modules/IO/GIPL/test/CMakeLists.txt
@@ -13,6 +13,8 @@ itk_add_test(
     itkGiplImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/ramp.gipl}
     ${ITK_TEST_OUTPUT_DIR}/ramp.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ramp.{mhd,raw}
 )
 itk_add_test(
   NAME itkGiplImageIOGzTest
@@ -24,6 +26,8 @@ itk_add_test(
     itkGiplImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/ramp.gipl.gz}
     ${ITK_TEST_OUTPUT_DIR}/ramp-gz.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ramp-gz.{mhd,raw}
 )
 itk_add_test(
   NAME itkGiplImageIOTest2
@@ -31,5 +35,7 @@ itk_add_test(
     ITKIOGIPLTestDriver
     itkGiplImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/ramp.gipl}
+    ${ITK_TEST_OUTPUT_DIR}/ramp.gipl
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/ramp.gipl
 )

--- a/Modules/IO/IOMeshMZ3/test/CMakeLists.txt
+++ b/Modules/IO/IOMeshMZ3/test/CMakeLists.txt
@@ -12,6 +12,9 @@ itk_add_test(
     DATA{Input/11ScalarMesh.mz3}
     ${ITK_TEST_OUTPUT_DIR}/itkMZ3MeshIOTestOutput1.mz3
     ${ITK_TEST_OUTPUT_DIR}/itkMZ3MeshIOTestOutputCompressed1.mz3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMZ3MeshIOTestOutput1.mz3
+    ${ITK_TEST_OUTPUT_DIR}/itkMZ3MeshIOTestOutputCompressed1.mz3
 )
 
 itk_add_test(
@@ -20,6 +23,9 @@ itk_add_test(
     IOMeshMZ3TestDriver
     itkMZ3MeshIOTest
     DATA{Input/3Mesh.mz3}
+    ${ITK_TEST_OUTPUT_DIR}/itkMZ3MeshIOTestOutput2.mz3
+    ${ITK_TEST_OUTPUT_DIR}/itkMZ3MeshIOTestOutputCompressed2.mz3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkMZ3MeshIOTestOutput2.mz3
     ${ITK_TEST_OUTPUT_DIR}/itkMZ3MeshIOTestOutputCompressed2.mz3
 )
@@ -32,6 +38,9 @@ itk_add_test(
     DATA{Input/BrainMesh_ICBM152.lh.motor.mz3}
     ${ITK_TEST_OUTPUT_DIR}/itkMZ3MeshIOTestOutput3.mz3
     ${ITK_TEST_OUTPUT_DIR}/itkMZ3MeshIOTestOutputCompressed3.mz3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMZ3MeshIOTestOutput3.mz3
+    ${ITK_TEST_OUTPUT_DIR}/itkMZ3MeshIOTestOutputCompressed3.mz3
 )
 
 itk_add_test(
@@ -40,6 +49,9 @@ itk_add_test(
     IOMeshMZ3TestDriver
     itkMZ3MeshIOTest
     DATA{Input/cortex_5124.mz3}
+    ${ITK_TEST_OUTPUT_DIR}/itkMZ3MeshIOTestOutput4.mz3
+    ${ITK_TEST_OUTPUT_DIR}/itkMZ3MeshIOTestOutputCompressed4.mz3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkMZ3MeshIOTestOutput4.mz3
     ${ITK_TEST_OUTPUT_DIR}/itkMZ3MeshIOTestOutputCompressed4.mz3
 )

--- a/Modules/IO/IOMeshSTL/test/CMakeLists.txt
+++ b/Modules/IO/IOMeshSTL/test/CMakeLists.txt
@@ -12,6 +12,8 @@ itk_add_test(
     DATA{Baseline/sphere.vtk}
     ${ITK_TEST_OUTPUT_DIR}/sphere00.stl
     0 # write in ASCII
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/sphere00.stl
 )
 
 itk_add_test(
@@ -22,6 +24,8 @@ itk_add_test(
     DATA{Baseline/sphere.vtk}
     ${ITK_TEST_OUTPUT_DIR}/sphere01.stl
     1 # write in BINARY
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/sphere01.stl
 )
 
 itk_add_test(
@@ -32,6 +36,8 @@ itk_add_test(
     DATA{Baseline/sphere.stl}
     ${ITK_TEST_OUTPUT_DIR}/sphere02.stl
     0 # write in ASCII
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/sphere02.stl
 )
 
 itk_add_test(
@@ -42,6 +48,8 @@ itk_add_test(
     DATA{Baseline/sphere.stl}
     ${ITK_TEST_OUTPUT_DIR}/sphere03.stl
     1 # write in BINARY
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/sphere03.stl
 )
 
 itk_add_test(
@@ -52,6 +60,8 @@ itk_add_test(
     DATA{Baseline/tetrahedron.vtk}
     ${ITK_TEST_OUTPUT_DIR}/tetrahedron01.stl
     0 # write in ASCII
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/tetrahedron01.stl
 )
 
 itk_add_test(
@@ -62,6 +72,8 @@ itk_add_test(
     DATA{Baseline/tetrahedron.vtk}
     ${ITK_TEST_OUTPUT_DIR}/tetrahedron02.stl
     1 # write in BINARY
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/tetrahedron02.stl
 )
 
 itk_add_test(
@@ -72,6 +84,8 @@ itk_add_test(
     DATA{Baseline/tetrahedron.stl}
     ${ITK_TEST_OUTPUT_DIR}/tetrahedron03.stl
     0 # write in ASCII
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/tetrahedron03.stl
 )
 
 itk_add_test(
@@ -82,4 +96,6 @@ itk_add_test(
     DATA{Baseline/tetrahedron.stl}
     ${ITK_TEST_OUTPUT_DIR}/tetrahedron04.stl
     1 # write in BINARY
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/tetrahedron04.stl
 )

--- a/Modules/IO/IOMeshSWC/test/CMakeLists.txt
+++ b/Modules/IO/IOMeshSWC/test/CMakeLists.txt
@@ -11,6 +11,8 @@ itk_add_test(
     itkMeshFileReadWriteTest
     DATA{Input/17109_4101-X6753-Y6197_reg.swc}
     ${ITK_TEST_OUTPUT_DIR}/17109_4101-X6753-Y6197_reg.swc.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/17109_4101-X6753-Y6197_reg.swc.vtk
 )
 
 itk_add_test(
@@ -19,6 +21,8 @@ itk_add_test(
     IOMeshSWCTestDriver
     itkMeshFileReadWriteTest
     DATA{Input/17109_4101-X6753-Y6197_reg.swc}
+    ${ITK_TEST_OUTPUT_DIR}/17109_4101-X6753-Y6197_reg.swc
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/17109_4101-X6753-Y6197_reg.swc
 )
 
@@ -29,6 +33,8 @@ itk_add_test(
     itkMeshFileReadWriteTest
     DATA{Input/18453_3564-X30226-Y9677_reg.swc}
     ${ITK_TEST_OUTPUT_DIR}/18453_3564-X30226-Y9677_reg.swc.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/18453_3564-X30226-Y9677_reg.swc.vtk
 )
 
 itk_add_test(
@@ -37,6 +43,8 @@ itk_add_test(
     IOMeshSWCTestDriver
     itkMeshFileReadWriteTest
     DATA{Input/18453_3564-X30226-Y9677_reg.swc}
+    ${ITK_TEST_OUTPUT_DIR}/18453_3564-X30226-Y9677_reg.swc
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/18453_3564-X30226-Y9677_reg.swc
 )
 
@@ -47,6 +55,8 @@ itk_add_test(
     itkMeshFileReadWriteTest
     DATA{Input/11706c2.CNG.swc}
     ${ITK_TEST_OUTPUT_DIR}/11706c2.CNG.swc.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/11706c2.CNG.swc.vtk
 )
 
 itk_add_test(
@@ -55,6 +65,8 @@ itk_add_test(
     IOMeshSWCTestDriver
     itkMeshFileReadWriteTest
     DATA{Input/11706c2.CNG.swc}
+    ${ITK_TEST_OUTPUT_DIR}/11706c2.CNG.swc
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/11706c2.CNG.swc
 )
 

--- a/Modules/IO/IOScanco/test/CMakeLists.txt
+++ b/Modules/IO/IOScanco/test/CMakeLists.txt
@@ -23,6 +23,8 @@ if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 5)
       itkScancoImageIOTest
       DATA{Input/C0004255.ISQ}
       ${ITK_TEST_OUTPUT_DIR}/C0004255.mha
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/C0004255.mha
   )
   set_tests_properties(
     itkScancoImageIOISQConvertTest
@@ -42,6 +44,8 @@ itk_add_test(
     itkScancoImageIOTest
     DATA{Input/AIMIOTestImage.AIM}
     ${ITK_TEST_OUTPUT_DIR}/AIMIOTestImage.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/AIMIOTestImage.mha
 )
 
 if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 5)
@@ -53,6 +57,8 @@ if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 5)
       DATA{Input/C0004255.ISQ}
       ${ITK_TEST_OUTPUT_DIR}/C0003665.isq
       1
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/C0003665.isq
   )
   set_tests_properties(
     itkScancoImageIOISQHeaderCheckTest
@@ -70,6 +76,8 @@ itk_add_test(
     DATA{Input/AIMIOTestImage.AIM}
     ${ITK_TEST_OUTPUT_DIR}/AIMIOTestImage2.isq
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/AIMIOTestImage2.isq
 )
 
 if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 5)
@@ -82,6 +90,8 @@ if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 5)
       ${ITK_TEST_OUTPUT_DIR}/C0004255Test2.mha
       itkScancoImageIOTest2
       DATA{Input/C0004255.ISQ}
+      ${ITK_TEST_OUTPUT_DIR}/C0004255Test2.mha
+    ITK_REMOVE_TEMPORARY_TEST_FILES
       ${ITK_TEST_OUTPUT_DIR}/C0004255Test2.mha
   )
 
@@ -116,6 +126,8 @@ itk_add_test(
     itkScancoImageIOTest3
     DATA{Input/AIMIOTestImage.AIM}
     ${ITK_TEST_OUTPUT_DIR}/AIMIOTestImageTest3.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/AIMIOTestImageTest3.mha
 )
 set_property(
   TEST
@@ -133,6 +145,8 @@ if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 5)
       IOScancoTestDriver
       itkScancoImageIOTest2
       ${ITK_TEST_OUTPUT_DIR}/C0004255Test2.isq
+      ${ITK_TEST_OUTPUT_DIR}/ISQWrite.ISQ
+    ITK_REMOVE_TEMPORARY_TEST_FILES
       ${ITK_TEST_OUTPUT_DIR}/ISQWrite.ISQ
   )
   set_property(
@@ -170,6 +184,8 @@ itk_add_test(
     itkScancoImageIOTest3
     ${ITK_TEST_OUTPUT_DIR}/AIMIOTestWrite.aim
     ${ITK_TEST_OUTPUT_DIR}/AIMIOTestWrite2.aim
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/AIMIOTestWrite2.aim
 )
 
 set_property(
@@ -193,4 +209,6 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/AIMIOTestWritev030.aim
     0
     "AIMDATA_V030   "
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/AIMIOTestWritev030.aim
 )

--- a/Modules/IO/IOTransformDCMTK/test/CMakeLists.txt
+++ b/Modules/IO/IOTransformDCMTK/test/CMakeLists.txt
@@ -40,4 +40,7 @@ itk_add_test(
     DATA{Input/rect-offset-sro-rigid/transform.dcm}
     ${TEMP}/DicomTransformFixedOutput.mha
     ${TEMP}/DicomTransformResampledMovingOutput.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/DicomTransformResampledMovingOutput.mha
+    ${TEMP}/DicomTransformFixedOutput.mha
 )

--- a/Modules/IO/ImageBase/test/CMakeLists.txt
+++ b/Modules/IO/ImageBase/test/CMakeLists.txt
@@ -43,6 +43,8 @@ if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 16)
       itkLargeImageWriteConvertReadTest
       ${ITK_TEST_OUTPUT_DIR}/itkLargeImageWriteConvertReadTest.mha
       30000L
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/itkLargeImageWriteConvertReadTest.mha
   )
 
   itk_add_test(
@@ -52,6 +54,8 @@ if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 16)
       itkLargeImageWriteReadTest
       ${ITK_TEST_OUTPUT_DIR}/itkLargeImageWriteReadTest_2D.mha
       30000L
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/itkLargeImageWriteReadTest_2D.mha
   )
 
   itk_add_test(
@@ -62,6 +66,8 @@ if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 16)
       ${ITK_TEST_OUTPUT_DIR}/itkLargeImageWriteReadTest_3D.mha
       30000L
       4L
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/itkLargeImageWriteReadTest_3D.mha
   )
 
   # BigIO tests produce multi-gigabyte files; MEMORY_SIZE lock serializes them
@@ -77,15 +83,6 @@ if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 16)
   )
 
   # Clean up BigIO output files after completion
-  itk_add_file_test_cleanup(
-    itkLargeImageWriteConvertReadTest ${ITK_TEST_OUTPUT_DIR}/itkLargeImageWriteConvertReadTest.mha
-  )
-  itk_add_file_test_cleanup(
-    itkLargeImageWriteReadTest_2D ${ITK_TEST_OUTPUT_DIR}/itkLargeImageWriteReadTest_2D.mha
-  )
-  itk_add_file_test_cleanup(
-    itkLargeImageWriteReadTest_3D ${ITK_TEST_OUTPUT_DIR}/itkLargeImageWriteReadTest_3D.mha
-  )
 endif()
 
 itk_add_test(
@@ -110,6 +107,8 @@ itk_add_test(
     ITKIOImageBaseTestDriver
     itkImageFileWriterTest
     ${ITK_TEST_OUTPUT_DIR}/test.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/test.png
 )
 itk_add_test(
   NAME itk64bitTestNRRDtoMHA
@@ -120,6 +119,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/Test64bit.mha
     itk64bitTest
     DATA{Input/Test64bit.nrrd}
+    ${ITK_TEST_OUTPUT_DIR}/Test64bit.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/Test64bit.mha
 )
 itk_add_test(
@@ -132,6 +133,8 @@ itk_add_test(
     itk64bitTest
     DATA{Input/Test64bit.mha}
     ${ITK_TEST_OUTPUT_DIR}/Test64bit.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/Test64bit.nrrd
 )
 itk_add_test(
   NAME itk64bitTestNRRDtoMHA2
@@ -143,6 +146,8 @@ itk_add_test(
     itk64bitTest
     DATA{Input/Test64bit.mha}
     ${ITK_TEST_OUTPUT_DIR}/Test64bit2.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/Test64bit2.mha
 )
 itk_add_test(
   NAME itk64bitTestNRRDtoNIFTI
@@ -153,6 +158,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/Test64bit.nii
     itk64bitTest
     DATA{Input/Test64bit.nrrd}
+    ${ITK_TEST_OUTPUT_DIR}/Test64bit.nii
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/Test64bit.nii
 )
 itk_add_test(
@@ -166,6 +173,8 @@ itk_add_test(
     itk64bitTest
     DATA{Input/Test64bit.nrrd}
     ${ITK_TEST_OUTPUT_DIR}/Test64bit.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/Test64bit.vtk
 )
 
 itk_add_test(
@@ -176,6 +185,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkRegularExpressionSeriesFileNamesTest.txt
     itkRegularExpressionSeriesFileNamesTest
     ${ITK_DATA_ROOT}/Input
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkRegularExpressionSeriesFileNamesTest.txt
 )
 set_tests_properties(
   itkRegularExpressionSeriesFileNamesTest
@@ -246,6 +257,8 @@ itk_add_test(
     itkImageFileWriterPastingTest1
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mhd,HeadMRVolume.raw}
     ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterPastingTest1_01.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterPastingTest1_01.mha
 )
 itk_add_test(
   NAME itkImageFileWriterPastingTest2_5
@@ -253,6 +266,8 @@ itk_add_test(
     ITKIOImageBaseTestDriver
     itkImageFileWriterPastingTest2
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mha}
+    ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterPastingTest2_5.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterPastingTest2_5.mha
 )
 itk_add_test(
@@ -266,6 +281,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterPastingTest2_6.mha
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mha}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterPastingTest2_6.mha
 )
 itk_add_test(
   NAME itkImageFileWriterPastingTest2_7
@@ -275,6 +292,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterPastingTest2_7.mha
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolumeCompressed.mha}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterPastingTest2_7.mha
 )
 itk_add_test(
   NAME itkImageFileWriterPastingTest3
@@ -282,6 +301,8 @@ itk_add_test(
     ITKIOImageBaseTestDriver
     itkImageFileWriterPastingTest3
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mhd,HeadMRVolume.raw}
+    ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterPastingTest3_01.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterPastingTest3_01.mha
 )
 itk_add_test(
@@ -354,6 +375,8 @@ itk_add_test(
     0
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterStreamingPastingCompressingTest000.vtk
 )
 
 # JIRA ITK182
@@ -374,6 +397,8 @@ itk_add_test(
     itkImageFileWriterStreamingTest1
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterStreaming1_1.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterStreaming1_1.mha
 )
 itk_add_test(
   NAME itkImageFileWriterStreamingTest1_2
@@ -387,6 +412,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterStreaming1_2.mha
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolumeCompressed.mha}
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterStreaming1_2.mha
 )
 itk_add_test(
   NAME itkImageFileWriterStreamingTest1_3
@@ -400,6 +427,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterStreaming1_3.mha
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mha}
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterStreaming1_3.mha
 )
 itk_add_test(
   NAME itkImageFileWriterStreamingTest2_4
@@ -411,12 +440,16 @@ itk_add_test(
     itkImageFileWriterStreamingTest2
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterStreaming2_4.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterStreaming2_4.mha
 )
 itk_add_test(
   NAME itkImageFileWriterTest2_1
   COMMAND
     ITKIOImageBaseTestDriver
     itkImageFileWriterTest2
+    ${ITK_TEST_OUTPUT_DIR}/test.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/test.nrrd
 )
 itk_add_test(
@@ -425,12 +458,16 @@ itk_add_test(
     ITKIOImageBaseTestDriver
     itkImageFileWriterTest2
     ${ITK_TEST_OUTPUT_DIR}/test.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/test.mha
 )
 itk_add_test(
   NAME itkImageFileWriterTest2_3
   COMMAND
     ITKIOImageBaseTestDriver
     itkImageFileWriterTest2
+    ${ITK_TEST_OUTPUT_DIR}/test.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/test.vtk
 )
 itk_add_test(
@@ -442,6 +479,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterUpdateLargestPossibleRegionTest.png
     itkImageFileWriterUpdateLargestPossibleRegionTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
+    ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterUpdateLargestPossibleRegionTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkImageFileWriterUpdateLargestPossibleRegionTest.png
 )
 itk_add_test(
@@ -455,6 +494,8 @@ itk_add_test(
     0.0
     1.0
     ${ITK_TEST_OUTPUT_DIR}/BrainProtonDensitySliceBorder20.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/BrainProtonDensitySliceBorder20.{mhd,raw}
 )
 itk_add_test(
   NAME itkImageIODirection2DTest02
@@ -467,6 +508,8 @@ itk_add_test(
     0.0
     1.0
     ${ITK_TEST_OUTPUT_DIR}/BrainProtonDensitySliceShifted13x17y.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/BrainProtonDensitySliceShifted13x17y.{mhd,raw}
 )
 itk_add_test(
   NAME itkImageIODirection2DTest03
@@ -479,6 +522,8 @@ itk_add_test(
     0.5
     0.8660254
     ${ITK_TEST_OUTPUT_DIR}/BrainProtonDensitySliceBorder20DirectionPlus30.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/BrainProtonDensitySliceBorder20DirectionPlus30.{mhd,raw}
 )
 itk_add_test(
   NAME itkImageIODirection2DTest04
@@ -491,6 +536,8 @@ itk_add_test(
     0.5
     0.8660254
     ${ITK_TEST_OUTPUT_DIR}/BrainProtonDensitySliceShifted13x17yDirectionPlus30.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/BrainProtonDensitySliceShifted13x17yDirectionPlus30.{mhd,raw}
 )
 itk_add_test(
   NAME itkImageIODirection2DTest05
@@ -503,6 +550,8 @@ itk_add_test(
     0.5
     0.8660254
     ${ITK_TEST_OUTPUT_DIR}/BrainT1SliceBorder20DirectionPlus30.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/BrainT1SliceBorder20DirectionPlus30.{mhd,raw}
 )
 itk_add_test(
   NAME itkImageIODirection2DTest06
@@ -515,6 +564,8 @@ itk_add_test(
     0.0
     1.0
     ${ITK_TEST_OUTPUT_DIR}/BrainProtonDensitySliceBorder20.nhdr
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/BrainProtonDensitySliceBorder20.{nhdr,raw}
 )
 itk_add_test(
   NAME itkImageIODirection2DTest07
@@ -527,6 +578,8 @@ itk_add_test(
     0.0
     1.0
     ${ITK_TEST_OUTPUT_DIR}/BrainProtonDensitySliceShifted13x17y.nhdr
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/BrainProtonDensitySliceShifted13x17y.{nhdr,raw}
 )
 itk_add_test(
   NAME itkImageIODirection2DTest08
@@ -539,6 +592,8 @@ itk_add_test(
     0.5
     0.8660254
     ${ITK_TEST_OUTPUT_DIR}/BrainProtonDensitySliceBorder20DirectionPlus30.nhdr
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/BrainProtonDensitySliceBorder20DirectionPlus30.{nhdr,raw}
 )
 itk_add_test(
   NAME itkImageIODirection2DTest09
@@ -551,6 +606,8 @@ itk_add_test(
     0.5
     0.8660254
     ${ITK_TEST_OUTPUT_DIR}/BrainProtonDensitySliceShifted13x17yDirectionPlus30.nhdr
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/BrainProtonDensitySliceShifted13x17yDirectionPlus30.{nhdr,raw}
 )
 itk_add_test(
   NAME itkImageIODirection2DTest10
@@ -563,6 +620,8 @@ itk_add_test(
     0.5
     0.8660254
     ${ITK_TEST_OUTPUT_DIR}/BrainT1SliceBorder20DirectionPlus30.nhdr
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/BrainT1SliceBorder20DirectionPlus30.{nhdr,raw}
 )
 itk_add_test(
   NAME itkImageIODirection2DTest11
@@ -635,6 +694,8 @@ itk_add_test(
     0.0
     1.0
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeWithDirectionIdentity.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeWithDirectionIdentity.{mhd,raw}
 )
 itk_add_test(
   NAME itkImageIODirection3DTest02
@@ -652,6 +713,8 @@ itk_add_test(
     0.0
     1.0
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeWithDirection.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeWithDirection.{mhd,raw}
 )
 itk_add_test(
   NAME itkImageIODirection3DTest03
@@ -669,6 +732,8 @@ itk_add_test(
     0.0
     1.0
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeWithDirectionIdentity.nhdr
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeWithDirectionIdentity.{nhdr,raw}
 )
 itk_add_test(
   NAME itkImageIODirection3DTest04
@@ -686,6 +751,8 @@ itk_add_test(
     0.0
     1.0
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeWithDirection.nhdr
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeWithDirection.{nhdr,raw}
 )
 itk_add_test(
   NAME itkImageIODirection3DTest05
@@ -735,6 +802,8 @@ itk_add_test(
     0.0
     1.0
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeWithDirection001.nhdr
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeWithDirection001.{nhdr,raw}
 )
 itk_add_test(
   NAME itkImageIODirection3DTest08
@@ -752,6 +821,8 @@ itk_add_test(
     -1.0
     0.0
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeWithDirection002.nhdr
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeWithDirection002.{nhdr,raw}
 )
 itk_add_test(
   NAME itkImageIODirection3DTest09
@@ -769,6 +840,8 @@ itk_add_test(
     0.0
     0.0
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeWithDirection003.nhdr
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeWithDirection003.{nhdr,raw}
 )
 itk_add_test(
   NAME itkImageSeriesReaderDimensionsTest1
@@ -888,6 +961,8 @@ if(ITK_BUILD_SHARED_LIBS)
       ${ITK_TEST_OUTPUT_DIR}
       "FileFreeIO::Size=128,256:Spacing=.5,.8:Origin=5,6:Direction=-1,0,0,-1"
       ${ITK_TEST_OUTPUT_DIR}/itkIOPluginTest.png
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/itkIOPluginTest.png
   )
 endif()
 itk_add_test(
@@ -900,12 +975,16 @@ itk_add_test(
     itkNoiseImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkNoiseImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkNoiseImageFilterTest.png
 )
 itk_add_test(
   NAME itkMatrixImageWriteReadTest
   COMMAND
     ITKIOImageBaseTestDriver
     itkMatrixImageWriteReadTest
+    ${ITK_TEST_OUTPUT_DIR}/testMatrix1.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/testMatrix1.mha
 )
 itk_add_test(
@@ -914,12 +993,16 @@ itk_add_test(
     ITKIOImageBaseTestDriver
     itkReadWriteImageWithDictionaryTest
     ${ITK_TEST_OUTPUT_DIR}/test.hdr
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/test.hdr
 )
 itk_add_test(
   NAME itkReadWriteImageWithDictionaryTest1
   COMMAND
     ITKIOImageBaseTestDriver
     itkReadWriteImageWithDictionaryTest
+    ${ITK_TEST_OUTPUT_DIR}/itkReadWriteImageWithDictionaryTest1.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkReadWriteImageWithDictionaryTest1.mha
 )
 itk_add_test(
@@ -928,12 +1011,16 @@ itk_add_test(
     ITKIOImageBaseTestDriver
     itkVectorImageReadWriteTest
     ${ITK_TEST_OUTPUT_DIR}/VectorImageReadWriteTest.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/VectorImageReadWriteTest.{mhd,raw}
 )
 itk_add_test(
   NAME itkVectorImageReadWriteTest2
   COMMAND
     ITKIOImageBaseTestDriver
     itkVectorImageReadWriteTest
+    ${ITK_TEST_OUTPUT_DIR}/VectorImageReadWriteTest.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/VectorImageReadWriteTest.nrrd
 )
 

--- a/Modules/IO/JPEG/test/CMakeLists.txt
+++ b/Modules/IO/JPEG/test/CMakeLists.txt
@@ -20,6 +20,8 @@ itk_add_test(
     itkJPEGImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.jpg}
     ${ITK_TEST_OUTPUT_DIR}/cthead1.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1.png
 )
 itk_add_test(
   NAME itkJPEGImageIOTest2
@@ -31,12 +33,16 @@ itk_add_test(
     itkJPEGImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.jpg}
     ${ITK_TEST_OUTPUT_DIR}/cthead1.jpg
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/cthead1.jpg
 )
 itk_add_test(
   NAME itkJPEGImageIOSpacing
   COMMAND
     ITKIOJPEGTestDriver
     itkJPEGImageIOTest2
+    ${ITK_TEST_OUTPUT_DIR}/itkJPEGImageIOSpacing.jpg
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkJPEGImageIOSpacing.jpg
 )
 itk_add_test(

--- a/Modules/IO/JPEG2000/test/CMakeLists.txt
+++ b/Modules/IO/JPEG2000/test/CMakeLists.txt
@@ -44,6 +44,8 @@ itk_add_test(
     itkJPEG2000ImageIOTest03
     DATA{Input/Bretagne1.j2k}
     ${ITK_TEST_OUTPUT_DIR}/Bretagne1_01.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/Bretagne1_01.png
 )
 itk_add_test(
   NAME itkJPEG2000Test02
@@ -52,6 +54,8 @@ itk_add_test(
     itkJPEG2000ImageIOTest03
     DATA{Input/Cevennes2.jp2}
     ${ITK_TEST_OUTPUT_DIR}/Cevennes2_01.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/Cevennes2_01.png
 )
 itk_add_test(
   NAME itkJPEG2000Test03
@@ -59,6 +63,8 @@ itk_add_test(
     ITKIOJPEG2000TestDriver
     itkJPEG2000ImageIOTest03
     ${ITK_TEST_OUTPUT_DIR}/Bretagne1_RegionTest01.tif
+    ${ITK_TEST_OUTPUT_DIR}/Bretagne1_02.j2k
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/Bretagne1_02.j2k
 )
 set_tests_properties(
@@ -88,5 +94,7 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkJPEG2000Test06_cthead1.tif
     itkJPEG2000ImageIOTest06
     DATA{Input/cthead1.j2k}
+    ${ITK_TEST_OUTPUT_DIR}/itkJPEG2000Test06_cthead1.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkJPEG2000Test06_cthead1.tif
 )

--- a/Modules/IO/LSM/test/CMakeLists.txt
+++ b/Modules/IO/LSM/test/CMakeLists.txt
@@ -18,4 +18,6 @@ itk_add_test(
     itkLSMImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.lsm}
     ${ITK_TEST_OUTPUT_DIR}/itkLSMImageIOTest_cthead1.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLSMImageIOTest_cthead1.tif
 )

--- a/Modules/IO/MINC/test/CMakeLists.txt
+++ b/Modules/IO/MINC/test/CMakeLists.txt
@@ -38,6 +38,8 @@ itk_add_test(
     itkMINCImageIOTest2
     DATA{Input/t1_z+_byte_cor.mnc}
     ${ITK_TEST_OUTPUT_DIR}/t1_z+_byte_cor_3.mnc
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/t1_z+_byte_cor_3.mnc
 )
 
 itk_add_test(
@@ -51,6 +53,8 @@ itk_add_test(
     DATA{Input/t1_z+_byte_cor.mnc}
     ${ITK_TEST_OUTPUT_DIR}/t1_z+_byte_cor_2.mnc
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/t1_z+_byte_cor_2.mnc
 )
 
 itk_add_test(
@@ -64,6 +68,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mhd,HeadMRVolume.raw}
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolume.mnc
     -1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolume.mnc
 )
 
 # Test to make sure that inter-slice normalization was properly dealt with
@@ -78,6 +84,8 @@ itk_add_test(
     DATA{Input/t1_z+_ubyte_yxz_nonorm.mnc}
     ${ITK_TEST_OUTPUT_DIR}/t1_z+_ubyte_yxz_nonorm_noParams.mnc
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/t1_z+_ubyte_yxz_nonorm_noParams.mnc
 )
 
 itk_add_test(
@@ -91,6 +99,8 @@ itk_add_test(
     DATA{Input/t1_z+_float_yxz_nonorm.mnc}
     ${ITK_TEST_OUTPUT_DIR}/t1_z+_float_yxz_nonorm_noParams.mnc
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/t1_z+_float_yxz_nonorm_noParams.mnc
 )
 
 itk_add_test(
@@ -102,6 +112,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/cthead1.mnc
     itkMINCImageIOTest_2D
     DATA{${ITK_DATA_ROOT}/Input/cthead1.tif}
+    ${ITK_TEST_OUTPUT_DIR}/cthead1.mnc
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/cthead1.mnc
 )
 
@@ -115,6 +127,8 @@ itk_add_test(
     itkMINCImageIOTest_4D
     DATA{Input/dti_sample.mnc}
     ${ITK_TEST_OUTPUT_DIR}/dti_sample.mnc
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/dti_sample.mnc
 )
 
 itk_add_test(
@@ -126,6 +140,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/labels_sample.mnc
     itkMINCImageIOTest_Labels
     DATA{Input/labels_sample.mnc}
+    ${ITK_TEST_OUTPUT_DIR}/labels_sample.mnc
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/labels_sample.mnc
 )
 
@@ -146,6 +162,8 @@ itk_add_test(
     -8.195741583
     72.45998819
     -3.148534512
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/t1_z+_float_yxz_nonorm.mnc
 )
 
 itk_add_test(
@@ -163,6 +181,8 @@ itk_add_test(
     -8.195741583
     72.45998819
     -3.148534512
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/t1_z+_float_yxz_norm.mnc
 )
 
 itk_add_test(
@@ -180,6 +200,8 @@ itk_add_test(
     -8.195741583
     72.45998819
     -3.148534512
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/t1_z+_ubyte_yxz_nonorm.mnc
 )
 
 # multiple loops because of different numerical parameters

--- a/Modules/IO/MRC/test/CMakeLists.txt
+++ b/Modules/IO/MRC/test/CMakeLists.txt
@@ -25,6 +25,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/tilt_series_little.mrc}
     ${ITK_TEST_OUTPUT_DIR}/itkMRCImageIOTest2a.mrc
     5eac5b2827533e8df8b061ff0ab33718
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMRCImageIOTest2a.mrc
 )
 itk_add_test(
   NAME itkMRCImageIOTest2b
@@ -37,6 +39,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/tilt_series_big.mrc}
     ${ITK_TEST_OUTPUT_DIR}/itkMRCImageIOTest2b.mrc
     5eac5b2827533e8df8b061ff0ab33718
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMRCImageIOTest2b.mrc
 )
 itk_add_test(
   NAME itkMRCImageIOTest2c
@@ -49,6 +53,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/RGBTestImageLZW.tif}
     ${ITK_TEST_OUTPUT_DIR}/itkMRCImageIOTest2c.mrc
     38a2dcfc08812e04b1528f15ca3d2ab7
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMRCImageIOTest2c.mrc
 )
 itk_add_test(
   NAME itkMRCImageIOTest2d
@@ -61,4 +67,6 @@ itk_add_test(
     DATA{Input/tilt_uint8.mrc}
     ${ITK_TEST_OUTPUT_DIR}/itkMRCImageIOTest2d.mrc
     96093c8573ce2b4f197f0b0bfcc574bf
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMRCImageIOTest2d.mrc
 )

--- a/Modules/IO/Mesh/test/CMakeLists.txt
+++ b/Modules/IO/Mesh/test/CMakeLists.txt
@@ -11,6 +11,8 @@ itk_add_test(
     itkMeshFileReadWriteTest
     DATA{Baseline/sphere.fsb}
     ${ITK_TEST_OUTPUT_DIR}/sphere01.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/sphere01.vtk
 )
 itk_add_test(
   NAME itkMeshFileReadWriteTest03
@@ -19,6 +21,8 @@ itk_add_test(
     itkMeshFileReadWriteTest
     DATA{Baseline/sphere_curv.vtk}
     ${ITK_TEST_OUTPUT_DIR}/sphere_curv_03.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/sphere_curv_03.vtk
 )
 itk_add_test(
   NAME itkMeshFileReadWriteTest04
@@ -26,6 +30,8 @@ itk_add_test(
     ITKIOMeshTestDriver
     itkMeshFileReadWriteTest
     DATA{Baseline/thickness.fcv}
+    ${ITK_TEST_OUTPUT_DIR}/thickness.fcv
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/thickness.fcv
 )
 itk_add_test(
@@ -36,4 +42,6 @@ itk_add_test(
     DATA{Baseline/sphere_curv_b.vtk}
     ${ITK_TEST_OUTPUT_DIR}/sphere_curv_07.vtk
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/sphere_curv_07.vtk
 )

--- a/Modules/IO/MeshBYU/test/CMakeLists.txt
+++ b/Modules/IO/MeshBYU/test/CMakeLists.txt
@@ -26,6 +26,9 @@ itk_add_test(
     0
     6
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/byumeshiocube.byu
+    ${ITK_TEST_OUTPUT_DIR}/byu2vtkcube.vtk
 )
 itk_add_test(
   NAME itkMeshFileReadWriteTest06
@@ -33,5 +36,7 @@ itk_add_test(
     ITKIOMeshBYUTestDriver
     itkMeshFileReadWriteTest
     DATA{Baseline/cube.byu}
+    ${ITK_TEST_OUTPUT_DIR}/cube.byu
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/cube.byu
 )

--- a/Modules/IO/MeshBase/test/CMakeLists.txt
+++ b/Modules/IO/MeshBase/test/CMakeLists.txt
@@ -12,4 +12,6 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/mushroom.vtk}
     ${ITK_TEST_OUTPUT_DIR}/itkMeshFileReaderWriterTest.vtk
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mha}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMeshFileReaderWriterTest.vtk
 )

--- a/Modules/IO/MeshFreeSurfer/test/CMakeLists.txt
+++ b/Modules/IO/MeshFreeSurfer/test/CMakeLists.txt
@@ -27,6 +27,9 @@ itk_add_test(
     320
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/fsmeshiosphere.fsa
+    ${ITK_TEST_OUTPUT_DIR}/fsa2fsbsphere.fsb
 )
 itk_add_test(
   NAME itkFreeSurferMeshIOTestBinary
@@ -47,6 +50,9 @@ itk_add_test(
     320
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/fsmeshiosphere.fsb
+    ${ITK_TEST_OUTPUT_DIR}/fsb2fsasphere.fsa
 )
 itk_add_test(
   NAME itkMeshFileReadWriteTestFreeSurfer1
@@ -55,6 +61,8 @@ itk_add_test(
     itkMeshFileReadWriteTest
     DATA{Baseline/sphere.fsb}
     ${ITK_TEST_OUTPUT_DIR}/sphere.fsb
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/sphere.fsb
 )
 itk_add_test(
   NAME itkMeshFileReadWriteTestFreeSurfer2
@@ -62,5 +70,7 @@ itk_add_test(
     ITKIOMeshFreeSurferTestDriver
     itkMeshFileReadWriteTest
     DATA{Baseline/sphere.fsa}
+    ${ITK_TEST_OUTPUT_DIR}/sphere.fsa
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/sphere.fsa
 )

--- a/Modules/IO/MeshGifti/test/CMakeLists.txt
+++ b/Modules/IO/MeshGifti/test/CMakeLists.txt
@@ -30,6 +30,9 @@ itk_add_test(
     0
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/giftimeshioaparc.gii
+    ${ITK_TEST_OUTPUT_DIR}/gifti2vtkaparc.vtk
 )
 itk_add_test(
   NAME itkGiftiMeshIOTest2
@@ -53,6 +56,9 @@ itk_add_test(
     44264
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/giftimeshiowhite.gii
+    ${ITK_TEST_OUTPUT_DIR}/gifti2vtkwhite.vtk
 )
 itk_add_test(
   NAME itkMeshFileReadWriteTestGifti1
@@ -61,6 +67,8 @@ itk_add_test(
     itkMeshFileReadWriteTest
     DATA{Baseline/white.gii}
     ${ITK_TEST_OUTPUT_DIR}/white.gii
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/white.gii
 )
 itk_add_test(
   NAME itkMeshFileReadWriteTestGifti2
@@ -68,5 +76,7 @@ itk_add_test(
     ITKIOMeshGiftiTestDriver
     itkMeshFileReadWriteTest
     DATA{Baseline/aparc.gii}
+    ${ITK_TEST_OUTPUT_DIR}/aparc.gii
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/aparc.gii
 )

--- a/Modules/IO/MeshOBJ/test/CMakeLists.txt
+++ b/Modules/IO/MeshOBJ/test/CMakeLists.txt
@@ -15,6 +15,8 @@ itk_add_test(
     itkMeshFileReadWriteTest
     DATA{Baseline/box.obj}
     ${ITK_TEST_OUTPUT_DIR}/box.obj
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/box.obj
 )
 
 itk_add_test(
@@ -23,6 +25,8 @@ itk_add_test(
     ITKIOMeshOBJTestDriver
     itkMeshFileReadWriteTest
     DATA{Baseline/bunny.obj}
+    ${ITK_TEST_OUTPUT_DIR}/bunny.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/bunny.vtk
 )
 
@@ -44,6 +48,9 @@ itk_add_test(
     0
     6
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/objmeshiobox.obj
+    ${ITK_TEST_OUTPUT_DIR}/obj2vtkbox.vtk
 )
 
 itk_add_test(
@@ -64,4 +71,7 @@ itk_add_test(
     4968
     4968
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/objmeshiobunny.obj
+    ${ITK_TEST_OUTPUT_DIR}/obj2vtkbunny.vtk
 )

--- a/Modules/IO/MeshOFF/test/CMakeLists.txt
+++ b/Modules/IO/MeshOFF/test/CMakeLists.txt
@@ -15,6 +15,8 @@ itk_add_test(
     itkMeshFileReadWriteTest
     DATA{Baseline/octa.off}
     ${ITK_TEST_OUTPUT_DIR}/octa.off
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/octa.off
 )
 itk_add_test(
   NAME itkOFFMeshIOTest
@@ -34,4 +36,7 @@ itk_add_test(
     0
     8
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/offmeshioocta.off
+    ${ITK_TEST_OUTPUT_DIR}/off2vtkocta.vtk
 )

--- a/Modules/IO/MeshVTK/test/CMakeLists.txt
+++ b/Modules/IO/MeshVTK/test/CMakeLists.txt
@@ -19,6 +19,8 @@ itk_add_test(
     itkMeshFileReadWriteTest
     DATA{Input/sphere.vtk}
     ${ITK_TEST_OUTPUT_DIR}/sphere00.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/sphere00.vtk
 )
 itk_add_test(
   NAME itkMeshFileReadWriteTest01
@@ -26,6 +28,8 @@ itk_add_test(
     ITKIOMeshVTKTestDriver
     itkMeshFileReadWriteTest
     DATA{Input/sphere_51.vtk}
+    ${ITK_TEST_OUTPUT_DIR}/sphere_51_01.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/sphere_51_01.vtk
 )
 itk_add_test(
@@ -36,6 +40,8 @@ itk_add_test(
     DATA{Input/sphere_51_b.vtk}
     ${ITK_TEST_OUTPUT_DIR}/sphere_51_b_02.vtk
     binary
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/sphere_51_b_02.vtk
 )
 itk_add_test(
   NAME itkMeshFileReadWriteVectorAttributeTest
@@ -44,6 +50,8 @@ itk_add_test(
     itkMeshFileReadWriteVectorAttributeTest
     DATA{Baseline/sphere_norm.vtk}
     ${ITK_TEST_OUTPUT_DIR}/sphere_norm.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/sphere_norm.vtk
 )
 itk_add_test(
   NAME itkPolyLineReadWriteTest00
@@ -51,6 +59,8 @@ itk_add_test(
     ITKIOMeshVTKTestDriver
     itkPolylineReadWriteTest
     DATA{Baseline/fibers.vtk}
+    ${ITK_TEST_OUTPUT_DIR}/fibers.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/fibers.vtk
 )
 itk_add_test(
@@ -61,6 +71,8 @@ itk_add_test(
     DATA{Baseline/fibers.vtk}
     ${ITK_TEST_OUTPUT_DIR}/fibers_b.vtk
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/fibers_b.vtk
 )
 itk_add_test(
   NAME itkPolyLineReadWriteTest02
@@ -68,6 +80,8 @@ itk_add_test(
     ITKIOMeshVTKTestDriver
     itkPolylineReadWriteTest
     DATA{Baseline/hollow_test.vtk}
+    ${ITK_TEST_OUTPUT_DIR}/hollow_test.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/hollow_test.vtk
 )
 itk_add_test(
@@ -78,12 +92,17 @@ itk_add_test(
     DATA{Baseline/hollow_test.vtk}
     ${ITK_TEST_OUTPUT_DIR}/hollow_test_b.vtk
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/hollow_test_b.vtk
 )
 itk_add_test(
   NAME itkMeshFileWriteReadTensorTest
   COMMAND
     ITKIOMeshVTKTestDriver
     itkMeshFileWriteReadTensorTest
+    ${ITK_TEST_OUTPUT_DIR}/itkMeshFileWriteReadTensorTest2D.vtk
+    ${ITK_TEST_OUTPUT_DIR}/itkMeshFileWriteReadTensorTest3D.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkMeshFileWriteReadTensorTest2D.vtk
     ${ITK_TEST_OUTPUT_DIR}/itkMeshFileWriteReadTensorTest3D.vtk
 )
@@ -114,6 +133,9 @@ itk_add_test(
     0
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/sphere_a.vtk
+    ${ITK_TEST_OUTPUT_DIR}/ascii2asciivtk2mhaHeadMRVolume.mha
 )
 itk_add_test(
   NAME itkVTKPolyDataMeshIOTestInAsciiOutBinary
@@ -135,6 +157,9 @@ itk_add_test(
     0
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/sphere_b.vtk
+    ${ITK_TEST_OUTPUT_DIR}/ascii2binaryvtk2mhaHeadMRVolume.mha
 )
 itk_add_test(
   NAME itkVTKPolyDataMeshIOTestInBinaryOutAscii
@@ -156,6 +181,9 @@ itk_add_test(
     2
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/fibers_a.vtk
+    ${ITK_TEST_OUTPUT_DIR}/binary2asciivtk2mhaHeadMRVolume.mha
 )
 itk_add_test(
   NAME itkVTKPolyDataMeshIOTestInOutBinary
@@ -177,6 +205,9 @@ itk_add_test(
     2
     1
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/fibers_b_VTKPolyDataMeshIO.vtk
+    ${ITK_TEST_OUTPUT_DIR}/binary2binaryvtk2mhaHeadMRVolume.mha
 )
 itk_add_test(
   NAME itkMeshFileReadWriteTestField
@@ -184,6 +215,8 @@ itk_add_test(
     ITKIOMeshVTKTestDriver
     itkMeshFileReadWriteTest
     DATA{Input/gourd.vtk}
+    ${ITK_TEST_OUTPUT_DIR}/gourd.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/gourd.vtk
 )
 

--- a/Modules/IO/Meta/test/CMakeLists.txt
+++ b/Modules/IO/Meta/test/CMakeLists.txt
@@ -24,6 +24,8 @@ itk_add_test(
     ITKIOMetaTestDriver
     itkMetaImageIOMetaDataTest
     ${ITK_TEST_OUTPUT_DIR}/MetaImageIOMetaDataTest.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/MetaImageIOMetaDataTest.{mhd,raw}
 )
 itk_add_test(
   NAME itkMetaImageIOGzTest
@@ -42,6 +44,8 @@ itk_add_test(
     itkMetaImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mhd,HeadMRVolume.raw}
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolume.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolume.{mhd,raw}
 )
 itk_add_test(
   NAME itkMetaImageIOTestList
@@ -53,6 +57,8 @@ itk_add_test(
     itkMetaImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/MetaIO/SmallRampVolumeList.mhd,SmallRampVolume01.tif,SmallRampVolume02.tif,SmallRampVolume03.tif,SmallRampVolume04.tif,SmallRampVolume05.tif,SmallRampVolume06.tif}
     ${ITK_TEST_OUTPUT_DIR}/itkMetaImageIOTestList.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMetaImageIOTestList.{mhd,raw}
 )
 
 # Suppress on FreeBSD, `man make` says "There is no way of escaping a space character in a filename" and indeed make will fail here because of the spaces in the filenames.
@@ -78,6 +84,8 @@ if(
       itkMetaImageIOTest
       DATA{${ITK_DATA_ROOT}/Input/MetaIO/Small\ Ramp\ Volume\ List.mhd,Small\ Ramp\ Volume\ 01.tif,Small\ Ramp\ Volume\ 02.tif,Small\ Ramp\ Volume\ 03.tif,Small\ Ramp\ Volume\ 04.tif,Small\ Ramp\ Volume\ 05.tif,Small\ Ramp\ Volume\ 06.tif}
       ${ITK_TEST_OUTPUT_DIR}/itkMetaImageIOTestListWithFilenameSpaces.mhd
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/itkMetaImageIOTestListWithFilenameSpaces.{mhd,raw}
   )
 endif()
 
@@ -91,6 +99,8 @@ itk_add_test(
     itkMetaImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/MetaIO/SmallRampVolumeRegEx.mhd,SmallRampVolume01.tif,SmallRampVolume02.tif,SmallRampVolume03.tif,SmallRampVolume04.tif,SmallRampVolume05.tif,SmallRampVolume06.tif}
     ${ITK_TEST_OUTPUT_DIR}/itkMetaImageIOTestRegEx.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMetaImageIOTestRegEx.{mhd,raw}
 )
 
 # Suppress on FreeBSD, `man make` says "There is no way of escaping a space character in a filename" and indeed make will fail here because of the spaces in the filenames.
@@ -116,6 +126,8 @@ if(
       itkMetaImageIOTest
       DATA{${ITK_DATA_ROOT}/Input/MetaIO/Small\ Ramp\ Volume\ Reg\ Ex.mhd,Small\ Ramp\ Volume\ 01.tif,Small\ Ramp\ Volume\ 02.tif,Small\ Ramp\ Volume\ 03.tif,Small\ Ramp\ Volume\ 04.tif,Small\ Ramp\ Volume\ 05.tif,Small\ Ramp\ Volume\ 06.tif}
       ${ITK_TEST_OUTPUT_DIR}/itkMetaImageIOTestRegExWithFilenameSpaces.mhd
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/itkMetaImageIOTestRegExWithFilenameSpaces.{mhd,raw}
   )
 endif()
 
@@ -124,6 +136,8 @@ itk_add_test(
   COMMAND
     ITKIOMetaTestDriver
     itkMetaImageIOTest2
+    ${ITK_TEST_OUTPUT_DIR}/itkMetaImageIOTest2.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkMetaImageIOTest2.mha
 )
 itk_add_test(
@@ -393,6 +407,8 @@ itk_add_test(
     itkMetaImageStreamingIOTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mhd,HeadMRVolume.raw}
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeStreamed.mhd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeStreamed.{mhd,raw}
 )
 itk_add_test(
   NAME itkMetaImageCompressedStreamingIOTest
@@ -404,6 +420,8 @@ itk_add_test(
     itkMetaImageStreamingIOTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolumeCompressed.mha}
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeCompressedStreamed.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeCompressedStreamed.mha
 )
 itk_add_test(
   NAME itkMetaImageStreamingWriterIOTest
@@ -414,6 +432,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/MetaImageStreamingWriterIOTest.mha
     itkMetaImageStreamingWriterIOTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mhd,HeadMRVolume.raw}
+    ${ITK_TEST_OUTPUT_DIR}/MetaImageStreamingWriterIOTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/MetaImageStreamingWriterIOTest.mha
 )
 
@@ -442,6 +462,8 @@ itk_add_test(
     itkMetaImageStreamingWriterIOTest
     DATA{${ITK_DATA_ROOT}/Input/mri3D.mhd}
     ${ITK_TEST_OUTPUT_DIR}/mri3DWriteStreamed.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/mri3DWriteStreamed.mha
 )
 
 itk_add_test(
@@ -460,6 +482,8 @@ if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 5)
       itkLargeMetaImageWriteReadTest
       ${ITK_TEST_OUTPUT_DIR}/LargeImage01.mhd
       30000L
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/LargeImage01.{mhd,raw}
   )
 
   # Image of 2.98 Gigabytes (pixels size is 16bits)
@@ -470,6 +494,8 @@ if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 5)
       itkLargeMetaImageWriteReadTest
       ${ITK_TEST_OUTPUT_DIR}/LargeImage02.mhd
       40000L
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/LargeImage02.{mhd,raw}
   )
 
   # Image of 4.9 Gigabytes (pixels size is 8-bits out and 16-bit in)
@@ -480,6 +506,8 @@ if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 5)
       itkLargeMetaImageWriteReadTest
       ${ITK_TEST_OUTPUT_DIR}/LargeImage03.mhd
       50000L
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/LargeImage03.{mhd,raw}
   )
 
   # Due to the large memory requirements these tests must be run one by one
@@ -520,9 +548,6 @@ if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 5)
         RUNS_LONG
   )
   # Clean up BigIO output files after completion
-  itk_add_file_test_cleanup(itkLargeMetaImageWriteReadTest1 ${ITK_TEST_OUTPUT_DIR}/LargeImage01.mhd)
-  itk_add_file_test_cleanup(itkLargeMetaImageWriteReadTest2 ${ITK_TEST_OUTPUT_DIR}/LargeImage02.mhd)
-  itk_add_file_test_cleanup(itkLargeMetaImageWriteReadTest3 ${ITK_TEST_OUTPUT_DIR}/LargeImage03.mhd)
 endif()
 
 if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 12)
@@ -534,6 +559,8 @@ if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 12)
       itkLargeMetaImageWriteReadTest
       ${ITK_TEST_OUTPUT_DIR}/LargeImage04.mhd
       70000L
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/LargeImage04.{mhd,raw}
   )
 
   # Due to the large memory requirements this test must be run serially
@@ -557,5 +584,4 @@ if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 12)
       LABELS
         RUNS_LONG
   )
-  itk_add_file_test_cleanup(itkLargeMetaImageWriteReadTest4 ${ITK_TEST_OUTPUT_DIR}/LargeImage04.mhd)
 endif()

--- a/Modules/IO/NIFTI/test/CMakeLists.txt
+++ b/Modules/IO/NIFTI/test/CMakeLists.txt
@@ -44,6 +44,8 @@ itk_add_test(
     itkNiftiImageIOTest
     ${ITK_TEST_OUTPUT_DIR}/itkNiftisform2DirectionDefNiiGzTest.nii.gz
     DATA{${ITK_DATA_ROOT}/Input/itkNiftisform2DirectionDef.nii.gz}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkNiftisform2DirectionDefNiiGzTest.nii.gz
 )
 
 itk_add_test(
@@ -54,6 +56,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOBigEndianCompressedHdrTest.nii.gz
     itkNiftiIOBigEndianCompressed.hdr
     DATA{${ITK_DATA_ROOT}/Input/BigEndianCompressed.hdr}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOBigEndianCompressedHdrTest.nii.gz
 )
 itk_add_test(
   NAME itkNiftiIOBigEndianCompressed.img
@@ -63,6 +67,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOBigEndianCompressedImgTest.nii.gz
     itkNiftiIOBigEndianCompressed.img
     DATA{${ITK_DATA_ROOT}/Input/BigEndianCompressed.img}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOBigEndianCompressedImgTest.nii.gz
 )
 itk_add_test(
   NAME itkNiftiIOBigEndianCompressed.img.gz
@@ -72,6 +78,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOBigEndianCompressedImgGz.nii.gz
     itkNiftiIOBigEndianCompressed.img.gz
     DATA{${ITK_DATA_ROOT}/Input/BigEndianCompressed.img.gz}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOBigEndianCompressedImgGz.nii.gz
 )
 itk_add_test(
   NAME itkNiftiIOBigEndian
@@ -81,6 +89,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOBigEndianTest.nii.gz
     itkNiftiIOBigEndian
     DATA{${ITK_DATA_ROOT}/Input/BigEndian.hdr,BigEndian.mhd,BigEndian.img}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOBigEndianTest.nii.gz
 )
 itk_add_test(
   NAME itkNiftiIOLittleEndianCompressed
@@ -90,6 +100,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOLittleEndianCompressedTest.nii.gz
     itkNiftiImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/LittleEndianCompressed.hdr,LittleEndianCompressed.img.gz}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOLittleEndianCompressedTest.nii.gz
 )
 itk_add_test(
   NAME itkNiftiIOLittleEndian
@@ -99,12 +111,16 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOLittleEndianTest.nii.gz
     itkNiftiIOLittleEndian
     DATA{${ITK_DATA_ROOT}/Input/LittleEndian.hdr,LittleEndian.mhd,LittleEndian.img}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOLittleEndianTest.nii.gz
 )
 itk_add_test(
   NAME itkNiftiIOInternalTests
   COMMAND
     ITKIONIFTITestDriver
     itkNiftiImageIOTest
+    ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOInternalTestsTest.nii.gz
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkNiftiIOInternalTestsTest.nii.gz
 )
 itk_add_test(
@@ -218,6 +234,8 @@ itk_add_test(
     itkExtractSlice
     DATA{Input/SlopeInterceptUCHAR.nii.gz}
     ${ITK_TEST_OUTPUT_DIR}/SlopeInterceptUCHAR-midSlice.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/SlopeInterceptUCHAR-midSlice.nrrd
 )
 
 itk_add_test(
@@ -264,6 +282,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/xyzt_units_output_check.nii
     DATA{Input/xyzt_units_test_scl_mm_s.nii.gz}
     DATA{Input/xyzt_units_test_scl.nii.gz}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/xyzt_units_output_check.nii
 )
 
 itk_add_test(
@@ -274,6 +294,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/xyzt_units_output_check2.nii
     DATA{Input/xyzt_units_test_scl_mm_s.nii.gz}
     DATA{Input/xyzt_units_test_scl_mm_s.nii.gz}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/xyzt_units_output_check2.nii
 )
 
 itk_add_test(
@@ -289,6 +311,8 @@ itk_add_test(
   COMMAND
     ITKIONIFTITestDriver
     itkNiftiLargeImageRegionReadTest
+    ${ITK_TEST_OUTPUT_DIR}/itkNiftiLargeImageRegionReadTest.nii.gz
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkNiftiLargeImageRegionReadTest.nii.gz
 )
 

--- a/Modules/IO/NRRD/test/CMakeLists.txt
+++ b/Modules/IO/NRRD/test/CMakeLists.txt
@@ -33,6 +33,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkNrrdImageIOTest1.txt
     itkNrrdImageIOTest
     ${ITK_TEST_OUTPUT_DIR}/testNrrd.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkNrrdImageIOTest1.txt
+    ${ITK_TEST_OUTPUT_DIR}/testNrrd.nrrd
 )
 set_tests_properties(
   itkNrrdImageIOTest1
@@ -49,6 +52,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkNrrdImageIOTest2.txt
     itkNrrdImageIOTest
     ${ITK_TEST_OUTPUT_DIR}/testNrrd.nhdr
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkNrrdImageIOTest2.txt
+    ${ITK_TEST_OUTPUT_DIR}/testNrrd.{nhdr,raw,raw.gz}
 )
 set_tests_properties(
   itkNrrdImageIOTest2
@@ -74,6 +80,8 @@ itk_add_test(
     itkNrrdComplexImageReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/mini-complex-slow.nrrd}
     ${ITK_TEST_OUTPUT_DIR}/mini-complex.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/mini-complex.nrrd
 )
 itk_add_test(
   NAME itkNrrdCovariantVectorImageReadTest
@@ -92,6 +100,8 @@ itk_add_test(
     itkNrrdCovariantVectorImageReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/mini-covector-slow.nrrd}
     ${ITK_TEST_OUTPUT_DIR}/mini-covector.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/mini-covector.nrrd
 )
 itk_add_test(
   NAME itkNrrdDiffusionTensor3DImageReadTensorDoubleWriteTensorDouble
@@ -102,6 +112,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/small-tensors-double.nrrd
     itkNrrdDiffusionTensor3DImageReadTensorDoubleWriteTensorDoubleTest
     DATA{${ITK_DATA_ROOT}/Input/small-tensors.nhdr,small-tensors.raw}
+    ${ITK_TEST_OUTPUT_DIR}/small-tensors-double.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/small-tensors-double.nrrd
 )
 itk_add_test(
@@ -135,6 +147,8 @@ itk_add_test(
     itkNrrdDiffusionTensor3DImageReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/mini-ten-nomask-fast.nrrd}
     ${ITK_TEST_OUTPUT_DIR}/mini-ten.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/mini-ten.nrrd
 )
 itk_add_test(
   NAME itkNrrdDiffusionTensor3DImageReadWriteTest4
@@ -146,6 +160,8 @@ itk_add_test(
     itkNrrdDiffusionTensor3DImageReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/small-tensors.nhdr}
     ${ITK_TEST_OUTPUT_DIR}/small-tensors.nhdr
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/small-tensors.{nhdr,raw}
 )
 itk_add_test(
   NAME itkNrrdImageReadWriteTest1
@@ -156,6 +172,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/box.nrrd
     itkNrrdImageReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/box.nhdr,box.raw}
+    ${ITK_TEST_OUTPUT_DIR}/box.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/box.nrrd
 )
 itk_add_test(
@@ -168,6 +186,8 @@ itk_add_test(
     itkNrrdImageReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/vol-ascii.nrrd}
     ${ITK_TEST_OUTPUT_DIR}/vol2.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/vol2.nrrd
 )
 itk_add_test(
   NAME itkNrrdImageReadWriteTest3
@@ -178,6 +198,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/vol3.nrrd
     itkNrrdImageReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/vol-raw-big.nrrd}
+    ${ITK_TEST_OUTPUT_DIR}/vol3.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/vol3.nrrd
 )
 itk_add_test(
@@ -190,6 +212,8 @@ itk_add_test(
     itkNrrdImageReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/vol-raw-little.nrrd}
     ${ITK_TEST_OUTPUT_DIR}/vol4.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/vol4.nrrd
 )
 itk_add_test(
   NAME itkNrrdImageReadWriteTest5
@@ -200,6 +224,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/vol5.nrrd
     itkNrrdImageReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/vol-gzip-big.nrrd}
+    ${ITK_TEST_OUTPUT_DIR}/vol5.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/vol5.nrrd
 )
 itk_add_test(
@@ -212,6 +238,8 @@ itk_add_test(
     itkNrrdImageReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/vol-gzip-little.nrrd}
     ${ITK_TEST_OUTPUT_DIR}/vol6.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/vol6.nrrd
 )
 itk_add_test(
   NAME itkNrrdImageReadWriteTest7
@@ -222,6 +250,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/vol7.nrrd
     itkNrrdImageReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/vol-ascii.nhdr,vol-ascii.ascii}
+    ${ITK_TEST_OUTPUT_DIR}/vol7.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/vol7.nrrd
 )
 itk_add_test(
@@ -234,6 +264,8 @@ itk_add_test(
     itkNrrdImageReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/vol-raw-big.nhdr,vol-raw-big.raw}
     ${ITK_TEST_OUTPUT_DIR}/vol8.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/vol8.nrrd
 )
 itk_add_test(
   NAME itkNrrdImageReadWriteTest9
@@ -244,6 +276,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/vol9.nrrd
     itkNrrdImageReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/vol-raw-little.nhdr,vol-raw-little.raw}
+    ${ITK_TEST_OUTPUT_DIR}/vol9.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/vol9.nrrd
 )
 itk_add_test(
@@ -256,6 +290,8 @@ itk_add_test(
     itkNrrdImageReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/vol-gzip-big.nhdr,vol-gzip-big.raw.gz}
     ${ITK_TEST_OUTPUT_DIR}/vol10.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/vol10.nrrd
 )
 itk_add_test(
   NAME itkNrrdImageReadWriteTest11
@@ -266,6 +302,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/vol11.nrrd
     itkNrrdImageReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/vol-gzip-little.nhdr,vol-gzip-little.raw.gz}
+    ${ITK_TEST_OUTPUT_DIR}/vol11.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/vol11.nrrd
 )
 itk_add_test(
@@ -278,6 +316,8 @@ itk_add_test(
     itkNrrdRGBAImageReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/testrgba.nrrd}
     ${ITK_TEST_OUTPUT_DIR}/NrrdRGBAImageReadWriteTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/NrrdRGBAImageReadWriteTest.png
 )
 itk_add_test(
   NAME itkNrrdRGBImageReadWriteTest0
@@ -288,6 +328,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/NrrdRGBImageReadWriteTest0.png
     itkNrrdRGBImageReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/testrgb-0.nhdr,testrgb-0.raw}
+    ${ITK_TEST_OUTPUT_DIR}/NrrdRGBImageReadWriteTest0.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/NrrdRGBImageReadWriteTest0.png
 )
 itk_add_test(
@@ -300,6 +342,8 @@ itk_add_test(
     itkNrrdRGBImageReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/testrgb-1.nhdr,testrgb-1.raw}
     ${ITK_TEST_OUTPUT_DIR}/NrrdRGBImageReadWriteTest1.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/NrrdRGBImageReadWriteTest1.png
 )
 itk_add_test(
   NAME itkNrrdRGBImageReadWriteTest2
@@ -310,6 +354,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/NrrdRGBImageReadWriteTest2.png
     itkNrrdRGBImageReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/testrgb-2.nhdr,testrgb-2.raw}
+    ${ITK_TEST_OUTPUT_DIR}/NrrdRGBImageReadWriteTest2.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/NrrdRGBImageReadWriteTest2.png
 )
 itk_add_test(
@@ -329,6 +375,8 @@ itk_add_test(
     itkNrrdVectorImageReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/mini-vector-slow.nrrd}
     ${ITK_TEST_OUTPUT_DIR}/mini-vector.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/mini-vector.nrrd
 )
 itk_add_test(
   NAME itkNrrdVectorImageUnitLabelReadTest
@@ -342,6 +390,13 @@ itk_add_test(
   COMMAND
     ITKIONRRDTestDriver
     itkNrrd5dVectorImageReadWriteTest
+    ${ITK_TEST_OUTPUT_DIR}/2d-double.seq.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/3d-double.seq.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/2d-displacement-field-vector.seq.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/3d-displacement-field-vector.seq.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/2d-rgb-color-image-vector.seq.nrrd
+    ${ITK_TEST_OUTPUT_DIR}/3d-rgba-color-image-vector.seq.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/2d-double.seq.nrrd
     ${ITK_TEST_OUTPUT_DIR}/3d-double.seq.nrrd
     ${ITK_TEST_OUTPUT_DIR}/2d-displacement-field-vector.seq.nrrd

--- a/Modules/IO/PNG/test/CMakeLists.txt
+++ b/Modules/IO/PNG/test/CMakeLists.txt
@@ -19,6 +19,8 @@ itk_add_test(
     0
     4
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPNGImageIOTest1Grey.png
 )
 itk_add_test(
   NAME itkPNGImageIOTest1Color
@@ -30,6 +32,8 @@ itk_add_test(
     0
     4
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPNGImageIOTest1Color.png
 )
 itk_add_test(
   NAME itkPNGImageIOTest1Palette
@@ -41,6 +45,8 @@ itk_add_test(
     0
     4
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPNGImageIOTest1Palette.png
 )
 itk_add_test(
   NAME itkPNGImageIOTest1Palette2Scalar
@@ -52,6 +58,8 @@ itk_add_test(
     1
     9
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPNGImageIOTest1Palette2Scalar.png
 )
 itk_add_test(
   NAME itkPNGImageIOTest1PaletteExpanded
@@ -63,6 +71,8 @@ itk_add_test(
     1
     9
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPNGImageIOTest1PaletteExpanded.png
 )
 itk_add_test(
   NAME itkPNGImageIOTest2GreyAlpha
@@ -77,6 +87,8 @@ itk_add_test(
     0
     4
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPNGImageIOTest2GreyAlpha.png
 )
 itk_add_test(
   NAME itkPNGImageIOTest2Palette
@@ -91,6 +103,8 @@ itk_add_test(
     1
     9
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPNGImageIOTest2Palette.png
 )
 
 # expand + RGB image
@@ -106,6 +120,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkPNGImageIOTest3RGBExpanded.png
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPNGImageIOTest3RGBExpanded.png
 )
 
 # not expand + RGB image
@@ -121,6 +137,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkPNGImageIOTest3RGBNotExpanded.png
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPNGImageIOTest3RGBNotExpanded.png
 )
 
 # not expand + palette
@@ -136,6 +154,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkPNGImageIOTest3PaletteNotExpanded.png
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPNGImageIOTest3PaletteNotExpanded.png
 )
 
 # expand + palette image
@@ -151,6 +171,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkPNGImageIOTest3PaletteExpanded.png
     1
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPNGImageIOTest3PaletteExpanded.png
 )
 
 # not expand + grey palette image
@@ -166,6 +188,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkPNGImageIOTest3GreyPaletteNotExpandedGrey.png
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPNGImageIOTest3GreyPaletteNotExpandedGrey.png
 )
 
 # expand + grey palette image
@@ -181,6 +205,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkPNGImageIOTest3GreyPaletteExpandedGrey.png
     1
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPNGImageIOTest3GreyPaletteExpandedGrey.png
 )
 
 itk_add_test(

--- a/Modules/IO/PhilipsREC/test/CMakeLists.txt
+++ b/Modules/IO/PhilipsREC/test/CMakeLists.txt
@@ -20,6 +20,8 @@ itk_add_test(
     itkPhilipsRECImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/T1_MEASUREMENT_4_1.PAR,T1_MEASUREMENT_4_1.REC}
     ${ITK_TEST_OUTPUT_DIR}/itkPhilipsRECImageIOTest1.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPhilipsRECImageIOTest1.mha
 )
 itk_add_test(
   NAME itkPhilipsRECImageIOOrientationTest1
@@ -31,6 +33,8 @@ itk_add_test(
     itkPhilipsRECImageIOOrientationTest
     DATA{Input/Test_Orientation_2_3.PAR}
     DATA{Input/Test_Orientation_2_1.PAR}
+    ${ITK_TEST_OUTPUT_DIR}/itkPhilipsRECImageIOOrientationTest1.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkPhilipsRECImageIOOrientationTest1.mha
 )
 itk_add_test(
@@ -44,6 +48,8 @@ itk_add_test(
     DATA{Input/Test_Orientation_2_5.PAR}
     DATA{Input/Test_Orientation_2_1.REC.gz}
     ${ITK_TEST_OUTPUT_DIR}/itkPhilipsRECImageIOOrientationTest2.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPhilipsRECImageIOOrientationTest2.mha
 )
 itk_add_test(
   NAME itkPhilipsRECImageIOOrientationTest3
@@ -56,6 +62,8 @@ itk_add_test(
     DATA{Input/Test_Orientation_2_5.REC.gz}
     DATA{Input/Test_Orientation_2_3.REC.gz}
     ${ITK_TEST_OUTPUT_DIR}/itkPhilipsRECImageIOOrientationTest3.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPhilipsRECImageIOOrientationTest3.mha
 )
 itk_add_test(
   NAME itkPhilipsRECImageIOTest2
@@ -63,6 +71,8 @@ itk_add_test(
     ITKIOPhilipsRECTestDriver
     itkPhilipsRECImageIOTest
     DATA{Input/Test_Cardiac_Phase_7_1.REC.gz}
+    ${ITK_TEST_OUTPUT_DIR}/itkPhilipsRECImageIOTest2.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkPhilipsRECImageIOTest2.mha
 )
 itk_add_test(

--- a/Modules/IO/RAW/test/CMakeLists.txt
+++ b/Modules/IO/RAW/test/CMakeLists.txt
@@ -17,6 +17,9 @@ itk_add_test(
     itkRawImageIOTest
     ${ITK_TEST_OUTPUT_DIR}/raw1.raw
     ${ITK_TEST_OUTPUT_DIR}/raw2.raw
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/raw1.raw
+    ${ITK_TEST_OUTPUT_DIR}/raw2.raw
 )
 itk_add_test(
   NAME itkRawImageIOTest2
@@ -32,12 +35,18 @@ itk_add_test(
     itkRawImageIOTest3
     ${ITK_TEST_OUTPUT_DIR}/raw3.raw
     ${ITK_TEST_OUTPUT_DIR}/raw4.raw
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/raw3.raw
+    ${ITK_TEST_OUTPUT_DIR}/raw4.raw
 )
 itk_add_test(
   NAME itkRawImageIOTest4
   COMMAND
     ITKIORAWTestDriver
     itkRawImageIOTest4
+    ${ITK_TEST_OUTPUT_DIR}/bigendian.raw
+    ${ITK_TEST_OUTPUT_DIR}/littleendian.raw
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/bigendian.raw
     ${ITK_TEST_OUTPUT_DIR}/littleendian.raw
 )

--- a/Modules/IO/SpatialObjects/test/CMakeLists.txt
+++ b/Modules/IO/SpatialObjects/test/CMakeLists.txt
@@ -16,6 +16,8 @@ itk_add_test(
     ITKIOSpatialObjectsTestDriver
     itkReadWriteSpatialObjectTest
     ${ITK_TEST_OUTPUT_DIR}/Objects.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/Objects.meta
 )
 itk_add_test(
   NAME itkReadWriteSpatialObjectTest1
@@ -24,6 +26,8 @@ itk_add_test(
     itkReadWriteSpatialObjectTest
     ${ITK_TEST_OUTPUT_DIR}/Objects1.meta
     binary
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/Objects1.meta
 )
 itk_add_test(
   NAME itkReadWriteSpatialObjectTest2
@@ -32,6 +36,8 @@ itk_add_test(
     itkReadWriteSpatialObjectTest
     ${ITK_TEST_OUTPUT_DIR}/Objects2.meta
     DATA{${ITK_DATA_ROOT}/Input/SpatialObjects.meta}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/Objects2.meta
 )
 itk_add_test(
   NAME itkPolygonGroupSpatialObjectXMLFileTest

--- a/Modules/IO/Stimulate/test/CMakeLists.txt
+++ b/Modules/IO/Stimulate/test/CMakeLists.txt
@@ -14,6 +14,9 @@ itk_add_test(
     itkStimulateImageIOTest
     ${ITK_TEST_OUTPUT_DIR}/test1.spr
     ${ITK_TEST_OUTPUT_DIR}/test2.spr
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/test1.spr
+    ${ITK_TEST_OUTPUT_DIR}/test2.spr
 )
 itk_add_test(
   NAME itkStimulateImageIOTest2

--- a/Modules/IO/TIFF/test/CMakeLists.txt
+++ b/Modules/IO/TIFF/test/CMakeLists.txt
@@ -22,6 +22,8 @@ itk_add_test(
     itkTIFFImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.tif}
     ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOTest_cthead1.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOTest_cthead1.tif
 )
 itk_add_test(
   NAME itkTIFFImageIOTest1
@@ -32,6 +34,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RGBTestImage.tif
     itkTIFFImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/RGBTestImage.tif}
+    ${ITK_TEST_OUTPUT_DIR}/RGBTestImage.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/RGBTestImage.tif
 )
 itk_add_test(
@@ -44,6 +48,8 @@ itk_add_test(
     itkTIFFImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/RGBTestImageCCITTFax3.tif}
     ${ITK_TEST_OUTPUT_DIR}/RGBTestImageCCITTFax3.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RGBTestImageCCITTFax3.tif
 )
 itk_add_test(
   NAME itkTIFFImageIOTest3
@@ -54,6 +60,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RGBTestImageCCITTFax4.tif
     itkTIFFImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/RGBTestImageCCITTFax4.tif}
+    ${ITK_TEST_OUTPUT_DIR}/RGBTestImageCCITTFax4.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/RGBTestImageCCITTFax4.tif
 )
 itk_add_test(
@@ -66,6 +74,8 @@ itk_add_test(
     itkTIFFImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/RGBTestImageGray.tif}
     ${ITK_TEST_OUTPUT_DIR}/RGBTestImageGray.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RGBTestImageGray.tif
 )
 itk_add_test(
   NAME itkTIFFImageIOTest5
@@ -76,6 +86,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RGBTestImageHuffmanRLE.tif
     itkTIFFImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/RGBTestImageHuffmanRLE.tif}
+    ${ITK_TEST_OUTPUT_DIR}/RGBTestImageHuffmanRLE.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/RGBTestImageHuffmanRLE.tif
 )
 itk_add_test(
@@ -88,6 +100,8 @@ itk_add_test(
     itkTIFFImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/RGBTestImageJPEG.tif}
     ${ITK_TEST_OUTPUT_DIR}/RGBTestImageJPEG.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RGBTestImageJPEG.tif
 )
 itk_add_test(
   NAME itkTIFFImageIOTest7
@@ -98,6 +112,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RGBTestImageLZW.tif
     itkTIFFImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/RGBTestImageLZW.tif}
+    ${ITK_TEST_OUTPUT_DIR}/RGBTestImageLZW.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/RGBTestImageLZW.tif
 )
 itk_add_test(
@@ -110,6 +126,8 @@ itk_add_test(
     itkTIFFImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/RGBTestImageNone.tif}
     ${ITK_TEST_OUTPUT_DIR}/RGBTestImageNone.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RGBTestImageNone.tif
 )
 itk_add_test(
   NAME itkTIFFImageIOTest9
@@ -121,6 +139,8 @@ itk_add_test(
     itkTIFFImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/RGBTestImagePackBits.tif}
     ${ITK_TEST_OUTPUT_DIR}/RGBTestImagePackBits.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RGBTestImagePackBits.tif
 )
 itk_add_test(
   NAME itkTIFFImageIOTest10
@@ -131,6 +151,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RGBTestImageZIP.tif
     itkTIFFImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/RGBTestImageZIP.tif}
+    ${ITK_TEST_OUTPUT_DIR}/RGBTestImageZIP.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/RGBTestImageZIP.tif
 )
 itk_add_test(
@@ -145,6 +167,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/ShortTestImage.tiff
     2
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ShortTestImage.tiff
 )
 itk_add_test(
   NAME itkTIFFImageIOTest12
@@ -158,6 +182,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/48BitTestImage.tif
     2
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/48BitTestImage.tif
 )
 itk_add_test(
   NAME itkTIFFImageIOTest13
@@ -169,6 +195,8 @@ itk_add_test(
     itkTIFFImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/RGBTestImageCCITTFax3.tif}
     ${ITK_TEST_OUTPUT_DIR}/RGBTestImageCCITTFax3.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RGBTestImageCCITTFax3.mha
 )
 itk_add_test(
   NAME itkTIFFImageIOTest14
@@ -179,6 +207,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RGBTestImageCCITTFax4.mha
     itkTIFFImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/RGBTestImageCCITTFax4.tif}
+    ${ITK_TEST_OUTPUT_DIR}/RGBTestImageCCITTFax4.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/RGBTestImageCCITTFax4.mha
 )
 itk_add_test(
@@ -193,6 +223,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOTest15.png
     2
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOTest15.png
 )
 
 itk_add_test(
@@ -206,6 +238,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/ramp.tif}
     ${ITK_TEST_OUTPUT_DIR}/ramp.tif
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ramp.tif
 )
 itk_add_test(
   NAME itkTIFFImageIOMultiPagesTest2
@@ -219,6 +253,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/rampShort.tif
     3
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/rampShort.tif
 )
 itk_add_test(
   NAME itkTIFFImageIOMultResTest1
@@ -229,6 +265,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOMultResTest1.tif
     itkTIFFImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1-multires.tif}
+    ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOMultResTest1.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOMultResTest1.tif
 )
 itk_add_test(
@@ -242,12 +280,16 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1-multires.tif}
     ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOMultResTest2.tif
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOMultResTest2.tif
 )
 itk_add_test(
   NAME itkTIFFImageIOSpacing
   COMMAND
     ITKIOTIFFTestDriver
     itkTIFFImageIOTest2
+    ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOSpacing.tif
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOSpacing.tif
 )
 itk_add_test(
@@ -262,6 +304,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/rampFloat.tif
     3
     4
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/rampFloat.tif
 )
 itk_add_test(
   NAME itkTIFFImageIORGBATest
@@ -275,6 +319,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIORGBATest.tif
     3
     5
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIORGBATest.tif
 )
 
 itk_add_test(
@@ -289,6 +335,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOOrientation1.tif
     2
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOOrientation1.tif
 )
 itk_add_test(
   NAME itkTIFFImageIOOrientation2
@@ -302,6 +350,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOOrientation2.tif
     2
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOOrientation2.tif
 )
 itk_add_test(
   NAME itkTIFFImageIOOrientation3
@@ -315,6 +365,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOOrientation3.tif
     2
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOOrientation3.tif
 )
 itk_add_test(
   NAME itkTIFFImageIOOrientation4
@@ -328,6 +380,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOOrientation4.tif
     2
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOOrientation4.tif
 )
 itk_add_test(
   NAME itkTIFFImageIOPlannarConfig1
@@ -341,6 +395,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOPlannarConfig1.tif
     2
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOPlannarConfig1.tif
 )
 itk_add_test(
   NAME itkTIFFImageIOPlannarConfig2
@@ -354,6 +410,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOPlannarConfig2.tif
     2
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOPlannarConfig2.tif
 )
 itk_add_test(
   NAME itkTIFFImageIOTestUShortPlanarConfig2
@@ -367,6 +425,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/ShortPlanarTestImage.tiff
     2
     5
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ShortPlanarTestImage.tiff
 )
 
 itk_add_test(
@@ -464,6 +524,8 @@ if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 5)
       itkLargeTIFFImageWriteReadTest
       ${ITK_TEST_OUTPUT_DIR}/LargeImage01.tif
       30000L
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/LargeImage01.tif
   )
 
   # Image of 2.98 Gigabytes (pixels size is 16bits)
@@ -474,6 +536,8 @@ if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 5)
       itkLargeTIFFImageWriteReadTest
       ${ITK_TEST_OUTPUT_DIR}/LargeImage02.tif
       40000L
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/LargeImage02.tif
   )
 
   # Image of 4.9 Gigabytes (pixels size is 8-bits out and 16-bit in)
@@ -484,6 +548,8 @@ if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 5)
       itkLargeTIFFImageWriteReadTest
       ${ITK_TEST_OUTPUT_DIR}/LargeImage03.tif
       50000L
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/LargeImage03.tif
   )
 
   # Due to the large memory requirements these tests must be run one by one
@@ -524,9 +590,6 @@ if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 5)
         RUNS_LONG
   )
   # Clean up BigIO output files after completion
-  itk_add_file_test_cleanup(itkLargeTIFFImageWriteReadTest1 ${ITK_TEST_OUTPUT_DIR}/LargeImage01.tif)
-  itk_add_file_test_cleanup(itkLargeTIFFImageWriteReadTest2 ${ITK_TEST_OUTPUT_DIR}/LargeImage02.tif)
-  itk_add_file_test_cleanup(itkLargeTIFFImageWriteReadTest3 ${ITK_TEST_OUTPUT_DIR}/LargeImage03.tif)
 endif()
 
 if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 12)
@@ -538,6 +601,8 @@ if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 12)
       itkLargeTIFFImageWriteReadTest
       ${ITK_TEST_OUTPUT_DIR}/LargeImage04.tif
       70000L
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/LargeImage04.tif
   )
 
   # Due to the large memory requirements this test must be run serially
@@ -561,7 +626,6 @@ if("${ITK_COMPUTER_MEMORY_SIZE}" GREATER 12)
       LABELS
         RUNS_LONG
   )
-  itk_add_file_test_cleanup(itkLargeTIFFImageWriteReadTest4 ${ITK_TEST_OUTPUT_DIR}/LargeImage04.tif)
 endif()
 
 # expand + RGB image
@@ -577,6 +641,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOTestRGBExpanded.tif
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOTestRGBExpanded.tif
 )
 
 # not expand + RGB image
@@ -592,6 +658,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOTestRGBNotExpanded.tif
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOTestRGBNotExpanded.tif
 )
 
 # not expand + palette image
@@ -607,6 +675,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOTestPaletteNotExpanded.tif
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOTestPaletteNotExpanded.tif
 )
 
 # expand + palette image
@@ -622,6 +692,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOTestPaletteExpanded.tif
     1
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOTestPaletteExpanded.tif
 )
 
 # not expand + grey palette image
@@ -637,6 +709,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOTestGreyPaletteNotExpanded.tif
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOTestGreyPaletteNotExpanded.tif
 )
 
 # expand + grey palette image
@@ -652,6 +726,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOTestGreyPaletteExpanded.tif
     1
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTIFFImageIOTestGreyPaletteExpanded.tif
 )
 
 itk_add_test(

--- a/Modules/IO/TransformInsightLegacy/test/CMakeLists.txt
+++ b/Modules/IO/TransformInsightLegacy/test/CMakeLists.txt
@@ -24,4 +24,6 @@ itk_add_test(
     itkIOEuler3DTransformTxtTest
     DATA{Input/euler3DOldFormat.tfm}
     ${ITK_TEST_OUTPUT_DIR}/euler3DNewFormat.tfm
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/euler3DNewFormat.tfm
 )

--- a/Modules/IO/VTK/test/CMakeLists.txt
+++ b/Modules/IO/VTK/test/CMakeLists.txt
@@ -101,6 +101,8 @@ itk_add_test(
     itkVTIImageIOReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkVTIImageIOReadWriteTest_CTHead1.vti
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkVTIImageIOReadWriteTest_CTHead1.vti
 )
 
 itk_add_test(
@@ -112,6 +114,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkVTIImageIOReadWriteTest_VisibleWomanEyeSlice.vti
     itkVTIImageIOReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/VisibleWomanEyeSlice.png}
+    ${ITK_TEST_OUTPUT_DIR}/itkVTIImageIOReadWriteTest_VisibleWomanEyeSlice.vti
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkVTIImageIOReadWriteTest_VisibleWomanEyeSlice.vti
 )
 
@@ -125,6 +129,8 @@ itk_add_test(
     itkVTIImageIOReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkVTIImageIOReadWriteTest_HeadMRVolume.vti
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkVTIImageIOReadWriteTest_HeadMRVolume.vti
 )
 
 itk_add_test(
@@ -137,6 +143,8 @@ itk_add_test(
     itkVTIImageIOReadWriteTest
     DATA{${ITK_DATA_ROOT}/Input/VHFColor.mhd,VHFColor.raw}
     ${ITK_TEST_OUTPUT_DIR}/itkVTIImageIOReadWriteTest_VHFColor.vti
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkVTIImageIOReadWriteTest_VHFColor.vti
 )
 
 itk_add_test(
@@ -148,6 +156,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkVTIImageIOReadWriteTest_reco2D_16line.vti
     itkVTIImageIOReadWriteTest
     DATA{Input/reco2D_16line.mha}
+    ${ITK_TEST_OUTPUT_DIR}/itkVTIImageIOReadWriteTest_reco2D_16line.vti
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkVTIImageIOReadWriteTest_reco2D_16line.vti
 )
 
@@ -162,6 +172,8 @@ itk_add_test(
     DATA{Input/reco2D_16line.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkVTIImageIOReadWriteTest_reco2D_16line_compressed.vti
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkVTIImageIOReadWriteTest_reco2D_16line_compressed.vti
 )
 
 # itkVTIImageIOReadWriteTestVHFColorZLib is temporarily disabled until
@@ -208,12 +220,17 @@ itk_add_test(
     itkVTKImageIOTest
     ${ITK_TEST_OUTPUT_DIR}/test1.vtk
     ${ITK_TEST_OUTPUT_DIR}/test2.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/test1.vtk
+    ${ITK_TEST_OUTPUT_DIR}/test2.vtk
 )
 itk_add_test(
   NAME itkVTKImageIO2Test2
   COMMAND
     ITKIOVTKTestDriver
     itkVTKImageIO2Test2
+    ${ITK_TEST_OUTPUT_DIR}/itkVTKImageIO2Test2.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkVTKImageIO2Test2.vtk
 )
 itk_add_test(
@@ -222,6 +239,8 @@ itk_add_test(
     ITKIOVTKTestDriver
     itkVTKImageIOTest2
     DATA{${ITK_DATA_ROOT}/Input/VHFColor.mhd,VHFColor.raw}
+    ${ITK_TEST_OUTPUT_DIR}/testVector.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/testVector.vtk
 )
 itk_add_test(
@@ -236,6 +255,8 @@ itk_add_test(
   COMMAND
     ITKIOVTKTestDriver
     itkVTKImageIOStreamTest
+    ${ITK_TEST_OUTPUT_DIR}/itkVTKImageIOStreamTest.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkVTKImageIOStreamTest.vtk
 )
 itk_add_test(

--- a/Modules/IO/XML/test/CMakeLists.txt
+++ b/Modules/IO/XML/test/CMakeLists.txt
@@ -29,6 +29,8 @@ itk_add_test(
     itkDOMTest2
     DATA{${ITK_DATA_ROOT}/Input/XML/test.xml}
     ${ITK_TEST_OUTPUT_DIR}/xmldom-test21-output.xml
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/xmldom-test21-output.xml
 )
 
 itk_add_test(
@@ -37,6 +39,8 @@ itk_add_test(
     ITKIOXMLTestDriver
     itkDOMTest2
     DATA{${ITK_DATA_ROOT}/Input/XML/test.pso.xml}
+    ${ITK_TEST_OUTPUT_DIR}/xmldom-test22-output.xml
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/xmldom-test22-output.xml
 )
 
@@ -294,6 +298,8 @@ itk_add_test(
     ITKIOXMLTestDriver
     itkDOMTest5
     ${ITK_TEST_OUTPUT_DIR}/xmldom-test5/output.xml
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/xmldom-test5/output.xml
 )
 
 itk_add_test(
@@ -310,6 +316,8 @@ itk_add_test(
     itkDOMTest8
     ${ITK_TEST_OUTPUT_DIR}/xmldom-test8/
     output/test_file
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/xmldom-test8/output/test_file
 )
 
 itk_add_test(
@@ -325,5 +333,7 @@ itk_add_test(
     ITKIOXMLTestDriver
     itkFileToolsTest
     ${ITK_TEST_OUTPUT_DIR}/mytestdir
+    ${ITK_TEST_OUTPUT_DIR}/mytestfile.txt
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/mytestfile.txt
 )

--- a/Modules/Nonunit/IntegratedTest/test/CMakeLists.txt
+++ b/Modules/Nonunit/IntegratedTest/test/CMakeLists.txt
@@ -113,6 +113,8 @@ itk_add_test(
     --redirectOutput
     ${TEMP}/itkCommonPrintTest.txt
     itkCommonPrintTest
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkCommonPrintTest.txt
 )
 set_tests_properties(
   itkCommonPrintTest
@@ -128,6 +130,8 @@ itk_add_test(
     --redirectOutput
     ${TEMP}/itkBasicFiltersPrintTest.txt
     itkBasicFiltersPrintTest
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkBasicFiltersPrintTest.txt
 )
 set_tests_properties(
   itkBasicFiltersPrintTest

--- a/Modules/Nonunit/Review/test/CMakeLists.txt
+++ b/Modules/Nonunit/Review/test/CMakeLists.txt
@@ -66,6 +66,8 @@ itk_add_test(
     1000
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkAreaClosingImageFilterTest0.png
 )
 itk_add_test(
   NAME itkAreaOpeningImageFilterTest0
@@ -80,6 +82,8 @@ itk_add_test(
     1000
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkAreaOpeningImageFilterTest0.png
 )
 itk_add_test(
   NAME itkConformalFlatteningMeshFilterTest1
@@ -89,6 +93,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/genusZeroSurface01.vtk}
     ${ITK_TEST_OUTPUT_DIR}/genusZeroMesh01ConformalFlattenedToSphere.vtk
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/genusZeroMesh01ConformalFlattenedToSphere.vtk
 )
 itk_add_test(
   NAME itkConformalFlatteningMeshFilterTest2
@@ -98,6 +104,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/genusZeroSurface01.vtk}
     ${ITK_TEST_OUTPUT_DIR}/genusZeroMesh01ConformalFlattenedToPlane.vtk
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/genusZeroMesh01ConformalFlattenedToPlane.vtk
 )
 itk_add_test(
   NAME itkConformalFlatteningQuadEdgeMeshFilterTest1
@@ -109,6 +117,8 @@ itk_add_test(
     3
     100.0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/genusZeroQuadEdgeMesh01ConformalFlattenedToSphere.vtk
 )
 itk_add_test(
   NAME itkConformalFlatteningQuadEdgeMeshFilterTest2
@@ -120,6 +130,8 @@ itk_add_test(
     3
     100.0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/genusZeroQuadEdgeMesh01ConformalFlattenedToPlane.vtk
 )
 itk_add_test(
   NAME itkDirectFourierReconstructionImageToImageFilterTest
@@ -146,6 +158,8 @@ itk_add_test(
     64
     2
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/reconstruct.mha
 )
 itk_add_test(
   NAME itkFastApproximateRankImageFilterTest3
@@ -158,6 +172,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkFastApproximateRankImageFilter3.png
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFastApproximateRankImageFilter3.png
 )
 itk_add_test(
   NAME itkFastApproximateRankImageFilterTest10
@@ -170,6 +186,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkFastApproximateRankImageFilter10.png
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFastApproximateRankImageFilter10.png
 )
 itk_add_test(
   NAME itkGridForwardWarpImageFilterTest
@@ -179,6 +197,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkGridForwardWarpImageFilterTest.mha
     7dea362b3fac8e00956a4952a3d4f474
     itkGridForwardWarpImageFilterTest
+    ${ITK_TEST_OUTPUT_DIR}/itkGridForwardWarpImageFilterTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkGridForwardWarpImageFilterTest.mha
 )
 itk_add_test(
@@ -200,6 +220,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkLabelGeometryImageFilterTest.png
     ${ITK_TEST_OUTPUT_DIR}/itkLabelGeometryImageFilterTest.csv
     DATA{${BASELINE}/itkLabelGeometryImageFilterTest.csv}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelGeometryImageFilterTest.png
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelGeometryImageFilterTest.csv
 )
 itk_add_test(
   NAME itkLabelGeometryImageFilterTest3D
@@ -214,6 +237,9 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkLabelGeometryImageFilterTest3D.mhd
     ${ITK_TEST_OUTPUT_DIR}/itkLabelGeometryImageFilterTest3D.csv
     DATA{${BASELINE}/itkLabelGeometryImageFilterTest3D.csv}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelGeometryImageFilterTest3D.{mhd,raw}
+    ${ITK_TEST_OUTPUT_DIR}/itkLabelGeometryImageFilterTest3D.csv
 )
 itk_add_test(
   NAME itkMultiphaseDenseFiniteDifferenceImageFilterTest
@@ -243,6 +269,8 @@ itk_add_test(
     itkOptImageToImageMetricsTest
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceBorder20.png
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceBorder20.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkOptImageToImageMetricsTest01.txt
 )
 set_tests_properties(
   itkOptImageToImageMetricsTest01
@@ -262,6 +290,8 @@ itk_add_test(
     itkOptImageToImageMetricsTest
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceBorder20.png
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceBorder20.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkOptImageToImageMetricsTest02.txt
 )
 set_tests_properties(
   itkOptImageToImageMetricsTest02
@@ -280,6 +310,8 @@ itk_add_test(
     itkOptImageToImageMetricsTest
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceBorder20.png
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceBorder20.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkOptImageToImageMetricsTest03.txt
 )
 set_tests_properties(
   itkOptImageToImageMetricsTest03
@@ -326,6 +358,8 @@ itk_add_test(
     65535
     0
     94
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkRobustAutomaticThresholdImageFilterTest.png
 )
 itk_add_test(
   NAME itkRobustAutomaticThresholdCalculatorTest
@@ -358,6 +392,8 @@ itk_add_test(
     0
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkScalarChanAndVeseDenseLevelSetImageFilterTest2_0.mha
 )
 itk_add_test(
   NAME itkScalarChanAndVeseDenseLevelSetImageFilterTest2_1
@@ -375,6 +411,8 @@ itk_add_test(
     1
     1
     200
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkScalarChanAndVeseDenseLevelSetImageFilterTest2_1.mha
 )
 itk_add_test(
   NAME itkScalarChanAndVeseDenseLevelSetImageFilterTest2_2
@@ -392,6 +430,8 @@ itk_add_test(
     1
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkScalarChanAndVeseDenseLevelSetImageFilterTest2_2.mha
 )
 itk_add_test(
   NAME itkScalarChanAndVeseDenseLevelSetImageFilterTest2_3
@@ -406,6 +446,8 @@ itk_add_test(
     0
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkScalarChanAndVeseDenseLevelSetImageFilterTest2_3.mha
 )
 itk_add_test(
   NAME itkScalarChanAndVeseDenseLevelSetImageFilterTest3
@@ -429,6 +471,8 @@ itk_add_test(
     0
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkScalarChanAndVeseDenseLevelSetImageFilterTest4.mha
 )
 itk_add_test(
   NAME itkScalarChanAndVeseLevelSetFunctionTest1
@@ -458,6 +502,8 @@ itk_add_test(
     itkScalarChanAndVeseSparseLevelSetImageFilterTest2
     DATA{${ITK_DATA_ROOT}/Baseline/Segmentation/ShapeDetectionLevelSetLeftVentricleTest.png,:}
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySlice.png
+    ${ITK_TEST_OUTPUT_DIR}/itkScalarChanAndVeseSparseLevelSetImageFilterTest2.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkScalarChanAndVeseSparseLevelSetImageFilterTest2.mha
 )
 itk_add_test(
@@ -497,6 +543,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/TreeBarkTexture.png}
     ${ITK_TEST_OUTPUT_DIR}/itkStochasticFractalDimensionImageFilterTest1.mha
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkStochasticFractalDimensionImageFilterTest1.mha
 )
 itk_add_test(
   NAME itkStochasticFractalDimensionImageFilterTest2
@@ -512,6 +560,8 @@ itk_add_test(
     2
     DATA{${ITK_DATA_ROOT}/Input/circle100.png}
     255
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkStochasticFractalDimensionImageFilterTest2.mha
 )
 itk_add_test(
   NAME itkTimeAndMemoryProbeTest1
@@ -526,6 +576,8 @@ itk_add_test(
     itkVoxBoCUBImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mhd,HeadMRVolume.raw}
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolume.cub
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolume.cub
 )
 itk_add_test(
   NAME itkVoxBoCUBImageIOTest2
@@ -533,6 +585,8 @@ itk_add_test(
     ITKReviewTestDriver
     itkVoxBoCUBImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.cub}
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolume1.cub
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolume1.cub
 )
 itk_add_test(
@@ -542,6 +596,8 @@ itk_add_test(
     itkVoxBoCUBImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume1.cub}
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolume1.cub.gz
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolume1.cub.gz
 )
 itk_add_test(
   NAME itkVoxBoCUBImageIOTest4
@@ -550,6 +606,8 @@ itk_add_test(
     itkVoxBoCUBImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume1.cub.gz}
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolume2.cub.gz
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolume2.cub.gz
 )
 itk_add_test(
   NAME itkVoxBoCUBImageIOTest5
@@ -557,6 +615,8 @@ itk_add_test(
     ITKReviewTestDriver
     itkVoxBoCUBImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume2.cub.gz}
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolume2.cub
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolume2.cub
 )
 itk_add_test(
@@ -569,6 +629,8 @@ itk_add_test(
     itkVoxBoCUBImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume2.cub}
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeFromCUB2.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeFromCUB2.mha
 )
 itk_add_test(
   NAME itkVoxBoCUBImageIOTest7
@@ -579,6 +641,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeFromCUB3.mha
     itkVoxBoCUBImageIOTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume2.cub.gz}
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeFromCUB3.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolumeFromCUB3.mha
 )
 itk_add_test(

--- a/Modules/Numerics/FEM/test/CMakeLists.txt
+++ b/Modules/Numerics/FEM/test/CMakeLists.txt
@@ -357,6 +357,8 @@ itk_add_test(
     itkFEMElement2DC0LinearQuadrilateralStrainTest
     DATA{Input/2DC0LinearQuadrilateralStrainTest.meta}
     ${ITK_TEST_OUTPUT_DIR}/2DC0LinearQuadrilateralStrainTestWrite.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/2DC0LinearQuadrilateralStrainTestWrite.meta
 )
 
 itk_add_test(
@@ -394,6 +396,8 @@ itk_add_test(
     itkFEMElement2DC0LinearQuadrilateralMembraneTest
     DATA{Input/2DC0LinearQuadrilateralMembraneTest.meta}
     ${ITK_TEST_OUTPUT_DIR}/2DC0LinearQuadrilateralMembraneTestWrite.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/2DC0LinearQuadrilateralMembraneTestWrite.meta
 )
 
 itk_add_test(
@@ -403,6 +407,8 @@ itk_add_test(
     ITKFEMTestDriver
     itkFEMElement2DC0LinearTriangleMembraneTest
     DATA{Input/2DC0LinearTriangleMembraneTest.meta}
+    ${ITK_TEST_OUTPUT_DIR}/2DC0LinearTriangleMembraneTestWrite.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/2DC0LinearTriangleMembraneTestWrite.meta
 )
 
@@ -414,6 +420,8 @@ itk_add_test(
     itkFEMElement2DC0LinearTriangleStressTest
     DATA{Input/2DC0LinearTriangleStressTest.meta}
     ${ITK_TEST_OUTPUT_DIR}/2DC0LinearTriangleStressTestWrite.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/2DC0LinearTriangleStressTestWrite.meta
 )
 
 itk_add_test(
@@ -423,6 +431,8 @@ itk_add_test(
     ITKFEMTestDriver
     itkFEMElement2DC0LinearTriangleStrainTest
     DATA{Input/2DC0LinearTriangleStrainTest.meta}
+    ${ITK_TEST_OUTPUT_DIR}/2DC0LinearTriangleStrainTestWrite.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/2DC0LinearTriangleStrainTestWrite.meta
 )
 
@@ -434,6 +444,8 @@ itk_add_test(
     itkFEMElement2DC0QuadraticTriangleStrainTest
     DATA{Input/2DC0QuadraticTriangleStrainTest.meta}
     ${ITK_TEST_OUTPUT_DIR}/2DC0QuadraticTriangleStrainTestWrite.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/2DC0QuadraticTriangleStrainTestWrite.meta
 )
 
 itk_add_test(
@@ -443,6 +455,8 @@ itk_add_test(
     ITKFEMTestDriver
     itkFEMElement2DC0QuadraticTriangleStressTest
     DATA{Input/2DC0QuadraticTriangleStressTest.meta}
+    ${ITK_TEST_OUTPUT_DIR}/2DC0QuadraticTriangleStressTestWrite.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/2DC0QuadraticTriangleStressTestWrite.meta
 )
 
@@ -454,6 +468,8 @@ itk_add_test(
     itkFEMElement2DC0LinearLineStressTest
     DATA{Input/2DC0LinearLineStressTest.meta}
     ${ITK_TEST_OUTPUT_DIR}/2DC0LinearLineStressTestWrite.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/2DC0LinearLineStressTestWrite.meta
 )
 
 itk_add_test(
@@ -463,6 +479,8 @@ itk_add_test(
     ITKFEMTestDriver
     itkFEMElement2DC0LinearQuadrilateralStrainItpackTest
     DATA{Input/2DC0LinearQuadrilateralStrainTest.meta}
+    ${ITK_TEST_OUTPUT_DIR}/2DC0LinearQuadrilateralStrainItpackTestWrite.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/2DC0LinearQuadrilateralStrainItpackTestWrite.meta
 )
 
@@ -474,6 +492,8 @@ itk_add_test(
     itkFEMElement2DC1BeamTest
     DATA{Input/2DC1BeamTest.meta}
     ${ITK_TEST_OUTPUT_DIR}/2DC1BeamTestWrite.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/2DC1BeamTestWrite.meta
 )
 
 itk_add_test(
@@ -483,6 +503,8 @@ itk_add_test(
     ITKFEMTestDriver
     itkFEMElement3DC0LinearHexahedronStrainTest
     DATA{Input/3DC0LinearHexahedronStrainTest.meta}
+    ${ITK_TEST_OUTPUT_DIR}/3DC0LinearHexahedronStrainTestWrite.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/3DC0LinearHexahedronStrainTestWrite.meta
 )
 
@@ -494,6 +516,8 @@ itk_add_test(
     itkFEMElement3DC0LinearHexahedronMembraneTest
     DATA{Input/3DC0LinearHexahedronMembraneTest.meta}
     ${ITK_TEST_OUTPUT_DIR}/3DC0LinearHexahedronMembraneTestWrite.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/3DC0LinearHexahedronMembraneTestWrite.meta
 )
 
 itk_add_test(
@@ -503,6 +527,8 @@ itk_add_test(
     ITKFEMTestDriver
     itkFEMElement3DC0LinearTetrahedronStrainTest
     DATA{Input/3DC0LinearTetrahedronStrainTest.meta}
+    ${ITK_TEST_OUTPUT_DIR}/3DC0LinearTetrahedronStrainTestWrite.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/3DC0LinearTetrahedronStrainTestWrite.meta
 )
 
@@ -514,6 +540,8 @@ itk_add_test(
     itkFEMElement3DC0LinearTetrahedronMembraneTest
     DATA{Input/3DC0LinearTetrahedronMembraneTest.meta}
     ${ITK_TEST_OUTPUT_DIR}/3DC0LinearTetrahedronMembraneTestWrite.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/3DC0LinearTetrahedronMembraneTestWrite.meta
 )
 
 itk_add_test(
@@ -523,6 +551,8 @@ itk_add_test(
     ITKFEMTestDriver
     itkFEMLoadBCMFCTest
     DATA{Input/LoadBCMFCTest.meta}
+    ${ITK_TEST_OUTPUT_DIR}/LoadBCMFCTestWrite.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/LoadBCMFCTestWrite.meta
 )
 
@@ -542,6 +572,8 @@ itk_add_test(
     itkFEMLoadEdgeTest
     DATA{Input/LoadEdgeTest.meta}
     ${ITK_TEST_OUTPUT_DIR}/LoadEdgeTestWrite.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/LoadEdgeTestWrite.meta
 )
 
 itk_add_test(
@@ -551,6 +583,8 @@ itk_add_test(
     ITKFEMTestDriver
     itkFEMLoadGravConstTest
     DATA{Input/LoadGravConstTest.meta}
+    ${ITK_TEST_OUTPUT_DIR}/LoadGravConstWrite.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/LoadGravConstWrite.meta
 )
 
@@ -569,6 +603,8 @@ itk_add_test(
     ITKFEMTestDriver
     itkFEMLandmarkLoadImplementationTest
     DATA{Input/quad-lm.meta}
+    ${ITK_TEST_OUTPUT_DIR}/QuadLandmardkWrite.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/QuadLandmardkWrite.meta
 )
 
@@ -609,6 +645,8 @@ itk_add_test(
     ITKFEMTestDriver
     itkFEMSolverTest3D
     DATA{Input/3DC0LinearHexahedronMembraneTest.meta}
+    ${ITK_TEST_OUTPUT_DIR}/3DC0LinearHexahedronMembraneTestWrite_NewSolver.meta
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/3DC0LinearHexahedronMembraneTestWrite_NewSolver.meta
 )
 

--- a/Modules/Numerics/NarrowBand/test/CMakeLists.txt
+++ b/Modules/Numerics/NarrowBand/test/CMakeLists.txt
@@ -19,4 +19,6 @@ itk_add_test(
     ITKNarrowBandTestDriver
     itkNarrowBandImageFilterBaseTest
     ${ITK_TEST_OUTPUT_DIR}/itkNarrowBandImageFilterBaseTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkNarrowBandImageFilterBaseTest.png
 )

--- a/Modules/Numerics/Statistics/test/CMakeLists.txt
+++ b/Modules/Numerics/Statistics/test/CMakeLists.txt
@@ -137,6 +137,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkGaussianRandomSubsamplingTest.mha
     itkGaussianRandomSpatialNeighborSubsamplerTest
     ${ITK_TEST_OUTPUT_DIR}/itkGaussianRandomSubsamplingTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkGaussianRandomSubsamplingTest.mha
 )
 itk_add_test(
   NAME itkKalmanLinearEstimatorTest
@@ -174,6 +176,8 @@ itk_add_test(
     100
     1
     ${ITK_TEST_OUTPUT_DIR}/itkKdTreeTest1_100.dot
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkKdTreeTest1.txt
 )
 set_tests_properties(
   itkKdTreeTest1
@@ -192,6 +196,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/pointsForKdTree.txt}
     1
     ${ITK_TEST_OUTPUT_DIR}/itkKdTreeTest2.dot
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkKdTreeTest2.txt
 )
 set_tests_properties(
   itkKdTreeTest2
@@ -210,6 +216,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/pointsForKdTree2.txt}
     1
     ${ITK_TEST_OUTPUT_DIR}/itkKdTreeTest3.dot
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkKdTreeTest3.txt
 )
 set_tests_properties(
   itkKdTreeTest3
@@ -228,6 +236,8 @@ itk_add_test(
     1000
     1000
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkKdTreeTest4.txt
 )
 set_tests_properties(
   itkKdTreeTest4
@@ -246,6 +256,8 @@ itk_add_test(
     1000
     1000
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkKdTreeTest5.txt
 )
 set_tests_properties(
   itkKdTreeTest5
@@ -264,6 +276,8 @@ itk_add_test(
     1000
     1000
     3
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkKdTreeTest6.txt
 )
 set_tests_properties(
   itkKdTreeTest6
@@ -282,6 +296,8 @@ itk_add_test(
     1000
     1000
     5
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkKdTreeTest7.txt
 )
 set_tests_properties(
   itkKdTreeTest7
@@ -300,6 +316,8 @@ itk_add_test(
     1000
     1000
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkKdTreeTest8.txt
 )
 set_tests_properties(
   itkKdTreeTest8
@@ -318,6 +336,8 @@ itk_add_test(
     1000
     1000
     20
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkKdTreeTest9.txt
 )
 set_tests_properties(
   itkKdTreeTest9
@@ -336,6 +356,8 @@ itk_add_test(
     1000
     1000
     100
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkKdTreeTest10.txt
 )
 set_tests_properties(
   itkKdTreeTest10
@@ -355,6 +377,8 @@ itk_add_test(
     100
     20
     16
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkKdTreeTest11.txt
 )
 set_tests_properties(
   itkKdTreeTest11
@@ -380,6 +404,8 @@ if(DOXYGEN_DOT_EXECUTABLE)
       -o
       ${ITK_TEST_OUTPUT_DIR}/itkKdTreeTest1_100.png
       ${ITK_TEST_OUTPUT_DIR}/itkKdTreeTest1_100.dot
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/itkKdTreeTest1_100.png
   )
   set_tests_properties(
     itkKdTreeTest1Plot
@@ -395,6 +421,8 @@ if(DOXYGEN_DOT_EXECUTABLE)
       -o
       ${ITK_TEST_OUTPUT_DIR}/itkKdTreeTest2.png
       ${ITK_TEST_OUTPUT_DIR}/itkKdTreeTest2.dot
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/itkKdTreeTest2.png
   )
   set_tests_properties(
     itkKdTreeTest2Plot
@@ -410,6 +438,8 @@ if(DOXYGEN_DOT_EXECUTABLE)
       -o
       ${ITK_TEST_OUTPUT_DIR}/itkKdTreeTest3.png
       ${ITK_TEST_OUTPUT_DIR}/itkKdTreeTest3.dot
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/itkKdTreeTest3.png
   )
   set_tests_properties(
     itkKdTreeTest3Plot
@@ -908,6 +938,8 @@ itk_add_test(
     itkUniformRandomSpatialNeighborSubsamplerTest
     0
     ${ITK_TEST_OUTPUT_DIR}/itkUniformRandomSubsamplingTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkUniformRandomSubsamplingTest.mha
 )
 itk_add_test(
   NAME itkImageToHistogramFilterTest
@@ -922,6 +954,8 @@ itk_add_test(
     itkImageToHistogramFilterTest2
     DATA{${ITK_DATA_ROOT}/Input/VisibleWomanEyeSlice.png}
     ${ITK_TEST_OUTPUT_DIR}/itkImageToHistogramFilterTest2.txt
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkImageToHistogramFilterTest2.txt
 )
 itk_add_test(
   NAME itkImageToHistogramFilterTest2_Auto
@@ -931,6 +965,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/VisibleWomanEyeSlice.png}
     ${ITK_TEST_OUTPUT_DIR}/itkImageToHistogramFilterTest2_Auto.txt
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkImageToHistogramFilterTest2_Auto.txt
 )
 itk_add_test(
   NAME itkScalarImageToHistogramGeneratorTest
@@ -938,6 +974,8 @@ itk_add_test(
     ITKStatisticsTestDriver
     itkScalarImageToHistogramGeneratorTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
+    ${ITK_TEST_OUTPUT_DIR}/itkScalarImageToHistogramGeneratorTest.txt
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkScalarImageToHistogramGeneratorTest.txt
 )
 

--- a/Modules/Registration/Common/test/CMakeLists.txt
+++ b/Modules/Registration/Common/test/CMakeLists.txt
@@ -177,6 +177,8 @@ itk_add_test(
     --redirectOutput
     ${TEMP}/itkImageRegistrationMethodTest_16.txt
     itkImageRegistrationMethodTest_16
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkImageRegistrationMethodTest_16.txt
 )
 set_tests_properties(
   itkImageRegistrationMethodTest_16
@@ -478,6 +480,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkBlockMatchingImageFilterTest.mha
     itkBlockMatchingImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolume.mha}
+    ${ITK_TEST_OUTPUT_DIR}/itkBlockMatchingImageFilterTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkBlockMatchingImageFilterTest.mha
 )
 

--- a/Modules/Registration/Common/test/RegistrationITKv3/test/CMakeLists.txt
+++ b/Modules/Registration/Common/test/RegistrationITKv3/test/CMakeLists.txt
@@ -16,6 +16,10 @@ itk_add_test(
     ${TEMP}/ImageRegistration1TestPixelCentered.png
     ${TEMP}/ImageRegistration1DifferenceAfterTestPixelCentered.png
     ${TEMP}/ImageRegistration1DifferenceBeforeTestPixelCentered.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/ImageRegistration1TestPixelCentered.png
+    ${TEMP}/ImageRegistration1DifferenceAfterTestPixelCentered.png
+    ${TEMP}/ImageRegistration1DifferenceBeforeTestPixelCentered.png
 )
 
 itk_add_test(
@@ -28,6 +32,8 @@ itk_add_test(
     $<TARGET_FILE:ITKv3ImageRegistration3>
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceBorder20.png
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceShifted13x17y.png
+    ${TEMP}/ImageRegistration3TestPixelCentered.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${TEMP}/ImageRegistration3TestPixelCentered.png
 )
 
@@ -48,6 +54,10 @@ itk_add_test(
     24
     10000
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/ImageRegistration4Test.png
+    ${TEMP}/ImageRegistration4BeforeTest.png
+    ${TEMP}/ImageRegistration4AfterTest.png
 )
 
 itk_add_test(
@@ -67,6 +77,10 @@ itk_add_test(
     24
     10000
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/ImageRegistration4Test2.png
+    ${TEMP}/ImageRegistration4BeforeTest2.png
+    ${TEMP}/ImageRegistration4AfterTest2.png
 )
 
 itk_add_test(
@@ -83,6 +97,10 @@ itk_add_test(
     5
     10000
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/ImageRegistration4Test3.png
+    ${TEMP}/ImageRegistration4BeforeTest3.png
+    ${TEMP}/ImageRegistration4AfterTest3.png
 )
 
 itk_add_test(
@@ -95,6 +113,8 @@ itk_add_test(
     $<TARGET_FILE:ITKv3ImageRegistration5>
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceBorder20.png
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceRotated10.png
+    ${TEMP}/ImageRegistration5Test1PixelCentered.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${TEMP}/ImageRegistration5Test1PixelCentered.png
 )
 
@@ -109,6 +129,8 @@ itk_add_test(
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceBorder20.png
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceR10X13Y17.png
     ${TEMP}/ImageRegistration5Test2PixelCentered.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/ImageRegistration5Test2PixelCentered.png
 )
 
 itk_add_test(
@@ -121,6 +143,8 @@ itk_add_test(
     $<TARGET_FILE:ITKv3ImageRegistration6>
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceBorder20.png
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceR10X13Y17.png
+    ${TEMP}/ImageRegistration6TestPixelCentered.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${TEMP}/ImageRegistration6TestPixelCentered.png
 )
 
@@ -140,6 +164,10 @@ itk_add_test(
     1.0
     1.0
     0.0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/ImageRegistration7TestPixelCentered.png
+    ${TEMP}/ImageRegistration7BeforeTestPixelCentered.png
+    ${TEMP}/ImageRegistration7AfterTestPixelCentered.png
 )
 
 if(ITK_USE_BRAINWEB_DATA)
@@ -151,6 +179,8 @@ if(ITK_USE_BRAINWEB_DATA)
       $<TARGET_FILE:ConfidenceConnected3D>
       DATA{${ITK_EXAMPLE_DATA_ROOT}/BrainWeb/brainweb165a10f17.mha}
       ${TEMP}/WhiteMatterSegmentation.mhd
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${TEMP}/WhiteMatterSegmentation.{mhd,raw}
   )
 
   itk_add_test(
@@ -170,6 +200,14 @@ if(ITK_USE_BRAINWEB_DATA)
       ${TEMP}/ImageRegistration8v3DifferenceBefore.png
       ${TEMP}/ImageRegistration8v3DifferenceAfter.png
       ${TEMP}/ImageRegistration8v3RegisteredSlice.png
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${TEMP}/ImageRegistration8v3RegisteredSlice.png
+      ${TEMP}/ImageRegistration8v3Output.{mhd,raw}
+      ${TEMP}/ImageRegistration8v3DifferenceBefore.{mhd,raw}
+      ${TEMP}/ImageRegistration8v3DifferenceAfter.{mhd,raw}
+      ${TEMP}/ImageRegistration8v3Output.png
+      ${TEMP}/ImageRegistration8v3DifferenceBefore.png
+      ${TEMP}/ImageRegistration8v3DifferenceAfter.png
   )
 endif()
 
@@ -183,6 +221,8 @@ itk_add_test(
     $<TARGET_FILE:ITKv3ImageRegistration9>
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceBorder20.png
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceR10X13Y17.png
+    ${TEMP}/ImageRegistration9TestPixelCentered.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${TEMP}/ImageRegistration9TestPixelCentered.png
 )
 
@@ -198,6 +238,8 @@ itk_add_test(
     $<TARGET_FILE:ITKv3ImageRegistration13>
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceBorder20.png
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceR10X13Y17.png
+    ${TEMP}/ImageRegistration13TestPixelCentered.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${TEMP}/ImageRegistration13TestPixelCentered.png
 )
 
@@ -216,6 +258,8 @@ itk_add_test(
     ${TEMP}/ImageRegistration13Test2PixelCentered.png
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/ImageRegistration13Test2PixelCentered.png
 )
 
 itk_add_test(
@@ -233,6 +277,8 @@ itk_add_test(
     ${TEMP}/ImageRegistration13Test3PixelCentered.png
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/ImageRegistration13Test3PixelCentered.png
 )
 
 itk_add_test(
@@ -250,6 +296,8 @@ itk_add_test(
     ${TEMP}/ImageRegistration13Test4PixelCentered.png
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/ImageRegistration13Test4PixelCentered.png
 )
 
 itk_add_test(
@@ -267,6 +315,8 @@ itk_add_test(
     ${TEMP}/ImageRegistration13Test5PixelCentered.png
     1
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/ImageRegistration13Test5PixelCentered.png
 )
 
 itk_add_test(
@@ -288,6 +338,8 @@ itk_add_test(
     0.15
     10.0
     14.0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/ImageRegistration14Test.png
 )
 set_property(
   TEST
@@ -314,6 +366,10 @@ itk_add_test(
     ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceShifted13x17y.png
     ${TEMP}/MultiResImageRegistration1Test.png
     100
+    ${TEMP}/MultiResImageRegistration1CheckerBoardBeforeTest.png
+    ${TEMP}/MultiResImageRegistration1CheckerBoardAfterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/MultiResImageRegistration1Test.png
     ${TEMP}/MultiResImageRegistration1CheckerBoardBeforeTest.png
     ${TEMP}/MultiResImageRegistration1CheckerBoardAfterTest.png
 )
@@ -345,6 +401,10 @@ itk_add_test(
     ${TEMP}/MultiResImageRegistration1CheckerBoardBeforeTest2.png
     ${TEMP}/MultiResImageRegistration1CheckerBoardAfterTest2.png
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/MultiResImageRegistration1Test2.png
+    ${TEMP}/MultiResImageRegistration1CheckerBoardBeforeTest2.png
+    ${TEMP}/MultiResImageRegistration1CheckerBoardAfterTest2.png
 )
 set_property(
   TEST
@@ -373,6 +433,12 @@ itk_add_test(
     ${TEMP}/DeformableRegistration12Test1DisplacementField.mhd
     0
     0
+    ${TEMP}/DeformableRegistration12Test1FinalTransformParameters.txt
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/DeformableRegistration12Test1.png
+    ${TEMP}/DeformableRegistration12Test1DifferenceAfter.png
+    ${TEMP}/DeformableRegistration12Test1DifferenceBefore.png
+    ${TEMP}/DeformableRegistration12Test1DisplacementField.{mhd,raw}
     ${TEMP}/DeformableRegistration12Test1FinalTransformParameters.txt
 )
 set_property(
@@ -403,6 +469,12 @@ itk_add_test(
     0
     1
     ${TEMP}/DeformableRegistration12Test2FinalTransformParameters.txt
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/DeformableRegistration12Test2.png
+    ${TEMP}/DeformableRegistration12Test2DifferenceAfter.png
+    ${TEMP}/DeformableRegistration12Test2DifferenceBefore.png
+    ${TEMP}/DeformableRegistration12Test2DisplacementField.{mhd,raw}
+    ${TEMP}/DeformableRegistration12Test2FinalTransformParameters.txt
 )
 
 itk_add_test(
@@ -423,6 +495,12 @@ itk_add_test(
     ${TEMP}/DeformableRegistration12Test3DisplacementField.mhd
     1
     0
+    ${TEMP}/DeformableRegistration12Test3FinalTransformParameters.txt
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/DeformableRegistration12Test3.png
+    ${TEMP}/DeformableRegistration12Test3DifferenceAfter.png
+    ${TEMP}/DeformableRegistration12Test3DifferenceBefore.png
+    ${TEMP}/DeformableRegistration12Test3DisplacementField.{mhd,raw}
     ${TEMP}/DeformableRegistration12Test3FinalTransformParameters.txt
 )
 set_property(
@@ -453,6 +531,12 @@ itk_add_test(
     1
     1
     ${TEMP}/DeformableRegistration12Test4FinalTransformParameters.txt
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/DeformableRegistration12Test4.png
+    ${TEMP}/DeformableRegistration12Test4DifferenceAfter.png
+    ${TEMP}/DeformableRegistration12Test4DifferenceBefore.png
+    ${TEMP}/DeformableRegistration12Test4DisplacementField.{mhd,raw}
+    ${TEMP}/DeformableRegistration12Test4FinalTransformParameters.txt
 )
 
 if(ITK_USE_BRAINWEB_DATA)
@@ -482,6 +566,12 @@ if(ITK_USE_BRAINWEB_DATA)
         ${TEMP}/DeformableRegistration8Test1FinalTransformParameters.txt
         ${NUMBER_OF_BSPLINE_GRID_NODES}
         ${ITK_EXAMPLE_DATA_ROOT}/IdentityTransform.tfm
+      ITK_REMOVE_TEMPORARY_TEST_FILES
+        ${TEMP}/DeformableRegistration8Test1.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test1DifferenceAfter.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test1DifferenceBefore.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test1DisplacementField.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test1FinalTransformParameters.txt
     )
     set_property(
       TEST
@@ -522,6 +612,12 @@ if(ITK_USE_BRAINWEB_DATA)
         ${TEMP}/DeformableRegistration8Test2FinalTransformParameters.txt
         ${NUMBER_OF_BSPLINE_GRID_NODES}
         ${ITK_EXAMPLE_DATA_ROOT}/IdentityTransform.tfm
+      ITK_REMOVE_TEMPORARY_TEST_FILES
+        ${TEMP}/DeformableRegistration8Test2.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test2DifferenceAfter.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test2DifferenceBefore.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test2DisplacementField.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test2FinalTransformParameters.txt
     )
     set_property(
       TEST
@@ -562,6 +658,12 @@ if(ITK_USE_BRAINWEB_DATA)
         ${TEMP}/DeformableRegistration8Test3FinalTransformParameters.txt
         ${NUMBER_OF_BSPLINE_GRID_NODES}
         ${ITK_EXAMPLE_DATA_ROOT}/IdentityTransform.tfm
+      ITK_REMOVE_TEMPORARY_TEST_FILES
+        ${TEMP}/DeformableRegistration8Test3.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test3DifferenceAfter.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test3DifferenceBefore.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test3DisplacementField.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test3FinalTransformParameters.txt
     )
     set_property(
       TEST
@@ -610,6 +712,12 @@ if(ITK_USE_BRAINWEB_DATA)
         ${TEMP}/DeformableRegistration8Test4FinalTransformParameters.txt
         ${NUMBER_OF_BSPLINE_GRID_NODES}
         ${ITK_EXAMPLE_DATA_ROOT}/IdentityTransform.tfm
+      ITK_REMOVE_TEMPORARY_TEST_FILES
+        ${TEMP}/DeformableRegistration8Test4.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test4DifferenceAfter.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test4DifferenceBefore.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test4DisplacementField.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test4FinalTransformParameters.txt
     )
     set_property(
       TEST
@@ -645,6 +753,12 @@ if(ITK_USE_BRAINWEB_DATA)
         0
         ${TEMP}/DeformableRegistration8Test5FinalTransformParameters.txt
         ${NUMBER_OF_BSPLINE_GRID_NODES}
+      ITK_REMOVE_TEMPORARY_TEST_FILES
+        ${TEMP}/DeformableRegistration8Test5.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test5DifferenceAfter.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test5DifferenceBefore.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test5DisplacementField.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test5FinalTransformParameters.txt
     )
     set_property(
       TEST
@@ -685,6 +799,12 @@ if(ITK_USE_BRAINWEB_DATA)
         1
         ${TEMP}/DeformableRegistration8Test6FinalTransformParameters.txt
         ${NUMBER_OF_BSPLINE_GRID_NODES}
+      ITK_REMOVE_TEMPORARY_TEST_FILES
+        ${TEMP}/DeformableRegistration8Test6.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test6DifferenceAfter.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test6DifferenceBefore.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test6DisplacementField.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test6FinalTransformParameters.txt
     )
     set_property(
       TEST
@@ -717,6 +837,12 @@ if(ITK_USE_BRAINWEB_DATA)
         0
         ${TEMP}/DeformableRegistration8Test7FinalTransformParameters.txt
         ${NUMBER_OF_BSPLINE_GRID_NODES}
+      ITK_REMOVE_TEMPORARY_TEST_FILES
+        ${TEMP}/DeformableRegistration8Test7.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test7DifferenceAfter.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test7DifferenceBefore.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test7DisplacementField.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test7FinalTransformParameters.txt
     )
     set_property(
       TEST
@@ -757,6 +883,12 @@ if(ITK_USE_BRAINWEB_DATA)
         1
         ${TEMP}/DeformableRegistration8Test8FinalTransformParameters.txt
         ${NUMBER_OF_BSPLINE_GRID_NODES}
+      ITK_REMOVE_TEMPORARY_TEST_FILES
+        ${TEMP}/DeformableRegistration8Test8.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test8DifferenceAfter.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test8DifferenceBefore.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test8DisplacementField.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test8FinalTransformParameters.txt
     )
     set_property(
       TEST
@@ -798,6 +930,12 @@ if(ITK_USE_BRAINWEB_DATA)
         0
         ${TEMP}/DeformableRegistration8Test9FinalTransformParameters.txt
         ${NUMBER_OF_BSPLINE_GRID_NODES}
+      ITK_REMOVE_TEMPORARY_TEST_FILES
+        ${TEMP}/DeformableRegistration8Test9.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test9DifferenceAfter.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test9DifferenceBefore.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test9DisplacementField.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test9FinalTransformParameters.txt
     )
     set_property(
       TEST
@@ -838,6 +976,12 @@ if(ITK_USE_BRAINWEB_DATA)
         1
         ${TEMP}/DeformableRegistration8Test10FinalTransformParameters.txt
         ${NUMBER_OF_BSPLINE_GRID_NODES}
+      ITK_REMOVE_TEMPORARY_TEST_FILES
+        ${TEMP}/DeformableRegistration8Test10.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test10DifferenceAfter.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test10DifferenceBefore.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test10DisplacementField.{mhd,raw}
+        ${TEMP}/DeformableRegistration8Test10FinalTransformParameters.txt
     )
     set_property(
       TEST
@@ -884,6 +1028,12 @@ if(ITK_USE_BRAINWEB_DATA)
           0
           ${TEMP}/DeformableRegistration8Test11FinalTransformParameters.txt
           ${NUMBER_OF_BSPLINE_GRID_NODES}
+        ITK_REMOVE_TEMPORARY_TEST_FILES
+          ${TEMP}/DeformableRegistration8Test11.{mhd,raw}
+          ${TEMP}/DeformableRegistration8Test11DifferenceAfter.{mhd,raw}
+          ${TEMP}/DeformableRegistration8Test11DifferenceBefore.{mhd,raw}
+          ${TEMP}/DeformableRegistration8Test11DisplacementField.{mhd,raw}
+          ${TEMP}/DeformableRegistration8Test11FinalTransformParameters.txt
       )
       set_property(
         TEST
@@ -916,6 +1066,12 @@ if(ITK_USE_BRAINWEB_DATA)
           1
           ${TEMP}/DeformableRegistration8Test12FinalTransformParameters.txt
           ${NUMBER_OF_BSPLINE_GRID_NODES}
+        ITK_REMOVE_TEMPORARY_TEST_FILES
+          ${TEMP}/DeformableRegistration8Test12.{mhd,raw}
+          ${TEMP}/DeformableRegistration8Test12DifferenceAfter.{mhd,raw}
+          ${TEMP}/DeformableRegistration8Test12DifferenceBefore.{mhd,raw}
+          ${TEMP}/DeformableRegistration8Test12DisplacementField.{mhd,raw}
+          ${TEMP}/DeformableRegistration8Test12FinalTransformParameters.txt
       )
       set_property(
         TEST
@@ -961,6 +1117,8 @@ if(TEST_DISABLED)
       ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceBorder20.png
       ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceR10X13Y17.png
       ${ITK_EXAMPLE_DATA_ROOT}/BrainProtonDensitySliceBorder20Mask.png
+      ${TEMP}/ImageRegistration12TestPixelCentered.png
+    ITK_REMOVE_TEMPORARY_TEST_FILES
       ${TEMP}/ImageRegistration12TestPixelCentered.png
   )
 endif()

--- a/Modules/Registration/FEM/test/CMakeLists.txt
+++ b/Modules/Registration/FEM/test/CMakeLists.txt
@@ -20,6 +20,10 @@ itk_add_test(
     ITKFEMRegistrationTestDriver
     itkFEMFiniteDifferenceFunctionLoadTest
     ${ITK_TEST_OUTPUT_DIR}/FiniteDifferenceFunctionLoadTest
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/FiniteDifferenceFunctionLoadTest*Image.mha
+    ${ITK_TEST_OUTPUT_DIR}/FiniteDifferenceFunctionLoadTest*Image.raw
+    ${ITK_TEST_OUTPUT_DIR}/FiniteDifferenceFunctionLoadTest*ForcesWithMetric[0-3].vtk
 )
 itk_add_test(
   NAME itkFEMRegistrationFilterTest
@@ -28,6 +32,9 @@ itk_add_test(
     itkFEMRegistrationFilterTest
     ${ITK_TEST_OUTPUT_DIR}/FEMDeformationField3D
     ${ITK_TEST_OUTPUT_DIR}/FEMDeformedMovingImage3D
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/FEMDeformationField3D[0-3].{mhd,raw}
+    ${ITK_TEST_OUTPUT_DIR}/FEMDeformedMovingImage3D[0-3].{mhd,raw}
 )
 itk_add_test(
   NAME itkFEMRegistrationFilter2DTest
@@ -36,6 +43,9 @@ itk_add_test(
     itkFEMRegistrationFilter2DTest
     ${ITK_TEST_OUTPUT_DIR}/FEMDeformationField2D
     ${ITK_TEST_OUTPUT_DIR}/FEMDeformedMovingImage2D
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/FEMDeformationField2D[0-3].{mhd,raw}
+    ${ITK_TEST_OUTPUT_DIR}/FEMDeformedMovingImage2D[0-3].{mhd,raw}
 )
 itk_add_test(
   NAME itkMIRegistrationFunctionTest
@@ -50,6 +60,9 @@ itk_add_test(
     itkFEMRegistrationFilterTest2
     ${ITK_TEST_OUTPUT_DIR}/FEMDeformationField3DMultiRes
     ${ITK_TEST_OUTPUT_DIR}/FEMDeformedMovingImage3DMultiRes
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/FEMDeformationField3DMultiRes[0-3].{mhd,raw}
+    ${ITK_TEST_OUTPUT_DIR}/FEMDeformedMovingImage3DMultiRes[0-3].{mhd,raw}
 )
 itk_add_test(
   NAME itkPhysicsBasedNonRigidRegistrationMethodTest
@@ -76,4 +89,6 @@ itk_add_test(
     5
     10
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkPhysicsBasedNonRigidRegistrationMethodTest.mha
 )

--- a/Modules/Registration/GPUPDEDeformable/test/CMakeLists.txt
+++ b/Modules/Registration/GPUPDEDeformable/test/CMakeLists.txt
@@ -21,6 +21,8 @@ if(ITK_USE_GPU)
       DATA{Input/LenaFix.png}
       DATA{Input/LenaMov.png}
       ${ITK_TEST_OUTPUT_DIR}/gpuDemonsRegistrationTest2D.mha
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/gpuDemonsRegistrationTest2D.mha
   )
 
   itk_add_test(
@@ -33,6 +35,8 @@ if(ITK_USE_GPU)
       DATA{Input/LenaFix.png}
       DATA{Input/LenaMov.png}
       ${ITK_TEST_OUTPUT_DIR}/gpuDemonsRegistrationTest3D.mha
+    ITK_REMOVE_TEMPORARY_TEST_FILES
+      ${ITK_TEST_OUTPUT_DIR}/gpuDemonsRegistrationTest3D.mha
   )
 
   itk_add_test(
@@ -40,6 +44,9 @@ if(ITK_USE_GPU)
     COMMAND
       ITKGPUPDEDeformableRegistrationTestDriver
       itkGPUDemonsRegistrationFilterTest2
+      ${ITK_TEST_OUTPUT_DIR}/gpuDemonsRegistrationTest2Fixed.mha
+      ${ITK_TEST_OUTPUT_DIR}/gpuDemonsRegistrationTest2Warped.mha
+    ITK_REMOVE_TEMPORARY_TEST_FILES
       ${ITK_TEST_OUTPUT_DIR}/gpuDemonsRegistrationTest2Fixed.mha
       ${ITK_TEST_OUTPUT_DIR}/gpuDemonsRegistrationTest2Warped.mha
   )

--- a/Modules/Registration/Metricsv4/test/CMakeLists.txt
+++ b/Modules/Registration/Metricsv4/test/CMakeLists.txt
@@ -122,6 +122,8 @@ itk_add_test(
     ${TEMP}/itkJointHistogramMutualInformationImageToImageRegistrationTest.nii.gz
     2
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkJointHistogramMutualInformationImageToImageRegistrationTest.nii.gz
 )
 
 itk_add_test(
@@ -134,6 +136,8 @@ itk_add_test(
     ${TEMP}/itkJointHistogramMutualInformationImageToImageRegistrationTest2.nii.gz
     2
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkJointHistogramMutualInformationImageToImageRegistrationTest2.nii.gz
 )
 
 itk_add_test(
@@ -182,6 +186,8 @@ itk_add_test(
     1
     1
     0.25
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkANTSNeighborhoodCorrelationImageToImageRegistrationTest.nii.gz
 )
 
 itk_add_test(
@@ -201,6 +207,8 @@ itk_add_test(
     ${TEMP}/itkMattesMutualInformationImageToImageMetricv4RegistrationTest.nii.gz
     5
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkMattesMutualInformationImageToImageMetricv4RegistrationTest.nii.gz
 )
 
 itk_add_test(
@@ -213,6 +221,8 @@ itk_add_test(
     ${TEMP}/itkMultiStartImageToImageMetricv4RegistrationTest.nii.gz
     5
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkMultiStartImageToImageMetricv4RegistrationTest.nii.gz
 )
 
 itk_add_test(
@@ -224,6 +234,8 @@ itk_add_test(
     DATA{Input/face_b.jpg}
     ${TEMP}/itkMultiGradientImageToImageMetricv4RegistrationTest.nii.gz
     5
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkMultiGradientImageToImageMetricv4RegistrationTest.nii.gz
 )
 
 itk_add_test(
@@ -243,6 +255,8 @@ itk_add_test(
     ${TEMP}/itkMeanSquaresImageToImageMetricv4RegistrationTest.nii.gz
     2
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkMeanSquaresImageToImageMetricv4RegistrationTest.nii.gz
 )
 
 itk_add_test(
@@ -252,6 +266,8 @@ itk_add_test(
     itkMeanSquaresImageToImageMetricv4RegistrationTest2
     DATA{${INPUTDATA}/r16slice.nii.gz}
     DATA{${INPUTDATA}/r64slice.nii.gz}
+    ${TEMP}/itkMeanSquaresImageToImageMetricv4RegistrationTest2.nii.gz
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${TEMP}/itkMeanSquaresImageToImageMetricv4RegistrationTest2.nii.gz
 )
 
@@ -317,6 +333,8 @@ itk_add_test(
     35 #iterations
     0 #sampling
     0 #image gradient filter
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkDemonsImageToImageMetricv4RegistrationTest.nii.gz
 )
 
 itk_add_test(
@@ -335,6 +353,8 @@ itk_add_test(
     35 #iterations
     1 #sampling
     0 #image gradient filter
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkDemonsImageToImageMetricv4RegistrationTest2.nii.gz
 )
 
 itk_add_test(
@@ -353,6 +373,8 @@ itk_add_test(
     35 #iterations
     0 #sampling
     1 #image gradient filter
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkDemonsImageToImageMetricv4RegistrationTest3.nii.gz
 )
 
 itk_add_test(
@@ -398,4 +420,6 @@ itk_add_test(
     ${TEMP}/itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.nii.gz
     100
     25
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkMeanSquaresImageToImageMetricv4VectorRegistrationTest.nii.gz
 )

--- a/Modules/Registration/PDEDeformable/test/CMakeLists.txt
+++ b/Modules/Registration/PDEDeformable/test/CMakeLists.txt
@@ -33,6 +33,10 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkLevelSetMotionRegistrationFilterTestFixedImage.mha
     ${ITK_TEST_OUTPUT_DIR}/itkLevelSetMotionRegistrationFilterTestMovingImage.mha
     ${ITK_TEST_OUTPUT_DIR}/itkLevelSetMotionRegistrationFilterTestResampledImage.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkLevelSetMotionRegistrationFilterTestFixedImage.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkLevelSetMotionRegistrationFilterTestMovingImage.mha
+    ${ITK_TEST_OUTPUT_DIR}/itkLevelSetMotionRegistrationFilterTestResampledImage.mha
 )
 itk_add_test(
   NAME itkSymmetricForcesDemonsRegistrationFilterTest
@@ -51,6 +55,8 @@ itk_add_test(
     --compareNumberOfPixelsTolerance
     20
     itkMultiResolutionPDEDeformableRegistrationTest
+    ${TEMP}/itkMultiResolutionPDEDeformableRegistrationTestPixelCentered.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${TEMP}/itkMultiResolutionPDEDeformableRegistrationTestPixelCentered.png
 )
 itk_add_test(
@@ -86,6 +92,8 @@ itk_add_test(
     0.9
     10
     70
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkDiffeomorphicDemonsRegistrationFilterTest02.txt
 )
 set_tests_properties(
   itkDiffeomorphicDemonsRegistrationFilterTest02
@@ -141,6 +149,8 @@ itk_add_test(
     0.08
     5
     70
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkDiffeomorphicDemonsRegistrationFilterTest05.txt
 )
 set_tests_properties(
   itkDiffeomorphicDemonsRegistrationFilterTest05
@@ -176,6 +186,8 @@ itk_add_test(
     0
     0.001
     0.1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDiffeomorphicDemonsRegistrationFilterTest07.mha
 )
 itk_add_test(
   NAME itkDiffeomorphicDemonsRegistrationFilterTest08
@@ -189,6 +201,8 @@ itk_add_test(
     0
     0.001
     0.1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDiffeomorphicDemonsRegistrationFilterTest08.mha
 )
 itk_add_test(
   NAME itkDiffeomorphicDemonsRegistrationFilterTest09
@@ -202,6 +216,8 @@ itk_add_test(
     0
     0.001
     0.1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDiffeomorphicDemonsRegistrationFilterTest09.mha
 )
 itk_add_test(
   NAME itkDiffeomorphicDemonsRegistrationFilterTest10
@@ -215,6 +231,8 @@ itk_add_test(
     0
     0.001
     0.1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDiffeomorphicDemonsRegistrationFilterTest10.mha
 )
 itk_add_test(
   NAME itkDiffeomorphicDemonsRegistrationFilterTest11
@@ -228,6 +246,8 @@ itk_add_test(
     1
     0.001
     0.1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkDiffeomorphicDemonsRegistrationFilterTest11.mha
 )
 itk_add_test(
   NAME itkFastSymmetricForcesDemonsRegistrationFilterTest

--- a/Modules/Registration/RegistrationMethodsv4/test/CMakeLists.txt
+++ b/Modules/Registration/RegistrationMethodsv4/test/CMakeLists.txt
@@ -57,6 +57,8 @@ itk_add_test(
     ${TEMP}/itkSimpleImageRegistrationTestDouble.nii
     100 # number of affine iterations
     10 # number of deformable iterations
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkSimpleImageRegistrationTestDouble.nii
 )
 set_property(
   TEST
@@ -94,6 +96,8 @@ itk_add_test(
     ${TEMP}/itkSimpleImageRegistrationTestFloat.nii
     100 # number of affine iterations
     10 # number of deformable iterations
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkSimpleImageRegistrationTestFloat.nii
 )
 set_property(
   TEST
@@ -124,6 +128,8 @@ itk_add_test(
     ${TEMP}/itkSimpleImageRegistrationTestWithMaskAndSamplingDouble.nii.gz
     100 # number of affine iterations
     10 # number of deformable iterations
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkSimpleImageRegistrationTestWithMaskAndSamplingDouble.nii.gz
 )
 set_property(
   TEST
@@ -148,6 +154,8 @@ itk_add_test(
     ${TEMP}/itkSimpleImageRegistrationTestWithMaskAndSamplingFloat.nii.gz
     100 # number of affine iterations
     10 # number of deformable iterations
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkSimpleImageRegistrationTestWithMaskAndSamplingFloat.nii.gz
 )
 set_property(
   TEST
@@ -170,6 +178,8 @@ itk_add_test(
     DATA{Input/r64slice.nii.gz}
     ${TEMP}/itkSimpleImageRegistrationTest2New.nii.gz
     100 # number of affine iterations
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkSimpleImageRegistrationTest2New.nii.gz
 )
 set_property(
   TEST
@@ -190,6 +200,8 @@ itk_add_test(
     2 # number of dimensions
     DATA{Input/r16slice_rigid.nii.gz}
     DATA{Input/r64slice.nii.gz}
+    ${TEMP}/itkSimpleImageRegistrationTest3New.nii.gz
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${TEMP}/itkSimpleImageRegistrationTest3New.nii.gz
 )
 set_property(
@@ -302,6 +314,8 @@ itk_add_test(
     0.0
     1.0
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkExponentialImageRegistrationTestNew.nii.gz
 )
 set_property(
   TEST
@@ -331,6 +345,8 @@ itk_add_test(
     ${TEMP}/itkBSplineExponentialImageRegistrationTestNew.nii.gz
     100 # number of affine iterations
     10 # number of deformable iterations
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkBSplineExponentialImageRegistrationTestNew.nii.gz
 )
 set_property(
   TEST
@@ -355,6 +371,8 @@ itk_add_test(
     1 # number of iterations for second level of the displacement field
     1 # number of iterations for third level of the displacement field
     0.5 # learning rate
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkTimeVaryingVelocityFieldImageRegistrationTest*.nii.gz
 )
 set_property(
   TEST
@@ -381,6 +399,8 @@ itk_add_test(
     0.5 # learning rate
     1.0e-7
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkTimeVaryingBSplineVelocityFieldImageRegistrationTest*.nii.gz
 )
 
 set_property(
@@ -403,6 +423,8 @@ itk_add_test(
     ${TEMP}/itkSyNImageRegistrationTest
     10 # number of optimization iterations of the displacement field
     0.5 # learning rate
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkSyNImageRegistrationTest*.nii.gz
 )
 
 itk_add_test(
@@ -416,6 +438,8 @@ itk_add_test(
     ${TEMP}/itkBSplineSyNImageRegistrationTest
     10 # number of optimization iterations of the displacement field
     0.5 # learning rate
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkBSplineSyNImageRegistrationTest*.nii.gz
 )
 
 itk_add_test(
@@ -430,6 +454,8 @@ itk_add_test(
     ${TEMP}/itkQuasiNewtonOptimizerv4RegistrationTest1.nii.gz
     5
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkQuasiNewtonOptimizerv4RegistrationTest1.nii.gz
 )
 
 itk_add_test(
@@ -444,6 +470,8 @@ itk_add_test(
     ${TEMP}/itkQuasiNewtonOptimizerv4RegistrationTest2.nii.gz
     5
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkQuasiNewtonOptimizerv4RegistrationTest2.nii.gz
 )
 
 itk_add_test(
@@ -458,6 +486,8 @@ itk_add_test(
     ${TEMP}/itkQuasiNewtonOptimizerv4RegistrationTest3.nii.gz
     5
     2
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkQuasiNewtonOptimizerv4RegistrationTest3.nii.gz
 )
 
 itk_add_test(
@@ -479,6 +509,8 @@ itk_add_test(
     ${TEMP}/itkBSplineImageRegistrationTestNew.nii.gz
     100 # number of affine iterations
     10 # number of deformable iterations
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkBSplineImageRegistrationTestNew.nii.gz
 )
 set_property(
   TEST

--- a/Modules/Registration/TwoProjectionRegistration/test/CMakeLists.txt
+++ b/Modules/Registration/TwoProjectionRegistration/test/CMakeLists.txt
@@ -30,6 +30,9 @@ itk_add_test(
     DATA{Input/boxheadDRRDev1_G90.tif}
     90
     DATA{Input/BoxheadCT.img,BoxheadCT.hdr}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/boxheadDRRDev1_G0_Reg.tif
+    ${ITK_TEST_OUTPUT_DIR}/boxheadDRRDev1_G90_Reg.tif
 )
 
 # Disabled: BoxheadCTFull.img is orphaned (404 from gh-pages, Girder, itk.org).
@@ -74,6 +77,8 @@ itk_add_test(
     -o
     ${ITK_TEST_OUTPUT_DIR}/boxheadDRRDev1_G0.tif
     DATA{Input/BoxheadCT.img,BoxheadCT.hdr}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/boxheadDRRDev1_G0.tif
 )
 
 itk_add_test(
@@ -106,6 +111,8 @@ itk_add_test(
     -o
     ${ITK_TEST_OUTPUT_DIR}/boxheadDRRDev1_G90.tif
     DATA{Input/BoxheadCT.img,BoxheadCT.hdr}
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/boxheadDRRDev1_G90.tif
 )
 
 # Disabled: BoxheadCTFull.img is orphaned (404 from gh-pages, Girder, itk.org).

--- a/Modules/Segmentation/Classifiers/test/CMakeLists.txt
+++ b/Modules/Segmentation/Classifiers/test/CMakeLists.txt
@@ -32,6 +32,8 @@ itk_add_test(
     4
     2
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBayesianClassifierImageFilterTestLabelMapNoPriors.png
 )
 itk_add_test(
   NAME itkBayesianClassifierImageFilterTest2
@@ -46,6 +48,8 @@ itk_add_test(
     4
     2
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkBayesianClassifierImageFilterTestLabelMapPriors.png
 )
 itk_add_test(
   NAME itkKmeansModelEstimatorTest
@@ -61,6 +65,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Baseline/Statistics/ImageClassifierFilterTestClassifiedImageTest.png}
     ${ITK_TEST_OUTPUT_DIR}/ImageClassifierFilterTestClassifiedImage.png
     itkImageClassifierFilterTest
+    ${ITK_TEST_OUTPUT_DIR}/ImageClassifierFilterTestClassifiedImage.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/ImageClassifierFilterTestClassifiedImage.png
 )
 itk_add_test(
@@ -130,6 +136,8 @@ itk_add_test(
     165
     190
     220
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkScalarImageKmeansImageFilterTest.png
 )
 itk_add_test(
   NAME itkScalarImageKmeansImageFilter3DTest
@@ -141,5 +149,7 @@ itk_add_test(
     itkScalarImageKmeansImageFilter3DTest
     ${ITK_EXAMPLE_DATA_ROOT}/KmeansTest_T1UCharRaw.nii.gz
     ${ITK_EXAMPLE_DATA_ROOT}/KmeansTest_T1RawSkullStrip.nii.gz
+    ${ITK_TEST_OUTPUT_DIR}/KmeansTest_T1KmeansPrelimSegmentation.nii.gz
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/KmeansTest_T1KmeansPrelimSegmentation.nii.gz
 )

--- a/Modules/Segmentation/ConnectedComponents/test/CMakeLists.txt
+++ b/Modules/Segmentation/ConnectedComponents/test/CMakeLists.txt
@@ -27,6 +27,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RelabelComponentImageFilterTest.png
     130
     145
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/RelabelComponentImageFilterTest.png
 )
 itk_add_test(
   NAME itkHardConnectedComponentImageFilterTest
@@ -40,6 +42,10 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/HardConnectedComponentImageFilterTestUnsignedShort.png
     itkHardConnectedComponentImageFilterTest
     ${ITK_TEST_OUTPUT_DIR}/HardConnectedComponentImageFilterTest
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HardConnectedComponentImageFilterTestUnsignedChar.png
+    ${ITK_TEST_OUTPUT_DIR}/HardConnectedComponentImageFilterTestUnsignedShort.png
+    ${ITK_TEST_OUTPUT_DIR}/HardConnectedComponentImageFilterTestUnsigned*.png
 )
 itk_add_test(
   NAME itkConnectedComponentImageFilterTestRGB
@@ -53,6 +59,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/ConnectedComponentImageFilterTestRGB.png
     130
     145
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ConnectedComponentImageFilterTestRGB.png
 )
 itk_add_test(
   NAME itkConnectedComponentImageFilterTest
@@ -66,6 +74,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/ConnectedComponentImageFilterTest.png
     130
     145
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ConnectedComponentImageFilterTest.png
 )
 itk_add_test(
   NAME itkConnectedComponentImageFilterTest2
@@ -80,6 +90,8 @@ itk_add_test(
     128
     255
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ConnectedComponentImageFilterTest2.png
 )
 itk_add_test(
   NAME itkConnectedComponentImageFilterTest3
@@ -94,6 +106,8 @@ itk_add_test(
     128
     255
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ConnectedComponentImageFilterTest3.png
 )
 itk_add_test(
   NAME itkConnectedComponentImageFilterBackgroundTest1
@@ -120,6 +134,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/CellsFluorescence1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkThresholdMaximumConnectedComponentsImageFilterTest1.png
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkThresholdMaximumConnectedComponentsImageFilterTest1.png
 )
 itk_add_test(
   NAME itkThresholdMaximumConnectedComponentsImageFilterTest2
@@ -132,6 +148,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/CellsFluorescence2.png}
     ${ITK_TEST_OUTPUT_DIR}/itkThresholdMaximumConnectedComponentsImageFilterTest2.png
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkThresholdMaximumConnectedComponentsImageFilterTest2.png
 )
 itk_add_test(
   NAME itkScalarConnectedComponentImageFilterTest
@@ -145,6 +163,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/ScalarConnectedComponentImageFilterTest.png
     20
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ScalarConnectedComponentImageFilterTest.png
 )
 itk_add_test(
   NAME itkVectorConnectedComponentImageFilterTest
@@ -154,6 +174,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Baseline/BasicFilters/VectorConnectedComponentImageFilterTest.png,:}
     ${ITK_TEST_OUTPUT_DIR}/VectorConnectedComponentImageFilterTest.png
     itkVectorConnectedComponentImageFilterTest
+    ${ITK_TEST_OUTPUT_DIR}/VectorConnectedComponentImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/VectorConnectedComponentImageFilterTest.png
 )
 itk_add_test(
@@ -174,6 +196,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/MaskConnectedComponentImageFilterTest.png
     130
     145
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/MaskConnectedComponentImageFilterTest.png
 )
 
 set(

--- a/Modules/Segmentation/GrowCut/test/CMakeLists.txt
+++ b/Modules/Segmentation/GrowCut/test/CMakeLists.txt
@@ -26,6 +26,8 @@ itk_add_test(
     DATA{Input/DzZ_L1.nrrd}
     DATA{Input/DzZ_L1_seeds-label.nrrd}
     ${ITK_TEST_OUTPUT_DIR}/itkFastGrowCutTestDzZ_L1-label.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkFastGrowCutTestDzZ_L1-label.nrrd
 )
 
 itk_add_test(
@@ -38,6 +40,8 @@ itk_add_test(
     itkFastGrowCutTest
     DATA{Input/DzZ_T1_orig.nhdr,DzZ_T1_orig.raw.gz}
     DATA{Input/DzZ_Seeds.seg.nrrd}
+    ${ITK_TEST_OUTPUT_DIR}/itkFastGrowCutTestDzZ_T1-label.nrrd
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkFastGrowCutTestDzZ_T1-label.nrrd
 )
 

--- a/Modules/Segmentation/KLMRegionGrowing/test/CMakeLists.txt
+++ b/Modules/Segmentation/KLMRegionGrowing/test/CMakeLists.txt
@@ -12,6 +12,8 @@ itk_add_test(
     --redirectOutput
     ${TEMP}/itkRegionGrow2DTest.txt
     itkRegionGrow2DTest
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${TEMP}/itkRegionGrow2DTest.txt
 )
 set_tests_properties(
   itkRegionGrow2DTest

--- a/Modules/Segmentation/LabelVoting/test/CMakeLists.txt
+++ b/Modules/Segmentation/LabelVoting/test/CMakeLists.txt
@@ -24,6 +24,8 @@ itk_add_test(
     5
     255
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkVotingBinaryImageFilterTest0.mha
 )
 itk_add_test(
   NAME itkVotingBinaryImageFilterTest1
@@ -38,6 +40,8 @@ itk_add_test(
     5
     100
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkVotingBinaryImageFilterTest1.mha
 )
 itk_add_test(
   NAME itkLabelVotingImageFilterTest
@@ -66,6 +70,8 @@ itk_add_test(
     fd3bd75fc6270e3c416a3f0807a6e24b
     itkVotingBinaryHoleFillingImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
+    ${ITK_TEST_OUTPUT_DIR}/itkVotingBinaryHoleFillingImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkVotingBinaryHoleFillingImageFilterTest.png
 )
 itk_add_test(

--- a/Modules/Segmentation/LevelSets/test/CMakeLists.txt
+++ b/Modules/Segmentation/LevelSets/test/CMakeLists.txt
@@ -60,6 +60,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/VectorThresholdSegmentationLevelSetImageFilterTest.png
     5.0
     50
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/VectorThresholdSegmentationLevelSetImageFilterTest.png
 )
 itk_add_test(
   NAME itkAnisotropicFourthOrderLevelSetImageFilterTest
@@ -106,6 +108,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/ParallelSparseFieldLevelSetImageFilterTest.mha
     itkParallelSparseFieldLevelSetImageFilterTest
     ${ITK_TEST_OUTPUT_DIR}/ParallelSparseFieldLevelSetImageFilterTest.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ParallelSparseFieldLevelSetImageFilterTest.mha
 )
 itk_add_test(
   NAME itkShapeDetectionLevelSetImageFilterTest
@@ -127,6 +131,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Baseline/Algorithms/itkNarrowBandCurvesLevelSetImageFilterTest.png}
     ${ITK_TEST_OUTPUT_DIR}/itkNarrowBandCurvesLevelSetImageFilterTest.png
     itkNarrowBandCurvesLevelSetImageFilterTest
+    ${ITK_TEST_OUTPUT_DIR}/itkNarrowBandCurvesLevelSetImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkNarrowBandCurvesLevelSetImageFilterTest.png
 )
 itk_add_test(

--- a/Modules/Segmentation/LevelSetsv4/test/CMakeLists.txt
+++ b/Modules/Segmentation/LevelSetsv4/test/CMakeLists.txt
@@ -113,6 +113,9 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/circle.png}
     ${ITK_TEST_OUTPUT_DIR}/output_binary_whitaker_adaptor.mha
     ${ITK_TEST_OUTPUT_DIR}/status_binary_whitaker_adaptor.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/output_binary_whitaker_adaptor.mha
+    ${ITK_TEST_OUTPUT_DIR}/status_binary_whitaker_adaptor.mha
 )
 itk_add_test(
   NAME itkBinaryImageToMalcolmSparseLevelSetsv4AdaptorTest
@@ -121,6 +124,8 @@ itk_add_test(
     itkBinaryImageToMalcolmSparseLevelSetAdaptorTest
     DATA{${ITK_DATA_ROOT}/Input/circle.png}
     ${ITK_TEST_OUTPUT_DIR}/output_binary_malcolm_adaptor.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/output_binary_malcolm_adaptor.mha
 )
 itk_add_test(
   NAME itkBinaryImageToShiSparseLevelSetsv4AdaptorTest
@@ -128,6 +133,8 @@ itk_add_test(
     ITKLevelSetsv4TestDriver
     itkBinaryImageToShiSparseLevelSetAdaptorTest
     DATA{${ITK_DATA_ROOT}/Input/circle.png}
+    ${ITK_TEST_OUTPUT_DIR}/output_binary_shi_adaptor.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/output_binary_shi_adaptor.mha
 )
 # domain partition classes
@@ -182,6 +189,8 @@ itk_add_test(
     25
     25
     ${ITK_TEST_OUTPUT_DIR}/whiteSpot_output_dense_single.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/whiteSpot_output_dense_single.mha
 )
 
 itk_add_test(
@@ -197,6 +206,8 @@ itk_add_test(
     25
     ${ITK_TEST_OUTPUT_DIR}/whiteSpot_output_dense_advection_single_5.mha
     5
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/whiteSpot_output_dense_advection_single_5.mha
 )
 
 itk_add_test(
@@ -209,6 +220,8 @@ itk_add_test(
     itkSingleLevelSetWhitakerImage2DTest
     DATA{${ITK_DATA_ROOT}/Input/whiteSpot.png}
     50
+    ${ITK_TEST_OUTPUT_DIR}/whiteSpot_output_sparse_single.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/whiteSpot_output_sparse_single.mha
 )
 itk_add_test(
@@ -224,6 +237,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/whiteSpot.png}
     50
     ${ITK_TEST_OUTPUT_DIR}/whiteSpot_output_sparse_single_threads.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/whiteSpot_output_sparse_single_threads.mha
 )
 
 itk_add_test(
@@ -237,6 +252,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/whiteSpot.png}
     15
     ${ITK_TEST_OUTPUT_DIR}/whiteSpot_output_malcolm_single.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/whiteSpot_output_malcolm_single.mha
 )
 itk_add_test(
   NAME itkSingleLevelSetsv4ShiImage2DTest
@@ -248,6 +265,8 @@ itk_add_test(
     itkSingleLevelSetShiImage2DTest
     DATA{${ITK_DATA_ROOT}/Input/whiteSpot.png}
     15
+    ${ITK_TEST_OUTPUT_DIR}/whiteSpot_output_shi_single.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/whiteSpot_output_shi_single.mha
 )
 itk_add_test(
@@ -307,6 +326,8 @@ itk_add_test(
     25
     10
     ${ITK_TEST_OUTPUT_DIR}/whiteSpot_output_dense_two.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/whiteSpot_output_dense_two.mha
 )
 
 itk_add_test(
@@ -319,6 +340,8 @@ itk_add_test(
     itkTwoLevelSetWhitakerImage2DTest
     DATA{${ITK_DATA_ROOT}/Input/whiteSpot.png}
     1
+    ${ITK_TEST_OUTPUT_DIR}/whiteSpot_output_sparse_two.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/whiteSpot_output_sparse_two.mha
 )
 
@@ -333,6 +356,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/whiteSpot.png}
     1
     ${ITK_TEST_OUTPUT_DIR}/whiteSpot_output_malcolm_two.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/whiteSpot_output_malcolm_two.mha
 )
 
 itk_add_test(
@@ -345,6 +370,8 @@ itk_add_test(
     itkTwoLevelSetShiImage2DTest
     DATA{${ITK_DATA_ROOT}/Input/whiteSpot.png}
     1
+    ${ITK_TEST_OUTPUT_DIR}/whiteSpot_output_shi_two.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/whiteSpot_output_shi_two.mha
 )
 

--- a/Modules/Segmentation/RegionGrowing/test/CMakeLists.txt
+++ b/Modules/Segmentation/RegionGrowing/test/CMakeLists.txt
@@ -22,6 +22,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/NeighborhoodConnectedImageFilterTest.png
     146
     167
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/NeighborhoodConnectedImageFilterTest.png
 )
 itk_add_test(
   NAME itkIsolatedConnectedImageFilterTest
@@ -38,6 +40,8 @@ itk_add_test(
     85
     107
     110
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/IsolatedConnectedImageFilterTest.png
 )
 itk_add_test(
   NAME itkIsolatedConnectedImageFilterTest2
@@ -58,6 +62,8 @@ itk_add_test(
     125
     101
     170
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/IsolatedConnectedImageFilterTest2.png
 )
 itk_add_test(
   NAME itkConfidenceConnectedImageFilterTest
@@ -71,6 +77,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/ConfidenceConnectedImageFilterTest.png
     165
     165
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ConfidenceConnectedImageFilterTest.png
 )
 itk_add_test(
   NAME itkConfidenceConnectedImageFilterTest2
@@ -84,6 +92,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/ConfidenceConnectedImageFilterTest2.png
     9999
     9999
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ConfidenceConnectedImageFilterTest2.png
 )
 itk_add_test(
   NAME itkVectorConfidenceConnectedImageFilterTest
@@ -101,6 +111,8 @@ itk_add_test(
     67
     5.0
     6
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/VectorConfidenceConnectedImageFilterTest.png
 )
 itk_add_test(
   NAME itkVectorConfidenceConnectedImageFilterTest2
@@ -118,6 +130,8 @@ itk_add_test(
     9999
     5.0
     6
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/VectorConfidenceConnectedImageFilterTest2.png
 )
 itk_add_test(
   NAME itkConnectedThresholdImageFilterTest
@@ -133,6 +147,8 @@ itk_add_test(
     165
     0
     150
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ConnectedThresholdImageFilterTest.png
 )
 itk_add_test(
   NAME itkConnectedThresholdImageFilterTest2
@@ -149,4 +165,6 @@ itk_add_test(
     200
     255
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/ConnectedThresholdImageFilterTest2.png
 )

--- a/Modules/Segmentation/SuperPixel/test/CMakeLists.txt
+++ b/Modules/Segmentation/SuperPixel/test/CMakeLists.txt
@@ -19,6 +19,8 @@ itk_add_test(
     "${ITK_TEST_OUTPUT_DIR}/itkSLICImageFilterTestOutput1.png"
     25
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSLICImageFilterTestOutput1.png
 )
 
 itk_add_test(
@@ -33,6 +35,8 @@ itk_add_test(
     "${ITK_TEST_OUTPUT_DIR}/itkSLICImageFilterTestOutput2.png"
     25
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSLICImageFilterTestOutput2.png
 )
 
 itk_add_test(
@@ -47,6 +51,8 @@ itk_add_test(
     "${ITK_TEST_OUTPUT_DIR}/itkSLICImageFilterTestOutput3.png"
     25
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkSLICImageFilterTestOutput3.png
 )
 
 set(${itk-module}GTests itkSLICImageFilterGTest.cxx)

--- a/Modules/Segmentation/Voronoi/test/CMakeLists.txt
+++ b/Modules/Segmentation/Voronoi/test/CMakeLists.txt
@@ -43,6 +43,8 @@ itk_add_test(
     ITKVoronoiTestDriver
     itkVoronoiDiagram2DTest
     ${ITK_TEST_OUTPUT_DIR}/VoronoiDiagram2DTest.vtk
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/VoronoiDiagram2DTest.vtk
 )
 itk_add_test(
   NAME itkVoronoiPartitioningImageFilterTest1
@@ -57,6 +59,8 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/sf4.png}
     ${ITK_TEST_OUTPUT_DIR}/VoronoiPartioningImageFilterTest1.png
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/VoronoiPartioningImageFilterTest1.png
 )
 itk_add_test(
   NAME itkVoronoiPartitioningImageFilterTest2
@@ -69,4 +73,6 @@ itk_add_test(
     DATA{${ITK_DATA_ROOT}/Input/sf4.png}
     ${ITK_TEST_OUTPUT_DIR}/VoronoiPartioningImageFilterTest2.png
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/VoronoiPartioningImageFilterTest2.png
 )

--- a/Modules/Segmentation/Watersheds/test/CMakeLists.txt
+++ b/Modules/Segmentation/Watersheds/test/CMakeLists.txt
@@ -28,6 +28,8 @@ itk_add_test(
     itkTobogganImageFilterTest
     DATA{${ITK_DATA_ROOT}/Input/cthead1.png}
     ${ITK_TEST_OUTPUT_DIR}/itkTobogganImageFilterTest.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkTobogganImageFilterTest.png
 )
 itk_add_test(
   NAME itkIsolatedWatershedImageFilterTest
@@ -45,6 +47,8 @@ itk_add_test(
     99
     0.001
     .0001
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkIsolatedWatershedImageFilterTest.png
 )
 itk_add_test(
   NAME itkIsolatedWatershedImageFilterTestCloseThresholds
@@ -62,6 +66,8 @@ itk_add_test(
     99
     0.1
     1.0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkIsolatedWatershedImageFilterTestCloseThresholds.png
 )
 itk_add_test(
   NAME itkWatershedImageFilterTest
@@ -83,6 +89,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedFromMarkersImageFilterTestM0F0.png
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedFromMarkersImageFilterTestM0F0.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedFromMarkersImageFilterTestM0F1
@@ -97,6 +105,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedFromMarkersImageFilterTestM0F1.png
     0
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedFromMarkersImageFilterTestM0F1.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedFromMarkersImageFilterTestM1F0
@@ -111,6 +121,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedFromMarkersImageFilterTestM1F0.png
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedFromMarkersImageFilterTestM1F0.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedFromMarkersImageFilterTestM1F1
@@ -125,6 +137,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedFromMarkersImageFilterTestM1F1.png
     1
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedFromMarkersImageFilterTestM1F1.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestButtonHoleM0F0
@@ -139,6 +153,8 @@ itk_add_test(
     0
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestButtonHoleM0F0.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestPassValuesM0F0
@@ -153,6 +169,8 @@ itk_add_test(
     0
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestPassValuesM0F0.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestPlateauM0F0
@@ -167,6 +185,8 @@ itk_add_test(
     0
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestPlateauM0F0.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestThickLinesM0F0
@@ -181,6 +201,8 @@ itk_add_test(
     0
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestThickLinesM0F0.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestButtonHoleM0F1
@@ -195,6 +217,8 @@ itk_add_test(
     0
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestButtonHoleM0F1.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestPassValuesM0F1
@@ -209,6 +233,8 @@ itk_add_test(
     0
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestPassValuesM0F1.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestPlateauM0F1
@@ -223,6 +249,8 @@ itk_add_test(
     0
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestPlateauM0F1.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestThickLinesM0F1
@@ -237,6 +265,8 @@ itk_add_test(
     0
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestThickLinesM0F1.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestButtonHoleM1F0
@@ -251,6 +281,8 @@ itk_add_test(
     1
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestButtonHoleM1F0.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestPassValuesM1F0
@@ -265,6 +297,8 @@ itk_add_test(
     1
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestPassValuesM1F0.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestPlateauM1F0
@@ -279,6 +313,8 @@ itk_add_test(
     1
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestPlateauM1F0.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestThickLinesM1F0
@@ -293,6 +329,8 @@ itk_add_test(
     1
     0
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestThickLinesM1F0.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestButtonHoleM1F1
@@ -307,6 +345,8 @@ itk_add_test(
     1
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestButtonHoleM1F1.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestPassValuesM1F1
@@ -321,6 +361,8 @@ itk_add_test(
     1
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestPassValuesM1F1.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestPlateauM1F1
@@ -335,6 +377,8 @@ itk_add_test(
     1
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestPlateauM1F1.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestThickLinesM1F1
@@ -349,6 +393,8 @@ itk_add_test(
     1
     1
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestThickLinesM1F1.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestLevel00
@@ -363,6 +409,8 @@ itk_add_test(
     1
     0
     00
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestLevel00.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestLevel10
@@ -377,6 +425,8 @@ itk_add_test(
     1
     0
     10
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestLevel10.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestLevel20
@@ -391,6 +441,8 @@ itk_add_test(
     1
     0
     20
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestLevel20.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestLevel30
@@ -405,6 +457,8 @@ itk_add_test(
     1
     0
     30
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestLevel30.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestLevel40
@@ -419,6 +473,8 @@ itk_add_test(
     1
     0
     40
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestLevel40.png
 )
 itk_add_test(
   NAME itkMorphologicalWatershedImageFilterTestLevel50
@@ -433,4 +489,6 @@ itk_add_test(
     1
     0
     50
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/itkMorphologicalWatershedImageFilterTestLevel50.png
 )

--- a/Modules/Video/BridgeOpenCV/test/CMakeLists.txt
+++ b/Modules/Video/BridgeOpenCV/test/CMakeLists.txt
@@ -33,6 +33,9 @@ itk_add_test(
     # Width Height
     320
     240
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/OpenCVVideoCaptureTest_ScalarOut.avi
+    ${ITK_TEST_OUTPUT_DIR}/OpenCVVideoCaptureTest_RGBOut.avi
 )
 
 # OpenCVImageBridge:
@@ -82,6 +85,9 @@ itk_add_test(
     240
     30
     14.985
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/OpenCVVideoIOTest_Out.avi
+    ${ITK_TEST_OUTPUT_DIR}/OpenCVVideoIOTest_CameraOut.mha
 )
 
 # OpenCVVideoIOFactory:
@@ -96,6 +102,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/OpenCVVideoIOFactoryTest_Out.avi
     # Webcam Number:
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/OpenCVVideoIOFactoryTest_Out.avi
 )
 
 # OpenCVBasicTypeBridgeTest

--- a/Modules/Video/BridgeVXL/test/CMakeLists.txt
+++ b/Modules/Video/BridgeVXL/test/CMakeLists.txt
@@ -40,6 +40,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/VXLVideoIOFactoryTest_Out.avi
     # Webcam Number:
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/VXLVideoIOFactoryTest_Out.avi
 )
 itk_add_test(
   NAME vidl_itk_istreamTest
@@ -53,4 +55,6 @@ itk_add_test(
     # Width Height
     320
     240
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/vidl_itk_istreamTest_Out.avi
 )

--- a/Modules/Video/Core/test/CMakeLists.txt
+++ b/Modules/Video/Core/test/CMakeLists.txt
@@ -75,6 +75,8 @@ itk_add_test(
     itkImageToVideoFilterTest
     DATA{${ITK_DATA_ROOT}/Input/HeadMRVolumeCompressed.mha}
     ${ITK_TEST_OUTPUT_DIR}/HeadMRVolume_Frame0.mha
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/HeadMRVolume_Frame0.mha
 )
 
 itk_add_test(
@@ -86,6 +88,8 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/RGBTestImage_Slice0.png
     itkVectorImageToVideoTest
     DATA{${ITK_DATA_ROOT}/Input/RGBTestImage.tif}
+    ${ITK_TEST_OUTPUT_DIR}/RGBTestImage_Slice0.png
+  ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/RGBTestImage_Slice0.png
 )
 

--- a/Modules/Video/Filtering/test/CMakeLists.txt
+++ b/Modules/Video/Filtering/test/CMakeLists.txt
@@ -20,6 +20,10 @@ itk_add_test(
     #,DATA{Input/frame2.jpg},DATA{Input/frame3.jpg},DATA{Input/frame4.jpg}"
     # Output
     "${ITK_TEST_OUTPUT_DIR}/avg_frame0.png,${ITK_TEST_OUTPUT_DIR}/avg_frame1.png,${ITK_TEST_OUTPUT_DIR}/avg_frame2.png"
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/avg_frame0.png
+    ${ITK_TEST_OUTPUT_DIR}/avg_frame1.png
+    ${ITK_TEST_OUTPUT_DIR}/avg_frame2.png
 )
 
 # DecimateFramesVideoFilter
@@ -32,6 +36,9 @@ itk_add_test(
     "DATA{Input/frame0.jpg},DATA{Input/frame1.jpg},DATA{Input/frame2.jpg},DATA{Input/frame3.jpg},DATA{Input/frame4.jpg}"
     # Output
     "${ITK_TEST_OUTPUT_DIR}/dec_frame0.png,${ITK_TEST_OUTPUT_DIR}/dec_frame1.png"
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/dec_frame0.png
+    ${ITK_TEST_OUTPUT_DIR}/dec_frame1.png
 )
 
 # ImageFilterToVideoFilterWrapperTest
@@ -44,6 +51,12 @@ itk_add_test(
     "DATA{Input/frame0.jpg},DATA{Input/frame1.jpg},DATA{Input/frame2.jpg},DATA{Input/frame3.jpg},DATA{Input/frame4.jpg}"
     # Output
     "${ITK_TEST_OUTPUT_DIR}/wrapper_frame0.png,${ITK_TEST_OUTPUT_DIR}/wrapper_frame1.png,${ITK_TEST_OUTPUT_DIR}/wrapper_frame2.png,${ITK_TEST_OUTPUT_DIR}/wrapper_frame3.png,${ITK_TEST_OUTPUT_DIR}/wrapper_frame4.png"
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/wrapper_frame0.png
+    ${ITK_TEST_OUTPUT_DIR}/wrapper_frame1.png
+    ${ITK_TEST_OUTPUT_DIR}/wrapper_frame2.png
+    ${ITK_TEST_OUTPUT_DIR}/wrapper_frame3.png
+    ${ITK_TEST_OUTPUT_DIR}/wrapper_frame4.png
 )
 
 # FrameDifferenceVideoFilter

--- a/Modules/Video/IO/test/CMakeLists.txt
+++ b/Modules/Video/IO/test/CMakeLists.txt
@@ -23,6 +23,12 @@ itk_add_test(
     1
     24
     MP42
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/frame0.png
+    ${ITK_TEST_OUTPUT_DIR}/frame1.png
+    ${ITK_TEST_OUTPUT_DIR}/frame2.png
+    ${ITK_TEST_OUTPUT_DIR}/frame3.png
+    ${ITK_TEST_OUTPUT_DIR}/frame4.png
 )
 
 # FileListVideoIO:
@@ -43,6 +49,13 @@ itk_add_test(
     240
     5
     1
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/filelistvideoio_frame0.png
+    ${ITK_TEST_OUTPUT_DIR}/filelistvideoio_frame1.png
+    ${ITK_TEST_OUTPUT_DIR}/filelistvideoio_frame2.png
+    ${ITK_TEST_OUTPUT_DIR}/filelistvideoio_frame3.png
+    ${ITK_TEST_OUTPUT_DIR}/filelistvideoio_frame4.png
+    ${ITK_TEST_OUTPUT_DIR}/FileListVideoIOTest_CameraOut.mha
 )
 
 # FileListVideoIOFactory:
@@ -58,4 +71,10 @@ itk_add_test(
     DATA{Input/frame4.jpg}
     "${ITK_TEST_OUTPUT_DIR}/filelistfactory_frame0.png,${ITK_TEST_OUTPUT_DIR}/filelistfactory_frame1.png,${ITK_TEST_OUTPUT_DIR}/filelistfactory_frame2.png,${ITK_TEST_OUTPUT_DIR}/filelistfactory_frame3.png,${ITK_TEST_OUTPUT_DIR}/filelistfactory_frame4.png"
     0
+  ITK_REMOVE_TEMPORARY_TEST_FILES
+    ${ITK_TEST_OUTPUT_DIR}/filelistfactory_frame0.png
+    ${ITK_TEST_OUTPUT_DIR}/filelistfactory_frame1.png
+    ${ITK_TEST_OUTPUT_DIR}/filelistfactory_frame2.png
+    ${ITK_TEST_OUTPUT_DIR}/filelistfactory_frame3.png
+    ${ITK_TEST_OUTPUT_DIR}/filelistfactory_frame4.png
 )


### PR DESCRIPTION
Add an optional `ITK_REMOVE_TEMPORARY_TEST_FILES <file>...` argument to `itk_add_test()` so a test can list the transient `${ITK_TEST_OUTPUT_DIR}`/`${TEMP}` outputs it owns; each such test gets a `FIXTURES_CLEANUP` companion that deletes them. Gated by the `ITK_REMOVE_TEMPORARY_TEST_FILES` option (**`ON` by default**); configure `-DITK_REMOVE_TEMPORARY_TEST_FILES=OFF` to retain outputs for debugging.

**1355 tests instrumented across 126 `test/CMakeLists.txt`.** Supersedes the original 12-file scope after a reviewer asked why only a subset was cleaned.

<details>
<summary>Scope: how the test set was selected</summary>

A deterministic parser over all `Modules/**/test/CMakeLists.txt` groups every writable `${ITK_TEST_OUTPUT_DIR}`/`${TEMP}` output by the tests referencing it:

- **1355** tests have outputs owned by exactly one test → **safe to clean**, wired here.
- **42** outputs are referenced by more than one test (one writes, another consumes) → **excluded** so the file persists for the consumer (BSplineWarping moving image, KdTree `.dot`→`*Plot`, IOScanco read-written `.isq`/`.aim`, etc.). No `DEPENDS`-based consumer chains exist, so no shared file is missed.

Commented-out `itk_add_test` blocks and tests whose `NAME` is an unresolved `${var}` are skipped.
</details>

<details>
<summary>Default behavior (default-ON is intentional)</summary>

Removing transient outputs is the **intended default**. Per CMake, a `FIXTURES_CLEANUP` test runs **unconditionally** after its fixture — pass, fail, or skip — so outputs are removed even on failure. A developer who needs to inspect outputs opts out with `-DITK_REMOVE_TEMPORARY_TEST_FILES=OFF`. The option documentation in `CMake/ITKModuleTest.cmake` states this explicitly.
</details>

<details>
<summary>Helper details</summary>

- The keyword is the only one parsed by `itk_add_test`, so it **must appear last**; this is documented in the helper, and `CMake/stubs/itk_add_test.cmake` declares it so gersemi formats call sites correctly.
- The cleanup command uses `cmake -E rm -rf`, so directory outputs (DICOM series, `FileTools` dirs) are removed as well as plain files.
- Detached-header outputs auto-remove their companion raw data: `.mhd` → `.raw`/`.zraw`, `.nhdr` → `.raw`/`.raw.gz`.
</details>

<details>
<summary>Local validation</summary>

- Rebased on current `upstream/main`; `pre-commit run --all-files` clean.
- Rebuilt affected test drivers; **all 1068 `_cleanup` tests in the default build config pass** (0 failures).
- Targeted run of the 3 directory-output tests + a `.nhdr` test + a comma-list Video test: pass, with the actual outputs (dirs, files, companions) confirmed removed.
</details>

<!--
provenance: claude-code session 2026-06-09 (triage of #6414)
mechanism: ITK_REMOVE_TEMPORARY_TEST_FILES keyword arg to itk_add_test (CMake/ITKModuleTest.cmake); gated by ITK_REMOVE_TEMPORARY_TEST_FILES option, default ON
renames: option ITK_REMOVE_TEST_FILES_ON_SUCCESS -> ITK_REMOVE_TEMPORARY_TEST_FILES; keyword CLEANUP -> ITK_REMOVE_TEMPORARY_TEST_FILES (1355 sites)
fixes: rm -f -> rm -rf (directory outputs); .nhdr companion cleanup; comma-joined cleanup lists -> space-separated multi-values
scope: 1355 single-owner-output tests wired; 42 shared outputs excluded
default_decision: default-ON intended; OFF retains outputs (greptile r3368386930 resolved by doc, not by flipping default)
-->
