### PR TITLE
WIP: Compiler-flag suppression audit (CI triage — do not merge)

### DIFF
--- a/Utilities/CompilerFlagAudit/WIP-notes.md
+++ b/Utilities/CompilerFlagAudit/WIP-notes.md
@@ -1,0 +1,136 @@
+# WIP: Compiler Flag Suppression Audit
+
+**Branch:** compiler-suppression-audit
+**WIP PR:** InsightSoftwareConsortium/ITK#6442 (draft, CI-triage only — do not merge)
+**Status:** investigation in progress — this directory is removed before PR merge
+
+CI watch target for MSVC warnings: `Pixi-Cxx (windows-2022)` GitHub Actions job.
+
+---
+
+## Status
+
+### Done (committed)
+
+| Commit | Change |
+|---|---|
+| `COMP: Remove obsolete Solaris flags and dead MSVC C4786 pragmas` | Removed Solaris blocks; removed 4786 from Video/MinimalPath; converted DCMTKTransformIO raw pragma to macro; added include guard + fixed tab in MinimalPathTest.h |
+| `COMP: Remove dead and fixed compiler-warning suppressions` | Promoted from WIP after CI triage validated it: drops MSVC 4127/4244/4305/4309 + `-Wno-strict-overflow`. 4127/4305/4309 + strict-overflow are dead (0 warnings); 4244 sites fixed (see next row). |
+| `COMP: Add explicit casts at MSVC C4244 narrowing sites` | 5 files: `itkProcessObject.h:927` (619 instances), `itkWin32OutputWindow.cxx`, `itkCSVFileReaderBase.cxx` (×4), `itkFixedArrayGTest.cxx`, `itkNarrowBandTest.cxx`. Built + ran affected tests locally (all pass). |
+| `COMP: Remove global -Wno-format-nonliteral from warning flags` | 5 targeted `ITK_GCC_SUPPRESS_Wformat_nonliteral` sites already present; global flag dropped. ITK proper clean; only RTK remote site fires (legit). |
+| `ENH: Add ccache launcher to configure-release pixi task` | `pixi run build-release` now uses ccache |
+
+**Still WIP (remove at merge-prep):** `WIP: Add compiler-flag audit scripts`, `WIP: Update audit notes` — and this `Utilities/CompilerFlagAudit/` directory.
+
+### Audited — no action needed
+
+| Item | Finding |
+|---|---|
+| `ITK_GCC_SUPPRESS_Wfloat_equal` (all 15 sites) | All intentional: sentinel comparisons to `NumericTraits<T>::max()`, Set-macro "has value changed?", and VNL FFT header wrap. No code smell. |
+| `ITK_GCC_SUPPRESS_Wformat_nonliteral` (5 sites) | All legitimate: user-controlled format strings for numeric series filenames and TIFF field format strings. |
+| `ITK_GCC_SUPPRESS_Wmaybe_uninitialized` in `itkSymmetricEigenAnalysis.h` | GCC 11+ false positive in Eigen SIMD code. Keep. |
+| `INTEL_SUPPRESS_warning_1292` in `itkMultiThreaderBase.h` | Needed while ICC 19.1 is in compiler matrix. Keep. |
+| `#pragma optimize("", off/on)` in `itkCompensatedSummation.hxx` | Kahan summation correctness control, not a warning suppression. Keep. |
+| Intel ICC name detection via `icc.*`/`icpc.*` | If ICC is dropped from CDash matrix, remove ICC blocks in ITKSetStandardCompilerFlags.cmake. Verify first. |
+
+---
+
+## Remaining — awaiting CI results
+
+### MSVC (Windows CI)
+
+C4127, C4244, C4305, C4309 exposed in WIP commit. Triage CI output:
+
+```powershell
+# After CI run completes, on local Windows build:
+.\build-windows.ps1 -Expose 4244,4305,4309
+Select-String -Path build-flag-audit\warnings-C4244.txt -Pattern "warning C4244" | Select-Object -First 30
+```
+
+Decision criteria per warning number:
+- **C4244** — each narrowing site: use `static_cast<>`, or if the value is known safe, use `itk::Math::CastWithRangeCheck` where applicable.
+- **C4305** — each truncation: explicit `static_cast<float>(x)` at assignment.
+- **C4309** — constant truncation: use the correct literal type suffix (e.g. `0x80u` not `0x80`).
+- **C4127** — each `if (constant)`: convert to `if constexpr` or `static_assert` where appropriate.
+
+#### Windows CI result (Pixi-Cxx windows-2022, MSVC, commit 4015d541cf)
+
+Job passed (warnings are not errors in ITK CI). Warning counts:
+
+| Code | Count | Verdict |
+|---|---|---|
+| C4127 | 0 | **Dead suppression — safe to remove permanently.** |
+| C4305 | 0 | **Dead suppression — safe to remove permanently.** |
+| C4309 | 0 | **Dead suppression — safe to remove permanently.** |
+| C4244 | 629 | **Live — must fix code before re-suppressing or removing.** |
+
+C4244 is highly concentrated:
+
+- **619 / 629** = one line: `itkProcessObject.h(927)` — `progressFixedToFloat()` returns
+  `float` but the body computes in `double`. Fix: wrap the return expression in
+  `static_cast<float>(...)`. One edit clears 619 instances.
+- `itkWin32OutputWindow.cxx(112)` — `__int64`→`int` (1, real code)
+- `itkCSVFileReaderBase.cxx(86,154,157,158)` — `streamoff`/`SizeValueType` narrowing (4, real code)
+- `itkFixedArrayGTest.cxx(419,420,436,437)` — `__int64`→`unsigned int` (4, test code)
+- `itkNarrowBandTest.cxx(44)` — `double`→`TDataType` (1, test code)
+
+All are straightforward `static_cast<>` fixes. None in ThirdParty.
+
+### GCC/Clang (Linux/macOS CI)
+
+`-Wno-strict-overflow` removed in WIP commit. Check CI output for:
+```
+overflow in expression; result is X with type Y [-Wstrict-overflow]
+```
+Each site: use unsigned arithmetic, restructure the expression, or use a `__builtin_add_overflow` guard.
+
+#### Local GCC 14.3 result (Release/-O3, suppressions genuinely removed)
+
+Verified after unsetting the cached `ITK_CXX_WARNING_FLAGS` / `ITK_C_WARNING_FLAGS`
+(see the cache gotcha below) and a full recompile:
+
+- **`-Wstrict-overflow`: 0 warnings** across ITK proper and all enabled remote
+  modules, at -O3 (optimizer on, which is when this warning fires). The
+  `-Wno-strict-overflow` suppression is dead on GCC 14 — removal is safe on
+  this config. Pending full-matrix CI confirmation.
+- **`-Wformat-nonliteral`: 1 site only** — `Modules/Remote/RTK/include/rtkIterationCommands.h:161`,
+  a `snprintf(buffer, 1024, m_FileFormat.c_str(), m_IterationCount)` for a
+  user-controlled output-filename pattern (`%d` iteration number). Legitimate,
+  and it is a *remote module* (RTK upstream owns it), not ITK proper. ITK proper
+  is clean — the 5 targeted `ITK_GCC_SUPPRESS_Wformat_nonliteral` sites already
+  cover its own cases.
+
+#### Cache gotcha (cost one wasted build)
+
+`ITKSetStandardCompilerFlags.cmake:371` computes the warning flags once and
+stores them in the `ITK_CXX_WARNING_FLAGS` / `ITK_C_WARNING_FLAGS` CACHE STRINGs.
+Editing the suppression list in source has **no effect on an existing build
+tree** — reconfigure skips recomputation. To re-trigger locally:
+`cmake -Bbuild -U ITK_CXX_WARNING_FLAGS -U ITK_C_WARNING_FLAGS .` then rebuild.
+CI is unaffected (fresh checkout each run).
+
+#### Unrelated to this audit
+
+32 RTK application executables fail to link (undefined references to RTK's own
+`*ImageIOFactoryRegister__Private()` symbols). Pre-existing RTK remote-module
+linkage issue — warning-flag changes cannot cause undefined-symbol link errors.
+
+---
+
+## Still to investigate
+
+| Item | Status |
+|---|---|
+| MSVC `4505` (unreferenced local function) | Kept for now; check CI Windows output to see if it fires on template headers |
+| `-Wno-uninitialized` (C compiler only) | Try removing; check if C files in ThirdParty wrappers warn |
+| `-Wno-long-double` on Apple Silicon | Likely dead on ARM64; test with macOS CI arm64 runner |
+| `#pragma warning(disable : 4996)` in RLEImage/MorphologicalContourInterpolation manualTest.cxx | Review which deprecated APIs are called; fix or document |
+| `ITK_CLANG_SUPPRESS_Wduplicate_enum` in `itkCommonEnums.h` | Track with `ITK_LEGACY_REMOVE` sweep; keep for now |
+
+---
+
+## Open Questions
+
+- Is Intel ICC still being tested on CDash? Check: https://open.cdash.org/index.php?project=Insight
+- Does `4505` fire in Release CI builds?
+- Does `-Wno-long-double` still fire on Apple Silicon (ARM64)?

