### PR TITLE
ENH: DCMTKSeriesFileNames parity with GDCMSeriesFileNames (recursive, grouping, restrictions, caching)

### DIFF
--- a/Modules/IO/DCMTK/include/itkDCMTKSeriesFileNames.h
+++ b/Modules/IO/DCMTK/include/itkDCMTKSeriesFileNames.h
@@ -23,6 +23,7 @@
 #include "itkObjectFactory.h"
 #include "itkMacro.h"
 #include <map>
+#include <utility>
 #include <vector>
 
 namespace itk
@@ -162,10 +163,7 @@ public:
    * \warning UseSeriesDetails needs to be set to true.
    */
   void
-  AddSeriesRestriction(const std::string & /* tag */)
-  {
-    // m_SeriesHelper->AddRestriction(tag);
-  }
+  AddSeriesRestriction(const std::string & tag);
 
   /** Parse any sequences in the DICOM file. Defaults to false
    *  to skip sequences. This makes loading DICOM files faster when
@@ -210,6 +208,10 @@ private:
 
   /** Ordered file names per distinct series identifier. */
   std::map<std::string, FileNamesContainerType> m_SeriesFiles{};
+
+  /** Extra (group,element) tags appended to the series identifier when
+   * UseSeriesDetails is enabled. */
+  std::vector<std::pair<unsigned short, unsigned short>> m_Restrictions{};
 
   /** Internal structure to keep the list of series UIDs */
   SeriesUIDContainerType m_SeriesUIDs{};

--- a/Modules/IO/DCMTK/include/itkDCMTKSeriesFileNames.h
+++ b/Modules/IO/DCMTK/include/itkDCMTKSeriesFileNames.h
@@ -216,6 +216,10 @@ private:
   /** Internal structure to keep the list of series UIDs */
   SeriesUIDContainerType m_SeriesUIDs{};
 
+  /** Modified time of the last directory parse; the cache is rebuilt only
+   * when the object has been Modified() since. */
+  TimeStamp m_CacheBuildTime{};
+
   bool m_UseSeriesDetails{};
   bool m_Recursive{};
   bool m_LoadSequences{};

--- a/Modules/IO/DCMTK/include/itkDCMTKSeriesFileNames.h
+++ b/Modules/IO/DCMTK/include/itkDCMTKSeriesFileNames.h
@@ -22,10 +22,12 @@
 #include "itkProcessObject.h"
 #include "itkObjectFactory.h"
 #include "itkMacro.h"
