### PR TITLE
COMP: Fix GCC -Wmaybe-uninitialized in SymmetricEigenAnalysis column permute

### DIFF
--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
@@ -107,8 +107,8 @@ permuteColumnsWithSortIndices(QMatrix & eigenVectors, const std::vector<int> & i
   EigenLibPermutationMatrix perm(numberOfElements);
   perm.setIdentity();
   std::copy(indicesSortPermutations.begin(), indicesSortPermutations.end(), perm.indices().data());
-  // Apply it
-  eigenVectors = eigenVectors * perm;
+  // .eval() avoids a GCC -Wmaybe-uninitialized false positive on assignment.
+  eigenVectors = (eigenVectors * perm).eval();
 }
 
 } // end namespace detail


### PR DESCRIPTION
GCC 14 emits 66 `-Wmaybe-uninitialized` false positives from `permuteColumnsWithSortIndices` in `itkSymmetricEigenAnalysis.h`. Eigen's `.eval()` idiom clears all of them, no behavior change.

<details>
<summary>Root cause</summary>

The original line assigns a fixed-size matrix in place from a product with a dynamic-size operand:

```cpp
eigenVectors = eigenVectors * perm;   // fixed-size matrix = fixed-size matrix * dynamic PermutationMatrix
```

The product's source type has dynamic columns. After inlining, GCC's `-Wmaybe-uninitialized` analysis of Eigen's vectorized `dense_assignment_loop` unroll cannot prove every coefficient of the fixed-size destination is written, so it flags the inlined SSE load / `assign_op::assignCoeff` store. This is a known Eigen/GCC false positive.

</details>

<details>
<summary>Why .eval()</summary>

`.eval()` materializes the product into a complete temporary first, so the assignment source is a fully-initialized object and the unroll analysis is satisfied.

The idiomatic in-place alternative `eigenVectors.applyOnTheRight(perm)` was tried and verified to NOT suppress the warnings — it routes through the same fixed-from-dynamic assignment internally. `.eval()` is the minimal change that actually clears them.

</details>

<details>
<summary>Verification (GCC 14.3, full ccache build)</summary>

| variant | -Wmaybe-uninitialized |
|---|---|
| original | 66 |
| applyOnTheRight(perm) | 66 (no effect) |
| (eigenVectors * perm).eval() | 0 |

Behavior unchanged (same column permutation); the SymmetricEigenAnalysis and transform tests pass.

</details>

<!--
provenance: claude-code session 2026-06-15
file: Modules/Core/Common/include/itkSymmetricEigenAnalysis.h (permuteColumnsWithSortIndices)
note: warnings reproduce only under the project ccache-on build; incremental / ccache-disabled compiles do not reproduce them (ccache preprocessor-mode sensitivity).
-->

