### PR TITLE
COMP: Remove dead compiler-warning suppressions (Windows/Unix/SunOS)

### DIFF
--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -348,38 +348,6 @@ macro(check_compiler_platform_flags)
     )
   endif()
 
-  #-----------------------------------------------------------------------------
-
-  # for the gnu compiler a -D_PTHREADS is needed on sun
-  # for the native compiler a -mt flag is needed on the sun
-  if(CMAKE_SYSTEM MATCHES "SunOS.*")
-    if(CMAKE_COMPILER_IS_GNUCXX)
-      set(ITK_REQUIRED_CXX_FLAGS "${ITK_REQUIRED_CXX_FLAGS} -D_PTHREADS")
-      set(ITK_REQUIRED_LINK_FLAGS "${ITK_REQUIRED_LINK_FLAGS} -lrt")
-    else()
-      set(ITK_REQUIRED_CXX_FLAGS "${ITK_REQUIRED_CXX_FLAGS} -mt")
-      set(ITK_REQUIRED_C_FLAGS "${ITK_REQUIRED_C_FLAGS} -mt")
-    endif()
-    # Add flags for the SUN compiler to provide all the methods for std::allocator.
-    #
-    check_cxx_source_compiles(
-      "-features=no%anachronisms"
-      SUN_COMPILER
-    )
-    if(SUN_COMPILER)
-      check_cxx_source_compiles(
-        "-library=stlport4"
-        SUN_COMPILER_HAS_STL_PORT_4
-      )
-      if(SUN_COMPILER_HAS_STL_PORT_4)
-        set(
-          ITK_REQUIRED_CXX_FLAGS
-          "${ITK_REQUIRED_CXX_FLAGS} -library=stlport4"
-        )
-      endif()
-    endif()
-  endif()
-
   # mingw thread support
   if(MINGW)
     set(ITK_REQUIRED_CXX_FLAGS "${ITK_REQUIRED_CXX_FLAGS} -mthreads")

--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -122,12 +122,10 @@ function(check_compiler_warning_flags c_warning_flags_var cxx_warning_flags_var)
     -Wextra
     -Wformat=2
     -Winvalid-pch
-    -Wno-format-nonliteral
     -Wpointer-arith
     -Wshadow
     -Wunused
     -Wwrite-strings
-    -Wno-strict-overflow
   )
 
   # Check this list on C++ compiler only

--- a/Modules/Core/Common/include/itkProcessObject.h
+++ b/Modules/Core/Common/include/itkProcessObject.h
@@ -924,7 +924,7 @@ protected:
   static inline constexpr float
   progressFixedToFloat(uint32_t fixed)
   {
-    return static_cast<double>(fixed) / static_cast<double>(std::numeric_limits<uint32_t>::max());
+    return static_cast<float>(static_cast<double>(fixed) / static_cast<double>(std::numeric_limits<uint32_t>::max()));
   }
 
   /**

--- a/Modules/Core/Common/include/itkWin32Header.h
+++ b/Modules/Core/Common/include/itkWin32Header.h
@@ -31,12 +31,6 @@
 /** Disable some common warnings in MS VC++ */
 #if defined(_MSC_VER)
 
-// conditional expression is constant
-#  pragma warning(disable : 4127)
-
-// 'conversion' conversion from 'type1' to 'type2', possible loss of data
-#  pragma warning(disable : 4244)
-
 // 'identifier' : class 'type' needs to have dll-interface to be used by
 // clients of class 'type2'
 #  pragma warning(disable : 4251)
@@ -46,12 +40,6 @@
 
 // non dll-interface class 'type' used as base for dll-interface class 'type2'
 #  pragma warning(disable : 4275)
-
-// 'identifier' : truncation from 'type1' to 'type2'
-#  pragma warning(disable : 4305)
-
-// 'conversion' : truncation of constant value
-#  pragma warning(disable : 4309)
 
 // unreferenced local function has been removed
 #  pragma warning(disable : 4505)

--- a/Modules/Core/Common/src/itkWin32OutputWindow.cxx
+++ b/Modules/Core/Common/src/itkWin32OutputWindow.cxx
@@ -109,7 +109,7 @@ Win32OutputWindow::DisplayText(const char * text)
      *  and add the buffer with a control new line */
     else
     {
-      int len = NewLinePos - text;
+      int len = static_cast<int>(NewLinePos - text);
       strncpy(buffer.get(), text, len);
       buffer[len] = 0;
       text = NewLinePos + 1;

--- a/Modules/Core/Common/test/itkFixedArrayGTest.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayGTest.cxx
@@ -402,6 +402,13 @@ TEST(FixedArray, CArrayInteropAndIndexTypes)
     EXPECT_EQ(array20.GetElement(k), k);
   }
 
