### PR TITLE
ENH: Add Eigen-backed itk::Math::SVD and migrate ITK's vnl_svd consumers

### DIFF
--- a/Documentation/docs/migration_guides/itk_6_migration_guide.md
+++ b/Documentation/docs/migration_guides/itk_6_migration_guide.md
@@ -784,42 +784,58 @@ representation of the same result, not an indication of a failure.** Update such
 expected values to the new (now platform-stable) representatives; the migrated
 ITK tests have been updated this way.
 
-## Optional Eigen-backed `itk::Math::SVD` for square matrices
+## Optional Eigen-backed `itk::Math::SVD`
 
 A new opt-in, header-only `itk::Math::SVD` (`itkMathSVD.h`) provides an
-Eigen-backed singular value decomposition for **square** matrices. It returns
-`U`, `W`, `V` as vnl types plus `pinverse()`, `Solve()` and `rank()` -- the
-dominant `vnl_svd` operations. This is purely additive: `vnl_svd` is unchanged
-and is **not** deprecated.
+Eigen-backed singular value decomposition. It returns `U`, `W`, `V` as vnl types
+plus `pinverse()`, `Solve()`, `rank()` and `recompose()` -- the dominant `vnl_svd`
+operations. `vnl_svd` is unchanged by this addition, but the direction is to
+migrate ITK and downstream code onto `itk::Math::SVD` and ultimately **deprecate
+and remove** the `vnl_svd` path. Prefer `itk::Math::SVD` in new code.
+
+A runtime-sized `vnl_matrix` of any shape is accepted: square inputs take a fast
+JacobiSVD/BDCSVD path; rectangular inputs use BDCSVD with thin U/V (`U` is m x k,
+`V` is n x k, `k = min(m, n)`). The square-vs-rectangular choice is a single
+runtime dimension comparison, so the square fast path is unaffected. The
+fixed-size overloads (`vnl_matrix_fixed`, `itk::Matrix`) are square-only by
+signature.
 
 ### What you need to do
 
-Nothing is required. For **square** decompositions you may prefer
-`itk::Math::SVD` for the performance and reproducibility below. `vnl_svd` remains
-the path for rectangular matrices and for operations the new API does not yet
-expose (`recompose`, `nullvector`, `well_condition`, `singularities`, ...).
+Nothing is required immediately, but prefer `itk::Math::SVD` in new code. The
+`vnl_svd`-only operations (`nullvector`, `well_condition`, `singularities`) have
+no remaining callers in ITK, so the new API already covers every ITK use; the few
+remaining `vnl_svd` call sites are slated for migration as part of the broader
+vnl-to-Eigen deprecation effort.
 
 ### Performance: faster on the common and critical paths, at equal accuracy
 
 Accuracy is equivalent to `vnl_svd` -- reconstruction and singular values agree
-to machine precision (BDCSVD is marginally more accurate at large sizes). Speed
-is size-dependent (idle, single-thread, AppleClang arm64; ratio > 1 means the
-Eigen path is faster):
+to machine precision (the newer BDCSVD divide-and-conquer engine is marginally
+more accurate at large sizes). Speed is size-dependent (idle, single-thread,
+AppleClang arm64; ratio > 1 means the Eigen path is faster):
 
 | Square size | Eigen vs vnl_svd |
 |---|---|
 | 3x3 | ~2.2x faster |
 | 4x4 | ~2.0x faster |
 | 6x6 | ~parity |