--- a/Utilities/CompilerFlagAudit/WIP-notes.md
+++ b/Utilities/CompilerFlagAudit/WIP-notes.md
@@ -1,10 +1,31 @@
 # WIP: Compiler Flag Suppression Audit
 
-**Branch:** compiler-suppression-audit
-**WIP PR:** InsightSoftwareConsortium/ITK#6442 (draft, CI-triage only — do not merge)
+**Branch:** compiler-suppression-audit (#6442, WIP umbrella superset — do not merge)
 **Status:** investigation in progress — this directory is removed before PR merge
 
+### PR landscape (2026-06-15)
+
+- **#6443 — MERGED**: SunOS flags, GCC/Clang `-Wno-strict-overflow` + `-Wno-format-nonliteral`,
+  MSVC pragmas 4127/4244/4305/4309/4786/4996, and the C4244 code fixes (`itkProcessObject`
+  `static_cast<float>`, `itkCSVFileReaderBase` `std::streamoff`, scoped MSVC suppression in
+  the FixedArray index test).
+- **#6444 — open (draft)**: dead Intel ICC cmake block, `-Wno-long-double`, `-Wno-uninitialized`,
+  the `__INTEL_COMPILER` source blocks, and `-Wno-invalid-offsetof`.
+- **#6442 — this branch**: superset of #6444 + the audit tooling (this directory + the ccache task).
+
 CI watch target for MSVC warnings: `Pixi-Cxx (windows-2022)` GitHub Actions job.
+
+### Iteration-4 findings
+
+- **`__INTEL_COMPILER` source blocks removed** (#6444): `itkMacro.h` convenience macros +
+  Intel<19.1 `#error` + two simplified GCC guards; `itkMultiThreaderBase.h`, `itkArray.h`,
+  `itkCompensatedSummation.hxx` Intel pragmas. Built + tested locally; no-op on all CI compilers.
+- **`-Wno-invalid-offsetof` is dead** (#6444): full GCC 14 rebuild → 0 `-Winvalid-offsetof`
+  warnings; ITK proper does not use `offsetof`. Removed.
+- **Retained-flag scope review**: source-level `ITK_GCC/CLANG_SUPPRESS_*` macros are
+  compiler-guarded + single-site (exemplary); MSVC 4251/4273/4275 are blanket-but-justified
+  (DLL-export); the global cmake `-Wno-*` are the broadest remaining surface.
+- **Sole open item: MSVC 4505** — needs a Windows-CI exposure cycle (can't test locally).
 
 ---
 

--- a/Utilities/CompilerFlagAudit/build-linux.sh
+++ b/Utilities/CompilerFlagAudit/build-linux.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# ITK Release+ccache build for compiler-flag investigation (Linux)
+# Usage:
+#   ./build-linux.sh                        # baseline Release build
+#   ./build-linux.sh --remove-strict-overflow  # patch out -Wno-strict-overflow first
+#   ./build-linux.sh --jobs 8               # override parallel job count
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/build-flag-audit"
+JOBS="${JOBS:-$(nproc)}"
+REMOVE_STRICT_OVERFLOW=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --remove-strict-overflow) REMOVE_STRICT_OVERFLOW=1 ;;
+    --jobs) shift; JOBS="$1" ;;
+    *) echo "Unknown arg: $arg"; exit 1 ;;
+  esac
+done
+
+FLAGS_FILE="${REPO_ROOT}/CMake/ITKSetStandardCompilerFlags.cmake"
+BACKUP="${FLAGS_FILE}.bak"
+
+restore() {
+  if [[ -f "${BACKUP}" ]]; then
+    mv "${BACKUP}" "${FLAGS_FILE}"
+    echo "[restore] ${FLAGS_FILE} restored"
+  fi
+}
+trap restore EXIT
+
+if [[ ${REMOVE_STRICT_OVERFLOW} -eq 1 ]]; then
+  cp "${FLAGS_FILE}" "${BACKUP}"
+  sed -i 's/\s*-Wno-strict-overflow//' "${FLAGS_FILE}"
+  echo "[patch] removed -Wno-strict-overflow from ${FLAGS_FILE}"
+fi
+
+cmake \
+  -B "${BUILD_DIR}" \
+  -S "${REPO_ROOT}" \
+  -G Ninja \
+  -DCMAKE_BUILD_TYPE:STRING=Release \
+  -DBUILD_TESTING:BOOL=ON \
+  -DCMAKE_C_COMPILER_LAUNCHER:STRING=ccache \
+  -DCMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache
+
+cmake --build "${BUILD_DIR}" -j "${JOBS}" 2>&1 | tee "${BUILD_DIR}/build.log"
+
+echo ""
+echo "=== Warning summary ==="
+grep -c " warning:" "${BUILD_DIR}/build.log" || true
+echo "Log: ${BUILD_DIR}/build.log"

--- a/Utilities/CompilerFlagAudit/build-macos.sh
+++ b/Utilities/CompilerFlagAudit/build-macos.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# ITK Release+ccache build for compiler-flag investigation (macOS)
+# Usage:
+#   ./build-macos.sh                           # baseline Release build
+#   ./build-macos.sh --remove-strict-overflow  # patch out -Wno-strict-overflow
+#   ./build-macos.sh --check-long-double       # test if -Wno-long-double still fires
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/build-flag-audit"
+JOBS="${JOBS:-$(sysctl -n hw.logicalcpu)}"
+REMOVE_STRICT_OVERFLOW=0
+CHECK_LONG_DOUBLE=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --remove-strict-overflow) REMOVE_STRICT_OVERFLOW=1 ;;
+    --check-long-double)      CHECK_LONG_DOUBLE=1 ;;
+    *) echo "Unknown arg: $arg"; exit 1 ;;
+  esac
+done
+
+FLAGS_FILE="${REPO_ROOT}/CMake/ITKSetStandardCompilerFlags.cmake"
+BACKUP="${FLAGS_FILE}.bak"
+
+restore() {
+  if [[ -f "${BACKUP}" ]]; then
+    mv "${BACKUP}" "${FLAGS_FILE}"
+    echo "[restore] ${FLAGS_FILE} restored"
+  fi
+}
+trap restore EXIT
+
+cp "${FLAGS_FILE}" "${BACKUP}"
+PATCHED=0
+
+if [[ ${REMOVE_STRICT_OVERFLOW} -eq 1 ]]; then
+  sed -i.tmp 's/[[:space:]]*-Wno-strict-overflow//' "${FLAGS_FILE}"
+  echo "[patch] removed -Wno-strict-overflow"
+  PATCHED=1
+fi
+
+if [[ ${CHECK_LONG_DOUBLE} -eq 1 ]]; then
+  # Remove -Wno-long-double to see if AppleClang still warns on ARM64 or x86_64
+  sed -i.tmp 's/[[:space:]]*-Wno-long-double[[:space:]]*#Needed on APPLE//' "${FLAGS_FILE}"
+  echo "[patch] removed -Wno-long-double (check if warnings appear)"
+  PATCHED=1
+fi
+
+[[ ${PATCHED} -eq 0 ]] && rm -f "${BACKUP}"
+
+cmake \
+  -B "${BUILD_DIR}" \
+  -S "${REPO_ROOT}" \
+  -G Ninja \
+  -DCMAKE_BUILD_TYPE:STRING=Release \
+  -DBUILD_TESTING:BOOL=ON \
+  -DCMAKE_C_COMPILER_LAUNCHER:STRING=ccache \
+  -DCMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache
+
+cmake --build "${BUILD_DIR}" -j "${JOBS}" 2>&1 | tee "${BUILD_DIR}/build.log"
+
+echo ""
+echo "=== Warning summary ==="
+grep -c "warning:" "${BUILD_DIR}/build.log" || echo "0 warnings"
+if [[ ${CHECK_LONG_DOUBLE} -eq 1 ]]; then
+  echo "--- long-double hits ---"
+  grep "long.double\|Wlong-double" "${BUILD_DIR}/build.log" | sort -u || echo "(none)"
+fi
+echo "Log: ${BUILD_DIR}/build.log"

