### PR TITLE
COMP: Register FFT factory in examples via the meta-module

### DIFF
--- a/Examples/Filtering/CMakeLists.txt
+++ b/Examples/Filtering/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(
   FFTImageFilter
   PRIVATE
     ITK::ITKFFTModule
+    ITK::ITKFFTImageFilterInit
     ITK::ITKImageIntensityModule
     ITK::ITKImageIO
 )
@@ -30,6 +31,7 @@ if(ITK_USE_FFTWF)
     FFTDirectInverse2
     PRIVATE
       ITK::ITKFFTModule
+      ITK::ITKFFTImageFilterInit
       ITK::ITKImageIntensityModule
       ITK::ITKImageIO
   )
@@ -454,6 +456,7 @@ target_link_libraries(
   FFTImageFilterFourierDomainFiltering
   PRIVATE
     ITK::ITKFFTModule
+    ITK::ITKFFTImageFilterInit
     ITK::ITKImageIntensityModule
     ITK::ITKImageIO
 )
@@ -617,6 +620,7 @@ target_link_libraries(
   FFTDirectInverse
   PRIVATE
     ITK::ITKFFTModule
+    ITK::ITKFFTImageFilterInit
     ITK::ITKImageGridModule
     ITK::ITKImageIO
 )


### PR DESCRIPTION
ITK's FFT examples call `itk::ForwardFFTImageFilter::New()` (factory-only) but linked `ITK::ITKFFTModule` and `ITK::ITKImageIO` **without** the `ITK::ITKFFTImageFilterInit` factory meta-module — so `New()` returned null at runtime (*"Object factory failed to instantiate"*). This links the FFT factory meta-module to those examples, following the documented meta-module registration pattern.

<details>
<summary>Root cause & fix</summary>

- `itkForwardFFTImageFilter.h` uses `itkFactoryOnlyNewMacro` — `New()` requires a registered backend.
- Registration is carried by the `ITKFFTImageFilterInit` meta-module (the FFT analog of `ITKImageIO`), and `Examples/CMakeLists.txt` already calls `itk_generate_factory_registration()`.
- The four FFT examples (`FFTImageFilter`, `FFTDirectInverse`, `FFTDirectInverse2`, `FFTImageFilterFourierDomainFiltering`) linked `ITK::ITKImageIO` (hence IO factories registered) but not `ITK::ITKFFTImageFilterInit`, so no FFT backend was registered.
- Fix: add `ITK::ITKFFTImageFilterInit` to those targets — the documented pattern (`itk_6_migration_guide.md`, "Factory Registration with Meta-Modules").

This replaces an earlier approach (propagating the register-manager define through `ITKFFTModule`'s interface) that was incorrect — it injected a define without the matching include path and conflicts with the ITK-6 goal of not adding global defines/includes outside the meta-module interfaces.

</details>

<!--
provenance: surfaced by a downstream forest build/test run exercising the FFT example tests.
related: blowekamp review comment on meta-module registration; ITK_INTERFACE_LIBRARIES.
-->
