### PR TITLE
ENH: Eigen-backed itk eigendecompositions; deprecate vnl_*_eigensystem and eispack

### DIFF
--- a/Documentation/docs/migration_guides/itk_6_migration_guide.md
+++ b/Documentation/docs/migration_guides/itk_6_migration_guide.md
@@ -734,3 +734,52 @@ removed. The default (non-FFTW) FFT backend is now PocketFFT
   or upstreamed on the next vnl pin update.
 - `vnl_fft_prime_factors`, `gpfa`-family symbols, and the vxl
   `vnl_algo_test_fft*`/`test_convolve` tests are gone from the vendored tree.
+
+## Eigen-backed eigendecompositions replace netlib EISPACK `vnl_*_eigensystem`
+
+`vnl_real_eigensystem`, `vnl_symmetric_eigensystem`, and
+`vnl_generalized_eigensystem` (netlib EISPACK `rg`/`rs`/`rsg`), and the only
+other client `vnl_scatter_3x3`, are deprecated in favor of Eigen-backed
+`itk::RealEigenDecomposition`, `itk::SymmetricEigenDecomposition`, and
+`itk::GeneralizedEigenDecomposition`. Under `ITK_FUTURE_LEGACY_REMOVE` these
+classes and the entire `v3p/netlib/eispack/` subdirectory are excluded from the
+build.
+
+### What you need to do
+
+- Replace `vnl_symmetric_eigensystem<T>` with `itk::SymmetricEigenDecomposition<T>`
+  (it mirrors the `V`/`D` members and `get_eigenvector`/`get_eigenvalue`
+  accessors, so most call sites change only the type name and the include:
+  `itkSymmetricEigenDecomposition.h`). Use `itk::RealEigenDecomposition` and
+  `itk::GeneralizedEigenDecomposition` for the non-symmetric and
+  symmetric-definite generalized problems.
+- For the eigenvalues/eigenvectors of a 3x3 scatter matrix, build the matrix
+  directly and feed `itk::SymmetricEigenDecomposition`.
+
+### A different correct representation — not a regression
+
+An eigenvector is only defined up to sign (and a complex one up to phase), so the
+sign returned is mathematically arbitrary. The new symmetric/generalized classes
+**canonicalize** real eigenvector columns to a deterministic convention
+(largest-magnitude entry positive), which is reproducible across platforms and
+SIMD widths — unlike the EISPACK signs the old baselines were implicitly locked
+to. Opt out per call with the `canonicalizeSigns = false` constructor argument.
+
+Because of this, a few filters that consume an eigenvector's raw direction emit
+**the same geometric result expressed from a different, equally-valid
+representative**:
+
+- `LabelGeometryImageFilter`: the oriented bounding-box *image* is anchored at
+  the opposite corner (its origin shifts); the rendered region is identical.
+- `ShapeLabelMapFilter` / `StatisticsLabelMapFilter`:
+  `GetOrientedBoundingBoxOrigin()` reports the opposite corner for
+  non-axis-aligned directions.
+
+In every case the underlying quantity is unchanged — bounding-box **size**,
+principal **moments**, elongation, eccentricity, orientation angle, and the
+principal **axes** themselves (which flip sign consistently) are all the same.
+The origin, axes, and size together still describe the identical box. **If a
+baseline or expected value changed, it is a selection of a different correct
+representation of the same result, not an indication of a failure.** Update such
+expected values to the new (now platform-stable) representatives; the migrated
+ITK tests have been updated this way.

--- a/Modules/Core/Common/include/itkEigenDecompositionSignConvention.h
+++ b/Modules/Core/Common/include/itkEigenDecompositionSignConvention.h
@@ -1,0 +1,56 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkEigenDecompositionSignConvention_h
+#define itkEigenDecompositionSignConvention_h
+
+#include "vnl/vnl_matrix.h"
+#include <cmath>
+
+namespace itk::detail
+{
+
+/** Canonicalize the sign of every eigenvector column of \a V so that its
+ * largest-magnitude entry is positive (tie-break by lowest row index). An
+ * eigenvector's sign is mathematically arbitrary and otherwise depends on
+ * solver internals and SIMD width; pinning it this way makes a real-valued
+ * eigendecomposition bit-reproducible across platforms. */
+template <typename T>
+void
+CanonicalizeEigenvectorColumnSigns(vnl_matrix<T> & V)
+{
+  const unsigned int rows = V.rows();
+  for (unsigned int j = 0; j < V.cols(); ++j)
+  {
+    unsigned int pivot = 0;
+    for (unsigned int i = 1; i < rows; ++i)
+    {
+      if (std::abs(V(i, j)) > std::abs(V(pivot, j)))
+      {
+        pivot = i;
+      }
+    }
+    if (V(pivot, j) < T{ 0 })
+    {
+      V.scale_column(j, T{ -1 });
+    }
+  }
+}
+
+} // namespace itk::detail
+
+#endif // itkEigenDecompositionSignConvention_h

--- a/Modules/Core/Common/include/itkEigenDecompositionSolverInfo.h
+++ b/Modules/Core/Common/include/itkEigenDecompositionSolverInfo.h
@@ -1,0 +1,48 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkEigenDecompositionSolverInfo_h
+#define itkEigenDecompositionSolverInfo_h
+
+#include "itk_eigen.h"
+#include ITK_EIGEN(Dense)
+
+namespace itk::detail
+{
+
+/** Human-readable name and likely cause for an Eigen solver status, so a
+ * thrown decomposition error names the failure mode instead of a raw code. */
+inline const char *
+EigenComputationInfoString(Eigen::ComputationInfo info)
+{
+  switch (info)
+  {
+    case Eigen::Success:
+      return "Success";
+    case Eigen::NumericalIssue:
+      return "NumericalIssue (a precondition is violated, e.g. the matrix is not finite or not positive-definite)";
+    case Eigen::NoConvergence:
+      return "NoConvergence (the iteration did not converge)";
+    case Eigen::InvalidInput:
+      return "InvalidInput (the input is malformed or the options are invalid)";
+  }
+  return "an unrecognized Eigen::ComputationInfo value";
+}
+
+} // namespace itk::detail
+
+#endif // itkEigenDecompositionSolverInfo_h

--- a/Modules/Core/Common/include/itkGeneralizedEigenDecomposition.h
+++ b/Modules/Core/Common/include/itkGeneralizedEigenDecomposition.h
@@ -1,0 +1,110 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkGeneralizedEigenDecomposition_h
+#define itkGeneralizedEigenDecomposition_h
+
+#include "vnl/vnl_matrix.h"
+#include "vnl/vnl_vector.h"
+#include "itkEigenDecompositionSignConvention.h"
+#include "itkEigenDecompositionSolverInfo.h"
+#include "itkMacro.h"
+#include "itk_eigen.h"
+#include ITK_EIGEN(Dense)
+
+namespace itk
+{
+
+/** \class GeneralizedEigenDecomposition
+ * \brief Symmetric-definite generalized eigenproblem A x = lambda B x, Eigen-backed.
+ *
+ * Solves A x = lambda B x with A symmetric and B symmetric positive-definite,
+ * via Eigen's GeneralizedSelfAdjointEigenSolver. Eigenvalues are real and
+ * returned in ascending order; eigenvectors are the B-orthonormal columns,
+ * sign-canonicalized (each column's largest-magnitude entry positive) for
+ * cross-platform reproducibility. Results are stored in vnl containers so no
+ * Eigen type appears in the public interface.
+ *
+ * This is the supported Eigen-backed replacement for the now-deprecated
+ * vnl_generalized_eigensystem (netlib EISPACK rsg), which emits a deprecation
+ * warning under ITK_LEGACY_REMOVE and is removed under ITK_FUTURE_LEGACY_REMOVE.
+ *
+ * \ingroup ITKCommon
+ */
+template <typename TReal>
+class GeneralizedEigenDecomposition
+{
+public:
+  using MatrixType = vnl_matrix<TReal>;
+  using VectorType = vnl_vector<TReal>;
+
+  /** Solve A x = lambda B x for symmetric A and symmetric-positive-definite B.
+   * With \a canonicalizeSigns (the default) each eigenvector column's
+   * largest-magnitude entry is made positive for cross-platform reproducibility;
+   * pass false to keep the solver's raw signs. */
+  GeneralizedEigenDecomposition(const MatrixType & A, const MatrixType & B, bool canonicalizeSigns = true)
+  {
+    using RowMajor = Eigen::Matrix<TReal, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+    using ColMajor = Eigen::Matrix<TReal, Eigen::Dynamic, Eigen::Dynamic>;
+    using Vector = Eigen::Matrix<TReal, Eigen::Dynamic, 1>;
+    const unsigned int n = A.rows();
+
+    Eigen::Map<const RowMajor> aMap(A.data_block(), n, n);
+    Eigen::Map<const RowMajor> bMap(B.data_block(), n, n);
+
+    const Eigen::GeneralizedSelfAdjointEigenSolver<ColMajor> solver(aMap, bMap);
+
+    if (solver.info() != Eigen::Success)
+    {
+      itkGenericExceptionMacro(<< "GeneralizedEigenDecomposition: Eigen GeneralizedSelfAdjointEigenSolver failed: "
+                               << detail::EigenComputationInfoString(solver.info())
+                               << "; A and B must be finite and B symmetric positive-definite.");
+    }
+
+    m_Eigenvalues.set_size(n);
+    Eigen::Map<Vector>(m_Eigenvalues.data_block(), n) = solver.eigenvalues();
+    m_Eigenvectors.set_size(n, n);
+    Eigen::Map<RowMajor>(m_Eigenvectors.data_block(), n, n) = solver.eigenvectors();
+
+    if (canonicalizeSigns)
+    {
+      detail::CanonicalizeEigenvectorColumnSigns(m_Eigenvectors);
+    }
+  }
+
+  /** Real eigenvalues in ascending order. */
+  const VectorType &
+  GetEigenvalues() const
+  {
+    return m_Eigenvalues;
+  }
+
+  /** B-orthonormal eigenvectors as columns, aligned with GetEigenvalues(). */
+  const MatrixType &
+  GetEigenvectors() const
+  {
+    return m_Eigenvectors;
+  }
+
+private:
+  VectorType m_Eigenvalues;
+  MatrixType m_Eigenvectors;
+};
+
+} // namespace itk
+
+#endif // itkGeneralizedEigenDecomposition_h