-| 8x8 - 16x16 | slower (~0.5-0.8x) -- `vnl_svd`/LINPACK wins |
+| 7x7 | not benchmarked |
+| 8x8 | slower (~0.5-0.8x) -- `vnl_svd`/LINPACK wins ([rarely used](#midsize-rarity)) |
+| 16x16 | slower (~0.5-0.8x) -- `vnl_svd`/LINPACK wins ([rarely used](#midsize-rarity)) |
 | >= 50x50 | ~1.5-2.3x faster (BDCSVD) |
 
+The 7x7 size was not benchmarked, and LINPACK may have a hardware-alignment
+advantage at these mid sizes that has not been explored.
+
+<a id="midsize-rarity"></a>
 The **rare** cases where Eigen is similar or slightly slower are mid-sized dense
-square matrices (roughly 8-16). These are uncommon across the ITK and downstream
-call sites, which are dominated by 3x3/4x4 transform and image-orientation
-problems (where Eigen is ~2x faster) plus occasional large dense systems (where
-BDCSVD wins). On the common and critical paths the Eigen path is a significant
-performance improvement with no loss of accuracy.
+square matrices (8x8 and 16x16). These are seldom -- perhaps never -- exercised in
+practice across the ITK and downstream call sites, which are dominated by 3x3/4x4
+transform and image-orientation problems (where Eigen is ~2x faster) plus
+occasional large dense systems (where BDCSVD wins). On the common and critical
+paths the Eigen path is a significant performance improvement with no loss of
+accuracy.
 
 ### Deterministic signs -- a different correct representation
 

--- a/Documentation/docs/migration_guides/itk_6_migration_guide.md
+++ b/Documentation/docs/migration_guides/itk_6_migration_guide.md
@@ -788,7 +788,7 @@ ITK tests have been updated this way.
 
 A new opt-in, header-only `itk::Math::SVD` (`itkMathSVD.h`) provides an
 Eigen-backed singular value decomposition. It returns `U`, `W`, `V` as vnl types
-plus `pinverse()`, `Solve()`, `rank()` and `recompose()` -- the dominant `vnl_svd`
+plus `PseudoInverse()`, `Solve()`, `Rank()` and `Recompose()` -- the dominant `vnl_svd`
 operations. `vnl_svd` is unchanged by this addition, but the direction is to
 migrate ITK and downstream code onto `itk::Math::SVD` and ultimately **deprecate
 and remove** the `vnl_svd` path. Prefer `itk::Math::SVD` in new code.
@@ -820,13 +820,12 @@ AppleClang arm64; ratio > 1 means the Eigen path is faster):
 | 3x3 | ~2.2x faster |
 | 4x4 | ~2.0x faster |
 | 6x6 | ~parity |
-| 7x7 | not benchmarked |
 | 8x8 | slower (~0.5-0.8x) -- `vnl_svd`/LINPACK wins ([rarely used](#midsize-rarity)) |
 | 16x16 | slower (~0.5-0.8x) -- `vnl_svd`/LINPACK wins ([rarely used](#midsize-rarity)) |
 | >= 50x50 | ~1.5-2.3x faster (BDCSVD) |
 
-The 7x7 size was not benchmarked, and LINPACK may have a hardware-alignment
-advantage at these mid sizes that has not been explored.
+LINPACK may have a hardware-alignment advantage at these mid sizes that has not
+been explored.
 
 <a id="midsize-rarity"></a>
 The **rare** cases where Eigen is similar or slightly slower are mid-sized dense
@@ -842,7 +841,7 @@ accuracy.
 Like the eigendecomposition classes above, `itk::Math::SVD` canonicalizes the
 singular-vector signs by default (reproducible across platforms and SIMD width),
 whereas `vnl_svd`'s signs depend on solver internals. Sign-invariant operations
--- `U * V^T`, `pinverse()`, `Solve()` -- are stable across the swap; code that
+-- `U * V^T`, `PseudoInverse()`, `Solve()` -- are stable across the swap; code that
 reads individual `U`/`V` columns as directions may see the same geometry from a
 different, equally-valid representative. Pass `canonicalizeSigns = false` to
 reproduce `vnl_svd`'s raw signs (e.g. for equivalence testing).

--- a/Documentation/docs/migration_guides/itk_6_migration_guide.md
+++ b/Documentation/docs/migration_guides/itk_6_migration_guide.md
@@ -783,3 +783,50 @@ baseline or expected value changed, it is a selection of a different correct
 representation of the same result, not an indication of a failure.** Update such
 expected values to the new (now platform-stable) representatives; the migrated
 ITK tests have been updated this way.
+
+## Optional Eigen-backed `itk::Math::SVD` for square matrices
+
+A new opt-in, header-only `itk::Math::SVD` (`itkMathSVD.h`) provides an
+Eigen-backed singular value decomposition for **square** matrices. It returns
+`U`, `W`, `V` as vnl types plus `pinverse()`, `Solve()` and `rank()` -- the
+dominant `vnl_svd` operations. This is purely additive: `vnl_svd` is unchanged
+and is **not** deprecated.
+
+### What you need to do
+
+Nothing is required. For **square** decompositions you may prefer
+`itk::Math::SVD` for the performance and reproducibility below. `vnl_svd` remains
+the path for rectangular matrices and for operations the new API does not yet
+expose (`recompose`, `nullvector`, `well_condition`, `singularities`, ...).
+
+### Performance: faster on the common and critical paths, at equal accuracy
+
+Accuracy is equivalent to `vnl_svd` -- reconstruction and singular values agree
+to machine precision (BDCSVD is marginally more accurate at large sizes). Speed
+is size-dependent (idle, single-thread, AppleClang arm64; ratio > 1 means the
+Eigen path is faster):
+
+| Square size | Eigen vs vnl_svd |
+|---|---|
+| 3x3 | ~2.2x faster |
+| 4x4 | ~2.0x faster |
+| 6x6 | ~parity |
+| 8x8 - 16x16 | slower (~0.5-0.8x) -- `vnl_svd`/LINPACK wins |
+| >= 50x50 | ~1.5-2.3x faster (BDCSVD) |
+
+The **rare** cases where Eigen is similar or slightly slower are mid-sized dense
+square matrices (roughly 8-16). These are uncommon across the ITK and downstream
+call sites, which are dominated by 3x3/4x4 transform and image-orientation
+problems (where Eigen is ~2x faster) plus occasional large dense systems (where
+BDCSVD wins). On the common and critical paths the Eigen path is a significant
+performance improvement with no loss of accuracy.
+
+### Deterministic signs -- a different correct representation
+
+Like the eigendecomposition classes above, `itk::Math::SVD` canonicalizes the
+singular-vector signs by default (reproducible across platforms and SIMD width),
+whereas `vnl_svd`'s signs depend on solver internals. Sign-invariant operations
+-- `U * V^T`, `pinverse()`, `Solve()` -- are stable across the swap; code that
+reads individual `U`/`V` columns as directions may see the same geometry from a
+different, equally-valid representative. Pass `canonicalizeSigns = false` to
+reproduce `vnl_svd`'s raw signs (e.g. for equivalence testing).

--- a/Modules/Core/Common/include/itkEigenDecompositionSignConvention.h
+++ b/Modules/Core/Common/include/itkEigenDecompositionSignConvention.h
@@ -51,6 +51,37 @@ CanonicalizeEigenvectorColumnSigns(vnl_matrix<T> & V)
   }
 }
 
+/** Same canonicalization as above, applied to \a u, with the identical per-column
+ * flip mirrored onto \a paired so a factor pair (e.g. the U and V of an SVD) stays
+ * consistent. Templated on the matrix type so it serves vnl_matrix and
+ * vnl_matrix_fixed; the sign is well-defined only when the leading per-column
+ * magnitude is unambiguous (distinct singular values). */
+template <typename TMatrix>
+void
+CanonicalizeColumnSignsPaired(TMatrix & u, TMatrix & paired)
+{
+  const unsigned int rows = u.rows();
+  for (unsigned int j = 0; j < u.cols(); ++j)
+  {
+    unsigned int pivot = 0;
+    for (unsigned int i = 1; i < rows; ++i)
+    {
+      if (std::abs(u(i, j)) > std::abs(u(pivot, j)))
+      {
+        pivot = i;
+      }
+    }
+    if (u(pivot, j) < 0)
+    {
+      for (unsigned int i = 0; i < rows; ++i)
+      {
+        u(i, j) = -u(i, j);
+        paired(i, j) = -paired(i, j);
+      }
+    }
+  }
+}
+
 } // namespace itk::detail
 
 #endif // itkEigenDecompositionSignConvention_h

--- a/Modules/Core/Common/include/itkEigenDecompositionSignConvention.h
+++ b/Modules/Core/Common/include/itkEigenDecompositionSignConvention.h
@@ -75,7 +75,7 @@ CanonicalizeColumnSignsPaired(TMatrix & u, TMatrix & paired)
         pivot = i;
       }
     }
-    if (u(pivot, j) < 0)
+    if (u(pivot, j) < typename TMatrix::element_type{ 0 })
     {
       for (unsigned int i = 0; i < uRows; ++i)
       {

--- a/Modules/Core/Common/include/itkEigenDecompositionSignConvention.h
+++ b/Modules/Core/Common/include/itkEigenDecompositionSignConvention.h
@@ -51,8 +51,9 @@ CanonicalizeEigenvectorColumnSigns(vnl_matrix<T> & V)
   }
 }
 
-/** Same canonicalization as above, applied to \a u, with the identical per-column
- * flip mirrored onto \a paired so a factor pair (e.g. the U and V of an SVD) stays
+/** Same canonicalization as \c CanonicalizeEigenvectorColumnSigns, applied to \a u,
+ * with the identical per-column flip mirrored onto \a paired so a factor pair (e.g.
+ * the U and V of an SVD) stays
  * consistent. Templated on the matrix type so it serves vnl_matrix and
  * vnl_matrix_fixed; the sign is well-defined only when the leading per-column
  * magnitude is unambiguous (distinct singular values). */
@@ -60,11 +61,14 @@ template <typename TMatrix>
 void
 CanonicalizeColumnSignsPaired(TMatrix & u, TMatrix & paired)
 {
-  const unsigned int rows = u.rows();
+  // u and paired share a column count but may differ in row count (an SVD's
+  // thin U is rows x k, V is cols x k), so each is flipped over its own rows.
+  const unsigned int uRows = u.rows();
+  const unsigned int pairedRows = paired.rows();
   for (unsigned int j = 0; j < u.cols(); ++j)
   {
     unsigned int pivot = 0;
-    for (unsigned int i = 1; i < rows; ++i)
+    for (unsigned int i = 1; i < uRows; ++i)
     {
       if (std::abs(u(i, j)) > std::abs(u(pivot, j)))
       {
@@ -73,9 +77,12 @@ CanonicalizeColumnSignsPaired(TMatrix & u, TMatrix & paired)
     }
     if (u(pivot, j) < 0)
     {
-      for (unsigned int i = 0; i < rows; ++i)
+      for (unsigned int i = 0; i < uRows; ++i)
       {
         u(i, j) = -u(i, j);
+      }
+      for (unsigned int i = 0; i < pairedRows; ++i)
+      {
         paired(i, j) = -paired(i, j);
       }
     }

--- a/Modules/Core/Common/include/itkMathSVD.h
+++ b/Modules/Core/Common/include/itkMathSVD.h
@@ -1,0 +1,322 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkMathSVD_h
+#define itkMathSVD_h
+
+#include "itkMacro.h"
+#include "itkMatrix.h"
+#include "itkEigenDecompositionSignConvention.h"
+#include "vnl/vnl_matrix.h"
+#include "vnl/vnl_matrix_fixed.h"
+#include "vnl/vnl_vector.h"
+#include "vnl/vnl_vector_fixed.h"
+
+#include "itk_eigen.h"
+#include ITK_EIGEN(Dense)
+
+#include <limits>
+
+namespace itk
+{
+namespace Math
+{
+
+namespace detail
+{
+// rcond < 0 selects an automatic relative threshold of n * epsilon.
+template <typename TReal>
+TReal
+ResolveRcond(TReal rcond, unsigned int n)
+{
+  return rcond < TReal{ 0 } ? static_cast<TReal>(n) * std::numeric_limits<TReal>::epsilon() : rcond;
+}
+
+// Moore-Penrose pseudo-inverse V diag(1/w) U^T, with singular values at or below
+// rcond*max(w) treated as zero. Works for vnl_matrix and vnl_matrix_fixed.
+template <typename TMatrix, typename TVector, typename TReal>
+TMatrix
+PseudoInverse(const TMatrix & U, const TVector & W, const TMatrix & V, TReal rcond)
+{
+  const unsigned int n = W.size();
+  const TReal        tol = ResolveRcond(rcond, n) * W.max_value();
+  TMatrix            scaledV = V;
+  for (unsigned int k = 0; k < n; ++k)
+  {
+    const TReal s = (W[k] > tol) ? TReal{ 1 } / W[k] : TReal{ 0 };
+    for (unsigned int i = 0; i < n; ++i)
+    {
+      scaledV(i, k) *= s;
+    }
+  }
+  return scaledV * U.transpose();
+}
+
+// Least-squares / minimum-norm solution x = V diag(1/w) U^T b of A x = b.
+template <typename TMatrix, typename TVector, typename TReal>
+TVector
+SolveLinear(const TMatrix & U, const TVector & W, const TMatrix & V, const TVector & b, TReal rcond)
+{
+  const unsigned int n = W.size();
+  const TReal        tol = ResolveRcond(rcond, n) * W.max_value();
+  TVector            utb = U.transpose() * b;
+  for (unsigned int k = 0; k < n; ++k)
+  {
+    utb[k] = (W[k] > tol) ? utb[k] / W[k] : TReal{ 0 };
+  }
+  return V * utb;
+}
+
+template <typename TVector, typename TReal>
+unsigned int
+NumericalRank(const TVector & W, TReal rcond)
+{
+  const unsigned int n = W.size();
+  const TReal        tol = ResolveRcond(rcond, n) * W.max_value();
+  unsigned int       count = 0;
+  for (unsigned int k = 0; k < n; ++k)
+  {
+    if (W[k] > tol)
+    {
+      ++count;
+    }
+  }
+  return count;
+}
+} // namespace detail
+
+/** Result of a fixed-size square SVD: A == U * diag(W) * V^T, W descending.
+ * For all solver methods, \a rcond < 0 auto-selects a VDim*epsilon threshold. */
+template <typename TReal, unsigned int VDim>
+struct FixedSquareSVDResult
+{
+  vnl_matrix_fixed<TReal, VDim, VDim> U{};
+  vnl_vector_fixed<TReal, VDim>       W{};
+  vnl_matrix_fixed<TReal, VDim, VDim> V{};
+
+  /** Moore-Penrose pseudo-inverse A^+. */
+  vnl_matrix_fixed<TReal, VDim, VDim>
+  pinverse(TReal rcond = TReal{ -1 }) const
+  {
+    return detail::PseudoInverse(U, W, V, rcond);
+  }
+
+  /** Least-squares / minimum-norm solution of A x = b. */
+  vnl_vector_fixed<TReal, VDim>
+  Solve(const vnl_vector_fixed<TReal, VDim> & b, TReal rcond = TReal{ -1 }) const
+  {
+    return detail::SolveLinear(U, W, V, b, rcond);
+  }
+
+  /** Numerical rank (count of singular values above rcond*max(w)). */
+  unsigned int
+  rank(TReal rcond = TReal{ -1 }) const
+  {
+    return detail::NumericalRank(W, rcond);
+  }
+};
+
+/** Result of a runtime-sized square SVD: A == U * diag(W) * V^T, W descending.
+ * For all solver methods, \a rcond < 0 auto-selects an n*epsilon threshold. */
+template <typename TReal>
+struct SquareSVDResult
+{
+  vnl_matrix<TReal> U{};
+  vnl_vector<TReal> W{};
+  vnl_matrix<TReal> V{};
+
+  /** Moore-Penrose pseudo-inverse A^+. */
+  vnl_matrix<TReal>
+  pinverse(TReal rcond = TReal{ -1 }) const
+  {
+    return detail::PseudoInverse(U, W, V, rcond);
+  }
+
+  /** Least-squares / minimum-norm solution of A x = b. */
+  vnl_vector<TReal>
+  Solve(const vnl_vector<TReal> & b, TReal rcond = TReal{ -1 }) const
+  {
+    return detail::SolveLinear(U, W, V, b, rcond);
+  }
+
+  /** Numerical rank (count of singular values above rcond*max(w)). */
+  unsigned int
+  rank(TReal rcond = TReal{ -1 }) const
+  {
+    return detail::NumericalRank(W, rcond);
+  }
+};
+
+namespace detail
+{
+// Above this compile-time size the fixed overload delegates to the runtime path
+// (keeps a large VDim off Eigen's stack-allocation limit).
+constexpr unsigned int kFixedSVDMaxDim = 16;
+
+// JacobiSVD+NoQRPreconditioner is fastest for small square inputs; BDCSVD is
+// faster and more accurate for larger n.
+constexpr unsigned int kJacobiMaxDim = 6;
+
+// Runtime-sized square SVD: JacobiSVD + NoQRPreconditioner for small n, BDCSVD for
+// larger n where Jacobi sweeps scale poorly. Throws on a failed decomposition.
+template <typename TReal>
+void
+DynamicSquareSVDEigen(const TReal * inData, unsigned int n, TReal * uData, TReal * wData, TReal * vData)
+{
+  using RowMajor = Eigen::Matrix<TReal, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+  using ColMajor = Eigen::Matrix<TReal, Eigen::Dynamic, Eigen::Dynamic>;
+  constexpr int full = Eigen::ComputeFullU | Eigen::ComputeFullV;
+
+  const Eigen::Map<const RowMajor> inMap(inData, n, n);
+  Eigen::Map<RowMajor>             uMap(uData, n, n);
+  Eigen::Map<RowMajor>             vMap(vData, n, n);
+
+  const auto extract = [&](const auto & svd) {
+    if (svd.info() != Eigen::Success)
+    {
+      itkGenericExceptionMacro("itk::Math::SVD failed; input is likely non-finite (NaN/Inf).");
+    }
+    uMap = svd.matrixU();
+    vMap = svd.matrixV();
+    for (unsigned int i = 0; i < n; ++i)
+    {
+      wData[i] = svd.singularValues()[i];
+    }
+  };
+
+  if (n <= kJacobiMaxDim)
+  {
+    extract(Eigen::JacobiSVD < ColMajor, full | Eigen::NoQRPreconditioner > (inMap));
+  }
+  else
+  {
+    extract(Eigen::BDCSVD<ColMajor, full>(inMap));
+  }
+}
+
+// NoQRPreconditioner skips the column-pivot QR (wasted for a square input); large
+// VDim falls back to the runtime path. Throws on a failed/non-finite decomposition.
+template <unsigned int VDim, typename TReal>
+void
+SquareSVDEigen(const TReal * inData, TReal * uData, TReal * wData, TReal * vData)
+{
+  if constexpr (VDim > kFixedSVDMaxDim)
+  {
+    DynamicSquareSVDEigen<TReal>(inData, VDim, uData, wData, vData);
+  }
+  else
+  {
+    using RowMajor = Eigen::Matrix<TReal, VDim, VDim, Eigen::RowMajor>;
+    using ColMajor = Eigen::Matrix<TReal, VDim, VDim>;
+    constexpr int options = Eigen::ComputeFullU | Eigen::ComputeFullV | Eigen::NoQRPreconditioner;
+
+    const Eigen::Map<const RowMajor>          inMap(inData);
+    const Eigen::JacobiSVD<ColMajor, options> svd(inMap);
+    if (svd.info() != Eigen::Success)
+    {
+      itkGenericExceptionMacro("itk::Math::SVD failed; input is likely non-finite (NaN/Inf).");
+    }
+
+    Eigen::Map<RowMajor> uMap(uData);
+    Eigen::Map<RowMajor> vMap(vData);
+    uMap = svd.matrixU();
+    vMap = svd.matrixV();
+    for (unsigned int i = 0; i < VDim; ++i)
+    {
+      wData[i] = svd.singularValues()[i];
+    }
+  }
+}
+} // namespace detail
+
+/** \brief Singular value decomposition A = U diag(W) V^T, backed by Eigen.
+ *
+ * Opt-in Eigen-backed alternative to vnl_svd: the optimized Eigen path is
+ * competitive with vnl_svd at the small fixed sizes that dominate ITK usage and
+ * at large sizes (via BDCSVD), at equal accuracy. Factors are returned as vnl
+ * matrices/vectors, so no Eigen type appears in the interface. The result offers
+ * pinverse(), Solve(), rank() and recompose(); their default rcond truncates
+ * singular values at k*epsilon*max(W), so pass rcond = 0 to keep every nonzero
+ * singular value.
+ *
+ * Fixed compile-time sizes use JacobiSVD with NoQRPreconditioner (valid for
+ * square inputs) over a zero-copy Eigen::Map; runtime sizes select JacobiSVD for
+ * small n and BDCSVD for larger n.
+ *
+ * Singular vectors are defined only up to a sign (and, for repeated singular
+ * values, a rotation within the shared subspace). With \a canonicalizeSigns
+ * (default) the largest-magnitude entry of each U column is made positive and the
+ * paired V column flipped to match, giving a deterministic convention when the
+ * singular values are distinct; a degenerate subspace still has an arbitrary
+ * basis. Unlike vnl_svd -- whose singular-vector signs depend on solver internals
+ * and SIMD width -- this canonicalization makes results reproducible across builds
+ * and platforms at negligible cost (under 1% of the decomposition); it is an added
+ * benefit of the Eigen-backed path. Pass canonicalizeSigns = false to instead
+ * reproduce vnl_svd's raw (non-canonical) signs, e.g. for equivalence testing. A
+ * non-finite input throws an itk::ExceptionObject.
+ *
+ * \ingroup ITKCommon
+ */
+template <typename TReal, unsigned int VDim>
+FixedSquareSVDResult<TReal, VDim>
+SVD(const vnl_matrix_fixed<TReal, VDim, VDim> & A, bool canonicalizeSigns = true)
+{
+  FixedSquareSVDResult<TReal, VDim> result;
+  detail::SquareSVDEigen<VDim>(A.data_block(), result.U.data_block(), result.W.data_block(), result.V.data_block());
+  if (canonicalizeSigns)
+  {
+    itk::detail::CanonicalizeColumnSignsPaired(result.U, result.V);
+  }
+  return result;
+}
+
+/** SVD of a fixed-size square itk::Matrix. */
+template <typename TReal, unsigned int VDim>
+FixedSquareSVDResult<TReal, VDim>
+SVD(const Matrix<TReal, VDim, VDim> & A, bool canonicalizeSigns = true)
+{
+  return SVD<TReal, VDim>(A.GetVnlMatrix(), canonicalizeSigns);
+}
+
+/** SVD of a runtime-sized square vnl_matrix. */
+template <typename TReal>
+SquareSVDResult<TReal>
+SVD(const vnl_matrix<TReal> & A, bool canonicalizeSigns = true)
+{
+  if (A.rows() == 0 || A.rows() != A.cols())
+  {
+    itkGenericExceptionMacro("itk::Math::SVD requires a non-empty square matrix; got " << A.rows() << 'x' << A.cols()
+                                                                                       << '.');
+  }
+  const unsigned int     n = A.rows();
+  SquareSVDResult<TReal> result;
+  result.U.set_size(n, n);
+  result.V.set_size(n, n);
+  result.W.set_size(n);
+  detail::DynamicSquareSVDEigen<TReal>(
+    A.data_block(), n, result.U.data_block(), result.W.data_block(), result.V.data_block());
+  if (canonicalizeSigns)
+  {
+    itk::detail::CanonicalizeColumnSignsPaired(result.U, result.V);
+  }
+  return result;
+}
+
+} // namespace Math
+} // namespace itk
+
+#endif // itkMathSVD_h

--- a/Modules/Core/Common/include/itkMathSVD.h
+++ b/Modules/Core/Common/include/itkMathSVD.h
@@ -52,15 +52,15 @@ template <typename TMatrix, typename TVector, typename TReal>
 TMatrix
 PseudoInverse(const TMatrix & U, const TVector & W, const TMatrix & V, TReal rcond)
 {
-  const unsigned int n = W.size();
-  const TReal        tol = ResolveRcond(rcond, n) * W.max_value();
+  const unsigned int k = W.size();
+  const TReal        tol = ResolveRcond(rcond, k) * W.max_value();
   TMatrix            scaledV = V;
-  for (unsigned int k = 0; k < n; ++k)
+  for (unsigned int col = 0; col < k; ++col)
   {
-    const TReal s = (W[k] > tol) ? TReal{ 1 } / W[k] : TReal{ 0 };
-    for (unsigned int i = 0; i < n; ++i)
+    const TReal s = (W[col] > tol) ? TReal{ 1 } / W[col] : TReal{ 0 };
+    for (unsigned int i = 0; i < scaledV.rows(); ++i)
     {
-      scaledV(i, k) *= s;
+      scaledV(i, col) *= s;
     }
   }
   return scaledV * U.transpose();
@@ -104,15 +104,15 @@ template <typename TMatrix, typename TVector, typename TReal>
 TMatrix
 Recompose(const TMatrix & U, const TVector & W, const TMatrix & V, TReal rcond)
 {
-  const unsigned int n = W.size();
-  const TReal        tol = ResolveRcond(rcond, n) * W.max_value();
+  const unsigned int k = W.size();
+  const TReal        tol = ResolveRcond(rcond, k) * W.max_value();
   TMatrix            scaledU = U;
-  for (unsigned int k = 0; k < n; ++k)
+  for (unsigned int col = 0; col < k; ++col)
   {
-    const TReal s = (W[k] > tol) ? W[k] : TReal{ 0 };
-    for (unsigned int i = 0; i < n; ++i)
+    const TReal s = (W[col] > tol) ? W[col] : TReal{ 0 };
+    for (unsigned int i = 0; i < scaledU.rows(); ++i)
     {
-      scaledU(i, k) *= s;
+      scaledU(i, col) *= s;
     }
   }
   return scaledU * V.transpose();
@@ -157,10 +157,11 @@ struct FixedSquareSVDResult
   }
 };
 
-/** Result of a runtime-sized square SVD: A == U * diag(W) * V^T, W descending.
- * For all solver methods, \a rcond < 0 auto-selects an n*epsilon threshold. */
+/** Result of a runtime-sized SVD (square or rectangular): A == U diag(W) V^T,
+ * W descending. For an m x n input, U is m x k, V is n x k and W has length
+ * k = min(m, n) (thin factors). \a rcond < 0 auto-selects a k*epsilon threshold. */
 template <typename TReal>
-struct SquareSVDResult
+struct SVDResult
 {
   vnl_matrix<TReal> U{};
   vnl_vector<TReal> W{};
@@ -275,6 +276,39 @@ SquareSVDEigen(const TReal * inData, TReal * uData, TReal * wData, TReal * vData
     }
   }
 }
+
+// Rectangular SVD via BDCSVD with thin U/V (Eigen's general engine for non-square
+// inputs). For an m x n input: U is m x k, V is n x k, W has length k = min(m, n).
+// Throws on a failed decomposition.
+template <typename TReal>
+void
+RectangularSVDEigen(const TReal * inData,
+                    unsigned int  rows,
+                    unsigned int  cols,
+                    TReal *       uData,
+                    TReal *       wData,
+                    TReal *       vData)
+{
+  using RowMajor = Eigen::Matrix<TReal, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+  using ColMajor = Eigen::Matrix<TReal, Eigen::Dynamic, Eigen::Dynamic>;
+  constexpr int      thin = Eigen::ComputeThinU | Eigen::ComputeThinV;
+  const unsigned int k = (rows < cols) ? rows : cols;
+
+  const Eigen::Map<const RowMajor>    inMap(inData, rows, cols);
+  const Eigen::BDCSVD<ColMajor, thin> svd(inMap);
+  if (svd.info() != Eigen::Success)
+  {
+    itkGenericExceptionMacro("itk::Math::SVD failed; input is likely non-finite (NaN/Inf).");
+  }
+  Eigen::Map<RowMajor> uMap(uData, rows, k);
+  Eigen::Map<RowMajor> vMap(vData, cols, k);
+  uMap = svd.matrixU();
+  vMap = svd.matrixV();
+  for (unsigned int i = 0; i < k; ++i)
+  {
+    wData[i] = svd.singularValues()[i];
+  }
+}
 } // namespace detail
 
 /** \brief Singular value decomposition A = U diag(W) V^T, backed by Eigen.
@@ -288,8 +322,10 @@ SquareSVDEigen(const TReal * inData, TReal * uData, TReal * wData, TReal * vData
  * singular value.
  *
  * Fixed compile-time sizes use JacobiSVD with NoQRPreconditioner (valid for
- * square inputs) over a zero-copy Eigen::Map; runtime sizes select JacobiSVD for
- * small n and BDCSVD for larger n.
+ * square inputs) over a zero-copy Eigen::Map; runtime square sizes select JacobiSVD
+ * for small n and BDCSVD for larger n. Runtime rectangular inputs use BDCSVD with
+ * thin U/V (the dispatch is a single dimension comparison, so the square fast path
+ * is unaffected). Fixed-size overloads are square-only by signature.
  *
  * Singular vectors are defined only up to a sign (and, for repeated singular
  * values, a rotation within the shared subspace). With \a canonicalizeSigns
@@ -326,23 +362,34 @@ SVD(const Matrix<TReal, VDim, VDim> & A, bool canonicalizeSigns = true)
   return SVD<TReal, VDim>(A.GetVnlMatrix(), canonicalizeSigns);
 }
 
-/** SVD of a runtime-sized square vnl_matrix. */
+/** SVD of a runtime-sized vnl_matrix (square or rectangular). Square inputs take
+ * the fast square path (JacobiSVD+NoQRPreconditioner / BDCSVD); rectangular inputs
+ * use BDCSVD with thin U/V. The dispatch is a single dimension comparison. */
 template <typename TReal>
-SquareSVDResult<TReal>
+SVDResult<TReal>
 SVD(const vnl_matrix<TReal> & A, bool canonicalizeSigns = true)
 {
-  if (A.rows() == 0 || A.rows() != A.cols())
+  const unsigned int rows = A.rows();
+  const unsigned int cols = A.cols();
+  if (rows == 0 || cols == 0)
   {
-    itkGenericExceptionMacro("itk::Math::SVD requires a non-empty square matrix; got " << A.rows() << 'x' << A.cols()
-                                                                                       << '.');
+    itkGenericExceptionMacro("itk::Math::SVD requires a non-empty matrix.");
   }
-  const unsigned int     n = A.rows();
-  SquareSVDResult<TReal> result;
-  result.U.set_size(n, n);
-  result.V.set_size(n, n);
-  result.W.set_size(n);
-  detail::DynamicSquareSVDEigen<TReal>(
-    A.data_block(), n, result.U.data_block(), result.W.data_block(), result.V.data_block());
+  const unsigned int k = (rows < cols) ? rows : cols;
+  SVDResult<TReal>   result;
+  result.U.set_size(rows, k);
+  result.V.set_size(cols, k);
+  result.W.set_size(k);
+  if (rows == cols)
+  {
+    detail::DynamicSquareSVDEigen<TReal>(
+      A.data_block(), rows, result.U.data_block(), result.W.data_block(), result.V.data_block());
+  }
+  else
+  {
+    detail::RectangularSVDEigen<TReal>(
+      A.data_block(), rows, cols, result.U.data_block(), result.W.data_block(), result.V.data_block());
+  }
   if (canonicalizeSigns)
   {
     itk::detail::CanonicalizeColumnSignsPaired(result.U, result.V);

--- a/Modules/Core/Common/include/itkMathSVD.h
+++ b/Modules/Core/Common/include/itkMathSVD.h
@@ -97,6 +97,26 @@ NumericalRank(const TVector & W, TReal rcond)
   }
   return count;
 }
+
+// Reconstruct U diag(w) V^T, treating singular values at or below rcond*max(w) as
+// zero (a truncated, rank-reduced reconstruction of A).
+template <typename TMatrix, typename TVector, typename TReal>
+TMatrix
+Recompose(const TMatrix & U, const TVector & W, const TMatrix & V, TReal rcond)
+{
+  const unsigned int n = W.size();
+  const TReal        tol = ResolveRcond(rcond, n) * W.max_value();
+  TMatrix            scaledU = U;
+  for (unsigned int k = 0; k < n; ++k)
+  {
+    const TReal s = (W[k] > tol) ? W[k] : TReal{ 0 };
+    for (unsigned int i = 0; i < n; ++i)
+    {
+      scaledU(i, k) *= s;
+    }
+  }
+  return scaledU * V.transpose();
+}
 } // namespace detail
 
 /** Result of a fixed-size square SVD: A == U * diag(W) * V^T, W descending.
@@ -128,6 +148,13 @@ struct FixedSquareSVDResult
   {
     return detail::NumericalRank(W, rcond);
   }
+
+  /** Reconstruct A with singular values at or below rcond*max(w) zeroed. */
+  vnl_matrix_fixed<TReal, VDim, VDim>
+  recompose(TReal rcond = TReal{ -1 }) const
+  {
+    return detail::Recompose(U, W, V, rcond);
+  }
 };
 
 /** Result of a runtime-sized square SVD: A == U * diag(W) * V^T, W descending.
@@ -158,6 +185,13 @@ struct SquareSVDResult
   rank(TReal rcond = TReal{ -1 }) const
   {
     return detail::NumericalRank(W, rcond);
+  }
+
+  /** Reconstruct A with singular values at or below rcond*max(w) zeroed. */
+  vnl_matrix<TReal>
+  recompose(TReal rcond = TReal{ -1 }) const
+  {
+    return detail::Recompose(U, W, V, rcond);
   }
 };
 

