### PR TITLE
COMP: Mark in-tree-overridden Get/Set macros with itkVirtual* (refs #6232, #2785)

### DIFF
--- a/Modules/Core/Common/include/itkImageBase.h
+++ b/Modules/Core/Common/include/itkImageBase.h
@@ -186,7 +186,7 @@ public:
    * as SpacePrecisionType but may be set from float or double.
    * \sa GetOrigin() */
   /** @ITKStartGrouping */
-  itkSetMacro(Origin, PointType);
+  itkVirtualSetMacro(Origin, PointType);
   virtual void
   SetOrigin(const double origin[VImageDimension]);
   virtual void
@@ -223,7 +223,7 @@ public:
   /** Get the direction cosines of the image. The direction cosines
    * are vectors that point from one pixel to the next.
    * For ImageBase and Image, the default direction is identity. */
-  itkGetConstReferenceMacro(Direction, DirectionType);
+  itkVirtualGetConstReferenceMacro(Direction, DirectionType);
 
   /** Get the inverse direction cosines of the image.
    * These are calculated automatically in SetDirection, thus there
@@ -234,13 +234,13 @@ public:
    * spacing is the geometric distance between image samples along
    * each dimension. The value returned is a Vector<double, VImageDimension>.
    * For ImageBase and Image, the default data spacing is unity. */
-  itkGetConstReferenceMacro(Spacing, SpacingType);
+  itkVirtualGetConstReferenceMacro(Spacing, SpacingType);
 
   /** Get the origin of the image. The origin is the geometric
    * coordinates of the index (0,0).  The value returned is a
    * Point<double, VImageDimension>. For ImageBase and Image, the
    * default origin is 0. */
-  itkGetConstReferenceMacro(Origin, PointType);
+  itkVirtualGetConstReferenceMacro(Origin, PointType);
 
   /** Allocate the image memory. The size of the image must
    * already be set, e.g. by calling SetRegions() or SetBufferedRegion().

--- a/Modules/Core/Common/include/itkImageSink.h
+++ b/Modules/Core/Common/include/itkImageSink.h
@@ -177,11 +177,11 @@ protected:
 
   /** Set the number of pieces to divide the input.  The upstream pipeline
    * will be executed this many times. */
-  itkSetMacro(NumberOfStreamDivisions, unsigned int);
+  itkVirtualSetMacro(NumberOfStreamDivisions, unsigned int);
 
   /** Get the number of pieces to divide the input. The upstream pipeline
    * will be executed this many times. */
-  itkGetConstMacro(NumberOfStreamDivisions, unsigned int);
+  itkVirtualGetConstMacro(NumberOfStreamDivisions, unsigned int);
 
   /** Set/Get Helper class for dividing the input into regions for
    * streaming */

--- a/Modules/Core/Common/include/itkProcessObject.h
+++ b/Modules/Core/Common/include/itkProcessObject.h
@@ -500,7 +500,7 @@ public:
 
   /** Get/Set the number of work units to create when executing. */
   /** @ITKStartGrouping */
-  itkSetClampMacro(NumberOfWorkUnits, ThreadIdType, 1, ITK_MAX_THREADS);
+  itkVirtualSetClampMacro(NumberOfWorkUnits, ThreadIdType, 1, ITK_MAX_THREADS);
   itkGetConstReferenceMacro(NumberOfWorkUnits, ThreadIdType);
   /** @ITKEndGrouping */
 

--- a/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.h
+++ b/Modules/Core/FiniteDifference/include/itkFiniteDifferenceImageFilter.h
@@ -196,14 +196,14 @@ public:
   /** Set/Get the maximum error allowed in the solution.  This may not be
       defined for all solvers and its meaning may change with the application. */
   /** @ITKStartGrouping */
-  itkSetMacro(MaximumRMSError, double);
+  itkVirtualSetMacro(MaximumRMSError, double);
   itkGetConstReferenceMacro(MaximumRMSError, double);
   /** @ITKEndGrouping */
   /** Set/Get the root mean squared change of the previous iteration. May not
       be used by all solvers. */
   /** @ITKStartGrouping */
   itkSetMacro(RMSChange, double);
-  itkGetConstReferenceMacro(RMSChange, double);
+  itkVirtualGetConstReferenceMacro(RMSChange, double);
   /** @ITKEndGrouping */
   /** Require the filter to be manually reinitialized (by calling
       SetStateToUninitialized() */

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.h
@@ -100,7 +100,7 @@ public:
   itkGetConstReferenceMacro(Gradient, DerivativeType);
 
   /** Get stop condition enum */
-  itkGetConstReferenceMacro(StopCondition, StopConditionObjectToObjectOptimizerEnum);
+  itkVirtualGetConstReferenceMacro(StopCondition, StopConditionObjectToObjectOptimizerEnum);
 
   /** Start and run the optimization */
   void

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.h
@@ -157,7 +157,7 @@ public:
    *  tests. It is suggested to use 1e-6 for less stringent convergence
    *  checking.
    */
-  itkSetMacro(MinimumConvergenceValue, TInternalComputationValueType);
+  itkVirtualSetMacro(MinimumConvergenceValue, TInternalComputationValueType);
 
   /** Window size for the convergence checker.
    *  The convergence checker calculates convergence value by fitting to
@@ -167,12 +167,12 @@ public:
    *  tests. It is suggested to use 10 for less stringent convergence
    *  checking.
    */
-  itkSetMacro(ConvergenceWindowSize, SizeValueType);
+  itkVirtualSetMacro(ConvergenceWindowSize, SizeValueType);
 
   /** Get current convergence value.
    *  WindowConvergenceMonitoringFunction always returns output convergence
    *  value in 'TInternalComputationValueType' precision. */
-  itkGetConstReferenceMacro(ConvergenceValue, TInternalComputationValueType);
+  itkVirtualGetConstReferenceMacro(ConvergenceValue, TInternalComputationValueType);
 
   /** Flag. Set to have the optimizer track and return the best
    *  best metric value and corresponding best parameters that were

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.h
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetric.h
@@ -191,13 +191,13 @@ public:
   UpdateTransformParameters(const DerivativeType & derivative, TParametersValueType factor) override;
 
   /** Connect the fixed transform. */
-  itkSetObjectMacro(FixedTransform, FixedTransformType);
+  itkVirtualSetObjectMacro(FixedTransform, FixedTransformType);
 
   /** Get a pointer to the fixed transform.  */
   itkGetModifiableObjectMacro(FixedTransform, FixedTransformType);
 
   /** Connect the moving transform. */
-  itkSetObjectMacro(MovingTransform, MovingTransformType);
+  itkVirtualSetObjectMacro(MovingTransform, MovingTransformType);
 
   /** Get a pointer to the moving transform.  */
   itkGetModifiableObjectMacro(MovingTransform, MovingTransformType);

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetricBase.h
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectMetricBase.h
@@ -122,12 +122,12 @@ public:
 
   /** Get/Set the Fixed Object.  */
   /** @ITKStartGrouping */
-  itkSetConstObjectMacro(FixedObject, ObjectType);
+  itkVirtualSetConstObjectMacro(FixedObject, ObjectType);
   itkGetConstObjectMacro(FixedObject, ObjectType);
   /** @ITKEndGrouping */
   /** Get/Set the Moving Object.  */
   /** @ITKStartGrouping */
-  itkSetConstObjectMacro(MovingObject, ObjectType);
+  itkVirtualSetConstObjectMacro(MovingObject, ObjectType);
   itkGetConstObjectMacro(MovingObject, ObjectType);
   /** @ITKEndGrouping */
   using GradientSourceEnum = itk::ObjectToObjectMetricBaseTemplateEnums::GradientSource;

--- a/Modules/Numerics/Optimizersv4/include/itkObjectToObjectOptimizerBase.h
+++ b/Modules/Numerics/Optimizersv4/include/itkObjectToObjectOptimizerBase.h
@@ -152,7 +152,7 @@ public:
 
   /** Accessors for Metric */
   /** @ITKStartGrouping */
-  itkSetObjectMacro(Metric, MetricType);
+  itkVirtualSetObjectMacro(Metric, MetricType);
   itkGetModifiableObjectMacro(Metric, MetricType);
   /** @ITKEndGrouping */
 
@@ -249,10 +249,10 @@ public:
   itkGetConstMacro(CurrentIteration, SizeValueType);
 
   /** Set the number of iterations. */
-  itkSetMacro(NumberOfIterations, SizeValueType);
+  itkVirtualSetMacro(NumberOfIterations, SizeValueType);
 
   /** Get the number of iterations. */
-  itkGetConstMacro(NumberOfIterations, SizeValueType);
+  itkVirtualGetConstMacro(NumberOfIterations, SizeValueType);
 
   /** Get a reference to the current position of the optimization.
    * This returns the parameters from the assigned metric, since the optimizer

--- a/Modules/Numerics/Statistics/include/itkSample.h
+++ b/Modules/Numerics/Statistics/include/itkSample.h
@@ -150,7 +150,7 @@ public:
   }
 
   /** Get method for the length of the measurement vector */
-  itkGetConstMacro(MeasurementVectorSize, MeasurementVectorSizeType);
+  itkVirtualGetConstMacro(MeasurementVectorSize, MeasurementVectorSizeType);
 
   /** Method to graft another sample */
   void

--- a/Modules/Numerics/Statistics/include/itkSubsamplerBase.h
+++ b/Modules/Numerics/Statistics/include/itkSubsamplerBase.h
@@ -93,7 +93,7 @@ public:
    *  The seed value will be used by subclasses where appropriate.
    */
   /** @ITKStartGrouping */
-  itkSetMacro(Seed, SeedType);
+  itkVirtualSetMacro(Seed, SeedType);
   itkGetConstReferenceMacro(Seed, SeedType);
   /** @ITKEndGrouping */
 

--- a/Modules/Registration/Common/include/itkImageToImageMetric.h
+++ b/Modules/Registration/Common/include/itkImageToImageMetric.h
@@ -146,7 +146,7 @@ public:
   itkGetConstObjectMacro(MovingImage, MovingImageType);
   /** @ITKEndGrouping */
   /** Connect the Transform. */
-  itkSetObjectMacro(Transform, TransformType);
+  itkVirtualSetObjectMacro(Transform, TransformType);
 
   /** Get a pointer to the Transform.  */
   itkGetModifiableObjectMacro(Transform, TransformType);

--- a/Modules/Registration/Common/include/itkTransformParametersAdaptorBase.h
+++ b/Modules/Registration/Common/include/itkTransformParametersAdaptorBase.h
@@ -80,7 +80,7 @@ public:
   SetTransform(TransformBaseType * _arg, void * priorityLower = nullptr) = 0;
 
   /** Set the fixed parameters */
-  itkSetMacro(RequiredFixedParameters, FixedParametersType);
+  itkVirtualSetMacro(RequiredFixedParameters, FixedParametersType);
 
   /** Get the fixed parameters */
   itkGetConstReferenceMacro(RequiredFixedParameters, FixedParametersType);

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.h
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryImageFilter.h
@@ -92,14 +92,14 @@ public:
   /** Birth threshold. Pixels that are OFF will turn ON when the number of
    * neighbors ON is larger than the value defined in this threshold. */
   /** @ITKStartGrouping */
-  itkGetConstReferenceMacro(BirthThreshold, unsigned int);
-  itkSetMacro(BirthThreshold, unsigned int);
+  itkVirtualGetConstReferenceMacro(BirthThreshold, unsigned int);
+  itkVirtualSetMacro(BirthThreshold, unsigned int);
   /** @ITKEndGrouping */
   /** Survival threshold. Pixels that are ON will turn OFF when the number of
    * neighbors ON is smaller than the value defined in this survival threshold. */
   /** @ITKStartGrouping */
-  itkGetConstReferenceMacro(SurvivalThreshold, unsigned int);
-  itkSetMacro(SurvivalThreshold, unsigned int);
+  itkVirtualGetConstReferenceMacro(SurvivalThreshold, unsigned int);
+  itkVirtualSetMacro(SurvivalThreshold, unsigned int);
   /** @ITKEndGrouping */
   /** VotingBinaryImageFilter needs a larger input requested region than
    * the output requested region.  As such, VotingBinaryImageFilter needs

--- a/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.h
+++ b/Modules/Segmentation/LevelSets/include/itkSparseFieldLevelSetImageFilter.h
@@ -296,7 +296,7 @@ public:
    *  number of layers on ONE side of the active layer, so the total layers in
    *   the sparse field is 2 * NumberOfLayers +1 */
   /** @ITKStartGrouping */
-  itkSetMacro(NumberOfLayers, unsigned int);
+  itkVirtualSetMacro(NumberOfLayers, unsigned int);
   itkGetConstMacro(NumberOfLayers, unsigned int);
   /** @ITKEndGrouping */
   /** Set/Get the value of the isosurface to use in the input image. */


### PR DESCRIPTION
Mark the 29 base-class Get/Set macro sites that an **in-tree derived class overrides** with the explicit `itkVirtual*` variants added in #6253. Zero behavior change — the legacy and `itkVirtual*` macros both emit `virtual` today; this only makes the intentional polymorphism visible at the call site and pre-stages the non-virtual default flip discussed in #6232. Refs #2785.

<details>
<summary>Why these sites, and why now</summary>

#6253 added `itkVirtual*`/`itkFinal*`/`itkNonVirtual*` macro variants as additive, ABI-neutral infrastructure. This PR is the first consumer: it converts the legacy `itkSetMacro`/`itkGetConstMacro`/… calls **at the specific base-class members that a derived ITK class actually overrides** to `itkVirtual*`, so a future change that makes the plain macros non-virtual (tracked in #6232, originally proposed in #2785) leaves these polymorphic members untouched.

The conversion is mechanical and provably non-behavioral: every removed legacy macro has a 1:1 matching `itkVirtual*` macro with identical arguments, and both expand to a `virtual` member today.
</details>

<details>
<summary>How the 29 sites were verified (and 13 candidates dropped)</summary>

The starting point was the conversion list in #2785 (42 sites). Each was re-verified against current `main` by transitive-descendant analysis — a site is kept only if a class that *transitively derives* from the macro's owning class hand-writes `Set/Get<X>(...) override`. Plain name matching is insufficient (e.g. `FileListVideoIO::SetFileName` is unrelated to `ImageIOBase::SetFileName`; the former does not derive from the latter).

Dropped as **not** in-tree override sites:
- `STAPLEImageFilter::MaximumIterations` (not subclassed; also now `itkSetClampMacro`)
- `ImageIOBase::FileName`, `FiniteDifferenceImageFilter::NumberOfIterations` (only "overridden" in unrelated hierarchies)
- `ImageToSpatialObjectMetric::MovingSpatialObject` (class not subclassed in-tree)
- `MRFImageFilter::{NumberOfClasses, MaximumNumberOfIterations}` (subclass `RGBGibbsPriorFilter` does not override)
- `TemporalProcessObject::{UnitInputNumberOfFrames, UnitOutputNumberOfFrames, FrameSkipPerOutput, InputStencilCurrentFrameIndex}` (subclasses `VideoSource`/`VideoFileWriter` do not override)

Kept (descendant override confirmed): `ImageBase` Origin/Spacing/Direction (→`ImageAdaptor`), `ImageSink::NumberOfStreamDivisions` (→`StatisticsImageFilter`), `ProcessObject::NumberOfWorkUnits`, `FiniteDifferenceImageFilter` MaximumRMSError/RMSChange (→`NarrowBandImageFilterBase`/demons), the Optimizersv4 metric/transform/convergence family (→`LBFGS*`/`ObjectToObjectMultiMetricv4`), `Sample::MeasurementVectorSize`, `SubsamplerBase::Seed`, `ImageToImageMetric::Transform` (→`HistogramImageToImageMetric`), `VotingBinaryImageFilter` thresholds (→`VotingBinaryHoleFillingImageFilter`), `SparseFieldLevelSetImageFilter::NumberOfLayers`.
</details>

<details>
<summary>Validation</summary>

- `pre-commit run --all-files` — exit 0.
- Diff is a verified 1:1 macro rename: `29 insertions(+), 29 deletions(-)`, every `-` line a legacy macro and every `+` line its `itkVirtual*` equivalent with identical arguments.
- Local build (macOS arm64, pixi cxx, Release) of the affected module drivers links cleanly: `ITKCommonGTestDriver`, `ITKOptimizersv4TestDriver`, `ITKStatisticsTestDriver`, `ITKRegistrationCommonTestDriver`, `ITKLabelVotingTestDriver`, `ITKLevelSetsTestDriver`.
</details>

<!--
provenance: claude-code session 2026-06-06 (hjmjohnson); regenerated PR-B from #2785 against current main
tracking_issue: #6232 (master umbrella for virtual/override/final Get/Set semantics)
macro_infra: #6253 (itkVirtual/itkFinal/itkNonVirtual variants — additive, merged)
behavior: zero codegen change in v6 (legacy and itkVirtual* both emit virtual); markers pin in-tree-overridden members ahead of any future non-virtual default flip
verification: transitive-descendant override analysis; 42 candidate sites from #2785 -> 29 kept, 13 dropped (STAPLE/ImageIOBase::FileName/FiniteDiff::NumberOfIterations/ImageToSpatialObjectMetric/MRF x2/TemporalProcessObject x5)
co_authors: N-Dekker (canonical #2785 list), jhlegarreta (blocked-on #2568)
-->