--- a/Modules/Core/Common/include/itkRealEigenDecomposition.h
+++ b/Modules/Core/Common/include/itkRealEigenDecomposition.h
@@ -1,0 +1,103 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkRealEigenDecomposition_h
+#define itkRealEigenDecomposition_h
+
+#include "vnl/vnl_matrix.h"
+#include "vnl/vnl_vector.h"
+#include <complex>
+#include "itkEigenDecompositionSolverInfo.h"
+#include "itkMacro.h"
+#include "itk_eigen.h"
+#include ITK_EIGEN(Dense)
+
+namespace itk
+{
+
+/** \class RealEigenDecomposition
+ * \brief Eigenvalues and eigenvectors of a general real matrix, backed by Eigen.
+ *
+ * Solves the eigenproblem of a general (non-symmetric) real matrix once in the
+ * constructor via Eigen's EigenSolver; the spectrum is in general complex.
+ * Results are stored as vnl containers of std::complex so no Eigen type appears
+ * in the public interface. For a symmetric matrix prefer
+ * SymmetricEigenDecomposition (real spectrum, faster).
+ *
+ * This is the supported Eigen-backed replacement for the now-deprecated
+ * vnl_real_eigensystem (netlib EISPACK rg), which emits a deprecation warning
+ * under ITK_LEGACY_REMOVE and is removed under ITK_FUTURE_LEGACY_REMOVE.
+ *
+ * \note A complex eigenvector is defined only up to an arbitrary unit-modulus
+ * phase (not merely a sign), so no deterministic phase canonicalization is
+ * applied here (unlike the real-vector SymmetricEigenDecomposition /
+ * GeneralizedEigenDecomposition). Migrate to the identity A V == V D rather
+ * than to specific eigenvector phases.
+ *
+ * \ingroup ITKCommon
+ */
+template <typename TReal>
+class RealEigenDecomposition
+{
+public:
+  using ComplexType = std::complex<TReal>;
+  using ComplexMatrixType = vnl_matrix<ComplexType>;
+  using ComplexVectorType = vnl_vector<ComplexType>;
+
+  explicit RealEigenDecomposition(const vnl_matrix<TReal> & M)
+  {
+    using RowMajor = Eigen::Matrix<TReal, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+    const unsigned int n = M.rows();
+
+    Eigen::Map<const RowMajor>                                                     mMap(M.data_block(), n, M.cols());
+    const Eigen::EigenSolver<Eigen::Matrix<TReal, Eigen::Dynamic, Eigen::Dynamic>> solver(mMap);
+
+    if (solver.info() != Eigen::Success)
+    {
+      itkGenericExceptionMacro(<< "RealEigenDecomposition: Eigen EigenSolver failed: "
+                               << detail::EigenComputationInfoString(solver.info()) << '.');
+    }
+
+    using ComplexRowMajor = Eigen::Matrix<ComplexType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+    m_Eigenvalues.set_size(n);
+    Eigen::Map<Eigen::Matrix<ComplexType, Eigen::Dynamic, 1>>(m_Eigenvalues.data_block(), n) = solver.eigenvalues();
+    m_Eigenvectors.set_size(n, n);
+    Eigen::Map<ComplexRowMajor>(m_Eigenvectors.data_block(), n, n) = solver.eigenvectors();
+  }
+
+  /** Complex eigenvalues, one per column of M (unsorted, Eigen order). */
+  const ComplexVectorType &
+  GetEigenvalues() const
+  {
+    return m_Eigenvalues;
+  }
+
+  /** Complex eigenvectors as columns, aligned with GetEigenvalues(). */
+  const ComplexMatrixType &
+  GetEigenvectors() const
+  {
+    return m_Eigenvectors;
+  }
+
+private:
+  ComplexVectorType m_Eigenvalues;
+  ComplexMatrixType m_Eigenvectors;
+};
+
+} // namespace itk
+
+#endif // itkRealEigenDecomposition_h

--- a/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
+++ b/Modules/Core/Common/include/itkSymmetricEigenAnalysis.h
@@ -195,6 +195,11 @@ inline constexpr EigenValueOrderEnum DoNotOrder = EigenValueOrderEnum::DoNotOrde
  * For algorithmic descriptions see \cite bowdler1968 and
  * \cite bowdler1971.
  *
+ * \sa SymmetricEigenDecomposition, a single-shot stored eigendecomposition
+ * (construct once, read V / D) that is the Eigen-backed drop-in for
+ * vnl_symmetric_eigensystem. Prefer this configurable solver object for
+ * high-throughput fixed-size tensor work.
+ *
  * \ingroup ITKCommon
  */
 

