### PR TITLE
ENH: Decouple itk::Math from vnl_math (constants and functions)

### DIFF
--- a/Documentation/docs/migration_guides/itk_6_migration_guide.md
+++ b/Documentation/docs/migration_guides/itk_6_migration_guide.md
@@ -227,6 +227,12 @@ ITKVNL module. The ITKVNLInstantiation library was an empty library used for
 compatibility and provided transitive linking to ITKVNL.
 
 
+`itk::Math::sqrteps` changed by 1 ULP for accuracy
+--------------------------------------------------
+
+`itk::Math::sqrteps` is now `0x1p-26`, the exact `sqrt(eps)`;
+`vnl_math::sqrteps` (`1.490116119384766e-08`) was 1 ULP higher.
+
 Prefer itk::AnatomicalOrientation over itk::SpatialOrientation
 ------------------------------------------------
 

--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -33,6 +33,11 @@
 #include <cmath>
 #include <limits>
 #include <type_traits>
+// _MSVC_LANG tracks /std: even when __cplusplus stays 199711L (no /Zc:__cplusplus),
+// matching the STL condition under which <limits> defines __cpp_lib_math_constants.
+#if (defined(__cplusplus) && __cplusplus >= 202002L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
+#  include <numbers>
+#endif
 #include "itkMathDetail.h"
 #include "itkConceptChecking.h"
 #include <vnl/vnl_math.h>
