### PR TITLE
ENH: Re-enable Gaussian3D and NCC3D VariationalRegistration tests on macOS ARM64

### DIFF
--- a/Modules/Registration/VariationalRegistration/test/CMakeLists.txt
+++ b/Modules/Registration/VariationalRegistration/test/CMakeLists.txt
@@ -158,6 +158,10 @@ test2d(VariationalRegistrationSymDiff2DTest "" -r 1 -a 1.5 -s 2 -e 2)
 #####################################
 
 function(Test3D TestName)
+  set(npixels_tol ${VR_NPIXELS_TOL})
+  if(DEFINED ${TestName}_NPIXELS_TOL)
+    set(npixels_tol ${${TestName}_NPIXELS_TOL})
+  endif()
   itk_add_test(
     NAME ${TestName}
     COMMAND
@@ -167,7 +171,7 @@ function(Test3D TestName)
       --compareIntensityTolerance
       ${VR_INTENSITY_TOL}
       --compareNumberOfPixelsTolerance
-      ${VR_NPIXELS_TOL}
+      ${npixels_tol}
       --compare
       DATA{Baseline/${TestName}.nii.gz}
       ${TEMP}/${TestName}.nii.gz
@@ -219,8 +223,9 @@ itk_add_test(
 )
 
 # Active Thirion forces and gaussian smoothing
-# Disabled: baseline diverges on native macOS ARM64 (issue #6305).
-# test3d(VariationalRegistrationGaussian3DTest -r 0 -v 1.5 -u 0)
+# ~0.08% of voxels diverge on native macOS ARM64 (issue #6459).
+set(VariationalRegistrationGaussian3DTest_NPIXELS_TOL "400")
+test3d(VariationalRegistrationGaussian3DTest -r 0 -v 1.5 -u 0)
 
 # Active Thirion forces and diffusive regularization
 test3d(VariationalRegistrationDiffusive3DTest -r 1 -a 1)
@@ -239,8 +244,9 @@ endif()
 test3d(VariationalRegistrationSSD3DTest -f 1 -t 0.00001 -a 1)
 
 # NCC forces and gaussian smoothing
-# Disabled: baseline diverges on native macOS ARM64 (issue #6305).
-# test3d(VariationalRegistrationNCC3DTest -f 2 -t 40 -r 0 -v 1 -u 0 -q 2 -p 1)
+# ~0.09% of voxels diverge on native macOS ARM64 (issue #6459).
+set(VariationalRegistrationNCC3DTest_NPIXELS_TOL "400")
+test3d(VariationalRegistrationNCC3DTest -f 2 -t 40 -r 0 -v 1 -u 0 -q 2 -p 1)
 
 # Active Thirion forces and diffusive regularization, diffeomorphic transform
 test3d(VariationalRegistrationDiffeomorph3DTest -r 1 -a 1 -s 1 -e 2)


### PR DESCRIPTION
Re-enable the `VariationalRegistrationGaussian3DTest` and `VariationalRegistrationNCC3DTest` tests that were left disabled in #6453, using a small per-test pixel-count tolerance for native macOS ARM64. Closes #6459.

<details>
<summary>Why these two were disabled, and the measurement</summary>

In #6453, 11 of the 13 VariationalRegistration tests were re-enabled against ITK-proper baselines; Gaussian3D and NCC3D were held back because their outputs diverge from the x86_64 baselines on native macOS ARM64.

Measured on Apple silicon against the (94×70×56 = 368,480-voxel) baselines, after the existing radius-2 / intensity-20 neighborhood search:

| Test | Voxels differing | Fraction | Max intensity diff |
|---|---|---|---|
| Gaussian3D | 308 | 0.084% | 85 |
| NCC3D | 322 | 0.087% | 53 |

This is sub-0.1% floating-point convergence drift — the regime `--compareNumberOfPixelsTolerance` exists to absorb — not a structural mismatch that would warrant a separate macOS baseline.

</details>

<details>
<summary>The fix</summary>

`Test3D` gains an optional `${TestName}_NPIXELS_TOL` override that falls back to the global `VR_NPIXELS_TOL` (200). The two divergent tests set it to 400. The shared x86_64 baseline serves both platforms:

- x86_64 stays bit-exact (0 ≤ 400)
- macOS ARM64 passes (≤ 322 ≤ 400)
- the other 11 tests keep the tight global tolerance of 200

No baseline (`.cid`) changes — the baselines already landed in #6453.

</details>

<details>
<summary>Local verification (macOS ARM64)</summary>

All 23 VariationalRegistration tests pass:

```
100% tests passed, 0 tests failed out of 23
```

`pre-commit run --all-files`: all content hooks (gersemi, clang-format, trailing-whitespace, end-of-file) pass.

</details>

<!--
provenance: claude-code session 2026-06-17, machine = macOS ARM64 (forest-build testbed)
branch: reenable-vr-gaussian-ncc-3d-macos off origin/main a0c7720e1e (contains merged #6453)
measured NumberOfPixelsWithDifferences: Gaussian3D=308, NCC3D=322 (vol 94x70x56=368480)
fix: per-test ${TestName}_NPIXELS_TOL override in Test3D, set to 400 for both
related_files: Modules/Registration/VariationalRegistration/test/CMakeLists.txt
closes: #6459
-->
