### PR TITLE
DOC: Update Code of Conduct incident report link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -18,7 +18,7 @@ You can find the long version of the Code of Conduct on the NumFOCUS website: [h
 
 ## How to Report
 
-If you feel that the Code of Conduct has been violated, feel free to submit a report, by using the form: [NumFOCUS Code of Conduct Reporting Form](https://numfocus.typeform.com/to/ynjGdT).
+If you feel that the Code of Conduct has been violated, feel free to submit a report, by using the form: [NumFOCUS Code of Conduct Reporting Form](https://forms.monday.com/forms/f130e8cddb99568fa86cf077b8912a60?r=use1).
 
 ## Who Will Receive Your Report
 


### PR DESCRIPTION
NumFOCUS is moving of Typeform and has replaced the reporting link.