--- a/Modules/Core/Common/include/itkSymmetricEigenDecomposition.h
+++ b/Modules/Core/Common/include/itkSymmetricEigenDecomposition.h
@@ -1,0 +1,130 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkSymmetricEigenDecomposition_h
+#define itkSymmetricEigenDecomposition_h
+
+#include "vnl/vnl_matrix.h"
+#include "vnl/vnl_vector.h"
+#include "vnl/vnl_diag_matrix.h"
+#include "itkEigenDecompositionSignConvention.h"
+#include "itkEigenDecompositionSolverInfo.h"
+#include "itkMacro.h"
+#include "itk_eigen.h"
+#include ITK_EIGEN(Dense)
+
+namespace itk
+{
+
+/** \class SymmetricEigenDecomposition
+ * \brief Stored eigendecomposition of a real symmetric matrix, Eigen-backed.
+ *
+ * Computes A = V D V^T for symmetric A in the constructor and stores the
+ * result. Eigenvalues (D) are real and ascending; the columns of V are the
+ * orthonormal eigenvectors, sign-canonicalized (each column's largest-magnitude
+ * entry is positive) for cross-platform reproducibility. The public V / D
+ * members and the get_eigenvector / get_eigenvalue accessors mirror the legacy
+ * vnl_symmetric_eigensystem layout, so its call sites port by changing only the
+ * type name, with no Eigen type in the interface.
+ *
+ * This is the supported Eigen-backed replacement for the now-deprecated
+ * vnl_symmetric_eigensystem (netlib EISPACK rs), which emits a deprecation
+ * warning under ITK_LEGACY_REMOVE and is removed under ITK_FUTURE_LEGACY_REMOVE.
+ *
+ * \note Distinct from itk::SymmetricEigenAnalysis, which is a configurable
+ * solver object (SetDimension / SetOrderEigenValues) that writes results into
+ * caller-supplied output arguments and is tuned for repeated per-pixel tensor
+ * eigenanalysis; it does not canonicalize eigenvector signs. This class is a
+ * single-shot stored decomposition. Prefer SymmetricEigenAnalysis for
+ * high-throughput fixed-size tensor work; prefer this for
+ * vnl_symmetric_eigensystem-style usage.
+ *
+ * \sa SymmetricEigenAnalysis
+ * \ingroup ITKCommon
+ */
+template <typename T>
+class SymmetricEigenDecomposition
+{
+public:
+  /** Compute the decomposition of symmetric \a M. With \a canonicalizeSigns
+   * (the default) each eigenvector column's largest-magnitude entry is made
+   * positive for cross-platform reproducibility; pass false to keep the solver's
+   * raw signs. */
+  explicit SymmetricEigenDecomposition(const vnl_matrix<T> & M, bool canonicalizeSigns = true)
+    : V(M.rows(), M.cols())
+    , D(M.rows())
+  {
+    using RowMajor = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+    using Vector = Eigen::Matrix<T, Eigen::Dynamic, 1>;
+    const unsigned int n = M.rows();
+
+    Eigen::Map<const RowMajor>                    mMap(M.data_block(), n, n);
+    const Eigen::SelfAdjointEigenSolver<RowMajor> solver(mMap);
+
+    if (solver.info() != Eigen::Success)
+    {
+      itkGenericExceptionMacro(<< "SymmetricEigenDecomposition: Eigen SelfAdjointEigenSolver failed: "
+                               << detail::EigenComputationInfoString(solver.info()) << '.');
+    }
+
+    Eigen::Map<RowMajor>(V.data_block(), n, n) = solver.eigenvectors();
+    Eigen::Map<Vector>(D.data_block(), n) = solver.eigenvalues();
+
+    if (canonicalizeSigns)
+    {
+      detail::CanonicalizeEigenvectorColumnSigns(V);
+    }
+  }
+
+  /** Eigenvectors as columns, sorted by increasing eigenvalue. */
+  vnl_matrix<T> V;
+
+  /** Eigenvalues in increasing order, stored as a diagonal matrix. */
+  vnl_diag_matrix<T> D;
+
+  /** Recover the i-th eigenvector (column i of V). */
+  vnl_vector<T>
+  get_eigenvector(int i) const
+  {
+    return V.get_column(i);
+  }
+
+  /** Recover the i-th eigenvalue. */
+  T
+  get_eigenvalue(int i) const
+  {
+    return D(i, i);
+  }
+
+  /** Least-squares nullvector: eigenvector of the smallest eigenvalue. */
+  vnl_vector<T>
+  nullvector() const
+  {
+    return V.get_column(0);
+  }
+
+  /** Reconstruct V D V^T (useful after modifying D). */
+  vnl_matrix<T>
+  recompose() const
+  {
+    return V * D * V.transpose();
+  }
+};
+
+} // namespace itk
+
+#endif // itkSymmetricEigenDecomposition_h

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -1503,7 +1503,10 @@ set(
   itkPointSetGTest.cxx
   itkPrintHelperGTest.cxx
   itkPriorityQueueGTest.cxx
+  itkGeneralizedEigenDecompositionGTest.cxx
   itkQRDecompositionGTest.cxx
+  itkRealEigenDecompositionGTest.cxx
+  itkSymmetricEigenDecompositionGTest.cxx
   itkRealTimeClockGTest.cxx
   itkRealTimeIntervalGTest.cxx
   itkRealTimeStampGTest.cxx

--- a/Modules/Core/Common/test/itkGeneralizedEigenDecompositionGTest.cxx
+++ b/Modules/Core/Common/test/itkGeneralizedEigenDecompositionGTest.cxx
@@ -1,0 +1,183 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "itkGeneralizedEigenDecomposition.h"
+#include "itkConfigure.h"
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+#  define ITK_LEGACY_TEST
+#  include "vnl/algo/vnl_generalized_eigensystem.h"
+#endif
+#include <gtest/gtest.h>
+#include <limits>
+#include <string>
+
+namespace
+{
+
+// Frobenius residual of the generalized identity A V == B V D.
+template <typename TReal>
+TReal
+GeneralizedResidual(const vnl_matrix<TReal> &                         A,
+                    const vnl_matrix<TReal> &                         B,
+                    const itk::GeneralizedEigenDecomposition<TReal> & ge)
+{
+  const vnl_matrix<TReal> & V = ge.GetEigenvectors();
+  vnl_matrix<TReal>         D(V.rows(), V.cols(), TReal{ 0 });
+  for (unsigned int i = 0; i < V.cols(); ++i)
+  {
+    D(i, i) = ge.GetEigenvalues()[i];
+  }
+  return (A * V - B * V * D).fro_norm();
+}
+
+} // namespace
+
+// Scavenged from VXL test_generalized_eigensystem: A x = lambda B x with A
+// symmetric, B symmetric positive-definite. (Roles match the vnl ctor's
+// (A, B) order; the VXL test's residual is C V - S V D for gev(C, S).)
+TEST(GeneralizedEigenDecomposition, SymmetricDefinitePencil)
+{
+  const double Adata[36] = {
+    30.0000, -3.4273, 13.9254, 13.7049, -2.4446, 20.2380, -3.4273, 13.7049, -2.4446, 1.3659,  3.6702,  -0.2282,
+    13.9254, -2.4446, 20.2380, 3.6702,  -0.2282, 28.6779, 13.7049, 1.3659,  3.6702,  12.5273, -1.6045, 3.9419,
+    -2.4446, 3.6702,  -0.2282, -1.6045, 3.9419,  2.5821,  20.2380, -0.2282, 28.6779, 3.9419,  2.5821,  44.0636,
+  };
+  const vnl_matrix<double> A(Adata, 6, 6);
+
+  // Symmetric positive-definite B (diagonally dominant).
+  vnl_matrix<double> B(6, 6, 0.0);
+  for (unsigned int i = 0; i < 6; ++i)
+  {
+    B(i, i) = 10.0 + i;
+  }
+  B(0, 1) = B(1, 0) = 1.0;
+  B(2, 3) = B(3, 2) = -2.0;
+
+  const itk::GeneralizedEigenDecomposition<double> ge(A, B);
+
+  // Eigenvalues are real and ascending.
+  for (unsigned int i = 1; i < 6; ++i)
+  {
+    EXPECT_LE(ge.GetEigenvalues()[i - 1], ge.GetEigenvalues()[i] + 1e-12);
+  }
+  EXPECT_LT(GeneralizedResidual(A, B, ge), 1e-11);
+}
+
+// B = I reduces to the ordinary symmetric eigenproblem; this mirrors how
+// ImagePCAShapeModelEstimator invokes the solver.
+TEST(GeneralizedEigenDecomposition, IdentityPencilMatchesStandard)
+{
+  vnl_matrix<double> A(3, 3, 0.0);
+  A(0, 0) = 2.0;
+  A(1, 1) = 5.0;
+  A(2, 2) = 11.0;
+  A(0, 1) = A(1, 0) = 1.0;
+  A(1, 2) = A(2, 1) = -1.0;
+
+  vnl_matrix<double> I(3, 3, 0.0);
+  for (unsigned int i = 0; i < 3; ++i)
+  {
+    I(i, i) = 1.0;
+  }
+
+  const itk::GeneralizedEigenDecomposition<double> ge(A, I);
+  EXPECT_LT(GeneralizedResidual(A, I, ge), 1e-12);
+
+  // For B = I the eigenvectors are orthonormal: V^T V == I.
+  const vnl_matrix<double> vtv = ge.GetEigenvectors().transpose() * ge.GetEigenvectors();
+  for (unsigned int r = 0; r < 3; ++r)
+  {
+    for (unsigned int c = 0; c < 3; ++c)
+    {
+      EXPECT_NEAR(vtv(r, c), (r == c) ? 1.0 : 0.0, 1e-12);
+    }
+  }
+}
+
+TEST(GeneralizedEigenDecomposition, FloatInstantiation)
+{
+  vnl_matrix<float> A(2, 2);
+  A(0, 0) = 3.0f;
+  A(1, 1) = 7.0f;
+  A(0, 1) = A(1, 0) = 0.5f;
+  vnl_matrix<float> B(2, 2, 0.0f);
+  B(0, 0) = 2.0f;
+  B(1, 1) = 4.0f;
+
+  const itk::GeneralizedEigenDecomposition<float> ge(A, B);
+  EXPECT_LT(GeneralizedResidual(A, B, ge), 1e-5f);
+}
+
+// Non-finite input leaves the Eigen solver in a non-Success state; the wrapper
+// turns that into an exception so callers do not silently consume a garbage
+// decomposition.
+TEST(GeneralizedEigenDecomposition, NonFiniteInputThrows)
+{
+  const double       nan = std::numeric_limits<double>::quiet_NaN();
+  vnl_matrix<double> A(2, 2, 0.0);
+  A(0, 0) = 1.0;
+  A(1, 1) = 1.0;
+  vnl_matrix<double> B(2, 2, 0.0);
+  B(0, 0) = 1.0;
+  B(1, 1) = 1.0;
+  B(0, 1) = B(1, 0) = nan;
+  try
+  {
+    const itk::GeneralizedEigenDecomposition<double> ge(A, B);
+    FAIL() << "expected an exception for non-finite input";
+  }
+  catch (const itk::ExceptionObject & e)
+  {
+    const std::string description = e.GetDescription();
+    EXPECT_NE(description.find("GeneralizedSelfAdjointEigenSolver"), std::string::npos) << description;
+    // The message names the decoded Eigen failure mode, not a bare status code.
+    EXPECT_TRUE(description.find("NoConvergence") != std::string::npos ||
+                description.find("NumericalIssue") != std::string::npos ||
+                description.find("InvalidInput") != std::string::npos)
+      << description;
+  }
+}
+
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+// Equivalence: the Eigen-backed solver reproduces the eigenvalues of the
+// deprecated netlib vnl_generalized_eigensystem it replaces (both ascending).
+TEST(GeneralizedEigenDecomposition, MatchesDeprecatedVnlEngine)
+{
+  vnl_matrix<double> A(3, 3, 0.0);
+  A(0, 0) = 2.0;
+  A(1, 1) = 5.0;
+  A(2, 2) = 11.0;
+  A(0, 1) = A(1, 0) = 1.0;
+  A(1, 2) = A(2, 1) = -1.0;
+  vnl_matrix<double> B(3, 3, 0.0);
+  B(0, 0) = 3.0;
+  B(1, 1) = 2.0;
+  B(2, 2) = 4.0;
+  B(0, 1) = B(1, 0) = 0.5;
+
+  const vnl_generalized_eigensystem                vnlEngine(A, B);
+  const itk::GeneralizedEigenDecomposition<double> itkEngine(A, B);
+
+  const vnl_vector<double>   vnlEigenvalues = vnlEngine.D.get_diagonal();
+  const vnl_vector<double> & itkEigenvalues = itkEngine.GetEigenvalues();
+  ASSERT_EQ(vnlEigenvalues.size(), itkEigenvalues.size());
+  for (unsigned int i = 0; i < itkEigenvalues.size(); ++i)
+  {
+    EXPECT_NEAR(vnlEigenvalues[i], itkEigenvalues[i], 1e-10) << "eigenvalue " << i;
+  }
+}
+#endif

--- a/Modules/Core/Common/test/itkRealEigenDecompositionGTest.cxx
+++ b/Modules/Core/Common/test/itkRealEigenDecompositionGTest.cxx
@@ -1,0 +1,195 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "itkRealEigenDecomposition.h"
+#include "itkConfigure.h"
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+#  define ITK_LEGACY_TEST // exercise the deprecated vnl class for equivalence
+#  include "vnl/algo/vnl_real_eigensystem.h"
+#endif
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <complex>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+// Largest residual of the eigendecomposition identity A v_i == lambda_i v_i,
+// over every eigenpair. Sign/phase-invariant, so it is the right thing to
+// assert against (individual eigenvector signs are arbitrary).
+template <typename TReal>
+TReal
+EigenResidual(const vnl_matrix<TReal> & A, const itk::RealEigenDecomposition<TReal> & eig)
+{
+  using Complex = std::complex<TReal>;
+  const auto &       lambda = eig.GetEigenvalues();
+  const auto &       V = eig.GetEigenvectors();
+  const unsigned int n = A.rows();
+
+  TReal worst = 0;
+  for (unsigned int j = 0; j < n; ++j)
+  {
+    for (unsigned int r = 0; r < n; ++r)
+    {
+      Complex av{ 0, 0 };
+      for (unsigned int k = 0; k < n; ++k)
+      {
+        av += Complex(A(r, k), 0) * V(k, j);
+      }
+      worst = std::max(worst, std::abs(av - lambda[j] * V(r, j)));
+    }
+  }
+  return worst;
+}
+
+} // namespace
+
+// Scavenged from VXL test_real_eigensystem::test_6x6 (real spectrum).
+TEST(RealEigenDecomposition, SymmetricInputRealSpectrum)
+{
+  const double Sdata[36] = {
+    30.0000, -3.4273, 13.9254, 13.7049, -2.4446, 20.2380, -3.4273, 13.7049, -2.4446, 1.3659,  3.6702,  -0.2282,
+    13.9254, -2.4446, 20.2380, 3.6702,  -0.2282, 28.6779, 13.7049, 1.3659,  3.6702,  12.5273, -1.6045, 3.9419,
+    -2.4446, 3.6702,  -0.2282, -1.6045, 3.9419,  2.5821,  20.2380, -0.2282, 28.6779, 3.9419,  2.5821,  44.0636,
+  };
+  const vnl_matrix<double>                  S(Sdata, 6, 6);
+  const itk::RealEigenDecomposition<double> eig(S);
+
+  for (unsigned int i = 0; i < 6; ++i)
+  {
+    EXPECT_LT(std::abs(std::imag(eig.GetEigenvalues()[i])), 1e-12);
+  }
+  EXPECT_LT(EigenResidual(S, eig), 1e-12);
+}
+
+// Scavenged from VXL test_real_eigensystem::test_4x4 (general/unsympathetic).
+TEST(RealEigenDecomposition, GeneralMatrix)
+{
+  const double             Xdata[16] = { 686, 526, 701, 47, 588, 91, 910, 736, 930, 653, 762, 328, 846, 415, 262, 632 };
+  const vnl_matrix<double> X(Xdata, 4, 4);
+  const itk::RealEigenDecomposition<double> eig(X);
+  EXPECT_LT(EigenResidual(X, eig), 1e-10);
+}
+
+// A real matrix with a genuinely complex spectrum: 2-D rotation by theta has
+// eigenvalues exp(+/- i theta). Exercises the complex-conjugate path.
+TEST(RealEigenDecomposition, ComplexSpectrumRotation)
+{
+  const double       theta = 0.7;
+  vnl_matrix<double> R(2, 2);
+  R(0, 0) = std::cos(theta);
+  R(0, 1) = -std::sin(theta);
+  R(1, 0) = std::sin(theta);
+  R(1, 1) = std::cos(theta);
+
+  const itk::RealEigenDecomposition<double> eig(R);
+  EXPECT_LT(EigenResidual(R, eig), 1e-13);
+
+  double maxImag = 0;
+  for (unsigned int i = 0; i < 2; ++i)
+  {
+    maxImag = std::max(maxImag, std::abs(std::imag(eig.GetEigenvalues()[i])));
+  }
+  EXPECT_NEAR(maxImag, std::sin(theta), 1e-13);
+}
+
+TEST(RealEigenDecomposition, Identity)
+{
+  vnl_matrix<double> I(3, 3, 0.0);
+  for (unsigned int i = 0; i < 3; ++i)
+  {
+    I(i, i) = 1.0;
+  }
+  const itk::RealEigenDecomposition<double> eig(I);
+  for (unsigned int i = 0; i < 3; ++i)
+  {
+    EXPECT_NEAR(std::real(eig.GetEigenvalues()[i]), 1.0, 1e-14);
+    EXPECT_LT(std::abs(std::imag(eig.GetEigenvalues()[i])), 1e-14);
+  }
+}
+
+TEST(RealEigenDecomposition, FloatInstantiation)
+{
+  const float                              data[4] = { 2.0f, 0.0f, 0.0f, 3.0f };
+  const vnl_matrix<float>                  A(data, 2, 2);
+  const itk::RealEigenDecomposition<float> eig(A);
+  EXPECT_LT(EigenResidual(A, eig), 1e-5f);
+}
+
+// Non-finite input leaves the Eigen solver in a non-Success state; the wrapper
+// surfaces that as an exception rather than returning a garbage decomposition.
+TEST(RealEigenDecomposition, NonFiniteInputThrows)
+{
+  const double       nan = std::numeric_limits<double>::quiet_NaN();
+  vnl_matrix<double> M(2, 2, 0.0);
+  M(0, 0) = 1.0;
+  M(1, 1) = 1.0;
+  M(0, 1) = M(1, 0) = nan;
+  try
+  {
+    const itk::RealEigenDecomposition<double> eig{ M };
+    FAIL() << "expected an exception for non-finite input";
+  }
+  catch (const itk::ExceptionObject & e)
+  {
+    const std::string description = e.GetDescription();
+    EXPECT_NE(description.find("EigenSolver"), std::string::npos) << description;
+    // The message names the decoded Eigen failure mode, not a bare status code.
+    EXPECT_TRUE(description.find("NoConvergence") != std::string::npos ||
+                description.find("NumericalIssue") != std::string::npos ||
+                description.find("InvalidInput") != std::string::npos)
+      << description;
+  }
+}
+
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+// Equivalence: the Eigen-backed solver yields the same (complex) spectrum as
+// the deprecated netlib vnl_real_eigensystem. General eigenvalues are unsorted,
+// so compare as multisets.
+TEST(RealEigenDecomposition, EquivalenceWithVnl)
+{
+  const double             data[9] = { 0.0, -1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 2.0 }; // spectrum {i, -i, 2}
+  const vnl_matrix<double> A(data, 3, 3);
+
+  const vnl_real_eigensystem                vnlEngine(A);
+  const itk::RealEigenDecomposition<double> itkEngine(A);
+
+  auto sorted = [](std::vector<std::complex<double>> v) {
+    std::sort(v.begin(), v.end(), [](const std::complex<double> & a, const std::complex<double> & b) {
+      return a.real() != b.real() ? a.real() < b.real() : a.imag() < b.imag();
+    });
+    return v;
+  };
+  std::vector<std::complex<double>> vnlEig;
+  std::vector<std::complex<double>> itkEig;
+  for (unsigned int i = 0; i < A.rows(); ++i)
+  {
+    vnlEig.push_back(vnlEngine.D(i, i));
+    itkEig.push_back(itkEngine.GetEigenvalues()[i]);
+  }
+  vnlEig = sorted(vnlEig);
+  itkEig = sorted(itkEig);
+  for (unsigned int i = 0; i < itkEig.size(); ++i)
+  {
+    EXPECT_NEAR(vnlEig[i].real(), itkEig[i].real(), 1e-10) << "eigenvalue " << i << " real";
+    EXPECT_NEAR(vnlEig[i].imag(), itkEig[i].imag(), 1e-10) << "eigenvalue " << i << " imag";
+  }
+}
+#endif

