### PR TITLE
ENH: Build DCMTK in-scope with FetchContent

### DIFF
--- a/Modules/ThirdParty/DCMTK/CMakeLists.txt
+++ b/Modules/ThirdParty/DCMTK/CMakeLists.txt
@@ -127,12 +127,7 @@ else(ITK_USE_SYSTEM_DCMTK)
     set(DCMTK_ENABLE_CHARSET_CONVERSION "oficonv" CACHE INTERNAL "")
   endif()
 
-  if(MSVC)
-    set(DCMTK_OVERWRITE_WIN32_COMPILER_FLAGS OFF)
-    # MSVC underreports __cplusplus (read by DCMTK's STL probes) without this;
-    # directory-scoped so it does not leak to sibling ITK modules.
-    string(APPEND CMAKE_CXX_FLAGS " /Zc:__cplusplus")
-  endif()
+  set(DCMTK_OVERWRITE_WIN32_COMPILER_FLAGS OFF)
 
   # Silence DCMTK third-party warnings here because add_subdirectory() runs
   # before itk_module_impl() would disable them.

--- a/Modules/ThirdParty/DCMTK/CMakeLists.txt
+++ b/Modules/ThirdParty/DCMTK/CMakeLists.txt
@@ -2,128 +2,19 @@ project(ITKDCMTK)
 
 set(ITKDCMTK_THIRD_PARTY 1)
 
-# This depends on the external project, nothing locally built
+# DCMTK is built in-scope via FetchContent; this module dir has no sources.
 set(ITKDCMTK_NO_SRC 1)
 
 include(CMakeParseArguments)
 
-# oficonv is the fixed data backend; ICU and external iconv are mutually exclusive add-ons.
-set(
-  CHARSET_CONVERSION_ARGS
-  -DDCMTK_ENABLE_BUILTIN_OFICONV_DATA:BOOL=${DCMTK_ENABLE_BUILTIN_OFICONV_DATA}
-)
 if(DCMTK_USE_ICU)
   option(ITK_USE_SYSTEM_ICU "Use an installed version of ICU" OFF)
-  # ICU backend for both system and in-tree ICU; external iconv stays off.
-  list(
-    APPEND
-    CHARSET_CONVERSION_ARGS
-    -DDCMTK_WITH_STDLIBC_ICONV:BOOL=OFF
-    -DDCMTK_WITH_ICU:BOOL=ON
-    -DDCMTK_WITH_ICONV:BOOL=OFF
-    -DDCMTK_ENABLE_CHARSET_CONVERSION:STRING=ICU
-  )
   if(NOT ITK_USE_SYSTEM_ICU)
