### PR TITLE
WIP: BUG: Disable Strain Lagrangian and Eulerian tests pending missing baselines

### DIFF
--- a/Modules/Filtering/Strain/test/CMakeLists.txt
+++ b/Modules/Filtering/Strain/test/CMakeLists.txt
@@ -23,31 +23,34 @@ itk_add_test(
     "INFINITESIMAL"
 )
 
-itk_add_test(
-  NAME itkStrainImageFilterLagrangianTest
-  COMMAND
-    StrainTestDriver
-    --compare
-    DATA{Baseline/LineLoadStrainLagrangian.mha}
-    ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterLagrangianTestOutput.vtk
-    itkStrainImageFilterTest
-    DATA{Input/LineLoadDisplacement.mha}
-    ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterLagrangianTest
-    "GREENLAGRANGIAN"
-)
-
-itk_add_test(
-  NAME itkStrainImageFilterEulerianTest
-  COMMAND
-    StrainTestDriver
-    --compare
-    DATA{Baseline/LineLoadStrainEulerian.mha}
-    ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterEulerianTestOutput.vtk
-    itkStrainImageFilterTest
-    DATA{Input/LineLoadDisplacement.mha}
-    ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterEulerianTest
-    "EULERIANALMANSI"
-)
+# Disabled: baselines LineLoadStrainLagrangian.mha and LineLoadStrainEulerian.mha
+# are empty (0-byte) blobs in ITKTestingData and cannot be fetched. Re-enable once
+# the data is restored. See InsightSoftwareConsortium/ITK#6417.
+#itk_add_test(
+#  NAME itkStrainImageFilterLagrangianTest
+#  COMMAND
+#    StrainTestDriver
+#    --compare
+#    DATA{Baseline/LineLoadStrainLagrangian.mha}
+#    ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterLagrangianTestOutput.vtk
+#    itkStrainImageFilterTest
+#    DATA{Input/LineLoadDisplacement.mha}
+#    ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterLagrangianTest
+#    "GREENLAGRANGIAN"
+#)
+#
+#itk_add_test(
+#  NAME itkStrainImageFilterEulerianTest
+#  COMMAND
+#    StrainTestDriver
+#    --compare
+#    DATA{Baseline/LineLoadStrainEulerian.mha}
+#    ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterEulerianTestOutput.vtk
+#    itkStrainImageFilterTest
+#    DATA{Input/LineLoadDisplacement.mha}
+#    ${ITK_TEST_OUTPUT_DIR}/itkStrainImageFilterEulerianTest
+#    "EULERIANALMANSI"
+#)
 
 itk_add_test(
   NAME itkStrainImageFilterDoGTest


### PR DESCRIPTION
**WIP / holding change.** Disables two Strain tests whose baseline images are missing from ITKTestingData, to keep builds green while the data is recovered. Tracking: #6417.

This is intentionally temporary — it should be **reverted** (re-enabling the tests) once the baselines are restored, or this PR **closed** if the data is recovered before it merges.

<details>
<summary>Why the tests fail</summary>

`itkStrainImageFilterLagrangianTest` and `itkStrainImageFilterEulerianTest` compare against `DATA{Baseline/LineLoadStrainLagrangian.mha}` and `DATA{Baseline/LineLoadStrainEulerian.mha}`. Both were committed to `ITKTestingData` (commit `e318e62`) as **empty 0-byte blobs**, so they cannot be fetched from any ExternalData source (IPFS gateways return "no provider", GitHub Pages 404). MetaIO then reports `INVALID_BASELINE_GIVEN`.

Only these two baselines are affected — `LineLoadStrain.mha` (Infinitesimal / DoG / RecursiveGaussian tests) is intact.

CIDs of the missing data:
- `LineLoadStrainLagrangian.mha` → `bafkreiaq2quooedgibkhgtzqgwwgrwverrz3vf7j7z7gx2gbieyqjz7vy4`
- `LineLoadStrainEulerian.mha` → `bafkreibpcbnp2xrgbyl3zkzfdohejk26sqs6dbdra54el6aphc2okrwnj4`
</details>

<details>
<summary>Disposition</summary>

- Baselines restored to ITKTestingData → **revert this commit** to re-enable the tests.
- Data recovered before this merges → **close** this PR.
</details>

<!--
provenance: companion to issue #6417 (missing Strain baselines / empty ITKTestingData blobs).
discovered while validating an ITK maximal build (BUILD_EXAMPLES+Testing+remote modules).
ITKTestingData empty-blob commit: e318e62 ; 5/3671 CID blobs empty.
revert-target commit: this PR's single commit. re-enable by reverting once data lands.
-->