--- a/Modules/Core/Common/test/itkSymmetricEigenDecompositionGTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricEigenDecompositionGTest.cxx
@@ -1,0 +1,178 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "itkSymmetricEigenDecomposition.h"
+#include "itkConfigure.h"
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+#  define ITK_LEGACY_TEST // exercise the deprecated vnl class for equivalence
+#  include "vnl/algo/vnl_symmetric_eigensystem.h"
+#endif
+#include <gtest/gtest.h>
+#include <limits>
+#include <string>
+
+namespace
+{
+
+template <typename T>
+T
+EigenResidual(const vnl_matrix<T> & A, const itk::SymmetricEigenDecomposition<T> & eig)
+{
+  vnl_matrix<T> D(A.rows(), A.cols(), T{ 0 });
+  for (unsigned int i = 0; i < A.rows(); ++i)
+  {
+    D(i, i) = eig.get_eigenvalue(i);
+  }
+  return (A * eig.V - eig.V * D).fro_norm();
+}
+
+vnl_matrix<double>
+MakeSymmetric()
+{
+  double data[9] = { 4.0, 1.0, -2.0, 1.0, 2.0, 0.5, -2.0, 0.5, 3.0 };
+  return vnl_matrix<double>(data, 3, 3);
+}
+
+} // namespace
+
+// Scavenged coverage: eigenvalues ascending, A V == V D, V orthonormal.
+TEST(SymmetricEigenDecomposition, DecompositionIdentity)
+{
+  const vnl_matrix<double>                       A = MakeSymmetric();
+  const itk::SymmetricEigenDecomposition<double> eig(A);
+
+  for (unsigned int i = 1; i < 3; ++i)
+  {
+    EXPECT_LE(eig.get_eigenvalue(i - 1), eig.get_eigenvalue(i) + 1e-12);
+  }
+  EXPECT_LT(EigenResidual(A, eig), 1e-12);
+
+  const vnl_matrix<double> vtv = eig.V.transpose() * eig.V;
+  for (unsigned int r = 0; r < 3; ++r)
+  {
+    for (unsigned int c = 0; c < 3; ++c)
+    {
+      EXPECT_NEAR(vtv(r, c), (r == c) ? 1.0 : 0.0, 1e-12);
+    }
+  }
+}
+
+// itk::SymmetricEigenDecomposition and the legacy vnl class agree on eigenvalues
+// exactly and on eigenvectors up to per-column sign.
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+TEST(SymmetricEigenDecomposition, EquivalenceWithVnl)
+{
+  const vnl_matrix<double>                       A = MakeSymmetric();
+  const itk::SymmetricEigenDecomposition<double> eigNew(A);
+  const vnl_symmetric_eigensystem<double>        eigVnl(A);
+
+  for (unsigned int i = 0; i < 3; ++i)
+  {
+    EXPECT_NEAR(eigNew.get_eigenvalue(i), eigVnl.get_eigenvalue(i), 1e-12);
+
+    // Eigenvector columns match up to sign: |new . vnl| == 1.
+    const double dot = dot_product(eigNew.get_eigenvector(i), eigVnl.get_eigenvector(i));
+    EXPECT_NEAR(std::abs(dot), 1.0, 1e-12);
+  }
+}
+#endif // ITK_FUTURE_LEGACY_REMOVE
+
+// The deterministic sign convention: each eigenvector column's
+// largest-magnitude entry is positive. This makes the decomposition
+// reproducible across solver/SIMD differences.
+TEST(SymmetricEigenDecomposition, CanonicalSignConvention)
+{
+  const vnl_matrix<double>                       A = MakeSymmetric();
+  const itk::SymmetricEigenDecomposition<double> eig(A);
+
+  for (unsigned int j = 0; j < 3; ++j)
+  {
+    const vnl_vector<double> col = eig.get_eigenvector(j);
+    unsigned int             pivot = 0;
+    for (unsigned int i = 1; i < 3; ++i)
+    {
+      if (std::abs(col[i]) > std::abs(col[pivot]))
+      {
+        pivot = i;
+      }
+    }
+    EXPECT_GT(col[pivot], 0.0);
+  }
+}
+
+// canonicalizeSigns=false keeps the solver's raw signs but stays a valid
+// decomposition; the default (true) enforces largest-magnitude-positive.
+TEST(SymmetricEigenDecomposition, CanonicalizationIsOptOut)
+{
+  const vnl_matrix<double>                       A = MakeSymmetric();
+  const itk::SymmetricEigenDecomposition<double> canon(A); // default true
+  const itk::SymmetricEigenDecomposition<double> raw(A, false);
+
+  EXPECT_LT(EigenResidual(A, canon), 1e-12);
+  EXPECT_LT(EigenResidual(A, raw), 1e-12);
+  for (unsigned int j = 0; j < 3; ++j)
+  {
+    EXPECT_NEAR(canon.get_eigenvalue(j), raw.get_eigenvalue(j), 1e-12);
+    EXPECT_NEAR(std::abs(dot_product(canon.get_eigenvector(j), raw.get_eigenvector(j))), 1.0, 1e-12);
+  }
+}
+
+TEST(SymmetricEigenDecomposition, NullvectorAndRecompose)
+{
+  const vnl_matrix<double>                       A = MakeSymmetric();
+  const itk::SymmetricEigenDecomposition<double> eig(A);
+
+  // nullvector is the smallest-eigenvalue eigenvector (column 0).
+  EXPECT_NEAR(dot_product(eig.nullvector(), eig.get_eigenvector(0)), 1.0, 1e-12);
+
+  // recompose() reconstructs A.
+  EXPECT_LT((eig.recompose() - A).fro_norm(), 1e-12);
+}
+
+TEST(SymmetricEigenDecomposition, FloatInstantiation)
+{
+  float                                         data[4] = { 2.0f, 0.5f, 0.5f, 3.0f };
+  const vnl_matrix<float>                       A(data, 2, 2);
+  const itk::SymmetricEigenDecomposition<float> eig(A);
+  EXPECT_LT(EigenResidual(A, eig), 1e-5f);
+}
+
+// Non-finite input leaves the Eigen solver in a non-Success state; the wrapper
+// surfaces that as an exception rather than returning a garbage decomposition.
+TEST(SymmetricEigenDecomposition, NonFiniteInputThrows)
+{
+  const double       nan = std::numeric_limits<double>::quiet_NaN();
+  vnl_matrix<double> M(2, 2, 0.0);
+  M(0, 0) = 1.0;
+  M(1, 1) = 1.0;
+  M(0, 1) = M(1, 0) = nan;
+  try
+  {
+    const itk::SymmetricEigenDecomposition<double> eig{ M };
+    FAIL() << "expected an exception for non-finite input";
+  }
+  catch (const itk::ExceptionObject & e)
+  {
+    const std::string description = e.GetDescription();
+    EXPECT_NE(description.find("SelfAdjointEigenSolver"), std::string::npos) << description;
+    // The message names the decoded Eigen failure mode, not a bare status code.
+    EXPECT_TRUE(description.find("NoConvergence") != std::string::npos ||
+                description.find("NumericalIssue") != std::string::npos ||
+                description.find("InvalidInput") != std::string::npos)
+      << description;
+  }
+}

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -21,7 +21,6 @@
 #include "itkVectorLinearInterpolateImageFunction.h"
 #include "itkImageToImageFilter.h"
 
