### PR TITLE
COMP: Guard vnl_math integral predicates from MSVC fpclassify

### DIFF
--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_math.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_math.h
@@ -38,6 +38,7 @@
 #include <algorithm>
 #include <complex>
 #include <limits>
+#include <type_traits>
 #include <utility>
 #ifdef _MSC_VER
 #  include <vcl_msvc_warnings.h>
@@ -179,29 +180,54 @@ namespace numeric_predicates
 {
 // Wrap the <cmath> classification functions to guarantee a bool return type;
 // some standard libraries returned a signed integer from these.
+// Integral arguments are short-circuited: an integer is always finite, never
+// inf/NaN, and normal when non-zero. This also avoids an ambiguous fpclassify
+// overload in older Windows SDK <corecrt_math.h> integer templates.
+// ITK-local patch (not yet upstream in VXL): the `if constexpr` integral
+// branches below; remove if a future VXL sync fixes this upstream.
 template <typename TArg>
 inline bool
 isinf(TArg arg)
 {
-  return bool(std::isinf(arg));
+  // Integral branch: works around an ambiguous fpclassify overload in old
+  // Windows SDK <corecrt_math.h>; an integer is never inf.
+  if constexpr (std::is_integral_v<TArg>)
+    return false;
+  else
+    return bool(std::isinf(arg));
 }
 template <typename TArg>
 inline bool
 isnan(TArg arg)
 {
-  return bool(std::isnan(arg));
+  // Integral branch: works around an ambiguous fpclassify overload in old
+  // Windows SDK <corecrt_math.h>; an integer is never NaN.
+  if constexpr (std::is_integral_v<TArg>)
+    return false;
+  else
+    return bool(std::isnan(arg));
 }
 template <typename TArg>
 inline bool
 isfinite(TArg arg)
 {
-  return bool(std::isfinite(arg));
+  // Integral branch: works around an ambiguous fpclassify overload in old
+  // Windows SDK <corecrt_math.h>; an integer is always finite.
+  if constexpr (std::is_integral_v<TArg>)
+    return true;
+  else
+    return bool(std::isfinite(arg));
 }
 template <typename TArg>
 inline bool
 isnormal(TArg arg)
 {
-  return bool(std::isnormal(arg));
+  // Integral branch: works around an ambiguous fpclassify overload in old
+  // Windows SDK <corecrt_math.h>; a non-zero integer is normal.
+  if constexpr (std::is_integral_v<TArg>)
+    return arg != TArg(0);
+  else
+    return bool(std::isnormal(arg));
 }
 } // namespace numeric_predicates
 


### PR DESCRIPTION
Guard `vnl_math` integral classification predicates so integer-typed `vnl_matrix`/`vnl_vector` compile on MSVC toolsets where `fpclassify(<integral>)` is ambiguous. Regression from the VXL 2026-06-09 sync (#6421); below ITK's MSVC floor of 19.20 but inside the supported range.

<details>
<summary>Root cause</summary>

The VXL 2026-06-09 sync routes `vnl_matrix<T>::is_finite()` / `has_nans()` through `numeric_predicates::isfinite/isnan`, which forward `std::isfinite(arg)` for **every** `T`. For integral `T` this instantiates the Windows UCRT `<corecrt_math.h>` integer template

```cpp
template <class _Ty> inline bool isfinite(_In_ _Ty _X) throw() { return fpclassify(_X) <= 0; }
```

where `fpclassify(<integral>)` is an ambiguous call (`error C2668`: `float`/`double`/`long double`). Every integer-typed `vnl_matrix`/`vnl_vector` TU then fails to compile.

| Result | MSVC toolset (cl) | Windows SDK |
|---|---|---|
| ❌ Fails | 14.38.33130 (19.38) | 10.0.22621.0 / 10.0.22000.0 |
| ✅ Builds | 14.44.35207 (19.44) | CI `windows-2022` runner |

Fix: short-circuit integral arguments with `if constexpr` — an integer is always finite, never inf/NaN, normal when non-zero — which also avoids the ambiguous SDK template. Marked as an ITK-local patch pending an upstream VXL fix.

</details>

<details>
<summary>Test results</summary>

Full `RelWithDebInfo` build of current `main` + this patch on the failing toolchain (MSVC 14.38.33130, Windows SDK 10.0.22621.0): **3396/3396 targets, 0 errors**. Without the patch, every integer-typed `vnl_matrix`/`vnl_vector` TU failed with `C2668`.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code (claude-opus-4-8)
- Role: diagnosed the regression (bisected to the VXL 2026-06-09 sync; identified the ambiguous SDK `fpclassify` integer template), wrote the `if constexpr` guard, and verified the full local build.
- All changes reviewed and built locally before committing.

</details>