--- a/Utilities/CompilerFlagAudit/build-windows.bat
+++ b/Utilities/CompilerFlagAudit/build-windows.bat
@@ -1,0 +1,27 @@
+@echo off
+:: Thin wrapper: opens an x64 Native Tools shell and runs build-windows.ps1
+:: Run this from any Command Prompt on a VS 2022 machine.
+::
+:: Usage:
+::   build-windows.bat                        (baseline)
+::   build-windows.bat -Expose 4244,4305,4309 (expose specific warnings)
+::
+:: Requires:
+::   Visual Studio 2022 (default install path assumed; edit VCVARS64 if different)
+
+set "VCVARS64=%ProgramFiles%\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+if not exist "%VCVARS64%" set "VCVARS64=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvars64.bat"
+if not exist "%VCVARS64%" set "VCVARS64=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+
+if not exist "%VCVARS64%" (
+  echo ERROR: Could not find vcvars64.bat for VS 2022.
+  echo        Edit VCVARS64 path in %~f0
+  exit /b 1
+)
+
+set "PS=%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe"
+set "SCRIPT=%~dp0build-windows.ps1"
+
+:: Forward all arguments to the PowerShell script
+"%PS%" -NoProfile -ExecutionPolicy Bypass -Command ^
+  "& { & '%VCVARS64%'; & '%SCRIPT%' %* }"

