### PR TITLE
COMP: Fix nightly compiler warnings and a CumulativeGaussianOptimizer use-after-free

### DIFF
--- a/Modules/Core/Common/include/itkImageBoundaryCondition.h
+++ b/Modules/Core/Common/include/itkImageBoundaryCondition.h
@@ -107,6 +107,13 @@ public:
 
   virtual ~ImageBoundaryCondition() = default;
 
+  ImageBoundaryCondition(const ImageBoundaryCondition &) = default;
+  ImageBoundaryCondition(ImageBoundaryCondition &&) = default;
+  ImageBoundaryCondition &
+  operator=(const ImageBoundaryCondition &) = default;
+  ImageBoundaryCondition &
+  operator=(ImageBoundaryCondition &&) = default;
+
   /** Tell if the boundary condition can index to any location within
    * the associated iterator's neighborhood or if it has some limited
    * subset (such as none) that it relies upon.

--- a/Modules/Core/Common/include/itkObjectStore.h
+++ b/Modules/Core/Common/include/itkObjectStore.h
@@ -183,14 +183,13 @@ protected:
       , Size(n)
     {}
 
-    ~MemoryBlock() = default; // Purposely does *not* free memory
-
     void
     Delete()
     {
       delete[] Begin;
     }
 
+    // Owns the allocation but is freed manually via Delete(), never in a destructor.
     ObjectType *  Begin{};
     SizeValueType Size{ 0 };
   };

--- a/Modules/Core/Common/include/itkRealTimeInterval.h
+++ b/Modules/Core/Common/include/itkRealTimeInterval.h
@@ -57,9 +57,6 @@ public:
   /** Constructor with values. Intentionally made public */
   RealTimeInterval(SecondsDifferenceType, MicroSecondsDifferenceType);
 
-  /** Destructor */
-  ~RealTimeInterval();
-
   /** Native type used to represent the time in different time units. */
   using TimeRepresentationType = double;
 

--- a/Modules/Core/Common/include/itkResourceProbe.h
+++ b/Modules/Core/Common/include/itkResourceProbe.h
@@ -56,6 +56,13 @@ public:
   /** Destructor */
   virtual ~ResourceProbe() = default;
 
+  ResourceProbe(const ResourceProbe &) = default;
+  ResourceProbe(ResourceProbe &&) = default;
+  ResourceProbe &
+  operator=(const ResourceProbe &) = default;
+  ResourceProbe &
+  operator=(ResourceProbe &&) = default;
+
   /** Returns the type probed value */
   [[nodiscard]] std::string
   GetType() const;

--- a/Modules/Core/Common/include/itkSparseFieldLayer.h
+++ b/Modules/Core/Common/include/itkSparseFieldLayer.h
@@ -90,8 +90,6 @@ public:
     : m_Pointer(p)
   {}
 
-  ~ConstSparseFieldLayerIterator() = default;
-
 protected:
   TNodeType * m_Pointer;
 };

--- a/Modules/Core/Common/include/itkTimeProbe.h
+++ b/Modules/Core/Common/include/itkTimeProbe.h
@@ -61,6 +61,13 @@ public:
   /** Destructor */
   ~TimeProbe() override;
 
+  TimeProbe(const TimeProbe &) = default;
+  TimeProbe(TimeProbe &&) = default;
+  TimeProbe &
+  operator=(const TimeProbe &) = default;
+  TimeProbe &
+  operator=(TimeProbe &&) = default;
+
   void
   Print(std::ostream & os, Indent indent) const override;
 

--- a/Modules/Core/Common/src/itkRealTimeInterval.cxx
+++ b/Modules/Core/Common/src/itkRealTimeInterval.cxx
@@ -62,11 +62,6 @@ RealTimeInterval::RealTimeInterval(SecondsDifferenceType seconds, MicroSecondsDi
 }
 
 /**
- * Destructor.
- */
-RealTimeInterval::~RealTimeInterval() = default;
-
-/**
  * Set the interval to a given combination of seconds and micro seconds.
  */
 void

--- a/Modules/Core/Common/src/itkTBBMultiThreader.cxx
+++ b/Modules/Core/Common/src/itkTBBMultiThreader.cxx
@@ -167,6 +167,8 @@ struct TBBImageRegionSplitter : public itk::ImageIORegion
   // specialization.
   static constexpr bool is_splittable_in_proportion = true;
   TBBImageRegionSplitter(const TBBImageRegionSplitter &) = default;
