### PR TITLE
COMP: Move ITK Python wrapping to SWIG 4.4.1

### DIFF
--- a/CMake/ITKSetPython3Vars.cmake
+++ b/CMake/ITKSetPython3Vars.cmake
@@ -58,7 +58,14 @@ else()
   set(ITK_WRAP_PYTHON_VERSION "${Python3_VERSION}")
 
   # start section to define package components based on LIMITED_API support and choices
-  set(_ITK_MINIMUM_SUPPORTED_LIMITED_API_VERSION 3.11)
+  # Cached so the abi3 floor is a single source of truth shared with the module
+  # wrapping macros (itk_end_wrap_module.cmake USE_SABI).
+  set(
+    _ITK_MINIMUM_SUPPORTED_LIMITED_API_VERSION
+    3.11
+    CACHE INTERNAL
+    "Minimum Python minor version for the abi3 / Limited API floor"
+  )
 
   # Force ITK_WRAP_PYTHON_VERSION if SKBUILD_SABI_COMPONENT requests it
   string(
@@ -173,7 +180,8 @@ else()
   endif()
   unset(_missing_required_component)
   unset(_python_find_components)
-  unset(_ITK_MINIMUM_SUPPORTED_LIMITED_API_VERSION)
+  # _ITK_MINIMUM_SUPPORTED_LIMITED_API_VERSION is cached (INTERNAL) and intentionally
+  # left set so itk_end_wrap_module.cmake can pin USE_SABI to the same floor.
   # end section to define package components based on LIMITED_API support and choices
   if(DEFINED _specified_Python3_EXECUTABLE)
     set(

--- a/Wrapping/Generators/Python/CMakeLists.txt
+++ b/Wrapping/Generators/Python/CMakeLists.txt
@@ -288,8 +288,9 @@ macro(
   endif()
 
   set(_swig_depend)
-  if(NOT ITK_USE_SYSTEM_SWIG)
-    # The ExternalProject SWIG install.
+  if(NOT ITK_USE_SYSTEM_SWIG AND TARGET swig)
+    # Build-order against the source-build ExternalProject SWIG target. Prebuilt
+    # binaries are fetched at configure time (FetchContent) and need no target.
     set(_swig_depend swig)
   endif()
 

--- a/Wrapping/Generators/Python/CMakeLists.txt
+++ b/Wrapping/Generators/Python/CMakeLists.txt
@@ -495,10 +495,48 @@ macro(itk_end_wrap_submodule_python group_name)
   PyObject * ${base_name}AlreadyImported = PyDict_GetItemString(sysModules, \"itk._${base_name}Python\");
   if(${base_name}AlreadyImported == NULL)
     {
-    PyImport_AddModule(\"itk._${base_name}Python\");
-    PyObject * ${base_name}Module = PyInit__${base_name}Python();
-    PyDict_SetItemString(sysModules, \"itk._${base_name}Python\", ${base_name}Module);
-    SWIG_Py_DECREF( ${base_name}Module);
+    PyObject * ${base_name}Init = PyInit__${base_name}Python();
+    PyObject * ${base_name}Module = ${base_name}Init;
+    if (${base_name}Init != NULL && !PyModule_Check(${base_name}Init))
+      {
+      // SWIG >= 4.4 uses PEP 489 multi-phase init: PyInit_* returns a
+      // PyModuleDef that must be instantiated against a spec, not used directly.
+      ${base_name}Module = NULL;
+      PyObject * ${base_name}Spec = NULL;
+      PyObject * ${base_name}Machinery = PyImport_ImportModule(\"importlib.machinery\");
+      if (${base_name}Machinery != NULL)
+        {
+        PyObject * ${base_name}SpecType = PyObject_GetAttrString(${base_name}Machinery, \"ModuleSpec\");
+        if (${base_name}SpecType != NULL)
+          {
+          ${base_name}Spec = PyObject_CallFunction(${base_name}SpecType, \"sO\", \"itk._${base_name}Python\", Py_None);
+          SWIG_Py_DECREF(${base_name}SpecType);
+          }
+        SWIG_Py_DECREF(${base_name}Machinery);
+        }
+      if (${base_name}Spec != NULL)
+        {
+        ${base_name}Module = PyModule_FromDefAndSpec((PyModuleDef *)${base_name}Init, ${base_name}Spec);
+        SWIG_Py_DECREF(${base_name}Spec);
+        if (${base_name}Module != NULL && PyModule_ExecDef(${base_name}Module, (PyModuleDef *)${base_name}Init) != 0)
+          {
+          // Exec failed: drop the half-initialized module so it is not cached.
+          SWIG_Py_DECREF(${base_name}Module);
+          ${base_name}Module = NULL;
+          }
+        }
+      if (${base_name}Module == NULL)
+        {
+        // Surface the init failure (prints + clears the exception) so the root
+        // cause is visible and a later submodule init is not poisoned.
+        PyErr_WriteUnraisable(${base_name}Init);
+        }
+      }
+    if (${base_name}Module != NULL)
+      {
+      PyDict_SetItemString(sysModules, \"itk._${base_name}Python\", ${base_name}Module);
+      SWIG_Py_DECREF(${base_name}Module);
+      }
     }
 "
   )

--- a/Wrapping/Generators/SwigInterface/CMakeLists.txt
+++ b/Wrapping/Generators/SwigInterface/CMakeLists.txt
@@ -23,8 +23,6 @@ mark_as_advanced(ITK_USE_SYSTEM_SWIG)
 set(swig_version_min 4.3.0)
 # Version of the vendored prebuilt binary or source build configured here.
 set(ITK_SWIG_VERSION 4.4.1)
-# Layout version of the share/swig/<dir> directory inside the vendored binary.
-set(swig_cmake_version 4.4.1)
 
 # The prebuilt binary's version is verified against swig_version_min after
 # download; the source build produces exactly ITK_SWIG_VERSION, so assert here
@@ -39,7 +37,7 @@ endif()
 # Select the prebuilt binary for this host. The vendored swig<os>-<arch>-${VER}.zip
 # archives are repackaged from the official, broadly-portable SWIG PyPI wheels
 # (manylinux / macOS universal2 / Windows) so every archive shares the same
-# bin/swig[.exe] + share/swig/${swig_cmake_version} layout. They are downloaded
+# bin/swig[.exe] + share/swig/${ITK_SWIG_VERSION} layout. They are downloaded
 # from data.kitware.com keyed by their SHA512 hash.
 set(swig_prebuilt 0)
 if(WIN32)
@@ -47,7 +45,7 @@ if(WIN32)
 else()
   set(swig_exe_subpath "bin/swig")
 endif()
-set(swig_dir_subpath "share/swig/${swig_cmake_version}")
+set(swig_dir_subpath "share/swig/${ITK_SWIG_VERSION}")
 if(WIN32)
   set(swig_prebuilt 1)
   set(
@@ -234,7 +232,7 @@ elseif(swig_prebuilt)
     if(NOT EXISTS "${SWIG_DIR}/swig.swg")
       message(
         FATAL_ERROR
-        "Vendored swig library not found at \"${SWIG_DIR}\" (expected swig.swg). The archive layout may not match share/swig/${swig_cmake_version}."
+        "Vendored swig library not found at \"${SWIG_DIR}\" (expected swig.swg). The archive layout may not match share/swig/${ITK_SWIG_VERSION}."
       )
     endif()
 

--- a/Wrapping/Generators/SwigInterface/CMakeLists.txt
+++ b/Wrapping/Generators/SwigInterface/CMakeLists.txt
@@ -20,21 +20,44 @@ option(
 mark_as_advanced(ITK_USE_SYSTEM_SWIG)
 
 # Minimal swig version
-set(swig_version_min 4.2.0)
-# Version used in vendored binary or source build configured in this file.
-set(ITK_SWIG_VERSION 2024-03-26-master)
+set(swig_version_min 4.3.0)
+# Version of the vendored prebuilt binary or source build configured here.
+set(ITK_SWIG_VERSION 4.4.1)
+# Layout version of the share/swig/<dir> directory inside the vendored binary.
+set(swig_cmake_version 4.4.1)
 
-if(WIN32)
-  set(swig_cmake_version 4.3.0)
-  set(
-    swigwin_hash
-    "cec9eeebfec7f2a8ccf7b166a11cf8dbbc5e1eacca35563e4f0882b2b261658f394f6607243813d7083e7e2a2bbec23c5cf8b4dd92ad85838c6eb971f3833715"
+# The prebuilt binary's version is verified against swig_version_min after
+# download; the source build produces exactly ITK_SWIG_VERSION, so assert here
+# that the configured version satisfies the floor for every vendored path.
+if(ITK_SWIG_VERSION VERSION_LESS swig_version_min)
+  message(
+    FATAL_ERROR
+    "ITK_SWIG_VERSION (${ITK_SWIG_VERSION}) is below the required swig_version_min (${swig_version_min})."
   )
-  set(swigwin_cid "bafybeibljxzip2irc3q3w5qlh2ae5ns27xpi7mo6iskxni45dcmwtk2x6a")
+endif()
 
+# Select the prebuilt binary for this host. The vendored swig<os>-<arch>-${VER}.zip
+# archives are repackaged from the official, broadly-portable SWIG PyPI wheels
+# (manylinux / macOS universal2 / Windows) so every archive shares the same
+# bin/swig[.exe] + share/swig/${swig_cmake_version} layout. They are downloaded
+# from data.kitware.com keyed by their SHA512 hash.
+set(swig_prebuilt 0)
+if(WIN32)
+  set(swig_exe_subpath "bin/swig.exe")
+else()
+  set(swig_exe_subpath "bin/swig")
+endif()
+set(swig_dir_subpath "share/swig/${swig_cmake_version}")
+if(WIN32)
+  set(swig_prebuilt 1)
+  set(swig_archive "swigwin-amd64")
   set(
-    swig_ep
-    "${CMAKE_CURRENT_BINARY_DIR}/swigwin-amd64-${ITK_SWIG_VERSION}/bin/swig.exe"
+    swig_archive_hash
+    "700bd4deed1abc33800efb70fd7ba7e59fc7e2b330e32e41165c942521b55ca752153558e1ccf2e5930b214db368d22b00dcfef06b07e4086e2ec55e338f3892"
+  )
+  set(
+    swig_archive_cid
+    "bafybeifxjnbydus4eq46bocwb2hcj5ufpbj4etocia5ims426gfiw7krfi"
   )
 elseif(
   CMAKE_HOST_SYSTEM_NAME
@@ -51,85 +74,104 @@ elseif(
           "aarch64"
     )
 )
-  set(swig_cmake_version 4.3.0)
+  set(swig_prebuilt 1)
   if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
+    set(swig_archive "swiglinux-arm64")
     set(
-      swiglinux_hash
-      "9a3cfa330235ac78799c7401299506db5ea7459314b781bf27f2db8ddb582508ec5b15c2fa96fc241d5b832c4f702cd9ef043a61e37a574cac7ca78e4aba8f78"
+      swig_archive_hash
+      "44a6d174c73a5f2e3ccbae4283e9888c55f88bc40df972abd27c7f041cb29cf03806067e8585fb08d01be7e858203a675f0c13d769f566a6517a0cb4c8902d24"
     )
     set(
-      swiglinux_cid
-      "bafybeiaa2xv7oxnvaz6qupdaykgwakldrmahk54n2pp2z2ianuvq57uvmy"
+      swig_archive_cid
+      "bafybeifaqaus3yzp5oujxupxk422hfmcg2idf3oyvdtsppzq7ymn64nvze"
     )
-    set(swiglinux_arch "arm64")
   else()
+    set(swig_archive "swiglinux-amd64")
     set(
-      swiglinux_hash
-      "bdf82ad5281dfdba4b24c83b0d15c76e83cd58c6c78ecfc7a449f869f524d12fad9ad7f517995f864c2c00e61e7cd04132a442038197b92821b4011673a7d4fe"
+      swig_archive_hash
+      "6447a7b965077ceec0980daabe8628cc88fe1956bb2488a9edf569ad25ab8aa9ba2b568f4384e9dc3a213d58bc330e9d585f806461eb826ee2340b450d88ca11"
     )
     set(
-      swiglinux_cid
-      "bafybeihp7hk4ljxuf7duqzei2h7y7xshzyhahxaot5mapv2xevkvwuci5m"
+      swig_archive_cid
+      "bafybeiep2wbecrcii7xzfe2cekhfco6mlxqym4jhfdl6xi3p4aieblgz6m"
     )
-    set(swiglinux_arch "amd64")
   endif()
-
-  set(
-    swig_ep
-    "${CMAKE_CURRENT_BINARY_DIR}/swiglinux-${swiglinux_arch}-${ITK_SWIG_VERSION}/bin/swig"
-  )
 elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
-  set(swig_cmake_version 4.3.0)
+  set(swig_prebuilt 1)
+  # macOS archives are the universal2 (x86_64 + arm64) wheel; both host
+  # architectures resolve to the same content.
   if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")
-    set(
-      swigmacos_hash
-      "96eec93fd9e1df35813f8cc194a8811c8c84f265284c1515ec81aa7e696aee2c952f426e5155c011c163376e76245f5d7f479525f0d1ea8396524629ed6b8aec"
-    )
-    set(
-      swigmacos_cid
-      "bafybeialov6ur5q2yli4mtclrvqoirk2nsteum3vgnswjypquwejwomxnm"
-    )
-    set(swigmacos_arch "arm64")
+    set(swig_archive "swigmacos-arm64")
   else()
-    set(
-      swigmacos_hash
-      "169760d2a34c2a95a907e80d93c1dc7ebc33a7dd34eb7ed7a9841866db3e25f7d7e93bf49ea28db01843aca5c2c6712756c1f01f6531d6ee027dc6eb293d95d7"
-    )
-    set(
-      swigmacos_cid
-      "bafybeifkl5wfscum7pnsjdmwhshrv5v6srilinkrftunq5g4gqzgqmyqf4"
-    )
-    set(swigmacos_arch "amd64")
+    set(swig_archive "swigmacos-amd64")
   endif()
-
   set(
-    swig_ep
-    "${CMAKE_CURRENT_BINARY_DIR}/swigmacos-${swigmacos_arch}-${ITK_SWIG_VERSION}/bin/swig"
+    swig_archive_hash
+    "17c4637d49ab26dfe3442d668a6fc95068b9ee4a743fa45a90448bf28062bf4554b7fc4eeb4b8c19b620677e4017ae4491b59b7629a9eb11af4d6d191ce3cef9"
   )
-else()
-  # Build from source
-
   set(
-    swig_hash
-    "9292f6786abed379278b8024f91b91f293f1be9764fe3c1a19023f7891c4e40587f965680ac6a595a5610cfb6650a73fd2f3932a83d5effad83f351fa70810a9"
+    swig_archive_cid
+    "bafybeidllsbllkqwoby6r5w4ueqzky2o7r6qkjbh45q57mczyh2fwfwd3q"
   )
-  set(swig_cid "bafybeib56uexrqtccgzxjgmlammjii5ntwush4732kbkr6okbtjhzcmvia")
-
-  # follow the standard EP_PREFIX locations
-  set(swig_binary_dir ${CMAKE_CURRENT_BINARY_DIR}/swig-prefix/src/swig-build)
-  set(swig_source_dir ${CMAKE_CURRENT_BINARY_DIR}/swig-prefix/src/swig)
-  set(swig_install_dir ${CMAKE_CURRENT_BINARY_DIR}/swig)
-
-  set(swig_ep "${swig_install_dir}/bin/swig")
 endif()
 
+# Assert a prebuilt/system swig satisfies swig_version_min at configure time, so
+# a wrong or corrupt upload fails here rather than thousands of lines into the
+# build.
+function(itk_assert_swig_version _swig_exe _min_version)
+  execute_process(
+    COMMAND
+      "${_swig_exe}" -version
+    OUTPUT_VARIABLE _swig_version_output
+    ERROR_VARIABLE _swig_version_error
+    RESULT_VARIABLE _swig_version_result
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if(NOT _swig_version_result EQUAL 0)
+    message(
+      FATAL_ERROR
+      "Failed to run vendored swig \"${_swig_exe}\": ${_swig_version_output}${_swig_version_error}"
+    )
+  endif()
+  # The captured group is read from CMAKE_MATCH_1; the match output is unused.
+  string(
+    REGEX
+    MATCH
+    "SWIG Version ([0-9]+\\.[0-9]+\\.[0-9]+)"
+    _
+    "${_swig_version_output}"
+  )
+  if(NOT CMAKE_MATCH_1)
+    message(
+      FATAL_ERROR
+      "Could not parse SWIG version from: ${_swig_version_output}"
+    )
+  endif()
+  if(CMAKE_MATCH_1 VERSION_LESS _min_version)
+    message(
+      FATAL_ERROR
+      "Vendored SWIG ${CMAKE_MATCH_1} is older than the required ${_min_version}."
+    )
+  endif()
+  message(STATUS "Using vendored SWIG ${CMAKE_MATCH_1} (${_swig_exe})")
+endfunction()
+
 if(ITK_USE_SYSTEM_SWIG)
-  # the path set for the EP build prevents find_package to do its job
-  if("${SWIG_EXECUTABLE}" STREQUAL "${swig_ep}")
+  # A cached executable from a prior prebuilt download lives under the build
+  # tree and would prevent find_package from doing its job. Use a literal
+  # substring test (not MATCHES, which treats the path as a regex).
+  string(
+    FIND
+    "${SWIG_EXECUTABLE}"
+    "${CMAKE_CURRENT_BINARY_DIR}"
+    _swig_executable_in_build_tree
+  )
+  if(NOT _swig_executable_in_build_tree EQUAL -1)
     unset(SWIG_DIR CACHE)
     unset(SWIG_EXECUTABLE CACHE)
     unset(SWIG_VERSION CACHE)
   endif()
+  unset(_swig_executable_in_build_tree)
 
   # Look for system swig
   find_package(SWIG REQUIRED)
@@ -137,20 +179,94 @@ if(ITK_USE_SYSTEM_SWIG)
   # Check for the swig version
   if(${SWIG_VERSION} VERSION_LESS ${swig_version_min})
     message(
-      WARNING
-      "Swig version less than ${swig_version_min}: \"${SWIG_VERSION}\"."
+      FATAL_ERROR
+      "Swig version less than ${swig_version_min}: \"${SWIG_VERSION}\". Set ITK_USE_SYSTEM_SWIG=OFF or provide a newer swig."
     )
   endif()
-else()
-  if(NOT TARGET swig)
-    # Install swig ourselves
+elseif(swig_prebuilt)
+  # Download and extract the prebuilt swig binary at configure time via
+  # FetchContent so SWIG_EXECUTABLE exists immediately and can be verified.
+  # Re-fetch if the cached path no longer exists (e.g. _deps was cleaned but
+  # CMakeCache.txt kept).
+  if(NOT SWIG_EXECUTABLE OR NOT EXISTS "${SWIG_EXECUTABLE}")
     set(SWIG_VERSION ${ITK_SWIG_VERSION})
+
+    if(ITK_BINARY_DIR)
+      itk_download_attempt_check(SWIG)
+    endif()
+
+    include(FetchContent)
+    # DOWNLOAD_EXTRACT_TIMESTAMP requires CMake >= 3.24.
+    if(${CMAKE_VERSION} VERSION_LESS 3.24)
+      set(swig_extract_timestamp)
+    else()
+      set(
+        swig_extract_timestamp
+        DOWNLOAD_EXTRACT_TIMESTAMP
+        TRUE
+      )
+    endif()
+
+    # data.kitware.com (keyed by SHA512) is the primary; ITKTestingData serves the
+    # same bytes by content id over the GitHub Pages CDN, and the IPFS gateways
+    # provide further fallback once pinned. URL_HASH validates whichever responds.
+    FetchContent_Declare(
+      itkswig
+      URL
+        "https://data.kitware.com/api/v1/file/hashsum/sha512/${swig_archive_hash}/download"
+        "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/${swig_archive_cid}"
+        "https://dweb.link/ipfs/${swig_archive_cid}"
+        "https://ipfs.io/ipfs/${swig_archive_cid}"
+        "https://gateway.pinata.cloud/ipfs/${swig_archive_cid}"
+      URL_HASH SHA512=${swig_archive_hash}
+      ${swig_extract_timestamp}
+    )
+    FetchContent_MakeAvailable(itkswig)
+
+    set(
+      SWIG_EXECUTABLE
+      "${itkswig_SOURCE_DIR}/${swig_exe_subpath}"
+      CACHE FILEPATH
+      "swig executable."
+      FORCE
+    )
+    set(
+      SWIG_DIR
+      "${itkswig_SOURCE_DIR}/${swig_dir_subpath}"
+      CACHE FILEPATH
+      "swig directory."
+      FORCE
+    )
+    mark_as_advanced(SWIG_DIR)
+
+    if(NOT EXISTS "${SWIG_DIR}/swig.swg")
+      message(
+        FATAL_ERROR
+        "Vendored swig library not found at \"${SWIG_DIR}\" (expected swig.swg). The archive layout may not match share/swig/${swig_cmake_version}."
+      )
+    endif()
+
+    itk_assert_swig_version("${SWIG_EXECUTABLE}" ${swig_version_min})
+  endif()
+  mark_as_advanced(SWIG_EXECUTABLE)
+else()
+  # No prebuilt binary for this host: build swig from source.
+  if(NOT TARGET swig)
+    set(SWIG_VERSION ${ITK_SWIG_VERSION})
+
+    set(
+      swig_hash
+      "5ca61bd3eac0b3c6a3196afdfc2c4f40d3dce5d626b29543ba5f16560efada1c38b7f53184f79e983b32a0c0ebc26e63fe035b5680fcea0ba9a1de6aa33550c7"
+    )
+    set(swig_cid "bafybeignhqa2zcb3x4dykjgw6h3ghxxkkd3jh5jn4yxd3uhu7u6mxbf5mi")
+    set(swig_install_dir ${CMAKE_CURRENT_BINARY_DIR}/swig)
+    set(swig_ep "${swig_install_dir}/bin/swig")
 
     include(ExternalProject)
 
-    # Set the timestamps of the extracted files to their archived
-    # timestamps. Necessary to build configure/autoconf-based
-    # projects such as SWIG and PCRE robustly.
+    # Set the timestamps of the extracted files to their archived timestamps.
+    # Necessary to build configure/autoconf-based projects such as SWIG and
+    # PCRE robustly.
     if(${CMAKE_VERSION} VERSION_LESS 3.24)
       set(download_extract_timestamp_flag)
     else()
@@ -161,181 +277,80 @@ else()
       )
     endif()
 
-    if(WIN32)
-      # If we are building ITK
-      if(ITK_BINARY_DIR)
-        itk_download_attempt_check(SWIG)
-      endif()
-      ExternalProject_Add(
-        swig
-        URL
-          "https://data.kitware.com/api/v1/file/hashsum/sha512/${swigwin_hash}/download"
-          "https://dweb.link/ipfs/${swigwin_cid}/swigwin-amd64-${SWIG_VERSION}.zip"
-          "https://itk.mypinata.cloud/ipfs/${swigwin_cid}/swigwin-amd64-${SWIG_VERSION}.zip"
-          "https://w3s.link/ipfs/${swigwin_cid}/swigwin-amd64-${SWIG_VERSION}.zip"
-        URL_HASH SHA512=${swigwin_hash}
-        SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/swigwin-amd64-${SWIG_VERSION}
-        CONFIGURE_COMMAND
-          ""
-        BUILD_COMMAND
-          ""
-        INSTALL_COMMAND
-          "" ${download_extract_timestamp_flag}
+    # If we are building ITK
+    if(ITK_BINARY_DIR)
+      itk_download_attempt_check(PCRE)
+    endif()
+    set(compiler_information)
+    if(NOT CMAKE_CROSSCOMPILING)
+      set(
+        CMAKE_CXX_COMPILER_LAUNCHER_FLAG
+        -DCMAKE_CXX_COMPILER_LAUNCHER:FILEPATH=${CMAKE_CXX_COMPILER_LAUNCHER}
       )
       set(
-        SWIG_DIR
-        ${CMAKE_CURRENT_BINARY_DIR}/swigwin-amd64-${SWIG_VERSION}/bin
-      )
-    elseif(
-      CMAKE_HOST_SYSTEM_NAME
-        MATCHES
-        "Linux"
-      AND
-        (
-          CMAKE_HOST_SYSTEM_PROCESSOR
-            STREQUAL
-            "x86_64"
-          OR
-            CMAKE_HOST_SYSTEM_PROCESSOR
-              STREQUAL
-              "aarch64"
-        )
-    )
-      # If we are building ITK
-      if(ITK_BINARY_DIR)
-        itk_download_attempt_check(SWIG)
-      endif()
-      ExternalProject_Add(
-        swig
-        URL
-          "https://data.kitware.com/api/v1/file/hashsum/sha512/${swiglinux_hash}/download"
-          "https://dweb.link/ipfs/${swiglinux_cid}/swiglinux-${swiglinux_arch}-${SWIG_VERSION}.zip"
-          "https://itk.mypinata.cloud/ipfs/${swiglinux_cid}/swiglinux-${swiglinux_arch}-${SWIG_VERSION}.zip"
-          "https://w3s.link/ipfs/${swiglinux_cid}/swiglinux-${swiglinux_arch}-${SWIG_VERSION}.zip"
-        URL_HASH SHA512=${swiglinux_hash}
-        SOURCE_DIR
-          ${CMAKE_CURRENT_BINARY_DIR}/swiglinux-${swiglinux_arch}-${SWIG_VERSION}
-        CONFIGURE_COMMAND
-          ""
-        BUILD_COMMAND
-          ""
-        INSTALL_COMMAND
-          "" ${download_extract_timestamp_flag}
+        CMAKE_C_COMPILER_LAUNCHER_FLAG
+        -DCMAKE_C_COMPILER_LAUNCHER:FILEPATH=${CMAKE_C_COMPILER_LAUNCHER}
       )
       set(
-        SWIG_DIR
-        ${CMAKE_CURRENT_BINARY_DIR}/swiglinux-${swiglinux_arch}-${SWIG_VERSION}/share/swig/${swig_cmake_version}
-        CACHE FILEPATH
-        "swig directory."
-      )
-    elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
-      # If we are building ITK
-      if(ITK_BINARY_DIR)
-        itk_download_attempt_check(SWIG)
-      endif()
-      ExternalProject_Add(
-        swig
-        URL
-          "https://data.kitware.com/api/v1/file/hashsum/sha512/${swigmacos_hash}/download"
-          "https://dweb.link/ipfs/${swigmacos_cid}/swigmacos-${swigmacos_arch}-${SWIG_VERSION}.zip"
-          "https://itk.mypinata.cloud/ipfs/${swigmacos_cid}/swigmacos-${swigmacos_arch}-${SWIG_VERSION}.zip"
-          "https://w3s.link/ipfs/${swigmacos_cid}/swigmacos-${swigmacos_arch}-${SWIG_VERSION}.zip"
-        URL_HASH SHA512=${swigmacos_hash}
-        SOURCE_DIR
-          ${CMAKE_CURRENT_BINARY_DIR}/swigmacos-${swigmacos_arch}-${SWIG_VERSION}
-        CONFIGURE_COMMAND
-          ""
-        BUILD_COMMAND
-          ""
-        INSTALL_COMMAND
-          "" ${download_extract_timestamp_flag}
-      )
-      set(
-        SWIG_DIR
-        ${CMAKE_CURRENT_BINARY_DIR}/swigmacos-${swigmacos_arch}-${SWIG_VERSION}/share/swig/${swig_cmake_version}
-        CACHE FILEPATH
-        "swig directory."
-      )
-    else()
-      # build swig as an external project
-
-      # If we are building ITK
-      if(ITK_BINARY_DIR)
-        itk_download_attempt_check(PCRE)
-      endif()
-      set(compiler_information)
-      if(NOT CMAKE_CROSSCOMPILING)
-        set(
-          CMAKE_CXX_COMPILER_LAUNCHER_FLAG
-          -DCMAKE_CXX_COMPILER_LAUNCHER:FILEPATH=${CMAKE_CXX_COMPILER_LAUNCHER}
-        )
-        set(
-          CMAKE_C_COMPILER_LAUNCHER_FLAG
-          -DCMAKE_C_COMPILER_LAUNCHER:FILEPATH=${CMAKE_C_COMPILER_LAUNCHER}
-        )
-        set(
-          compiler_information
-          -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
-          ${CMAKE_CXX_COMPILER_LAUNCHER_FLAG}
-          "-DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS} -w"
-          -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
-          ${CMAKE_C_COMPILER_LAUNCHER_FLAG}
-          "-DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS} -w"
-        )
-      endif()
-      set(
-        pcre_hash
-        "e1183226ea3e56a1c7ec97e2c7d7ad5a163b9b576930c997e6ac4c26f1c92fc7e9491b5b297b1dd68d43432f7fbbddcc6207a189beb37ef158ad68bad5598988"
-      )
-      set(
-        pcre_cid
-        "bafybeicnpyjts3vq4lpdfhktr5qioq4qdifmtjkbemyyqpkayxjsqtwz74"
-      )
-      ExternalProject_Add(
-        PCRE
-        URL
-          "https://data.kitware.com/api/v1/file/hashsum/sha512/${pcre_hash}/download"
-          "https://dweb.link/ipfs/${pcre_cid}/pcre-10.43.tar.gz"
-          "https://itk.pinata.cloud/ipfs/${pcre_cid}/pcre-10.43.tar.gz"
-          "https://w3s.link/ipfs/${pcre_cid}/pcre-10.43.tar.gz"
-        URL_HASH SHA512=${pcre_hash}
-        CMAKE_GENERATOR "${CMAKE_GENERATOR}"
-        CMAKE_CACHE_ARGS
-          ${compiler_information} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-          -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
-        INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/PCRE2
-        ${download_extract_timestamp_flag}
-      )
-
-      # swig uses bison find it by cmake and pass it down
-      find_package(BISON)
-      set(BISON_FLAGS "" CACHE STRING "Flags used by bison")
-      mark_as_advanced(BISON_FLAGS)
-
-      # If we are building ITK
-      if(ITK_BINARY_DIR)
-        itk_download_attempt_check(SWIG)
-      endif()
-
-      ExternalProject_Add(
-        swig
-        URL
-          "https://data.kitware.com/api/v1/file/hashsum/sha512/${swig_hash}/download"
-          "https://dweb.link/ipfs/${swig_cid}/swig-4.0.2.tar.gz"
-          "https://itk.pinata.cloud/ipfs/${swig_cid}/swig-4.0.2.tar.gz"
-          "https://w3s.link/ipfs/${swig_cid}/swig-4.0.2.tar.gz"
-        URL_HASH SHA512=${swig_hash}
-        CMAKE_GENERATOR "${CMAKE_GENERATOR}"
-        CMAKE_CACHE_ARGS
-          ${compiler_information} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-          -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
-          -DPCRE2_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/PCRE2
-        INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/swig
-        DEPENDS
-          PCRE
-          ${download_extract_timestamp_flag}
+        compiler_information
+        -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
+        ${CMAKE_CXX_COMPILER_LAUNCHER_FLAG}
+        "-DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS} -w"
+        -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+        ${CMAKE_C_COMPILER_LAUNCHER_FLAG}
+        "-DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS} -w"
       )
     endif()
+    set(
+      pcre_hash
+      "e1183226ea3e56a1c7ec97e2c7d7ad5a163b9b576930c997e6ac4c26f1c92fc7e9491b5b297b1dd68d43432f7fbbddcc6207a189beb37ef158ad68bad5598988"
+    )
+    set(pcre_cid "bafybeicnpyjts3vq4lpdfhktr5qioq4qdifmtjkbemyyqpkayxjsqtwz74")
+    ExternalProject_Add(
+      PCRE
+      URL
+        "https://data.kitware.com/api/v1/file/hashsum/sha512/${pcre_hash}/download"
+        "https://dweb.link/ipfs/${pcre_cid}/pcre-10.43.tar.gz"
+        "https://itk.pinata.cloud/ipfs/${pcre_cid}/pcre-10.43.tar.gz"
+        "https://w3s.link/ipfs/${pcre_cid}/pcre-10.43.tar.gz"
+      URL_HASH SHA512=${pcre_hash}
+      CMAKE_GENERATOR "${CMAKE_GENERATOR}"
+      CMAKE_CACHE_ARGS
+        ${compiler_information} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+        -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+      INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/PCRE2
+      ${download_extract_timestamp_flag}
+    )
+
+    # swig uses bison find it by cmake and pass it down
+    find_package(BISON)
+    set(BISON_FLAGS "" CACHE STRING "Flags used by bison")
+    mark_as_advanced(BISON_FLAGS)
+
+    # If we are building ITK
+    if(ITK_BINARY_DIR)
+      itk_download_attempt_check(SWIG)
+    endif()
+
+    ExternalProject_Add(
+      swig
+      URL
+        "https://data.kitware.com/api/v1/file/hashsum/sha512/${swig_hash}/download"
+        "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/${swig_cid}"
+        "https://dweb.link/ipfs/${swig_cid}"
+        "https://ipfs.io/ipfs/${swig_cid}"
+        "https://gateway.pinata.cloud/ipfs/${swig_cid}"
+      URL_HASH SHA512=${swig_hash}
+      CMAKE_GENERATOR "${CMAKE_GENERATOR}"
+      CMAKE_CACHE_ARGS
+        ${compiler_information} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+        -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+        -DPCRE2_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/PCRE2
+      INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/swig
+      ${download_extract_timestamp_flag}
+      DEPENDS
+        PCRE
+    )
 
     set(
       SWIG_DIR

--- a/Wrapping/Generators/SwigInterface/CMakeLists.txt
+++ b/Wrapping/Generators/SwigInterface/CMakeLists.txt
@@ -50,7 +50,6 @@ endif()
 set(swig_dir_subpath "share/swig/${swig_cmake_version}")
 if(WIN32)
   set(swig_prebuilt 1)
-  set(swig_archive "swigwin-amd64")
   set(
     swig_archive_hash
     "700bd4deed1abc33800efb70fd7ba7e59fc7e2b330e32e41165c942521b55ca752153558e1ccf2e5930b214db368d22b00dcfef06b07e4086e2ec55e338f3892"
@@ -76,7 +75,6 @@ elseif(
 )
   set(swig_prebuilt 1)
   if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
-    set(swig_archive "swiglinux-arm64")
     set(
       swig_archive_hash
       "44a6d174c73a5f2e3ccbae4283e9888c55f88bc40df972abd27c7f041cb29cf03806067e8585fb08d01be7e858203a675f0c13d769f566a6517a0cb4c8902d24"
@@ -86,7 +84,6 @@ elseif(
       "bafybeifaqaus3yzp5oujxupxk422hfmcg2idf3oyvdtsppzq7ymn64nvze"
     )
   else()
-    set(swig_archive "swiglinux-amd64")
     set(
       swig_archive_hash
       "6447a7b965077ceec0980daabe8628cc88fe1956bb2488a9edf569ad25ab8aa9ba2b568f4384e9dc3a213d58bc330e9d585f806461eb826ee2340b450d88ca11"
@@ -98,13 +95,8 @@ elseif(
   endif()
 elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
   set(swig_prebuilt 1)
-  # macOS archives are the universal2 (x86_64 + arm64) wheel; both host
+  # macOS archive is the universal2 (x86_64 + arm64) wheel; both host
   # architectures resolve to the same content.
-  if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")
-    set(swig_archive "swigmacos-arm64")
-  else()
-    set(swig_archive "swigmacos-amd64")
-  endif()
   set(
     swig_archive_hash
     "17c4637d49ab26dfe3442d668a6fc95068b9ee4a743fa45a90448bf28062bf4554b7fc4eeb4b8c19b620677e4017ae4491b59b7629a9eb11af4d6d191ce3cef9"

--- a/Wrapping/Generators/SwigInterface/CMakeLists.txt
+++ b/Wrapping/Generators/SwigInterface/CMakeLists.txt
@@ -105,6 +105,22 @@ elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
   )
 endif()
 
+# Emit the canonical mirror URL list for a content-addressed archive:
+# data.kitware.com (keyed by SHA512) primary, then ITKTestingData over the
+# GitHub Pages CDN and the IPFS gateways by content id. URL_HASH validates
+# whichever responds.
+function(itk_swig_mirror_urls _out_var _hash _cid)
+  set(
+    ${_out_var}
+    "https://data.kitware.com/api/v1/file/hashsum/sha512/${_hash}/download"
+    "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/${_cid}"
+    "https://dweb.link/ipfs/${_cid}"
+    "https://ipfs.io/ipfs/${_cid}"
+    "https://gateway.pinata.cloud/ipfs/${_cid}"
+    PARENT_SCOPE
+  )
+endfunction()
+
 # Assert a prebuilt/system swig satisfies swig_version_min at configure time, so
 # a wrong or corrupt upload fails here rather than thousands of lines into the
 # build.
@@ -197,17 +213,11 @@ elseif(swig_prebuilt)
       )
     endif()
 
-    # data.kitware.com (keyed by SHA512) is the primary; ITKTestingData serves the
-    # same bytes by content id over the GitHub Pages CDN, and the IPFS gateways
-    # provide further fallback once pinned. URL_HASH validates whichever responds.
+    itk_swig_mirror_urls(swig_urls "${swig_archive_hash}" "${swig_archive_cid}")
     FetchContent_Declare(
       itkswig
       URL
-        "https://data.kitware.com/api/v1/file/hashsum/sha512/${swig_archive_hash}/download"
-        "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/${swig_archive_cid}"
-        "https://dweb.link/ipfs/${swig_archive_cid}"
-        "https://ipfs.io/ipfs/${swig_archive_cid}"
-        "https://gateway.pinata.cloud/ipfs/${swig_archive_cid}"
+        ${swig_urls}
       URL_HASH SHA512=${swig_archive_hash}
       ${swig_extract_timestamp}
     )
@@ -228,16 +238,17 @@ elseif(swig_prebuilt)
       FORCE
     )
     mark_as_advanced(SWIG_DIR)
-
-    if(NOT EXISTS "${SWIG_DIR}/swig.swg")
-      message(
-        FATAL_ERROR
-        "Vendored swig library not found at \"${SWIG_DIR}\" (expected swig.swg). The archive layout may not match share/swig/${ITK_SWIG_VERSION}."
-      )
-    endif()
-
-    itk_assert_swig_version("${SWIG_EXECUTABLE}" ${swig_version_min})
   endif()
+
+  # Verify on every configure, not only when downloading, so a stale cached
+  # SWIG_EXECUTABLE (e.g. an older prebuilt left in _deps) is still caught.
+  if(NOT EXISTS "${SWIG_DIR}/swig.swg")
+    message(
+      FATAL_ERROR
+      "Vendored swig library not found at \"${SWIG_DIR}\" (expected swig.swg). The archive layout may not match share/swig/${ITK_SWIG_VERSION}."
+    )
+  endif()
+  itk_assert_swig_version("${SWIG_EXECUTABLE}" ${swig_version_min})
   mark_as_advanced(SWIG_EXECUTABLE)
 else()
   # No prebuilt binary for this host: build swig from source.
@@ -322,14 +333,11 @@ else()
       itk_download_attempt_check(SWIG)
     endif()
 
+    itk_swig_mirror_urls(swig_source_urls "${swig_hash}" "${swig_cid}")
     ExternalProject_Add(
       swig
       URL
-        "https://data.kitware.com/api/v1/file/hashsum/sha512/${swig_hash}/download"
-        "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/${swig_cid}"
-        "https://dweb.link/ipfs/${swig_cid}"
-        "https://ipfs.io/ipfs/${swig_cid}"
-        "https://gateway.pinata.cloud/ipfs/${swig_cid}"
+        ${swig_source_urls}
       URL_HASH SHA512=${swig_hash}
       CMAKE_GENERATOR "${CMAKE_GENERATOR}"
       CMAKE_CACHE_ARGS

--- a/Wrapping/macro_files/itk_end_wrap_module.cmake
+++ b/Wrapping/macro_files/itk_end_wrap_module.cmake
@@ -487,7 +487,7 @@ ${DO_NOT_WAIT_FOR_THREADS_CALLS}
       set(
         _Python3_ABI_SETTINGS
         USE_SABI
-        ${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}
+        ${_ITK_MINIMUM_SUPPORTED_LIMITED_API_VERSION}
         WITH_SOABI
       )
     else()

--- a/pixi.lock
+++ b/pixi.lock
@@ -1591,6 +1591,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.5-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.11.0-h4d9bdce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/castxml-0.7.0-hde8d07d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.1.2-hc85cc9f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-14.3.0-hb991d5c_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.11.0-hfcd1e18_0.conda
@@ -1600,11 +1601,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-14.3.0-he448592_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-he663afc_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-h95f728e_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-h1aa0949_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-38_h4a7cf45_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-38_h0358290_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.8-default_h99862b1_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.16.0-h4e3cde8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
@@ -1615,7 +1618,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-hcd61629_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-h767d61c_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-38_h47877c9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.8-hf7376ad_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
@@ -1627,14 +1632,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-h4852527_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-hca6bf5a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-he237659_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.13.1-h171cf75_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.3.4-py313hf6604e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.4-h26f9b46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.9-hc97d973_101_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/swig-4.4.1-h7a96c5f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.10.5-hbd8a1cb_0.conda
@@ -1661,6 +1670,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.5-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.11.0-hdceaead_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/castxml-0.7.0-ha3e84ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-4.1.2-hc9d863e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-gcc-specs-14.3.0-h92dcf8a_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.11.0-h7b35c40_0.conda
@@ -1670,11 +1680,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-14.3.0-ha28f942_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-14.3.0-h72695c8_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-14.3.0-hda493e9_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.44-hd32f0e1_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-38_haddc8a3_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-38_hd72aa62_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp20.1-20.1.8-default_he95a3c9_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.16.0-h7bfdcfb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
@@ -1685,7 +1697,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h87db57e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-he277a41_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-38_h88aeb00_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm20-20.1.8-hfd2ba90_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.1-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmpdec-4.0.0-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.67.0-ha888d0e_0.conda
@@ -1697,14 +1711,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hf1166c9_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.41.2-h3e4203c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.51.0-he30d5cf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-16-2.15.1-h79dcc73_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.15.1-h825857f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.13.1-hdc560ac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.3.4-py313h11e5ff7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.5.4-h8e36d6e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.13.9-h4c0d347_101_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8382b9d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.6-h86ecc28_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/swig-4.4.1-h512d76c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h5688188_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-hbcf94c1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.10.5-hbd8a1cb_0.conda
@@ -1740,6 +1758,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_8.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.5-hf13058a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.11.0-h7a00415_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/castxml-0.7.0-hb171174_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools-1024.3-h67a6458_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-1024.3-llvm19_1_h3b512aa_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-19-19.1.7-default_hc369343_5.conda
@@ -1758,6 +1777,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-38_he492b99_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-38_h9b27e0a_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp19.1-19.1.7-default_hc369343_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp20.1-20.1.8-default_h9399c5b_16.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.16.0-h7dd4100_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-21.1.4-h3d58e20_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-devel-19.1.7-h7c275be_1.conda
@@ -1770,6 +1790,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h57a12c2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-38_h859234e_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm19-19.1.7-h56e7563_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm20-20.1.8-h56e7563_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.1-hd471939_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-h6e16a3a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.67.0-h3338091_0.conda
@@ -1787,10 +1808,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.13.1-h0ba0a54_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.3.4-py313ha99c057_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.5.4-h230baf5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.9-h17c18a5_101_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h7cca4af_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rhash-1.4.6-h6e16a3a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/swig-4.4.1-hdac4ec2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hf689a15_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h8210216_2.conda
@@ -1811,6 +1834,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.5-h5505292_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.11.0-h61f9b84_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/castxml-0.7.0-hfc9ce51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-1024.3-hd01ab73_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-1024.3-llvm19_1_h8c76c84_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-19-19.1.7-default_h73dfc95_5.conda
@@ -1830,6 +1854,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-38_h51639a9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-38_hb0561ab_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp19.1-19.1.7-default_h73dfc95_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp20.1-20.1.8-default_hf3020a7_16.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.16.0-hdece5d2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.4-hf598326_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-devel-19.1.7-h6dc3340_1.conda
@@ -1842,6 +1867,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-38_hd9741b5_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm19-19.1.7-h8e0c9ce_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm20-20.1.8-h8e0c9ce_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h5505292_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.67.0-hc438710_0.conda
@@ -1859,10 +1885,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.13.1-h4f10f1e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.3.4-py313h9771d21_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.4-h5503f6c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.9-hfc2f54d_101_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.6-h5505292_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/swig-4.4.1-h4366dc5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
@@ -1882,6 +1910,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/vswhere-3.1.7-h40126e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/castxml-0.7.0-ha22e26b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cmake-4.1.2-hdcbee5b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.11.0-h1c1089f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
@@ -1911,7 +1940,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/ninja-1.13.1-h477610d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.3.4-py313hce7ae62_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.5.4-h725018a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.47-hd2b5f0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.9-h09917c8_101_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/swig-4.4.1-h9b0202b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2022.3.0-hd094cb3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
@@ -2154,6 +2185,20 @@ packages:
   license: LGPL-2.1-only or MPL-1.1
   size: 978114
   timestamp: 1741554591855
+- conda: https://conda.anaconda.org/conda-forge/linux-64/castxml-0.7.0-hde8d07d_0.conda
+  sha256: f5fa7216baac5b21c13e834e4b176f940621abcf56b9b00f559bdf88644706fa
+  md5: 710546db9e8bcdc45c5c7221b2d203c4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - libllvm20 >=20.1.8,<20.2.0a0
+  - libclang-cpp20.1 >=20.1.8,<20.2.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 1020766
+  timestamp: 1772089430517
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ccache-4.13.6-hedf47ba_0.conda
   sha256: 552639ac2f3d28d93053fa91cd828186730d9ae0a4d7c1dcc40efe8d7cd026ce
   md5: d66e791d7524770340296e9d34e7f324
@@ -2629,6 +2674,9 @@ packages:
   - libstdcxx >=14
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - icu >=78.3,<79.0a0
   size: 12723451
   timestamp: 1773822285671
 - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
@@ -2781,6 +2829,21 @@ packages:
   license_family: BSD
   size: 17503
   timestamp: 1761680091587
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.8-default_h99862b1_16.conda
+  sha256: 83ef7425c3c5c5b179b6d5accb57acfe1ddf16010727afc642be484b4526044e
+  md5: ff256a40b66a4b6968075efd741523d5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libllvm20 >=20.1.8,<20.2.0a0
+  - libstdcxx >=14
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports:
+    weak:
+    - libclang-cpp20.1 >=20.1.8,<20.2.0a0
+  size: 21300452
+  timestamp: 1779374233040
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
   sha256: 205c4f19550f3647832ec44e35e6d93c8c206782bdd620c1d7cf66237580ff9c
   md5: 49c553b47ff679a6a1e9fc80b9c5a2d4
@@ -3152,6 +3215,9 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   license: LGPL-2.1-only
+  run_exports:
+    weak:
+    - libiconv >=1.18,<2.0a0
   size: 790176
   timestamp: 1754908768807
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
@@ -3179,6 +3245,24 @@ packages:
   license_family: BSD
   size: 17501
   timestamp: 1761680098660
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.8-hf7376ad_1.conda
+  sha256: bd2981488f63afbc234f6c7759f8363c63faf38dd0f4e64f48ef5a06541c12b4
+  md5: eafa8fd1dfc9a107fe62f7f12cabbc9c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxml2
+  - libxml2-16 >=2.14.5
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports:
+    weak:
+    - libllvm20 >=20.1.8,<20.2.0a0
+  size: 43977914
+  timestamp: 1757353652788
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
   sha256: f2591c0069447bbe28d4d696b7fcb0c5bd0b4ac582769b89addbcf26fb3430d8
   md5: 1a580f7796c7bf6393fddb8bbbde58dc
@@ -3530,6 +3614,23 @@ packages:
   license_family: MIT
   size: 556302
   timestamp: 1761015637262
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-hca6bf5a_1.conda
+  sha256: 8331284bf9ae641b70cdc0e5866502dd80055fc3b9350979c74bb1d192e8e09e
+  md5: 3fdd8d99683da9fe279c2f4cecd1e048
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.1,<79.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - libxml2 2.15.1
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 555747
+  timestamp: 1766327145986
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-h26afc86_0.conda
   sha256: ec0735ae56c3549149eebd7dc22c0bed91fd50c02eaa77ff418613ddda190aa8
   md5: e512be7dc1f84966d50959e900ca121f
@@ -3545,6 +3646,25 @@ packages:
   license_family: MIT
   size: 45283
   timestamp: 1761015644057
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-he237659_1.conda
+  sha256: 047be059033c394bd32ae5de66ce389824352120b3a7c0eff980195f7ed80357
+  md5: 417955234eccd8f252b86a265ccdab7f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.1,<79.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libxml2-16 2.15.1 hca6bf5a_1
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libxml2
+    - libxml2-16 >=2.15.1
+  size: 45402
+  timestamp: 1766327161688
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
   sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
   md5: edb0dca6bc32e4f4789199455a1dbeb8
@@ -3725,6 +3845,9 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
+  run_exports:
+    weak:
+    - pcre2 >=10.47,<10.48.0a0
   size: 1222481
   timestamp: 1763655398280
 - conda: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
@@ -3855,6 +3978,21 @@ packages:
   license_family: MIT
   size: 193775
   timestamp: 1748644872902
+- conda: https://conda.anaconda.org/conda-forge/linux-64/swig-4.4.1-h7a96c5f_0.conda
+  sha256: 45ec1eedd1de2d7985955290015773a4adc9b8ea95d0f839aaabda2ed075d83c
+  md5: ce50bd18ea2a92833be8b62881929e23
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - pcre2 >=10.47,<10.48.0a0
+  constrains:
+  - swig-abi ==5
+  license: GPL-3.0-or-later
+  license_family: GPL
+  run_exports: {}
+  size: 1329174
+  timestamp: 1773251886390
 - conda: https://conda.anaconda.org/conda-forge/linux-64/texlive-core-20230313-he8f7729_15.conda
   sha256: c7046cce309c0cec2a4b0e59c4e8530a6f7581903d7b999fc84f9bd07e37472c
   md5: f1967a2bfb7d45e0739c0e8832d9ffe4
@@ -4398,6 +4536,19 @@ packages:
   license: LGPL-2.1-only or MPL-1.1
   size: 966667
   timestamp: 1741554768968
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/castxml-0.7.0-ha3e84ed_0.conda
+  sha256: c3c01516fbd6268ee4151f42798f5fa467e5a3548eef0d47a35c9540cd60b763
+  md5: 644b19c2844cb3fb1a7a776dbc24be38
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - libllvm20 >=20.1.8,<20.2.0a0
+  - libclang-cpp20.1 >=20.1.8,<20.2.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 1024757
+  timestamp: 1772089445719
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ccache-4.13.6-h185addb_0.conda
   sha256: 68ddb4618c6720343e0f4a4de707e3ec09f4c9fdc464070aed91ac4f7bd4bac7
   md5: 529eb8e276a92d5d30c924e94c1b8099
@@ -4856,6 +5007,9 @@ packages:
   - libstdcxx >=14
   license: MIT
   license_family: MIT
+  run_exports:
+    weak:
+    - icu >=78.3,<79.0a0
   size: 12837286
   timestamp: 1773822650615
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
@@ -4999,6 +5153,20 @@ packages:
   license_family: BSD
   size: 17539
   timestamp: 1761680168765
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp20.1-20.1.8-default_he95a3c9_16.conda
+  sha256: 403befc6e10443ba3a48e303ca9fba503f8a98d522c08239e06c37c567fc92d0
+  md5: a9b12b5650d566ba204a5725a41986a9
+  depends:
+  - libgcc >=14
+  - libllvm20 >=20.1.8,<20.2.0a0
+  - libstdcxx >=14
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports:
+    weak:
+    - libclang-cpp20.1 >=20.1.8,<20.2.0a0
+  size: 20862034
+  timestamp: 1779374601544
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h4f2b762_6.conda
   sha256: 41b04f995c9f63af8c4065a35931e46cbc2fdd6b9bf7e4c19f90d53cbb2bc8e5
   md5: 67828c963b17db7dc989fe5d509ef04a
@@ -5339,6 +5507,9 @@ packages:
   depends:
   - libgcc >=14
   license: LGPL-2.1-only
+  run_exports:
+    weak:
+    - libiconv >=1.18,<2.0a0
   size: 791226
   timestamp: 1754910975665
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.1.4.1-he30d5cf_0.conda
@@ -5365,6 +5536,23 @@ packages:
   license_family: BSD
   size: 17549
   timestamp: 1761680174207
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm20-20.1.8-hfd2ba90_1.conda
+  sha256: 1a5eb7ebccdc23b0e606f9645cf5b436e01f161c80705bfb34d2793a36846b8f
+  md5: 36f730da2c88718ea21242a7326292da
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxml2
+  - libxml2-16 >=2.14.5
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports:
+    weak:
+    - libllvm20 >=20.1.8,<20.2.0a0
+  size: 42749733
+  timestamp: 1757353785740
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.1-h86ecc28_2.conda
   sha256: 498ea4b29155df69d7f20990a7028d75d91dbea24d04b2eb8a3d6ef328806849
   md5: 7d362346a479256857ab338588190da0
@@ -5674,6 +5862,22 @@ packages:
   license_family: MIT
   size: 875994
   timestamp: 1780213408784
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-16-2.15.1-h79dcc73_1.conda
+  sha256: c76951407554d69dd348151f91cc2dc164efbd679b4f4e77deb2f9aa6eba3c12
+  md5: e42758e7b065c34fd1b0e5143752f970
+  depends:
+  - icu >=78.1,<79.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - libxml2 2.15.1
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 599721
+  timestamp: 1766327134458
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-16-2.15.1-h8591a01_0.conda
   sha256: 7a13450bce2eeba8f8fb691868b79bf0891377b707493a527bd930d64d9b98af
   md5: e7177c6fbbf815da7b215b4cc3e70208
@@ -5703,6 +5907,24 @@ packages:
   license_family: MIT
   size: 47192
   timestamp: 1761015739999
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.15.1-h825857f_1.conda
+  sha256: 9fe997c3e5a8207161d093a5d73f586ae46dc319cb054220086395e150dd1469
+  md5: eb4665cdf78fd02d4abc4edf8c15b7b9
+  depends:
+  - icu >=78.1,<79.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libxml2-16 2.15.1 h79dcc73_1
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libxml2
+    - libxml2-16 >=2.15.1
+  size: 47725
+  timestamp: 1766327143205
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
   sha256: 5a2c1eeef69342e88a98d1d95bff1603727ab1ff4ee0e421522acd8813439b84
   md5: 08aad7cbe9f5a6b460d0976076b6ae64
@@ -5869,6 +6091,9 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
+  run_exports:
+    weak:
+    - pcre2 >=10.47,<10.48.0a0
   size: 1166552
   timestamp: 1763655534263
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/perl-5.32.1-7_h31becfc_perl5.conda
@@ -5993,6 +6218,20 @@ packages:
   license_family: MIT
   size: 207475
   timestamp: 1748644952027
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/swig-4.4.1-h512d76c_0.conda
+  sha256: ac5e52ae7aededf3aa1489a8b4a47b2210915c2760f25c374dffba2335f014ee
+  md5: 91c99a0fec455afa9137c1d978445166
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - pcre2 >=10.47,<10.48.0a0
+  constrains:
+  - swig-abi ==5
+  license: GPL-3.0-or-later
+  license_family: GPL
+  run_exports: {}
+  size: 1399015
+  timestamp: 1773251896861
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/texlive-core-20230313-h7479a69_15.conda
   sha256: df15db9801cdeba1f353add9352896b40d015067121d78326eb37762aac24630
   md5: bc4680b033375ee63fe0c808166f463d
@@ -7113,6 +7352,19 @@ packages:
   license: LGPL-2.1-only or MPL-1.1
   size: 896676
   timestamp: 1766416262450
+- conda: https://conda.anaconda.org/conda-forge/osx-64/castxml-0.7.0-hb171174_0.conda
+  sha256: 465108d705ff05850f1ef65ba12edc87d1576922131cd4a1687f89a750330327
+  md5: ee04620f071f9b842c1b5b356d48df35
+  depends:
+  - libcxx >=19
+  - __osx >=11.0
+  - libllvm20 >=20.1.8,<20.2.0a0
+  - libclang-cpp20.1 >=20.1.8,<20.2.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 1017185
+  timestamp: 1772089532763
 - conda: https://conda.anaconda.org/conda-forge/osx-64/ccache-4.13.6-h894318c_0.conda
   sha256: ff8588dfe87de5e4cc682762997ca8d64e9e3837420bd07411118f34707a762c
   md5: 8ae9dfcda989b435223605126a97a963
@@ -7795,6 +8047,20 @@ packages:
   license_family: Apache
   size: 14856234
   timestamp: 1759436552121
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp20.1-20.1.8-default_h9399c5b_16.conda
+  sha256: 6e608b34adcd41a18e8bf8bb1ef3153d6580b9598edc323542e9d8681bf6c04a
+  md5: c38065ba1fea846f1dd11374fc677f1f
+  depends:
+  - __osx >=11.0
+  - libcxx >=20.1.8
+  - libllvm20 >=20.1.8,<20.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports:
+    weak:
+    - libclang-cpp20.1 >=20.1.8,<20.2.0a0
+  size: 14727362
+  timestamp: 1779376169143
 - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.16.0-h7dd4100_0.conda
   sha256: faec28271c0c545b6b95b5d01d8f0bbe0a94178edca2f56e93761473077edb78
   md5: b905caaffc1753671e1284dcaa283594
@@ -8090,6 +8356,23 @@ packages:
   license_family: Apache
   size: 28801374
   timestamp: 1757354631264
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm20-20.1.8-h56e7563_1.conda
+  sha256: d61976b0938af6025de5907486f6c4686c6192e9842d9fc9873eb7f50815e17d
+  md5: 862eed3ed84906f3387d15ac20075a0d
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - libxml2
+  - libxml2-16 >=2.14.5
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports:
+    weak:
+    - libllvm20 >=20.1.8,<20.2.0a0
+  size: 30758108
+  timestamp: 1757354844443
 - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.1-hd471939_2.conda
   sha256: 7e22fd1bdb8bf4c2be93de2d4e718db5c548aa082af47a7430eb23192de6bb36
   md5: 8468beea04b9065b9807fc8b9cdc5894
@@ -8562,6 +8845,9 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
+  run_exports:
+    weak:
+    - pcre2 >=10.47,<10.48.0a0
   size: 1106584
   timestamp: 1763655837207
 - conda: https://conda.anaconda.org/conda-forge/osx-64/perl-5.32.1-7_h10d778d_perl5.conda
@@ -8687,6 +8973,20 @@ packages:
   license_family: MIT
   size: 123083
   timestamp: 1767045007433
+- conda: https://conda.anaconda.org/conda-forge/osx-64/swig-4.4.1-hdac4ec2_0.conda
+  sha256: 5f89ae3ec8f2ac47f355838e5071708440807c78afbe68bf5d5719e0d9483197
+  md5: 4f5f602a207a0b56d48ada419014b26e
+  depends:
+  - libcxx >=19
+  - __osx >=11.0
+  - pcre2 >=10.47,<10.48.0a0
+  constrains:
+  - swig-abi ==5
+  license: GPL-3.0-or-later
+  license_family: GPL
+  run_exports: {}
+  size: 1234602
+  timestamp: 1773252006725
 - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
   sha256: f97372a1c75b749298cb990405a690527e8004ff97e452ed2c59e4bc6a35d132
   md5: c6ee25eb54accb3f1c8fc39203acfaf1
@@ -8886,6 +9186,19 @@ packages:
   license: LGPL-2.1-only or MPL-1.1
   size: 900035
   timestamp: 1766416416791
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/castxml-0.7.0-hfc9ce51_0.conda
+  sha256: 5c7885b980e3a55acee9500ed696341cdfd337911d635ce69e88bde42cb0ed4a
+  md5: 20e240fa69e39c2af78ae9138a1f0e66
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libllvm20 >=20.1.8,<20.2.0a0
+  - libclang-cpp20.1 >=20.1.8,<20.2.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 1013942
+  timestamp: 1772089510243
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ccache-4.13.6-h414bf82_0.conda
   sha256: ea63ad4cba40ec76439f69d9d396db20c016d5b595c8815efff4497436fb575c
   md5: 1628795893a799313a719264fd7f2227
@@ -9578,6 +9891,20 @@ packages:
   license_family: Apache
   size: 14064699
   timestamp: 1776988581784
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp20.1-20.1.8-default_hf3020a7_16.conda
+  sha256: 67f1e3fb6a44047bc4d1c7d53c883ceb117c579defa88ab76b0ddc3416052bbf
+  md5: c046cb62d7149b09340c782eb2be3d3a
+  depends:
+  - __osx >=11.0
+  - libcxx >=20.1.8
+  - libllvm20 >=20.1.8,<20.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports:
+    weak:
+    - libclang-cpp20.1 >=20.1.8,<20.2.0a0
+  size: 13963413
+  timestamp: 1779377618958
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.16.0-hdece5d2_0.conda
   sha256: f20ce8db8c62f1cdf4d7a9f92cabcc730b1212a7165f4b085e45941cc747edac
   md5: 0537c38a90d179dcb3e46727ccc5bcc1
@@ -9873,6 +10200,23 @@ packages:
   license_family: Apache
   size: 26914852
   timestamp: 1757353228286
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm20-20.1.8-h8e0c9ce_1.conda
+  sha256: 6639cbbde4143b14b666db9dc33beddbf6772317a42d317c8c5162b9524bd24a
+  md5: 717f1efdf0a0240255c7c34d55889d58
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libxml2
+  - libxml2-16 >=2.14.5
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports:
+    weak:
+    - libllvm20 >=20.1.8,<20.2.0a0
+  size: 28800783
+  timestamp: 1757354439972
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
   sha256: 0cb92a9e026e7bd4842f410a5c5c665c89b2eb97794ffddba519a626b8ce7285
   md5: d6df911d4564d77c4374b02552cb17d1
@@ -10344,6 +10688,9 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
+  run_exports:
+    weak:
+    - pcre2 >=10.47,<10.48.0a0
   size: 850231
   timestamp: 1763655726735
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/perl-5.32.1-7_h4614cfb_perl5.conda
@@ -10470,6 +10817,20 @@ packages:
   license_family: MIT
   size: 114331
   timestamp: 1767045086274
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/swig-4.4.1-h4366dc5_0.conda
+  sha256: 6491edeb3df94578b016015f78dd80bddc0f85e2624ed9cea79ad9f9f4b240ca
+  md5: f9a4ce9ad596a0feac7cc7aba8517389
+  depends:
+  - libcxx >=19
+  - __osx >=11.0
+  - pcre2 >=10.47,<10.48.0a0
+  constrains:
+  - swig-abi ==5
+  license: GPL-3.0-or-later
+  license_family: GPL
+  run_exports: {}
+  size: 1189583
+  timestamp: 1773252068990
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
   sha256: 37cd4f62ec023df8a6c6f9f6ffddde3d6620a83cbcab170a8fff31ef944402e5
   md5: b703bc3e6cba5943acf0e5f987b5d0e2
@@ -10661,6 +11022,19 @@ packages:
   license: LGPL-2.1-only or MPL-1.1
   size: 1537783
   timestamp: 1766416059188
+- conda: https://conda.anaconda.org/conda-forge/win-64/castxml-0.7.0-ha22e26b_0.conda
+  sha256: 18602218a9a045c2798c449fa3afa1625960abdc7091a8680eba086e59d5375c
+  md5: 444b03cc1fd97f111454a99f92a23e01
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libzlib >=1.3.1,<2.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 32530472
+  timestamp: 1772089442701
 - conda: https://conda.anaconda.org/conda-forge/win-64/ccache-4.13.6-h7fd822b_0.conda
   sha256: e3363b5ee179a2b369421f69e8879203a958d4efb5cb8c1c52f6b462c1197df7
   md5: d9a4b1ce7d3d948ebe662ea7adf79219
@@ -11616,6 +11990,9 @@ packages:
   - vc14_runtime >=14.44.35208
   license: BSD-3-Clause
   license_family: BSD
+  run_exports:
+    weak:
+    - pcre2 >=10.47,<10.48.0a0
   size: 995992
   timestamp: 1763655708300
 - conda: https://conda.anaconda.org/conda-forge/win-64/perl-5.32.1.1-7_h57928b3_strawberry.conda
@@ -11710,6 +12087,21 @@ packages:
   license_family: MIT
   size: 182043
   timestamp: 1758892011955
+- conda: https://conda.anaconda.org/conda-forge/win-64/swig-4.4.1-h9b0202b_0.conda
+  sha256: f05e256f8edd14786c7832288e842f313b244a506975c2830ea9bbe7d4abc205
+  md5: 0341bd38d90eae2041629f9084bb143a
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - pcre2 >=10.47,<10.48.0a0
+  constrains:
+  - swig-abi ==5
+  license: GPL-3.0-or-later
+  license_family: GPL
+  run_exports: {}
+  size: 1154778
+  timestamp: 1773251909868
 - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2022.3.0-hd094cb3_0.conda
   sha256: 290b1ae188d614d7e1fb98dc04b8afd9762dd82d3a0e2de2a8616c750de7cfab
   md5: d21952ac3d528fa8ca2f268f262f9ec6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ pytest = ">=8.4.1,<9"
 numpy = ">=2.3.4,<3"
 libopenblas = ">=0.3.30,<0.4"
 libgfortran5 = ">=15.2.0,<16"
+swig = ">=4.4.1"
+castxml = ">=0.7.0,<0.8"
 
 [tool.pixi.feature.cxx.tasks.configure]
 cmd = '''cmake \
@@ -230,6 +232,8 @@ cmd = '''cmake \
   -S. \
   -GNinja \
   -DITK_WRAP_PYTHON:BOOL=ON \
+  -DITK_USE_SYSTEM_SWIG:BOOL=ON \
+  -DITK_USE_SYSTEM_CASTXML:BOOL=ON \
   -DCMAKE_BUILD_TYPE:STRING=Release \
   -DBUILD_TESTING:BOOL=ON'''
 description = "Configure ITK Python"
@@ -258,6 +262,8 @@ cmd = '''cmake \
   -S. \
   -GNinja \
   -DITK_WRAP_PYTHON:BOOL=ON \
+  -DITK_USE_SYSTEM_SWIG:BOOL=ON \
+  -DITK_USE_SYSTEM_CASTXML:BOOL=ON \
   -DCMAKE_BUILD_TYPE:STRING=Debug \
   -DBUILD_TESTING:BOOL=ON'''
 description = "Configure ITK Python - Debug"


### PR DESCRIPTION
Move ITK Python wrapping to **SWIG 4.4.1**. Fixes the import regression in #6479; supersedes the temporary #6480 (4.3.x baseline) and #6481 (WIP CI).

Three focused commits, no WIP — standard GHA + Azure CI run on this PR. The Azure/ARM Python pipelines exercise the vendored 4.4.1 binaries; local `pixi run build-python` uses conda-forge SWIG/CastXML.

<details>
<summary>What changed</summary>

- **Multi-phase init fix.** ITK packs several SWIG modules per shared library and injects C that calls `PyInit__<X>Python()` and stores the return in `sys.modules`. SWIG 4.4 (PEP 489 multi-phase init) makes `PyInit_*` return a raw `PyModuleDef`, so the proxy failed at import with `'moduledef' object has no attribute 'delete_SwigPyIterator'`. The injection now detects a returned def at runtime and instantiates it via `PyModule_FromDefAndSpec` + `PyModule_ExecDef`; the single-phase (≤4.3) path is unchanged; all APIs are Limited-API-safe (≥3.5).
- **abi3 floor.** Pinned to a single cached source of truth `_ITK_MINIMUM_SUPPORTED_LIMITED_API_VERSION` (3.11), shared by the Limited-API auto-detect and `USE_SABI`. 3.11+ build abi3 and load on 3.11; 3.10 keeps the non-Limited-API path.
- **Vendored SWIG 4.4.1 via FetchContent + version assertion.** The prebuilt-binary download moves from `ExternalProject_Add` to `FetchContent`, so `SWIG_EXECUTABLE` exists at configure time and `itk_assert_swig_version()` confirms it reports ≥ `swig_version_min` (now 4.3.0; too-old system swig is a `FATAL_ERROR`). Binaries are repackaged from the official, broadly-portable SWIG PyPI wheels and hosted on data.kitware.com (resolved by SHA512). Source-build fallback stays on ExternalProject.
- **Local dev.** `configure-python` / `configure-debug-python` pass `ITK_USE_SYSTEM_SWIG`/`ITK_USE_SYSTEM_CASTXML`; `swig (>=4.4.1)` + `castxml` added to the `python` pixi feature.
</details>

<details>
<summary>How the vendored binaries were produced (reproducible)</summary>

The `swig<os>-<arch>-4.4.1.zip` archives are **repackaged from the official `swig` PyPI package** (https://pypi.org/project/swig/, maintained by the SWIG team, built with cibuildwheel). These wheels are the broadest-portability prebuilt SWIG available — Linux manylinux2010 (glibc 2.12) / manylinux2014, macOS 10.9 **universal2** (x86_64+arm64 in one file), and Windows — far more portable than building on a dev box. Each wheel contains `swig/data/bin/swig[.exe]` + `swig/data/share/swig/4.4.1/`, i.e. ITK's exact layout, so repackaging is just extract-and-rezip (platform-independent — no cross-compiling):

```bash
process() {  # $1=pip-platform-tag  $2=itk-archive-name
  wd=$(mktemp -d)
  pip download --no-deps swig==4.4.1 --platform "$1" --only-binary=:all: -d "$wd"
  ( cd "$wd" && unzip -q swig-4.4.1*.whl )
  chmod +x "$wd/swig/data/bin/"*
  ( cd "$wd/swig/data" && zip -r -q "$OLDPWD/$2.zip" bin share )   # bin/ + share/ at archive root
}
process macosx_10_9_universal2   swigmacos-arm64-4.4.1   # universal2 also serves swigmacos-amd64
process manylinux2010_x86_64     swiglinux-amd64-4.4.1
process manylinux2014_aarch64    swiglinux-arm64-4.4.1
process win_amd64                swigwin-amd64-4.4.1
```

The resulting archives were uploaded to data.kitware.com and are fetched by SHA512:

| archive | wheel source | SHA512 |
|---|---|---|
| swigmacos-arm64 / -amd64 | `macosx_10_9_universal2` | `17c4637d…1ce3cef9` |
| swiglinux-amd64 | `manylinux2010_x86_64` | `6447a7b9…d88ca11` |
| swiglinux-arm64 | `manylinux2014_aarch64` | `44a6d174…c8902d24` |
| swigwin-amd64 | `win_amd64` | `700bd4de…e338f3892` |

`itk_assert_swig_version()` runs `swig -version` on the downloaded binary at configure time and fails if it is not ≥ `swig_version_min`, so a wrong/corrupt upload is caught immediately. For a future SWIG bump, rerun the recipe with the new version, re-upload, and update `ITK_SWIG_VERSION` + the per-platform SHA512s.
</details>

<details>
<summary>Validation</summary>

Builds and imports on Python **3.11.15** and **3.13.9** (same abi3 build); the `std::vector`/`SwigPyIterator` path and 10/10 scoped Python ctests pass. The vendored FetchContent download from data.kitware.com was verified at configure time to fetch 4.4.1, pass the assertion, and build `_ITKCommonPython.abi3.so` cleanly.
</details>

<details>
<summary>Download mirrors</summary>

`data.kitware.com` (keyed by SHA512) is the primary; `dweb.link`, `ipfs.io`, and `gateway.pinata.cloud` serve the same bytes by content id as IPFS fallbacks, matching ITK's ExternalData gateway set. `URL_HASH SHA512` validates whichever mirror responds. The content ids are the reproducible `ipfs-car`/IPIP-0499 CIDs produced by the ExternalData upload pipeline:

| archive | CID |
|---|---|
| swigwin-amd64 | `bafybeifxjnbydus4eq46bocwb2hcj5ufpbj4etocia5ims426gfiw7krfi` |
| swiglinux-amd64 | `bafybeiep2wbecrcii7xzfe2cekhfco6mlxqym4jhfdl6xi3p4aieblgz6m` |
| swiglinux-arm64 | `bafybeifaqaus3yzp5oujxupxk422hfmcg2idf3oyvdtsppzq7ymn64nvze` |
| swigmacos-arm64/amd64 | `bafybeidllsbllkqwoby6r5w4ueqzky2o7r6qkjbh45q57mczyh2fwfwd3q` |

The archives are pinned to IPFS and mirrored into ITKTestingData via the ExternalData upload pipeline.
</details>

<!--
provenance: claude-code session investigate-pixi-castxml-swig 2026-06-21
supersedes: #6480 (4.3.x baseline), #6481 (WIP CI)
fixes: #6479 (SWIG 4.4.1 Limited-API import regression)
binaries: repackaged from PyPI `swig` 4.4.1 wheels (macosx_10_9_universal2, manylinux2010_x86_64, manylinux2014_aarch64, win_amd64) -> data.kitware.com (by SHA512)
mirrors: data.kitware.com (SHA512) + IPFS gateways by ipfs-car CID; pin via Utilities/Maintenance/ExternalDataUpload/upload.py (Filebase) + ITKTestingData mirror
done-in-pr: source-build fallback bumped swig-4.0.2 -> 4.4.1; greptile review addressed (surface init errors via PyErr_WriteUnraisable; verify swig on every configure; confirmed source tarball is SWIG 4.4.1)
post-merge-followups: shared C helper for multi-phase init (replace per-submodule adapter); remove dead find_package(BISON) in source-build branch
-->

