### PR TITLE
COMP: Wrap build-tree system include dirs in BUILD_INTERFACE

### DIFF
--- a/CMake/ITKModuleMacros.cmake
+++ b/CMake/ITKModuleMacros.cmake
@@ -275,7 +275,18 @@ endif()
   # and thus do not have separate install interface paths.
   if(${itk-module}_SYSTEM_INCLUDE_DIRS)
     foreach(_dir ${${itk-module}_SYSTEM_INCLUDE_DIRS})
-      list(APPEND ${itk-module}_SYSTEM_GENEX_INCLUDE_DIRS ${_dir})
+      # Build-tree paths (e.g. fetched header-only deps) are build-only; wrap for install(EXPORT).
+      string(FIND "${_dir}" "${CMAKE_BINARY_DIR}" _itk_bin_prefix)
+      string(FIND "${_dir}" "${PROJECT_BINARY_DIR}" _itk_proj_prefix)
+      if(_itk_bin_prefix EQUAL 0 OR _itk_proj_prefix EQUAL 0)
+        list(
+          APPEND
+          ${itk-module}_SYSTEM_GENEX_INCLUDE_DIRS
+          "$<BUILD_INTERFACE:${_dir}>"
+        )
+      else()
+        list(APPEND ${itk-module}_SYSTEM_GENEX_INCLUDE_DIRS ${_dir})
+      endif()
     endforeach()
   endif()
 


### PR DESCRIPTION
A module's `<module>_SYSTEM_INCLUDE_DIRS` entries are placed in the module target's interface include directories verbatim. When a module fetches a header-only dependency into its **build tree**, that build-directory path becomes part of `install(EXPORT ITKTargets)` and CMake 4.x fails generation with *"INTERFACE_INCLUDE_DIRECTORIES property contains path which is prefixed in the build directory."* This wraps only build-tree-prefixed system include paths in `$<BUILD_INTERFACE:>`; stable system paths are unchanged.

<details>
<summary>Why this is needed — full analysis</summary>

`CMake/ITKModuleMacros.cmake` builds `<module>_SYSTEM_GENEX_INCLUDE_DIRS` from `<module>_SYSTEM_INCLUDE_DIRS` and applies it to the module targets as `target_include_directories(<tgt> SYSTEM PUBLIC ...)` (both the library and the `<module>Module` interface target). Unlike the **regular** include dirs a few lines above — which are wrapped per entry in `$<BUILD_INTERFACE:>` plus an explicit `$<INSTALL_INTERFACE:>` — the **system** include dirs were appended raw:

```cmake
# before
foreach(_dir ${${itk-module}_SYSTEM_INCLUDE_DIRS})
  list(APPEND ${itk-module}_SYSTEM_GENEX_INCLUDE_DIRS ${_dir})
endforeach()
```

The in-code comment states the assumption: *"System include directories are assumed to be external dependencies that are not installed, and thus do not have separate install interface paths."* That holds for **stable system paths** (`/usr/include/eigen3`, a system OpenCL SDK, …) which are valid at both build and install time, so a raw entry is fine.

It breaks when a module's system include dir is a **build-tree** path. A remote module that pulls a header-only library via `FetchContent`/`ExternalData` typically exposes something like `${CMAKE_BINARY_DIR}/.../_deps/include`. That path:

1. is not relocatable (it is meaningless after install / on another machine), and
2. is rejected outright by `install(EXPORT)`. Because the raw build-tree path lands in `INTERFACE_INCLUDE_DIRECTORIES` of an exported target, CMake (strict since 3.x, hard-erroring under the 4.x policy set) fails at generate time:

   ```
   CMake Error in CMakeLists.txt:
     install(EXPORT "ITKTargets" ...) ... Target "<Mod>" INTERFACE_INCLUDE_DIRECTORIES
     property contains path:
       ".../_deps/include"
     which is prefixed in the build directory.
   ```

The whole ITK configure then fails generation, even if the consumer never installs, because `install(EXPORT ITKTargets)` is always set up.

**Fix:** wrap only the build-tree-prefixed system paths in `$<BUILD_INTERFACE:>` (apply during build, dropped from the install interface, mirroring how regular include dirs are already handled). Non-build paths pass through unchanged, so the common case is byte-for-byte unaffected.

```cmake
# after
foreach(_dir ${${itk-module}_SYSTEM_INCLUDE_DIRS})
  if(_dir MATCHES "^${CMAKE_BINARY_DIR}" OR _dir MATCHES "^${PROJECT_BINARY_DIR}")
    list(APPEND ${itk-module}_SYSTEM_GENEX_INCLUDE_DIRS "$<BUILD_INTERFACE:${_dir}>")
  else()
    list(APPEND ${itk-module}_SYSTEM_GENEX_INCLUDE_DIRS ${_dir})
  endif()
endforeach()
```

</details>

<details>
<summary>How it was found + validation</summary>

Surfaced building ITK `main` with `Module_VkFFTBackend=ON` (the VkFFT remote module fetches the header-only VkFFT library into `<build>/.../_deps/include` and adds it to `VkFFTBackend_SYSTEM_INCLUDE_DIRS`) under CMake 4.2.1. Without this change, generate fails as above; with it, generate and the full build/install succeed.

- `pre-commit run --all-files` → clean (gersemi-formatted).
- Full ITK `main` configure **+ generate + build + install** with `Module_VkFFTBackend=ON` (where the build-tree path is wrapped) → success.
- Clean ITK `main` configure + generate with **no** remote modules (where every system path is a stable `/usr`-style path and the new branch is a no-op) → success, confirming no regression for the common case.

CMake-build-system change only; no new tests.

</details>

<!--
provenance: investigated 2026-06-17 while enabling VkFFT GPU FFT in ANTs (ANTsX/ANTs#1331)
file: CMake/ITKModuleMacros.cmake (SYSTEM include dirs -> SYSTEM_GENEX_INCLUDE_DIRS)
cmake: 4.2.1; reproduced with Module_VkFFTBackend=ON
no_regression: clean configure+generate without remote modules verified
-->
