### PR TITLE
COMP: Reduce Linux CI disk pressure and harden ccache management

### DIFF
--- a/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesBatch.yml
@@ -17,6 +17,7 @@ variables:
   CCACHE_COMPILERCHECK: content
   CCACHE_NOHASHDIR: 'true'
   CCACHE_SLOPPINESS: pch_defines,time_macros
+  CCACHE_MAXSIZE: 8G
 jobs:
   - job: Windows
     timeoutInMinutes: 0
@@ -114,7 +115,6 @@ jobs:
         displayName: 'Build and test'
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
-          CCACHE_MAXSIZE: 2.4G
 
       - bash: ccache --show-stats
         condition: always()
@@ -135,3 +135,17 @@ jobs:
           testRunTitle: 'CTest $(Agent.OS)'
         condition: succeededOrFailed()
         displayName: 'Publish test results'
+
+      - bash: |
+          set -e
+          set -x
+          if [ "$AGENT_JOBSTATUS" = "Succeeded" ]; then
+            ccache --evict-older-than 3d || true
+          else
+            ccache --evict-older-than 14d || true
+          fi
+          ccache -c || true
+          rm -rf "$(Build.SourcesDirectory)-build" || true
+          rm -rf "$(Agent.BuildDirectory)/ITK-dashboard" || true
+        condition: always()
+        displayName: 'Free build tree before post-job cache save'

--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -33,6 +33,7 @@ variables:
   CCACHE_COMPILERCHECK: content
   CCACHE_NOHASHDIR: 'true'
   CCACHE_SLOPPINESS: pch_defines,time_macros
+  CCACHE_MAXSIZE: 8G
 jobs:
 - job: LinuxLegacyRemovedDebugCxx20
   timeoutInMinutes: 0
@@ -136,19 +137,17 @@ jobs:
         c++ --version
         cmake --version
 
-        # ccache refreshes timestamps on hit; evict-older-than prunes untouched entries (1d on pass keeps it lean, 4d on fail retains fix-retry objects).
         ctest -S $(Agent.BuildDirectory)/ITK-dashboard/dashboard.cmake -V -j 2
         ctest_rc=$?
         if [ $ctest_rc -eq 0 ]; then
-          ccache --evict-older-than 1d
+          ccache --evict-older-than 3d || true
         else
-          ccache --evict-older-than 4d
+          ccache --evict-older-than 14d || true
         fi
         exit $ctest_rc
       displayName: 'Build and test'
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-        CCACHE_MAXSIZE: 4.5G
 
     - bash: ccache --show-stats
       condition: always()
@@ -170,11 +169,12 @@ jobs:
       condition: succeededOrFailed()
       displayName: 'Publish test results'
 
-    # The Debug+Examples build tree fills the agent's free space; remove it so
-    # the post-job ccache/ExternalData Cache@2 save has room to write its tar.
     - bash: |
+        set -e
         set -x
+        ccache -c || true
         rm -rf $(Build.SourcesDirectory)-build
+        rm -rf $(Agent.BuildDirectory)/ITK-dashboard
         df -h /
       condition: always()
       displayName: 'Free build tree before post-job cache save'

--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -40,6 +40,18 @@ jobs:
   pool:
     vmImage: ubuntu-24.04
   steps:
+    - bash: |
+        set -e
+        set -x
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc /usr/local/.ghcup
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/share/swift /opt/hostedtoolcache/CodeQL
+        sudo rm -rf /usr/local/include/boost /usr/local/lib/libboost_* /usr/local/share/boost
+        docker image prune -af || true
+        df -h /
+      displayName: 'Free preinstalled software'
+
     - checkout: self
       clean: true
       fetchDepth: 5

