### PR TITLE
COMP: Modernize itk.support.types for the Python 3.11 floor

### DIFF
--- a/.github/skills/fix-nightly-warnings/scripts/list_nightly_warnings.py
+++ b/.github/skills/fix-nightly-warnings/scripts/list_nightly_warnings.py
@@ -27,7 +27,7 @@ import json
 import sys
 import urllib.error
 import urllib.request
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 CDASH_GRAPHQL = "https://open.cdash.org/graphql"
 INSIGHT_PROJECT_ID = "2"
@@ -134,12 +134,12 @@ def main() -> None:
         # parsing (no manual tz mapping required): `HH:MM:SS+00:00`.
         CTEST_NIGHTLY_START = "01:00:00+00:00"
         # Build an aware datetime from today's date + the hard-coded time offset.
-        today = datetime.now(timezone.utc).date()
+        today = datetime.now(UTC).date()
         dt = datetime.fromisoformat(f"{today.isoformat()}T{CTEST_NIGHTLY_START}")
-        now_utc = datetime.now(timezone.utc)
+        now_utc = datetime.now(UTC)
         since_dt = dt if now_utc >= dt else dt - timedelta(days=1)
     else:
-        since_dt = datetime.now(timezone.utc) - timedelta(hours=args.since)
+        since_dt = datetime.now(UTC) - timedelta(hours=args.since)
 
     since_str = since_dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
 

--- a/.github/skills/fix-nightly-warnings/scripts/triage_nightly.py
+++ b/.github/skills/fix-nightly-warnings/scripts/triage_nightly.py
@@ -25,7 +25,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 from get_build_warnings import extract_flag, fetch_entries
 from list_nightly_warnings import graphql, INSIGHT_PROJECT_ID, QUERY_TEMPLATE
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 
 def main() -> None:
@@ -78,12 +78,12 @@ def main() -> None:
     # Determine time window
     if args.since is None:
         CTEST_NIGHTLY_START = "01:00:00+00:00"
-        today = datetime.now(timezone.utc).date()
+        today = datetime.now(UTC).date()
         dt = datetime.fromisoformat(f"{today.isoformat()}T{CTEST_NIGHTLY_START}")
-        now_utc = datetime.now(timezone.utc)
+        now_utc = datetime.now(UTC)
         since_dt = dt if now_utc >= dt else dt - timedelta(days=1)
     else:
-        since_dt = datetime.now(timezone.utc) - timedelta(hours=args.since)
+        since_dt = datetime.now(UTC) - timedelta(hours=args.since)
 
     since_str = since_dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,7 +82,7 @@ repos:
     hooks:
     -   id: pyupgrade
         exclude: ".*build.*|\\/ThirdParty\\/|\\/Data\\/"
-        args: [--py310-plus]
+        args: [--py311-plus]
 - repo: https://github.com/SimpleITK/CommentSpellCheck.git
   rev: v0.4.4
   hooks:

--- a/Wrapping/Generators/Python/itk/support/types.py
+++ b/Wrapping/Generators/Python/itk/support/types.py
@@ -16,6 +16,8 @@
 #
 # ==========================================================================
 
+from __future__ import annotations
+
 import importlib
 from importlib.metadata import metadata
 from typing import TypeAlias, Union, TYPE_CHECKING
@@ -47,7 +49,7 @@ class itkCType:
     # import locally to facilitate dynamic loading in itk/__init__.py
     import numpy as np
 