+#include <map>
 #include <vector>
 
 namespace itk
 {
+class DCMTKFileReader;
 /**
  * \class DCMTKSeriesFileNames
  * \brief Generate a sequence of filenames from a DICOM series.
@@ -188,9 +190,14 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  /** internal method for reading out filenames and UID lists */
+  /** Parse the input directory into the per-series file-name map. */
   void
-  GetDicomData(const std::string & series, bool saveFileNames);
+  BuildSeriesMap();
+
+  /** Build the identifier that groups files into one series. */
+  std::string
+  CreateSeriesIdentifier(DCMTKFileReader * reader) const;
+
   /** Contains the input directory where the DICOM series is found */
   std::string m_InputDirectory{};
 
@@ -201,7 +208,8 @@ private:
   FileNamesContainerType m_InputFileNames{};
   FileNamesContainerType m_OutputFileNames{};
 
-  /** Internal structure to order series from one directory */
+  /** Ordered file names per distinct series identifier. */
+  std::map<std::string, FileNamesContainerType> m_SeriesFiles{};
 
   /** Internal structure to keep the list of series UIDs */
   SeriesUIDContainerType m_SeriesUIDs{};

--- a/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
@@ -925,6 +925,22 @@ DCMTKFileReader::GetElementUI(const unsigned short group,
 }
 
 int
+DCMTKFileReader::GetElementAsString(const unsigned short group,
+                                    const unsigned short element,
+                                    std::string &        target,
+                                    const bool           throwException) const
+{
+  DcmTagKey tagKey(group, element);
+  OFString  ofString;
+  if (this->m_Dataset->findAndGetOFStringArray(tagKey, ofString) != EC_Normal)
+  {
+    DCMTKExceptionOrErrorReturn(<< "Cant find tag " << std::hex << group << ' ' << std::hex << element << std::dec);
+  }
+  target.assign(ofString.c_str(), ofString.length());
+  return EXIT_SUCCESS;
+}
+
+int
 DCMTKFileReader::GetElementDA(const unsigned short group,
                               const unsigned short element,
                               std::string &        target,

--- a/Modules/IO/DCMTK/src/itkDCMTKFileReader.h
+++ b/Modules/IO/DCMTK/src/itkDCMTKFileReader.h
@@ -446,6 +446,13 @@ public:
                std::string &        target,
                const bool           throwException = true) const;
 
+  /** Read any element as its string representation, regardless of VR. */
+  int
+  GetElementAsString(const unsigned short group,
+                     const unsigned short element,
+                     std::string &        target,
+                     const bool           throwException = true) const;
+
   int
   GetElementDA(const unsigned short group,
                const unsigned short element,

--- a/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
@@ -167,26 +167,31 @@ DCMTKSeriesFileNames::SetInputDirectory(const std::string & name)
   this->Modified();
 }
 
-void
-DCMTKSeriesFileNames::GetDicomData(const std::string & series, bool saveFileNames)
+std::string
+DCMTKSeriesFileNames::CreateSeriesIdentifier(DCMTKFileReader * reader) const
 {
-  if (saveFileNames)
-  {
-    this->m_InputFileNames.clear();
-  }
+  std::string uid;
+  reader->GetElementUI(0x0020, 0x000e, uid); // Series Instance UID
+  return uid;
+}
+
+void
+DCMTKSeriesFileNames::BuildSeriesMap()
+{
   this->m_SeriesUIDs.clear();
+  this->m_SeriesFiles.clear();
 
   // make an absolute path from whatever is passed in
   std::string fullPath = itksys::SystemTools::CollapseFullPath(m_InputDirectory.c_str());
-
   // work in Unix filename conventions, but convert to actually use filename
   itksys::SystemTools::ConvertToUnixSlashes(fullPath);
 
   std::vector<std::string> candidateFiles;
   CollectCandidateFiles(fullPath, m_Recursive, candidateFiles);
 
-  std::vector<DCMTKFileReader *> allHeaders;
-
+  // Group readers by series identifier, preserving first-encountered order
+  // of the distinct identifiers.
+  std::map<std::string, std::vector<DCMTKFileReader *>> groups;
   for (const std::string & localFilePath : candidateFiles)
   {
     if (!DCMTKFileReader::IsImageFile(localFilePath))
@@ -204,50 +209,50 @@ DCMTKSeriesFileNames::GetDicomData(const std::string & series, bool saveFileName
       delete reader;
       continue;
     }
-    std::string uid;
-    reader->GetElementUI(0x0020, 0x000e, uid);
-    //
-    // if you've restricted it to a particular series instance ID
-    if (series.empty() || series == uid)
+    const std::string id = this->CreateSeriesIdentifier(reader);
+    if (groups.find(id) == groups.end())
     {
-      allHeaders.push_back(reader);
+      this->m_SeriesUIDs.push_back(id);
     }
-    else
-    {
-      delete reader;
-    }
-    //
-    // save the UID at any rate
-    this->m_SeriesUIDs.push_back(uid);
+    groups[id].push_back(reader);
   }
 
-  if (saveFileNames)
+  // Order each series geometrically and store its file names; free the headers.
+  for (auto & [id, readers] : groups)
   {
-    OrderFileReadersByPosition(allHeaders);
-  }
-  //
-  // save the filenames, and delete the headers
-  for (auto & allHeader : allHeaders)
-  {
-    if (saveFileNames)
+    OrderFileReadersByPosition(readers);
+    FileNamesContainerType names;
+    names.reserve(readers.size());
+    for (auto * reader : readers)
     {
-      m_InputFileNames.push_back(allHeader->GetFileName());
+      names.push_back(reader->GetFileName());
+      delete reader;
     }
-    delete allHeader;
+    this->m_SeriesFiles[id] = std::move(names);
   }
 }
 
 const DCMTKSeriesFileNames::FileNamesContainerType &
 DCMTKSeriesFileNames::GetFileNames(const std::string series)
 {
-  this->GetDicomData(series, true);
+  this->BuildSeriesMap();
+  const auto it = m_SeriesFiles.find(series);
+  if (it == m_SeriesFiles.end())
+  {
+    itkWarningMacro("No files were found for series " << series);
+    m_InputFileNames.clear();
+  }
+  else
+  {
+    m_InputFileNames = it->second;
+  }
   return m_InputFileNames;
 }
 
 const DCMTKSeriesFileNames::SeriesUIDContainerType &
 DCMTKSeriesFileNames::GetSeriesUIDs()
 {
-  this->GetDicomData("", false);
+  this->BuildSeriesMap();
   return this->m_SeriesUIDs;
 }
 
@@ -255,8 +260,14 @@ DCMTKSeriesFileNames::GetSeriesUIDs()
 const DCMTKSeriesFileNames::FileNamesContainerType &
 DCMTKSeriesFileNames::GetInputFileNames()
 {
-  // Do not specify any UID
-  this->GetDicomData("", true);
+  this->BuildSeriesMap();
+  // Return the first series encountered (single-series assumption), matching
+  // itk::GDCMSeriesFileNames.
+  m_InputFileNames.clear();
+  if (!m_SeriesUIDs.empty())
+  {
+    m_InputFileNames = m_SeriesFiles[m_SeriesUIDs.front()];
+  }
   return this->m_InputFileNames;
 }
 

--- a/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
@@ -45,7 +45,7 @@ OrderFileReadersByPosition(std::vector<DCMTKFileReader *> & headers)
   // Derive the slice normal from the first slice that carries a valid
   // orientation; a single mis-globbed entry without one must not suppress
   // geometric ordering for the whole series.
-  double dircos[6];
+  double dircos[6] = {};
   bool   haveOrientation = false;
   for (auto * reader : headers)
   {

--- a/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
@@ -23,6 +23,7 @@
 #include "itkPrintHelper.h"
 #include "itksys/Directory.hxx"
 #include <algorithm>
+#include <exception>
 #include <vector>
 
 namespace itk
@@ -126,10 +127,10 @@ DCMTKSeriesFileNames::DCMTKSeriesFileNames()
 {
   m_InputDirectory = "";
   m_OutputDirectory = "";
-  m_UseSeriesDetails = true;
   m_Recursive = false;
   m_LoadSequences = false;
   m_LoadPrivateTags = false;
+  this->SetUseSeriesDetails(true); // seeds the default series-detail restrictions
 }
 
 DCMTKSeriesFileNames::~DCMTKSeriesFileNames() = default;
@@ -170,9 +171,19 @@ DCMTKSeriesFileNames::SetInputDirectory(const std::string & name)
 std::string
 DCMTKSeriesFileNames::CreateSeriesIdentifier(DCMTKFileReader * reader) const
 {
-  std::string uid;
-  reader->GetElementUI(0x0020, 0x000e, uid); // Series Instance UID
-  return uid;
+  std::string id;
+  reader->GetElementUI(0x0020, 0x000e, id, false); // Series Instance UID
+  if (m_UseSeriesDetails)
+  {
+    for (const auto & [group, element] : m_Restrictions)
+    {
+      std::string value;
+      reader->GetElementAsString(group, element, value, false);
+      id += '_';
+      id += value;
+    }
+  }
+  return id;
 }
 
 void
@@ -310,7 +321,47 @@ void
 DCMTKSeriesFileNames::SetUseSeriesDetails(bool useSeriesDetails)
 {
   m_UseSeriesDetails = useSeriesDetails;
-  //  m_SerieHelper->SetUseSeriesDetails(m_UseSeriesDetails);
-  //  m_SerieHelper->CreateDefaultUniqueSeriesIdentifier();
+  m_Restrictions.clear();
+  if (m_UseSeriesDetails)
+  {
+    // Default detail tags, matching gdcm::SerieHelper::CreateDefaultUniqueSeriesIdentifier.
+    m_Restrictions.emplace_back(0x0020, 0x0011); // Series Number
+    m_Restrictions.emplace_back(0x0018, 0x0024); // Sequence Name
+    m_Restrictions.emplace_back(0x0018, 0x0050); // Slice Thickness
+    m_Restrictions.emplace_back(0x0028, 0x0010); // Rows
+    m_Restrictions.emplace_back(0x0028, 0x0011); // Columns
+  }
+  this->Modified();
+}
+
+void
+DCMTKSeriesFileNames::AddSeriesRestriction(const std::string & tag)
+{
+  // Parse a "group|element" tag (hex) and append it to the identifier criteria.
+  const std::string::size_type bar = tag.find('|');
+  if (bar == std::string::npos || bar == 0 || bar + 1 >= tag.size())
+  {
+    itkWarningMacro("Ignoring malformed series restriction tag '" << tag << "' (expected \"group|element\")");
+    return;
+  }
+  unsigned long group = 0;
+  unsigned long element = 0;
+  try
+  {
+    group = std::stoul(tag.substr(0, bar), nullptr, 16);
+    element = std::stoul(tag.substr(bar + 1), nullptr, 16);
+  }
+  catch (const std::exception &)
+  {
+    itkWarningMacro("Ignoring malformed series restriction tag '" << tag << "' (expected \"group|element\")");
+    return;
+  }
+  if (group > 0xFFFF || element > 0xFFFF)
+  {
+    itkWarningMacro("Ignoring out-of-range series restriction tag '" << tag << "' (group/element exceed 16 bits)");
+    return;
+  }
+  m_Restrictions.emplace_back(static_cast<unsigned short>(group), static_cast<unsigned short>(element));
+  this->Modified();
 }
 } // namespace itk

--- a/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
@@ -90,6 +90,36 @@ OrderFileReadersByPosition(std::vector<DCMTKFileReader *> & headers)
 
   std::transform(keys.begin(), keys.end(), headers.begin(), [](const SortKey & k) { return k.reader; });
 }
