### PR TITLE
BUG: Fix label iteration and harden tests in MorphologicalContourInterpolation

### DIFF
--- a/Modules/Filtering/MorphologicalContourInterpolation/include/itkMorphologicalContourInterpolator.hxx
+++ b/Modules/Filtering/MorphologicalContourInterpolation/include/itkMorphologicalContourInterpolator.hxx
@@ -1584,17 +1584,19 @@ MorphologicalContourInterpolator<TImage>::GenerateData()
     {
       if (this->m_Label == 0) // examine all labels
       {
-        for (unsigned l = 0; l < m_LabeledSlices[i].size(); l++)
+        for (const auto & labelSlices : m_LabeledSlices[i])
         {
-          if (m_LabeledSlices[i][l].size() > 1)
+          if (labelSlices.second.size() > 1)
           {
             aggregate[i] = true;
+            break;
           }
         }
       }
       else // we only care about this label
       {
-        if (m_LabeledSlices[i][m_Label].size() > 1)
+        const auto labelSlices = m_LabeledSlices[i].find(m_Label);
+        if (labelSlices != m_LabeledSlices[i].end() && labelSlices->second.size() > 1)
         {
           aggregate[i] = true;
         }

--- a/Modules/Filtering/MorphologicalContourInterpolation/test/dscComparison.cxx
+++ b/Modules/Filtering/MorphologicalContourInterpolation/test/dscComparison.cxx
@@ -21,6 +21,7 @@
 #include "itkMorphologicalContourInterpolator.h"
 #include "itkTestDriverIncludeRequiredIOFactories.h"
 #include "itkTimeProbe.h"
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -122,77 +123,90 @@ main(int argc, char * argv[])
     outFilenameBase = argv[2];
     fout.open((outFilenameBase + ".csv").c_str(), std::ios::out);
   }
-  RegisterRequiredFactories();
-
-  using ReaderType = itk::ImageFileReader<TestImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName(argv[1]);
-  reader->Update();
-  TestImageType::Pointer inImage = reader->GetOutput();
-  inImage->DisconnectPipeline();
-
-  using mciType = itk::MorphologicalContourInterpolator<TestImageType>;
-  mciType::Pointer mci = mciType::New();
-  mci->SetUseBallStructuringElement(true); // test cross?
-
-  using WriterType = itk::ImageFileWriter<TestImageType>;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetUseCompression(true);
-
-  const TestImageType::RegionType & lpr = inImage->GetLargestPossibleRegion();
-  TestImageType::IndexType          maxInd;
-  for (unsigned axis = 0; axis < testDim; axis++)
+  try
   {
-    maxInd[axis] = itk::IndexValueType(lpr.GetSize(axis));
-  }
-  fout << "Image, nth, axis, time, TP, FP, FN, TN\n";
-  // the big for loop which does the work
-  for (int sparsity = 2; sparsity <= 8; sparsity++)
-  {
-    unsigned long long tpCount, fpCount, fnCount;
-    for (int axis = -1; axis < int(testDim); axis++)
+    RegisterRequiredFactories();
+
+    using ReaderType = itk::ImageFileReader<TestImageType>;
+    ReaderType::Pointer reader = ReaderType::New();
+    reader->SetFileName(argv[1]);
+    reader->Update();
+    TestImageType::Pointer inImage = reader->GetOutput();
+    inImage->DisconnectPipeline();
+
+    using mciType = itk::MorphologicalContourInterpolator<TestImageType>;
+    mciType::Pointer mci = mciType::New();
+    mci->SetUseBallStructuringElement(true); // test cross?
+
+    using WriterType = itk::ImageFileWriter<TestImageType>;
+    WriterType::Pointer writer = WriterType::New();
+    writer->SetUseCompression(true);
+
+    const TestImageType::RegionType & lpr = inImage->GetLargestPossibleRegion();
+    TestImageType::IndexType          maxInd;
+    for (unsigned axis = 0; axis < testDim; axis++)
     {
-      mci->SetAxis(axis);
-      TestImageType::IndexType axisSparsity = maxInd;
-      if (axis < 0) // all axes
+      maxInd[axis] = itk::IndexValueType(lpr.GetSize(axis));
+    }
+    fout << "Image, nth, axis, time, TP, FP, FN, TN\n";
+    // the big for loop which does the work
+    for (int sparsity = 2; sparsity <= 8; sparsity++)
+    {
+      unsigned long long tpCount, fpCount, fnCount;
+      for (int axis = -1; axis < int(testDim); axis++)
       {
-        for (unsigned a = 0; a < testDim; a++)
+        mci->SetAxis(axis);
+        TestImageType::IndexType axisSparsity = maxInd;
+        if (axis < 0) // all axes
         {
-          axisSparsity[a] = sparsity;
+          for (unsigned a = 0; a < testDim; a++)
+          {
+            axisSparsity[a] = sparsity;
+          }
+        }
+        else // just one axis
+        {
+          axisSparsity[axis] = sparsity;
+        }
+
+        TestImageType::Pointer sparseImage = createSparseCopy(inImage, axisSparsity);
+        mci->SetInput(sparseImage);
+        itk::TimeProbe timeProbe;
+        timeProbe.Start();
+        mci->Update();
+        timeProbe.Stop();
+        TestImageType::Pointer result = mci->GetOutput();
+        result->DisconnectPipeline();
+        calcOverlap(result, inImage, tpCount, fpCount, fnCount);
+
+        fout << argv[1] << ", " << sparsity << ", " << axis << ", " << timeProbe.GetMean();
+        fout << ", " << tpCount << ", " << fpCount << ", " << fnCount << ", ";
+        fout << (lpr.GetNumberOfPixels() - tpCount - fpCount - fnCount) << std::endl;
+
+        if (saveImages)
+        {
+          std::cout << outFilenameBase + '_' + char(sparsity + '0') + char(axis + 'X') + "\nWriting sparse... ";
+          writer->SetInput(sparseImage);
+          writer->SetFileName(outFilenameBase + "_in" + char(sparsity + '0') + char(axis + 'X') + ".mha");
+          writer->Update();
+          std::cout << "interpolated... ";
+          writer->SetInput(result);
+          writer->SetFileName(outFilenameBase + "_out" + char(sparsity + '0') + char(axis + 'X') + ".mha");
+          writer->Update();
+          std::cout << "finished." << std::endl;
         }
       }
-      else // just one axis
-      {
-        axisSparsity[axis] = sparsity;
-      }
-
-      TestImageType::Pointer sparseImage = createSparseCopy(inImage, axisSparsity);
-      mci->SetInput(sparseImage);
-      itk::TimeProbe timeProbe;
-      timeProbe.Start();
-      mci->Update();
-      timeProbe.Stop();
-      TestImageType::Pointer result = mci->GetOutput();
-      result->DisconnectPipeline();
-      calcOverlap(result, inImage, tpCount, fpCount, fnCount);
-
-      fout << argv[1] << ", " << sparsity << ", " << axis << ", " << timeProbe.GetMean();
-      fout << ", " << tpCount << ", " << fpCount << ", " << fnCount << ", ";
-      fout << (lpr.GetNumberOfPixels() - tpCount - fpCount - fnCount) << std::endl;
-
-      if (saveImages)
-      {
-        std::cout << outFilenameBase + '_' + char(sparsity + '0') + char(axis + 'X') + "\nWriting sparse... ";
-        writer->SetInput(sparseImage);
-        writer->SetFileName(outFilenameBase + "_in" + char(sparsity + '0') + char(axis + 'X') + ".mha");
-        writer->Update();
-        std::cout << "interpolated... ";
-        writer->SetInput(result);
-        writer->SetFileName(outFilenameBase + "_out" + char(sparsity + '0') + char(axis + 'X') + ".mha");
-        writer->Update();
-        std::cout << "finished." << std::endl;
-      }
     }
+    return EXIT_SUCCESS;
   }
-  return 0;
+  catch (const itk::ExceptionObject & error)
+  {
+    std::cerr << "Error: " << error << std::endl;
+    return EXIT_FAILURE;
+  }
+  catch (const std::exception & error)
+  {
+    std::cerr << "Error: " << error.what() << std::endl;
+    return EXIT_FAILURE;
+  }
 }

