### PR TITLE
COMP: Use ITK_EIGEN macro and ITK_LIBRARY_NAMESPACE in proxTV

### DIFF
--- a/Modules/ThirdParty/proxTV/CMakeLists.txt
+++ b/Modules/ThirdParty/proxTV/CMakeLists.txt
@@ -47,7 +47,7 @@ endif()
   )
 
   set(proxTV_USE_LAPACK 0)
-  set(proxTV_Eigen_LIBRARIES ITK::ITKEigen3Module)
+  set(proxTV_Eigen_LIBRARIES ${ITK_LIBRARY_NAMESPACE}::ITKEigen3Module)
 
   include(${CMAKE_CURRENT_LIST_DIR}/proxTVGitTag.cmake)
 
@@ -60,15 +60,6 @@ endif()
   # end proxTV options
 
   FetchContent_MakeAvailable(proxTV_fetch)
-
-  # proxTV sources include <Eigen/...>; ITK vendors Eigen under an itkeigen/
-  # prefix, so add the directory that holds Eigen/ directly to the build.
-  target_include_directories(
-    proxTV
-    SYSTEM
-    PRIVATE
-      "${ITKEigen3_SOURCE_DIR}/src/itkeigen"
-  )
 endif()
 
 itk_module_impl()

--- a/Modules/ThirdParty/proxTV/proxTVGitTag.cmake
+++ b/Modules/ThirdParty/proxTV/proxTVGitTag.cmake
@@ -3,4 +3,4 @@ set(
   proxTV_GIT_REPOSITORY
   "https://github.com/InsightSoftwareConsortium/proxTV.git"
 )
-set(proxTV_GIT_TAG "for/itk-proxtv-3.3.0-ae0dc0da")
+set(proxTV_GIT_TAG "for/itk-proxtv-3.3.0-69062fe5")


### PR DESCRIPTION
Replace the manual `itkeigen/` include path workaround with the `ITK_EIGEN()` macro, and use `ITK_LIBRARY_NAMESPACE` for the Eigen target name.

<details>
<summary>Vendored ITK Eigen — valid usage patterns</summary>

ITK vendors Eigen3 under an `itkeigen/` prefix when `ITK_USE_SYSTEM_EIGEN=OFF`. Code that includes Eigen headers must use the `ITK_EIGEN()` macro from `itk_eigen.h` so the include path resolves correctly for both vendored and system Eigen.

**Include the header:**
```cpp
#include "itk_eigen.h"
#include ITK_EIGEN(Dense)         // expands to <itkeigen/Eigen/Dense> or <Eigen/Dense>
#include ITK_EIGEN(Eigenvalues)
#include ITK_EIGEN(Sparse)
```

**Do not use:**
```cpp
#include <Eigen/Dense>            // breaks with vendored Eigen
#include <itkeigen/Eigen/Dense>   // breaks with system Eigen
```

**CMake target linkage** — use `ITK_LIBRARY_NAMESPACE` rather than the hard-coded `ITK` prefix:
```cmake
target_link_libraries(myTarget PRIVATE ${ITK_LIBRARY_NAMESPACE}::ITKEigen3Module)
```
`ITK_LIBRARY_NAMESPACE` defaults to `"ITK"` but respects downstream projects that configure a custom namespace. The per-module variable `ITK_MODULE_<name>_TARGETS_NAMESPACE` is an equivalent derived value used internally by the ITK macro infrastructure; either is correct, but `ITK_LIBRARY_NAMESPACE` is available earlier in the configure sequence.

</details>

<details>
<summary>AI assistance</summary>

- Tool: GitHub Copilot (Claude Sonnet 4.6)
- Role: identified the include path mismatch, applied macro and namespace fixes

</details>