### PR TITLE
ENH: Publish the Doxygen tag file on release tags

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -7,6 +7,8 @@ on:
         branches:
             - main
             - 'release*'
+        tags:
+            - 'v*'
         paths-ignore:
             - '*.md'
             - LICENSE
@@ -46,6 +48,14 @@ jobs:
       - name: Run warnings-only Doxygen pass
         run: pixi run doxygen-ci
 
+      - name: Upload Doxygen tag file for the release job
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v4
+        with:
+          name: doxygen-tagfile
+          path: build-doxygen/Utilities/Doxygen/InsightDoxygen.tag
+          if-no-files-found: error
+
       - name: Upload warnings log and effective configuration
         if: failure()
         uses: actions/upload-artifact@v4
@@ -55,3 +65,31 @@ jobs:
             build-doxygen/doxygen-warnings.log
             build-doxygen/Utilities/Doxygen/Doxyfile.Documentation
           if-no-files-found: ignore
+
+  publish-doxygen-tagfile:
+    needs: doxygen-warnings
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-26.04
+    timeout-minutes: 10
+    permissions:
+      # Uploads the Doxygen tag file to the release for this version tag.
+      contents: write
+
+    steps:
+      - name: Download Doxygen tag file
+        uses: actions/download-artifact@v4
+        with:
+          name: doxygen-tagfile
+
+      - name: Publish Doxygen tag file to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG_NAME#v}"
+          gzip -9 -c InsightDoxygen.tag > "InsightDoxygenDocTag-${VERSION}.gz"
+          if ! gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            gh release create "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --draft --verify-tag \
+              --title "$TAG_NAME" --notes "Draft created by the Doxygen workflow to hold the tag file."
+          fi
+          gh release upload "$TAG_NAME" "InsightDoxygenDocTag-${VERSION}.gz" --clobber --repo "$GITHUB_REPOSITORY"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,10 @@ cmd = '''cmake \
   -DBUILD_TESTING:BOOL=OFF \
   -DITK_FORBID_DOWNLOADS:BOOL=ON \
   -DITK_BUILD_DOCUMENTATION:BOOL=ON \
+  -DModule_ITKReview:BOOL=ON \
+  -DModule_MGHIO:BOOL=ON \
+  -DModule_GenericLabelInterpolator:BOOL=ON \
+  -DModule_AdaptiveDenoising:BOOL=ON \
   -DITK_DOXYGEN_WARNINGS_ONLY:BOOL=ON'''
 description = "Configure ITK for the Doxygen warnings check"
 


### PR DESCRIPTION
Restores the `InsightDoxygenDocTag-<version>.gz` release artifact (required by `Documentation/Maintenance/Release.md`, last shipped with v5.3.0) by publishing the tag file the warnings-only Doxygen pass already generates, on every `v*` tag push.

<details>
<summary>Background and design</summary>

The DocTag asset silently disappeared when nightly Doxygen generation moved to the ITKDoxygen GHA repo (Discourse #4790): its packaging only ships Html and Xml, while `Release.md` still lists the tag in the required-artifact checklist and the "download from latest ITKDoxygen release and rename" flow. Downstream, ITKSphinxExamples links class references through this tag and is pinned to the stale 5.3.0 copy, which predates several class compounds.

In `ITK_DOXYGEN_WARNINGS_ONLY` mode every Doxygen output is disabled except `GENERATE_TAGFILE` (the cheapest output, see `Utilities/Doxygen/CMakeLists.txt`), so the tag is free: release-tag runs gzip `build-doxygen/Utilities/Doxygen/InsightDoxygen.tag` and `gh release upload` it.

The `configure-doxygen-ci` module set adds Review, MGHIO, GenericLabelInterpolator, and AdaptiveDenoising (all in-tree, dependency-free) to match the ITKDoxygen nightly's coverage, so tag and XML stay consistent for consumers — and the warnings gate now also covers those modules' documentation. VtkGlue/BridgeOpenCV need VTK/OpenCV and remain covered only by the ITKDoxygen docker build (companion PR there).

</details>

<!--
provenance: claude-code session 2026-06-12
companion: ITKDoxygen PR (publish tag + enable VtkGlue/BridgeOpenCV in docker), ITKSphinxExamples #458 (consume current artifacts)
trigger note: tag pushes added to on.push; paths-ignore does not apply to tags. Job permissions raised to contents:write for the release upload; fork PR tokens remain read-only.
-->