+  // operator[](unsigned int) narrows wide index types by design here; the
+  // test exercises that implicit conversion, so suppress MSVC C4244 for it.
+#if defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable : 4244)
+#endif
+
   // Test various index types (const access)
 #define TRY_INDEX_CONST(T)       \
   {                              \
@@ -435,4 +442,7 @@ TEST(FixedArray, CArrayInteropAndIndexTypes)
   TRY_INDEX(unsigned long);
   TRY_INDEX(long long);
   TRY_INDEX(unsigned long long);
+#if defined(_MSC_VER)
+#  pragma warning(pop)
+#endif
 }

--- a/Modules/Filtering/MinimalPathExtraction/test/MinimalPathTest.h
+++ b/Modules/Filtering/MinimalPathExtraction/test/MinimalPathTest.h
@@ -15,11 +15,8 @@
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.  See the above copyright notices for more information.
 =========================================================================*/
-
-#if defined(_MSC_VER)
-// Warning about: identifier was truncated to '255' characters in the debug information (MVC6.0 Debug)
-#  pragma warning(disable : 4786)
-#endif
+#ifndef MinimalPathTest_h
+#define MinimalPathTest_h
 
 // General includes
 #include <string>
@@ -165,7 +162,7 @@ ReadPathImage(const char * PathImagename, typename PathFilterType::Pointer pathF
 
   /* for (unsigned ii = 0; ii < pmap[1].size(); ++ii) */
   /*   { */
-  /* 	std::cout << pmap[1][ii] << std::endl; */
+  /*   std::cout << pmap[1][ii] << std::endl; */
   /*   } */
 
   info->SetStartPoint(pmap[1]);
@@ -740,3 +737,5 @@ Test_SpeedToPath_IterateNeighborhood_ExtendedSeed_ND(int argc, char * argv[])
   // Return
   return EXIT_SUCCESS;
 }
+
+#endif

--- a/Modules/Filtering/MorphologicalContourInterpolation/test/manualTest.cxx
+++ b/Modules/Filtering/MorphologicalContourInterpolation/test/manualTest.cxx
@@ -16,10 +16,6 @@
  *
  *=========================================================================*/
 
-#ifdef _MSC_VER
-#  pragma warning(disable : 4996) /* deprecation */
-#endif
-
 #include "itkTestDriverIncludeRequiredIOFactories.h"
 
 extern int

--- a/Modules/Filtering/RLEImage/test/manualTest.cxx
+++ b/Modules/Filtering/RLEImage/test/manualTest.cxx
@@ -16,10 +16,6 @@
  *
  *=========================================================================*/
 
-#ifdef _MSC_VER
-#  pragma warning(disable : 4996) /* deprecation */
-#endif
-
 #include "itkTestDriverIncludeRequiredIOFactories.h"
 
 extern int

--- a/Modules/IO/CSV/include/itkCSVFileReaderBase.h
+++ b/Modules/IO/CSV/include/itkCSVFileReaderBase.h
@@ -163,15 +163,15 @@ public:
   Parse() = 0;
 
 protected:
-  std::string   m_FileName{};
-  char          m_FieldDelimiterCharacter{};
-  char          m_StringDelimiterCharacter{};
-  bool          m_UseStringDelimiterCharacter{};
-  bool          m_HasRowHeaders{};
-  bool          m_HasColumnHeaders{};
-  std::ifstream m_InputStream{};
-  int           m_EndOfColumnHeadersLine{};
-  std::string   m_Line{};
+  std::string    m_FileName{};
+  char           m_FieldDelimiterCharacter{};
+  char           m_StringDelimiterCharacter{};
+  bool           m_UseStringDelimiterCharacter{};
+  bool           m_HasRowHeaders{};
+  bool           m_HasColumnHeaders{};
+  std::ifstream  m_InputStream{};
+  std::streamoff m_EndOfColumnHeadersLine{};
+  std::string    m_Line{};
 
   CSVFileReaderBase();
   ~CSVFileReaderBase() override = default;

--- a/Modules/IO/CSV/src/itkCSVFileReaderBase.cxx
+++ b/Modules/IO/CSV/src/itkCSVFileReaderBase.cxx
@@ -151,11 +151,11 @@ CSVFileReaderBase::GetDataDimension(SizeValueType & rows, SizeValueType & cols)
     ++rows;
 
     // Determine the max #columns and #rows