-    set(ITKDCMTK_PREREQS ${ITKDCMTK_BINARY_DIR}/DCMTK_Prereqs)
-    set(ITKDCMTK_ICU_LIBRARIES)
-    if(WIN32)
-      message(
-        FATAL_ERROR
-        "ICU is not built as part of ITK on Windows. Please compile it outside of ITK."
-      )
-    else()
-      set(
-        ITKDCMTK_ICU_LIBRARY_NAMES
-        uc
-        data
-      )
-    endif()
-    foreach(lib_name ${ITKDCMTK_ICU_LIBRARY_NAMES})
-      set(lib ICU::${lib_name})
-      list(APPEND ITKDCMTK_ICU_LIBRARIES ${lib})
-      add_library(${lib} STATIC IMPORTED GLOBAL)
-      if(CMAKE_CONFIGURATION_TYPES)
-        foreach(c ${CMAKE_CONFIGURATION_TYPES})
-          string(TOUPPER "${c}" C)
-          set(debug_suffix)
-          if("${C}" STREQUAL "DEBUG")
-            set(
-              lib_path
-              ${ITKDCMTK_PREREQS}/${c}/lib/${lib_prefix}icu${lib_name}d${CMAKE_STATIC_LIBRARY_SUFFIX}
-            )
-          else() # For all non-debug, use release
-            set(
-              lib_path
-              ${ITKDCMTK_PREREQS}/Release/lib/${lib_prefix}icu${lib_name}${CMAKE_STATIC_LIBRARY_SUFFIX}
-            )
-          endif()
-          set_property(
-            TARGET
-              ${lib}
-            PROPERTY
-              IMPORTED_LOCATION_${C}
-                ${lib_path}
-          )
-        endforeach()
-      else()
-        set(
-          lib_path
-          ${ITKDCMTK_PREREQS}/lib/${lib_prefix}icu${lib_name}${CMAKE_STATIC_LIBRARY_SUFFIX}
-        )
-        set_property(
-          TARGET
-            ${lib}
-          PROPERTY
-            IMPORTED_LOCATION
-              ${lib_path}
-        )
-      endif()
-      list(APPEND ICU_BYPRODUCTS "${lib_path}")
-    endforeach()
-
-    set(
-      ICU_URL
-      "http://download.icu-project.org/files/icu4c/58.2/icu4c-58_2-src.tgz"
+    message(
+      FATAL_ERROR
+      "DCMTK_USE_ICU requires ITK_USE_SYSTEM_ICU=ON: building ICU from source is incompatible with DCMTK's in-scope FetchContent configuration, which runs DCMTK's find_package(ICU) at configure time. Provide a system ICU or disable DCMTK_USE_ICU."
     )
-    set(ICU_MD5 fac212b32b7ec7ab007a12dff1f3aea1)
-    # If not Debug, use Release (for Release, MinSizeRel,...)
-    if(CMAKE_CONFIGURATION_TYPES)
-      set(
-        ICU_ROOT_DIR
-        ${ITKDCMTK_PREREQS}/$<$<CONFIG:Debug>:Debug>$<$<NOT:$<CONFIG:Debug>>:Release>
-      )
-    else()
-      set(ICU_ROOT_DIR ${ITKDCMTK_PREREQS})
-    endif()
-    list(APPEND CHARSET_CONVERSION_ARGS -DICU_ROOT:PATH=${ICU_ROOT_DIR})
-    itk_download_attempt_check(icu)
-    ExternalProject_Add(
-      icu
-      URL
-        ${ICU_URL}
-      URL_MD5 ${ICU_MD5}
-      PREFIX ${ITKDCMTK_BINARY_DIR}
-      UPDATE_COMMAND
-        ""
-      BUILD_BYPRODUCTS
-        ${ICU_BYPRODUCTS}
-      CONFIGURE_COMMAND
-        <SOURCE_DIR>/source/configure --prefix=${ITKDCMTK_PREREQS}
-        --with-data-packaging=static --enable-static=yes --enable-shared=no
-        "CC=${CMAKE_C_COMPILER_LAUNCHER} ${CMAKE_C_COMPILER}"
-        "CXX=${CMAKE_CXX_COMPILER_LAUNCHER} ${CMAKE_CXX_COMPILER}"
-        "CFLAGS=-fPIC" "CXXFLAGS=-fPIC"
-    )
-    set(ICU_DEPENDENCY icu)
   endif()
-else()
-  # Built-in oficonv only; disable ICU and external iconv for a deterministic backend.
-  list(
-    APPEND
-    CHARSET_CONVERSION_ARGS
-    -DDCMTK_WITH_ICU:BOOL=OFF
-    -DDCMTK_WITH_ICONV:BOOL=OFF
-  )
 endif()
 
 set(
@@ -196,333 +87,108 @@ endif()
 
   itk_module_impl()
 else(ITK_USE_SYSTEM_DCMTK)
-  set(DCMTK_EPNAME ITKDCMTK_ExtProject)
-  set(lib_dir ${CMAKE_CURRENT_BINARY_DIR}/${DCMTK_EPNAME}-build/lib)
+  # FetchContent + add_subdirectory builds DCMTK in ITK's scope so it consumes
+  # ITK's codec targets directly.
+  include(FetchContent)
+  include(${CMAKE_CURRENT_LIST_DIR}/DCMTKGitTag.cmake)
 
-  if(BUILD_SHARED_LIBS)
-    set(_ITKDCMTK_LIB_LINKAGE SHARED)
+  # Pass ITK's codec libraries as the standard find_package variables; in-scope
+  # they resolve to ITK's imported targets with their transitive usage requirements.
+  set(DCMTK_USE_FIND_PACKAGE ON)
+  set(DCMTK_WITH_TIFF ON)
+  set(DCMTK_WITH_PNG ON)
+  set(DCMTK_WITH_ZLIB ON)
+  set(DCMTK_WITH_OPENSSL OFF)
+  set(DCMTK_WITH_XML OFF)
+  set(TIFF_LIBRARIES ITK::ITKTIFFModule)
+  set(JPEG_LIBRARIES ITK::ITKJPEGModule)
+  set(PNG_LIBRARIES ITK::ITKPNGModule)
+  set(ZLIB_LIBRARIES ITK::ITKZLIBModule)
+
+  # DCMTK build options; compiler and language-standard settings inherit from ITK's scope.
+  set(BUILD_APPS OFF)
+  set(DCMTK_ENABLE_CXX11 ON)
+  set(DCMTK_FORCE_FPIC_ON_UNIX ON)
+  set(DCMTK_DEFAULT_DICT builtin)
+  set(DCMTK_WITH_DOXYGEN OFF)
+  set(DCMTK_WITH_SNDFILE OFF)
+  set(DCMTK_WITH_WRAP OFF)
+  set(DCMTK_ENABLE_PRIVATE_TAGS ON)
+
+  # Charset conversion: system ICU when DCMTK_USE_ICU is set, otherwise
+  # DCMTK's built-in oficonv data.
+  if(DCMTK_USE_ICU)
+    set(DCMTK_WITH_ICU ON)
+    set(DCMTK_WITH_STDLIBC_ICONV OFF)
+    set(DCMTK_ENABLE_CHARSET_CONVERSION "ICU" CACHE INTERNAL "") # NOTE: DCMTK requires a cache entry
   else()
-    set(_ITKDCMTK_LIB_LINKAGE STATIC)
+    set(DCMTK_WITH_ICU OFF)
+    set(DCMTK_ENABLE_BUILTIN_OFICONV_DATA ON)
+    set(DCMTK_ENABLE_CHARSET_CONVERSION "oficonv" CACHE INTERNAL "")
   endif()
-  foreach(lib ${_ITKDCMTK_LIB_NAMES})
-    # add it as an imported  library target
-    # Note: because of the manual export, we can not use an ALIAS target for the namespace
-    add_library(
-      ${ITK_MODULE_${itk-module}_TARGETS_NAMESPACE}${lib}
-      ${_ITKDCMTK_LIB_LINKAGE}
-      IMPORTED
-      GLOBAL
-    )
-  endforeach()
 
-  # Use DCMTK include files in place in the build directory.
-  set(ITKDCMTK_INCLUDE ${CMAKE_CURRENT_BINARY_DIR}/${DCMTK_EPNAME})
+  if(MSVC)
+    set(DCMTK_OVERWRITE_WIN32_COMPILER_FLAGS OFF)
+    # MSVC underreports __cplusplus (read by DCMTK's STL probes) without this;
+    # directory-scoped so it does not leak to sibling ITK modules.
+    string(APPEND CMAKE_CXX_FLAGS " /Zc:__cplusplus")
+  endif()
 
-  # 'stringize' the libraries. Brad King addition
-  set(ITKDCMTK_LIBRARIES "${_ITKDCMTK_LIB_NAMES}")
-  #
-  # add all the embedded include directories to include dirs
-  foreach(lib ${_ITKDCMTK_LIB_NAMES})
-    # add to include list
-    list(APPEND ITKDCMTK_INCLUDE_DIRS ${ITKDCMTK_INCLUDE}/${lib}/include)
-  endforeach()
+  # Silence DCMTK third-party warnings here because add_subdirectory() runs
+  # before itk_module_impl() would disable them.
+  itk_module_warnings_disable(C CXX)
 
-  #
-  # need the base include dir as well.
-  list(
-    APPEND
-    ITKDCMTK_INCLUDE_DIRS
-    ${CMAKE_CURRENT_BINARY_DIR}/${DCMTK_EPNAME}-build/config/include
+  # No EXCLUDE_FROM_ALL: it leaks onto ITK's own test targets and drops them
+  # from ALL. DCMTK's libraries are needed by ITKIODCMTK and it builds no apps
+  # (BUILD_APPS OFF) or tests.
+  FetchContent_Declare(
+    dcmtk
+    GIT_REPOSITORY ${DCMTK_GIT_REPOSITORY}
+    GIT_TAG ${DCMTK_GIT_TAG}
   )
 
+  FetchContent_MakeAvailable(dcmtk)
+
+  # DCMTK:: IMPORTED INTERFACE wrappers (not ALIAS): IMPORTED preserves the
+  # namespaced name in ITKTargets.cmake, matching what find_package(DCMTK)
+  # yields for downstream consumers.
+  foreach(_dcmtk_lib IN LISTS _ITKDCMTK_LIB_NAMES)
+    set(_dcmtk_target "${_dcmtk_lib}${DCMTK_LIBRARY_SUFFIX}")
+    if(TARGET "${_dcmtk_target}")
+      if(NOT TARGET "DCMTK::${_dcmtk_target}")
+        add_library("DCMTK::${_dcmtk_target}" INTERFACE IMPORTED GLOBAL)
+        target_link_libraries(
+          "DCMTK::${_dcmtk_target}"
+          INTERFACE
+            "${_dcmtk_target}"
+        )
+      endif()
+      list(APPEND ITKDCMTK_LIBRARIES "DCMTK::${_dcmtk_target}")
+    endif()
+  endforeach()
+  unset(_dcmtk_lib)
+  unset(_dcmtk_target)
+
+  # Build-tree consumers: locate DCMTKConfig.cmake in ITK's build root.
   set(
     ITKDCMTK_EXPORT_CODE_BUILD
     "
-set(CMAKE_MODULE_PATH
-  \"${CMAKE_CURRENT_SOURCE_DIR}/CMake\" \${CMAKE_MODULE_PATH})
+if(NOT ITK_BINARY_DIR)
+  set(DCMTK_DIR \"${CMAKE_BINARY_DIR}\")
+  find_package(DCMTK REQUIRED NO_MODULE)
+endif()
 "
   )
-
-  set(ITKDCMTK_LINK_DEPENDENCIES ${ITKDCMTK_LIBDEP_WIN})
-  # create imported targets when module is loaded from build tree
-  if(CMAKE_CONFIGURATION_TYPES)
-    set(
-      ITKDCMTK_EXPORT_CODE_BUILD
-      "
-${ITKDCMTK_EXPORT_CODE_BUILD}
-foreach(lib ${_ITKDCMTK_LIB_NAMES})
-  if(NOT TARGET ${ITK_MODULE_${itk-module}_TARGETS_NAMESPACE}\${lib})
-    add_library(${ITK_MODULE_${itk-module}_TARGETS_NAMESPACE}\${lib} ${_ITKDCMTK_LIB_LINKAGE} IMPORTED)
-    foreach(c ${CMAKE_CONFIGURATION_TYPES})
-      string(TOUPPER \"\${c}\" C)
-      set_property(TARGET ${ITK_MODULE_${itk-module}_TARGETS_NAMESPACE}\${lib} PROPERTY IMPORTED_LOCATION_\${C}
-        \"${lib_dir}/\${c}/${lib_prefix}\${lib}${lib_suffix}\")
-    set_property(TARGET ${ITK_MODULE_${itk-module}_TARGETS_NAMESPACE}\${lib} PROPERTY
-      IMPORTED_LINK_INTERFACE_LIBRARIES
-      ${ITKDCMTK_LINK_DEPENDENCIES})
-    endforeach()
-  endif()
-endforeach()
-"
-    )
-  else()
-    set(
-      ITKDCMTK_EXPORT_CODE_BUILD
-      "
-${ITKDCMTK_EXPORT_CODE_BUILD}
-foreach(lib ${_ITKDCMTK_LIB_NAMES})
-  if(NOT TARGET ${ITK_MODULE_${itk-module}_TARGETS_NAMESPACE}\${lib})
-    add_library(${ITK_MODULE_${itk-module}_TARGETS_NAMESPACE}\${lib} ${_ITKDCMTK_LIB_LINKAGE} IMPORTED)
-    set_property(TARGET ${ITK_MODULE_${itk-module}_TARGETS_NAMESPACE}\${lib} PROPERTY IMPORTED_LOCATION
-      \"${lib_dir}/${lib_prefix}\${lib}${lib_suffix}\")
-    set_property(TARGET ${ITK_MODULE_${itk-module}_TARGETS_NAMESPACE}\${lib} PROPERTY
-      IMPORTED_LINK_INTERFACE_LIBRARIES
-      ${ITKDCMTK_LINK_DEPENDENCIES})
-  endif()
-endforeach()
-"
-    )
-  endif()
-  # create imported targets when module is loaded from install tree
+  # Install-tree consumers: locate DCMTKConfig.cmake under ITK_INSTALL_PREFIX.
   set(
     ITKDCMTK_EXPORT_CODE_INSTALL
     "
-foreach(lib ${_ITKDCMTK_LIB_NAMES})
-  if(NOT TARGET ${ITK_MODULE_${itk-module}_TARGETS_NAMESPACE}\${lib})
-    add_library(${ITK_MODULE_${itk-module}_TARGETS_NAMESPACE}\${lib} ${_ITKDCMTK_LIB_LINKAGE} IMPORTED)
-    set_property(TARGET ${ITK_MODULE_${itk-module}_TARGETS_NAMESPACE}\${lib} PROPERTY IMPORTED_LOCATION
-            \"\${ITK_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${lib_prefix}\${lib}${lib_suffix}\")
-    set_property(TARGET ${ITK_MODULE_${itk-module}_TARGETS_NAMESPACE}\${lib} PROPERTY
-      IMPORTED_LINK_INTERFACE_LIBRARIES
-      ${ITKDCMTK_LINK_DEPENDENCIES})
-  endif()
-endforeach()
+set(DCMTK_DIR \"\${ITK_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake/dcmtk\")
+find_package(DCMTK REQUIRED NO_MODULE)
 "
   )
 
-  # implement module before the ExternalProject, to process
-  # dependencies
   itk_module_impl()
-
-  foreach(libdep JPEG TIFF ZLIB PNG)
-    #
-    # if we're using ITK-built versions of libraries, then
-    # have to find the actual library name, instead of the cmake logical name
-    set(DCMTK${libdep}_LIBRARIES "")
-
-    foreach(_lib ${ITK${libdep}_LIBRARIES})
-      if(TARGET ${_lib})
-        set(_lib $<TARGET_FILE:${_lib}>)
-      endif()
-      list(APPEND DCMTK${libdep}_LIBRARIES ${_lib})
-    endforeach()
-
-    # have to replace ; with another separator in order to pass lists into
-    # the external project without them getting messed up.
-    string(
-      REPLACE
-      ";"
-      ":::"
-      DCMTK${libdep}_LIBRARIES
-      "${DCMTK${libdep}_LIBRARIES}"
-    )
-    string(
-      REPLACE
-      ";"
-      ":::"
-      DCMTK${libdep}_INCLUDE_DIRS
-      "${ITK${libdep}_INCLUDE_DIRS}"
-    )
-  endforeach()
-
-  include(${CMAKE_CURRENT_LIST_DIR}/DCMTKGitTag.cmake)
-
-  set(
-    DCMTK_EP_FLAGS
-    -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}
-    -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=${CMAKE_CXX_STANDARD_REQUIRED}
-    -DCMAKE_CXX_EXTENSIONS:BOOL=${CMAKE_CXX_EXTENSIONS}
-    -DDCMTK_ENABLE_CXX11:BOOL=ON
-    -DDCMTK_FORCE_FPIC_ON_UNIX:BOOL=ON
-    -DBUILD_APPS:BOOL=OFF # Only DCMTK libraries are needed
-    -DDCMTK_USE_FIND_PACKAGE:BOOL=ON
-    -DDCMTK_WITH_OPENSSL:BOOL=OFF
-    -DDCMTK_WITH_PNG:BOOL=ON
-    -DDCMTK_WITH_XML:BOOL=OFF
-    -DDCMTK_WITH_TIFF:BOOL=ON
-    -DDCMTK_WITH_ZLIB:BOOL=ON
-  )
-
-  if(MSVC)
-    list(APPEND DCMTK_EP_FLAGS -DDCMTK_OVERWRITE_WIN32_COMPILER_FLAGS:BOOL=OFF)
-    # DCMTK's STL feature probes read __cplusplus, which MSVC underreports
-    # until /Zc:__cplusplus is set; pass it up front so the probes enable C++17.
-    list(
-      APPEND
-      DCMTK_EP_FLAGS
-      "-DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS} /Zc:__cplusplus"
-    )
-  endif()
-
-  if("${CMAKE_GENERATOR}" MATCHES "Unix Makefiles")
-    list(
-      APPEND
-      DCMTK_EP_FLAGS
-      -DCMAKE_VERBOSE_MAKEFILE:BOOL=${CMAKE_VERBOSE_MAKEFILE}
-    )
-  endif()
-
-  # build the list of libraries upon which DCMTK depends
-  set(ITKDCMTK_LIBDEP "")
-  list(APPEND ITKDCMTK_LIBDEP ${ITKDCMTK_LIBDEP_WIN})
-  foreach(
-    lib
-    ITKJPEG_LIBRARIES
-    ITKTIFF_LIBRARIES
-    ITKPNG_LIBRARIES
-    ITKZLIB_LIBRARIES
-    ITKDCMTK_ICU_LIBRARIES
-  )
-    foreach(_lib ${${lib}})
-      if(TARGET ${_lib})
-        list(APPEND ITKDCMTK_LIBDEP ${_lib})
-      endif()
-    endforeach()
-  endforeach()
-  # attach actual filenames to the
-  # imported libraries from the ExternalProject
-  foreach(lib ${_ITKDCMTK_LIB_NAMES})
-    # tell the imported library where it's file lives
-    if(CMAKE_CONFIGURATION_TYPES)
-      foreach(c ${CMAKE_CONFIGURATION_TYPES})
-        string(TOUPPER "${c}" C)
-        set_property(
-          TARGET
-            ${ITK_MODULE_${itk-module}_TARGETS_NAMESPACE}${lib}
-          PROPERTY
-            IMPORTED_LOCATION_${C}
-              ${lib_dir}/${c}/${lib_prefix}${lib}${lib_suffix}
-        )
-        list(
-          APPEND
-          DCMTK_BYPRODUCTS
-          "${lib_dir}/${c}/${lib_prefix}${lib}${lib_suffix}"
-        )
-      endforeach()
-    else()
-      set_property(
-        TARGET
-          ${ITK_MODULE_${itk-module}_TARGETS_NAMESPACE}${lib}
-        PROPERTY
-          IMPORTED_LOCATION
-            ${lib_dir}/${lib_prefix}${lib}${lib_suffix}
-      )
-      list(
-        APPEND
-        DCMTK_BYPRODUCTS
-        "${lib_dir}/${lib_prefix}${lib}${lib_suffix}"
-      )
-    endif()
-
-    # make the imported library depend on its prerequisite
-    # libraries
-    set_property(
-      TARGET
-        ${ITK_MODULE_${itk-module}_TARGETS_NAMESPACE}${lib}
-      PROPERTY
-        IMPORTED_LINK_INTERFACE_LIBRARIES
-          ${ITKDCMTK_LIBDEP}
-    )
-  endforeach()
-
-  set(
-    CMAKE_CXX_COMPILER_LAUNCHER_FLAG
-    -DCMAKE_CXX_COMPILER_LAUNCHER:FILEPATH=${CMAKE_CXX_COMPILER_LAUNCHER}
-  )
-  set(
-    CMAKE_C_COMPILER_LAUNCHER_FLAG
-    -DCMAKE_C_COMPILER_LAUNCHER:FILEPATH=${CMAKE_C_COMPILER_LAUNCHER}
-  )
-  set(_cross_compiling_flags)
-  if(CMAKE_TOOLCHAIN_FILE)
-    list(
-      APPEND
-      _cross_compiling_flags
-      -DCMAKE_TOOLCHAIN_FILE:FILEPATH=${CMAKE_TOOLCHAIN_FILE}
-    )
-  endif()
-  if(CMAKE_CROSSCOMPILING_EMULATOR)
-    list(
-      APPEND
-      _cross_compiling_flags
-      -DCMAKE_CROSSCOMPILING_EMULATOR:FILEPATH=${CMAKE_CROSSCOMPILING_EMULATOR}
-    )
-  endif()
-  itk_download_attempt_check(${DCMTK_EPNAME})
-  ExternalProject_Add(
-    ${DCMTK_EPNAME}
-    GIT_REPOSITORY ${DCMTK_GIT_REPOSITORY}
-    GIT_TAG ${DCMTK_GIT_TAG}
-    SOURCE_DIR ${DCMTK_EPNAME}
-    BINARY_DIR ${DCMTK_EPNAME}-build
-    LIST_SEPARATOR ":::"
-    INSTALL_COMMAND
-      ""
-    CMAKE_ARGS
-      -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
-      -DBUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS}
-      -DCMAKE_MSVC_RUNTIME_LIBRARY:STRING=${CMAKE_MSVC_RUNTIME_LIBRARY}
-      -DDCMTK_DEFAULT_DICT:STRING=builtin -DDCMTK_WITH_DOXYGEN:BOOL=OFF
-      -DDCMTK_WITH_SNDFILE:BOOL=OFF -DDCMTK_WITH_WRAP:BOOL=OFF
-      -DDCMTK_ENABLE_PRIVATE_TAGS:BOOL=ON
-      -DJPEG_LIBRARIES:STRING=${DCMTKJPEG_LIBRARIES}
-      -DJPEG_INCLUDE_DIRS:STRING=${DCMTKJPEG_INCLUDE_DIRS}
-      -DTIFF_LIBRARIES:STRING=${DCMTKTIFF_LIBRARIES}
-      -DTIFF_INCLUDE_DIRS:STRING=${DCMTKTIFF_INCLUDE_DIRS}
-      -DZLIB_LIBRARIES:STRING=${DCMTKZLIB_LIBRARIES}
-      -DZLIB_INCLUDE_DIRS:STRING=${DCMTKZLIB_INCLUDE_DIRS}
-      -DPNG_LIBRARIES:STRING=${DCMTKPNG_LIBRARIES}
-      -DPNG_INCLUDE_DIRS:STRING=${DCMTKPNG_INCLUDE_DIRS} ${DCMTK_EP_FLAGS}
-      ${_cross_compiling_flags}
-      -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
-      ${CMAKE_CXX_COMPILER_LAUNCHER_FLAG}
-      -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
-      ${CMAKE_C_COMPILER_LAUNCHER_FLAG}
-      -DCMAKE_LIBRARY_OUTPUT_DIRECTORY:PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
-      -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY:PATH=${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
-      -DCMAKE_RUNTIME_OUTPUT_DIRECTORY:PATH=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-      -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
-      -DCMAKE_INSTALL_LIBDIR:PATH=${CMAKE_INSTALL_LIBDIR}
-      -DCMAKE_INSTALL_BINDIR:PATH=${CMAKE_INSTALL_BINDIR}
-      ${CHARSET_CONVERSION_ARGS}
-    DEPENDS
-      ${JPEG_DEPENDENCY}
-      ${PNG_DEPENDENCY}
-      ${TIFF_DEPENDENCY}
-      ${ICU_DEPENDENCY}
-    BUILD_BYPRODUCTS
-      ${DCMTK_BYPRODUCTS}
-  )
-  foreach(lib ${_ITKDCMTK_LIB_NAMES})
-    # make imported library target depend on external project target
-    add_dependencies(
-      ${ITK_MODULE_${itk-module}_TARGETS_NAMESPACE}${lib}
-      ${DCMTK_EPNAME}
-    )
-  endforeach()
-
-  # Tell CPack to install DCMTK stuff
-  list(
-    APPEND
-    CPACK_INSTALL_CMAKE_PROJECTS
-    "${CMAKE_CURRENT_BINARY_DIR}/${DCMTK_EPNAME}-build;DCMTK;ALL;/"
-  )
-
-  #
-  # run DCMTK's cmake install script
-  install(
-    SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/${DCMTK_EPNAME}-build/cmake_install.cmake
-  )
 endif(ITK_USE_SYSTEM_DCMTK)
 
 if(MSVC)

--- a/Modules/ThirdParty/DCMTK/DCMTKGitTag.cmake
+++ b/Modules/ThirdParty/DCMTK/DCMTKGitTag.cmake
@@ -38,4 +38,7 @@ set(
 #COMP: fix WASI compiler errors
 #COMP: fix missing <csetjmp> header issue
 
-set(DCMTK_GIT_TAG "7c7dc11d8e638711ac9c475210d7c7b352832cee") # for/itk-dcmtk-3.7.0-ccfd10b
+#Bradley Lowekamp (1):
+#COMP: prefix CMake check commands with DCMTK_ to avoid leaking
+
+set(DCMTK_GIT_TAG "4ac9b4489d8f8fb1873a943dd214824bd2b11a6d") # for/itk-dcmtk-3.7.0-ccfd10b

--- a/Modules/ThirdParty/DCMTK/itk-module-init.cmake
+++ b/Modules/ThirdParty/DCMTK/itk-module-init.cmake
@@ -32,31 +32,10 @@ else()
     "Embed oficonv data files into oficonv library"
     ON
   )
-  # Copied and mofified from DCMTK/CMake/3rdparty.cmake
+  # ICU creates problems on macOS and Windows, so it is disabled by default;
+  # DCMTK's in-scope configuration selects builtin oficonv otherwise.
   if(NOT DEFINED DCMTK_USE_ICU)
-    include(CheckCXXSourceCompiles)
-    check_cxx_source_compiles(
-      "#include <iconv.h>\nint main(){iconv_t cd = iconv_open(\"\",\"\");iconv(cd,0,0,0,0);iconv_close(cd);return 0;}"
-      WITH_STDLIBC_ICONV
-    )
-    if(WITH_STDLIBC_ICONV)
-      message(
-        STATUS
-        "Info: found builtin ICONV support inside the C standard library."
-      )
-      set(
-        CHARSET_CONVERSION_ARGS
-        -DDCMTK_WITH_STDLIBC_ICONV:BOOL=ON
-        -DDCMTK_WITH_ICU:BOOL=OFF
-        "-DDCMTK_ENABLE_CHARSET_CONVERSION:STRING=stdlibc (iconv)"
-        CACHE INTERNAL
-        "DCMTK Internal arguments"
-      )
-    endif()
-    # ICU creates problems on MacOS and Windows, so by default it is disabled.
-    # On Linux, the C standard library can have builtin ICONV support. We
-    # disable building ICU by default.
-    option(DCMTK_USE_ICU "Downloads and compile ICU for DCMTK" OFF)
+    option(DCMTK_USE_ICU "Use system ICU for DCMTK charset conversion" OFF)
   endif()
   if(DCMTK_USE_ICU)
     if(ITK_USE_SYSTEM_ICU)

--- a/Modules/ThirdParty/DCMTK/itk-module-init.cmake
+++ b/Modules/ThirdParty/DCMTK/itk-module-init.cmake
@@ -1,25 +1,6 @@
 ## Only present and build DCMTK options if ITKIODCMTK is requested
 
 option(ITK_USE_SYSTEM_DCMTK "Use an outside build of DCMTK." OFF)
-if(NOT WIN32)
-  set(lib_prefix lib)
-  if(BUILD_SHARED_LIBS)
-    set(lib_suffix "${CMAKE_SHARED_LIBRARY_SUFFIX}")
-    set(lib_prefix "${CMAKE_SHARED_LIBRARY_PREFIX}")
-  else()
-    set(lib_suffix "${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    set(lib_prefix "${CMAKE_STATIC_LIBRARY_PREFIX}")
-  endif()
-else()
-  set(lib_prefix "")
-  if(BUILD_SHARED_LIBS)
-    set(lib_suffix "${CMAKE_IMPORT_LIBRARY_SUFFIX}")
-    set(lib_prefix "${CMAKE_IMPORT_LIBRARY_PREFIX}")
-  else()
-    set(lib_suffix "${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    set(lib_prefix "${CMAKE_IMPORT_LIBRARY_PREFIX}")
-  endif()
-endif()
 
 if(ITK_USE_SYSTEM_DCMTK)
   # Use local FindDCMTK.cmake.


### PR DESCRIPTION
Replace the ExternalProject-based DCMTK build with FetchContent so DCMTK compiles in ITKs CMake scope, consuming ITKs codec targets directly and exporting namespaced `DCMTK::` targets through ITKs module system.

DCMTK is exported in its own package and cmake target file. This reduced ITK burden and keeps the export code in DCMTK.

Supersedes #6397.

<details>
<summary>Changes</summary>

- FetchContent replaces ExternalProject; DCMTK is configured as an `add_subdirectory` inside ITKs scope
- Codec libraries wired via `ITK::ITKTIFFModule` / `ITK::ITKJPEGModule` / `ITK::ITKPNGModule` / `ITK::ITKZLIBModule` interface targets
- `DCMTK::` IMPORTED INTERFACE wrappers created so `ITKTargets.cmake` records namespaced target names that `find_package(DCMTK)` can satisfy
- `ITKDCMTK_EXPORT_CODE_BUILD` / `_INSTALL` set to locate `DCMTKConfig.cmake` in build and install trees
- DCMTK-internal CMake command overrides (`CHECK_FUNCTION_EXISTS`, `CHECK_CXX_SYMBOL_EXISTS`) renamed to `DCMTK_CHECK_*` to prevent leaking into sibling ITK modules
- `CACHE INTERNAL` variable noise removed; normal variables suffice in FetchContent scope

</details>

<details>
<summary>AI assistance</summary>

GitHub Copilot (Claude Sonnet 4.6) assisted with CMake design, export target strategy, and identifying the global command override leak. All changes reviewed and committed by blowekamp.

</details>