### PR TITLE
BUG: Fix flaky AdaptiveNonLocalMeansDenoisingImageFilterTest1 under parallel load

### DIFF
--- a/Modules/Filtering/AdaptiveDenoising/test/itkAdaptiveNonLocalMeansDenoisingImageFilterTest.cxx
+++ b/Modules/Filtering/AdaptiveDenoising/test/itkAdaptiveNonLocalMeansDenoisingImageFilterTest.cxx
@@ -115,6 +115,10 @@ itkAdaptiveNonLocalMeansDenoisingImageFilterTest(int argc, char * argv[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, AdaptiveNonLocalMeansDenoisingImageFilter, NonLocalPatchBasedImageFilter);
 
   filter->SetInput(reader->GetOutput());
+
+  // Single-threaded: m_RicianBiasImage data race across work-unit boundaries; see #6419.
+  filter->SetNumberOfWorkUnits(1);
+
   filter->SetUseRicianNoiseModel(false);
   ITK_TEST_SET_GET_VALUE(false, filter->GetUseRicianNoiseModel());
 


### PR DESCRIPTION
Pins `AdaptiveNonLocalMeansDenoisingImageFilterTest1`'s filter to a single work unit so the test is deterministic under parallel load. Fixes intermittent CI failures; tracks the underlying filter data race in #6419.

<details>
<summary>Why the test flakes (root cause)</summary>

`AdaptiveNonLocalMeansDenoisingImageFilter::ThreadedGenerateData` scatter-writes `m_RicianBiasImage` at `centerIndex + patchOffset` indices that cross work-unit boundaries, so multiple work units do unsynchronized `SetPixel` on the same shared pixels — a data race. It is benign at low contention (passes in isolation) but, under `ctest -j8` oversubscription, preemption widens the window and the output diverges from the baseline.

| Condition | Result |
|---|---|
| default work units, `-j8` | fails 50-100% of runs |
| `SetNumberOfWorkUnits(1)`, `-j8` | passes 100% (6/6), deterministic |

The baseline matches the single-threaded (race-free) result. Full analysis in #6419.
</details>

<details>
<summary>Scope / disposition</summary>

This is an **interim** test-only mitigation so CI stops flaking. The **proper fix belongs in the filter** (make the scatter race-free — gather formulation, per-work-unit buffers, or own-region-only writes); that is tracked in #6419 and should supersede this pin.
</details>

<!--
provenance: found validating an ITK build under ctest -j8; companion to issue #6419.
file: Modules/Filtering/AdaptiveDenoising/include/itkAdaptiveNonLocalMeansDenoisingImageFilter.hxx (ThreadedGenerateData m_RicianBiasImage scatter)
verified: 1 work unit => 6/6 pass under -j8; default => 50-100% fail.
post_merge_action: revert this pin once the filter scatter is made race-free (#6419).
-->
