### PR TITLE
COMP: Suppress LabelGeometryImageFilter self-deprecation warnings

### DIFF
--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -30,6 +30,11 @@
 
 namespace itk
 {
+// This class is deprecated; its own implementation legitimately references it.
+#if defined(__GNUC__) || defined(__clang__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 namespace
 {
@@ -1000,5 +1005,8 @@ LabelGeometryImageFilter<TImage, TLabelImage>::PrintSelf(std::ostream & os, Inde
     os << "\n\n";
   }
 }
+#if defined(__GNUC__) || defined(__clang__)
+#  pragma GCC diagnostic pop
+#endif
 } // end namespace itk
 #endif

--- a/Modules/Nonunit/Review/test/itkLabelGeometryImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkLabelGeometryImageFilterTest.cxx
@@ -15,6 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
+// Exercise the deprecated LabelGeometryImageFilter without warnings.
+#define ITK_LEGACY_SILENT
 #include "itkImage.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"


### PR DESCRIPTION
`itk::LabelGeometryImageFilter` is marked `[[deprecated]]`, but its own out-of-line method definitions in the `.hxx` reference the class name, so every translation unit that includes the header (e.g. `ITKReviewHeaderTest1`) and the unit test that exercises it emit `-Wdeprecated-declarations`. This silences a deprecated class warning about its own internal use.

<details>
<summary>Warning counts (GCC 14)</summary>

| Translation unit | before | after |
|---|---|---|
| `itkLabelGeometryImageFilterTest.cxx` | 31 | 0 |
| `ITKReviewHeaderTest1.cxx` | 29 | 0 |

</details>

<details>
<summary>Approach</summary>

- `itkLabelGeometryImageFilter.hxx` — wrap the `itk` namespace body in a `-Wdeprecated-declarations` push/ignore/pop, matching the existing idiom in the `Vnl*FFTImageFilter` headers. External includers can't define a silencing macro, so the pragma guard is the right tool here.
- `itkLabelGeometryImageFilterTest.cxx` — `#define ITK_LEGACY_SILENT` at the top of the file (per @blowekamp's review). The header gates the `[[deprecated]]` attribute on `!defined(ITK_LEGACY_SILENT)`, so the attribute disappears entirely for the test — cleaner than a pragma guard around the instantiation.

No behavior change. Rebuilt with `Module_ITKReview=ON`: 0 deprecation warnings; `ctest -R LabelGeometry` passes (4/4); `pre-commit run --all-files` clean.

</details>

<!--
provenance: claude-code session 2026-06-16
files: Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx, Modules/Nonunit/Review/test/itkLabelGeometryImageFilterTest.cxx
root_cause: [[deprecated]] class (added eb8230c46b1) self-references in its own .hxx out-of-line method definitions -> -Wdeprecated-declarations in every includer
test_approach: hxx uses pragma push/pop (external includers); test uses #define ITK_LEGACY_SILENT (blowekamp suggestion, comment 3421607758)
-->
