### PR TITLE
PERF: Hoist constant tensor-basis SVD out of the per-voxel DTI loop

### DIFF
--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.h
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.h
@@ -28,6 +28,7 @@
 #include "itkVectorContainer.h"
 #include "itkVectorImage.h"
 #include "ITKDiffusionTensorImageExport.h"
+#include <optional>
 
 namespace itk
 {
@@ -326,6 +327,10 @@ protected:
 private:
   /* Tensor basis coeffs */
   TensorBasisMatrixType m_TensorBasis{};
+
+  /* SVD of the constant tensor basis, computed once so the per-voxel loop reuses
+   * it via solve() instead of constructing a fresh SVD per voxel. */
+  std::optional<vnl_svd<double>> m_TensorBasisSvd{};
 
   CoefficientMatrixType m_BMatrix{};
 

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.h
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.h
@@ -28,7 +28,6 @@
 #include "itkVectorContainer.h"
 #include "itkVectorImage.h"
 #include "ITKDiffusionTensorImageExport.h"
-#include <optional>
 
 namespace itk
 {
@@ -328,9 +327,8 @@ private:
   /* Tensor basis coeffs */
   TensorBasisMatrixType m_TensorBasis{};
 
-  /* SVD of the constant tensor basis, computed once so the per-voxel loop reuses
-   * it via solve() instead of constructing a fresh SVD per voxel. */
-  std::optional<vnl_svd<double>> m_TensorBasisSvd{};
+  /* Pseudo-inverse of m_TensorBasis (dual tensor basis), precomputed in BeforeThreadedGenerateData. */
+  vnl_matrix<double> m_TensorBasisInverse{};
 
   CoefficientMatrixType m_BMatrix{};
 

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
@@ -152,10 +152,6 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
   }
 }
 
-// POTENTIAL WARNING:
-//
-// Until we fix netlib svd routines, we will need to set the number of thread
-// to 1.
 template <typename TReferenceImagePixelType,
           typename TGradientImagePixelType,
           typename TTensorPixelType,
@@ -259,14 +255,13 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
           ++(gradientItContainer[i]);
         }
 
-        const vnl_svd<double> pseudoInverseSolver{ m_TensorBasis.as_matrix() };
         if (m_NumberOfGradientDirections > 6)
         {
-          D = pseudoInverseSolver.solve(m_BMatrix * B);
+          D = m_TensorBasisSvd->solve(m_BMatrix * B);
         }
         else
         {
-          D = pseudoInverseSolver.solve(B);
+          D = m_TensorBasisSvd->solve(B);
         }
 
         tensor(0, 0) = D[0];
@@ -366,14 +361,13 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
           }
         }
 
-        const vnl_svd<double> pseudoInverseSolver{ m_TensorBasis.as_matrix() };
         if (m_NumberOfGradientDirections > 6)
         {
-          D = pseudoInverseSolver.solve(m_BMatrix * B);
+          D = m_TensorBasisSvd->solve(m_BMatrix * B);
         }
         else
         {
-          D = pseudoInverseSolver.solve(B);
+          D = m_TensorBasisSvd->solve(B);
         }
 
         tensor(0, 0) = D[0];
@@ -440,6 +434,12 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
   {
     m_TensorBasis = m_BMatrix;
   }
+
+  // The tensor basis is constant over the image, so compute its SVD once here.
+  // The per-voxel loop reuses it via solve() instead of constructing a fresh SVD
+  // per voxel, which removes redundant work and makes the loop thread-safe
+  // (solve() is const, so concurrent per-voxel calls are safe).
+  m_TensorBasisSvd.emplace(m_TensorBasis.as_matrix());
 
   m_BMatrix.inplace_transpose();
 }

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
@@ -257,11 +257,11 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
 
         if (m_NumberOfGradientDirections > 6)
         {
-          D = m_TensorBasisSvd->solve(m_BMatrix * B);
+          D = m_TensorBasisInverse * (m_BMatrix * B);
         }
         else
         {
-          D = m_TensorBasisSvd->solve(B);
+          D = m_TensorBasisInverse * B;
         }
 
         tensor(0, 0) = D[0];
@@ -363,11 +363,11 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
 
         if (m_NumberOfGradientDirections > 6)
         {
-          D = m_TensorBasisSvd->solve(m_BMatrix * B);
+          D = m_TensorBasisInverse * (m_BMatrix * B);
         }
         else
         {
-          D = m_TensorBasisSvd->solve(B);
+          D = m_TensorBasisInverse * B;
         }
 
         tensor(0, 0) = D[0];