+  TBBImageRegionSplitter &
+  operator=(const TBBImageRegionSplitter &) = default;
   TBBImageRegionSplitter(const itk::ImageIORegion & region)
     : itk::ImageIORegion(region) // use itk::ImageIORegion's copy constructor
   {}

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
@@ -287,7 +287,6 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::DynamicThreadedG
   PointType                    point{};
   DisplacementType             displacement{};
   NumericTraits<DisplacementType>::SetLength(displacement, ImageDimension);
-  const unsigned int numberOfDisplacementComponents = NumericTraits<DisplacementType>::GetLength(displacement);
   static_assert(PointType::Dimension == ImageDimension, "ERROR: Point type and ImageDimension must be the same!");
   if (this->m_DefFieldSameInformation)
   {
@@ -304,7 +303,7 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::DynamicThreadedG
       displacement = fieldIt.Get();
 
       // compute the required input image point
-      for (unsigned int j = 0; j < numberOfDisplacementComponents; ++j)
+      for (unsigned int j = 0; j < ImageDimension; ++j)
       {
         point[j] += displacement[j];
       }
@@ -334,7 +333,7 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::DynamicThreadedG
 
       this->EvaluateDisplacementAtPhysicalPoint(point, fieldPtr, displacement);
       // compute the required input image point
-      for (unsigned int j = 0; j < numberOfDisplacementComponents; ++j)
+      for (unsigned int j = 0; j < ImageDimension; ++j)
       {
         point[j] += displacement[j];
       }

--- a/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkFlatStructuringElement.h
@@ -123,6 +123,13 @@ public:
   /** Default destructor. */
   ~FlatStructuringElement() override = default;
 
+  FlatStructuringElement(const FlatStructuringElement &) = default;
+  FlatStructuringElement(FlatStructuringElement &&) = default;
+  FlatStructuringElement &
+  operator=(const FlatStructuringElement &) = default;
+  FlatStructuringElement &
+  operator=(FlatStructuringElement &&) = default;
+
   /** Default constructor. */
   FlatStructuringElement() = default;
 

--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
@@ -316,6 +316,8 @@ CumulativeGaussianOptimizer::StartOptimization()
   delete sampledGaussianArray;
   delete cumGaussianArrayCopy;
   delete derivative;
+  // m_CumulativeGaussianArray aliased derivative; clear it so PrintSelf does not dereference freed memory.
+  m_CumulativeGaussianArray = nullptr;
 }
 
 void

--- a/Modules/Numerics/Polynomials/include/itkMultivariateLegendrePolynomial.h
+++ b/Modules/Numerics/Polynomials/include/itkMultivariateLegendrePolynomial.h
@@ -90,6 +90,13 @@ public:
   /** Destructor. */
   virtual ~MultivariateLegendrePolynomial();
 
+  MultivariateLegendrePolynomial(const MultivariateLegendrePolynomial &) = default;
+  MultivariateLegendrePolynomial(MultivariateLegendrePolynomial &&) = default;
+  MultivariateLegendrePolynomial &
+  operator=(const MultivariateLegendrePolynomial &) = default;
+  MultivariateLegendrePolynomial &
+  operator=(MultivariateLegendrePolynomial &&) = default;
+
   /** Gets the dimension. */
   [[nodiscard]] unsigned int
   GetDimension() const

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.hxx
@@ -173,9 +173,8 @@ ESMDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Co
   auto *    globalData = (GlobalDataStruct *)gd;
   PixelType update{};
   NumericTraits<PixelType>::SetLength(update, ImageDimension);
-  const unsigned int numberOfUpdateComponents = NumericTraits<PixelType>::GetLength(update);
-  IndexType          FirstIndex = this->GetFixedImage()->GetLargestPossibleRegion().GetIndex();
-  IndexType          LastIndex = this->GetFixedImage()->GetLargestPossibleRegion().GetIndex() +
+  IndexType FirstIndex = this->GetFixedImage()->GetLargestPossibleRegion().GetIndex();
+  IndexType LastIndex = this->GetFixedImage()->GetLargestPossibleRegion().GetIndex() +
                         this->GetFixedImage()->GetLargestPossibleRegion().GetSize();
 
   const IndexType index = it.GetIndex();