--- a/Modules/Filtering/MorphologicalContourInterpolation/test/manualTest.cxx
+++ b/Modules/Filtering/MorphologicalContourInterpolation/test/manualTest.cxx
@@ -17,6 +17,8 @@
  *=========================================================================*/
 
 #include "itkTestDriverIncludeRequiredIOFactories.h"
+#include <cstdlib>
+#include <iostream>
 
 extern int
 itkMorphologicalContourInterpolationTest(int argc, char * argv[]);
@@ -24,6 +26,19 @@ itkMorphologicalContourInterpolationTest(int argc, char * argv[]);
 int
 main(int argc, char * argv[])
 {
-  RegisterRequiredFactories();
-  itkMorphologicalContourInterpolationTest(argc, argv);
+  try
+  {
+    RegisterRequiredFactories();
+    return itkMorphologicalContourInterpolationTest(argc, argv);
+  }
+  catch (const itk::ExceptionObject & error)
+  {
+    std::cerr << "Error: " << error << std::endl;
+    return EXIT_FAILURE;
+  }
+  catch (const std::exception & error)
+  {
+    std::cerr << "Error: " << error.what() << std::endl;
+    return EXIT_FAILURE;
+  }
 }


### PR DESCRIPTION
Three fixes for the MorphologicalContourInterpolation module: one algorithm correctness bug, and two test-robustness fixes that resolve the opaque "Subprocess aborted" failures tracked in #6448.