@@ -46,59 +51,80 @@
 
 namespace itk::Math
 {
-// These constants originate from VXL's vnl_math.h. They are exposed as
-// inline constexpr namespace-scope constants so they are usable in
-// constant expressions with a single shared definition across translation
-// units.
-
+// These mathematical constants originate from VXL's vnl_math.h: correctly-rounded
+// double-precision literals (OEIS references in vnl_math.h), defined identically under
+// every C++ standard level and verified against C++20 <numbers> below.
 
 /** \brief \f[e\f] The base of the natural logarithm or Euler's number */
-inline constexpr double e = vnl_math::e;
+inline constexpr double e = 2.71828182845904523536;
 /** \brief  \f[ \log_2 e \f] */
-inline constexpr double log2e = vnl_math::log2e;
+inline constexpr double log2e = 1.44269504088896340736;
 /** \brief \f[ \log_{10} e \f] */
-inline constexpr double log10e = vnl_math::log10e;
+inline constexpr double log10e = 0.43429448190325182765;
 /** \brief \f[ \log_e 2 \f] */
-inline constexpr double ln2 = vnl_math::ln2;
+inline constexpr double ln2 = 0.69314718055994530942;
 /** \brief \f[ \log_e 10 \f] */
-inline constexpr double ln10 = vnl_math::ln10;
+inline constexpr double ln10 = 2.30258509299404568402;
 /** \brief \f[ \pi \f]  */
-inline constexpr double pi = vnl_math::pi;
+inline constexpr double pi = 3.14159265358979323846;
 /** \brief \f[ 2\pi \f]  */
-inline constexpr double twopi = vnl_math::twopi;
+inline constexpr double twopi = 6.28318530717958647693;
 /** \brief \f[ \frac{\pi}{2} \f]  */
-inline constexpr double pi_over_2 = vnl_math::pi_over_2;
+inline constexpr double pi_over_2 = 1.57079632679489661923;
 /** \brief \f[ \frac{\pi}{4} \f]  */
-inline constexpr double pi_over_4 = vnl_math::pi_over_4;
+inline constexpr double pi_over_4 = 0.78539816339744830962;
 /** \brief \f[ \frac{\pi}{180} \f]  */
-inline constexpr double pi_over_180 = vnl_math::pi_over_180;
+inline constexpr double pi_over_180 = 0.01745329251994329577;
 /** \brief \f[ \frac{1}{\pi} \f]  */
-inline constexpr double one_over_pi = vnl_math::one_over_pi;
+inline constexpr double one_over_pi = 0.31830988618379067154;
 /** \brief \f[ \frac{2}{\pi} \f]  */
-inline constexpr double two_over_pi = vnl_math::two_over_pi;
+inline constexpr double two_over_pi = 0.63661977236758134308;
 /** \brief \f[ \frac{180}{\pi} \f]  */
-inline constexpr double deg_per_rad = vnl_math::deg_per_rad;
+inline constexpr double deg_per_rad = 57.2957795130823208768;
 /** \brief \f[ \sqrt{2\pi} \f]  */
-inline constexpr double sqrt2pi = vnl_math::sqrt2pi;
+inline constexpr double sqrt2pi = 2.50662827463100050242;
 /** \brief \f[ \frac{2}{\sqrt{\pi}} \f]  */
-inline constexpr double two_over_sqrtpi = vnl_math::two_over_sqrtpi;
+inline constexpr double two_over_sqrtpi = 1.12837916709551257390;
 /** \brief \f[ \frac{1}{\sqrt{2\pi}} \f]  */
-inline constexpr double one_over_sqrt2pi = vnl_math::one_over_sqrt2pi;
+inline constexpr double one_over_sqrt2pi = 0.39894228040143267794;
 /** \brief \f[ \sqrt{2} \f]  */
-inline constexpr double sqrt2 = vnl_math::sqrt2;
+inline constexpr double sqrt2 = 1.41421356237309504880;
 /** \brief \f[ \sqrt{ \frac{1}{2}} \f] */
-inline constexpr double sqrt1_2 = vnl_math::sqrt1_2;
+inline constexpr double sqrt1_2 = 0.70710678118654752440;
 /** \brief \f[ \sqrt{ \frac{1}{3}} \f] */
-inline constexpr double sqrt1_3 = vnl_math::sqrt1_3;
+inline constexpr double sqrt1_3 = 0.57735026918962576451;
 /** \brief euler constant */
-inline constexpr double euler = vnl_math::euler;
+inline constexpr double euler = 0.57721566490153286061;
+
+#if defined(__cpp_lib_math_constants)
+// Bit-exactness proof against C++20 <numbers>. sqrt2pi and one_over_sqrt2pi have no
+// exact std::numbers identity (inv_sqrtpi / sqrt2 double-rounds 1 ULP off).
+static_assert(e == std::numbers::e);
+static_assert(log2e == std::numbers::log2e);
+static_assert(log10e == std::numbers::log10e);
+static_assert(ln2 == std::numbers::ln2);
+static_assert(ln10 == std::numbers::ln10);
+static_assert(pi == std::numbers::pi);
+static_assert(twopi == 2 * std::numbers::pi);
+static_assert(pi_over_2 == std::numbers::pi / 2);
+static_assert(pi_over_4 == std::numbers::pi / 4);
+static_assert(pi_over_180 == std::numbers::pi / 180);
+static_assert(one_over_pi == std::numbers::inv_pi);
+static_assert(two_over_pi == 2 * std::numbers::inv_pi);
+static_assert(deg_per_rad == 180 * std::numbers::inv_pi);
+static_assert(two_over_sqrtpi == 2 * std::numbers::inv_sqrtpi);
+static_assert(sqrt2 == std::numbers::sqrt2);
+static_assert(sqrt1_2 == std::numbers::sqrt2 / 2);
+static_assert(sqrt1_3 == std::numbers::inv_sqrt3);
+static_assert(euler == std::numbers::egamma);
+#endif
 
 //: IEEE double machine precision
-inline constexpr double eps = vnl_math::eps;
-inline constexpr double sqrteps = vnl_math::sqrteps;
+inline constexpr double eps = std::numeric_limits<double>::epsilon();
+inline constexpr double sqrteps = 1.490116119384766e-08;
 //: IEEE single machine precision
-inline constexpr float float_eps = vnl_math::float_eps;
-inline constexpr float float_sqrteps = vnl_math::float_sqrteps;
+inline constexpr float float_eps = std::numeric_limits<float>::epsilon();
+inline constexpr float float_sqrteps = 3.4526698300e-4F;
 
 /** A useful macro to generate a template floating point to integer
  *  conversion templated on the return type and using either the 32

--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -40,7 +40,10 @@
 #endif
 #include "itkMathDetail.h"
 #include "itkConceptChecking.h"
-#include <vnl/vnl_math.h>
+#if !defined(ITK_FUTURE_LEGACY_REMOVE)
+// itk::Math no longer uses vnl_math; kept transitionally for downstream vnl_math:: users.
+#  include <vnl/vnl_math.h>
+#endif
 
 namespace itk::Math
 {

--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -853,8 +853,8 @@ UnsignedPower(const uintmax_t base, const uintmax_t exponent) noexcept -> TRetur
 
 
 /*==========================================
- * Alias the vnl_math functions in the itk::Math
- * namespace. If possible, use the std:: equivalents
+ * itk::Math utility functions. std:: equivalents are used where they exist;
+ * the remainder are native definitions providing the historical interface.
  */
 using std::isnan;
 using std::isinf;
@@ -862,20 +862,246 @@ using std::isfinite;
 using std::isnormal;
 using std::cbrt;
 using std::hypot;
-using vnl_math::angle_0_to_2pi;
-using vnl_math::angle_minuspi_to_pi;
-using vnl_math::rnd_halfinttoeven;
-using vnl_math::rnd_halfintup;
-using vnl_math::rnd;
-using vnl_math::floor;
-using vnl_math::ceil;
-using vnl_math::sgn;
-using vnl_math::sgn0;
-using vnl_math::remainder_truncated;
-using vnl_math::remainder_floored;
-using vnl_math::sqr;
-using vnl_math::cube;
-using vnl_math::squared_magnitude;
+
+/** \brief Sign of a value: -1, 0, or +1. */
+template <typename T, std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
+constexpr int
+sgn(T x)
+{
+  return (x != T{}) ? ((x > T{}) ? 1 : -1) : 0;
+}
+
+/** \brief Sign of a value in {-1, +1}; zero maps to +1. */
+template <typename T, std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
+constexpr int
+sgn0(T x)
+{
+  return (x >= T{}) ? 1 : -1;
+}
+
+/** \brief Square of a value. */
+constexpr bool
+sqr(bool x)
+{
+  return x;
+}
+template <typename T, std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
+constexpr T
+sqr(T x)
+{
+  return x * x;
+}
+
+/** \brief Cube of a value. */
+constexpr bool
+cube(bool x)
+{
+  return x;
+}
+template <typename T, std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
+constexpr T
+cube(T x)
+{
+  return x * x * x;
+}
+
+/** \brief Squared magnitude; integer results are unsigned. */
+constexpr unsigned int
+squared_magnitude(char x)
+{
+  return static_cast<unsigned int>(static_cast<int>(x) * static_cast<int>(x));
+}
+constexpr unsigned int
+squared_magnitude(unsigned char x)
+{
+  return static_cast<unsigned int>(static_cast<int>(x) * static_cast<int>(x));
+}
+constexpr unsigned int
+squared_magnitude(int x)
+{
+  return static_cast<unsigned int>(x * x);
+}
+constexpr unsigned int
+squared_magnitude(unsigned int x)
+{
+  return x * x;
+}
+constexpr unsigned long
+squared_magnitude(long x)
+{
+  return static_cast<unsigned long>(x * x);
+}
+constexpr unsigned long
+squared_magnitude(unsigned long x)
+{
+  return x * x;
+}
+constexpr unsigned long long
+squared_magnitude(long long x)
+{
+  return static_cast<unsigned long long>(x * x);
+}
+constexpr unsigned long long
+squared_magnitude(unsigned long long x)
+{
+  return x * x;
+}
+constexpr float
+squared_magnitude(float x)
+{
+  return x * x;
+}
+constexpr double
+squared_magnitude(double x)
+{
+  return x * x;
+}
+constexpr long double
+squared_magnitude(long double x)
+{
+  return x * x;
+}
+
+/** \brief Truncated remainder: quotient truncated toward zero, result has the sign of x. */
+template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
+constexpr T
+remainder_truncated(T x, T y)
+{
+  return x % y;
+}
+inline float
+remainder_truncated(float x, float y)
+{
+  return std::fmod(x, y);
+}
+inline double
+remainder_truncated(double x, double y)
+{
+  return std::fmod(x, y);
+}
+inline long double
+remainder_truncated(long double x, long double y)
+{
+  return std::fmod(x, y);
+}
+
+/** \brief Floored remainder: quotient rounded toward minus infinity, result has the sign of y. */
+template <typename T, std::enable_if_t<std::is_integral_v<T> && std::is_signed_v<T>, int> = 0>
+constexpr T
+remainder_floored(T x, T y)
+{
+  return ((x % y) + y) % y;
+}
+template <typename T, std::enable_if_t<std::is_integral_v<T> && std::is_unsigned_v<T>, int> = 0>
+constexpr T
+remainder_floored(T x, T y)
+{
+  return x % y;
+}
+inline float
+remainder_floored(float x, float y)
+{
+  return std::fmod(std::fmod(x, y) + y, y);
+}
+inline double
+remainder_floored(double x, double y)
+{
+  return std::fmod(std::fmod(x, y) + y, y);
+}
+inline long double
+remainder_floored(long double x, long double y)
+{
+  return std::fmod(std::fmod(x, y) + y, y);
+}
+
+/** \brief Round to nearest integer, halfway cases to the nearest even integer. */
+inline int
+rnd_halfinttoeven(float x)
+{
+  return static_cast<int>(std::lrint(x));
+}
+inline int
+rnd_halfinttoeven(double x)
+{
+  return static_cast<int>(std::lrint(x));
+}
+
+/** \brief Round to nearest integer, halfway cases upward (toward plus infinity).
+ *  Valid only for |x| < INT_MAX / 2. */
+inline int
+rnd_halfintup(float x)
+{
+  return rnd_halfinttoeven(2 * x + 0.5f) >> 1;
+}
+inline int
+rnd_halfintup(double x)
+{
+  return rnd_halfinttoeven(2 * x + 0.5) >> 1;
+}
+
+/** \brief Round to nearest integer; halfway cases follow round-half-to-even. */
+inline int
+rnd(float x)
+{
+  return static_cast<int>(std::lrint(x));
+}
+inline int
+rnd(double x)
+{
+  return static_cast<int>(std::lrint(x));
+}
+
+/** \brief Round toward minus infinity. */
+inline int
+floor(float x)
+{
+  return static_cast<int>(std::floor(x));
+}
+inline int
+floor(double x)
+{
+  return static_cast<int>(std::floor(x));
+}
+
+/** \brief Round toward plus infinity. */
+inline int
+ceil(float x)
+{
+  return static_cast<int>(std::ceil(x));
+}
+inline int
+ceil(double x)
+{
+  return static_cast<int>(std::ceil(x));
+}
+
+/** \brief Normalize an angle (radians) into [0, 2*pi). */
+inline double
+angle_0_to_2pi(double angle)
+{
+  angle = std::fmod(angle, twopi);
+  if (angle >= 0)
+    return angle;
+  const double a = angle + twopi;
+  if (a > 0 && a < twopi)
+    return a;
+  // Guard the boundary: tiny negative inputs can produce exactly twopi above.
+  if (angle < 0)
+    return 6.28318530717958575;
+  return angle;
+}
+
+/** \brief Normalize an angle (radians) into (-pi, pi]. */
+inline double
+angle_minuspi_to_pi(double angle)
+{
+  angle = std::fmod(angle, twopi);
+  if (angle > pi)
+    angle -= twopi;
+  if (angle < -pi)
+    angle += twopi;
+  return angle;
+}
 
 
 /**

--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -922,7 +922,9 @@ squared_magnitude(unsigned char x)
 constexpr unsigned int
 squared_magnitude(int x)
 {
-  return static_cast<unsigned int>(x * x);
+  // Multiply in unsigned: avoids the signed-overflow UB of vnl_math's x * x.
+  const auto ux = static_cast<unsigned int>(x);
+  return ux * ux;
 }
 constexpr unsigned int
 squared_magnitude(unsigned int x)
@@ -932,7 +934,8 @@ squared_magnitude(unsigned int x)
 constexpr unsigned long
 squared_magnitude(long x)
 {
-  return static_cast<unsigned long>(x * x);
+  const auto ux = static_cast<unsigned long>(x);
+  return ux * ux;
 }
 constexpr unsigned long
 squared_magnitude(unsigned long x)
@@ -942,7 +945,8 @@ squared_magnitude(unsigned long x)
 constexpr unsigned long long
 squared_magnitude(long long x)
 {
-  return static_cast<unsigned long long>(x * x);
+  const auto ux = static_cast<unsigned long long>(x);
+  return ux * ux;
 }
 constexpr unsigned long long
 squared_magnitude(unsigned long long x)
@@ -993,7 +997,9 @@ template <typename T, std::enable_if_t<std::is_integral_v<T> && std::is_signed_v
 constexpr T
 remainder_floored(T x, T y)
 {
-  return ((x % y) + y) % y;
+  // Conditional add: vnl_math's ((x % y) + y) % y overflows for |y| > max/2.
+  const T r = x % y;
+  return (r != 0 && ((r < 0) != (y < 0))) ? r + y : r;
 }
 template <typename T, std::enable_if_t<std::is_integral_v<T> && std::is_unsigned_v<T>, int> = 0>
 constexpr T
@@ -1086,12 +1092,8 @@ angle_0_to_2pi(double angle)
   if (angle >= 0)
     return angle;
   const double a = angle + twopi;
-  if (a > 0 && a < twopi)
-    return a;
-  // Guard the boundary: tiny negative inputs can produce exactly twopi above.
-  if (angle < 0)
-    return 6.28318530717958575;
-  return angle;
+  // Guard the boundary: tiny negative inputs round a up to exactly twopi; clamp 1 ULP below.
+  return (a < twopi) ? a : 6.28318530717958575;
 }
 
 /** \brief Normalize an angle (radians) into (-pi, pi]. */

--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -42,13 +42,6 @@
 #include "itkConceptChecking.h"
 #include <vnl/vnl_math.h>
 
-/* Only maintain backwards compatibility with old versions
- * of VXL back to the point where vnl_math:: was introduced
- * versions of VXL where only vnl_math_ was available are not
- * supported.
- */
-#include <vxl_version.h>
-
 namespace itk::Math
 {
 // These mathematical constants originate from VXL's vnl_math.h: correctly-rounded

--- a/Modules/Core/Common/include/itkMath.h
+++ b/Modules/Core/Common/include/itkMath.h
@@ -114,7 +114,9 @@ static_assert(euler == std::numbers::egamma);
 
 //: IEEE double machine precision
 inline constexpr double eps = std::numeric_limits<double>::epsilon();
-inline constexpr double sqrteps = 1.490116119384766e-08;
+// sqrt(2^-52) = 2^-26 = 1.490116119384765625e-8 exactly, matching C++26 constexpr std::sqrt(eps);
+// vnl_math::sqrteps used 1.490116119384766e-08, which rounds 1 ULP above (2^-26 + 2^-78).
+inline constexpr double sqrteps = 0x1p-26;
 //: IEEE single machine precision
 inline constexpr float float_eps = std::numeric_limits<float>::epsilon();
 inline constexpr float float_sqrteps = 3.4526698300e-4F;

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -1428,6 +1428,7 @@ set(
   itkMathCastWithRangeCheckGTest.cxx
   itkMathGTest.cxx
   itkMathRoundGTest.cxx
+  itkMathVnlParityGTest.cxx
   itkMatrixGTest.cxx
   itkMersenneTwisterRandomVariateGeneratorGTest.cxx
   itkMetaDataDictionaryGTest.cxx

--- a/Modules/Core/Common/test/itkMathVnlParityGTest.cxx
+++ b/Modules/Core/Common/test/itkMathVnlParityGTest.cxx
@@ -234,7 +234,8 @@ TEST(itkMathVnlParity, Constants)
   EXPECT_EQ(itk::Math::eps, vnl_math::eps);
   EXPECT_EQ(itk::Math::float_eps, vnl_math::float_eps);
   EXPECT_EQ(itk::Math::float_sqrteps, vnl_math::float_sqrteps);
-  // Intentional 1 ULP divergence: itk::Math::sqrteps is the exact sqrt(eps) = 2^-26,
-  // vnl_math::sqrteps rounds 1 ULP above it (see the ITKv6 migration guide).
-  EXPECT_EQ(std::nextafter(itk::Math::sqrteps, 1.0), vnl_math::sqrteps);
+  // itk::Math::sqrteps is the exact sqrt(eps) = 2^-26; vnl_math::sqrteps rounds
+  // 1 ULP above it before the VNL deprecation-campaign pin and matches exactly after.
+  EXPECT_TRUE(vnl_math::sqrteps == itk::Math::sqrteps || vnl_math::sqrteps == std::nextafter(itk::Math::sqrteps, 1.0))
+    << "vnl_math::sqrteps=" << vnl_math::sqrteps;
 }

--- a/Modules/Core/Common/test/itkMathVnlParityGTest.cxx
+++ b/Modules/Core/Common/test/itkMathVnlParityGTest.cxx
@@ -20,6 +20,11 @@
 // the vnl_math functions they superseded: identical results, bit-for-bit,
 // over the inputs each contract supports.
 
+// Comparing against vnl_math is this test's purpose; opt out of the vnl_math
+// deprecation attributes (no-ops before the deprecation campaign lands).
+#define VNL_MATH_DEPRECATE_CONSTANTS 0
+#define VNL_MATH_DEPRECATE_FUNCTIONS 0
+
 #include "itkMath.h"
 #include "itkGTest.h"
 #include <vnl/vnl_math.h>

--- a/Modules/Core/Common/test/itkMathVnlParityGTest.cxx
+++ b/Modules/Core/Common/test/itkMathVnlParityGTest.cxx
@@ -1,0 +1,235 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// Verifies that the native itk::Math functions are drop-in replacements for
+// the vnl_math functions they superseded: identical results, bit-for-bit,
+// over the inputs each contract supports.
+
+#include "itkMath.h"
+#include "itkGTest.h"
+#include <vnl/vnl_math.h>
+#include <cmath>
+#include <limits>
+
+namespace
+{
+constexpr double maxHalfIntDomain = static_cast<double>(INT_MAX / 2) - 2.0;
+
+const double roundingSamples[] = { 0.0,  -0.0,   0.5,        -0.5,      1.5,     -1.5,    2.5,   -2.5,  3.5,
+                                   -3.5, 0.4999, -0.4999,    0.5001,    -0.5001, 7.0,     -7.0,  7.25,  -7.25,
+                                   1e6,  -1e6,   1234567.89, -987654.3, 0.0001,  -0.0001, 1.5e9, -1.5e9 };
+
+const double angleSamples[] = { 0.0,
+                                -0.0,
+                                0.1,
+                                -0.1,
+                                itk::Math::pi / 2,
+                                -itk::Math::pi / 2,
+                                itk::Math::pi,
+                                -itk::Math::pi,
+                                3 * itk::Math::pi / 2,
+                                -3 * itk::Math::pi / 2,
+                                itk::Math::twopi,
+                                -itk::Math::twopi,
+                                itk::Math::twopi + 0.1,
+                                -itk::Math::twopi - 0.1,
+                                100.25,
+                                -100.25,
+                                1e6,
+                                -1e6,
+                                -1e-18,
+                                std::nextafter(0.0, -1.0) };
+} // namespace
+
+TEST(itkMathVnlParity, RoundHalfIntegerToEven)
+{
+  for (const double x : roundingSamples)
+  {
+    EXPECT_EQ(itk::Math::rnd_halfinttoeven(x), vnl_math::rnd_halfinttoeven(x)) << "x=" << x;
+    EXPECT_EQ(itk::Math::rnd_halfinttoeven(static_cast<float>(x)), vnl_math::rnd_halfinttoeven(static_cast<float>(x)))
+      << "x=" << x;
+    EXPECT_EQ(itk::Math::rnd(x), vnl_math::rnd(x)) << "x=" << x;
+    EXPECT_EQ(itk::Math::rnd(static_cast<float>(x)), vnl_math::rnd(static_cast<float>(x))) << "x=" << x;
+  }
+}
+
+TEST(itkMathVnlParity, RoundHalfIntegerUp)
+{
+  for (const double x : roundingSamples)
+  {
+    if (std::abs(x) >= maxHalfIntDomain)
+    {
+      continue; // outside the documented |x| < INT_MAX/2 contract
+    }
+    EXPECT_EQ(itk::Math::rnd_halfintup(x), vnl_math::rnd_halfintup(x)) << "x=" << x;
+    EXPECT_EQ(itk::Math::rnd_halfintup(static_cast<float>(x)), vnl_math::rnd_halfintup(static_cast<float>(x)))
+      << "x=" << x;
+  }
+}
+
+TEST(itkMathVnlParity, FloorCeil)
+{
+  for (const double x : roundingSamples)
+  {
+    EXPECT_EQ(itk::Math::floor(x), vnl_math::floor(x)) << "x=" << x;
+    EXPECT_EQ(itk::Math::floor(static_cast<float>(x)), vnl_math::floor(static_cast<float>(x))) << "x=" << x;
+    EXPECT_EQ(itk::Math::ceil(x), vnl_math::ceil(x)) << "x=" << x;
+    EXPECT_EQ(itk::Math::ceil(static_cast<float>(x)), vnl_math::ceil(static_cast<float>(x))) << "x=" << x;
+  }
+}
+
+TEST(itkMathVnlParity, SgnAndSgn0)
+{
+  for (const int x : { -5, -1, 0, 1, 5, INT_MAX, INT_MIN })
+  {
+    EXPECT_EQ(itk::Math::sgn(x), vnl_math::sgn(x)) << "x=" << x;
+    EXPECT_EQ(itk::Math::sgn0(x), vnl_math::sgn0(x)) << "x=" << x;
+  }
+  for (const double x : { -2.5, -0.0, 0.0, 1e-300, -1e-300, 3.75 })
+  {
+    EXPECT_EQ(itk::Math::sgn(x), vnl_math::sgn(x)) << "x=" << x;
+    EXPECT_EQ(itk::Math::sgn0(x), vnl_math::sgn0(x)) << "x=" << x;
+    EXPECT_EQ(itk::Math::sgn(static_cast<float>(x)), vnl_math::sgn(static_cast<float>(x))) << "x=" << x;
+    EXPECT_EQ(itk::Math::sgn0(static_cast<float>(x)), vnl_math::sgn0(static_cast<float>(x))) << "x=" << x;
+  }
+}
+
+TEST(itkMathVnlParity, SqrAndCube)
+{
+  for (const int x : { -46340, -7, -1, 0, 1, 7, 46340 })
+  {
+    EXPECT_EQ(itk::Math::sqr(x), vnl_math::sqr(x)) << "x=" << x;
+  }
+  for (const int x : { -1290, -3, 0, 3, 1290 })
+  {
+    EXPECT_EQ(itk::Math::cube(x), vnl_math::cube(x)) << "x=" << x;
+  }
+  for (const double x : { -2.5, 0.0, 0.125, 3.75, 1e150 })
+  {
+    EXPECT_EQ(itk::Math::sqr(x), vnl_math::sqr(x)) << "x=" << x;
+    EXPECT_EQ(itk::Math::cube(x), vnl_math::cube(x)) << "x=" << x;
+    EXPECT_EQ(itk::Math::sqr(static_cast<float>(x)), vnl_math::sqr(static_cast<float>(x))) << "x=" << x;
+  }
+}
+
+TEST(itkMathVnlParity, SquaredMagnitude)
+{
+  // static_cast: char is unsigned on some targets and char{ -11 } would narrow.
+  for (const char x : { static_cast<char>(-11), char{ 0 }, char{ 13 }, char{ 127 } })
+  {
+    EXPECT_EQ(itk::Math::squared_magnitude(x), vnl_math::squared_magnitude(x)) << "x=" << static_cast<int>(x);
+  }
+  for (const unsigned char x : { static_cast<unsigned char>(0u), static_cast<unsigned char>(200u) })
+  {
+    EXPECT_EQ(itk::Math::squared_magnitude(x), vnl_math::squared_magnitude(x)) << "x=" << static_cast<int>(x);
+  }
+  for (const int x : { -46340, -7, 0, 7, 46340 })
+  {
+    EXPECT_EQ(itk::Math::squared_magnitude(x), vnl_math::squared_magnitude(x)) << "x=" << x;
+  }
+  for (const unsigned int x : { 0u, 65535u, 65536u })
+  {
+    EXPECT_EQ(itk::Math::squared_magnitude(x), vnl_math::squared_magnitude(x)) << "x=" << x;
+  }
+  // Largest long whose square fits the unsigned result; long is 32-bit on LLP64.
+  const long longSafe = static_cast<long>(std::sqrt(static_cast<double>(std::numeric_limits<long>::max()))) - 2;
+  for (const long x : { -longSafe, -42L, 0L, 42L, longSafe })
+  {
+    EXPECT_EQ(itk::Math::squared_magnitude(x), vnl_math::squared_magnitude(x)) << "x=" << x;
+  }
+  for (const long long x : { -3037000499LL, 0LL, 3037000499LL })
+  {
+    EXPECT_EQ(itk::Math::squared_magnitude(x), vnl_math::squared_magnitude(x)) << "x=" << x;
+  }
+  for (const double x : { -2.5, 0.0, 3.75, 1e150 })
+  {
+    EXPECT_EQ(itk::Math::squared_magnitude(x), vnl_math::squared_magnitude(x)) << "x=" << x;
+    EXPECT_EQ(itk::Math::squared_magnitude(static_cast<float>(x)), vnl_math::squared_magnitude(static_cast<float>(x)))
+      << "x=" << x;
+    EXPECT_EQ(itk::Math::squared_magnitude(static_cast<long double>(x)),
+              vnl_math::squared_magnitude(static_cast<long double>(x)))
+      << "x=" << x;
+  }
+}
+
+TEST(itkMathVnlParity, RemainderSignMatrix)
+{
+  for (const int x : { -7, -3, 0, 3, 7, 1000000 })
+  {
+    for (const int y : { -5, -3, 3, 5, 1000003 })
+    {
+      EXPECT_EQ(itk::Math::remainder_truncated(x, y), vnl_math::remainder_truncated(x, y)) << "x=" << x << " y=" << y;
+      EXPECT_EQ(itk::Math::remainder_floored(x, y), vnl_math::remainder_floored(x, y)) << "x=" << x << " y=" << y;
+    }
+  }
+  for (const double x : { -7.5, -2.25, 0.0, 2.25, 7.5 })
+  {
+    for (const double y : { -2.0, -0.75, 0.75, 2.0 })
+    {
+      EXPECT_EQ(itk::Math::remainder_truncated(x, y), vnl_math::remainder_truncated(x, y)) << "x=" << x << " y=" << y;
+      EXPECT_EQ(itk::Math::remainder_floored(x, y), vnl_math::remainder_floored(x, y)) << "x=" << x << " y=" << y;
+      const auto fx = static_cast<float>(x);
+      const auto fy = static_cast<float>(y);
+      EXPECT_EQ(itk::Math::remainder_truncated(fx, fy), vnl_math::remainder_truncated(fx, fy))
+        << "x=" << x << " y=" << y;
+      EXPECT_EQ(itk::Math::remainder_floored(fx, fy), vnl_math::remainder_floored(fx, fy)) << "x=" << x << " y=" << y;
+    }
+  }
+}
+
+TEST(itkMathVnlParity, AngleNormalization)
+{
+  for (const double angle : angleSamples)
+  {
+    const double itkWrapped = itk::Math::angle_0_to_2pi(angle);
+    const double vnlWrapped = vnl_math::angle_0_to_2pi(angle);
+    EXPECT_EQ(itkWrapped, vnlWrapped) << "angle=" << angle;
+    EXPECT_EQ(std::signbit(itkWrapped), std::signbit(vnlWrapped)) << "angle=" << angle;
+    EXPECT_EQ(itk::Math::angle_minuspi_to_pi(angle), vnl_math::angle_minuspi_to_pi(angle)) << "angle=" << angle;
+  }
+}
+
+TEST(itkMathVnlParity, Constants)
+{
+  EXPECT_EQ(itk::Math::e, vnl_math::e);
+  EXPECT_EQ(itk::Math::log2e, vnl_math::log2e);
+  EXPECT_EQ(itk::Math::log10e, vnl_math::log10e);
+  EXPECT_EQ(itk::Math::ln2, vnl_math::ln2);
+  EXPECT_EQ(itk::Math::ln10, vnl_math::ln10);
+  EXPECT_EQ(itk::Math::pi, vnl_math::pi);
+  EXPECT_EQ(itk::Math::twopi, vnl_math::twopi);
+  EXPECT_EQ(itk::Math::pi_over_2, vnl_math::pi_over_2);
+  EXPECT_EQ(itk::Math::pi_over_4, vnl_math::pi_over_4);
+  EXPECT_EQ(itk::Math::pi_over_180, vnl_math::pi_over_180);
+  EXPECT_EQ(itk::Math::one_over_pi, vnl_math::one_over_pi);
+  EXPECT_EQ(itk::Math::two_over_pi, vnl_math::two_over_pi);
+  EXPECT_EQ(itk::Math::deg_per_rad, vnl_math::deg_per_rad);
+  EXPECT_EQ(itk::Math::sqrt2pi, vnl_math::sqrt2pi);
+  EXPECT_EQ(itk::Math::two_over_sqrtpi, vnl_math::two_over_sqrtpi);
+  EXPECT_EQ(itk::Math::one_over_sqrt2pi, vnl_math::one_over_sqrt2pi);
+  EXPECT_EQ(itk::Math::sqrt2, vnl_math::sqrt2);
+  EXPECT_EQ(itk::Math::sqrt1_2, vnl_math::sqrt1_2);
+  EXPECT_EQ(itk::Math::sqrt1_3, vnl_math::sqrt1_3);
+  EXPECT_EQ(itk::Math::euler, vnl_math::euler);
+  EXPECT_EQ(itk::Math::eps, vnl_math::eps);
+  EXPECT_EQ(itk::Math::float_eps, vnl_math::float_eps);
+  EXPECT_EQ(itk::Math::float_sqrteps, vnl_math::float_sqrteps);
+  // Intentional 1 ULP divergence: itk::Math::sqrteps is the exact sqrt(eps) = 2^-26,
+  // vnl_math::sqrteps rounds 1 ULP above it (see the ITKv6 migration guide).
+  EXPECT_EQ(std::nextafter(itk::Math::sqrteps, 1.0), vnl_math::sqrteps);
+}

--- a/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.hxx
+++ b/Modules/Core/Mesh/include/itkTriangleMeshCurvatureCalculator.hxx
@@ -34,7 +34,6 @@
 #include "itkObjectFactory.h"
 #include "itkMath.h"
 #include "vnl/vnl_cross.h"
-#include "vnl/vnl_math.h"
 
 namespace itk
 {

--- a/Modules/Filtering/BoneEnhancement/include/itkDescoteauxEigenToMeasureImageFilter.hxx
+++ b/Modules/Filtering/BoneEnhancement/include/itkDescoteauxEigenToMeasureImageFilter.hxx
@@ -55,9 +55,9 @@ DescoteauxEigenToMeasureImageFilter<TInputImage, TOutputImage>::ProcessPixel(con
   auto   a1 = static_cast<double>(pixel[0]);
   auto   a2 = static_cast<double>(pixel[1]);
   auto   a3 = static_cast<double>(pixel[2]);
-  double l1 = itk::Math::abs(a1);
-  double l2 = itk::Math::abs(a2);
-  double l3 = itk::Math::abs(a3);
+  double l1 = itk::Math::Absolute(a1);
+  double l2 = itk::Math::Absolute(a2);
+  double l3 = itk::Math::Absolute(a3);
 
   /* Deal with l3 > 0 */
   if (m_EnhanceType * a3 < 0)
@@ -73,7 +73,7 @@ DescoteauxEigenToMeasureImageFilter<TInputImage, TOutputImage>::ProcessPixel(con
 
   /* Compute measures */
   const double Rsheet = l2 / l3;
-  const double Rblob = itk::Math::abs(2 * l3 - l2 - l1) / l3;
+  const double Rblob = itk::Math::Absolute(2 * l3 - l2 - l1) / l3;
   const double Rnoise = sqrt(l1 * l1 + l2 * l2 + l3 * l3);
 
   /* Multiply together to get sheetness */

--- a/Modules/Filtering/BoneEnhancement/include/itkKrcahEigenToMeasureImageFilter.hxx
+++ b/Modules/Filtering/BoneEnhancement/include/itkKrcahEigenToMeasureImageFilter.hxx
@@ -56,9 +56,9 @@ KrcahEigenToMeasureImageFilter<TInputImage, TOutputImage>::ProcessPixel(const In
   auto   a1 = static_cast<double>(pixel[0]);
   auto   a2 = static_cast<double>(pixel[1]);
   auto   a3 = static_cast<double>(pixel[2]);
-  double l1 = itk::Math::abs(a1);
-  double l2 = itk::Math::abs(a2);
-  double l3 = itk::Math::abs(a3);
+  double l1 = itk::Math::Absolute(a1);
+  double l2 = itk::Math::Absolute(a2);
+  double l3 = itk::Math::Absolute(a3);
 
   /* Avoid divisions by zero (or close to zero) */
   if (static_cast<double>(l3) < Math::eps || static_cast<double>(l2) < Math::eps)

--- a/Modules/Filtering/BoneEnhancement/include/itkKrcahEigenToMeasureParameterEstimationFilter.hxx
+++ b/Modules/Filtering/BoneEnhancement/include/itkKrcahEigenToMeasureParameterEstimationFilter.hxx
@@ -181,7 +181,7 @@ KrcahEigenToMeasureParameterEstimationFilter<TInputImage, TOutputImage>::Calcula
   RealType trace = 0;
   for (unsigned int i = 0; i < pixel.Length; ++i)
   {
-    trace += itk::Math::abs(pixel[i]);
+    trace += itk::Math::Absolute(pixel[i]);
   }
   return trace;
 }

--- a/Modules/Filtering/BoneEnhancement/include/itkMaximumAbsoluteValueImageFilter.h
+++ b/Modules/Filtering/BoneEnhancement/include/itkMaximumAbsoluteValueImageFilter.h
@@ -62,7 +62,7 @@ public:
   inline TOutputPixel
   operator()(const TInputPixel1 A, const TInputPixel2 B)
   {
-    return static_cast<TOutputPixel>(itk::Math::abs(A) > itk::Math::abs(B) ? A : B);
+    return static_cast<TOutputPixel>(itk::Math::Absolute(A) > itk::Math::Absolute(B) ? A : B);
   }
 }; // end of class
 } // namespace Functor

--- a/Modules/Filtering/BoneMorphometry/include/itkBoneMorphometryFeaturesImageFilter.hxx
+++ b/Modules/Filtering/BoneMorphometry/include/itkBoneMorphometryFeaturesImageFilter.hxx
@@ -208,7 +208,7 @@ BoneMorphometryFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>::IsIns
   bool insideNeighborhood = true;
   for (unsigned int i = 0; i < this->m_NeighborhoodRadius.Dimension; ++i)
   {
-    int boundDistance = m_NeighborhoodRadius[i] - itk::Math::abs(iteratedOffset[i]);
+    int boundDistance = m_NeighborhoodRadius[i] - itk::Math::Absolute(iteratedOffset[i]);
     if (boundDistance < 0)
     {
       insideNeighborhood = false;

--- a/Modules/Filtering/Cuberille/include/itkCuberilleImageToMeshFilter.hxx
+++ b/Modules/Filtering/Cuberille/include/itkCuberilleImageToMeshFilter.hxx
@@ -476,8 +476,8 @@ CuberilleImageToMeshFilter<TInputImage, TOutputMesh, TInterpolator>::ProjectVert
       // Compute which direction moves vertex closer to iso-surface value
       value[0] = m_Interpolator->Evaluate(temp[0]);
       value[1] = m_Interpolator->Evaluate(temp[1]);
-      diff[0] = itk::Math::abs(value[0] - m_IsoSurfaceValue);
-      diff[1] = itk::Math::abs(value[1] - m_IsoSurfaceValue);
+      diff[0] = itk::Math::Absolute(value[0] - m_IsoSurfaceValue);
+      diff[1] = itk::Math::Absolute(value[1] - m_IsoSurfaceValue);
       i = (diff[0] <= diff[1]) ? 0 : 1;
       if (previousi < 0)
       {
@@ -537,7 +537,7 @@ CuberilleImageToMeshFilter<TInputImage, TOutputMesh, TInterpolator>::ProjectVert
         }
         // Compute metric (combination of difference and distance)
         value = m_Interpolator->Evaluate(temp);
-        metric = itk::Math::abs(value - m_IsoSurfaceValue); // Difference
+        metric = itk::Math::Absolute(value - m_IsoSurfaceValue); // Difference
 
         // Determine if current position is the "best"
         if (metric < bestMetric)
@@ -570,7 +570,7 @@ CuberilleImageToMeshFilter<TInputImage, TOutputMesh, TInterpolator>::ProjectVert
 
       // Compute whether vertex is close enough to iso-surface value
       value = m_Interpolator->Evaluate(vertex);
-      done |= itk::Math::abs(value - m_IsoSurfaceValue) < m_ProjectVertexSurfaceDistanceThreshold;
+      done |= itk::Math::Absolute(value - m_IsoSurfaceValue) < m_ProjectVertexSurfaceDistanceThreshold;
       if (done)
       {
         break;

--- a/Modules/Filtering/MinimalPathExtraction/include/itkSingleImageCostFunction.hxx
+++ b/Modules/Filtering/MinimalPathExtraction/include/itkSingleImageCostFunction.hxx
@@ -136,7 +136,7 @@ SingleImageCostFunction<TImage>::GetDerivative(const ParametersType & parameters
     //           (indicated by very large values) which may skew the gradient.
     //           To avoid this skewing effect, we reset gradient values larger
     //           than a given threshold.
-    if (itk::Math::abs(derivative[i]) > m_DerivativeThreshold)
+    if (itk::Math::Absolute(derivative[i]) > m_DerivativeThreshold)
     {
       derivative[i] = 0.0;
     }

--- a/Modules/Filtering/MorphologicalContourInterpolation/include/itkMorphologicalContourInterpolator.hxx
+++ b/Modules/Filtering/MorphologicalContourInterpolation/include/itkMorphologicalContourInterpolator.hxx
@@ -371,7 +371,7 @@ MorphologicalContourInterpolator<TImage>::FindMedianImageDilations(typename Bool
   {
     IdentifierType iS = CardinalSymmetricDifference(seq[x], iMask);
     IdentifierType jS = CardinalSymmetricDifference(seq[x], jMask);
-    IdentifierType xScore = iS >= jS ? iS - jS : jS - iS; // itk::Math::abs(iS-jS)
+    IdentifierType xScore = iS >= jS ? iS - jS : jS - iS; // itk::Math::Absolute(iS-jS)
     if (xScore < min)
     {
       min = xScore;
@@ -477,9 +477,9 @@ MorphologicalContourInterpolator<TImage>::FindMedianImageDistances(typename Bool
   long long bestDiff = LLONG_MAX;
   for (unsigned b = 0; b < maxSize; b++)
   {
-    long long iS = itk::Math::abs(iTotal - iSum[b] + jSum[b]);
-    long long jS = itk::Math::abs(jTotal - jSum[b] + iSum[b]);
-    long long diff = itk::Math::abs(iS - jS);
+    long long iS = itk::Math::Absolute(iTotal - iSum[b] + jSum[b]);
+    long long jS = itk::Math::Absolute(jTotal - jSum[b] + iSum[b]);
+    long long diff = itk::Math::Absolute(iS - jS);
     if (diff < bestDiff)
     {
       bestDiff = diff;
@@ -758,7 +758,7 @@ MorphologicalContourInterpolator<TImage>::Interpolate1to1(int                   
   } // iterator destroyed here
 
   // recurse if needed
-  if (itk::Math::abs(i - j) > 2)
+  if (itk::Math::Absolute(i - j) > 2)
   {
     PixelList regionIDs;
     regionIDs.push_back(1);
@@ -772,8 +772,8 @@ MorphologicalContourInterpolator<TImage>::Interpolate1to1(int                   
     int  mReq = mid < reqRegion.GetIndex(axis)
                   ? -1
                   : (mid > reqRegion.GetIndex(axis) + IndexValueType(reqRegion.GetSize(axis)) ? +1 : 0);
-    bool first = itk::Math::abs(i - mid) > 1 && itk::Math::abs(iReq + mReq) <= 1;  // i-mid?
-    bool second = itk::Math::abs(j - mid) > 1 && itk::Math::abs(jReq + mReq) <= 1; // j-mid?
+    bool first = itk::Math::Absolute(i - mid) > 1 && itk::Math::Absolute(iReq + mReq) <= 1;  // i-mid?
+    bool second = itk::Math::Absolute(j - mid) > 1 && itk::Math::Absolute(jReq + mReq) <= 1; // j-mid?
 
     if (first)
     {
@@ -1493,9 +1493,9 @@ MorphologicalContourInterpolator<TImage>::InterpolateAlong(int      axis,
                      ? -1
                      : (*next > reqRegion.GetIndex(axis) + IndexValueType(reqRegion.GetSize(axis)) ? +1 : 0);
 
-        if (*prev + 1 < *next                    // only if they are not adjacent slices
-            && itk::Math::abs(iReq + jReq) <= 1) // and not out of the requested region
-                                                 // unless they are on opposite ends
+        if (*prev + 1 < *next                         // only if they are not adjacent slices
+            && itk::Math::Absolute(iReq + jReq) <= 1) // and not out of the requested region
+                                                      // unless they are on opposite ends
         {
           SegmentBetweenTwo<TImage> s;
           s.axis = axis;

--- a/Modules/Filtering/PhaseSymmetry/include/itkSinusoidSpatialFunction.hxx
+++ b/Modules/Filtering/PhaseSymmetry/include/itkSinusoidSpatialFunction.hxx
@@ -19,7 +19,7 @@
 #define itkSinusoidSpatialFunction_hxx
 
 #include <cmath>
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 namespace itk
 {
@@ -45,7 +45,7 @@ SinusoidSpatialFunction<TOutput, VImageDimension, TInput>::Evaluate(const TInput
   {
     frequencyTerm += this->m_Frequency[ii] * position[ii];
   }
-  frequencyTerm *= 2.0 * vnl_math::pi;
+  frequencyTerm *= 2.0 * itk::Math::pi;
   frequencyTerm += this->m_PhaseOffset;
   const double value = std::cos(frequencyTerm);
   return static_cast<TOutput>(value);

--- a/Modules/Filtering/PolarTransform/test/itkPolarTransformTest.cxx
+++ b/Modules/Filtering/PolarTransform/test/itkPolarTransformTest.cxx
@@ -59,7 +59,7 @@ itkPolarTransformTest(int, char *[])
   tmp = p2c->TransformPoint(p);
   for (unsigned int i = 0; i < Dimension; ++i)
   {
-    if (itk::Math::abs(tmp[i] - c[i]) > epsilon)
+    if (itk::Math::Absolute(tmp[i] - c[i]) > epsilon)
     {
       return EXIT_FAILURE;
     }
@@ -69,7 +69,7 @@ itkPolarTransformTest(int, char *[])
   tmp = c2p->TransformPoint(c);
   for (unsigned int i = 0; i < Dimension; ++i)
   {
-    if (itk::Math::abs(tmp[i] - p[i]) > epsilon)
+    if (itk::Math::Absolute(tmp[i] - p[i]) > epsilon)
     {
       std::cout << "Invalid cartesian to polar computed." << std::endl;
       return EXIT_FAILURE;
@@ -80,7 +80,7 @@ itkPolarTransformTest(int, char *[])
   tmp = c2p->TransformPoint(p2c->TransformPoint(p));
   for (unsigned int i = 0; i < Dimension; ++i)
   {
-    if (itk::Math::abs(tmp[i] - p[i]) > epsilon)
+    if (itk::Math::Absolute(tmp[i] - p[i]) > epsilon)
     {
       std::cout << "Invalid polar to cartesian and back computed." << std::endl;
       return EXIT_FAILURE;
@@ -91,7 +91,7 @@ itkPolarTransformTest(int, char *[])
   tmp = p2c->TransformPoint(c2p->TransformPoint(c));
   for (unsigned int i = 0; i < Dimension; ++i)
   {
-    if (itk::Math::abs(tmp[i] - c[i]) > epsilon)
+    if (itk::Math::Absolute(tmp[i] - c[i]) > epsilon)
     {
       std::cout << "Invalid cartesian to polar and back computed." << std::endl;
       return EXIT_FAILURE;
@@ -147,7 +147,7 @@ itkPolarTransformTest(int, char *[])
     tmp = p2cOff->TransformPoint(c2pOff->TransformPoint(c));
     for (unsigned int i = 0; i < Dimension; ++i)
     {
-      if (itk::Math::abs(tmp[i] - c[i]) > epsilon)
+      if (itk::Math::Absolute(tmp[i] - c[i]) > epsilon)
       {
         std::cout << "Round-trip failed with non-zero center in pass-through dim." << std::endl;
         return EXIT_FAILURE;

--- a/Modules/Filtering/TextureFeatures/include/itkCoocurrenceTextureFeaturesImageFilter.hxx
+++ b/Modules/Filtering/TextureFeatures/include/itkCoocurrenceTextureFeaturesImageFilter.hxx
@@ -269,7 +269,7 @@ CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>::Is
   bool insideNeighborhood = true;
   for (unsigned int i = 0; i < this->m_NeighborhoodRadius.Dimension; ++i)
   {
-    int boundDistance = m_NeighborhoodRadius[i] - Math::abs(iteratedOffset[i]);
+    int boundDistance = m_NeighborhoodRadius[i] - Math::Absolute(iteratedOffset[i]);
     if (boundDistance < 0)
     {
       insideNeighborhood = false;

--- a/Modules/Filtering/TextureFeatures/include/itkRunLengthTextureFeaturesImageFilter.hxx
+++ b/Modules/Filtering/TextureFeatures/include/itkRunLengthTextureFeaturesImageFilter.hxx
@@ -327,7 +327,7 @@ RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>::IsIn
   bool insideNeighborhood = true;
   for (unsigned int i = 0; i < this->m_NeighborhoodRadius.Dimension; ++i)
   {
-    int boundDistance = m_NeighborhoodRadius[i] - Math::abs(iteratedOffset[i]);
+    int boundDistance = m_NeighborhoodRadius[i] - Math::Absolute(iteratedOffset[i]);
     if (boundDistance < 0)
     {
       insideNeighborhood = false;

--- a/Modules/IO/IOScanco/src/itkISQHeaderIO.cxx
+++ b/Modules/IO/IOScanco/src/itkISQHeaderIO.cxx
@@ -361,11 +361,11 @@ ISQHeaderIO::ReadISQHeader(ISQEncodedHeaderBlock * headerData)
   // fix m_SliceThickness and m_SliceIncrement if they were truncated
   double computedSpacing =
     this->m_HeaderData->m_ScanDimensionsPhysical[2] / this->m_HeaderData->m_ScanDimensionsPixels[2];
-  if (itk::Math::abs(computedSpacing - this->m_HeaderData->m_SliceThickness) < 1.1e-3)
+  if (itk::Math::Absolute(computedSpacing - this->m_HeaderData->m_SliceThickness) < 1.1e-3)
   {
     this->m_HeaderData->m_SliceThickness = computedSpacing;
   }
-  if (itk::Math::abs(computedSpacing - this->m_HeaderData->m_SliceIncrement) < 1.1e-3)
+  if (itk::Math::Absolute(computedSpacing - this->m_HeaderData->m_SliceIncrement) < 1.1e-3)
   {
     this->m_HeaderData->m_SliceIncrement = computedSpacing;
   }

--- a/Modules/IO/IOTransformDCMTK/test/itkDCMTKTransformIORigidScaleRoundTripTest.cxx
+++ b/Modules/IO/IOTransformDCMTK/test/itkDCMTKTransformIORigidScaleRoundTripTest.cxx
@@ -63,19 +63,23 @@ itkDCMTKTransformIORigidScaleRoundTripTest(int, char *[])
   similarity->SetMatrix(affine->GetMatrix(), 1e-5);
   similarity->SetOffset(affine->GetOffset());
 
-  ITK_TEST_EXPECT_TRUE_STATUS_VALUE(itk::Math::abs(similarity->GetScale() - expectedScale) < 1e-10, testStatus);
+  ITK_TEST_EXPECT_TRUE_STATUS_VALUE(itk::Math::Absolute(similarity->GetScale() - expectedScale) < 1e-10, testStatus);
 
   const auto recoveredVersor = similarity->GetVersor();
   const auto expectedVersor = expected->GetVersor();
-  ITK_TEST_EXPECT_TRUE_STATUS_VALUE(itk::Math::abs(recoveredVersor.GetX() - expectedVersor.GetX()) < 1e-10, testStatus);
-  ITK_TEST_EXPECT_TRUE_STATUS_VALUE(itk::Math::abs(recoveredVersor.GetY() - expectedVersor.GetY()) < 1e-10, testStatus);
-  ITK_TEST_EXPECT_TRUE_STATUS_VALUE(itk::Math::abs(recoveredVersor.GetZ() - expectedVersor.GetZ()) < 1e-10, testStatus);
-  ITK_TEST_EXPECT_TRUE_STATUS_VALUE(itk::Math::abs(recoveredVersor.GetW() - expectedVersor.GetW()) < 1e-10, testStatus);
+  ITK_TEST_EXPECT_TRUE_STATUS_VALUE(itk::Math::Absolute(recoveredVersor.GetX() - expectedVersor.GetX()) < 1e-10,
+                                    testStatus);
+  ITK_TEST_EXPECT_TRUE_STATUS_VALUE(itk::Math::Absolute(recoveredVersor.GetY() - expectedVersor.GetY()) < 1e-10,
+                                    testStatus);
+  ITK_TEST_EXPECT_TRUE_STATUS_VALUE(itk::Math::Absolute(recoveredVersor.GetZ() - expectedVersor.GetZ()) < 1e-10,
+                                    testStatus);
+  ITK_TEST_EXPECT_TRUE_STATUS_VALUE(itk::Math::Absolute(recoveredVersor.GetW() - expectedVersor.GetW()) < 1e-10,
+                                    testStatus);
 
   const auto recoveredTranslation = similarity->GetTranslation();
   for (unsigned int d = 0; d < Dimension; ++d)
   {
-    ITK_TEST_EXPECT_TRUE_STATUS_VALUE(itk::Math::abs(recoveredTranslation[d] - expectedTranslation[d]) < 1e-10,
+    ITK_TEST_EXPECT_TRUE_STATUS_VALUE(itk::Math::Absolute(recoveredTranslation[d] - expectedTranslation[d]) < 1e-10,
                                       testStatus);
   }
 
@@ -95,7 +99,7 @@ itkDCMTKTransformIORigidScaleRoundTripTest(int, char *[])
     const auto sOut = similarity->TransformPoint(p);
     for (unsigned int d = 0; d < Dimension; ++d)
     {
-      ITK_TEST_EXPECT_TRUE_STATUS_VALUE(itk::Math::abs(aOut[d] - sOut[d]) < 1e-10, testStatus);
+      ITK_TEST_EXPECT_TRUE_STATUS_VALUE(itk::Math::Absolute(aOut[d] - sOut[d]) < 1e-10, testStatus);
     }
   }
 

--- a/Modules/IO/MGHIO/src/itkMGHImageIO.cxx
+++ b/Modules/IO/MGHIO/src/itkMGHImageIO.cxx
@@ -771,7 +771,7 @@ MGHImageIO ::GetOrientation(itk::Matrix<double> directions)
     const double sag = directions(0, cAxes); // LR axis
     const double cor = directions(1, cAxes); // PA axis
     const double ax = directions(2, cAxes);  // IS axis
-    if (itk::Math::abs(sag) > itk::Math::abs(cor) && itk::Math::abs(sag) > itk::Math::abs(ax))
+    if (itk::Math::Absolute(sag) > itk::Math::Absolute(cor) && itk::Math::Absolute(sag) > itk::Math::Absolute(ax))
     {
       if (sag > 0)
       {
@@ -783,7 +783,7 @@ MGHImageIO ::GetOrientation(itk::Matrix<double> directions)
       }
       continue;
     }
-    if (itk::Math::abs(cor) > itk::Math::abs(ax))
+    if (itk::Math::Absolute(cor) > itk::Math::Absolute(ax))
     {
       if (cor > 0)
       {

--- a/Modules/IO/NIFTI/test/itkNiftiReadWriteDirectionTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiReadWriteDirectionTest.cxx
@@ -259,7 +259,7 @@ itkNiftiReadWriteDirectionTest(int argc, char * argv[])
   const double trace = rRelative[0][0] + rRelative[1][1] + rRelative[2][2];
 
   // Calculate the angle of rotation between the two matrices
-  const double angle = std::acos((trace - 1.0) / 2.0) * 180.0 / vnl_math::pi;
+  const double angle = std::acos((trace - 1.0) / 2.0) * 180.0 / itk::Math::pi;
 
   // The angle between the two matrices will depend on the amount of shear in the sform. Some test images
   // have relatively large shear to make sure they trigger the sform correction. In practice, permissive mode

--- a/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
+++ b/Modules/Registration/FEM/include/itkFEMRegistrationFilter.hxx
@@ -39,7 +39,7 @@ namespace itk::fem
 
 template <typename TMovingImage, typename TFixedImage, typename TFemObject>
 FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::FEMRegistrationFilter()
-  : m_MinE(vnl_huge_val(0))
+  : m_MinE(NumericTraits<Float>::max())
 {
   this->SetNumberOfRequiredInputs(2);
 
@@ -487,7 +487,7 @@ FEMRegistrationFilter<TMovingImage, TFixedImage, TFemObject>::IterativeSolve(Sol
 
   bool         Done = false;
   unsigned int iters = 0;
-  m_MinE = 10.e99;
+  m_MinE = NumericTraits<Float>::max();
   Float deltE = 0;
   while (!Done && iters < m_Maxiters[m_CurrentLevel])
   {

--- a/Modules/Registration/Montage/include/itkPhaseCorrelationOptimizer.hxx
+++ b/Modules/Registration/Montage/include/itkPhaseCorrelationOptimizer.hxx
@@ -412,7 +412,7 @@ PhaseCorrelationOptimizer<TRealPixelType, VImageDimension>::ComputeOffset()
         SizeValueType dist = 0;
         for (unsigned d = 0; d < ImageDimension; d++)
         {
-          SizeValueType d1 = itk::Math::abs(m_MaxIndices[i][d] - m_MaxIndices[k][d]);
+          SizeValueType d1 = itk::Math::Absolute(m_MaxIndices[i][d] - m_MaxIndices[k][d]);
           if (d1 > size[d] / 2) // wrap around
           {
             d1 = size[d] - d1;
@@ -484,7 +484,7 @@ PhaseCorrelationOptimizer<TRealPixelType, VImageDimension>::ComputeOffset()
         (movingOrigin[i] - fixedOrigin[i]) - 1 * spacing[i] * (maxIndex[i] - oIndex[i]);
       const OffsetScalarType mirrorOffset =
         (movingOrigin[i] - fixedOrigin[i]) - 1 * spacing[i] * (maxIndex[i] - adjustedSize[i]);
-      if (itk::Math::abs(directOffset) <= itk::Math::abs(mirrorOffset))
+      if (itk::Math::Absolute(directOffset) <= itk::Math::Absolute(mirrorOffset))
       {
         offset[i] = directOffset;
       }
@@ -562,7 +562,7 @@ PhaseCorrelationOptimizer<TRealPixelType, VImageDimension>::ComputeOffset()
           (movingOrigin[i] - fixedOrigin[i]) - 1 * spacing[i] * (maxIndex[i] - oIndex[i]);
         const OffsetScalarType mirrorOffset =
           (movingOrigin[i] - fixedOrigin[i]) - 1 * spacing[i] * (maxIndex[i] - adjustedSize[i]);
-        if (itk::Math::abs(directOffset) <= itk::Math::abs(mirrorOffset))
+        if (itk::Math::Absolute(directOffset) <= itk::Math::Absolute(mirrorOffset))
         {
           this->m_Offsets[offsetIndex][i] = directOffset;
         }
@@ -625,7 +625,7 @@ PhaseCorrelationOptimizer<TRealPixelType, VImageDimension>::ComputeOffset()
             (movingOrigin[i] - fixedOrigin[i]) - 1 * spacing[i] * (maxIndex[i] - oIndex[i]);
           const OffsetScalarType mirrorOffset =
             (movingOrigin[i] - fixedOrigin[i]) - 1 * spacing[i] * (maxIndex[i] - adjustedSize[i]);
-          if (itk::Math::abs(directOffset) <= itk::Math::abs(mirrorOffset))
+          if (itk::Math::Absolute(directOffset) <= itk::Math::Absolute(mirrorOffset))
           {
             this->m_Offsets[peak][i] = directOffset;
           }

--- a/Modules/Registration/Montage/include/itkTileMergeImageFilter.hxx
+++ b/Modules/Registration/Montage/include/itkTileMergeImageFilter.hxx
@@ -485,7 +485,7 @@ TileMergeImageFilter<TImageType, TPixelAccumulateType, TInterpolator>::ResampleS
       for (unsigned d = 0; d < ImageDimension; d++)
       {
         ContinuousValueType translation = (oOrigin[d] - iOrigin[d]) / spacing[d] + continuousIndexDifferences[t][d];
-        ContinuousValueType absDiff = itk::Math::abs(translation - std::round(translation));
+        ContinuousValueType absDiff = itk::Math::Absolute(translation - std::round(translation));
         if (absDiff > eps)
         {
           interpolate = true;

--- a/Modules/Registration/Montage/include/itkTileMontage.hxx
+++ b/Modules/Registration/Montage/include/itkTileMontage.hxx
@@ -517,7 +517,7 @@ TileMontage<TImageType, TCoordinate>::OptimizeTiles()
       for (unsigned d = 0; d < ImageDimension; d++)
       {
         TCoordinate trOverDev = translations(i, d) / stdDev0(d);
-        outlierScore[i] += itk::Math::abs(trOverDev);
+        outlierScore[i] += itk::Math::Absolute(trOverDev);
       }
       if (outlierScore[i] > m_RelativeThreshold) // more than this many standard deviations
       {

--- a/Modules/Registration/Montage/test/itkMontagePCMTestFiles.cxx
+++ b/Modules/Registration/Montage/test/itkMontagePCMTestFiles.cxx
@@ -116,8 +116,8 @@ PhaseCorrelationRegistrationFiles(int argc, char * argv[])
       std::cout << finalParameters[ii] << " == " << actualParameters[ii] << " == " << transformParameters[ii]
                 << std::endl;
 
-      if ((itk::Math::abs(finalParameters[ii] - actualParameters[ii]) > tolerance * spacing[ii]) ||
-          (itk::Math::abs(transformParameters[ii] - actualParameters[ii]) > tolerance * spacing[ii]))
+      if ((itk::Math::Absolute(finalParameters[ii] - actualParameters[ii]) > tolerance * spacing[ii]) ||
+          (itk::Math::Absolute(transformParameters[ii] - actualParameters[ii]) > tolerance * spacing[ii]))
       {
         std::cerr << "Tolerance exceeded at component " << ii << std::endl;
         pass = false;

--- a/Modules/Registration/Montage/test/itkMontagePCMTestSynthetic.cxx
+++ b/Modules/Registration/Montage/test/itkMontagePCMTestSynthetic.cxx
@@ -256,8 +256,8 @@ PhaseCorrelationRegistration(int argc, char * argv[])
           {
             std::cout << finalParameters[i] << " == " << actualParameters[i] << " == " << transformParameters[i];
 
-            if ((itk::Math::abs(finalParameters[i] - actualParameters[i]) > tolerance) ||
-                (itk::Math::abs(transformParameters[i] - actualParameters[i]) > tolerance))
+            if ((itk::Math::Absolute(finalParameters[i] - actualParameters[i]) > tolerance) ||
+                (itk::Math::Absolute(transformParameters[i] - actualParameters[i]) > tolerance))
             {
               std::cout << "    Tolerance exceeded at component " << i << std::endl;
               pass = false;
@@ -271,8 +271,8 @@ PhaseCorrelationRegistration(int argc, char * argv[])
           // All other parameters must be 0
           for (unsigned int i = numberOfParameters; i < VDimension; i++)
           {
-            if ((itk::Math::abs(finalParameters[i]) > tolerance) ||
-                (itk::Math::abs(transformParameters[i]) > tolerance))
+            if ((itk::Math::Absolute(finalParameters[i]) > tolerance) ||
+                (itk::Math::Absolute(transformParameters[i]) > tolerance))
             {
               std::cout << "Tolerance exceeded at component " << i << std::endl;
               pass = false;

--- a/Modules/Registration/Montage/test/itkMontageTestHelper.hxx
+++ b/Modules/Registration/Montage/test/itkMontageTestHelper.hxx
@@ -339,8 +339,8 @@ montageTest(const itk::TileConfiguration<Dimension> & stageTiles,
         {
           registrationErrors << '\t' << (tr[d] - ta[d]);
           std::cout << "  " << std::setw(8) << std::setprecision(3) << (tr[d] - ta[d]);
-          singleError += itk::Math::abs(tr[d] - ta[d]);
-          alternativeError += itk::Math::abs(avgPos[t][d] - ta[d]);
+          singleError += itk::Math::Absolute(tr[d] - ta[d]);
+          alternativeError += itk::Math::Absolute(avgPos[t][d] - ta[d]);
         }
 
         if (alternativeError >= 5.0 && alternativeError < singleError)

--- a/Modules/Registration/Montage/test/itkPairwiseTestHelper.hxx
+++ b/Modules/Registration/Montage/test/itkPairwiseTestHelper.hxx
@@ -154,7 +154,7 @@ calculateError(const itk::TileConfiguration<Dimension> &                        
     {
       out << '\t' << (tr[d] - ta[d]);
       std::cout << "  " << std::setw(8) << std::setprecision(8) << (tr[d] - ta[d]);
-      translationError += itk::Math::abs(tr[d] - ta[d]);
+      translationError += itk::Math::Absolute(tr[d] - ta[d]);
     }
     std::cout << std::endl;
     out << std::endl;

--- a/Modules/Registration/TwoProjectionRegistration/include/itkSiddonJacobsRayCastInterpolateImageFunction.hxx
+++ b/Modules/Registration/TwoProjectionRegistration/include/itkSiddonJacobsRayCastInterpolateImageFunction.hxx
@@ -262,7 +262,7 @@ SiddonJacobsRayCastInterpolateImageFunction<TInputImage, TCoordRep>::Evaluate(co
   /* Calculate alpha incremental values when the ray intercepts with x, y, and z-planes */
   if (rayVector[0] != 0)
   {
-    alphaUx = ctPixelSpacing[0] / itk::Math::abs(rayVector[0]);
+    alphaUx = ctPixelSpacing[0] / itk::Math::Absolute(rayVector[0]);
   }
   else
   {
@@ -270,7 +270,7 @@ SiddonJacobsRayCastInterpolateImageFunction<TInputImage, TCoordRep>::Evaluate(co
   }
   if (rayVector[1] != 0)
   {
-    alphaUy = ctPixelSpacing[1] / itk::Math::abs(rayVector[1]);
+    alphaUy = ctPixelSpacing[1] / itk::Math::Absolute(rayVector[1]);
   }
   else
   {
@@ -278,7 +278,7 @@ SiddonJacobsRayCastInterpolateImageFunction<TInputImage, TCoordRep>::Evaluate(co
   }
   if (rayVector[2] != 0)
   {
-    alphaUz = ctPixelSpacing[2] / itk::Math::abs(rayVector[2]);
+    alphaUz = ctPixelSpacing[2] / itk::Math::Absolute(rayVector[2]);
   }
   else
   {

--- a/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationDemonsFunction.hxx
+++ b/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationDemonsFunction.hxx
@@ -159,7 +159,7 @@ VariationalRegistrationDemonsFunction<TFixedImage, TMovingImage, TDisplacementFi
 
   // Calculate update
   PixelType update;
-  if (itk::Math::abs(speedValue) < m_IntensityDifferenceThreshold)
+  if (itk::Math::Absolute(speedValue) < m_IntensityDifferenceThreshold)
   {
     update = m_ZeroUpdateReturn;
   }

--- a/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationSSDFunction.hxx
+++ b/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationSSDFunction.hxx
@@ -104,7 +104,7 @@ VariationalRegistrationSSDFunction<TFixedImage, TMovingImage, TDisplacementField
 
   // Calculate update
   PixelType update;
-  if (itk::Math::abs(speedValue) < m_IntensityDifferenceThreshold)
+  if (itk::Math::Absolute(speedValue) < m_IntensityDifferenceThreshold)
   {
     update = m_ZeroUpdateReturn;
   }

--- a/Modules/Segmentation/GrowCut/include/itkFastGrowCut.hxx
+++ b/Modules/Segmentation/GrowCut/include/itkFastGrowCut.hxx
@@ -267,7 +267,7 @@ FastGrowCut<TInputImage, TLabelImage, TMaskImage>::DijkstraBasedClassificationAH
         NodeIndexType    indexNgbh = index + m_NeighborIndexOffsets[i];
         NodeKeyValueType neighborCurrentDistance = distanceVolumePtr[indexNgbh];
         NodeKeyValueType neighborNewDistance =
-          itk::Math::abs(pixCenter - imSrc[indexNgbh]) + currentDistance + m_NeighborDistancePenalties[i];
+          itk::Math::Absolute(pixCenter - imSrc[indexNgbh]) + currentDistance + m_NeighborDistancePenalties[i];
         if (neighborCurrentDistance > neighborNewDistance)
         {
           distanceVolumePtr[indexNgbh] = neighborNewDistance;
@@ -305,7 +305,7 @@ FastGrowCut<TInputImage, TLabelImage, TMaskImage>::DijkstraBasedClassificationAH
         NodeIndexType    indexNgbh = index + m_NeighborIndexOffsets[i];
         NodeKeyValueType neighborCurrentDistance = distanceVolumePtr[indexNgbh];
         NodeKeyValueType neighborNewDistance =
-          itk::Math::abs(pixCenter - imSrc[indexNgbh]) + currentDistance + m_NeighborDistancePenalties[i];
+          itk::Math::Absolute(pixCenter - imSrc[indexNgbh]) + currentDistance + m_NeighborDistancePenalties[i];
         if (neighborCurrentDistance > neighborNewDistance)
         {
           distanceVolumePtr[indexNgbh] = neighborNewDistance;

--- a/Utilities/Maintenance/VNL_ModernizeNaming.py
+++ b/Utilities/Maintenance/VNL_ModernizeNaming.py
@@ -1,105 +1,89 @@
-#!/bin/env python
+#!/usr/bin/env python3
 # \author Hans J. Johnson
 #
-# Prepare for the future by recommending
-# use of itk::Math:: functions over
-# vnl_math:: functions.
-# Rather than converting vnl_math_ to vnl_math::
-# this prefers to convert directly to itk::Math::
-# namespace.  In cases where vnl_math:: is simply
-# an alias to std:: functions, itk::Math directly
-# uses the std:: version of the function.
+# Migrate a source file away from deprecated vnl_math usage, preferring
+# replacements that compile under C++17:
+#   - vnl_math:: constants, functions, and predicates -> itk::Math:: equivalents
+#   - vnl_math:: re-exports of std functions (max/min/cbrt/hypot) -> std::
+#   - vnl_math::abs / vnl_math_abs -> itk::Math::Absolute
+#   - legacy vnl_math_* global-function spellings -> the same modern targets
+#   - "vnl/vnl_math.h" include -> "itkMath.h"
+# vnl_huge_val cannot be rewritten textually (the replacement type depends on
+# context); occurrences are reported for manual migration to
+# std::numeric_limits<T>::infinity() or itk::NumericTraits<T>::max().
 
-import os
 import sys
 from collections import OrderedDict
+from pathlib import Path
 
-## slight modification from grep command
-info_for_conversion = """
-XXXX,vnl_math_isnan,itk::Math::isnan
-XXXX,vnl_math_isinf,itk::Math::isinf
-XXXX,vnl_math_isfinite,itk::Math::isfinite
-XXXX,vnl_math_isnormal,itk::Math::isnormal
-XXXX,vnl_math_max,std::max
-XXXX,vnl_math_min,std::min
-XXXX,vnl_math_cuberoot,itk::Math::cbrt
-XXXX,vnl_math_hypot,itk::Math::hypot
-XXXX,vnl_math_angle_0_to_2pi,itk::Math::angle_0_to_2pi
-XXXX,vnl_math_angle_minuspi_to_pi,itk::Math::angle_minuspi_to_pi
-XXXX,vnl_math_rnd_halfinttoeven,itk::Math::halfinttoeven
-XXXX,vnl_math_rnd_halfintup,itk::Math::rnd_halfintup
-XXXX,vnl_math_rnd,itk::Math::rnd
-XXXX,vnl_math_floor,itk::Math::floor
-XXXX,vnl_math_ceil,itk::Math::ceil
-XXXX,vnl_math_abs,itk::Math::Absolute
-XXXX,vnl_math_sqr,itk::Math::sqr
-XXXX,vnl_math_cube,itk::Math::cube
-XXXX,vnl_math_sgn,itk::Math::sgn
-XXXX,vnl_math_sgn0,itk::Math::sgn0
-XXXX,vnl_math_squared_magnitude,itk::Math::squared_magnitude
-XXXX,vnl_math_remainder_truncated,itk::Math::remainder_truncated
-XXXX,vnl_math_remainder_floored,itk::Math::remainder_floored
-"""
+replacements = OrderedDict()
 
-ITK_replace_head_names = OrderedDict()
-ITK_replace_functionnames = OrderedDict()
-ITK_replace_manual = OrderedDict()
+# Includes.
+replacements['"vnl/vnl_math.h"'] = '"itkMath.h"'
+replacements["<vnl/vnl_math.h>"] = "<itkMath.h>"
 
-ITK_replace_manual['"vnl/vnl_math.h"'] = '"itkMath.h"'
-ITK_replace_manual["<vnl/vnl_math.h>"] = "<itkMath.h>"
+# Namespace spellings whose itk::Math name differs (must precede the catch-all).
+replacements["vnl_math::max"] = "std::max"
+replacements["vnl_math::min"] = "std::min"
+replacements["vnl_math::cbrt"] = "std::cbrt"
+replacements["vnl_math::hypot"] = "std::hypot"
+replacements["vnl_math::abs"] = "itk::Math::Absolute"
 
-for line in info_for_conversion.splitlines():
-    linevalues = line.split(",")
-    if len(linevalues) != 3:
-        # print("SKIPPING: " + str(linevalues))
-        continue
-    fname = linevalues[0]
-    new_name = fname.replace("ITK_", "").replace(".h", "")
-    ITK_replace_head_names[
-        f'#include "{fname}"'
-    ] = f"""#if !defined( ITK_LEGACY_FUTURE_REMOVE )
-# include "{fname}"
-#endif
-#include <{new_name}>"""
-    ITK_replace_head_names[
-        f"#include <{fname}>"
-    ] = f"""#if !defined( ITK_LEGACY_FUTURE_REMOVE )
-# include <{fname}>
-#endif
-#include <{new_name}>"""
-    ITK_pat = linevalues[1]
-    new_pat = linevalues[2]
-    ITK_replace_functionnames[ITK_pat] = new_pat
-    # Need to fix the fact that both std::ios is a base and a prefix
-    if "std::ios::" in new_pat:
-        ITK_replace_manual[new_pat.replace("std::ios::", "std::ios_")] = new_pat
+# Catch-all: every other deprecated vnl_math:: member (constants, the 14
+# functions, isnan/isinf/isfinite/isnormal) maps name-identically.
+replacements["vnl_math::"] = "itk::Math::"
 
-# print(ITK_replace_head_names)
-# print(ITK_replace_functionnames)
-
-cfile = sys.argv[1]
-
-file_as_string = ""
-with open(cfile) as rfp:
-    original_string = rfp.read()
-file_as_string = original_string
-
-required_header = ""  ## For ITK, this is always empty
-
-for searchval, replaceval in ITK_replace_head_names.items():
-    file_as_string_new = file_as_string.replace(searchval, required_header + replaceval)
-    if file_as_string_new != file_as_string:
-        required_header = ""
-    file_as_string = file_as_string_new
+# Legacy global-function spellings. Longer names precede their prefixes so
+# sequential str.replace cannot corrupt them.
+replacements["vnl_math_isnan"] = "itk::Math::isnan"
+replacements["vnl_math_isinf"] = "itk::Math::isinf"
+replacements["vnl_math_isfinite"] = "itk::Math::isfinite"
+replacements["vnl_math_isnormal"] = "itk::Math::isnormal"
+replacements["vnl_math_max"] = "std::max"
+replacements["vnl_math_min"] = "std::min"
+replacements["vnl_math_cuberoot"] = "std::cbrt"
+replacements["vnl_math_hypot"] = "std::hypot"
+replacements["vnl_math_abs"] = "itk::Math::Absolute"
+replacements["vnl_math_angle_0_to_2pi"] = "itk::Math::angle_0_to_2pi"
+replacements["vnl_math_angle_minuspi_to_pi"] = "itk::Math::angle_minuspi_to_pi"
+replacements["vnl_math_rnd_halfinttoeven"] = "itk::Math::rnd_halfinttoeven"
+replacements["vnl_math_rnd_halfintup"] = "itk::Math::rnd_halfintup"
+replacements["vnl_math_rnd"] = "itk::Math::rnd"
+replacements["vnl_math_floor"] = "itk::Math::floor"
+replacements["vnl_math_ceil"] = "itk::Math::ceil"
+replacements["vnl_math_sqr"] = "itk::Math::sqr"
+replacements["vnl_math_cube"] = "itk::Math::cube"
+replacements["vnl_math_sgn0"] = "itk::Math::sgn0"
+replacements["vnl_math_sgn"] = "itk::Math::sgn"
+replacements["vnl_math_squared_magnitude"] = "itk::Math::squared_magnitude"
+replacements["vnl_math_remainder_truncated"] = "itk::Math::remainder_truncated"
+replacements["vnl_math_remainder_floored"] = "itk::Math::remainder_floored"
 
 
-for searchval, replaceval in ITK_replace_functionnames.items():
-    file_as_string = file_as_string.replace(searchval, replaceval)
-for searchval, replaceval in ITK_replace_manual.items():
-    file_as_string = file_as_string.replace(searchval, replaceval)
-if file_as_string != original_string:
-    print(f"Processing: {cfile}")
-    with open(cfile, "w") as wfp:
-        wfp.write(file_as_string)
-else:
-    print(f"SKIPPING: {cfile}")
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {Path(sys.argv[0]).name} <source-file>", file=sys.stderr)
+        return 2
+    cfile = Path(sys.argv[1])
+    original_string = cfile.read_text()
+    file_as_string = original_string
+
+    for searchval, replaceval in replacements.items():
+        file_as_string = file_as_string.replace(searchval, replaceval)
+
+    if "vnl_huge_val" in file_as_string:
+        print(
+            f"MANUAL FIX NEEDED: {cfile}: vnl_huge_val -> "
+            "std::numeric_limits<T>::infinity() or itk::NumericTraits<T>::max()"
+        )
+
+    if file_as_string != original_string:
+        print(f"Processing: {cfile}")
+        cfile.write_text(file_as_string)
+    else:
+        print(f"SKIPPING: {cfile}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fully decouples `itk::Math` from `vnl_math`, preempting the deprecation of `vnl_math::` constants and functions in upstream vxl: constants become correctly-rounded literals (C++20 `static_assert`-verified against `std::numbers`), the 14 function aliases become native implementations, and ITK-proper's last deprecated-entity uses (`vnl_huge_val`, legacy `itk::Math::abs` spellings) are migrated.

<details>
<summary>What changed</summary>

- `itkMath.h` constants: 24 OEIS-referenced double literals, token-identical in every translation unit regardless of `-std` level; a C++20-guarded `static_assert` block proves bit-identity to `std::numbers` (18 identities; `sqrt2pi` has no `std::numbers` constant and `one_over_sqrt2pi` no exact identity — `inv_sqrtpi / sqrt2` double-rounds 1 ULP high).
- `itkMath.h` functions: the 14 `using vnl_math::<fn>` aliases (`sgn`, `sgn0`, `sqr`, `cube`, `squared_magnitude`, `remainder_truncated/floored`, `rnd*`, `floor`, `ceil`, `angle_*`) replaced by native `constexpr`/inline implementations preserving the historical interface; rounding functions delegate to existing `itk::Math::Round*/Floor/Ceil`.
- `#include <vnl/vnl_math.h>` in `itkMath.h` gated behind `!ITK_FUTURE_LEGACY_REMOVE` (kept transitionally for downstream `vnl_math::` users).
- `sqrteps` corrected to exactly-representable `0x1p-26` (vnl's decimal literal rounds 1 ULP above `sqrt(eps)`); documented in the ITKv6 migration guide.
- Tree sweep: last two `vnl_math::pi` uses → `itk::Math::pi`; `vnl_huge_val(0)` in FEMRegistrationFilter → `NumericTraits<Float>::max()`; 63 `itk::Math::abs` call sites (25 files) → `itk::Math::Absolute`; vestigial `vnl_math.h` includes removed.
- `VNL_ModernizeNaming.py` rewritten to migrate all deprecated `vnl_math` spellings (namespace + legacy globals) to C++17-compatible `itk::Math`/`std::` targets; `vnl_huge_val` flagged for manual type-aware fixes.
</details>

<details>
<summary>ODR rationale (review feedback)</summary>

Definitions dispatched on `__cpp_lib_math_constants` would give a program mixing C++17- and C++20-compiled translation units two definitions of the same `inline` variable — and for `one_over_sqrt2pi` the two paths actually differed by 1 ULP. Defining every constant from its literal makes the definitions standard-invariant; `std::numbers` participates only in C++20-guarded `static_assert`s, which are not entities and cannot violate ODR. See #5823 for the general concern.
</details>

<details>
<summary>Verification</summary>

- New `itkMathVnlParityGTest.cxx` (9 suites, all passing) asserts bit-for-bit equivalence of every native against its `vnl_math::` counterpart: halfway-case rounding, floor/ceil, sign functions, powers, all `squared_magnitude` overloads, the remainder sign matrix, angle normalization including the fmod boundary guard, and the constants (`sqrteps`'s intentional 1 ULP divergence asserted explicitly).
- A maximum-effort multi-angle review confirmed the rounding natives initially narrowed the valid input domain vs vnl's `std::lrint`/`std::floor`/`std::ceil`; fixed to the vnl bodies (full int range). Three vnl-inherited defects are fixed in a separate commit (`ENH: Harden itk::Math natives beyond vnl_math parity`): signed-overflow UB in `squared_magnitude`, intermediate-overflow UB in integral `remainder_floored`, and an unreachable tail in `angle_0_to_2pi`.
- Full local `ninja` build: exit 0; 63/63 ctests across touched modules (Math, NIFTI, Mesh, Statistics, MathematicalMorphology).
- `itkMath.h` compiled `-fsyntax-only` under all four configurations: `-std=c++17`/`c++20` × default/`ITK_FUTURE_LEGACY_REMOVE`.
- FEM change compile-verified by direct template instantiation (FEM tests not registered in local build config).
- Bit-equivalence audit of all 19 literal↔`std::numbers` identities: 18 EXACT; `one_over_sqrt2pi` expression mismatch (hence its exclusion).
- Tree-wide audit: zero remaining uses of any vxl-deprecated entity in ITK proper.
</details>

<!--
provenance: claude-code sessions 2026-06-09..2026-06-10, branch itk-math-vnl-decouple
odr_fix_commit: 62ba138693c; function_decouple_commit: a364db78305
key_fact: std::numbers::inv_sqrtpi / std::numbers::sqrt2 != 0.39894228040143267794 (1 ULP high) — do not reintroduce dispatch
coordination: precedes vxl deprecation branch for/itk-vxl-master (local tip fd75e8b965, amends e96c6ab2); testbed ~/src/vxl_downstream_tests re-vendor pin must move with it
-->