@@ -327,7 +326,7 @@ ESMDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Co
   {
     PointType mappedPoint{};
     this->GetFixedImage()->TransformIndexToPhysicalPoint(index, mappedPoint);
-    for (unsigned int j = 0; j < numberOfUpdateComponents; ++j)
+    for (unsigned int j = 0; j < ImageDimension; ++j)
     {
       mappedPoint[j] += it.GetCenterPixel()[j];
     }
@@ -367,7 +366,7 @@ ESMDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>::Co
     {
       const double factor = 2.0 * speedValue / denom;
 
-      for (unsigned int j = 0; j < numberOfUpdateComponents; ++j)
+      for (unsigned int j = 0; j < ImageDimension; ++j)
       {
         update[j] = factor * usedGradientTimes2[j];
       }

--- a/Modules/Video/Core/include/itkTemporalRegion.h
+++ b/Modules/Video/Core/include/itkTemporalRegion.h
@@ -90,6 +90,13 @@ public:
   /** Destructor */
   ~TemporalRegion() override;
 
+  TemporalRegion(const TemporalRegion &) = default;
+  TemporalRegion(TemporalRegion &&) = default;
+  TemporalRegion &
+  operator=(const TemporalRegion &) = default;
+  TemporalRegion &
+  operator=(TemporalRegion &&) = default;
+
   /** Compare two temporal regions in Frame space */
   [[nodiscard]] virtual bool
   IsEqualInFrames(const Self & region) const;


### PR DESCRIPTION
Fixes nightly-CDash compiler warnings, plus one real use-after-free the experimental Clang lifetime pass surfaced. Five commits grouped by kind of change.

<details>
<summary>What changed, per commit</summary>

| Commit | Kind | Diagnostic | Classes |
|---|---|---|---|
| Rule of Zero | drop redundant non-virtual `=default` destructors | `-Wdeprecated-copy-with-(user-provided-)dtor` | `RealTimeInterval`, `ConstSparseFieldLayerIterator`, `ObjectStore::MemoryBlock` |
| Rule of Five | default copy/move on polymorphic bases (must keep the virtual dtor) | `-Wdeprecated-copy-with-(user-provided-)dtor` | `ImageBoundaryCondition`, `ResourceProbe`, `TimeProbe`, `FlatStructuringElement`, `MultivariateLegendrePolynomial`, `TemporalRegion` |
| Bound loops by `ImageDimension` | GCC could not prove the runtime component count ≤ the fixed array size | `-Waggressive-loop-optimizations` | `WarpImageFilter`, `ESMDemonsRegistrationFunction` |
| Rule of Three | default copy-assignment alongside the user-declared copy ctor | `-Wdeprecated-copy` | `TBBImageRegionSplitter` |
| **BUG** | reset member after freeing the storage it aliases | `-Wlifetime-safety-invalidation` | `CumulativeGaussianOptimizer` |

</details>

<details>
<summary>The use-after-free (BUG commit)</summary>

`CumulativeGaussianOptimizer::StartOptimization()` points
`m_CumulativeGaussianArray` at a locally allocated `derivative` array,
then `delete`s that array before returning — leaving the member
dangling. `PrintSelf()` dereferences the member when it is non-null, so
printing the optimizer after optimization is a use-after-free. The fix
resets the member to `nullptr` once its storage is freed.

</details>

<details>
<summary>Warnings deliberately left unaddressed</summary>

- **6 other `-Wlifetime-safety-invalidation`** (StringTools, DOMNode, NrrdImageIO, VTIImageIO, PhilipsPAR): false positives of an experimental, unstable diagnostic — returning/appending to reference parameters is correct C++.
- **`-Wnrvo`**: pedantic optimization hints in multi-return functions; the `return std::move()` remedy risks `-Wredundant-move` elsewhere.
- **`-Wzero-as-null-pointer-constant` / `-Wnrvo` in `pocketfft_hdronly.h`**: vendored third-party; belongs upstream.

</details>

<details>
<summary>Verification</summary>

Affected libraries compiled clean on AppleClang via a configured build
tree; `WarpImageFilter`, `ESMDemons`, and `CumulativeGaussian` tests
pass. `TBBImageRegionSplitter` compiles only when `Module_ITKTBB` is
enabled (not in the local tree) and was verified by inspection.
`pre-commit` passes on every commit.

</details>

<!--
provenance: claude-code session 2026-06-16, /cdash-build-analysis on open.cdash.org Insight nightly
source_builds: Mac26.x-ClangMain-dbg-arm64, Mac26.x-AppleClang-dbg-TSan, Ubuntu-22.04-gcc11.4
key_facts: deprecated-copy 133 warns, aggressive-loop 34 warns, 1 real UAF in CumulativeGaussianOptimizer
-->