<details>
<summary>1. Algorithm: label iteration in all-labels aggregation (BUG)</summary>

In `GenerateData()`'s `m_Axis == -1` path, the examine-all-labels branch did:

```cpp
for (unsigned l = 0; l < m_LabeledSlices[i].size(); l++)
    if (m_LabeledSlices[i][l].size() > 1) ...
```

`m_LabeledSlices[i]` is a `std::unordered_map<PixelType, SliceSetType>` keyed by **label value**, not a contiguous array. So this:
- **skipped any label whose value was ≥ the map size** → missing interpolation for high-valued labels, and
- **mutated the map** via `operator[]`, inserting spurious empty entries during a read.

Fixed by iterating the map entries directly, and using `find()` in the single-label branch so the read no longer inserts. All 729 module tests pass.

</details>

<details>
<summary>2 & 3. Test robustness: uncaught exceptions → SIGABRT (#6448)</summary>

`dscComparison.cxx` and `manualTest.cxx` called `reader`/`writer`/filter `Update()` (and the test entry point) with no exception handling. Any I/O error — a missing ExternalData input, a transient write failure — escaped `main` as an uncaught `itk::ExceptionObject` → `std::terminate` → SIGABRT. CTest then reported the opaque **"Subprocess aborted"** instead of a clean failure, masking the cause.

This is the mechanism behind #6448: the test fails fast where the input is absent (Windows nightly) and aborts after a full run on a transient write failure (macOS CI).

- `dscComparison.cxx`: wrap the body in `try/catch(itk::ExceptionObject)`, return `EXIT_FAILURE`.
- `manualTest.cxx`: same hardening, and **return** the test's exit code (it previously discarded the result, so `main` always reported success).

Verified locally: a missing input now exits 1 with a clear message (was 134/SIGABRT); the happy path still exits 0.

</details>

<details>
<summary>Local validation</summary>

- All 729 `MorphologicalContourInterpolation` tests pass (incl. multi-label SevenLabels / ManyToMany / GridSeg).
- `pre-commit run --all-files` clean.

</details>

<!--
provenance: claude-code session 2026-06-16; surfaced while triaging PR #6447.
commits: itkMorphologicalContourInterpolator.hxx (algorithm), dscComparison.cxx + manualTest.cxx (test robustness).
related_issue: #6448 (itkMCI_DSC_case_2_binary aborts on Windows/macOS).
note: warnings/aborts reproduce only with the module enabled (EXCLUDE_FROM_DEFAULT) and RLEImage test-dep.
-->