@@ -435,11 +435,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
     m_TensorBasis = m_BMatrix;
   }
 
-  // The tensor basis is constant over the image, so compute its SVD once here.
-  // The per-voxel loop reuses it via solve() instead of constructing a fresh SVD
-  // per voxel, which removes redundant work and makes the loop thread-safe
-  // (solve() is const, so concurrent per-voxel calls are safe).
-  m_TensorBasisSvd.emplace(m_TensorBasis.as_matrix());
+  m_TensorBasisInverse = vnl_svd<double>{ m_TensorBasis.as_matrix() }.pinverse();
 
   m_BMatrix.inplace_transpose();
 }

--- a/Modules/Filtering/DiffusionTensorImage/test/CMakeLists.txt
+++ b/Modules/Filtering/DiffusionTensorImage/test/CMakeLists.txt
@@ -2,12 +2,19 @@ itk_module_test()
 set(
   ITKDiffusionTensorImageTests
   itkDiffusionTensor3DReconstructionImageFilterTest.cxx
+  itkDiffusionTensor3DReconstructionSingleImageTest.cxx
   itkDiffusionTensor3DTest.cxx
   itkTensorFractionalAnisotropyImageFilterTest.cxx
 )
 
 createtestdriver(ITKDiffusionTensorImage "${ITKDiffusionTensorImage-Test_LIBRARIES}" "${ITKDiffusionTensorImageTests}")
 
