### PR TITLE
ENH: Order DCMTKSeriesFileNames using first valid slice orientation

### DIFF
--- a/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
@@ -42,8 +42,19 @@ OrderFileReadersByPosition(std::vector<DCMTKFileReader *> & headers)
     return;
   }
 
-  double       dircos[6];
-  const bool   haveOrientation = headers.front()->GetDirCosArray(dircos) == EXIT_SUCCESS;
+  // Derive the slice normal from the first slice that carries a valid
+  // orientation; a single mis-globbed entry without one must not suppress
+  // geometric ordering for the whole series.
+  double dircos[6];
+  bool   haveOrientation = false;
+  for (auto * reader : headers)
+  {
+    if (reader->GetDirCosArray(dircos) == EXIT_SUCCESS)
+    {
+      haveOrientation = true;
+      break;
+    }
+  }
   const double normal[3] = { dircos[1] * dircos[5] - dircos[2] * dircos[4],
                              dircos[2] * dircos[3] - dircos[0] * dircos[5],
                              dircos[0] * dircos[4] - dircos[1] * dircos[3] };

--- a/Modules/IO/IOTransformDCMTK/test/itkDCMTKSeriesFileNamesOrderingGTest.cxx
+++ b/Modules/IO/IOTransformDCMTK/test/itkDCMTKSeriesFileNamesOrderingGTest.cxx
@@ -16,7 +16,7 @@
  *
  *=========================================================================*/
 
-// Regression for PR #6456: itk::DCMTKSeriesFileNames must order slices
+// Regression for issue #6463: itk::DCMTKSeriesFileNames must order slices
 // geometrically (ImagePositionPatient projected on the slice normal), matching
 // itk::GDCMSeriesFileNames, even when InstanceNumber (0020,0013) is absent or
 // constant. The rect-centered / rect-offset fixtures all carry InstanceNumber


### PR DESCRIPTION
Robustness follow-up to the DCMTKSeriesFileNames geometric ordering: derive the slice normal from the first slice that actually carries an ImageOrientationPatient, not just the first globbed file.

> **Rebased onto current `main`.** The core ordering fix originally in this PR (`f2c3bc0`) already merged via #6456, so this PR is now reduced to the two greptile P2 refinements that were not in that merge.

<details>
<summary>What remains in this PR</summary>

- `itkDCMTKSeriesFileNames.cxx` — scan for the first slice with a valid orientation before computing the slice normal; a single mis-globbed entry without `ImageOrientationPatient` (e.g. a localizer that sorted first) no longer suppresses geometric ordering for the whole series.
- `itkDCMTKSeriesFileNamesOrderingGTest.cxx` — comment now cites issue #6463 instead of the downstream PR #6456.

Net diff vs `main`: 2 files, +14/−3. The ordering GTest passes; `pre-commit run --all-files` is clean.

</details>

<!--
provenance: claude-code 2026-06-17 ; rebased onto main after #6456 merged f2c3bc0
note: core ordering already in main via #6456; this PR is now only the orientation-from-first-valid-slice refinement + comment fix
-->
