### PR TITLE
BUG: Adapt VtkGlue extent callback to VTK future-const signature

### DIFF
--- a/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.hxx
+++ b/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.hxx
@@ -39,7 +39,12 @@ ImageToVTKImageFilter<TInputImage>::ImageToVTKImageFilter()
 #endif
   m_Importer->SetScalarTypeCallback(m_Exporter->GetScalarTypeCallback());
   m_Importer->SetNumberOfComponentsCallback(m_Exporter->GetNumberOfComponentsCallback());
-  m_Importer->SetPropagateUpdateExtentCallback(m_Exporter->GetPropagateUpdateExtentCallback());
+  // Adapt the exporter callback to vtkImageImport's VTK_FUTURE_CONST extent
+  // signature; the const_cast is safe because the callback only reads the extent.
+  m_Importer->SetPropagateUpdateExtentCallback([](void * userData, VTK_FUTURE_CONST int * extent) {
+    static_cast<VTKImageExportBase *>(userData)->GetPropagateUpdateExtentCallback()(userData,
+                                                                                    const_cast<int *>(extent));
+  });
   m_Importer->SetUpdateDataCallback(m_Exporter->GetUpdateDataCallback());
   m_Importer->SetDataExtentCallback(m_Exporter->GetDataExtentCallback());
   m_Importer->SetBufferPointerCallback(m_Exporter->GetBufferPointerCallback());

--- a/Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.hxx
+++ b/Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.hxx
@@ -41,7 +41,11 @@ VTKImageToImageFilter<TOutputImage>::VTKImageToImageFilter()
 #endif
   this->SetScalarTypeCallback(m_Exporter->GetScalarTypeCallback());
   this->SetNumberOfComponentsCallback(m_Exporter->GetNumberOfComponentsCallback());
-  this->SetPropagateUpdateExtentCallback(m_Exporter->GetPropagateUpdateExtentCallback());
+  // Adapt vtkImageExport's VTK_FUTURE_CONST extent callback to the importer's
+  // int* signature; the int* argument binds to the VTK_FUTURE_CONST parameter.
+  this->SetPropagateUpdateExtentCallback([](void * userData, int * extent) {
+    static_cast<vtkImageExport *>(userData)->GetPropagateUpdateExtentCallback()(userData, extent);
+  });
   this->SetUpdateDataCallback(m_Exporter->GetUpdateDataCallback());
   this->SetDataExtentCallback(m_Exporter->GetDataExtentCallback());
   this->SetBufferPointerCallback(m_Exporter->GetBufferPointerCallback());


### PR DESCRIPTION
Fixes a compile regression in the ITK↔VTK glue: when VTK is built with `VTK_USE_FUTURE_CONST=ON`, `vtkImageImport`/`vtkImageExport` declare the `PropagateUpdateExtent` callback's extent parameter as `const int *`, which no longer matches ITK's `int *` callback type. Each assignment is bridged with a captureless-lambda adapter that matches the target setter's exact signature.

Closes #6462

<details>
<summary>Root cause</summary>

VTK commit `99e95adeae` ("Added VTK_FUTURE_CONST to extents related API") wrapped the extent parameter of `vtkImageImport::SetPropagateUpdateExtentCallback` and `vtkImageExport::GetPropagateUpdateExtentCallback` in `VTK_FUTURE_CONST`. With `VTK_USE_FUTURE_CONST=ON` that macro expands to `const`, so the callback type becomes `void (*)(void *, const int *)`.

ITK's `itk::VTKImageExportBase` / `itk::VTKImageImport` hardcode `void (*)(void *, int *)`. Function-pointer types do not implicitly convert across that `const` difference, so both glue assignments fail to compile:

- `itkImageToVTKImageFilter.hxx` — ITK exporter callback → `vtkImageImport`
- `itkVTKImageToImageFilter.hxx` — `vtkImageExport` callback → ITK importer

</details>

<details>
<summary>Why the fix lives in VtkGlue (and not by changing ITK's callback signature)</summary>

The const-incorrect typedef lives in `Modules/Bridge/VTK` (ITKVTK), which is intentionally **buildable without VTK**: it has no VTK headers (`grep '#include [<"]vtk'` is empty), declares `DEPENDS ITKCommon` only, and ships compiled as `libITKVTK` with `int *` baked into its ABI. The classes reproduce VTK's callback ABI by hand precisely so applications can wire ITK↔VTK without ITK itself depending on VTK.

Consequences for the fix:

- Making ITKVTK's typedef track `VTK_FUTURE_CONST` (by including a VTK header, or via a CMake-injected compile definition) would either end ITKVTK's ability to build without VTK, or turn a **public ITK type into a build-flag-dependent ABI** — `int *` in one build, `const int *` in another, for the same ITK version. That is a silent-ODR hazard for downstream consumers unless every one of them inherits the identical definition. Note also that VTK does not export `VTK_USE_FUTURE_CONST` as a CMake variable, so detection would require a configure-time compile probe.
- Simply switching ITK's signature to `const int *` does not fix the build — it only flips the breakage to the default (non-future-const) VTK configuration, which is the common case, and is a public API/ABI change to `VTKImageExportBase` and subclasses.

Keeping the adaptation in `Modules/Bridge/VtkGlue` — the module that already depends on VTK — leaves ITKVTK's ABI unconditionally `int *` (one stable type, no detection, no propagation) and confines all `VTK_FUTURE_CONST` awareness to the lambda parameter lists. The `const_cast<int *>` in the import direction is safe because every implementation of the callback only reads the extent.

</details>

<details>
<summary>Test plan</summary>

- VTK built from current `master` with `VTK_USE_FUTURE_CONST=ON` (reproduces the regression before the fix at both sites).
- ITK configured with `Module_ITKVtkGlue=ON` against that VTK.
- `ITKVtkGlueTestDriver` builds clean (`-Wall -Wextra`, no warnings) with the fix.
- `itkImageToVTKImageFilterTest`, `itkImageToVTKImageFilterRGBTest`, `itkVTKImageToImageFilterTest` all pass.
- Both VTK configurations (future-const on/off) verified compile-clean in an isolated model.

</details>

<!--
provenance: claude-code session 2026-06-18, issue #6462 (reporter: seanm)
root_cause: VTK commit 99e95adeae added VTK_FUTURE_CONST to PropagateUpdateExtent callback extent param
files:
  Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.hxx (ITK export -> vtkImageImport)
  Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.hxx (vtkImageExport -> ITK import)
key_constraint: Modules/Bridge/VTK (ITKVTK) is buildable without VTK (no vtk includes, DEPENDS ITKCommon only); fix must not add a VTK dependency or an ABI-affecting flag to it
alternatives_considered: (2) CMake-injected ITKVTK_FUTURE_CONST compile definition, (3) add VTK dependency to Modules/Bridge/VTK; both rejected to preserve build-without-VTK and avoid public ABI knob
-->