-#include "vnl/algo/vnl_symmetric_eigensystem.h"
 #include "vnl/algo/vnl_matrix_inverse.h"
 #include "itkCastImageFilter.h"
 #include <algorithm> // For min and max.

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
@@ -24,7 +24,7 @@
 #include "itkVector.h"
 #include "vnl/vnl_matrix.h"
 #include "vnl/vnl_vector_fixed.h"
-#include "vnl/algo/vnl_symmetric_eigensystem.h"
+#include "itkSymmetricEigenDecomposition.h"
 #include "itkMath.h"
 
 namespace itk
@@ -468,7 +468,7 @@ protected:
     }
 
     // Find the eigenvalues of g
-    const vnl_symmetric_eigensystem<TRealType> E(g);
+    const itk::SymmetricEigenDecomposition<TRealType> E(g);
 
     // Return the difference in length between the first two principle axes.
     // Note that other edge strength metrics may be appropriate here instead..

--- a/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.hxx
@@ -18,8 +18,8 @@
 #ifndef itkImageMomentsCalculator_hxx
 #define itkImageMomentsCalculator_hxx
 
-#include "vnl/algo/vnl_real_eigensystem.h"
-#include "vnl/algo/vnl_symmetric_eigensystem.h"
+#include "itkRealEigenDecomposition.h"
+#include "itkSymmetricEigenDecomposition.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
 
 namespace itk
@@ -146,8 +146,8 @@ ImageMomentsCalculator<TImage>::Compute()
   }
 
   // Compute principal moments and axes
-  const vnl_symmetric_eigensystem<double> eigen{ m_Cm.GetVnlMatrix().as_matrix() };
-  vnl_diag_matrix<double>                 pm{ eigen.D };
+  const itk::SymmetricEigenDecomposition<double> eigen{ m_Cm.GetVnlMatrix().as_matrix() };
+  vnl_diag_matrix<double>                        pm{ eigen.D };
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     m_Pm[i] = pm(i) * m_M0;
@@ -156,9 +156,9 @@ ImageMomentsCalculator<TImage>::Compute()
 
   // Add a final reflection if needed for a proper rotation,
   // by multiplying the last row by the determinant
-  const vnl_real_eigensystem            eigenrot{ m_Pa.GetVnlMatrix().as_matrix() };
-  vnl_diag_matrix<std::complex<double>> eigenval{ eigenrot.D };
-  std::complex<double>                  det(1.0, 0.0);
+  const itk::RealEigenDecomposition<double> eigenrot{ m_Pa.GetVnlMatrix().as_matrix() };
+  const vnl_vector<std::complex<double>> &  eigenval = eigenrot.GetEigenvalues();
+  std::complex<double>                      det(1.0, 0.0);
 
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.h
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.h
@@ -33,8 +33,7 @@
 #include "itkImageShapeModelEstimatorBase.h"
 #include "itkConceptChecking.h"
 #include "itkImage.h"
