### PR TITLE
BUG: Use imported target for system double-conversion

### DIFF
--- a/Modules/ThirdParty/DoubleConversion/CMakeLists.txt
+++ b/Modules/ThirdParty/DoubleConversion/CMakeLists.txt
@@ -10,16 +10,24 @@ option(
 mark_as_advanced(ITK_USE_SYSTEM_DOUBLECONVERSION)
 
 if(ITK_USE_SYSTEM_DOUBLECONVERSION)
-  find_package(double-conversion 3.1.6 REQUIRED)
-  get_target_property(
-    ITKDoubleConversion_INCLUDE_DIRS
-    double-conversion::double-conversion
-    INTERFACE_INCLUDE_DIRECTORIES
+  set(_double_conversion_compatible 3.1)
+  find_package(double-conversion ${_double_conversion_compatible} REQUIRED)
+  set(ITKDoubleConversion_LIBRARIES "double-conversion::double-conversion")
+  set(ITKDoubleConversion_NO_SRC 1)
+
+  set(
+    ITKDoubleConversion_EXPORT_CODE_INSTALL
+    "
+find_package(double-conversion ${_double_conversion_compatible} REQUIRED)
+"
   )
-  get_target_property(
-    ITKDoubleConversion_LIBRARIES
-    double-conversion::double-conversion
-    LOCATION
+  set(
+    ITKDoubleConversion_EXPORT_CODE_BUILD
+    "
+if(NOT ITK_BINARY_DIR)
+  find_package(double-conversion ${_double_conversion_compatible} REQUIRED)
+endif()
+"
   )
 else()
   set(


### PR DESCRIPTION
Replace `get_target_property` calls with the `double-conversion::double-conversion` imported target and add `find_package` export code to prevent baked-in paths in installed CMake config files.

Companion to #6491 and #6492 which applied the same fix to ZLIB, Expat, JPEG, and PNG.