+
+// Collect file paths under dir, descending into subdirectories when recursive.
+void
+CollectCandidateFiles(const std::string & dir, bool recursive, std::vector<std::string> & out)
+{
+  itksys::Directory directory;
+  directory.Load(dir.c_str());
+  for (unsigned int i = 0; i < directory.GetNumberOfFiles(); ++i)
+  {
+    const std::string curFile = directory.GetFile(i);
+    if (curFile == "." || curFile == "..")
+    {
+      continue;
+    }
+    std::string path = dir;
+    path += '/';
+    path += curFile;
+    if (itksys::SystemTools::FileIsDirectory(path.c_str()))
+    {
+      if (recursive)
+      {
+        CollectCandidateFiles(path, recursive, out);
+      }
+    }
+    else
+    {
+      out.push_back(path);
+    }
+  }
+}
 } // namespace
 
 DCMTKSeriesFileNames::DCMTKSeriesFileNames()
@@ -152,59 +182,43 @@ DCMTKSeriesFileNames::GetDicomData(const std::string & series, bool saveFileName
   // work in Unix filename conventions, but convert to actually use filename
   itksys::SystemTools::ConvertToUnixSlashes(fullPath);
 
-  std::string localFilePath = fullPath;
-
-  // load the directory
-  itksys::Directory directory;
-  directory.Load(localFilePath.c_str());
-
-  unsigned int numFiles = directory.GetNumberOfFiles();
+  std::vector<std::string> candidateFiles;
+  CollectCandidateFiles(fullPath, m_Recursive, candidateFiles);
 
   std::vector<DCMTKFileReader *> allHeaders;
 
-  for (unsigned int i = 0; i < numFiles; ++i)
+  for (const std::string & localFilePath : candidateFiles)
   {
-    std::string curFile = directory.GetFile(i);
-    if (curFile == "." || curFile == "..")
+    if (!DCMTKFileReader::IsImageFile(localFilePath))
     {
       continue;
     }
-    localFilePath = fullPath;
-    localFilePath += '/';
-    localFilePath += curFile;
-    if (!itksys::SystemTools::FileIsDirectory(localFilePath.c_str()))
+    auto * reader = new DCMTKFileReader;
+    try
     {
-      if (!DCMTKFileReader::IsImageFile(localFilePath))
-      {
-        continue;
-      }
-      auto * reader = new DCMTKFileReader;
-      try
-      {
-        reader->SetFileName(localFilePath);
-        reader->LoadFile();
-      }
-      catch (...)
-      {
-        delete reader;
-        continue;
-      }
-      std::string uid;
-      reader->GetElementUI(0x0020, 0x000e, uid);
-      //
-      // if you've restricted it to a particular series instance ID
-      if (series.empty() || series == uid)
-      {
-        allHeaders.push_back(reader);
-      }
-      else
-      {
-        delete reader;
-      }
-      //
-      // save the UID at any rate
-      this->m_SeriesUIDs.push_back(uid);
+      reader->SetFileName(localFilePath);
+      reader->LoadFile();
     }
+    catch (...)
+    {
+      delete reader;
+      continue;
+    }
+    std::string uid;
+    reader->GetElementUI(0x0020, 0x000e, uid);
+    //
+    // if you've restricted it to a particular series instance ID
+    if (series.empty() || series == uid)
+    {
+      allHeaders.push_back(reader);
+    }
+    else
+    {
+      delete reader;
+    }
+    //
+    // save the UID at any rate
+    this->m_SeriesUIDs.push_back(uid);
   }
 
   if (saveFileNames)

--- a/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx
@@ -189,6 +189,12 @@ DCMTKSeriesFileNames::CreateSeriesIdentifier(DCMTKFileReader * reader) const
 void
 DCMTKSeriesFileNames::BuildSeriesMap()
 {
+  // Reuse the previous parse unless the object has been modified since.
+  if (m_CacheBuildTime.GetMTime() > this->GetMTime())
+  {
+    return;
+  }
+
   this->m_SeriesUIDs.clear();
   this->m_SeriesFiles.clear();
 
@@ -241,6 +247,8 @@ DCMTKSeriesFileNames::BuildSeriesMap()
     }
     this->m_SeriesFiles[id] = std::move(names);
   }
