### PR TITLE
BUG: Remove hardcoded HDF5 system paths from ITKTargets

### DIFF
--- a/Modules/ThirdParty/HDF5/CMakeLists.txt
+++ b/Modules/ThirdParty/HDF5/CMakeLists.txt
@@ -34,31 +34,37 @@ endif()
   )
 
   if(BUILD_SHARED_LIBS)
-    if(TARGET hdf5-shared)
-      set(
-        ITKHDF5_LIBRARIES
-        hdf5_cpp-shared
-        hdf5-shared
-        hdf5_hl-shared
-        hdf5_hl_cpp-shared
-      )
-    elseif(TARGET hdf5::hdf5-shared)
-      set(
-        ITKHDF5_LIBRARIES
-        hdf5::hdf5_cpp-shared
-        hdf5::hdf5-shared
-        hdf5::hdf5_hl-shared
-        hdf5::hdf5_hl_cpp-shared
-      )
-    elseif(TARGET hdf5::hdf5)
-      set(
-        ITKHDF5_LIBRARIES
-        hdf5::hdf5_cpp
-        hdf5::hdf5
-        hdf5::hdf5_hl
-        hdf5::hdf5_hl_cpp
-      )
-    else()
+    set(_hdf5_type -shared)
+  else()
+    set(_hdf5_type -static)
+  endif()
+
+  if(TARGET hdf5::hdf5${_hdf5_type})
+    set(
+      ITKHDF5_LIBRARIES
+      hdf5::hdf5_cpp${_hdf5_type}
+      hdf5::hdf5${_hdf5_type}
+      hdf5::hdf5_hl${_hdf5_type}
+      hdf5::hdf5_hl_cpp${_hdf5_type}
+    )
+  elseif(TARGET hdf5${_hdf5_type})
+    set(
+      ITKHDF5_LIBRARIES
+      hdf5_cpp${_hdf5_type}
+      hdf5${_hdf5_type}
+      hdf5_hl${_hdf5_type}
+      hdf5_hl_cpp${_hdf5_type}
+    )
+  elseif(TARGET hdf5::hdf5)
+    set(
+      ITKHDF5_LIBRARIES
+      hdf5::hdf5_cpp
+      hdf5::hdf5
+      hdf5::hdf5_hl
+      hdf5::hdf5_hl_cpp
+    )
+  else()
+    if(BUILD_SHARED_LIBS)
       set(
         ITKHDF5_LIBRARIES
         ${HDF5_C_SHARED_LIBRARY}
@@ -66,32 +72,6 @@ endif()
         ${HDF5_CXX_LIBRARY_NAMES}
         ${HDF5_HL_SHARED_LIBRARY}
         ${HDF5_LIBRARIES}
-      )
-    endif()
-  else()
-    if(TARGET hdf5-static)
-      set(
-        ITKHDF5_LIBRARIES
-        hdf5_cpp-static
-        hdf5-static
-        hdf5_hl-static
-        hdf5_hl_cpp-static
-      )
-    elseif(TARGET hdf5::hdf5-static)
-      set(
-        ITKHDF5_LIBRARIES
-        hdf5::hdf5_cpp-static
-        hdf5::hdf5-static
-        hdf5::hdf5_hl-static
-        hdf5::hdf5_hl_cpp-static
-      )
-    elseif(TARGET hdf5::hdf5)
-      set(
-        ITKHDF5_LIBRARIES
-        hdf5::hdf5_cpp
-        hdf5::hdf5
-        hdf5::hdf5_hl
-        hdf5::hdf5_hl_cpp
       )
     else()
       set(
@@ -103,18 +83,18 @@ endif()
         ${HDF5_LIBRARIES}
       )
     endif()
+    set(
+      ITKHDF5_SYSTEM_INCLUDE_DIRS
+      ${HDF5_INCLUDE_DIR}
+      ${HDF5_INCLUDE_DIR_HL}
+      ${HDF5_INCLUDE_DIRS}
+      ${HDF5_INCLUDE_DIR_CPP}
+    )
   endif()
 
   set(
     ITKHDF5_INCLUDE_DIRS
     ${ITKHDF5_BINARY_DIR}/src # itk_hdf5.h and itk_H5Cpp.h
-  )
-  set(
-    ITKHDF5_SYSTEM_INCLUDE_DIRS
-    ${HDF5_INCLUDE_DIR}
-    ${HDF5_INCLUDE_DIR_HL}
-    ${HDF5_INCLUDE_DIRS}
-    ${HDF5_INCLUDE_DIR_CPP}
   )
 
   set(ITKHDF5_NO_SRC 1)

--- a/Modules/ThirdParty/HDF5/CMakeLists.txt
+++ b/Modules/ThirdParty/HDF5/CMakeLists.txt
@@ -64,31 +64,10 @@ endif()
       hdf5::hdf5_hl_cpp
     )
   else()
-    if(BUILD_SHARED_LIBS)
-      set(
-        ITKHDF5_LIBRARIES
-        ${HDF5_C_SHARED_LIBRARY}
-        ${HDF5_CXX_SHARED_LIBRARY}
-        ${HDF5_CXX_LIBRARY_NAMES}
-        ${HDF5_HL_SHARED_LIBRARY}
-        ${HDF5_LIBRARIES}
-      )
-    else()
-      set(
-        ITKHDF5_LIBRARIES
-        ${HDF5_C_STATIC_LIBRARY}
-        ${HDF5_CXX_STATIC_LIBRARY}
-        ${HDF5_CXX_LIBRARY_NAMES}
-        ${HDF5_HL_STATIC_LIBRARY}
-        ${HDF5_LIBRARIES}
-      )
-    endif()
-    set(
-      ITKHDF5_SYSTEM_INCLUDE_DIRS
-      ${HDF5_INCLUDE_DIR}
-      ${HDF5_INCLUDE_DIR_HL}
-      ${HDF5_INCLUDE_DIRS}
-      ${HDF5_INCLUDE_DIR_CPP}
+    message(
+      FATAL_ERROR
+      "ITK_USE_SYSTEM_HDF5 is ON but the HDF5 targets were not found. "
+      "Please set HDF5_DIR to the directory containing HDF5Config.cmake."
     )
   endif()
 


### PR DESCRIPTION
Two fixes to the `ITK_USE_SYSTEM_HDF5` path in `ITKHDF5` CMakeLists:

1. Scope `ITKHDF5_SYSTEM_INCLUDE_DIRS` to the variable-fallback branch only — imported targets carry their own include interface and do not need baked-in paths in the installed config files.
2. Consolidate the duplicated shared/static target-detection branches using a single `_hdf5_type` suffix variable.
3. Replace the unreachable variable-fallback branch with a `FATAL_ERROR`: CMake 3.19+ `FindHDF5` always provides `hdf5::hdf5` imported targets, and ITK requires CMake ≥ 3.22.

Companion to #6491, #6492, and #6493 which applied the same imported-target pattern to ZLIB, Expat, JPEG, PNG, and double-conversion.