-    __c_types__: dict[str, "itkCType"] = {}
+    __c_types__: dict[str, itkCType] = {}
     __c_types_for_dtype__: dict[str, np.dtype] = {}
 
     def __init__(
@@ -72,7 +74,7 @@ class itkCType:
         return f"<itkCType {self.name}>"
 
     @staticmethod
-    def GetCType(name: str) -> "itkCType | None":
+    def GetCType(name: str) -> itkCType | None:
         # import locally to facilitate dynamic loading in itk/__init__.py
 
         """Get the type corresponding to the provided C primitive type name."""
@@ -91,7 +93,7 @@ class itkCType:
             return None
 
     @staticmethod
-    def GetCTypeForDType(np_dtype: np.dtype) -> "itkCType | None":
+    def GetCTypeForDType(np_dtype: np.dtype) -> itkCType | None:
         """Get the type corresponding to the provided numpy.dtype."""
         try:
             return itkCType.__c_types_for_dtype__[np_dtype]
@@ -99,29 +101,29 @@ class itkCType:
             return None
 
     @staticmethod
-    def initialize_c_types_once() -> "tuple[itkCType, ...]":
+    def initialize_c_types_once() -> tuple[itkCType, ...]:
         """
         This function is intended to be run only one time
         """
         import numpy as np
 
-        _F: "itkCType" = itkCType("float", "F", np.dtype(np.float32))
-        _D: "itkCType" = itkCType("double", "D", np.dtype(np.float64))
-        _UC: "itkCType" = itkCType("unsigned char", "UC", np.dtype(np.uint8))
-        _US: "itkCType" = itkCType("unsigned short", "US", np.dtype(np.uint16))
-        _UI: "itkCType" = itkCType("unsigned int", "UI", np.dtype(np.uint32))
+        _F: itkCType = itkCType("float", "F", np.dtype(np.float32))
+        _D: itkCType = itkCType("double", "D", np.dtype(np.float64))
+        _UC: itkCType = itkCType("unsigned char", "UC", np.dtype(np.uint8))
+        _US: itkCType = itkCType("unsigned short", "US", np.dtype(np.uint16))
+        _UI: itkCType = itkCType("unsigned int", "UI", np.dtype(np.uint32))
         if os.name == "nt":
-            _UL: "itkCType" = itkCType("unsigned long", "UL", np.dtype(np.uint32))
-            _SL: "itkCType" = itkCType("signed long", "SL", np.dtype(np.int32))
+            _UL: itkCType = itkCType("unsigned long", "UL", np.dtype(np.uint32))
+            _SL: itkCType = itkCType("signed long", "SL", np.dtype(np.int32))
         else:
-            _UL: "itkCType" = itkCType("unsigned long", "UL", np.dtype(np.uint64))
-            _SL: "itkCType" = itkCType("signed long", "SL", np.dtype(np.int64))
-        _ULL: "itkCType" = itkCType("unsigned long long", "ULL", np.dtype(np.uint64))
-        _SC: "itkCType" = itkCType("signed char", "SC", np.dtype(np.int8))
-        _SS: "itkCType" = itkCType("signed short", "SS", np.dtype(np.int16))
-        _SI: "itkCType" = itkCType("signed int", "SI", np.dtype(np.int32))
-        _SLL: "itkCType" = itkCType("signed long long", "SLL", np.dtype(np.int64))
-        _B: "itkCType" = itkCType("bool", "B", np.dtype(np.bool_))
+            _UL: itkCType = itkCType("unsigned long", "UL", np.dtype(np.uint64))
+            _SL: itkCType = itkCType("signed long", "SL", np.dtype(np.int64))
+        _ULL: itkCType = itkCType("unsigned long long", "ULL", np.dtype(np.uint64))
+        _SC: itkCType = itkCType("signed char", "SC", np.dtype(np.int8))
+        _SS: itkCType = itkCType("signed short", "SS", np.dtype(np.int16))
+        _SI: itkCType = itkCType("signed int", "SI", np.dtype(np.int32))
+        _SLL: itkCType = itkCType("signed long long", "SLL", np.dtype(np.int64))
+        _B: itkCType = itkCType("bool", "B", np.dtype(np.bool_))
         return _F, _D, _UC, _US, _UI, _UL, _SL, _ULL, _SC, _SS, _SI, _SLL, _B
 
 

--- a/Wrapping/Generators/Python/itk/support/types.py
+++ b/Wrapping/Generators/Python/itk/support/types.py
@@ -18,7 +18,7 @@
 
 import importlib
 from importlib.metadata import metadata
-from typing import Union, TYPE_CHECKING
+from typing import TypeAlias, Union, TYPE_CHECKING
 import os
 
 try:
@@ -97,22 +97,7 @@ class itkCType:
             return None
 
     @staticmethod
-    def initialize_c_types_once() -> (
-        "itkCType",
-        "itkCType",
-        "itkCType",
-        "itkCType",
-        "itkCType",
-        "itkCType",
-        "itkCType",
-        "itkCType",
-        "itkCType",
-        "itkCType",
-        "itkCType",
-        "itkCType",
-        "itkCType",
-        "itkCType",
-    ):
+    def initialize_c_types_once() -> "tuple[itkCType, ...]":
         """
         This function is intended to be run only one time
         """
@@ -182,19 +167,20 @@ if os.name == "nt":
 if TYPE_CHECKING:
     import itk
 
-# These should eventually explicitly be marked as TypeAlias's per PEP 613, available in CPython 3.10
-ImageBase = "itk.ImageBase"
-Image = "itk.Image"
-VectorImage = "itk.VectorImage"
+# Marked as TypeAlias per PEP 613 so type checkers resolve the string
+# forward references instead of rejecting them as plain variables.
+ImageBase: TypeAlias = "itk.ImageBase"
+Image: TypeAlias = "itk.Image"
+VectorImage: TypeAlias = "itk.VectorImage"
 
-RGBPixel = "itk.RGBPixel"
-Vector = "itk.Vector"
-CovariantVector = "itk.CovariantVector"
-SymmetricSecondRankTensor = "itk.SymmetricSecondRankTensor"
-Offset = "itk.Offset"
-FixedArray = "itk.FixedArray"
-VariableLengthVector = "itk.VariableLengthVector"
-complex_ = "itk.complex"
+RGBPixel: TypeAlias = "itk.RGBPixel"
+Vector: TypeAlias = "itk.Vector"
+CovariantVector: TypeAlias = "itk.CovariantVector"
+SymmetricSecondRankTensor: TypeAlias = "itk.SymmetricSecondRankTensor"
+Offset: TypeAlias = "itk.Offset"
+FixedArray: TypeAlias = "itk.FixedArray"
+VariableLengthVector: TypeAlias = "itk.VariableLengthVector"
+complex_: TypeAlias = "itk.complex"
 
 PixelTypes = Union[
     itkCType,
@@ -207,7 +193,7 @@ PixelTypes = Union[
     complex_,
 ]
 
-ImageSource = "itk.ImageSource"
+ImageSource: TypeAlias = "itk.ImageSource"
 
 ImageOrImageSource = Union[ImageBase, ImageSource]
 # Can be coerced into an itk.ImageBase
@@ -220,28 +206,28 @@ elif _HAVE_TORCH:
 else:
     ImageLike = Union[ImageBase, ArrayLike]
 
-ImageIOBase = "itk.ImageIOBase"
+ImageIOBase: TypeAlias = "itk.ImageIOBase"
 
-LightObject = "itk.LightObject"
-Object = "itk.Object"
-DataObject = "itk.DataObject"
+LightObject: TypeAlias = "itk.LightObject"
+Object: TypeAlias = "itk.Object"
+DataObject: TypeAlias = "itk.DataObject"
 
-PointSet = "itk.PointSet"
-Mesh = "itk.Mesh"
-QuadEdgeMesh = "itk.QuadEdgeMesh"
+PointSet: TypeAlias = "itk.PointSet"
+Mesh: TypeAlias = "itk.Mesh"
+QuadEdgeMesh: TypeAlias = "itk.QuadEdgeMesh"
 
-Path = "itk.Path"
-ParametricPath = "itk.ParametricPath"
-PolyLineParametricPath = "itk.PolyLineParametricPath"
-SpatialObject = "itk.SpatialObject"
+Path: TypeAlias = "itk.Path"
+ParametricPath: TypeAlias = "itk.ParametricPath"
+PolyLineParametricPath: TypeAlias = "itk.PolyLineParametricPath"
+SpatialObject: TypeAlias = "itk.SpatialObject"
 
-TransformBase = "itk.TransformBaseTemplate"
-Transform = "itk.Transform"
+TransformBase: TypeAlias = "itk.TransformBaseTemplate"
+Transform: TypeAlias = "itk.Transform"
 
-ImageRegion = "itk.ImageRegion"
+ImageRegion: TypeAlias = "itk.ImageRegion"
 
-VectorContainer = "itk.VectorContainer"
-Matrix = "itk.Matrix"
+VectorContainer: TypeAlias = "itk.VectorContainer"
+Matrix: TypeAlias = "itk.Matrix"
 
 # Return types for the functional interfaces to ProcessObject's.
 # When there is a single indexed output, it is returned directly.
@@ -251,7 +237,7 @@ ImageSourceReturn = Union[ImageLike, tuple[ImageLike, ...]]
 MeshSourceReturn = Union[Mesh, tuple[Mesh, ...]]
 PathSourceReturn = Union[Path, tuple[Path, ...]]
 
-InterpolateImageFunction = "itk.InterpolateImageFunction"
-ExtrapolateImageFunction = "itk.ExtrapolateImageFunction"
-ImageBoundaryCondition = "itk.ImageBoundaryCondition"
-FlatStructuringElement = "itk.FlatStructuringElement"
+InterpolateImageFunction: TypeAlias = "itk.InterpolateImageFunction"
+ExtrapolateImageFunction: TypeAlias = "itk.ExtrapolateImageFunction"
+ImageBoundaryCondition: TypeAlias = "itk.ImageBoundaryCondition"
+FlatStructuringElement: TypeAlias = "itk.FlatStructuringElement"

--- a/Wrapping/Generators/Python/itk/support/types.py
+++ b/Wrapping/Generators/Python/itk/support/types.py
@@ -50,7 +50,9 @@ class itkCType:
     __c_types__: dict[str, "itkCType"] = {}
     __c_types_for_dtype__: dict[str, np.dtype] = {}
 
-    def __init__(self, name: str, short_name: str, np_dtype: np.dtype = None) -> None:
+    def __init__(
+        self, name: str, short_name: str, np_dtype: np.dtype | None = None
+    ) -> None:
         # Remove potential white space around type names
         self.name = name.strip()
         self.short_name = short_name.strip()

--- a/Wrapping/Generators/Python/itk/support/types.py
+++ b/Wrapping/Generators/Python/itk/support/types.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import importlib
 from importlib.metadata import metadata
-from typing import TypeAlias, Union, TYPE_CHECKING
+from typing import Self, TypeAlias, Union, TYPE_CHECKING
 import os
 
 try:
@@ -73,8 +73,8 @@ class itkCType:
     def __repr__(self) -> str:
         return f"<itkCType {self.name}>"
 
-    @staticmethod
-    def GetCType(name: str) -> itkCType | None:
+    @classmethod
+    def GetCType(cls, name: str) -> Self | None:
         # import locally to facilitate dynamic loading in itk/__init__.py
 
         """Get the type corresponding to the provided C primitive type name."""
@@ -88,42 +88,42 @@ class itkCType:
         name = name.strip()
         desired_name: str = aliases.get(name, name)
         try:
-            return itkCType.__c_types__[desired_name]
+            return cls.__c_types__[desired_name]
         except KeyError:
             return None
 
-    @staticmethod
-    def GetCTypeForDType(np_dtype: np.dtype) -> itkCType | None:
+    @classmethod
+    def GetCTypeForDType(cls, np_dtype: np.dtype) -> Self | None:
         """Get the type corresponding to the provided numpy.dtype."""
         try:
-            return itkCType.__c_types_for_dtype__[np_dtype]
+            return cls.__c_types_for_dtype__[np_dtype]
         except KeyError:
             return None
 
-    @staticmethod
-    def initialize_c_types_once() -> tuple[itkCType, ...]:
+    @classmethod
+    def initialize_c_types_once(cls) -> tuple[Self, ...]:
         """
         This function is intended to be run only one time
         """
         import numpy as np
 
-        _F: itkCType = itkCType("float", "F", np.dtype(np.float32))
-        _D: itkCType = itkCType("double", "D", np.dtype(np.float64))
-        _UC: itkCType = itkCType("unsigned char", "UC", np.dtype(np.uint8))
-        _US: itkCType = itkCType("unsigned short", "US", np.dtype(np.uint16))
-        _UI: itkCType = itkCType("unsigned int", "UI", np.dtype(np.uint32))
+        _F: itkCType = cls("float", "F", np.dtype(np.float32))
+        _D: itkCType = cls("double", "D", np.dtype(np.float64))
+        _UC: itkCType = cls("unsigned char", "UC", np.dtype(np.uint8))
+        _US: itkCType = cls("unsigned short", "US", np.dtype(np.uint16))
+        _UI: itkCType = cls("unsigned int", "UI", np.dtype(np.uint32))
         if os.name == "nt":
-            _UL: itkCType = itkCType("unsigned long", "UL", np.dtype(np.uint32))
-            _SL: itkCType = itkCType("signed long", "SL", np.dtype(np.int32))
+            _UL: itkCType = cls("unsigned long", "UL", np.dtype(np.uint32))
+            _SL: itkCType = cls("signed long", "SL", np.dtype(np.int32))
         else:
-            _UL: itkCType = itkCType("unsigned long", "UL", np.dtype(np.uint64))
-            _SL: itkCType = itkCType("signed long", "SL", np.dtype(np.int64))
-        _ULL: itkCType = itkCType("unsigned long long", "ULL", np.dtype(np.uint64))
-        _SC: itkCType = itkCType("signed char", "SC", np.dtype(np.int8))
-        _SS: itkCType = itkCType("signed short", "SS", np.dtype(np.int16))
-        _SI: itkCType = itkCType("signed int", "SI", np.dtype(np.int32))
-        _SLL: itkCType = itkCType("signed long long", "SLL", np.dtype(np.int64))
-        _B: itkCType = itkCType("bool", "B", np.dtype(np.bool_))
+            _UL: itkCType = cls("unsigned long", "UL", np.dtype(np.uint64))
+            _SL: itkCType = cls("signed long", "SL", np.dtype(np.int64))
+        _ULL: itkCType = cls("unsigned long long", "ULL", np.dtype(np.uint64))
+        _SC: itkCType = cls("signed char", "SC", np.dtype(np.int8))
+        _SS: itkCType = cls("signed short", "SS", np.dtype(np.int16))
+        _SI: itkCType = cls("signed int", "SI", np.dtype(np.int32))
+        _SLL: itkCType = cls("signed long long", "SLL", np.dtype(np.int64))
+        _B: itkCType = cls("bool", "B", np.dtype(np.bool_))
         return _F, _D, _UC, _US, _UI, _UL, _SL, _ULL, _SC, _SS, _SI, _SLL, _B
 
 

--- a/Wrapping/Generators/Python/itk/support/types.py
+++ b/Wrapping/Generators/Python/itk/support/types.py
@@ -18,8 +18,7 @@
 
 from __future__ import annotations
 
-import importlib
-from importlib.metadata import metadata
+import importlib.util
 from typing import Self, TypeAlias, Union, TYPE_CHECKING
 import os
 
@@ -28,20 +27,8 @@ try:
 except ImportError:
     from numpy import ndarray as ArrayLike
 
-_HAVE_XARRAY = False
-try:
-    metadata("xarray")
-
-    _HAVE_XARRAY = True
-except importlib.metadata.PackageNotFoundError:
-    pass
-_HAVE_TORCH = False
-try:
-    metadata("torch")
-
-    _HAVE_TORCH = True
-except importlib.metadata.PackageNotFoundError:
-    pass
+_HAVE_XARRAY = importlib.util.find_spec("xarray") is not None
+_HAVE_TORCH = importlib.util.find_spec("torch") is not None
 
 
 # noinspection PyPep8Naming


### PR DESCRIPTION
Modernize `itk.support.types` and the nightly-warning scripts for the Python 3.11 floor now enforced across the wrapping runtime and CI: PEP 613 `TypeAlias`, PEP 604 unions, PEP 563 deferred annotations, PEP 673 `Self`, and `datetime.UTC`.

<details>
<summary>Commits</summary>

| Commit | Change |
|--------|--------|
| Mark itk.support.types aliases as PEP 613 TypeAlias | Annotate string forward-ref aliases; fix `initialize_c_types_once` return type |
| Bump pyupgrade target to py311-plus | Align hook with the 3.11 minimum |
| Use datetime.UTC alias in nightly-warning scripts | Terser `datetime.UTC` over `timezone.utc` |
| Annotate itkCType np_dtype default as np.dtype \| None | PEP 604; fixes incompatible default annotation |
| Adopt PEP 563 deferred annotations | `from __future__ import annotations`; drop string-quoted forward refs |
| Type itkCType class-keyed methods with PEP 673 Self | staticmethod→classmethod returning `Self`; initializer builds via `cls()` |
| Detect optional xarray/torch with importlib.util.find_spec | Replace two `metadata()` try/except probes with `find_spec` expressions |

</details>

<details>
<summary>Note on the retained Union[...] aliases</summary>

The runtime `Union[...]` assignments (`PixelTypes`, `ImageLike`, `*Return`) are intentionally **not** rewritten to `X | Y`. Their operands are runtime strings (e.g. `"itk.RGBPixel"`), and `str | str` evaluates eagerly at import → `TypeError`. `from __future__ import annotations` only defers *annotations*, not assignment RHS values, so these must stay `Union`.

</details>

<details>
<summary>Local validation</summary>

- `pre-commit run --all-files` → all hooks Passed (gersemi, clang-format, black, pyupgrade, kw-pre-commit, kw-commit-msg).
- Module executed at import (it self-initializes): type registration, `GetCType` hit/miss→None, the 13-tuple, and `find_spec` detection all verified.

</details>

<!--
provenance: claude-code session 2026-06-22
files: Wrapping/Generators/Python/itk/support/types.py; .github/skills/fix-nightly-warnings/scripts/{list_nightly_warnings,triage_nightly}.py; .pre-commit-config.yaml
floor: Python 3.11 (wrapping runtime + CI)
-->
