### PR TITLE
COMP: Add ITKZLIB private dependency to ITKReview

### DIFF
--- a/CMake/ITKModuleMacros.cmake
+++ b/CMake/ITKModuleMacros.cmake
@@ -21,7 +21,8 @@ include(GenerateExportHeader)
 # dependent modules:
 #  DEPENDS = Modules that will be publicly linked to this module
 #  PRIVATE_DEPENDS = Modules that will be privately linked to this module
-#  COMPILE_DEPENDS = Modules that are needed at compile time by this module
+#  COMPILE_DEPENDS = (deprecated) Modules that are needed at compile time by
+#    this module; prefer DEPENDS or PRIVATE_DEPENDS
 #  TEST_DEPENDS = Modules that are needed by this modules testing executables
 #  DESCRIPTION = Free text description of the module
 #  FACTORY_NAMES = List of <factories>::<formats> to register

--- a/Modules/Nonunit/Review/itk-module.cmake
+++ b/Modules/Nonunit/Review/itk-module.cmake
@@ -10,6 +10,8 @@ itk_module(
   ITKReview
   DEPENDS
     ITKIOImageBase
+  PRIVATE_DEPENDS
+    ITKZLIB
   COMPILE_DEPENDS
     ITKAnisotropicSmoothing
     ITKAntiAlias

--- a/Modules/Registration/Montage/itk-module.cmake
+++ b/Modules/Registration/Montage/itk-module.cmake
@@ -17,6 +17,7 @@ itk_module(
     ITKIOImageBase
     ITKImageFrequency
     ITKDoubleConversion
+    ITKEigen3
   TEST_DEPENDS
     ITKIOTransformInsightLegacy
     ITKTestKernel


### PR DESCRIPTION
Fixes the `libITKReview` shared-library link failure (undefined `_itkzlib_gz*` symbols) seen in ITKSphinxExamples python-superbuild CI by adding `ITKZLIB` to the module's `PRIVATE_DEPENDS`.

<details>
<summary>Root cause and verification</summary>

`itkVoxBoCUBImageIO.cxx` includes `itk_zlib.h` and calls `itkzlib_gzopen/gzread/gzwrite/...`, but ada67f60ace ("COMP: Update ITKReview depends and linkage") moved all module dependencies except `ITKIOImageBase` to `COMPILE_DEPENDS`, dropping zlib from the link closure. `ITKZLIB` was never declared in either list.

The failure only manifests in `BUILD_SHARED_LIBS=ON` builds (e.g. Python wrapping), which is why ITK's own static-build CI stayed green. First observed in ITKSphinxExamples CI:
https://github.com/InsightSoftwareConsortium/ITKSphinxExamples/actions/runs/27319825769/job/80794743298

Reproduced and fix verified locally on macOS arm64 (AppleClang, Release, shared libs, `Module_ITKReview=ON`, `ITK_BUILD_DEFAULT_MODULES=ON`, `ITK_LEGACY_REMOVE=ON`): link succeeds and `otool -L` shows `@rpath/libitkzlib-6.0.1.dylib`.

`PRIVATE_DEPENDS` matches the pattern used by ITKIOVTK and ITKIOGIPL, since zlib is referenced only from the `.cxx`, not from module headers.

</details>

<!--
provenance: claude-code session 2026-06-11
related: ITKSphinxExamples PR #456 CI failure, job 80794743298
breaking commit: ada67f60ace
companion: [[maybe_unused]] vnl_error.h fix already on isc/vxl for/itk-vxl-master tip 7829892c34, arriving via the VNL update PR
-->