+itk_add_test(
+  NAME itkDiffusionTensor3DReconstructionSingleImageTest
+  COMMAND
+    ITKDiffusionTensorImageTestDriver
+    itkDiffusionTensor3DReconstructionSingleImageTest
+)
 itk_add_test(
   NAME itkDiffusionTensor3DTest
   COMMAND

--- a/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DReconstructionSingleImageTest.cxx
+++ b/Modules/Filtering/DiffusionTensorImage/test/itkDiffusionTensor3DReconstructionSingleImageTest.cxx
@@ -1,0 +1,139 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// Exercises the single-VectorImage gradient path (SetGradientImage), which the
+// existing reconstruction test does not cover, and verifies it produces the same
+// tensors as the multi-image path (AddGradientImage) on identical data.
+
+#include "itkDiffusionTensor3DReconstructionImageFilter.h"
+#include "itkImageRegionIterator.h"
+#include <cmath>
+#include "itkTestingMacros.h"
+
+int
+itkDiffusionTensor3DReconstructionSingleImageTest(int, char *[])
+{
+  using ReferencePixelType = short;
+  using GradientPixelType = short;
+  using TensorPrecisionType = double;
+  using FilterType =
+    itk::DiffusionTensor3DReconstructionImageFilter<ReferencePixelType, GradientPixelType, TensorPrecisionType>;
+
+  constexpr unsigned int numberOfGradientImages = 6;
+  const double           gradientDirections[numberOfGradientImages][3] = {
+    { -1.000000, 0.000000, 0.000000 },   { -0.166000, 0.986000, 0.000000 }, { 0.110000, 0.664000, 0.740000 },
+    { -0.901000, -0.419000, -0.110000 }, { 0.169000, -0.601000, 0.781000 }, { 0.815000, -0.386000, 0.433000 }
+  };
+  constexpr ReferencePixelType b0 = 100;
+  auto gradientValue = [](unsigned int i) { return static_cast<GradientPixelType>((i + 1) * (i + 1) * (i + 1)); };
+
+  using ReferenceImageType = FilterType::ReferenceImageType;
+  using RegionType = ReferenceImageType::RegionType;
+  constexpr RegionType::SizeType imageSize{ 4, 4, 4 };
+  const RegionType               region{ imageSize };
+
+  // --- Path A: multi-image (AddGradientImage) ---
+  auto multiFilter = FilterType::New();
+  {
+    auto reference = ReferenceImageType::New();
+    reference->SetRegions(region);
+    reference->Allocate();
+    reference->FillBuffer(b0);
+    multiFilter->SetReferenceImage(reference);
+    for (unsigned int i = 0; i < numberOfGradientImages; ++i)
+    {
+      using GradientImageType = FilterType::GradientImageType;
+      auto gradientImage = GradientImageType::New();
+      gradientImage->SetRegions(region);
+      gradientImage->Allocate();
+      gradientImage->FillBuffer(gradientValue(i));
+      FilterType::GradientDirectionType d;
+      d[0] = gradientDirections[i][0];
+      d[1] = gradientDirections[i][1];
+      d[2] = gradientDirections[i][2];
+      multiFilter->AddGradientImage(d, gradientImage);
+    }
+  }
+  multiFilter->SetBValue(1000.0);
+  multiFilter->Update();
+
+  // --- Path B: single VectorImage (SetGradientImage) with the SAME data ---
+  // Component 0 is the b0 baseline (direction (0,0,0)); components 1..n are the
+  // diffusion-weighted measurements.
+  auto singleFilter = FilterType::New();
+  {
+    using VectorImageType = itk::VectorImage<GradientPixelType, 3>;
+    auto vectorImage = VectorImageType::New();
+    vectorImage->SetRegions(region);
+    vectorImage->SetVectorLength(numberOfGradientImages + 1);
+    vectorImage->Allocate();
+    itk::VariableLengthVector<GradientPixelType> value(numberOfGradientImages + 1);
+    value[0] = b0;
+    for (unsigned int i = 0; i < numberOfGradientImages; ++i)
+    {
+      value[i + 1] = gradientValue(i);
+    }
+    vectorImage->FillBuffer(value);
+
+    auto                              directions = FilterType::GradientDirectionContainerType::New();
+    FilterType::GradientDirectionType zero{};
+    zero.fill(0.0);
+    directions->InsertElement(0, zero);
+    for (unsigned int i = 0; i < numberOfGradientImages; ++i)
+    {
+      FilterType::GradientDirectionType d;
+      d[0] = gradientDirections[i][0];
+      d[1] = gradientDirections[i][1];
+      d[2] = gradientDirections[i][2];
+      directions->InsertElement(i + 1, d);
+    }
+    singleFilter->SetGradientImage(directions, vectorImage);
+  }
+  singleFilter->SetBValue(1000.0);
+  singleFilter->Update();
+
+  // --- The two paths must reconstruct identical tensors ---
+  using TensorImageType = FilterType::TensorImageType;
+  itk::ImageRegionConstIterator<TensorImageType> mit(multiFilter->GetOutput(),
+                                                     multiFilter->GetOutput()->GetLargestPossibleRegion());
+  itk::ImageRegionConstIterator<TensorImageType> sit(singleFilter->GetOutput(),
+                                                     singleFilter->GetOutput()->GetLargestPossibleRegion());
+  double                                         maxDiff = 0.0;
+  constexpr double                               tolerance = 1e-8;
+  bool                                           anyNonZero = false;
+  for (mit.GoToBegin(), sit.GoToBegin(); !mit.IsAtEnd(); ++mit, ++sit)
+  {
+    for (unsigned int k = 0; k < 6; ++k)
+    {
+      maxDiff = std::max(maxDiff, std::abs(mit.Get()[k] - sit.Get()[k]));
+      anyNonZero = anyNonZero || (std::abs(sit.Get()[k]) > 1e-12);
+    }
+  }
+
+  std::cout << "SingleImage vs MultiImage max tensor difference: " << maxDiff << std::endl;
+  ITK_TEST_EXPECT_TRUE(anyNonZero);
+  if (maxDiff > tolerance)
+  {
+    std::cerr << "Single-image path disagrees with multi-image path (max diff " << maxDiff << " > " << tolerance << ')'
+              << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  std::cout << "Test finished." << std::endl;
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
`DiffusionTensor3DReconstructionImageFilter` constructed a `vnl_svd` of the constant `m_TensorBasis` **once per voxel** (~16.7M times for a 256³ DWI) to solve the Stejskal–Tanner equations. The pseudo-inverse (the dual tensor basis) is identical for every voxel, so this precomputes it once in `BeforeThreadedGenerateData` and applies it per voxel as a matrix-vector product. Since `vnl_svd::solve(X)` is `pinverse()·X`, the reconstructed tensors are unchanged. Removing the per-voxel SVD also frees the loop of the thread-unsafe netlib `dsvdc` call, so the stale single-thread warning is dropped.

<details>
<summary>Verification</summary>

`itkDiffusionTensor3DReconstructionImageFilterTest` passes (it reconstructs and checks the output tensor at voxel (3,3,3) against expected values at 1e-4). A mutation check (scaling the precomputed pseudo-inverse by 1.5) makes that test fail, confirming it exercises the changed path.

Note: the unit test exercises the `AddGradientImage` (many-images) path and the shared precompute; the `SetGradientImage` (single-image) path uses the byte-identical loop edit but has no direct unit-test coverage today.
</details>

<!--
provenance: claude-code session 2026-06-20
change: precompute pinverse of constant m_TensorBasis once; per-voxel loop becomes matvec; drop stale netlib single-thread comment
files: Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.{h,hxx}
-->