-    current_cols = cols;
+    current_cols = static_cast<unsigned int>(cols);
     if (!this->m_HasColumnHeaders && rows == 1)
     {
-      prev_cols = cols;
-      max_cols = cols;
+      prev_cols = static_cast<unsigned int>(cols);
+      max_cols = static_cast<unsigned int>(cols);
     }
     if (current_cols != prev_cols)
     {

--- a/Modules/IO/IOTransformDCMTK/include/itkDCMTKTransformIO.h
+++ b/Modules/IO/IOTransformDCMTK/include/itkDCMTKTransformIO.h
@@ -116,17 +116,11 @@ private:
 namespace itk
 {
 
-#if defined(__GNUC__)
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wattributes"
-#endif
-
+ITK_GCC_PRAGMA_DIAG_PUSH()
+ITK_GCC_PRAGMA_DIAG(ignored "-Wattributes")
 extern template class IOTransformDCMTK_EXPORT_EXPLICIT DCMTKTransformIO<double>;
 extern template class IOTransformDCMTK_EXPORT_EXPLICIT DCMTKTransformIO<float>;
-
-#if defined(__GNUC__)
-#  pragma GCC diagnostic pop
-#endif
+ITK_GCC_PRAGMA_DIAG_POP()
 
 } // end namespace itk
 #undef IOTransformDCMTK_EXPORT_EXPLICIT

--- a/Modules/Numerics/NarrowBand/test/itkNarrowBandTest.cxx
+++ b/Modules/Numerics/NarrowBand/test/itkNarrowBandTest.cxx
@@ -41,7 +41,7 @@ itkNarrowBandTest(int, char *[])
   band->SetInnerRadius(5);
   for (unsigned int i = 0; i < 20; ++i)
   {
-    node.m_Data = i * 5.0;
+    node.m_Data = static_cast<DataType>(i * 5.0);
     node.m_Index = i;
     node.m_NodeState = 0;
     // Fill the band

--- a/Modules/Video/BridgeVXL/include/itkVXLVideoIO.h
+++ b/Modules/Video/BridgeVXL/include/itkVXLVideoIO.h
@@ -23,10 +23,6 @@
 #  define ITK_VIDEO_USE_VXL
 #endif
 
-#ifdef _MSC_VER
-#  pragma warning(disable : 4786)
-#endif
-
 #include "itkVideoIOBase.h"
 #include "vidl/vidl_ffmpeg_istream.h"
 #include "vidl/vidl_ffmpeg_ostream.h"

--- a/Modules/Video/IO/src/itkVideoIOBase.cxx
+++ b/Modules/Video/IO/src/itkVideoIOBase.cxx
@@ -15,10 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#if defined(_MSC_VER)
-#  pragma warning(disable : 4786)
-#endif
-
 #include "itkVideoIOBase.h"
 
 namespace itk

--- a/Modules/Video/IO/src/itkVideoIOFactory.cxx
+++ b/Modules/Video/IO/src/itkVideoIOFactory.cxx
@@ -15,10 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifdef _MSC_VER
-#  pragma warning(disable : 4786)
-#endif
-
 #include "itkVideoIOFactory.h"
 #include "itkStringConvert.h"
 


### PR DESCRIPTION
Remove blanket compiler-warning suppressions that no longer fire, grouped by platform, and make the one remaining live narrowing explicit. Each removal was validated against the full CI matrix before landing here.

<details>
<summary>What is removed, per platform</summary>

- **SunOS** — the Solaris branch in `ITKSetStandardCompilerFlags.cmake` (SUN Forte `-mt`, `-D_PTHREADS`/`-lrt`, stlport4); targets toolchains ITK no longer builds against.
- **GCC/Clang (Unix)** — `-Wno-strict-overflow` (predated the GCC 7 minimum) and `-Wno-format-nonliteral` (handled at the five `ITK_GCC_SUPPRESS_Wformat_nonliteral` sites). Also normalizes the raw `__GNUC__` diagnostic pragma in `itkDCMTKTransformIO.h` to the `ITK_GCC_PRAGMA_DIAG` macros.
- **MSVC (Windows)** — blanket pragmas 4127, 4244, 4305, 4309, 4786, 4996. Keeps 4251/4273/4275 (DLL-export) and 4505 (separate review).
</details>

<details>
<summary>Validation</summary>

CI triage confirmed 4127/4305/4309/4786/4996 and `-Wstrict-overflow` no longer fire on any platform. MSVC C4244 was the only live case (629 instances, 619 from one `itkProcessObject.h` line). Most sites are made explicit with `static_cast`; the CSV header-offset member was widened to `std::streamoff` (no cast, no truncation), and the FixedArray index-type test keeps its implicit-conversion coverage under a scoped MSVC-only C4244 suppression. So this PR is warning-clean. Affected tests (`itkFixedArrayGTest`, `itkNarrowBandTest`, CSV reader/writer) built and pass locally.
</details>

<!--
provenance: claude-code session 2026-06-14
origin: split out of the local compiler-suppression-audit branch (audit scaffolding + ccache task excluded)
commit order: SunOS -> Unix -> C4244 casts -> Windows pragmas (fix precedes the 4244 suppression removal)
-->