-#include "vnl/algo/vnl_generalized_eigensystem.h"
-#include "vnl/algo/vnl_symmetric_eigensystem.h"
+#include "itkGeneralizedEigenDecomposition.h"
 
 namespace itk
 {

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
@@ -341,9 +341,9 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::EstimatePCAShapeModelPar
 
   identityMatrix.set_identity();
 
-  const vnl_generalized_eigensystem eigenVectors_eigenValues(m_InnerProduct, identityMatrix);
+  const itk::GeneralizedEigenDecomposition<double> eigenVectors_eigenValues(m_InnerProduct, identityMatrix);
 
-  MatrixOfDoubleType eigenVectorsOfInnerProductMatrix = eigenVectors_eigenValues.V;
+  MatrixOfDoubleType eigenVectorsOfInnerProductMatrix = eigenVectors_eigenValues.GetEigenvectors();
 
   // Calculate the principal shape variations
   //
@@ -375,11 +375,10 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::EstimatePCAShapeModelPar
 
   m_EigenValues.set_size(m_NumberOfTrainingImages);
 
-  // Extract the diagonal elements into the Eigen value vector
-  m_EigenValues = (eigenVectors_eigenValues.D).diagonal();
+  // Eigenvalues are returned in ascending order.
+  m_EigenValues = eigenVectors_eigenValues.GetEigenvalues();
 
-  // Flip the eigen values since the eigen vectors output
-  // is ordered in descending order of their corresponding eigen values.
+  // Flip to descending so the largest principal variation is first.
   m_EigenValues.flip();
 
   // Normalize the eigen values

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -25,8 +25,8 @@
 #include "itkConstantBoundaryCondition.h"
 #include "itkGeometryUtilities.h"
 #include "itkConnectedComponentAlgorithm.h"
-#include "vnl/algo/vnl_real_eigensystem.h"
-#include "vnl/algo/vnl_symmetric_eigensystem.h"
+#include "itkRealEigenDecomposition.h"
+#include "itkSymmetricEigenDecomposition.h"
 #include "itkMath.h"
 #include "itkLexicographicCompare.h"
 #include <deque>
@@ -306,9 +306,9 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ThreadedProcessLabelObject(LabelObject
   }
 
   // Compute principal moments and axes
-  VectorType                              principalMoments;
-  const vnl_symmetric_eigensystem<double> eigen{ centralMoments.GetVnlMatrix().as_matrix() };
-  vnl_diag_matrix<double>                 pm = eigen.D;
+  VectorType                                     principalMoments;
+  const itk::SymmetricEigenDecomposition<double> eigen{ centralMoments.GetVnlMatrix().as_matrix() };
+  vnl_diag_matrix<double>                        pm = eigen.D;
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     principalMoments[i] = pm(i);
@@ -317,9 +317,9 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ThreadedProcessLabelObject(LabelObject
 
   // Add a final reflection if needed for a proper rotation,
   // by multiplying the last row by the determinant
-  const vnl_real_eigensystem            eigenrot{ principalAxes.GetVnlMatrix().as_matrix() };
-  vnl_diag_matrix<std::complex<double>> eigenval{ eigenrot.D };
-  std::complex<double>                  det(1.0, 0.0);
+  const itk::RealEigenDecomposition<double> eigenrot{ principalAxes.GetVnlMatrix().as_matrix() };
+  const vnl_vector<std::complex<double>> &  eigenval = eigenrot.GetEigenvalues();
+  std::complex<double>                      det(1.0, 0.0);
 
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
@@ -21,8 +21,8 @@
 #include "itkMath.h"
 #include "itkMinimumMaximumImageCalculator.h"
 #include "itkProgressReporter.h"
-#include "vnl/algo/vnl_real_eigensystem.h"
-#include "vnl/algo/vnl_symmetric_eigensystem.h"
+#include "itkRealEigenDecomposition.h"
+#include "itkSymmetricEigenDecomposition.h"
 
 namespace itk
 {
@@ -228,8 +228,8 @@ StatisticsLabelMapFilter<TImage, TFeatureImage>::ThreadedProcessLabelObject(Labe
     }
 
     // Compute principal moments and axes
-    const vnl_symmetric_eigensystem<double> eigen{ centralMoments.GetVnlMatrix().as_matrix() };
-    vnl_diag_matrix<double>                 pm{ eigen.D };
+    const itk::SymmetricEigenDecomposition<double> eigen{ centralMoments.GetVnlMatrix().as_matrix() };
+    vnl_diag_matrix<double>                        pm{ eigen.D };
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       //    principalMoments[i] = 4 * std::sqrt( pm(i,i) );
@@ -239,9 +239,9 @@ StatisticsLabelMapFilter<TImage, TFeatureImage>::ThreadedProcessLabelObject(Labe
 
     // Add a final reflection if needed for a proper rotation,
     // by multiplying the last row by the determinant
-    const vnl_real_eigensystem            eigenrot{ principalAxes.GetVnlMatrix().as_matrix() };
-    vnl_diag_matrix<std::complex<double>> eigenval{ eigenrot.D };
-    std::complex<double>                  det(1.0, 0.0);
+    const itk::RealEigenDecomposition<double> eigenrot{ principalAxes.GetVnlMatrix().as_matrix() };
+    const vnl_vector<std::complex<double>> &  eigenval = eigenrot.GetEigenvalues();
+    std::complex<double>                      det(1.0, 0.0);
 
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {

--- a/Modules/Filtering/LabelMap/test/itkShapeLabelMapFilterGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeLabelMapFilterGTest.cxx
@@ -258,7 +258,7 @@ TEST_F(ShapeLabelMapFixture, 3D_T3x2x1_Direction)
   EXPECT_EQ(0u, labelObject->GetNumberOfPixelsOnBorder());
   ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(1u, 2u, 3u), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
   ITK_EXPECT_VECTOR_NEAR(
-    itk::MakePoint(3.22524, -3.19685, -14.83670), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
+    itk::MakePoint(6.02222, -4.47691, -15.57049), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
   EXPECT_NEAR(14.62414, labelObject->GetPerimeter(), 1e-4); // resulting value
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorder());
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorderRatio());
@@ -375,7 +375,7 @@ TEST_F(ShapeLabelMapFixture, 3D_T2x2x2_Spacing_Direction)
   EXPECT_EQ(0u, labelObject->GetNumberOfPixelsOnBorder());
   ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(2.0, 2.2, 4.4), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
   ITK_EXPECT_VECTOR_NEAR(
-    itk::MakePoint(8.92548, 4.27240, -23.31018), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4); // resulting value
+    itk::MakePoint(9.75747, 5.36134, -28.03480), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4); // resulting value
   EXPECT_NEAR(28.3919, labelObject->GetPerimeter(), 1e-4);                                           // resulting value
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorder());
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorderRatio());

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
@@ -24,7 +24,7 @@
 #include "itkSimpleDataObjectDecorator.h"
 #include <map>
 #include <vector>
-#include "vnl/algo/vnl_symmetric_eigensystem.h"
+#include "itkSymmetricEigenDecomposition.h"
 #include "vnl/vnl_det.h"
 #include "itkMath.h"
 
@@ -500,7 +500,7 @@ protected:
 
 private:
   bool
-  CalculateOrientedBoundingBoxVertices(vnl_symmetric_eigensystem<double> eig, LabelGeometry & m_LabelGeometry);
+  CalculateOrientedBoundingBoxVertices(itk::SymmetricEigenDecomposition<double> eig, LabelGeometry & m_LabelGeometry);
 
   bool m_CalculatePixelIndices{};
   bool m_CalculateOrientedBoundingBox{};

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -43,7 +43,7 @@ namespace
 //
 template <unsigned int VDimension>
 inline vnl_matrix<double>
-CalculateRotationMatrix(const vnl_symmetric_eigensystem<double> & eig)
+CalculateRotationMatrix(const itk::SymmetricEigenDecomposition<double> & eig)
 {
   vnl_matrix<double> rotationMatrix(VDimension, VDimension, 0);
   for (unsigned int i = 0; i < VDimension; ++i)
@@ -87,7 +87,7 @@ CalculateRotationMatrix(const vnl_symmetric_eigensystem<double> & eig)
 
 template <typename TLabelImage, typename TIntensityImage, typename TInputImage>
 inline bool
-CalculateOrientedImage(const vnl_symmetric_eigensystem<double> &                                        eig,
+CalculateOrientedImage(const itk::SymmetricEigenDecomposition<double> &                                 eig,
                        typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::LabelGeometry & labelGeometry,
                        bool                                                                             useLabelImage,
                        const TInputImage *                                                              inputImage)
@@ -365,7 +365,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
     // Compute the eigenvalues/eigenvectors of the covariance matrix.
     // The result is stored in increasing eigenvalues with
     // corresponding eigenvectors.
-    vnl_symmetric_eigensystem<double> eig(normalizedSecondOrderCentralMoments);
+    itk::SymmetricEigenDecomposition<double> eig(normalizedSecondOrderCentralMoments);
 
     // Calculate the eigenvalues/eigenvectors
     VectorType eigenvalues(ImageDimension, 0);
@@ -421,8 +421,8 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
 template <typename TLabelImage, typename TIntensityImage>
 bool
 LabelGeometryImageFilter<TLabelImage, TIntensityImage>::CalculateOrientedBoundingBoxVertices(
-  vnl_symmetric_eigensystem<double> eig,
-  LabelGeometry &                   labelGeometry)
+  itk::SymmetricEigenDecomposition<double> eig,
+  LabelGeometry &                          labelGeometry)
 {
   // Calculate the oriented bounding box using the eigenvectors.
   // For each label, the pixels are rotated to the new coordinate

--- a/Modules/Numerics/PrincipalComponentsAnalysis/include/itkVectorFieldPCA.hxx
+++ b/Modules/Numerics/PrincipalComponentsAnalysis/include/itkVectorFieldPCA.hxx
@@ -19,7 +19,7 @@
 #ifndef itkVectorFieldPCA_hxx
 #define itkVectorFieldPCA_hxx
 
-#include "vnl/algo/vnl_symmetric_eigensystem.h"
+#include "itkSymmetricEigenDecomposition.h"
 #include "vnl/vnl_c_vector.h"
 #include "itkMath.h"
 
@@ -254,7 +254,7 @@ VectorFieldPCA<TVectorFieldElementType,
     }
   }
 
-  vnl_symmetric_eigensystem<TPCType> eigs(K0);
+  itk::SymmetricEigenDecomposition<TPCType> eigs(K0);
 
   m_PCAEigenValues = eigs.D.diagonal();
 

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
@@ -18,7 +18,7 @@
 #ifndef itkLevelSetFunction_hxx
 #define itkLevelSetFunction_hxx
 
-#include "vnl/algo/vnl_symmetric_eigensystem.h"
+#include "itkSymmetricEigenDecomposition.h"
 
 namespace itk
 {
@@ -95,7 +95,7 @@ LevelSetFunction<TImageType>::ComputeMinimalCurvature(const NeighborhoodType & i
   }
 
   // Eigensystem
-  const vnl_symmetric_eigensystem<ScalarValueType> eig{ Curve.as_matrix() };
+  const itk::SymmetricEigenDecomposition<ScalarValueType> eig{ Curve.as_matrix() };
 
   constexpr ScalarValueType MIN_EIG{ NumericTraits<ScalarValueType>::min() };
   ScalarValueType           mincurve = itk::Math::Absolute(eig.get_eigenvalue(ImageDimension - 1));

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/CMakeLists.txt
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/CMakeLists.txt
@@ -15,13 +15,9 @@ set( vnl_algo_sources
   vnl_svd_fixed.hxx vnl_svd_fixed.h
   vnl_matrix_inverse.hxx vnl_matrix_inverse.h
   vnl_qr.hxx vnl_qr.h
-  vnl_scatter_3x3.hxx vnl_scatter_3x3.h
   vnl_cholesky.cxx vnl_cholesky.h
   vnl_ldl_cholesky.cxx vnl_ldl_cholesky.h
   vnl_sparse_lu.cxx vnl_sparse_lu.h
-  vnl_real_eigensystem.cxx vnl_real_eigensystem.h
-  vnl_symmetric_eigensystem.hxx vnl_symmetric_eigensystem.h
-  vnl_generalized_eigensystem.cxx vnl_generalized_eigensystem.h
 
   # optimisation
   vnl_discrete_diff.cxx vnl_discrete_diff.h
@@ -50,7 +46,25 @@ set( vnl_algo_sources
   vnl_adaptsimpson_integral.cxx vnl_adaptsimpson_integral.h
 )
 
+# EISPACK-backed legacy: the *_eigensystem classes and vnl_scatter_3x3 (their
+# only non-deprecated client) are the sole consumers of the netlib eispack
+# engine. They are deprecated; drop them and their template instantiations once
+# the APIs are removed, leaving no eispack dependency to build.
+if(NOT ITK_FUTURE_LEGACY_REMOVE)
+  list(APPEND vnl_algo_sources
+    vnl_scatter_3x3.hxx vnl_scatter_3x3.h
+    vnl_real_eigensystem.cxx vnl_real_eigensystem.h
+    vnl_symmetric_eigensystem.hxx vnl_symmetric_eigensystem.h
+    vnl_generalized_eigensystem.cxx vnl_generalized_eigensystem.h
+  )
+endif()
+
 aux_source_directory(Templates vnl_algo_sources)
+
+if(ITK_FUTURE_LEGACY_REMOVE)
+  list(FILTER vnl_algo_sources EXCLUDE REGEX "vnl_symmetric_eigensystem\\+")
+  list(FILTER vnl_algo_sources EXCLUDE REGEX "vnl_scatter_3x3\\+")
+endif()
 
 # If VXL_INSTALL_INCLUDE_DIR is the default value
 if("${VXL_INSTALL_INCLUDE_DIR}" STREQUAL "include/vxl")

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_generalized_eigensystem.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_generalized_eigensystem.h
@@ -1,6 +1,24 @@
 // This is core/vnl/algo/vnl_generalized_eigensystem.h
 #ifndef vnl_generalized_eigensystem_h_
 #define vnl_generalized_eigensystem_h_
+
+// ITK deprecation shim: the netlib EISPACK engine (rsg) behind
+// vnl_generalized_eigensystem is being retired; itk::GeneralizedEigenDecomposition
+// (Eigen-backed) is the supported replacement. The guard is active only when
+// itkConfigure.h is reachable (an ITK consumer), so ITK's own VXL build is
+// unaffected.
+#if __has_include(<itkConfigure.h>)
+#  include <itkConfigure.h>
+#  if defined(ITK_FUTURE_LEGACY_REMOVE)
+#    error "vnl/algo/vnl_generalized_eigensystem.h is deprecated; migrate to itk::GeneralizedEigenDecomposition (itkGeneralizedEigenDecomposition.h, Eigen-backed)."
+#  elif defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT) && !defined(ITK_LEGACY_TEST)
+#    if defined(_MSC_VER)
+#      pragma message("vnl/algo/vnl_generalized_eigensystem.h is deprecated; migrate to itk::GeneralizedEigenDecomposition (itkGeneralizedEigenDecomposition.h, Eigen-backed).")
+#    else
+#      warning "vnl/algo/vnl_generalized_eigensystem.h is deprecated; migrate to itk::GeneralizedEigenDecomposition (itkGeneralizedEigenDecomposition.h, Eigen-backed)."
+#    endif
+#  endif
+#endif
 //:
 // \file
 // \brief  Solves the generalized eigenproblem Ax=La

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_real_eigensystem.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_real_eigensystem.h
@@ -1,6 +1,23 @@
 // This is core/vnl/algo/vnl_real_eigensystem.h
 #ifndef vnl_real_eigensystem_h_
 #define vnl_real_eigensystem_h_
+
+// ITK deprecation shim: the netlib EISPACK engine (rg) behind vnl_real_eigensystem
+// is being retired; itk::RealEigenDecomposition (Eigen-backed) is the supported
+// replacement. The guard is active only when itkConfigure.h is reachable (an ITK
+// consumer), so ITK's own VXL build is unaffected.
+#if __has_include(<itkConfigure.h>)
+#  include <itkConfigure.h>
+#  if defined(ITK_FUTURE_LEGACY_REMOVE)
+#    error "vnl/algo/vnl_real_eigensystem.h is deprecated; migrate to itk::RealEigenDecomposition (itkRealEigenDecomposition.h, Eigen-backed)."
+#  elif defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT) && !defined(ITK_LEGACY_TEST)
+#    if defined(_MSC_VER)
+#      pragma message("vnl/algo/vnl_real_eigensystem.h is deprecated; migrate to itk::RealEigenDecomposition (itkRealEigenDecomposition.h, Eigen-backed).")
+#    else
+#      warning "vnl/algo/vnl_real_eigensystem.h is deprecated; migrate to itk::RealEigenDecomposition (itkRealEigenDecomposition.h, Eigen-backed)."
+#    endif
+#  endif
+#endif
 //:
 // \file
 // \brief Extract eigensystem of non-symmetric matrix M, using EISPACK

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_scatter_3x3.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_scatter_3x3.h
@@ -1,6 +1,25 @@
 // This is core/vnl/algo/vnl_scatter_3x3.h
 #ifndef vnl_scatter_3x3_h_
 #define vnl_scatter_3x3_h_
+
+// ITK deprecation shim: vnl_scatter_3x3 is the only non-deprecated client of the
+// netlib EISPACK symmetric eigensolver; it is deprecated alongside the
+// vnl_*_eigensystem classes so the dead engine can be retired. Build a 3x3
+// scatter matrix directly and use itk::SymmetricEigenDecomposition for its
+// eigensystem. The guard is active only when itkConfigure.h is reachable (an ITK
+// consumer), so ITK's own VXL build is unaffected.
+#if __has_include(<itkConfigure.h>)
+#  include <itkConfigure.h>
+#  if defined(ITK_FUTURE_LEGACY_REMOVE)
+#    error "vnl/algo/vnl_scatter_3x3.h is deprecated; build a 3x3 scatter matrix directly and use itk::SymmetricEigenDecomposition (itkSymmetricEigenDecomposition.h, Eigen-backed) for its eigensystem."
+#  elif defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT) && !defined(ITK_LEGACY_TEST)
+#    if defined(_MSC_VER)
+#      pragma message("vnl/algo/vnl_scatter_3x3.h is deprecated; use itk::SymmetricEigenDecomposition (itkSymmetricEigenDecomposition.h) for the eigensystem.")
+#    else
+#      warning "vnl/algo/vnl_scatter_3x3.h is deprecated; use itk::SymmetricEigenDecomposition (itkSymmetricEigenDecomposition.h) for the eigensystem."
+#    endif
+#  endif
+#endif
 //:
 // \file
 // \brief  3x3 scatter matrix

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_symmetric_eigensystem.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_symmetric_eigensystem.h
@@ -1,6 +1,24 @@
 // This is core/vnl/algo/vnl_symmetric_eigensystem.h
 #ifndef vnl_symmetric_eigensystem_h_
 #define vnl_symmetric_eigensystem_h_
+
+// ITK deprecation shim: the netlib EISPACK engine (rs) behind
+// vnl_symmetric_eigensystem is being retired; itk::SymmetricEigenDecomposition
+// (Eigen-backed) is the supported replacement. The guard is active only when
+// itkConfigure.h is reachable (an ITK consumer), so ITK's own VXL build is
+// unaffected.
+#if __has_include(<itkConfigure.h>)
+#  include <itkConfigure.h>
+#  if defined(ITK_FUTURE_LEGACY_REMOVE)
+#    error "vnl/algo/vnl_symmetric_eigensystem.h is deprecated; migrate to itk::SymmetricEigenDecomposition (itkSymmetricEigenDecomposition.h, Eigen-backed)."
+#  elif defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT) && !defined(ITK_LEGACY_TEST)
+#    if defined(_MSC_VER)
+#      pragma message("vnl/algo/vnl_symmetric_eigensystem.h is deprecated; migrate to itk::SymmetricEigenDecomposition (itkSymmetricEigenDecomposition.h, Eigen-backed).")
+#    else
+#      warning "vnl/algo/vnl_symmetric_eigensystem.h is deprecated; migrate to itk::SymmetricEigenDecomposition (itkSymmetricEigenDecomposition.h, Eigen-backed)."
+#    endif
+#  endif
+#endif
 //:
 // \file
 // \brief Find eigenvalues of a symmetric matrix

--- a/Modules/ThirdParty/VNL/src/vxl/v3p/netlib/CMakeLists.txt
+++ b/Modules/ThirdParty/VNL/src/vxl/v3p/netlib/CMakeLists.txt
@@ -110,6 +110,12 @@ set(V3P_NETLIB_eispack_SOURCES
      eispack/tred1.c eispack/tred1.h
      eispack/tred2.c eispack/tred2.h
    )
+# eispack (rs/rg/rsg) backs only the deprecated vnl_real_eigensystem,
+# vnl_symmetric_eigensystem, vnl_generalized_eigensystem and vnl_scatter_3x3.
+# Drop the dead engine once those APIs are removed.
+if(ITK_FUTURE_LEGACY_REMOVE)
+  set(V3P_NETLIB_eispack_SOURCES "")
+endif()
 set(V3P_NETLIB_napack_SOURCES
      napack/cg.c napack/cg.h
    )

--- a/Testing/Data/Baseline/Review/itkLabelGeometryImageFilterTest.png.cid
+++ b/Testing/Data/Baseline/Review/itkLabelGeometryImageFilterTest.png.cid
@@ -1,1 +1,1 @@
-bafkreihgmx4gzanftknndpadugjb4s72rvl7rvt6cfjbaocq7h46z7plle
+bafkreihnydkahvqsph6ec43yifgbfra7swq2xglf5r5u3x6zku3oph72bi

--- a/Testing/Data/Baseline/Review/itkLabelGeometryImageFilterTest3D.mhd.cid
+++ b/Testing/Data/Baseline/Review/itkLabelGeometryImageFilterTest3D.mhd.cid
@@ -1,1 +1,1 @@
-bafkreifqvmbnrvjy7nctcpo2ggk4kp6nr65l5vinsinb4jp7o4urgzvuvq
+bafkreicpmfdhcbamx7tw7ayuw7npbhscshw46ft7pmo2bn3kbgpoi4sp5e

--- a/Testing/Data/Baseline/Review/itkLabelGeometryImageFilterTest3D.raw.cid
+++ b/Testing/Data/Baseline/Review/itkLabelGeometryImageFilterTest3D.raw.cid
@@ -1,1 +1,1 @@
-bafkreifjiqemyirfat3izwccsghisrdghrrhdk2ltsnojzunrxuu6egusq
+bafkreiab6owerbif2uvilywfpkzcqsfjnuzmaxb3q2eehzd4vphrjmnxmq


### PR DESCRIPTION
Adds Eigen-backed `itk::RealEigenDecomposition`, `itk::GeneralizedEigenDecomposition`, and `itk::SymmetricEigenDecomposition`, and deprecates the three netlib-EISPACK-backed `vnl_*_eigensystem` classes (plus `vnl_scatter_3x3`, their only other client). All 12 ITK-internal consumers are migrated; under `ITK_FUTURE_LEGACY_REMOVE` the dead eispack engine is excluded from the build. Continues the VNL→Eigen direction of #6403 / #6230, following the #6473 (LINPACK) playbook.

> [!IMPORTANT]
> **Depends on InsightSoftwareConsortium/ITKTestingData#69** — that PR supplies the 3 regenerated LabelGeometry baseline blobs the updated `.cid` links resolve to. It must merge first (or together) or the LabelGeometry tests cannot fetch their baselines in CI.

<details>
<summary>What changed</summary>

- **New `itk::` APIs** (Core/Common): single-shot, construct-and-store eigendecompositions backed by Eigen's `EigenSolver` / `GeneralizedSelfAdjointEigenSolver` / `SelfAdjointEigenSolver`. Results are returned in vnl containers — no Eigen type in any public signature (#6230). A shared `itkEigenDecompositionSignConvention.h` helper canonicalizes real eigenvector column signs (largest-magnitude entry positive) for cross-platform/SIMD reproducibility, with a defaulted `canonicalizeSigns` ctor flag to opt out.
- **Deprecation**: three-state legacy guards (`__has_include(<itkConfigure.h>)`-gated) on the three eigensystem headers and `vnl_scatter_3x3.h` — silent by default, `#warning` under `ITK_LEGACY_REMOVE`, `#error` under `ITK_FUTURE_LEGACY_REMOVE`.
- **CMake gate**: under `ITK_FUTURE_LEGACY_REMOVE` the three eigensystem classes, `vnl_scatter_3x3`, their template instantiations, and the whole `eispack/` subdirectory are excluded — leaving no eispack dependency to build.
- **Consumers** (12 sites): image moments, label-map shape/statistics, label geometry, vector-field PCA, vector gradient magnitude, level-set curvature, PCA shape model — all moved onto the new APIs before the guards were added.
- `SymmetricEigenAnalysis` gains a `\sa` cross-reference distinguishing the configurable solver object from the new stored decomposition.

</details>

<details>
<summary>Why eispack isn't deleted in-PR (contrast with #6473)</summary>

#6473 re-backed `vnl_qr` / `vnl_cholesky` with a byte-exact native engine and deleted the netlib sources immediately, because byte-exactness meant zero change for direct `vnl_*` callers still in the forest. A byte-exact QL eigensolver port is far harder, and a non-byte-exact re-backing would silently flip eigenvector signs for direct forest `vnl_symmetric_eigensystem` callers (ANTs, PlusLib, …). So this PR keeps the EISPACK engine for the deprecation window and only gates it out under `ITK_FUTURE_LEGACY_REMOVE`; whole-`eispack/` deletion is a tracked follow-up once the window closes.

</details>

<details>
<summary>Sign canonicalization and the LabelGeometry baseline regen</summary>

An eigenvector's sign is mathematically arbitrary; the old baselines were implicitly locked to netlib's signs. The new classes pin a deterministic convention, which is a reproducibility win but deterministically changes the one sign-dependent output: `LabelGeometryImageFilter`'s oriented bounding-box image (origin shifts, e.g. 3D Offset Y from 16.8389 to 17.2097). Every scalar measurement is unchanged (eigenvalues, axis lengths, eccentricity, elongation, orientation angle), so the `.csv` baselines are untouched; only the `.png` / `.mhd` / `.raw` image links were regenerated. All other migrated consumers are sign-invariant (verified).

</details>

<details>
<summary>Testing</summary>

- New GoogleTests scavenged from the VXL coverage onto the `itk::` APIs, plus sign-convention, opt-out, and old-vs-new equivalence (eigenvalues exact, eigenvectors up to sign).
- Local: 14/14 Common eigendecomposition GTests; 23/23 affected consumer baselines (incl. LabelGeometry); default and `ITK_FUTURE_LEGACY_REMOVE` builds both verified (the latter links with zero eispack objects in the archive).
- `pre-commit run --all-files` clean.

</details>

<!--
provenance: claude-code session 2026-06-18, branch deprecate-vnl-eispack-eigensystem, base c352514
companion_pr: InsightSoftwareConsortium/ITKTestingData#69 (3 baseline CID blobs)
key_facts: eispack backs vnl_real/symmetric/generalized_eigensystem + vnl_scatter_3x3 only; gate keyed on ITK_FUTURE_LEGACY_REMOVE (requires ITK_LEGACY_REMOVE=ON via cmake_dependent_option). Sign canonicalization deterministic (largest-magnitude positive), opt-out via ctor bool. Determinant in moments/labelmap uses RealEigenDecomposition (solver-invariant, no baseline change).
followup: delete eispack/ subdir + the 4 deprecated classes once the legacy window closes.
related: #6403 (ITKv7 numerics), #6230 (no transitive Eigen exposure), #6473 (LINPACK precedent), #6454, #6441.
-->