--- a/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinux.yml
@@ -16,6 +16,8 @@ trigger:
     - Utilities/Maintenance/*
     - Modules/Remote/*.remote.cmake
 pr:
+  # Validate draft PRs (Azure default) so contributors see all gating results while iterating.
+  drafts: true
   paths:
     exclude:
     - '*.md'

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -16,6 +16,8 @@ trigger:
     - Utilities/Maintenance/*
     - Modules/Remote/*.remote.cmake
 pr:
+  # Validate draft PRs (Azure default) so contributors see all gating results while iterating.
+  drafts: true
   paths:
     exclude:
     - '*.md'

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -33,6 +33,7 @@ variables:
   CCACHE_COMPILERCHECK: content
   CCACHE_NOHASHDIR: 'true'
   CCACHE_SLOPPINESS: pch_defines,time_macros
+  CCACHE_MAXSIZE: 8G
 jobs:
 - job: Linux
   timeoutInMinutes: 0
@@ -137,35 +138,16 @@ jobs:
         cmake --version
 
         ctest -S $(Agent.BuildDirectory)/ITK-dashboard/dashboard.cmake -V -j 2 -L Python -E "(PythonExtrasTest)|(PythonFastMarching)|(PythonLazyLoadingImage)|(PythonThresholdSegmentationLevelSetWhiteMatterTest)|(PythonVerifyTTypeAPIConsistency)|(PythonWatershedSegmentation1Test)"
+        ctest_rc=$?
+        if [ $ctest_rc -eq 0 ]; then
+          ccache --evict-older-than 3d || true
+        else
+          ccache --evict-older-than 14d || true
+        fi
+        exit $ctest_rc
       displayName: 'Build and test'
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-        CCACHE_MAXSIZE: 8G
-
-    - bash: |
-        set -eo pipefail
-        set -x
-        # Shrink the local ccache and prune the build tree before the
-        # implicit post-job 'Cache@2' uploader tars CCACHE_DIR. The
-        # post-job tar fails ENOSPC when the runner's writable disk is
-        # too full to hold the temporary archive (Azure DevOps
-        # ITK.Linux.Python builds 14748 / 14751 both hit
-        #   tar: Wrote only 4096 of 10240 bytes
-        #   tar: Error is not recoverable
-        # at 95-96% disk usage). Drop ccache items > 5 days old, force
-        # the local store under 6.5G via env-var override (so the
-        # tighter ceiling does not get baked into ccache.conf inside
-        # CCACHE_DIR, which is what Cache@2 archives), then 'ninja
-        # clean' the build tree to free the .o files no longer needed
-        # after build/test reported.
-        df -h /
-        ccache --show-stats
-        ccache --evict-older-than 5d
-        CCACHE_MAXSIZE=6.5G ccache -c
-        ninja -C $(Build.SourcesDirectory)-build clean || true
-        df -h /
-      condition: always()
-      displayName: 'Free disk before post-job ccache upload'
 
     - bash: ccache --show-stats
       condition: always()
@@ -186,3 +168,13 @@ jobs:
         testRunTitle: 'CTest $(Agent.OS)'
       condition: succeededOrFailed()
       displayName: 'Publish test results'
+
+    - bash: |
+        set -e
+        set -x
+        ccache -c || true
+        rm -rf $(Build.SourcesDirectory)-build
+        rm -rf $(Agent.BuildDirectory)/ITK-dashboard
+        df -h /
+      condition: always()
+      displayName: 'Free build tree before post-job cache save'

--- a/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesLinuxPython.yml
@@ -40,6 +40,18 @@ jobs:
   pool:
     vmImage: ubuntu-22.04
   steps:
+    - bash: |
+        set -e
+        set -x
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc /usr/local/.ghcup
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/share/swift /opt/hostedtoolcache/CodeQL
+        sudo rm -rf /usr/local/include/boost /usr/local/lib/libboost_* /usr/local/share/boost
+        docker image prune -af || true
+        df -h /
+      displayName: 'Free preinstalled software'
+
     - checkout: self
       clean: true
       fetchDepth: 5

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -16,6 +16,8 @@ trigger:
     - Utilities/Maintenance/*
     - Modules/Remote/*.remote.cmake
 pr:
+  # Validate draft PRs (Azure default) so contributors see all gating results while iterating.
+  drafts: true
   paths:
     exclude:
     - '*.md'

--- a/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesMacOSPython.yml
@@ -33,6 +33,7 @@ variables:
   CCACHE_COMPILERCHECK: content
   CCACHE_NOHASHDIR: 'true'
   CCACHE_SLOPPINESS: pch_defines,time_macros
+  CCACHE_MAXSIZE: 8G
 jobs:
 - job: macOS
   timeoutInMinutes: 0
@@ -40,6 +41,14 @@ jobs:
   pool:
     vmImage: macos-15
   steps:
+    - bash: |
+        set -e
+        set -x
+        sudo rm -rf /usr/local/share/dotnet
+        sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes
+        df -h /
+      displayName: 'Free preinstalled software'
+
     - checkout: self
       clean: true
       fetchDepth: 5
@@ -133,10 +142,16 @@ jobs:
         cmake --version
 
         ctest -S $(Agent.BuildDirectory)/ITK-dashboard/dashboard.cmake -V -j 3
+        ctest_rc=$?
+        if [ $ctest_rc -eq 0 ]; then
+          ccache --evict-older-than 3d || true
+        else
+          ccache --evict-older-than 14d || true
+        fi
+        exit $ctest_rc
       displayName: 'Build and test'
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-        CCACHE_MAXSIZE: 8G
 
     - bash: ccache --show-stats
       condition: always()
@@ -157,3 +172,13 @@ jobs:
         testRunTitle: 'CTest $(Agent.OS)'
       condition: succeededOrFailed()
       displayName: 'Publish test results'
+
+    - bash: |
+        set -e
+        set -x
+        ccache -c || true
+        rm -rf $(Build.SourcesDirectory)-build
+        rm -rf $(Agent.BuildDirectory)/ITK-dashboard
+        df -h /
+      condition: always()
+      displayName: 'Free build tree before post-job cache save'

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -33,6 +33,7 @@ variables:
   CCACHE_COMPILERCHECK: content
   CCACHE_NOHASHDIR: 'true'
   CCACHE_SLOPPINESS: pch_defines,time_macros
+  CCACHE_MAXSIZE: 8G
 jobs:
 - job: Windows
   timeoutInMinutes: 0
@@ -125,7 +126,6 @@ jobs:
       displayName: 'Build and test'
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-        CCACHE_MAXSIZE: 8G
 
     - bash: ccache --show-stats
       condition: always()
@@ -146,3 +146,17 @@ jobs:
         testRunTitle: 'CTest $(Agent.OS)'
       condition: succeededOrFailed()
       displayName: 'Publish test results'
+
+    - bash: |
+        set -e
+        set -x
+        if [ "$AGENT_JOBSTATUS" = "Succeeded" ]; then
+          ccache --evict-older-than 3d || true
+        else
+          ccache --evict-older-than 14d || true
+        fi
+        ccache -c || true
+        rm -rf "$(Build.SourcesDirectory)-build" || true
+        rm -rf "$(Agent.BuildDirectory)/ITK-dashboard" || true
+      condition: always()
+      displayName: 'Free build tree before post-job cache save'

--- a/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
+++ b/Testing/ContinuousIntegration/AzurePipelinesWindowsPython.yml
@@ -16,6 +16,8 @@ trigger:
     - Utilities/Maintenance/*
     - Modules/Remote/*.remote.cmake
 pr:
+  # Validate draft PRs (Azure default) so contributors see all gating results while iterating.
+  drafts: true
   paths:
     exclude:
     - '*.md'


### PR DESCRIPTION
Reduce Linux CI disk pressure and harden ccache management across the Azure
pipelines. Freeing ~20 GB of unused preinstalled software first creates the
headroom to keep `CCACHE_MAXSIZE: 8G` and retain failure-run ccache objects
for 14 days. Fixes recurring near-ENOSPC in ITK.Linux.Python; the same
hardening is applied to macOS.Python, Windows.Python, and Batch. Also builds
draft PRs explicitly so contributors aren't gated waiting to mark a PR ready.

<details>
<summary>Commit summary</summary>

**1 — `COMP: Free unused preinstalled software in Linux Azure CI jobs`**
First step of both Linux jobs removes Android SDK, GHC/GHCup, .NET, Swift,
CodeQL, and Boost (~20 GB) and prunes Docker images, before checkout/ccache
restore/build consume disk. Introduced in final form (`set -e`, header+lib
boost path, `docker image prune -af || true`).

**2 — `COMP: Align Linux.Python CI disk management with Linux CI pattern`**
Replace the misplaced pre-diagnostic `Free disk` step with the Linux pattern:
`CCACHE_MAXSIZE: 8G` in the variables block, conditional eviction (3d success /
14d failure) in the build step, and post-diagnostic `ccache -c` + `rm -rf` of
the build tree and dashboard clone.

**3 — `COMP: Harden AzurePipelinesLinux.yml ccache and disk cleanup`**
Move `CCACHE_MAXSIZE` to the variables block at 8G; success eviction 1d -> 3d
and failure 4d -> 14d; delete the false "ccache refreshes timestamps on hit"
comment; add `ccache -c` and dashboard removal to the `always()` cleanup.

**4 — `COMP: Apply ccache and disk-cleanup hardening to macOS/Windows CI`**
Mirror the pattern to macOS.Python, Windows.Python, and Batch (8G variables
block, 3d/14d eviction, `ccache -c` + build-tree/dashboard cleanup). macOS adds
a `Free preinstalled software` step (.NET SDK, CoreSimulator runtimes).

**5 — `COMP: Build draft pull requests on the PR-triggered Azure pipelines`**
Set `drafts: true` explicitly on the four PR pipelines so the Azure default is
durable and self-documenting. `AzurePipelinesBatch.yml` keeps `pr: none` by
design (batch/coverage pipeline, not PR validation).

</details>

<!--
provenance: claude-code session 2026-06-20, ci/linux-azure-disk-management branch (history rewritten; pre-rewrite tip 6886b305a4 backed up locally as backup/pre-reorder-6478)
related_files: Testing/ContinuousIntegration/AzurePipelinesLinux.yml, AzurePipelinesLinuxPython.yml, AzurePipelinesMacOSPython.yml, AzurePipelinesWindowsPython.yml, AzurePipelinesBatch.yml
key_facts: CCACHE_MAXSIZE=8G in all five pipelines; failure eviction 14d, success 3d; ccache -c || true in always() cleanup; drafts:true on the 4 PR pipelines; Batch stays pr:none
caveat: drafts:true is the Azure GitHub default; if draft PRs still do not build, the cause is an Azure DevOps branch-policy/build-validation UI setting, not in-repo YAML
post_merge_action: Monitor first post-merge ITK.Linux.Python runs to confirm disk headroom holds
-->