+
+  m_CacheBuildTime.Modified();
 }
 
 const DCMTKSeriesFileNames::FileNamesContainerType &

--- a/Modules/IO/IOTransformDCMTK/test/CMakeLists.txt
+++ b/Modules/IO/IOTransformDCMTK/test/CMakeLists.txt
@@ -10,7 +10,11 @@ createtestdriver(IOTransformDCMTK "${IOTransformDCMTK-Test_LIBRARIES}" "${IOTran
 
 set(TEMP ${PROJECT_BINARY_DIR}/Testing/Temporary)
 
-set(IOTransformDCMTKGTests itkDCMTKSeriesFileNamesOrderingGTest.cxx)
+set(
+  IOTransformDCMTKGTests
+  itkDCMTKSeriesFileNamesOrderingGTest.cxx
+  itkDCMTKSeriesFileNamesParityGTest.cxx
+)
 creategoogletestdriver(IOTransformDCMTK "${IOTransformDCMTK-Test_LIBRARIES}" "${IOTransformDCMTKGTests}")
 
 ExternalData_Expand_Arguments(
@@ -28,6 +32,7 @@ target_compile_definitions(
   PRIVATE
     "RECT_CENTERED_DIR=${_rect_centered_dir}"
     "RECT_OFFSET_DIR=${_rect_offset_dir}"
+    "ITK_TEST_OUTPUT_DIR=${ITK_TEST_OUTPUT_DIR}"
 )
 set_property(
   TARGET

--- a/Modules/IO/IOTransformDCMTK/test/itkDCMTKSeriesFileNamesParityGTest.cxx
+++ b/Modules/IO/IOTransformDCMTK/test/itkDCMTKSeriesFileNamesParityGTest.cxx
@@ -117,3 +117,32 @@ TEST(DCMTKSeriesFileNamesParity, DistinctSeriesGroupedNoDuplicates)
   const std::vector<std::string> first = sf->GetInputFileNames();
   EXPECT_LT(first.size(), grouped) << "GetInputFileNames returns a single series, not the union";
 }
+
+// C (issue #2735): AddSeriesRestriction must no longer be a NOOP, and only
+// applies when UseSeriesDetails is on. rect-centered is one series whose
+// ImagePositionPatient (0020,0032) differs per slice, so restricting on it
+// over-splits the series into one identifier per slice.
+TEST(DCMTKSeriesFileNamesParity, AddSeriesRestrictionSplitsByVaryingTag)
+{
+  const std::string  root = FreshDir("restriction");
+  const unsigned int n = CopyDicomSlices(TOSTRING(RECT_CENTERED_DIR), root);
+  ASSERT_GT(n, 1u);
+
+  auto plain = itk::DCMTKSeriesFileNames::New();
+  plain->SetInputDirectory(root);
+  EXPECT_EQ(plain->GetSeriesUIDs().size(), 1u) << "rect-centered is a single series by default";
+
+  auto restricted = itk::DCMTKSeriesFileNames::New();
+  restricted->SetInputDirectory(root);
+  restricted->SetUseSeriesDetails(true);
+  restricted->AddSeriesRestriction("0020|0032"); // ImagePositionPatient varies per slice
+  EXPECT_EQ(restricted->GetSeriesUIDs().size(), static_cast<std::size_t>(n))
+    << "Restricting on a per-slice-varying tag must split into one series per slice";
+
+  auto restrictionOffDetails = itk::DCMTKSeriesFileNames::New();
+  restrictionOffDetails->SetInputDirectory(root);
+  restrictionOffDetails->SetUseSeriesDetails(false);
+  restrictionOffDetails->AddSeriesRestriction("0020|0032");
+  EXPECT_EQ(restrictionOffDetails->GetSeriesUIDs().size(), 1u)
+    << "Restrictions must be ignored when UseSeriesDetails is off";
+}

--- a/Modules/IO/IOTransformDCMTK/test/itkDCMTKSeriesFileNamesParityGTest.cxx
+++ b/Modules/IO/IOTransformDCMTK/test/itkDCMTKSeriesFileNamesParityGTest.cxx
@@ -16,11 +16,7 @@
  *
  *=========================================================================*/
 
-// Parity tests for itk::DCMTKSeriesFileNames (issue #2735): recursive scan,
-// distinct series-UID enumeration / grouping, UseSeriesDetails restrictions,
-// and cache invalidation. Fixtures are built at runtime by copying the
-// rect-centered / rect-offset DICOM series into temporary layouts, so no new
-// committed test data is required.
+// Parity tests for itk::DCMTKSeriesFileNames: recursive scan, series grouping, restrictions, caching.
 
 #include "gtest/gtest.h"
 #include "itkDCMTKSeriesFileNames.h"
@@ -34,8 +30,7 @@
 
 namespace
 {
-// Copy every *.dcm file from srcDir into dstDir (created if needed), optionally
-// prefixing the destination file name so two series can share one flat dir.
+// Copy *.dcm from srcDir into dstDir, optionally prefixing names so two series can share a flat dir.
 unsigned int
 CopyDicomSlices(const std::string & srcDir, const std::string & dstDir, const std::string & prefix = "")
 {
@@ -70,7 +65,7 @@ FreshDir(const std::string & name)
 }
 } // namespace
 
-// B (issue #2735): the Recursive flag must control descent into subdirectories.
+// The Recursive flag must control descent into subdirectories.
 TEST(DCMTKSeriesFileNamesParity, RecursiveFlagHonored)
 {
   const std::string root = FreshDir("recursive");
@@ -88,9 +83,7 @@ TEST(DCMTKSeriesFileNamesParity, RecursiveFlagHonored)
   EXPECT_FALSE(recursive->GetInputFileNames().empty()) << "Recursive scan must descend into seriesA / seriesB";
 }
 
-// A (issue #2735): GetSeriesUIDs() must return one entry per distinct series,
-// not one per file; files must be grouped by series; GetInputFileNames() must
-// return a single series, not the union.
+// GetSeriesUIDs() returns one entry per distinct series (grouped), not one per file.
 TEST(DCMTKSeriesFileNamesParity, DistinctSeriesGroupedNoDuplicates)
 {
   const std::string  root = FreshDir("grouping");
@@ -118,10 +111,7 @@ TEST(DCMTKSeriesFileNamesParity, DistinctSeriesGroupedNoDuplicates)
   EXPECT_LT(first.size(), grouped) << "GetInputFileNames returns a single series, not the union";
 }
 
-// C (issue #2735): AddSeriesRestriction must no longer be a NOOP, and only
-// applies when UseSeriesDetails is on. rect-centered is one series whose
-// ImagePositionPatient (0020,0032) differs per slice, so restricting on it
-// over-splits the series into one identifier per slice.
+// rect-centered's ImagePositionPatient (0020,0032) varies per slice, so restricting on it over-splits the series.
 TEST(DCMTKSeriesFileNamesParity, AddSeriesRestrictionSplitsByVaryingTag)
 {
   const std::string  root = FreshDir("restriction");
@@ -145,4 +135,32 @@ TEST(DCMTKSeriesFileNamesParity, AddSeriesRestrictionSplitsByVaryingTag)
   restrictionOffDetails->AddSeriesRestriction("0020|0032");
   EXPECT_EQ(restrictionOffDetails->GetSeriesUIDs().size(), 1u)
     << "Restrictions must be ignored when UseSeriesDetails is off";
+}
+
+// The parse is cached across calls and invalidated when the object is modified.
+TEST(DCMTKSeriesFileNamesParity, CacheReusedAndInvalidatedOnModify)
+{
+  const std::string dirA = FreshDir("cacheA");
+  const std::string dirB = FreshDir("cacheB");
+  ASSERT_GT(CopyDicomSlices(TOSTRING(RECT_CENTERED_DIR), dirA), 0u);
+  ASSERT_GT(CopyDicomSlices(TOSTRING(RECT_OFFSET_DIR), dirB), 0u);
+
+  auto sf = itk::DCMTKSeriesFileNames::New();
+  sf->SetInputDirectory(dirA);
+  const std::vector<std::string> first = sf->GetInputFileNames();
+  const std::vector<std::string> again = sf->GetInputFileNames();
+  EXPECT_EQ(first, again) << "Repeated calls without modification return the cached result";
+
+  // Changing the directory must invalidate the cache.
+  sf->SetInputDirectory(dirB);
+  const std::vector<std::string> afterDirChange = sf->GetInputFileNames();
+  ASSERT_FALSE(afterDirChange.empty());
+  EXPECT_NE(first, afterDirChange) << "SetInputDirectory must invalidate the cache";
+
+  // Adding a per-slice-varying restriction must invalidate and re-split.
+  sf->SetInputDirectory(dirA);
+  EXPECT_EQ(sf->GetSeriesUIDs().size(), 1u);
+  sf->SetUseSeriesDetails(true);
+  sf->AddSeriesRestriction("0020|0032");
+  EXPECT_GT(sf->GetSeriesUIDs().size(), 1u) << "AddSeriesRestriction must invalidate the cache";
 }

--- a/Modules/IO/IOTransformDCMTK/test/itkDCMTKSeriesFileNamesParityGTest.cxx
+++ b/Modules/IO/IOTransformDCMTK/test/itkDCMTKSeriesFileNamesParityGTest.cxx
@@ -34,9 +34,10 @@
 
 namespace
 {
-// Copy every *.dcm file from srcDir into dstDir (created if needed).
+// Copy every *.dcm file from srcDir into dstDir (created if needed), optionally
+// prefixing the destination file name so two series can share one flat dir.
 unsigned int
-CopyDicomSlices(const std::string & srcDir, const std::string & dstDir)
+CopyDicomSlices(const std::string & srcDir, const std::string & dstDir, const std::string & prefix = "")
 {
   itksys::SystemTools::MakeDirectory(dstDir);
   itksys::Directory directory;
@@ -50,7 +51,7 @@ CopyDicomSlices(const std::string & srcDir, const std::string & dstDir)
       continue;
     }
     const std::string src = srcDir + '/' + name;
-    const std::string dst = dstDir + '/' + name;
+    const std::string dst = dstDir + '/' + prefix + name;
     if (itksys::SystemTools::CopyFileAlways(src, dst))
     {
       ++copied;
@@ -85,4 +86,34 @@ TEST(DCMTKSeriesFileNamesParity, RecursiveFlagHonored)
   recursive->SetInputDirectory(root);
   recursive->RecursiveOn();
   EXPECT_FALSE(recursive->GetInputFileNames().empty()) << "Recursive scan must descend into seriesA / seriesB";
+}
+
+// A (issue #2735): GetSeriesUIDs() must return one entry per distinct series,
+// not one per file; files must be grouped by series; GetInputFileNames() must
+// return a single series, not the union.
+TEST(DCMTKSeriesFileNamesParity, DistinctSeriesGroupedNoDuplicates)
+{
+  const std::string  root = FreshDir("grouping");
+  const unsigned int nA = CopyDicomSlices(TOSTRING(RECT_CENTERED_DIR), root, "a_");
+  const unsigned int nB = CopyDicomSlices(TOSTRING(RECT_OFFSET_DIR), root, "b_");
+  ASSERT_GT(nA, 0u);
+  ASSERT_GT(nB, 0u);
+
+  auto sf = itk::DCMTKSeriesFileNames::New();
+  sf->SetInputDirectory(root);
+
+  const std::vector<std::string> uids = sf->GetSeriesUIDs();
+  EXPECT_EQ(uids.size(), 2u) << "Two distinct SeriesInstanceUIDs, no per-file duplicates";
+
+  std::size_t grouped = 0;
+  for (const std::string & uid : uids)
+  {
+    const std::vector<std::string> files = sf->GetFileNames(uid);
+    EXPECT_FALSE(files.empty()) << "Each series UID must resolve to its files";
+    grouped += files.size();
+  }
+  EXPECT_EQ(grouped, static_cast<std::size_t>(nA) + nB);
+
+  const std::vector<std::string> first = sf->GetInputFileNames();
+  EXPECT_LT(first.size(), grouped) << "GetInputFileNames returns a single series, not the union";
 }

--- a/Modules/IO/IOTransformDCMTK/test/itkDCMTKSeriesFileNamesParityGTest.cxx
+++ b/Modules/IO/IOTransformDCMTK/test/itkDCMTKSeriesFileNamesParityGTest.cxx
@@ -1,0 +1,88 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// Parity tests for itk::DCMTKSeriesFileNames (issue #2735): recursive scan,
+// distinct series-UID enumeration / grouping, UseSeriesDetails restrictions,
+// and cache invalidation. Fixtures are built at runtime by copying the
+// rect-centered / rect-offset DICOM series into temporary layouts, so no new
+// committed test data is required.
+
+#include "gtest/gtest.h"
+#include "itkDCMTKSeriesFileNames.h"
+#include "itksys/SystemTools.hxx"
+#include "itksys/Directory.hxx"
+#include <string>
+#include <vector>
+
+#define _STRING(s) #s
+#define TOSTRING(s) std::string(_STRING(s))
+
+namespace
+{
+// Copy every *.dcm file from srcDir into dstDir (created if needed).
+unsigned int
+CopyDicomSlices(const std::string & srcDir, const std::string & dstDir)
+{
+  itksys::SystemTools::MakeDirectory(dstDir);
+  itksys::Directory directory;
+  directory.Load(srcDir.c_str());
+  unsigned int copied = 0;
+  for (unsigned int i = 0; i < directory.GetNumberOfFiles(); ++i)
+  {
+    const std::string name = directory.GetFile(i);
+    if (itksys::SystemTools::GetFilenameLastExtension(name) != ".dcm")
+    {
+      continue;
+    }
+    const std::string src = srcDir + '/' + name;
+    const std::string dst = dstDir + '/' + name;
+    if (itksys::SystemTools::CopyFileAlways(src, dst))
+    {
+      ++copied;
+    }
+  }
+  return copied;
+}
+
+std::string
+FreshDir(const std::string & name)
+{
+  const std::string dir = TOSTRING(ITK_TEST_OUTPUT_DIR) + "/dcmtkparity_" + name;
+  itksys::SystemTools::RemoveADirectory(dir);
+  itksys::SystemTools::MakeDirectory(dir);
+  return dir;
+}
+} // namespace
+
+// B (issue #2735): the Recursive flag must control descent into subdirectories.
+TEST(DCMTKSeriesFileNamesParity, RecursiveFlagHonored)
+{
+  const std::string root = FreshDir("recursive");
+  ASSERT_GT(CopyDicomSlices(TOSTRING(RECT_CENTERED_DIR), root + "/seriesA"), 0u);
+  ASSERT_GT(CopyDicomSlices(TOSTRING(RECT_OFFSET_DIR), root + "/seriesB"), 0u);
+
+  auto flat = itk::DCMTKSeriesFileNames::New();
+  flat->SetInputDirectory(root);
+  flat->RecursiveOff();
+  EXPECT_TRUE(flat->GetInputFileNames().empty()) << "No DICOM lives directly under root; flat scan must find none";
+
+  auto recursive = itk::DCMTKSeriesFileNames::New();
+  recursive->SetInputDirectory(root);
+  recursive->RecursiveOn();
+  EXPECT_FALSE(recursive->GetInputFileNames().empty()) << "Recursive scan must descend into seriesA / seriesB";
+}


### PR DESCRIPTION
Bring `itk::DCMTKSeriesFileNames` to feature parity with `itk::GDCMSeriesFileNames`: recursive scan, distinct series enumeration, working `UseSeriesDetails`/`AddSeriesRestriction`, and a cached parse. Closes #2735 (concerns A–D).

Rebased onto current `upstream/main`. The dependency on #6464 is resolved — it merged, its shared ordering commit dropped out, and this is now a clean 5-commit topic.

<details>
<summary>Commits</summary>

One parity fix per #2735 concern:

1. **BUG: Zero-initialize dircos** — UBSAN zero-init for the case where no slice carries a valid `ImageOrientationPatient` (the scan-for-first-valid-orientation loop itself now comes from merged #6464).
2. **ENH: Honor Recursive flag** — `m_Recursive` was ignored; the scan now descends subdirectories.
3. **BUG: Group files by series; de-duplicate UIDs** — `GetSeriesUIDs()` pushed the UID once per file (N duplicates); now parses into a per-series map, returns distinct identifiers, `GetFileNames(uid)` returns just that series, `GetInputFileNames()` the first series only.
4. **ENH: Implement UseSeriesDetails/restrictions** — both were no-ops; the series identifier now appends the default `gdcm::SerieHelper` detail tags (Series Number / Sequence Name / Slice Thickness / Rows / Columns) plus user restrictions. Adds `DCMTKFileReader::GetElementAsString`.
5. **PERF: Cache the directory parse** — keyed by `TimeStamp`; a multi-call workflow over one directory now parses it once, invalidated by any `Set*`/`AddSeriesRestriction`.

</details>

<details>
<summary>Testing</summary>

New self-contained GoogleTests in `itkDCMTKSeriesFileNamesParityGTest` (fixtures built at runtime by copying the rect-centered / rect-offset series — no new committed data): recursive flag, distinct-series grouping / no duplicates, restriction-driven split (and ignored when details off), and cache reuse + invalidation. The IOTransformDCMTK + ITKIODCMTK suites pass locally; `pre-commit run --all-files` clean.

</details>

<details>
<summary>Not addressed: the reported gdcm::SerieHelper leak (concern E)</summary>

Verified not a leak — `gdcm::FileList` is `std::vector<SmartPointer<FileWithName>>` (since 2008); `Clear()` + `~SerieHelper()` free everything. See the correction on #2735. No change needed.

</details>

<!--
provenance: claude-code 2026-06-27 (rebased onto upstream/main 7d80605fd73 after #6464 merged; shared ordering commit dropped out; 5-commit topic; pre-commit --all-files clean)
closes: #2735 (concerns A-D; E verified invalid)
depends_on: none (#6464 merged)
key_files: Modules/IO/DCMTK/src/itkDCMTKSeriesFileNames.cxx; Modules/IO/DCMTK/include/itkDCMTKSeriesFileNames.h; Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx (GetElementAsString); Modules/IO/IOTransformDCMTK/test/itkDCMTKSeriesFileNamesParityGTest.cxx
-->
