### PR TITLE
COMP: Fix ITK_FUTURE_LEGACY_REMOVE build broken by deprecated vnl_cholesky

### DIFF
--- a/Modules/Core/Common/test/itkCholeskySolveGTest.cxx
+++ b/Modules/Core/Common/test/itkCholeskySolveGTest.cxx
@@ -20,8 +20,11 @@
 #include "itkCholeskySolve.h"
 
 // Exercise the deprecated VNL engine for the old-vs-new equivalence checks.
-#define ITK_LEGACY_TEST
-#include "vnl/algo/vnl_cholesky.h"
+// The VNL symbol is unavailable under ITK_FUTURE_LEGACY_REMOVE.
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+#  define ITK_LEGACY_TEST
+#  include "vnl/algo/vnl_cholesky.h"
+#endif
 
 #include <gtest/gtest.h>
 #include <cmath>
@@ -77,6 +80,7 @@ TEST(CholeskySolve, LowerTriangleReconstructsMatrix)
 }
 
 
+#ifndef ITK_FUTURE_LEGACY_REMOVE
 // The Eigen-backed itk:: solve agrees with the native vnl_cholesky engine.
 TEST(CholeskySolve, EquivalentToVnlCholesky)
 {
@@ -93,6 +97,7 @@ TEST(CholeskySolve, EquivalentToVnlCholesky)
 
   EXPECT_LT((xItk - xVnl).two_norm() / xVnl.two_norm(), 1e-10);
 }
+#endif
 
 
 // Single-precision path solves correctly.

--- a/Modules/Numerics/FEM/include/itkFEMSolverCrankNicolson.h
+++ b/Modules/Numerics/FEM/include/itkFEMSolverCrankNicolson.h
@@ -29,7 +29,6 @@
 #include "vnl/vnl_matrix.h"
 #include "vnl/vnl_vector.h"
 #include "vnl/algo/vnl_svd.h"
-#include "vnl/algo/vnl_cholesky.h"
 #include <vnl/vnl_sparse_matrix_linear_system.h>
 #include <cmath>
 


### PR DESCRIPTION
Fix the `ITK_FUTURE_LEGACY_REMOVE` build (Mac10.15-AppleClang-dbg nightly, [CDash build 11361413](https://open.cdash.org/builds/11361413/build)), which fails because two consumers still pull in the deprecated `vnl/algo/vnl_cholesky.h` shim.

Public API must not internally depend on features removed under `ITK_FUTURE_LEGACY_REMOVE`.

<details>
<summary>Root cause and fix</summary>

The `dbg` dashboard configures with `ITK_FUTURE_LEGACY_REMOVE`, under which the `vnl_cholesky.h` deprecation shim emits a hard `#error`. Two consumers tripped it:

- **`Modules/Core/Common/test/itkCholeskySolveGTest.cxx`** included the deprecated header for an old-vs-new equivalence check. `ITK_LEGACY_TEST` only silences the *warning* state, not the `#error`, so the include and the `EquivalentToVnlCholesky` test are now gated behind `#ifndef ITK_FUTURE_LEGACY_REMOVE`. The four `itk::Math` API tests remain unconditional.
- **`Modules/Numerics/FEM/include/itkFEMSolverCrankNicolson.h`** (a public header) carried a stale `vnl/algo/vnl_cholesky.h` include; the `vnl_cholesky` symbol is unused anywhere in the FEM module, so it only forced downstream consumers to compile the removed shim. Removed.

</details>

<details>
<summary>Verification</summary>

Built locally with `ITK_FUTURE_LEGACY_REMOVE:BOOL=ON` (Release, all CI remote modules enabled):

- Full build green end-to-end (`[5208/5209]`, exit 0, zero compile errors, zero `vnl_cholesky` deprecation `#error`s).
- `itkCholeskySolveGTest.cxx` — the exact TU that failed on CDash — compiles and links into `ITKCommonGTestDriver`.
- Default-state build (without the macro) still compiles with all five tests present.

</details>

<!--
provenance: claude-code session 2026-06-21
cdash build Mac10.15-AppleClang-dbg, ITK_FUTURE_LEGACY_REMOVE
files: Modules/Core/Common/test/itkCholeskySolveGTest.cxx (gate vnl include + EquivalentToVnlCholesky test); Modules/Numerics/FEM/include/itkFEMSolverCrankNicolson.h (remove stale vnl_cholesky.h include)
verified: full ITK_FUTURE_LEGACY_REMOVE build exit 0, 5208/5209
-->
