### PR TITLE
BUG: Fix floating-point exception in ShapeLabelMapFilter

### DIFF
--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -311,7 +311,8 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ThreadedProcessLabelObject(LabelObject
   vnl_diag_matrix<double>                 pm = eigen.D;
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
-    principalMoments[i] = pm(i);
+    // Clamp to zero: near-zero negative eigenvalues from numerical precision cause FPE in std::pow(edet, ...)
+    principalMoments[i] = std::max(pm(i), 0.0);
   }
   MatrixType principalAxes(eigen.V.transpose());
 

--- a/Modules/Filtering/LabelMap/test/itkShapeLabelMapFilterGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeLabelMapFilterGTest.cxx
@@ -22,6 +22,8 @@
 #include "itkLabelImageToShapeLabelMapFilter.h"
 #include "itkTestingMacros.h"
 
+#include <cmath>
+
 
 namespace Math = itk::Math;
 
@@ -533,4 +535,56 @@ TEST_F(ShapeLabelMapFixture, 2D_T2x4)
   {
     labelObject->Print(std::cout);
   }
+}
+
+
+TEST_F(ShapeLabelMapFixture, 3D_DegenerateFlatObject_NumericallyStableEllipsoidDiameter)
+{
+  using namespace itk::GTest::TypedefsAndConstructors::Dimension3;
+
+  using Utils = FixtureUtilities<3>;
+
+  auto image = Utils::ImageType::New();
+
+  Utils::ImageType::SizeType imageSize;
+  imageSize.Fill(64);
+  image->SetRegions(Utils::ImageType::RegionType(imageSize));
+  image->AllocateInitialized();
+
+  const double  d[9] = { 0.7950707161543119,     -0.44533237368675166, 0.41175433605536305,
+                         -0.6065167008084678,    -0.5840224148057925,  0.5394954222649374,
+                         0.00021898465942798317, -0.6786728931900383,  -0.7344406416415056 };
+  DirectionType direction = DirectionType::InternalMatrixType(d);
+
+  image->SetDirection(direction);
+  image->SetSpacing(itk::MakeVector(0.9, 1.1, 1.7));
+  image->SetOrigin(itk::MakePoint(1.0e8, -1.0e8, 0.5e8));
+
+  // 1D line with large physical coordinates amplifies numerical cancellation in moment computation.
+  for (unsigned int x = 8; x < 56; ++x)
+  {
+    image->SetPixel(itk::MakeIndex(static_cast<itk::IndexValueType>(x), 32, 31), 1);
+  }
+
+  Utils::LabelObjectType::ConstPointer labelObject = Utils::ComputeLabelObject(image, 1);
+
+  const auto & principalMoments = labelObject->GetPrincipalMoments();
+  const auto & ellipsoidDiameter = labelObject->GetEquivalentEllipsoidDiameter();
+
+  for (unsigned int i = 0; i < 3; ++i)
+  {
+    EXPECT_TRUE(std::isfinite(principalMoments[i])) << "Principal moment " << i << " is not finite";
+    EXPECT_GE(principalMoments[i], 0.0) << "Principal moment " << i << " should be non-negative";
+    EXPECT_TRUE(std::isfinite(ellipsoidDiameter[i])) << "Ellipsoid diameter[" << i << "] is not finite";
+    EXPECT_GE(ellipsoidDiameter[i], 0.0) << "Ellipsoid diameter[" << i << "] should be non-negative";
+  }
+
+  const double maxAbsPrincipalMoment =
+    std::max(std::max(std::abs(principalMoments[0]), std::abs(principalMoments[1])), std::abs(principalMoments[2]));
+
+  EXPECT_GT(maxAbsPrincipalMoment, 0.0) << "At least one principal moment should be non-zero";
+
+  const double rawDeterminant = principalMoments[0] * principalMoments[1] * principalMoments[2];
+  EXPECT_TRUE(std::isfinite(rawDeterminant)) << "Determinant of principal moments should be finite";
+  EXPECT_GE(rawDeterminant, 0.0) << "Product of non-negative principal moments should be non-negative";
 }


### PR DESCRIPTION
## Description:
- Computing equivalent ellipsoid diameter can fail with FP exception when principal moments have negative product due to numerical precision issues
- Occurs with degenerate geometries (very thin/flat objects with near-zero moments)
- Solution: Guard against non-positive principal moments 

fp exception was raised here
```cpp
edet = std::pow(edet, 1.0 / ImageDimension);
```

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
