### PR TITLE
COMP: Fix spFactor.c K&R prototypes for C23 compilers (GCC 15+/16)

### DIFF
--- a/Modules/ThirdParty/VNL/src/vxl/v3p/netlib/sparse/spFactor.c
+++ b/Modules/ThirdParty/VNL/src/vxl/v3p/netlib/sparse/spFactor.c
@@ -1343,7 +1343,7 @@ int  I, NumberOfTies;
 ElementPtr  ChosenPivot, TiedElements[MAX_MARKOWITZ_TIES + 1];
 RealNumber  Magnitude, LargestInCol, Ratio, MaxRatio;
 RealNumber  LargestOffDiagonal;
-RealNumber  FindBiggestInColExclude();
+RealNumber  FindBiggestInColExclude( MatrixPtr, ElementPtr, int );
 
 /* Begin `QuicklySearchDiagonal'. */
     NumberOfTies = -1;
@@ -1541,7 +1541,7 @@ register  ElementPtr  pDiag;
 int  I;
 ElementPtr  ChosenPivot, pOtherInRow, pOtherInCol;
 RealNumber  Magnitude, LargestInCol, LargestOffDiagonal;
-RealNumber  FindBiggestInColExclude();
+RealNumber  FindBiggestInColExclude( MatrixPtr, ElementPtr, int );
 
 /* Begin `QuicklySearchDiagonal'. */
     ChosenPivot = NULL;
@@ -1708,7 +1708,7 @@ register  ElementPtr  pDiag;
 int  NumberOfTies=0, Size = Matrix->Size;
 ElementPtr  ChosenPivot=0;
 RealNumber  Magnitude=0, Ratio=0, RatioOfAccepted =0, LargestInCol=0;
-RealNumber  FindBiggestInColExclude();
+RealNumber  FindBiggestInColExclude( MatrixPtr, ElementPtr, int );
 
 /* Begin `SearchDiagonal'. */
     ChosenPivot = NULL;
@@ -1837,7 +1837,7 @@ long  Product=0, MinMarkowitzProduct=0;
 ElementPtr  ChosenPivot=0, pLargestElement=0;
 RealNumber  Magnitude=0, LargestElementMag=0,
  Ratio=0, RatioOfAccepted=0, LargestInCol=0;
-RealNumber  FindLargestInCol();
+RealNumber  FindLargestInCol( ElementPtr );
 
 /* Begin `SearchEntireMatrix'. */
     ChosenPivot = NULL;


### PR DESCRIPTION
## Problem

GCC 15+ (Fedora 42/43/44, GCC 16 locally) defaults to C23, where an empty `()` function prototype means `(void)` instead of K&R unspecified-args. VXL's bundled netlib `v3p/netlib/sparse/spFactor.c` has four block-scope re-declarations of `FindBiggestInColExclude` / `FindLargestInCol` with empty `()`, then calls them with arguments. C23 rejects this:

```
error: too many arguments to function 'FindBiggestInColExclude'; expected 0, have 3
error: conflicting types for 'FindBiggestInColExclude'; have 'RealNumber(void)'
```

This breaks the ITK build on every C23-default toolchain. Reported downstream in BIC-MNI/minc-toolkit-v2#197, which works around it by forcing `-std=gnu17` on ITK's C flags — a build-flag workaround rather than a source fix.

## Fix

The file already carries correct file-scope `static` prototypes (lines 81-82). Replace the four stale empty-paren block-scope re-declarations with the full signatures so `()` no longer collapses to `(void)` under C23. C-only; pure prototype tightening with no codegen change under pre-C23 compilers, and no global `-std` override required.

## Validation

With GCC 16.1.1:
- pre-edit: `gcc -std=c23 -fsyntax-only` reproduces the `too many arguments` / `conflicting types` errors above
- post-edit: compiles cleanly with no `-std` override

Note: gcc-16 detection in `vcl/vcl_compiler.h` is already present (`VCL_GCC_16`, cascade extended through gcc-20 in 4f97f727c3), so no compiler-detection change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)