### PR TITLE
BUG: Fix argc guard and usage line in NRRD IO tests

### DIFF
--- a/Modules/IO/NRRD/test/itkNrrd5dVectorImageReadWriteTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrd5dVectorImageReadWriteTest.cxx
@@ -356,7 +356,7 @@ itkNrrd5dVectorImageReadWriteTest(int argc, char * argv[])
 {
   if (argc < 7)
   {
-    std::cerr << "Usage: " << argc << itkNameOfTestExecutableMacro(argv)
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
               << " 2d-double-vector.seq.nrrd 3d-double-vector.seq.nrrd"
               << " 2d-displacement-field-vector.seq.nrrd 3d-displacement-field-vector.seq.nrrd"
               << " 2d-color-image-vector.seq.nrrd 3d-color-image-vector.seq.nrrd\n";

--- a/Modules/IO/NRRD/test/itkNrrdVectorImageUnitLabelReadTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdVectorImageUnitLabelReadTest.cxx
@@ -49,7 +49,7 @@ checkField(itk::MetaDataDictionary & metadata, const std::string & key, const T 
 int
 itkNrrdVectorImageUnitLabelReadTest(int argc, char * argv[])
 {
-  if (argc < 1)
+  if (argc < 2)
   {
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv) << " Input\n";
     return EXIT_FAILURE;
@@ -127,18 +127,6 @@ itkNrrdVectorImageUnitLabelReadTest(int argc, char * argv[])
   checkField<std::string>(thisDic, "NRRD_units[pixel]", "s");
 
   checkField<int>(thisDic, "NRRD_pixel_original_axis", 0);
-
-  /* std::string key = "NRRD_original_component_axis";
-  int value{ -1 };
-  const int expectedValue = 0; // The expected value for the original component axis
-  itk::ExposeMetaData<int>(thisDic, key, value);
-  if (value != expectedValue)
-  {
-    std::cerr << "Metadata test failed: '" << key << "' value is expected to be '" << expectedValue << "', got '"
-              << value << "' instead" << std::endl;
-    exit(EXIT_FAILURE);
-  }
-  */
 
   // Test that additional metadata stored in the NRRD file is added to the metadata dictionary
   checkField<std::string>(thisDic, "axis 0 index type", "numeric");


### PR DESCRIPTION
Fix three defects in the new NRRD IO tests introduced with 5D support (10389fb01d4): an always-false `argc < 1` guard leaving `argv[1]` unprotected, a stray `argc` in a usage line, and a commented-out duplicate check. Same fixes applied to the release-5.4 backport in #6435.

<details>
<summary>Details and local validation</summary>

- `itkNrrdVectorImageUnitLabelReadTest.cxx`: `argc < 1` can never be true, so a no-argument invocation read `argv[1]` out of bounds. Now `argc < 2`. Also removed a commented-out block duplicating the `checkField` call above it.
- `itkNrrd5dVectorImageReadWriteTest.cxx`: usage line printed `argc` as an integer before the executable name.

Validated locally: rebuilt `ITKIONRRDTestDriver`, both tests pass, and the no-arg invocation now prints usage and exits with failure instead of undefined behavior. `pre-commit run --all-files` clean.

Flagged by greptile P1/P2 review on #6435.

</details>

<!--
provenance: claude-code session 2026-06-11 (gh-triage-pr on #6435)
commit: f263b51685
related_pr: 6435 (release-5.4 backport carries identical fixes squashed into its NRRD commit)
-->