--- a/Utilities/CompilerFlagAudit/build-windows.ps1
+++ b/Utilities/CompilerFlagAudit/build-windows.ps1
@@ -1,0 +1,114 @@
+# ITK Release+ccache build for compiler-flag investigation (Windows/MSVC)
+#
+# Run from a "Developer PowerShell for VS 2022" (or x64 Native Tools Command Prompt).
+#
+# Usage:
+#   .\build-windows.ps1                          # baseline Release build
+#   .\build-windows.ps1 -Expose 4244             # remove #pragma warning(disable:4244), rebuild
+#   .\build-windows.ps1 -Expose 4244,4305,4309   # remove multiple suppressions
+#   .\build-windows.ps1 -Expose 4127,4244,4305,4309,4505  # all removal candidates
+#   .\build-windows.ps1 -Jobs 16                 # parallel job count (default: CPU count)
+#
+# Prerequisites:
+#   - Visual Studio 2022 with C++ workload
+#   - CMake 3.22+ and Ninja in PATH (available after 'pixi install -e cxx')
+#   - ccache 4.x in PATH  (or set -UseScache to try sccache instead)
+#
+# Output:
+#   build-flag-audit\build.log  -- full build output
+#   build-flag-audit\warnings-C<num>.txt -- per-warning filtered output
+
+param(
+  [string]  $Expose    = "",     # comma-separated MSVC warning numbers, e.g. "4244,4305"
+  [int]     $Jobs      = [System.Environment]::ProcessorCount,
+  [switch]  $UseSccache,         # use sccache instead of ccache (sometimes easier on Windows)
+  [switch]  $NoPatch            # skip patching, just build (for re-runs after manual edits)
+)
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot  = (Resolve-Path "$ScriptDir\..\.." ).Path
+$BuildDir  = "$RepoRoot\build-flag-audit"
+$Win32Header = "$RepoRoot\Modules\Core\Common\include\itkWin32Header.h"
+$Backup    = "$Win32Header.bak"
+
+$Launcher = if ($UseSccache) { "sccache" } else { "ccache" }
+
+# ── Restore on exit ──────────────────────────────────────────────────────────
+$restoreNeeded = $false
+function Restore-Header {
+  if ($restoreNeeded -and (Test-Path $Backup)) {
+    Copy-Item $Backup $Win32Header -Force
+    Remove-Item $Backup -Force
+    Write-Host "[restore] itkWin32Header.h restored"
+  }
+}
+Register-EngineEvent PowerShell.Exiting -Action { Restore-Header } | Out-Null
+
+# ── Patch itkWin32Header.h ────────────────────────────────────────────────────
+$ExposeList = @()
+if ($Expose -ne "" -and -not $NoPatch) {
+  $ExposeList = $Expose -split "," | ForEach-Object { $_.Trim() }
+  Copy-Item $Win32Header $Backup -Force
+  $restoreNeeded = $true
+
+  $content = Get-Content $Win32Header -Raw
+  foreach ($num in $ExposeList) {
+    # Remove both the comment line and the pragma line for each warning number
+    $content = $content -replace "(?m)^[ \t]*//[^\n]*\n[ \t]*#[ \t]*pragma warning\(disable : $num\)[ \t]*\r?\n", ""
+    # Fallback: remove just the pragma line if no comment precedes it
+    $content = $content -replace "(?m)^[ \t]*#[ \t]*pragma warning\(disable : $num\)[ \t]*\r?\n", ""
+  }
+  Set-Content $Win32Header $content -NoNewline
+  Write-Host "[patch] Removed #pragma warning(disable) for: $($ExposeList -join ', ')"
+  Write-Host "        Edit: $Win32Header"
+}
+
+# ── CMake configure ───────────────────────────────────────────────────────────
+if (-not (Test-Path "$BuildDir\CMakeCache.txt")) {
+  Write-Host "[configure] $BuildDir"
+  cmake `
+    -B $BuildDir `
+    -S $RepoRoot `
+    -G Ninja `
+    -DCMAKE_BUILD_TYPE:STRING=Release `
+    -DBUILD_TESTING:BOOL=ON `
+    "-DCMAKE_C_COMPILER_LAUNCHER:STRING=$Launcher" `
+    "-DCMAKE_CXX_COMPILER_LAUNCHER:STRING=$Launcher"
+  if ($LASTEXITCODE -ne 0) { Restore-Header; exit $LASTEXITCODE }
+}
+
+# ── Build ─────────────────────────────────────────────────────────────────────
+Write-Host "[build] -j $Jobs"
+$LogFile = "$BuildDir\build.log"
+cmake --build $BuildDir -j $Jobs 2>&1 | Tee-Object -FilePath $LogFile
+$buildExit = $LASTEXITCODE
+
+# ── Extract per-warning files ─────────────────────────────────────────────────
+$allWarnings = @{}
+foreach ($num in $ExposeList) {
+  $hits = Select-String -Path $LogFile -Pattern "warning C$num" | Select-Object -ExpandProperty Line
+  if ($hits.Count -gt 0) {
+    $outFile = "$BuildDir\warnings-C$num.txt"
+    $hits | Set-Content $outFile
+    $allWarnings[$num] = $hits.Count
+    Write-Host "[C$num] $($hits.Count) warnings -> $outFile"
+  } else {
+    Write-Host "[C$num] 0 warnings (suppressed via pragma or not triggered)"
+  }
+}
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "=== Build summary ==="
+$totalWarnings = (Select-String -Path $LogFile -Pattern " warning C\d{4}").Count
+Write-Host "Total MSVC warnings: $totalWarnings"
+Write-Host "Log: $LogFile"
+
+Restore-Header
+
+if ($buildExit -ne 0) {
+  Write-Host "[FAIL] Build exited with code $buildExit"
+  exit $buildExit
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,7 +209,9 @@ cmd = '''cmake \
   -S. \
   -GNinja \
   -DCMAKE_BUILD_TYPE:STRING=Release \
-  -DBUILD_TESTING:BOOL=ON'''
+  -DBUILD_TESTING:BOOL=ON \
+  -DCMAKE_C_COMPILER_LAUNCHER:STRING=ccache \
+  -DCMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache'''
 description = "Configure ITK - Release"
 outputs = ["build-release/CMakeFiles/"]
 


### PR DESCRIPTION
**WIP / DRAFT — not for merge.** This branch deliberately removes several long-standing compiler-warning suppressions so that CI (especially the Windows/MSVC and GCC/Clang matrices) re-surfaces the underlying warnings for triage. The goal is to determine which suppressions are still load-bearing and which are dead, then fix the code rather than re-suppress.

Audit working notes live in `Utilities/CompilerFlagAudit/` — that directory and the two `WIP:` commits are removed before this is proposed for real review.

<details>
<summary>Suppressions exposed for CI triage</summary>

- **MSVC:** C4127 (`if (constant)`), C4244 (narrowing conversion), C4305 (truncation on assignment), C4309 (constant truncation)
- **GCC/Clang:** global `-Wno-strict-overflow` removed
- **Already dropped (separate commits, expected clean):** global `-Wno-format-nonliteral` (5 targeted suppressions retained), obsolete Solaris flags, dead MSVC C4786/C4996 pragmas

Per-warning remediation plan is in `Utilities/CompilerFlagAudit/WIP-notes.md`.
</details>

<details>
<summary>Why CI-first for the Windows warnings</summary>

The MSVC warnings (C4127/4244/4305/4309) cannot be exercised on the Linux/macOS developer workstations driving this audit, so the Windows CI run is the first executor for those. The GCC `-Wno-strict-overflow` removal is being triaged in parallel on a local Linux build.
</details>

<!--
provenance: claude-code session 2026-06-14, branch compiler-suppression-audit
purpose: CI triage of compiler-warning suppressions; NOT a merge candidate
remove-before-merge:
  - commit "WIP: Add compiler-flag audit scripts (remove before PR merge)" (adds Utilities/CompilerFlagAudit/)
  - commit "WIP: Remove MSVC 4127/4244/4305/4309 and -Wno-strict-overflow for CI audit"
  - commit "WIP: Update audit notes with iteration-1 findings"
watch: Windows/MSVC CI checks for C4127/C4244/C4305/C4309; GCC for -Wstrict-overflow
post_merge_action: split confirmed real fixes into focused COMP: PRs; re-suppress only verified false positives
-->