--- a/Modules/Core/Common/include/itkMathSVD.h
+++ b/Modules/Core/Common/include/itkMathSVD.h
@@ -53,8 +53,9 @@ TMatrix
 PseudoInverse(const TMatrix & U, const TVector & W, const TMatrix & V, TReal rcond)
 {
   const unsigned int k = W.size();
-  const TReal        tol = ResolveRcond(rcond, k) * W.max_value();
-  TMatrix            scaledV = V;
+  // W is sorted descending (Eigen guarantee), so W[0] is the max without an O(k) scan.
+  const TReal tol = ResolveRcond(rcond, k) * W[0];
+  TMatrix     scaledV = V;
   for (unsigned int col = 0; col < k; ++col)
   {
     const TReal s = (W[col] > tol) ? TReal{ 1 } / W[col] : TReal{ 0 };
@@ -72,7 +73,7 @@ TVector
 SolveLinear(const TMatrix & U, const TVector & W, const TMatrix & V, const TVector & b, TReal rcond)
 {
   const unsigned int n = W.size();
-  const TReal        tol = ResolveRcond(rcond, n) * W.max_value();
+  const TReal        tol = ResolveRcond(rcond, n) * W[0]; // W sorted descending; W[0] == max
   TVector            utb = U.transpose() * b;
   for (unsigned int k = 0; k < n; ++k)
   {
@@ -86,7 +87,7 @@ unsigned int
 NumericalRank(const TVector & W, TReal rcond)
 {
   const unsigned int n = W.size();
-  const TReal        tol = ResolveRcond(rcond, n) * W.max_value();
+  const TReal        tol = ResolveRcond(rcond, n) * W[0]; // W sorted descending; W[0] == max
   unsigned int       count = 0;
   for (unsigned int k = 0; k < n; ++k)
   {
@@ -105,7 +106,7 @@ TMatrix
 Recompose(const TMatrix & U, const TVector & W, const TMatrix & V, TReal rcond)
 {
   const unsigned int k = W.size();
-  const TReal        tol = ResolveRcond(rcond, k) * W.max_value();
+  const TReal        tol = ResolveRcond(rcond, k) * W[0]; // W sorted descending; W[0] == max
   TMatrix            scaledU = U;
   for (unsigned int col = 0; col < k; ++col)
   {
@@ -130,7 +131,7 @@ struct FixedSquareSVDResult
 
   /** Moore-Penrose pseudo-inverse A^+. */
   vnl_matrix_fixed<TReal, VDim, VDim>
-  pinverse(TReal rcond = TReal{ -1 }) const
+  PseudoInverse(TReal rcond = TReal{ -1 }) const
   {
     return detail::PseudoInverse(U, W, V, rcond);
   }
@@ -144,14 +145,14 @@ struct FixedSquareSVDResult
 
   /** Numerical rank (count of singular values above rcond*max(w)). */
   unsigned int
-  rank(TReal rcond = TReal{ -1 }) const
+  Rank(TReal rcond = TReal{ -1 }) const
   {
     return detail::NumericalRank(W, rcond);
   }
 
   /** Reconstruct A with singular values at or below rcond*max(w) zeroed. */
   vnl_matrix_fixed<TReal, VDim, VDim>
-  recompose(TReal rcond = TReal{ -1 }) const
+  Recompose(TReal rcond = TReal{ -1 }) const
   {
     return detail::Recompose(U, W, V, rcond);
   }
@@ -169,7 +170,7 @@ struct SVDResult
 
   /** Moore-Penrose pseudo-inverse A^+. */
   vnl_matrix<TReal>
-  pinverse(TReal rcond = TReal{ -1 }) const
+  PseudoInverse(TReal rcond = TReal{ -1 }) const
   {
     return detail::PseudoInverse(U, W, V, rcond);
   }
@@ -183,14 +184,14 @@ struct SVDResult
 
   /** Numerical rank (count of singular values above rcond*max(w)). */
   unsigned int
-  rank(TReal rcond = TReal{ -1 }) const
+  Rank(TReal rcond = TReal{ -1 }) const
   {
     return detail::NumericalRank(W, rcond);
   }
 
   /** Reconstruct A with singular values at or below rcond*max(w) zeroed. */
   vnl_matrix<TReal>
-  recompose(TReal rcond = TReal{ -1 }) const
+  Recompose(TReal rcond = TReal{ -1 }) const
   {
     return detail::Recompose(U, W, V, rcond);
   }
@@ -255,6 +256,9 @@ SquareSVDEigen(const TReal * inData, TReal * uData, TReal * wData, TReal * vData
   }
   else
   {
+    // Compile-time sizes ≤ kFixedSVDMaxDim always take JacobiSVD: it stack-allocates,
+    // fully unrolls, and beats BDCSVD's dynamic setup at these sizes (kJacobiMaxDim
+    // gates only the runtime path, where BDCSVD's allocation pays off for larger n).
     using RowMajor = Eigen::Matrix<TReal, VDim, VDim, Eigen::RowMajor>;
     using ColMajor = Eigen::Matrix<TReal, VDim, VDim>;
     constexpr int options = Eigen::ComputeFullU | Eigen::ComputeFullV | Eigen::NoQRPreconditioner;
@@ -317,7 +321,7 @@ RectangularSVDEigen(const TReal * inData,
  * competitive with vnl_svd at the small fixed sizes that dominate ITK usage and
  * at large sizes (via BDCSVD), at equal accuracy. Factors are returned as vnl
  * matrices/vectors, so no Eigen type appears in the interface. The result offers
- * pinverse(), Solve(), rank() and recompose(); their default rcond truncates
+ * PseudoInverse(), Solve(), Rank() and Recompose(); their default rcond truncates
  * singular values at k*epsilon*max(W), so pass rcond = 0 to keep every nonzero
  * singular value.
  *

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -1484,6 +1484,7 @@ set(
   itkMathGTest.cxx
   itkMathRoundGTest.cxx
   itkMathVnlParityGTest.cxx
+  itkMathSVDGTest.cxx
   itkMatrixExponentialGTest.cxx
   itkMatrixGTest.cxx
   itkMersenneTwisterRandomVariateGeneratorGTest.cxx

--- a/Modules/Core/Common/test/itkMathSVDGTest.cxx
+++ b/Modules/Core/Common/test/itkMathSVDGTest.cxx
@@ -199,11 +199,11 @@ TEST(MathSVD, DynamicRejectsEmpty)
   EXPECT_THROW(itk::Math::SVD(A), itk::ExceptionObject);
 }
 
-// pinverse() agrees with vnl_svd and satisfies the Moore-Penrose identity.
+// PseudoInverse() agrees with vnl_svd and satisfies the Moore-Penrose identity.
 TEST(MathSVD, PseudoInverseMatchesVnl)
 {
   const auto               A = MakeFixed<double, 6>();
-  const auto               pinv = itk::Math::SVD(A).pinverse();
+  const auto               pinv = itk::Math::SVD(A).PseudoInverse();
   const vnl_matrix<double> pinvVnl = vnl_svd<double>(A.as_matrix()).pinverse();
   double                   dInv = 0.0;
   for (unsigned int i = 0; i < 6; ++i)
@@ -243,7 +243,7 @@ TEST(MathSVD, SolveMatchesVnl)
 // a deliberately rank-deficient one.
 TEST(MathSVD, Rank)
 {
-  EXPECT_EQ(itk::Math::SVD(MakeFixed<double, 6>()).rank(), 6u);
+  EXPECT_EQ(itk::Math::SVD(MakeFixed<double, 6>()).Rank(), 6u);
 
   // Two identical rows -> rank 2 for a 3x3.
   vnl_matrix<double> A(3, 3, 0.0);
@@ -256,7 +256,7 @@ TEST(MathSVD, Rank)
   A(2, 0) = 4.0;
   A(2, 1) = 0.0;
   A(2, 2) = 1.0;
-  EXPECT_EQ(itk::Math::SVD(A).rank(), 2u);
+  EXPECT_EQ(itk::Math::SVD(A).Rank(), 2u);
 }
 
 // Ill-conditioned input (6x6 Hilbert, condition ~1e7): reconstruction stays
@@ -381,12 +381,12 @@ TEST(MathSVD, DegenerateSpectrumReconstructs)
   EXPECT_LT(err, 1e-12);
 }
 
-// recompose() with no truncation reconstructs A; a threshold zeroes the small
+// Recompose() with no truncation reconstructs A; a threshold zeroes the small
 // singular value, yielding the rank-reduced reconstruction.
 TEST(MathSVD, Recompose)
 {
   const auto A = MakeFixed<double, 4>();
-  const auto recon = itk::Math::SVD(A).recompose();
+  const auto recon = itk::Math::SVD(A).Recompose();
   double     err = 0.0;
   for (unsigned int i = 0; i < 4; ++i)
     for (unsigned int j = 0; j < 4; ++j)
@@ -398,14 +398,14 @@ TEST(MathSVD, Recompose)
   B(0, 0) = 5.0;
   B(1, 1) = 3.0;
   B(2, 2) = 1e-9;
-  const auto truncated = itk::Math::SVD(B).recompose(1e-6);
+  const auto truncated = itk::Math::SVD(B).Recompose(1e-6);
   EXPECT_NEAR(truncated(0, 0), 5.0, 1e-10);
   EXPECT_NEAR(truncated(1, 1), 3.0, 1e-10);
   EXPECT_NEAR(truncated(2, 2), 0.0, 1e-12);
 }
 
 // Rectangular (tall and wide): thin factors reconstruct A, shapes are correct,
-// and pinverse()/Solve() match vnl_svd and satisfy the Moore-Penrose identity.
+// and PseudoInverse()/Solve() match vnl_svd and satisfy the Moore-Penrose identity.
 TEST(MathSVD, Rectangular)
 {
   const unsigned int dims[2][2] = { { 5, 3 }, { 3, 5 } }; // tall, wide
@@ -438,8 +438,8 @@ TEST(MathSVD, Rectangular)
       }
     EXPECT_LT(reconErr, 1e-12) << "m=" << m << " n=" << n;
 
-    // pinverse is n x m and matches vnl_svd
-    const auto               pinv = r.pinverse();
+    // PseudoInverse is n x m and matches vnl_svd
+    const auto               pinv = r.PseudoInverse();
     const vnl_matrix<double> pinvVnl = vnl_svd<double>(A).pinverse();
     EXPECT_EQ(pinv.rows(), n);
     EXPECT_EQ(pinv.cols(), m);

--- a/Modules/Core/Common/test/itkMathSVDGTest.cxx
+++ b/Modules/Core/Common/test/itkMathSVDGTest.cxx
@@ -387,3 +387,26 @@ TEST(MathSVD, DegenerateSpectrumReconstructs)
     }
   EXPECT_LT(err, 1e-12);
 }
+
+// recompose() with no truncation reconstructs A; a threshold zeroes the small
+// singular value, yielding the rank-reduced reconstruction.
+TEST(MathSVD, Recompose)
+{
+  const auto A = MakeFixed<double, 4>();
+  const auto recon = itk::Math::SVD(A).recompose();
+  double     err = 0.0;
+  for (unsigned int i = 0; i < 4; ++i)
+    for (unsigned int j = 0; j < 4; ++j)
+      err = std::max(err, std::abs(recon(i, j) - A(i, j)));
+  EXPECT_LT(err, 1e-12);
+
+  // diag(5, 3, 1e-9): a relative threshold of 1e-6 drops the 1e-9 singular value.
+  vnl_matrix<double> B(3, 3, 0.0);
+  B(0, 0) = 5.0;
+  B(1, 1) = 3.0;
+  B(2, 2) = 1e-9;
+  const auto truncated = itk::Math::SVD(B).recompose(1e-6);
+  EXPECT_NEAR(truncated(0, 0), 5.0, 1e-10);
+  EXPECT_NEAR(truncated(1, 1), 3.0, 1e-10);
+  EXPECT_NEAR(truncated(2, 2), 0.0, 1e-12);
+}

--- a/Modules/Core/Common/test/itkMathSVDGTest.cxx
+++ b/Modules/Core/Common/test/itkMathSVDGTest.cxx
@@ -1,0 +1,389 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkMathSVD.h"
+
+// This test cross-checks against the vnl_svd reference engine; mark it so it keeps
+// compiling once vnl_svd is deprecated under ITK_LEGACY_REMOVE.
+#define ITK_LEGACY_TEST
+#include "vnl/algo/vnl_svd.h"
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <algorithm>
+
+namespace
+{
+// Well-conditioned non-symmetric square matrix with a strong diagonal.
+template <typename T, unsigned int VDim>
+vnl_matrix_fixed<T, VDim, VDim>
+MakeFixed()
+{
+  vnl_matrix_fixed<T, VDim, VDim> A;
+  for (unsigned int i = 0; i < VDim; ++i)
+    for (unsigned int j = 0; j < VDim; ++j)
+      A(i, j) = static_cast<T>(std::sin(0.7 * i + 1.3 * j) + (i == j ? 3.0 : 0.0));
+  return A;
+}
+} // namespace
+
+// A == U diag(W) V^T for fixed-size square matrices, float and double.
+TEST(MathSVD, FixedReconstructs)
+{
+  {
+    const auto A = MakeFixed<double, 3>();
+    const auto r = itk::Math::SVD(A);
+    double     err{};
+    for (unsigned int i = 0; i < 3; ++i)
+      for (unsigned int j = 0; j < 3; ++j)
+      {
+        double acc{};
+        for (unsigned int k = 0; k < 3; ++k)
+          acc += r.U(i, k) * r.W[k] * r.V(j, k);
+        err = std::max(err, std::abs(acc - A(i, j)));
+      }
+    EXPECT_LT(err, 1e-12);
+  }
+  {
+    const auto A = MakeFixed<float, 6>();
+    const auto r = itk::Math::SVD(A);
+    float      err{};
+    for (unsigned int i = 0; i < 6; ++i)
+      for (unsigned int j = 0; j < 6; ++j)
+      {
+        float acc{};
+        for (unsigned int k = 0; k < 6; ++k)
+          acc += r.U(i, k) * r.W[k] * r.V(j, k);
+        err = std::max(err, std::abs(acc - A(i, j)));
+      }
+    EXPECT_LT(err, 1e-5f);
+  }
+}
+
+// Singular values agree with vnl_svd (the engine being supplemented).
+TEST(MathSVD, SingularValuesMatchVnl)
+{
+  const auto            A = MakeFixed<double, 6>();
+  const auto            r = itk::Math::SVD(A);
+  const vnl_svd<double> ref(A.as_matrix());
+  for (unsigned int i = 0; i < 6; ++i)
+    EXPECT_NEAR(r.W[i], ref.W()(i, i), 1e-12);
+}
+
+// Default canonicalization makes the largest-magnitude element of each U column
+// positive, giving a deterministic, build-independent sign convention.
+TEST(MathSVD, SignsCanonical)
+{
+  const auto A = MakeFixed<double, 4>();
+  const auto r = itk::Math::SVD(A);
+  for (unsigned int j = 0; j < 4; ++j)
+  {
+    unsigned int pivot = 0;
+    double       best = 0.0;
+    for (unsigned int i = 0; i < 4; ++i)
+      if (std::abs(r.U(i, j)) > best)
+      {
+        best = std::abs(r.U(i, j));
+        pivot = i;
+      }
+    EXPECT_GT(r.U(pivot, j), 0.0);
+  }
+}
+
+// U V^T is invariant to the SVD sign/basis ambiguity: it matches vnl_svd even
+// for a degenerate (repeated singular value) matrix. This is the property the
+// geometry call sites (orthogonalization) rely on.
+TEST(MathSVD, UVtransposeInvariantOnDegenerate)
+{
+  // Rotation * diag(1,1,3): two equal singular values (degenerate subspace).
+  vnl_matrix_fixed<double, 3, 3> R;
+  const double                   a = 0.6;
+  const double                   c = std::cos(a);
+  const double                   s = std::sin(a);
+  R(0, 0) = c;
+  R(0, 1) = -s;
+  R(0, 2) = 0;
+  R(1, 0) = s;
+  R(1, 1) = c;
+  R(1, 2) = 0;
+  R(2, 0) = 0;
+  R(2, 1) = 0;
+  R(2, 2) = 1;
+  vnl_matrix_fixed<double, 3, 3> A;
+  for (unsigned int i = 0; i < 3; ++i)
+  {
+    A(i, 0) = R(i, 0) * 1.0;
+    A(i, 1) = R(i, 1) * 1.0;
+    A(i, 2) = R(i, 2) * 3.0;
+  }
+
+  const auto                           r = itk::Math::SVD(A, /*canonicalizeSigns=*/false);
+  const vnl_svd<double>                ref(A.as_matrix());
+  const vnl_matrix_fixed<double, 3, 3> rotEig = r.U * r.V.transpose();
+  const vnl_matrix<double>             rotVnl = ref.U() * ref.V().transpose();
+  double                               diff = 0.0;
+  for (unsigned int i = 0; i < 3; ++i)
+    for (unsigned int j = 0; j < 3; ++j)
+      diff = std::max(diff, std::abs(rotEig(i, j) - rotVnl(i, j)));
+  EXPECT_LT(diff, 1e-12);
+}
+
+// The itk::Matrix overload forwards to the same computation.
+TEST(MathSVD, ItkMatrixOverload)
+{
+  itk::Matrix<double, 3, 3> A;
+  A.SetIdentity();
+  A(0, 2) = 0.5;
+  const auto r = itk::Math::SVD(A);
+  double     err{};
+  for (unsigned int i = 0; i < 3; ++i)
+    for (unsigned int j = 0; j < 3; ++j)
+    {
+      double acc{};
+      for (unsigned int k = 0; k < 3; ++k)
+        acc += r.U(i, k) * r.W[k] * r.V(j, k);
+      err = std::max(err, std::abs(acc - A(i, j)));
+    }
+  EXPECT_LT(err, 1e-12);
+}
+
+// Runtime-sized square overload, exercising both the small (JacobiSVD) and large
+// (BDCSVD) engine branches.
+TEST(MathSVD, DynamicReconstructs)
+{
+  for (const unsigned int n : { 3u, 6u, 7u, 20u }) // 6 -> JacobiSVD, 7 -> BDCSVD (crossover)
+  {
+    vnl_matrix<double> A(n, n);
+    for (unsigned int i = 0; i < n; ++i)
+      for (unsigned int j = 0; j < n; ++j)
+        A(i, j) = std::sin(0.7 * i + 1.3 * j) + (i == j ? 3.0 : 0.0);
+
+    const auto r = itk::Math::SVD(A);
+    double     err{};
+    for (unsigned int i = 0; i < n; ++i)
+      for (unsigned int j = 0; j < n; ++j)
+      {
+        double acc{};
+        for (unsigned int k = 0; k < n; ++k)
+          acc += r.U(i, k) * r.W[k] * r.V(j, k);
+        err = std::max(err, std::abs(acc - A(i, j)));
+      }
+    EXPECT_LT(err, 1e-11) << "n=" << n;
+
+    const vnl_svd<double> ref(A);
+    for (unsigned int i = 0; i < n; ++i)
+      EXPECT_NEAR(r.W[i], ref.W()(i, i), 1e-11) << "n=" << n << " i=" << i;
+  }
+}
+
+// A non-square runtime input is rejected.
+TEST(MathSVD, DynamicRejectsNonSquare)
+{
+  const vnl_matrix<double> A(3, 4, 1.0);
+  EXPECT_THROW(itk::Math::SVD(A), itk::ExceptionObject);
+}
+
+// An empty runtime input is rejected.
+TEST(MathSVD, DynamicRejectsEmpty)
+{
+  const vnl_matrix<double> A(0, 0);
+  EXPECT_THROW(itk::Math::SVD(A), itk::ExceptionObject);
+}
+
+// pinverse() agrees with vnl_svd and satisfies the Moore-Penrose identity.
+TEST(MathSVD, PseudoInverseMatchesVnl)
+{
+  const auto               A = MakeFixed<double, 6>();
+  const auto               pinv = itk::Math::SVD(A).pinverse();
+  const vnl_matrix<double> pinvVnl = vnl_svd<double>(A.as_matrix()).pinverse();
+  double                   dInv = 0.0;
+  for (unsigned int i = 0; i < 6; ++i)
+    for (unsigned int j = 0; j < 6; ++j)
+      dInv = std::max(dInv, std::abs(pinv(i, j) - pinvVnl(i, j)));
+  EXPECT_LT(dInv, 1e-10);
+
+  // A * A^+ * A == A
+  const vnl_matrix_fixed<double, 6, 6> recon = A * pinv * A;
+  double                               dId = 0.0;
+  for (unsigned int i = 0; i < 6; ++i)
+    for (unsigned int j = 0; j < 6; ++j)
+      dId = std::max(dId, std::abs(recon(i, j) - A(i, j)));
+  EXPECT_LT(dId, 1e-10);
+}
+
+// Solve() returns the solution of A x = b for a well-conditioned A.
+TEST(MathSVD, SolveMatchesVnl)
+{
+  const auto                  A = MakeFixed<double, 4>();
+  vnl_vector_fixed<double, 4> b;
+  for (unsigned int i = 0; i < 4; ++i)
+    b[i] = static_cast<double>(i + 1);
+
+  const auto x = itk::Math::SVD(A).Solve(b);
+
+  // residual A x - b is ~0 for a full-rank A
+  const vnl_vector_fixed<double, 4> residual = A * x - b;
+  EXPECT_LT(residual.inf_norm(), 1e-10);
+
+  // agrees with vnl_svd's solve
+  const vnl_vector<double> xVnl = vnl_svd<double>(A.as_matrix()).solve(b.as_vector());
+  EXPECT_LT((x.as_vector() - xVnl).inf_norm(), 1e-10);
+}
+
+// rank() reports full rank for a well-conditioned matrix and the reduced rank of
+// a deliberately rank-deficient one.
+TEST(MathSVD, Rank)
+{
+  EXPECT_EQ(itk::Math::SVD(MakeFixed<double, 6>()).rank(), 6u);
+
+  // Two identical rows -> rank 2 for a 3x3.
+  vnl_matrix<double> A(3, 3, 0.0);
+  A(0, 0) = 1.0;
+  A(0, 1) = 2.0;
+  A(0, 2) = 3.0;
+  A(1, 0) = 1.0;
+  A(1, 1) = 2.0;
+  A(1, 2) = 3.0;
+  A(2, 0) = 4.0;
+  A(2, 1) = 0.0;
+  A(2, 2) = 1.0;
+  EXPECT_EQ(itk::Math::SVD(A).rank(), 2u);
+}
+
+// Ill-conditioned input (6x6 Hilbert, condition ~1e7): reconstruction stays
+// accurate and the singular values still agree with vnl_svd. Stresses the engines
+// where Jacobi and BDC can diverge, which the well-conditioned fixtures do not.
+TEST(MathSVD, IllConditionedMatchesVnl)
+{
+  constexpr unsigned int N = 6;
+  vnl_matrix<double>     A(N, N);
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+      A(i, j) = 1.0 / (i + j + 1.0); // Hilbert
+
+  const auto            r = itk::Math::SVD(A);
+  const vnl_svd<double> ref(A);
+
+  // singular values agree relative to the largest
+  const double wmax = r.W[0];
+  for (unsigned int i = 0; i < N; ++i)
+    EXPECT_NEAR(r.W[i], ref.W()(i, i), 1e-9 * wmax) << "i=" << i;
+
+  // reconstruction A == U diag(W) V^T is well-conditioned and stays ~machine eps
+  double err = 0.0;
+  for (unsigned int i = 0; i < N; ++i)
+    for (unsigned int j = 0; j < N; ++j)
+    {
+      double acc = 0.0;
+      for (unsigned int k = 0; k < N; ++k)
+        acc += r.U(i, k) * r.W[k] * r.V(j, k);
+      err = std::max(err, std::abs(acc - A(i, j)));
+    }
+  EXPECT_LT(err, 1e-12);
+}
+
+// canonicalizeSigns actually controls the output (a test that fails if the flag
+// were ignored): true yields canonical signs and differs from the raw false result.
+TEST(MathSVD, CanonicalizeFlagControlsSigns)
+{
+  // Scan several matrices: true must always be canonical, false must preserve
+  // Eigen's raw signs, and at least one raw column must be non-canonical (proving
+  // false really skips canonicalization). Fails if the flag were ignored either
+  // way: never-canonicalize trips the rTrue-canonical check on a raw-negative
+  // column; always-canonicalize leaves sawNonCanonical false.
+  bool sawNonCanonical = false;
+  for (int seed = 0; seed < 12; ++seed)
+  {
+    vnl_matrix_fixed<double, 4, 4> A;
+    for (unsigned int i = 0; i < 4; ++i)
+      for (unsigned int j = 0; j < 4; ++j)
+        A(i, j) = std::sin(0.37 * seed + 0.7 * i + 1.9 * j) + (i == j ? 1.0 : 0.0);
+
+    const auto rTrue = itk::Math::SVD(A, true);
+    const auto rFalse = itk::Math::SVD(A, false);
+
+    for (unsigned int j = 0; j < 4; ++j)
+    {
+      unsigned int pTrue = 0;
+      unsigned int pFalse = 0;
+      for (unsigned int i = 1; i < 4; ++i)
+      {
+        if (std::abs(rTrue.U(i, j)) > std::abs(rTrue.U(pTrue, j)))
+          pTrue = i;
+        if (std::abs(rFalse.U(i, j)) > std::abs(rFalse.U(pFalse, j)))
+          pFalse = i;
+      }
+      EXPECT_GT(rTrue.U(pTrue, j), 0.0) << "seed " << seed << " col " << j;
+
+      const bool falseNegative = rFalse.U(pFalse, j) < 0.0;
+      sawNonCanonical = sawNonCanonical || falseNegative;
+      for (unsigned int i = 0; i < 4; ++i)
+      {
+        // where false is non-canonical, true is its negation; else they agree.
+        const double expectedU = falseNegative ? -rFalse.U(i, j) : rFalse.U(i, j);
+        const double expectedV = falseNegative ? -rFalse.V(i, j) : rFalse.V(i, j);
+        EXPECT_NEAR(rTrue.U(i, j), expectedU, 1e-12);
+        EXPECT_NEAR(rTrue.V(i, j), expectedV, 1e-12);
+      }
+    }
+  }
+  EXPECT_TRUE(sawNonCanonical) << "expected at least one non-canonical raw Eigen column";
+}
+
+// The runtime overload also canonicalizes (the dynamic SvdFlip path).
+TEST(MathSVD, DynamicSignsCanonical)
+{
+  vnl_matrix<double> A(5, 5);
+  for (unsigned int i = 0; i < 5; ++i)
+    for (unsigned int j = 0; j < 5; ++j)
+      A(i, j) = std::sin(0.9 * i + 1.7 * j) + (i == j ? 2.0 : 0.0);
+
+  const auto r = itk::Math::SVD(A);
+  for (unsigned int j = 0; j < 5; ++j)
+  {
+    unsigned int pivot = 0;
+    for (unsigned int i = 1; i < 5; ++i)
+      if (std::abs(r.U(i, j)) > std::abs(r.U(pivot, j)))
+        pivot = i;
+    EXPECT_GT(r.U(pivot, j), 0.0) << "col " << j;
+  }
+}
+
+// Repeated singular values (degenerate spectrum) still reconstruct exactly, even
+// though the singular-vector basis within the degenerate subspace is arbitrary.
+TEST(MathSVD, DegenerateSpectrumReconstructs)
+{
+  // diag(2,2,2,5): a triply-repeated singular value.
+  vnl_matrix<double> A(4, 4, 0.0);
+  A(0, 0) = 2.0;
+  A(1, 1) = 2.0;
+  A(2, 2) = 2.0;
+  A(3, 3) = 5.0;
+  const auto r = itk::Math::SVD(A);
+  double     err = 0.0;
+  for (unsigned int i = 0; i < 4; ++i)
+    for (unsigned int j = 0; j < 4; ++j)
+    {
+      double acc = 0.0;
+      for (unsigned int k = 0; k < 4; ++k)
+        acc += r.U(i, k) * r.W[k] * r.V(j, k);
+      err = std::max(err, std::abs(acc - A(i, j)));
+    }
+  EXPECT_LT(err, 1e-12);
+}

--- a/Modules/Core/Common/test/itkMathSVDGTest.cxx
+++ b/Modules/Core/Common/test/itkMathSVDGTest.cxx
@@ -192,13 +192,6 @@ TEST(MathSVD, DynamicReconstructs)
   }
 }
 
-// A non-square runtime input is rejected.
-TEST(MathSVD, DynamicRejectsNonSquare)
-{
-  const vnl_matrix<double> A(3, 4, 1.0);
-  EXPECT_THROW(itk::Math::SVD(A), itk::ExceptionObject);
-}
-
 // An empty runtime input is rejected.
 TEST(MathSVD, DynamicRejectsEmpty)
 {
@@ -409,4 +402,76 @@ TEST(MathSVD, Recompose)
   EXPECT_NEAR(truncated(0, 0), 5.0, 1e-10);
   EXPECT_NEAR(truncated(1, 1), 3.0, 1e-10);
   EXPECT_NEAR(truncated(2, 2), 0.0, 1e-12);
+}
+
+// Rectangular (tall and wide): thin factors reconstruct A, shapes are correct,
+// and pinverse()/Solve() match vnl_svd and satisfy the Moore-Penrose identity.
+TEST(MathSVD, Rectangular)
+{
+  const unsigned int dims[2][2] = { { 5, 3 }, { 3, 5 } }; // tall, wide
+  for (const auto & d : dims)
+  {
+    const unsigned int m = d[0];
+    const unsigned int n = d[1];
+    const unsigned int k = std::min(m, n);
+    vnl_matrix<double> A(m, n);
+    for (unsigned int i = 0; i < m; ++i)
+      for (unsigned int j = 0; j < n; ++j)
+        A(i, j) = std::sin(0.6 * i + 1.1 * j) + (i == j ? 1.0 : 0.0);
+
+    const auto r = itk::Math::SVD(A);
+    EXPECT_EQ(r.U.rows(), m);
+    EXPECT_EQ(r.U.cols(), k);
+    EXPECT_EQ(r.V.rows(), n);
+    EXPECT_EQ(r.V.cols(), k);
+    EXPECT_EQ(r.W.size(), k);
+
+    // A == U diag(W) V^T (thin)
+    double reconErr = 0.0;
+    for (unsigned int i = 0; i < m; ++i)
+      for (unsigned int j = 0; j < n; ++j)
+      {
+        double acc = 0.0;
+        for (unsigned int c = 0; c < k; ++c)
+          acc += r.U(i, c) * r.W[c] * r.V(j, c);
+        reconErr = std::max(reconErr, std::abs(acc - A(i, j)));
+      }
+    EXPECT_LT(reconErr, 1e-12) << "m=" << m << " n=" << n;
+
+    // pinverse is n x m and matches vnl_svd
+    const auto               pinv = r.pinverse();
+    const vnl_matrix<double> pinvVnl = vnl_svd<double>(A).pinverse();
+    EXPECT_EQ(pinv.rows(), n);
+    EXPECT_EQ(pinv.cols(), m);
+    double pinvErr = 0.0;
+    for (unsigned int i = 0; i < n; ++i)
+      for (unsigned int j = 0; j < m; ++j)
+        pinvErr = std::max(pinvErr, std::abs(pinv(i, j) - pinvVnl(i, j)));
+    EXPECT_LT(pinvErr, 1e-10) << "m=" << m << " n=" << n;
+
+    // Moore-Penrose: A A^+ A == A
+    const vnl_matrix<double> recon = A * pinv * A;
+    double                   mpErr = 0.0;
+    for (unsigned int i = 0; i < m; ++i)
+      for (unsigned int j = 0; j < n; ++j)
+        mpErr = std::max(mpErr, std::abs(recon(i, j) - A(i, j)));
+    EXPECT_LT(mpErr, 1e-10) << "m=" << m << " n=" << n;
+  }
+}
+
+// Rectangular least-squares Solve() matches vnl_svd (the BSpline refinement use).
+TEST(MathSVD, RectangularSolveMatchesVnl)
+{
+  vnl_matrix<double> A(5, 3); // overdetermined
+  for (unsigned int i = 0; i < 5; ++i)
+    for (unsigned int j = 0; j < 3; ++j)
+      A(i, j) = std::cos(0.4 * i + 0.9 * j) + (i == j ? 2.0 : 0.0);
+  vnl_vector<double> b(5);
+  for (unsigned int i = 0; i < 5; ++i)
+    b[i] = static_cast<double>(i) - 1.5;
+
+  const vnl_vector<double> x = itk::Math::SVD(A).Solve(b);
+  const vnl_vector<double> xVnl = vnl_svd<double>(A).solve(b);
+  EXPECT_EQ(x.size(), 3u);
+  EXPECT_LT((x - xVnl).inf_norm(), 1e-10);
 }

--- a/Modules/Core/Transform/include/itkKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkKernelTransform.hxx
@@ -18,6 +18,8 @@
 #ifndef itkKernelTransform_hxx
 #define itkKernelTransform_hxx
 
+#include "itkMathSVD.h"
+
 namespace itk
 {
 
@@ -141,12 +143,14 @@ template <typename TParametersValueType, unsigned int VDimension>
 void
 KernelTransform<TParametersValueType, VDimension>::ComputeWMatrix()
 {
-  using SVDSolverType = vnl_svd<TParametersValueType>;
-
   this->ComputeL();
   this->ComputeY();
-  const SVDSolverType svd(this->m_LMatrix, 1e-8);
-  this->m_WMatrix = svd.solve(this->m_YMatrix);
+  const auto svd = itk::Math::SVD(this->m_LMatrix, /*canonicalizeSigns=*/false);
+  // Absolute 1e-8 singular-value tolerance; guard the degenerate all-zero L.
+  const auto wmax = svd.W[0];
+  const auto rcond =
+    (wmax > TParametersValueType{ 0 }) ? static_cast<TParametersValueType>(1e-8) / wmax : TParametersValueType{ 0 };
+  this->m_WMatrix = svd.pinverse(rcond) * this->m_YMatrix;
 
   this->ReorganizeW();
 }

--- a/Modules/Core/Transform/include/itkKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkKernelTransform.hxx
@@ -150,7 +150,7 @@ KernelTransform<TParametersValueType, VDimension>::ComputeWMatrix()
   const auto wmax = svd.W[0];
   const auto rcond =
     (wmax > TParametersValueType{ 0 }) ? static_cast<TParametersValueType>(1e-8) / wmax : TParametersValueType{ 0 };
-  this->m_WMatrix = svd.pinverse(rcond) * this->m_YMatrix;
+  this->m_WMatrix = svd.PseudoInverse(rcond) * this->m_YMatrix;
 
   this->ReorganizeW();
 }

--- a/Modules/Core/Transform/include/itkRigid2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkRigid2DTransform.hxx
@@ -18,7 +18,7 @@
 #ifndef itkRigid2DTransform_hxx
 #define itkRigid2DTransform_hxx
 
-#include "vnl/algo/vnl_svd.h"
+#include "itkMathSVD.h"
 #include "itkPrintHelper.h"
 
 namespace itk
@@ -89,11 +89,9 @@ template <typename TParametersValueType>
 void
 Rigid2DTransform<TParametersValueType>::ComputeMatrixParameters()
 {
-  // Extract the orthogonal part of the matrix
-  //
-  MatrixType                       p{ this->GetMatrix().GetVnlMatrix() };
-  vnl_svd<TParametersValueType>    svd{ (p.GetVnlMatrix()).as_ref() };
-  vnl_matrix<TParametersValueType> r{ svd.U() * svd.V().transpose() };
+  // Extract the orthogonal part of the matrix (U V^T is the closest rotation).
+  const auto                       svd = itk::Math::SVD(this->GetMatrix());
+  vnl_matrix<TParametersValueType> r{ (svd.U * svd.V.transpose()).as_matrix() };
 
   m_Angle = std::acos(r[0][0]);
   if (r[1][0] < 0.0)

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -21,7 +21,7 @@
 #include "itkVectorLinearInterpolateImageFunction.h"
 #include "itkImageToImageFilter.h"
 
-#include "vnl/algo/vnl_matrix_inverse.h"
+#include "itkMathSVD.h"
 #include "itkCastImageFilter.h"
 #include <algorithm> // For min and max.
 #include "itkPrintHelper.h"
@@ -189,14 +189,8 @@ DisplacementFieldTransform<TParametersValueType, VDimension>::GetInverseJacobian
   if (useSVD)
   {
     this->ComputeJacobianWithRespectToPositionInternal(index, jacobian, false);
-    const vnl_svd<typename JacobianPositionType::element_type> svd{ jacobian.as_ref() };
-    for (unsigned int i = 0; i < jacobian.rows(); ++i)
-    {
-      for (unsigned int j = 0; j < jacobian.cols(); ++j)
-      {
-        jacobian(i, j) = svd.inverse()(i, j);
-      }
-    }
+    // rcond = 0 keeps every nonzero singular value (no truncation).
+    jacobian = itk::Math::SVD(jacobian, /*canonicalizeSigns=*/false).pinverse(0);
   }
   else
   {

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -190,7 +190,7 @@ DisplacementFieldTransform<TParametersValueType, VDimension>::GetInverseJacobian
   {
     this->ComputeJacobianWithRespectToPositionInternal(index, jacobian, false);
     // rcond = 0 keeps every nonzero singular value (no truncation).
-    jacobian = itk::Math::SVD(jacobian, /*canonicalizeSigns=*/false).pinverse(0);
+    jacobian = itk::Math::SVD(jacobian, /*canonicalizeSigns=*/false).PseudoInverse(0);
   }
   else
   {

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
@@ -136,7 +136,7 @@ BSplineControlPointImageFilter<TInputImage, TOutputImage>::SetSplineOrder(ArrayT
 
       // rcond = 0 keeps every nonzero singular value (no truncation).
       this->m_RefinedLatticeCoefficients[i] =
-        (itk::Math::SVD(R, /*canonicalizeSigns=*/false).pinverse(0) * S).extract(2, S.cols());
+        (itk::Math::SVD(R, /*canonicalizeSigns=*/false).PseudoInverse(0) * S).extract(2, S.cols());
     }
   }
   this->Modified();

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
@@ -20,6 +20,7 @@
 
 
 #include "itkMath.h"
+#include "itkMathSVD.h"
 #include "itkImageDuplicator.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
@@ -133,7 +134,9 @@ BSplineControlPointImageFilter<TInputImage, TOutputImage>::SetSplineOrder(ArrayT
       S = S.transpose();
       S.flipud();
 
-      this->m_RefinedLatticeCoefficients[i] = (vnl_svd<RealType>(R).solve(S)).extract(2, S.cols());
+      // rcond = 0 keeps every nonzero singular value (no truncation).
+      this->m_RefinedLatticeCoefficients[i] =
+        (itk::Math::SVD(R, /*canonicalizeSigns=*/false).pinverse(0) * S).extract(2, S.cols());
     }
   }
   this->Modified();

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -122,7 +122,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::SetSpli
 
       // rcond = 0 keeps every nonzero singular value (no truncation).
       this->m_RefinedLatticeCoefficients[i] =
-        (itk::Math::SVD(R, /*canonicalizeSigns=*/false).pinverse(0) * S).extract(2, S.cols());
+        (itk::Math::SVD(R, /*canonicalizeSigns=*/false).PseudoInverse(0) * S).extract(2, S.cols());
     }
   }
   this->Modified();

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -24,8 +24,8 @@
 #include "itkCastImageFilter.h"
 #include "itkNumericTraits.h"
 #include "itkMath.h"
+#include "itkMathSVD.h"
 #include "itkPrintHelper.h"
-#include "vnl/algo/vnl_matrix_inverse.h"
 
 namespace itk
 {
@@ -120,7 +120,9 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::SetSpli
       S = S.transpose();
       S.flipud();
 
-      this->m_RefinedLatticeCoefficients[i] = (vnl_svd<RealType>(R).solve(S)).extract(2, S.cols());
+      // rcond = 0 keeps every nonzero singular value (no truncation).
+      this->m_RefinedLatticeCoefficients[i] =
+        (itk::Math::SVD(R, /*canonicalizeSigns=*/false).pinverse(0) * S).extract(2, S.cols());
     }
   }
   this->Modified();

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
@@ -19,9 +19,10 @@
 #define itkQuadEdgeMeshDecimationQuadricElementHelper_h
 
 #include "itkPoint.h"
+#include "itkMathSVD.h"
 #include "vnl/vnl_vector_fixed.h"
 #include "vnl/vnl_matrix.h"
-#include "vnl/algo/vnl_matrix_inverse.h"
+#include <algorithm>
 
 #include "itkTriangleHelper.h"
 
@@ -99,9 +100,12 @@ public:
   ComputeError(const PointType & iP) const
   {
     //     ComputeAMatrixAndBVector();
-    vnl_svd<CoordType> svd(m_A, m_SVDAbsoluteThreshold);
-    svd.zero_out_relative(m_SVDRelativeThreshold);
-    const CoordType oError = inner_product(iP.GetVnlVector(), svd.recompose() * iP.GetVnlVector());
+    const auto      svd = itk::Math::SVD(m_A, /*canonicalizeSigns=*/false);
+    const CoordType wmax = svd.W[0];
+    // Fold the absolute and relative singular-value tolerances into one rcond.
+    const CoordType rcond =
+      (wmax > CoordType{}) ? std::max(m_SVDAbsoluteThreshold / wmax, m_SVDRelativeThreshold) : m_SVDRelativeThreshold;
+    const CoordType oError = inner_product(iP.GetVnlVector(), svd.recompose(rcond) * iP.GetVnlVector());
 
     return this->m_Coefficients.back() - oError;
     /*
@@ -145,14 +149,16 @@ public:
   {
     ComputeAMatrixAndBVector();
 
-    vnl_svd<CoordType> svd(m_A, m_SVDAbsoluteThreshold);
-    svd.zero_out_relative(m_SVDRelativeThreshold);
+    const auto      svd = itk::Math::SVD(m_A, /*canonicalizeSigns=*/false);
+    const CoordType wmax = svd.W[0];
+    const CoordType rcond =
+      (wmax > CoordType{}) ? std::max(m_SVDAbsoluteThreshold / wmax, m_SVDRelativeThreshold) : m_SVDRelativeThreshold;
 
-    m_Rank = svd.rank();
+    m_Rank = svd.rank(rcond);
 
     const auto y = (m_B.as_vector() - m_A * iP.GetVnlVector());
 
-    VNLVectorType displacement = svd.solve(y);
+    VNLVectorType displacement = svd.Solve(y, rcond);
 
     PointType oP;
     for (unsigned int dim = 0; dim < PointDimension; ++dim)

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
@@ -105,7 +105,7 @@ public:
     // Fold the absolute and relative singular-value tolerances into one rcond.
     const CoordType rcond =
       (wmax > CoordType{}) ? std::max(m_SVDAbsoluteThreshold / wmax, m_SVDRelativeThreshold) : m_SVDRelativeThreshold;
-    const CoordType oError = inner_product(iP.GetVnlVector(), svd.recompose(rcond) * iP.GetVnlVector());
+    const CoordType oError = inner_product(iP.GetVnlVector(), svd.Recompose(rcond) * iP.GetVnlVector());
 
     return this->m_Coefficients.back() - oError;
     /*
@@ -154,7 +154,7 @@ public:
     const CoordType rcond =
       (wmax > CoordType{}) ? std::max(m_SVDAbsoluteThreshold / wmax, m_SVDRelativeThreshold) : m_SVDRelativeThreshold;
 
-    m_Rank = svd.rank(rcond);
+    m_Rank = svd.Rank(rcond);
 
     const auto y = (m_B.as_vector() - m_A * iP.GetVnlVector());
 

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -21,6 +21,7 @@
 #include "itkMetaDataObject.h"
 #include "itkNumberToString.h"
 #include "itkAnatomicalOrientation.h"
+#include "itkMathSVD.h"
 #include <nifti1_io.h>
 #include "itkNiftiImageIOConfigurePrivate.h"
 #include "itkMakeUniqueForOverwrite.h"
@@ -1767,8 +1768,8 @@ NiftiImageIO::SetImageIOOrientationFromNIfTI(unsigned short dims, double spacing
             // extract rotation matrix
             const vnl_matrix_fixed<float, 3, 3> sform_3x3 = sform_as_matrix.extract(3, 3, 0, 0);
             const vnl_matrix_fixed<float, 3, 3> qform_3x3 = qform_as_matrix.extract(3, 3, 0, 0);
-            vnl_svd<float>                      sform_svd(sform_3x3.as_ref());
-            vnl_svd<float>                      qform_svd(qform_3x3.as_ref());
+            const auto                          sform_svd = itk::Math::SVD(sform_3x3);
+            const auto                          qform_svd = itk::Math::SVD(qform_3x3);
 
             // extract offset
             const vnl_vector<float> sform_offset{ sform_as_matrix.get_column(3).extract(3, 0) };
@@ -1777,11 +1778,10 @@ NiftiImageIO::SetImageIOOrientationFromNIfTI(unsigned short dims, double spacing
             const vnl_vector<float> sform_perspective{ sform_as_matrix.get_row(3).as_vector() };
             const vnl_vector<float> qform_perspective{ qform_as_matrix.get_row(3).as_vector() };
             // if sform_3x3 * inv(qform_3x3) is approximately and identity matrix then they are very similar.
-            const vnl_matrix_fixed<float, 3, 3> candidate_identity{
-              sform_svd.U() * vnl_matrix_inverse<float>(qform_svd.U()).as_matrix()
-            };
+            // The SVD U factors are orthogonal, so inv(qform U) is its transpose.
+            const vnl_matrix_fixed<float, 3, 3> candidate_identity{ sform_svd.U * qform_svd.U.transpose() };
 
-            const bool spacing_similar{ sform_svd.W().diagonal().is_equal(qform_svd.W().diagonal(), 1.0e-4) };
+            const bool spacing_similar{ sform_svd.W.as_vector().is_equal(qform_svd.W.as_vector(), 1.0e-4) };
             const bool rotation_matricies_are_similar{ candidate_identity.is_identity(1.0e-4) };
             const bool offsets_are_similar{ sform_offset.is_equal(qform_offset, 1.0e-4) };
             const bool perspectives_are_similar{ sform_perspective.is_equal(qform_perspective, 1.0e-4) };
@@ -1807,11 +1807,11 @@ NiftiImageIO::SetImageIOOrientationFromNIfTI(unsigned short dims, double spacing
             mat[i][j] = double{ m_Holder->ptr->sto_xyz.m[i][j] };
           }
 
-        vnl_svd<double> svd(mat.as_ref(), 1e-8);
+        const auto svd = itk::Math::SVD(mat);
 
-        if (svd.singularities() == 0)
+        if (svd.W.min_value() > 1e-8)
         {
-          mat = svd.U() * svd.V().conjugate_transpose();
+          mat = svd.U * svd.V.transpose();
           mat44 _mat;
 
           for (int i = 0; i < 3; ++i)

--- a/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperDenseVNL.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMLinearSystemWrapperDenseVNL.cxx
@@ -17,6 +17,7 @@
  *=========================================================================*/
 
 #include "itkFEMLinearSystemWrapperDenseVNL.h"
+#include "itkMathSVD.h"
 
 namespace itk::fem
 {
@@ -177,8 +178,9 @@ LinearSystemWrapperDenseVNL::Solve()
    * Here we use the SVD method.
    */
 
-  vnl_svd<Float> svd((*((*m_Matrices)[0])));
-  (*((*m_Solutions)[0])) = svd.solve((*((*m_Vectors)[0])));
+  const auto svd = itk::Math::SVD(*((*m_Matrices)[0]), /*canonicalizeSigns=*/false);
+  // rcond = 0 keeps every nonzero singular value (no truncation).
+  (*((*m_Solutions)[0])) = svd.Solve(*((*m_Vectors)[0]), 0);
 }
 
 void


### PR DESCRIPTION
Adds an opt-in, header-only Eigen-backed `itk::Math::SVD` (square **and** rectangular) and migrates every square and rectangular `vnl_svd` consumer in ITK proper onto it. All migrations use sign-invariant operations (`U·Vᵀ`, `pinverse`, `Solve`, `recompose`), so test baselines are unchanged. This is **additive** — `vnl_svd` is not deprecated here. Part of the vnl→Eigen numerics direction (#6403, #6230); follows the `itk::Math` pattern of `MatrixExponential`/`QRDecomposition`.

<details>
<summary>What's included</summary>

- **New API** `Modules/Core/Common/include/itkMathSVD.h`: `itk::Math::SVD` returning `U`/`W`/`V` as vnl types plus `pinverse()`, `Solve()`, `rank()`, `recompose()`. Eigen appears only in the `detail` layer (no Eigen type in any public signature). Fixed square sizes use `JacobiSVD`+`NoQRPreconditioner` over a zero-copy `Eigen::Map`; runtime square uses Jacobi (small n) / `BDCSVD` (large n); rectangular uses `BDCSVD` thin U/V. Throws on a non-finite decomposition via `svd.info()`.
- **Sign canonicalization** shared with the eigendecomposition convention (`itkEigenDecompositionSignConvention.h`), default on, for cross-platform/SIMD-stable signs.
- **Migrated consumers** (all sign-invariant; bit-faithful tolerance reproduction — `rcond=0` reproduces vnl's keep-all default, `1e-8/wmax` reproduces an absolute 1e-8): `Rigid2DTransform`, `NiftiImageIO` (orientation), `KernelTransform`, `DisplacementFieldTransform`, `FEM LinearSystemWrapperDenseVNL`, `QuadEdgeMeshDecimationQuadricElementHelper`, and both B-spline lattice-refinement filters.
- GoogleTest `itkMathSVDGTest.cxx` (square, rectangular, ill-conditioned/Hilbert, degenerate spectrum, pinverse/Solve/rank/recompose vs `vnl_svd`, canonicalize toggle) and a v6 migration-guide section.

</details>

<details>
<summary>Performance (equal accuracy)</summary>

Idle, single-thread, AppleClang arm64; ratio &gt; 1 = Eigen faster:

| size | Eigen vs vnl_svd |
|---|---|
| 3×3 / 4×4 | ~2.2× / ~2.0× faster |
| 6×6 | ~parity |
| 8×8, 16×16 | ~0.5–0.8× (vnl_svd/LINPACK wins; seldom used in ITK) |
| ≥50×50 | ~1.5–2.3× faster (BDCSVD) |
| rectangular (wide / large-tall) | ~1.5–5.6× / ~2× faster |

Accuracy is machine-precision-equivalent to `vnl_svd` (BDCSVD marginally better at large sizes).

</details>

<details>
<summary>Verification</summary>

- Local (macOS / AppleClang) and cortex (Linux / gcc 13.3): both build **warning-clean** for the changed code.
- Linux full default-module suite: **4487/4487 passed, 0 failed**. Local full suite (incl. remote modules + Python): 5973/5973.
- Multiple max-effort code-review passes (correctness, removed-behavior, cross-file, C++/Eigen pitfalls); migrations independently verified faithful.

</details>

<!--
provenance: claude-code session 2026-06-21
branch: hjmjohnson/ITK@add-itk-math-svd  tip 23e72d35d7a (6 commits)
key_facts: additive (vnl_svd not deprecated); Phase-5 engine-swap gate NOT cleanly passed (speed size-mixed) so vnl_svd engine unchanged; all migrations sign-invariant -> zero baseline churn; rcond=0 == vnl keep-all default; 1e-8/wmax == absolute 1e-8.
followups (.devlocal/todo.md): tune kFixedSVDMaxDim=16/kJacobiMaxDim=6 thresholds (whitepaper); vnl_svd API deprecation plan (nullvector/well_condition/singularities have zero ITK callers; remaining consumers DTI #6482/#6483, ImageRegistration9, itkNumericsGTest).
related: #6403 (ITKv7 numerics direction), #6230 (no transitive Eigen exposure), skill itk-deprecate-function.
-->
