### PR TITLE
ENH: Extend itk::QRDecomposition and migrate in-tree vnl_qr consumers

### DIFF
--- a/Modules/Core/Common/include/itkQRDecomposition.h
+++ b/Modules/Core/Common/include/itkQRDecomposition.h
@@ -139,6 +139,18 @@ public:
     return out;
   }
 
+  /** Inverse of a square A, computed as the solution of A X = I. Requires A to
+   *  be square and full rank; a rank-deficient A yields a non-finite result. */
+  MatrixType
+  Inverse() const
+  {
+    const unsigned int rows = m_Q.rows();
+    itkAssertOrThrowMacro(rows == m_R.cols(), "QRDecomposition::Inverse requires a square matrix");
+    MatrixType identity(rows, rows);
+    identity.set_identity();
+    return this->Solve(identity);
+  }
+
   /** Determinant of a square A (zero-initialized value for non-square A). */
   T
   GetDeterminant() const

--- a/Modules/Core/Common/include/itkQRDecomposition.h
+++ b/Modules/Core/Common/include/itkQRDecomposition.h
@@ -109,6 +109,36 @@ public:
     return out;
   }
 
+  /** Solve A X = B for a multi-column right-hand side. Each column of B is an
+   *  independent system sharing the single stored factorization, so the result
+   *  X has one solution column per column of B (X.cols() == B.cols()); column j
+   *  equals Solve(B.get_column(j)). B.rows() must match the row count and A must
+   *  have full column rank, as in the vector overload. */
+  MatrixType
+  Solve(const MatrixType & B) const
+  {
+    using RowMajor = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+    const unsigned int rows = m_Q.rows();
+    const unsigned int cols = m_R.cols();
+    const unsigned int nrhs = B.cols();
+    itkAssertOrThrowMacro(B.rows() == rows, "QRDecomposition::Solve requires B row count to match the row count");
+    if (cols > rows)
+    {
+      itkGenericExceptionMacro("QRDecomposition::Solve supports square or overdetermined systems only (rows >= cols)");
+    }
+
+    Eigen::Map<const RowMajor> qMap(m_Q.data_block(), rows, rows);
+    Eigen::Map<const RowMajor> rMap(m_R.data_block(), rows, cols);
+    Eigen::Map<const RowMajor> bMap(B.data_block(), rows, nrhs);
+
+    const RowMajor qtb = qMap.adjoint() * bMap;
+    const RowMajor x = rMap.topLeftCorner(cols, cols).template triangularView<Eigen::Upper>().solve(qtb.topRows(cols));
+
+    MatrixType out(cols, nrhs);
+    Eigen::Map<RowMajor>(out.data_block(), cols, nrhs) = x;
+    return out;
+  }
+
   /** Determinant of a square A (zero-initialized value for non-square A). */
   T
   GetDeterminant() const

--- a/Modules/Core/Common/test/VNLSparseLUSolverTraitsGTest.cxx
+++ b/Modules/Core/Common/test/VNLSparseLUSolverTraitsGTest.cxx
@@ -16,13 +16,16 @@
  *
  *=========================================================================*/
 
-#define ITK_LEGACY_TEST // exercises the deprecated VNLSparseLUSolverTraits on purpose
-#include "VNLSparseLUSolverTraits.h"
-#include "itkGTest.h"
-#include "itkMath.h" // itk::Math::Absolute
+#include "itkConfigure.h" // defines ITK_FUTURE_LEGACY_REMOVE before the guard below
+// VNLSparseLUSolverTraits is unavailable under ITK_FUTURE_LEGACY_REMOVE.
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+#  define ITK_LEGACY_TEST // exercises the deprecated VNLSparseLUSolverTraits on purpose
+#  include "VNLSparseLUSolverTraits.h"
+#  include "itkGTest.h"
+#  include "itkMath.h" // itk::Math::Absolute
 
-#include <iostream>
-#include <cstdlib>
+#  include <iostream>
+#  include <cstdlib>
 
 template <class TVector>
 bool
@@ -234,3 +237,4 @@ DoVNLSparseLUSolverTraitsTest(int, char *[])
 
 
 TEST(VNLSparseLUSolverTraits, ConvertedLegacyTest) { EXPECT_EQ(0, DoVNLSparseLUSolverTraitsTest(0, nullptr)); }
+#endif

--- a/Modules/Core/Common/test/VnlEigenSparseLUEquivalenceGTest.cxx
+++ b/Modules/Core/Common/test/VnlEigenSparseLUEquivalenceGTest.cxx
@@ -22,13 +22,17 @@
 // direct LU solvers for the same A x = b, so agreement to tight tolerance is
 // required before the Eigen algorithm may be placed behind the vnl_* API.
 
-#define ITK_LEGACY_TEST // intentionally exercises the deprecated VNLSparseLUSolverTraits for equivalence
-#include "VNLSparseLUSolverTraits.h"
-#include "SparseLUSolverTraits.h"
-#include "itkGTest.h"
+#include "itkConfigure.h" // defines ITK_FUTURE_LEGACY_REMOVE before the guard below
+// The vnl_sparse_lu equivalence comparison is unavailable under
+// ITK_FUTURE_LEGACY_REMOVE, where VNLSparseLUSolverTraits is removed.
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+#  define ITK_LEGACY_TEST // intentionally exercises the deprecated VNLSparseLUSolverTraits for equivalence
+#  include "VNLSparseLUSolverTraits.h"
+#  include "SparseLUSolverTraits.h"
+#  include "itkGTest.h"
 
-#include <cmath>
-#include <vector>
+#  include <cmath>
+#  include <vector>
 
 namespace
 {
@@ -131,3 +135,4 @@ TEST(VnlEigenSparseLUEquivalence, WellConditioned)
 // Ill-conditioned system: tolerance is looser because both solvers amplify the
 // conditioning, but they must still track each other closely.
 TEST(VnlEigenSparseLUEquivalence, IllConditioned) { expectEquivalent(24, 1e-9, 1e-6); }
+#endif

--- a/Modules/Core/Common/test/itkQRDecompositionGTest.cxx
+++ b/Modules/Core/Common/test/itkQRDecompositionGTest.cxx
@@ -160,6 +160,24 @@ TEST(QRDecomposition, MatrixRHSEquivalentToVnlQR)
     EXPECT_LT((xItk - xVnl).fro_norm() / xVnl.fro_norm(), 1e-10);
   }
 }
+
+
+// Inverse matches legacy vnl_qr.inverse(). This is the operation itk::fem::Element
+// (JacobianInverse / JacobianDeterminant) relies on.
+TEST(QRDecomposition, InverseEquivalentToVnlQR)
+{
+  for (const unsigned int n : { 2u, 3u, 5u })
+  {
+    const vnl_matrix<double> A = MakeMatrix<double>(n, n);
+    const vnl_matrix<double> invItk = itk::QRDecomposition<double>(A).Inverse();
+    const vnl_matrix<double> invVnl = vnl_qr<double>(A).inverse();
+    EXPECT_LT((invItk - invVnl).fro_norm() / invVnl.fro_norm(), 1e-10);
+
+    vnl_matrix<double> ident(n, n);
+    ident.set_identity();
+    EXPECT_LT((A * invItk - ident).fro_norm(), 1e-10);
+  }
+}
 #endif
 
 

--- a/Modules/Core/Common/test/itkQRDecompositionGTest.cxx
+++ b/Modules/Core/Common/test/itkQRDecompositionGTest.cxx
@@ -20,8 +20,11 @@
 #include "itkQRDecomposition.h"
 
 // Exercise the deprecated VNL engine for the old-vs-new equivalence checks.
-#define ITK_LEGACY_TEST
-#include "vnl/algo/vnl_qr.h"
+// The VNL symbol is unavailable under ITK_FUTURE_LEGACY_REMOVE.
+#ifndef ITK_FUTURE_LEGACY_REMOVE
+#  define ITK_LEGACY_TEST
+#  include "vnl/algo/vnl_qr.h"
+#endif
 
 #include <gtest/gtest.h>
 #include <cmath>
@@ -77,6 +80,51 @@ TEST(QRDecomposition, SolveResidual)
 }
 
 
+// Multi-column RHS: each column solves against the one shared factorization.
+TEST(QRDecomposition, SolveMatrixRHS)
+{
+  const unsigned int       n = 5;
+  const unsigned int       k = 3;
+  const vnl_matrix<double> A = MakeMatrix<double>(n, n);
+  vnl_matrix<double>       B(n, k);
+  for (unsigned int i = 0; i < n; ++i)
+    for (unsigned int j = 0; j < k; ++j)
+      B(i, j) = std::cos(0.3 * (i + 1) * (j + 2));
+
+  const itk::QRDecomposition<double> qr(A);
+  const vnl_matrix<double>           X = qr.Solve(B);
+  ASSERT_EQ(X.rows(), n);
+  ASSERT_EQ(X.cols(), k);
+  EXPECT_LT((A * X - B).fro_norm() / B.fro_norm(), 1e-10);
+  for (unsigned int j = 0; j < k; ++j)
+    EXPECT_LT((X.get_column(j) - qr.Solve(B.get_column(j))).two_norm(), 1e-12);
+}
+
+
+// Overdetermined (rows > cols) multi-column solve yields the least-squares
+// solution, characterized by the normal equations A^T (A X - B) == 0.
+TEST(QRDecomposition, SolveMatrixRHSOverdetermined)
+{
+  const unsigned int       m = 6;
+  const unsigned int       n = 3;
+  const unsigned int       k = 2;
+  const vnl_matrix<double> A = MakeMatrix<double>(m, n);
+  vnl_matrix<double>       B(m, k);
+  for (unsigned int i = 0; i < m; ++i)
+    for (unsigned int j = 0; j < k; ++j)
+      B(i, j) = std::cos(0.35 * (i + 1) * (j + 2)) - 0.2 * (j + 1);
+
+  const itk::QRDecomposition<double> qr(A);
+  const vnl_matrix<double>           X = qr.Solve(B);
+  ASSERT_EQ(X.rows(), n);
+  ASSERT_EQ(X.cols(), k);
+  EXPECT_LT((A.transpose() * (A * X - B)).fro_norm() / (A.transpose() * B).fro_norm(), 1e-10);
+  for (unsigned int j = 0; j < k; ++j)
+    EXPECT_LT((X.get_column(j) - qr.Solve(B.get_column(j))).two_norm(), 1e-12);
+}
+
+
+#ifndef ITK_FUTURE_LEGACY_REMOVE
 // itk:: solve and determinant agree with the (sign-stable) legacy vnl_qr.
 TEST(QRDecomposition, EquivalentToVnlQR)
 {
@@ -92,6 +140,27 @@ TEST(QRDecomposition, EquivalentToVnlQR)
   EXPECT_LT((qrItk.Solve(b) - qrVnl.solve(b)).two_norm() / qrVnl.solve(b).two_norm(), 1e-10);
   EXPECT_NEAR(qrItk.GetDeterminant(), qrVnl.determinant(), 1e-9 * std::abs(qrVnl.determinant()) + 1e-12);
 }
+
+
+// Multi-column solve matches legacy vnl_qr column-for-column. This is the exact
+// operation itkLandmarkBasedTransformInitializer relies on (square Q, matrix C).
+TEST(QRDecomposition, MatrixRHSEquivalentToVnlQR)
+{
+  for (const unsigned int n : { 3u, 4u, 6u })
+  {
+    const unsigned int       k = n - 1;
+    const vnl_matrix<double> A = MakeMatrix<double>(n, n);
+    vnl_matrix<double>       B(n, k);
+    for (unsigned int i = 0; i < n; ++i)
+      for (unsigned int j = 0; j < k; ++j)
+        B(i, j) = std::cos(0.4 * (i + 1) * (j + 2)) - 0.3 * (j + 1);
+
+    const vnl_matrix<double> xItk = itk::QRDecomposition<double>(A).Solve(B);
+    const vnl_matrix<double> xVnl = vnl_qr<double>(A).solve(B);
+    EXPECT_LT((xItk - xVnl).fro_norm() / xVnl.fro_norm(), 1e-10);
+  }
+}
+#endif
 
 
 // Single-precision path reconstructs.

--- a/Modules/Numerics/FEM/include/itpack.h
+++ b/Modules/Numerics/FEM/include/itpack.h
@@ -526,16 +526,6 @@ extern "C"
   ddot_(integer * n, doublereal * dx, integer * incx, doublereal * dy, integer * incy);
 
   /**
-   * Subroutine that computes the determinant of a symmetric tridiagonal matrix
-   * given by tri. det(tri - xlmda*i) = 0
-   * \param n order of tridiagonal system
-   * \param tri symmetric tridiagonal matrix of order n
-   * \param xlmda argument for characteristic equation
-   */
-  extern doublereal
-  determ_(integer * n, doublereal * tri, doublereal * xlmda);
-
-  /**
    * Obtain default parameters
    * \param iparm array of 12 integer parameters
    * \param rparm array of 12 double parameters

--- a/Modules/Numerics/FEM/src/CMakeLists.txt
+++ b/Modules/Numerics/FEM/src/CMakeLists.txt
@@ -1,6 +1,9 @@
 set(
   ITKFEM_SRCS
   dsrc2c.c
+  itkfem_tqlrat.c
+  itkfem_pythag.c
+  itkfem_epslon.c
   itkFEMElement2DC0LinearLine.cxx
   itkFEMElement2DC0LinearLineStress.cxx
   itkFEMElement2DC0LinearQuadrilateral.cxx

--- a/Modules/Numerics/FEM/src/dsrc2c.c
+++ b/Modules/Numerics/FEM/src/dsrc2c.c
@@ -26,6 +26,7 @@
 
 #define V3P_NETLIB_SRC
 #include "v3p_netlib.h"
+#include "itkfem_eispack.h"
 
 /* Modified by Peter Vanroose, Oct 2003: manual optimisation and clean-up */
 
@@ -37,8 +38,6 @@ time(long * timer); /* #include <time.h> */
 
 extern doublereal
 cheby_(doublereal *, doublereal *, doublereal *, integer *, doublereal *, doublereal *);
-extern doublereal
-determ_(integer *, doublereal *, doublereal *);
 extern doublereal
 eigvns_(integer *, doublereal *, doublereal *, doublereal *, integer *);
 extern doublereal
@@ -4433,39 +4432,6 @@ L70:
   return ret_val;
 } /* itpackddot_ */
 
-doublereal
-determ_(integer * n, doublereal * tri, doublereal * xlmda)
-{
-  /* Local variables */
-  static integer    l;
-  static doublereal d1, d2, d3;
-  static integer    icnt;
-
-  /*     THIS SUBROUTINE COMPUTES THE DETERMINANT OF A SYMMETRIC */
-  /*     TRIDIAGONAL MATRIX GIVEN BY TRI. DET(TRI - XLMDA*I) = 0 */
-
-  /* ... PARAMETER LIST */
-
-  /*          N      ORDER OF TRIDIAGONAL SYSTEM */
-  /*          TRI    SYMMETRIC TRIDIAGONAL MATRIX OF ORDER N */
-  /*          XLMDA  ARGUMENT FOR CHARACTERISTIC EQUATION */
-
-  d2 = tri[(*n << 1) - 2] - *xlmda;
-  d1 = d2 * (tri[(*n << 1) - 4] - *xlmda) - tri[(*n << 1) - 1];
-  if (*n == 2)
-    return d1;
-
-  for (icnt = 2; icnt < *n; ++icnt)
-  {
-    l = *n - icnt + 1;
-    d3 = d2;
-    d2 = d1;
-    d1 = (tri[((l - 1) << 1) - 2] - *xlmda) * d2 - d3 * tri[(l << 1) - 1];
-  }
-
-  return d1;
-} /* determ_ */
-
 /* Subroutine */
 int
 dfault_(integer * iparm, doublereal * rparm)
@@ -4782,7 +4748,7 @@ eigvns_(integer * n, doublereal * tri, doublereal * d, doublereal * e2, integer 
   }
 
   // eqrt1s_(d, e2, n, &c__1, &c__0, ier);
-  v3p_netlib_tqlrat_(n, d, e2, ier);
+  itkfem_tqlrat_(n, d, e2, ier);
 
   return -d[0];
 } /* eigvns_ */

--- a/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangular.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElement3DC0LinearTriangular.cxx
@@ -20,7 +20,7 @@
 
 #include "itkFEMElement3DC0LinearTriangular.h"
 
-#include "vnl/algo/vnl_qr.h"
+#include "itkQRDecomposition.h"
 
 namespace itk::fem
 {
@@ -267,7 +267,7 @@ Element3DC0LinearTriangular::JacobianInverse(const VectorType & pt, MatrixType &
   }
 
   //  invJ=vnl_svd_inverse<Float>(*pJ);
-  invJ = vnl_qr<Float>(*pJ).inverse();
+  invJ = itk::QRDecomposition<Float>(*pJ).Inverse();
 
   /*
 // Note that inverse of Jacobian is not quadratic matrix

--- a/Modules/Numerics/FEM/src/itkFEMElementBase.cxx
+++ b/Modules/Numerics/FEM/src/itkFEMElementBase.cxx
@@ -17,7 +17,7 @@
  *=========================================================================*/
 
 #include "itkFEMElementBase.h"
-#include "vnl/algo/vnl_qr.h"
+#include "itkQRDecomposition.h"
 
 namespace itk::fem
 {
@@ -305,7 +305,7 @@ Element::JacobianDeterminant(const VectorType & pt, const MatrixType * pJ) const
   }
 
   //  Float det=vnl_svd<Float>(*pJ).determinant_magnitude();
-  Float det = vnl_qr<Float>(*pJ).determinant();
+  Float det = itk::QRDecomposition<Float>(*pJ).GetDeterminant();
 
   return det;
 }
@@ -324,7 +324,7 @@ Element::JacobianInverse(const VectorType & pt, MatrixType & invJ, const MatrixT
   }
 
   //  invJ=vnl_svd_inverse<Float>(*pJ);
-  invJ = vnl_qr<Float>(*pJ).inverse();
+  invJ = itk::QRDecomposition<Float>(*pJ).Inverse();
 }
 
 void

--- a/Modules/Numerics/FEM/src/itkfem_eispack.h
+++ b/Modules/Numerics/FEM/src/itkfem_eispack.h
@@ -1,0 +1,42 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkfem_eispack_h
+#define itkfem_eispack_h
+
+/* FEM-private EISPACK eigenvalue helpers (renamed tqlrat/pythag/epslon).
+ * v3p_netlib drops eispack under ITK_FUTURE_LEGACY_REMOVE; the itk::fem ITPACK
+ * solver (dsrc2c.c eigvns_) needs tqlrat, so FEM owns self-contained copies and
+ * no longer depends on the v3p_netlib eispack in any configuration. */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  int
+  itkfem_tqlrat_(long * n, double * d, double * e2, long * ierr);
+  double
+  itkfem_pythag_(double * a, double * b);
+  double
+  itkfem_epslon_(double * x);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Modules/Numerics/FEM/src/itkfem_epslon.c
+++ b/Modules/Numerics/FEM/src/itkfem_epslon.c
@@ -1,0 +1,94 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+/* FEM-private copy of the EISPACK epslon routine, renamed to itkfem_epslon_.
+ * v3p_netlib drops eispack under ITK_FUTURE_LEGACY_REMOVE, but the itk::fem
+ * ITPACK solver (dsrc2c.c) still needs it, so FEM owns a self-contained copy
+ * in every configuration. */
+
+#include "itkfem_eispack.h"
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+  typedef double doublereal;
+#ifndef abs
+#  define abs(x) ((x) >= 0 ? (x) : -(x))
+#endif
+
+  /*<       double precision function epslon (x) >*/
+  doublereal
+  itkfem_epslon_(doublereal * x)
+  {
+    /* System generated locals */
+    doublereal ret_val, d__1;
+
+    /* Local variables */
+    doublereal a, b, c__, eps;
+
+    /*<       double precision x >*/
+
+    /*     estimate unit roundoff in quantities of size x. */
+
+    /*<       double precision a,b,c,eps >*/
+
+    /*     this program should function properly on all systems */
+    /*     satisfying the following two assumptions, */
+    /*        1.  the base used in representing floating point */
+    /*            numbers is not a power of three. */
+    /*        2.  the quantity  a  in statement 10 is represented to */
+    /*            the accuracy used in floating point variables */
+    /*            that are stored in memory. */
+    /*     the statement number 10 and the go to 10 are intended to */
+    /*     force optimizing compilers to generate code satisfying */
+    /*     assumption 2. */
+    /*     under these assumptions, it should be true that, */
+    /*            a  is not exactly equal to four-thirds, */
+    /*            b  has a zero for its last bit or digit, */
+    /*            c  is not exactly equal to one, */
+    /*            eps  measures the separation of 1.0 from */
+    /*                 the next larger floating point number. */
+    /*     the developers of eispack would appreciate being informed */
+    /*     about any systems where these assumptions do not hold. */
+
+    /*     this version dated 4/6/83. */
+
+    /*<       a = 4.0d0/3.0d0 >*/
+    a = 1.3333333333333333;
+  /*<    10 b = a - 1.0d0 >*/
+  L10:
+    b = a - 1.;
+    /*<       c = b + b + b >*/
+    c__ = b + b + b;
+    /*<       eps = dabs(c-1.0d0) >*/
+    eps = (d__1 = c__ - 1., abs(d__1));
+    /*<       if (eps .eq. 0.0d0) go to 10 >*/
+    if (eps == 0.)
+    {
+      goto L10;
+    }
+    /*<       epslon = eps*dabs(x) >*/
+    ret_val = eps * abs(*x);
+    /*<       return >*/
+    return ret_val;
+    /*<       end >*/
+  } /* itkfem_epslon_ */
+
+#ifdef __cplusplus
+}
+#endif

--- a/Modules/Numerics/FEM/src/itkfem_pythag.c
+++ b/Modules/Numerics/FEM/src/itkfem_pythag.c
@@ -1,0 +1,101 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+/* FEM-private copy of the EISPACK pythag routine, renamed to itkfem_pythag_.
+ * v3p_netlib drops eispack under ITK_FUTURE_LEGACY_REMOVE, but the itk::fem
+ * ITPACK solver (dsrc2c.c) still needs it, so FEM owns a self-contained copy
+ * in every configuration. */
+
+#include "itkfem_eispack.h"
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+  typedef double doublereal;
+#ifndef abs
+#  define abs(x) ((x) >= 0 ? (x) : -(x))
+#endif
+#ifndef max
+#  define max(a, b) ((a) >= (b) ? (a) : (b))
+#endif
+#ifndef min
+#  define min(a, b) ((a) <= (b) ? (a) : (b))
+#endif
+
+  /*<       double precision function pythag(a,b) >*/
+  doublereal
+  itkfem_pythag_(doublereal * a, doublereal * b)
+  {
+    /* System generated locals */
+    doublereal ret_val, d__1, d__2, d__3;
+
+    /* Local variables */
+    doublereal p, r__, s, t, u;
+
+    /*<       double precision a,b >*/
+
+    /*     finds dsqrt(a**2+b**2) without overflow or destructive underflow */
+
+    /*<       double precision p,r,s,t,u >*/
+    /*<       p = dmax1(dabs(a),dabs(b)) >*/
+    /* Computing MAX */
+    d__1 = abs(*a), d__2 = abs(*b);
+    p = max(d__1, d__2);
+    /*<       if (p .eq. 0.0d0) go to 20 >*/
+    if (p == 0.)
+    {
+      goto L20;
+    }
+    /*<       r = (dmin1(dabs(a),dabs(b))/p)**2 >*/
+    /* Computing MIN */
+    d__2 = abs(*a), d__3 = abs(*b);
+    /* Computing 2nd power */
+    d__1 = min(d__2, d__3) / p;
+    r__ = d__1 * d__1;
+  /*<    10 continue >*/
+  L10:
+    /*<          t = 4.0d0 + r >*/
+    t = r__ + 4.;
+    /*<          if (t .eq. 4.0d0) go to 20 >*/
+    if (t == 4.)
+    {
+      goto L20;
+    }
+    /*<          s = r/t >*/
+    s = r__ / t;
+    /*<          u = 1.0d0 + 2.0d0*s >*/
+    u = s * 2. + 1.;
+    /*<          p = u*p >*/
+    p = u * p;
+    /*<          r = (s/u)**2 * r >*/
+    /* Computing 2nd power */
+    d__1 = s / u;
+    r__ = d__1 * d__1 * r__;
+    /*<       go to 10 >*/
+    goto L10;
+  /*<    20 pythag = p >*/
+  L20:
+    ret_val = p;
+    /*<       return >*/
+    return ret_val;
+    /*<       end >*/
+  } /* itkfem_pythag_ */
+
+#ifdef __cplusplus
+}
+#endif

--- a/Modules/Numerics/FEM/src/itkfem_tqlrat.c
+++ b/Modules/Numerics/FEM/src/itkfem_tqlrat.c
@@ -1,0 +1,330 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+/* FEM-private copy of the EISPACK tqlrat routine, renamed to itkfem_tqlrat_.
+ * v3p_netlib drops eispack under ITK_FUTURE_LEGACY_REMOVE, but the itk::fem
+ * ITPACK solver (dsrc2c.c) still needs it, so FEM owns a self-contained copy
+ * in every configuration. */
+
+#include "itkfem_eispack.h"
+#include <math.h>
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+  typedef double doublereal;
+#ifndef abs
+#  define abs(x) ((x) >= 0 ? (x) : -(x))
+#endif
+  typedef long integer; /* matches v3p_netlib/f2c integer that dsrc2c.c passes */
+  static doublereal
+  d_sign(doublereal * a, doublereal * b)
+  {
+    const doublereal x = (*a >= 0 ? *a : -*a);
+    return (*b >= 0 ? x : -x);
+  }
+
+  /* Table of constant values */
+
+  static doublereal c_b11 = 1.;
+
+  /*<       subroutine tqlrat(n,d,e2,ierr) >*/
+  /* Subroutine */ int
+  itkfem_tqlrat_(integer * n, doublereal * d__, doublereal * e2, integer * ierr)
+  {
+    /* System generated locals */
+    integer    i__1, i__2;
+    doublereal d__1, d__2;
+
+    /* sqrt comes from <math.h>; d_sign is the file-scope helper above. */
+
+    /* Local variables */
+    doublereal        b = 0, c__ = 0, f, g, h__;
+    integer           i__, j, l, m;
+    doublereal        p, r__, s, t;
+    integer           l1, ii, mml;
+    extern doublereal itkfem_pythag_(doublereal *, doublereal *), itkfem_epslon_(doublereal *);
+
+
+    /*<       integer i,j,l,m,n,ii,l1,mml,ierr >*/
+    /*<       double precision d(n),e2(n) >*/
+    /*<       double precision b,c,f,g,h,p,r,s,t,epslon,pythag >*/
+
+    /*     this subroutine is a translation of the algol procedure tqlrat, */
+    /*     algorithm 464, comm. acm 16, 689(1973) by reinsch. */
+
+    /*     this subroutine finds the eigenvalues of a symmetric */
+    /*     tridiagonal matrix by the rational ql method. */
+
+    /*     on input */
+
+    /*        n is the order of the matrix. */
+
+    /*        d contains the diagonal elements of the input matrix. */
+
+    /*        e2 contains the squares of the subdiagonal elements of the */
+    /*          input matrix in its last n-1 positions.  e2(1) is arbitrary. */
+
+    /*      on output */
+
+    /*        d contains the eigenvalues in ascending order.  if an */
+    /*          error exit is made, the eigenvalues are correct and */
+    /*          ordered for indices 1,2,...ierr-1, but may not be */
+    /*          the smallest eigenvalues. */
+
+    /*        e2 has been destroyed. */
+
+    /*        ierr is set to */
+    /*          zero       for normal return, */
+    /*          j          if the j-th eigenvalue has not been */
+    /*                     determined after 30 iterations. */
+
+    /*     calls pythag for  dsqrt(a*a + b*b) . */
+
+    /*     questions and comments should be directed to burton s. garbow, */
+    /*     mathematics and computer science div, argonne national laboratory */
+
+    /*     this version dated august 1983. */
+
+    /*     ------------------------------------------------------------------ */
+
+    /*<       ierr = 0 >*/
+    /* Parameter adjustments */
+    --e2;
+    --d__;
+
+    /* Function Body */
+    *ierr = 0;
+    /*<       if (n .eq. 1) go to 1001 >*/
+    if (*n == 1)
+    {
+      goto L1001;
+    }
+
+    /*<       do 100 i = 2, n >*/
+    i__1 = *n;
+    for (i__ = 2; i__ <= i__1; ++i__)
+    {
+      /*<   100 e2(i-1) = e2(i) >*/
+      /* L100: */
+      e2[i__ - 1] = e2[i__];
+    }
+
+    /*<       f = 0.0d0 >*/
+    f = 0.;
+    /*<       t = 0.0d0 >*/
+    t = 0.;
+    /*<       e2(n) = 0.0d0 >*/
+    e2[*n] = 0.;
+
+    /*<       do 290 l = 1, n >*/
+    i__1 = *n;
+    for (l = 1; l <= i__1; ++l)
+    {
+      /*<          j = 0 >*/
+      j = 0;
+      /*<          h = dabs(d(l)) + dsqrt(e2(l)) >*/
+      h__ = (d__1 = d__[l], abs(d__1)) + sqrt(e2[l]);
+      /*<          if (t .gt. h) go to 105 >*/
+      if (t > h__)
+      {
+        goto L105;
+      }
+      /*<          t = h >*/
+      t = h__;
+      /*<          b = epslon(t) >*/
+      b = itkfem_epslon_(&t);
+      /*<          c = b * b >*/
+      c__ = b * b;
+    /*     .......... look for small squared sub-diagonal element .......... */
+    /*<   105    do 110 m = l, n >*/
+    L105:
+      i__2 = *n;
+      for (m = l; m <= i__2; ++m)
+      {
+        /*<             if (e2(m) .le. c) go to 120 >*/
+        if (e2[m] <= c__)
+        {
+          goto L120;
+        }
+        /*     .......... e2(n) is always zero, so there is no exit */
+        /*                through the bottom of the loop .......... */
+        /*<   110    continue >*/
+        /* L110: */
+      }
+
+    /*<   120    if (m .eq. l) go to 210 >*/
+    L120:
+      if (m == l)
+      {
+        goto L210;
+      }
+    /*<   130    if (j .eq. 30) go to 1000 >*/
+    L130:
+      if (j == 30)
+      {
+        goto L1000;
+      }
+      /*<          j = j + 1 >*/
+      ++j;
+      /*     .......... form shift .......... */
+      /*<          l1 = l + 1 >*/
+      l1 = l + 1;
+      /*<          s = dsqrt(e2(l)) >*/
+      s = sqrt(e2[l]);
+      /*<          g = d(l) >*/
+      g = d__[l];
+      /*<          p = (d(l1) - g) / (2.0d0 * s) >*/
+      p = (d__[l1] - g) / (s * 2.);
+      /*<          r = pythag(p,1.0d0) >*/
+      r__ = itkfem_pythag_(&p, &c_b11);
+      /*<          d(l) = s / (p + dsign(r,p)) >*/
+      d__[l] = s / (p + d_sign(&r__, &p));
+      /*<          h = g - d(l) >*/
+      h__ = g - d__[l];
+
+      /*<          do 140 i = l1, n >*/
+      i__2 = *n;
+      for (i__ = l1; i__ <= i__2; ++i__)
+      {
+        /*<   140    d(i) = d(i) - h >*/
+        /* L140: */
+        d__[i__] -= h__;
+      }
+
+      /*<          f = f + h >*/
+      f += h__;
+      /*     .......... rational ql transformation .......... */
+      /*<          g = d(m) >*/
+      g = d__[m];
+      /*<          if (g .eq. 0.0d0) g = b >*/
+      if (g == 0.)
+      {
+        g = b;
+      }
+      /*<          h = g >*/
+      h__ = g;
+      /*<          s = 0.0d0 >*/
+      s = 0.;
+      /*<          mml = m - l >*/
+      mml = m - l;
+      /*     .......... for i=m-1 step -1 until l do -- .......... */
+      /*<          do 200 ii = 1, mml >*/
+      i__2 = mml;
+      for (ii = 1; ii <= i__2; ++ii)
+      {
+        /*<             i = m - ii >*/
+        i__ = m - ii;
+        /*<             p = g * h >*/
+        p = g * h__;
+        /*<             r = p + e2(i) >*/
+        r__ = p + e2[i__];
+        /*<             e2(i+1) = s * r >*/
+        e2[i__ + 1] = s * r__;
+        /*<             s = e2(i) / r >*/
+        s = e2[i__] / r__;
+        /*<             d(i+1) = h + s * (h + d(i)) >*/
+        d__[i__ + 1] = h__ + s * (h__ + d__[i__]);
+        /*<             g = d(i) - e2(i) / g >*/
+        g = d__[i__] - e2[i__] / g;
+        /*<             if (g .eq. 0.0d0) g = b >*/
+        if (g == 0.)
+        {
+          g = b;
+        }
+        /*<             h = g * p / r >*/
+        h__ = g * p / r__;
+        /*<   200    continue >*/
+        /* L200: */
+      }
+
+      /*<          e2(l) = s * g >*/
+      e2[l] = s * g;
+      /*<          d(l) = h >*/
+      d__[l] = h__;
+      /*     .......... guard against underflow in convergence test .......... */
+      /*<          if (h .eq. 0.0d0) go to 210 >*/
+      if (h__ == 0.)
+      {
+        goto L210;
+      }
+      /*<          if (dabs(e2(l)) .le. dabs(c/h)) go to 210 >*/
+      if ((d__1 = e2[l], abs(d__1)) <= (d__2 = c__ / h__, abs(d__2)))
+      {
+        goto L210;
+      }
+      /*<          e2(l) = h * e2(l) >*/
+      e2[l] = h__ * e2[l];
+      /*<          if (e2(l) .ne. 0.0d0) go to 130 >*/
+      if (e2[l] != 0.)
+      {
+        goto L130;
+      }
+    /*<   210    p = d(l) + f >*/
+    L210:
+      p = d__[l] + f;
+      /*     .......... order eigenvalues .......... */
+      /*<          if (l .eq. 1) go to 250 >*/
+      if (l == 1)
+      {
+        goto L250;
+      }
+      /*     .......... for i=l step -1 until 2 do -- .......... */
+      /*<          do 230 ii = 2, l >*/
+      i__2 = l;
+      for (ii = 2; ii <= i__2; ++ii)
+      {
+        /*<             i = l + 2 - ii >*/
+        i__ = l + 2 - ii;
+        /*<             if (p .ge. d(i-1)) go to 270 >*/
+        if (p >= d__[i__ - 1])
+        {
+          goto L270;
+        }
+        /*<             d(i) = d(i-1) >*/
+        d__[i__] = d__[i__ - 1];
+        /*<   230    continue >*/
+        /* L230: */
+      }
+
+    /*<   250    i = 1 >*/
+    L250:
+      i__ = 1;
+    /*<   270    d(i) = p >*/
+    L270:
+      d__[i__] = p;
+      /*<   290 continue >*/
+      /* L290: */
+    }
+
+    /*<       go to 1001 >*/
+    goto L1001;
+  /*     .......... set error -- no convergence to an */
+  /*                eigenvalue after 30 iterations .......... */
+  /*<  1000 ierr = l >*/
+  L1000:
+    *ierr = l;
+  /*<  1001 return >*/
+  L1001:
+    return 0;
+    /*<       end >*/
+  } /* itkfem_tqlrat_ */
+
+#ifdef __cplusplus
+}
+#endif

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
@@ -23,7 +23,7 @@
 #include "itkPrintHelper.h"
 
 #include <cmath>
-#include "vnl/algo/vnl_qr.h"
+#include "itkQRDecomposition.h"
 
 namespace itk
 {
@@ -314,7 +314,7 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
   // [Solve Qa=C]
   // :: Solving code is from
   // https://www.itk.org/pipermail/insight-users/2008-December/028207.html
-  const vnl_matrix<ParametersValueType> transposeAffine = vnl_qr<ParametersValueType>(Q).solve(C);
+  const vnl_matrix<ParametersValueType> transposeAffine = QRDecomposition<ParametersValueType>(Q).Solve(C);
   vnl_matrix<ParametersValueType>       Affine = transposeAffine.transpose();
 
   const vnl_matrix<ParametersValueType> AffineRotation(Affine.get_n_columns(0, ImageDimension));


### PR DESCRIPTION
Extends `itk::QRDecomposition` with the `Solve(MatrixType)` and `Inverse()` API, then migrates ITK's in-tree `vnl_qr` consumers (FEM, `LandmarkBasedTransformInitializer`, Core/Common gtests) onto it, so the affected code builds under `ITK_FUTURE_LEGACY_REMOVE` — where `vnl/algo/vnl_qr.h` hard-`#error`s. Both **ENH** (new QR API) and **COMP** (migrations + build fix), per @dzenanz's note.

<details>
<summary>Scope (ENH + COMP)</summary>

- **ENH** — `itk::QRDecomposition` gains `Solve(MatrixType)` (multi-column RHS, batched) and `Inverse()` (square `A`, `= A\I`).
- **COMP** — `itkLandmarkBasedTransformInitializer` migrates `vnl_qr` → `itk::QRDecomposition` (uses `Solve(matrix)`); `itk::fem::Element` migrates (uses `Inverse()` / `GetDeterminant()`).
- **COMP** — QR and `VNLSparseLUSolverTraits` gtests gated for `ITK_FUTURE_LEGACY_REMOVE`; FEM's ITPACK `tqlrat` co-located as self-contained (FEM no longer depends on the v3p_netlib eispack); the unused ITPACK routine `determ_` removed.

The two `ENH:` additions are **prerequisites** for the `COMP:` migrations (LandmarkBased needs `Solve(matrix)`, FEM needs `Inverse()`), so they ship together. Each commit is individually prefixed `ENH:` / `COMP:`.

</details>

<details>
<summary>Equivalence & verification</summary>

- `itk::QRDecomposition` is numerically identical to `vnl_qr` for the migrated operations — gtests `EquivalentToVnlQR`, `MatrixRHSEquivalentToVnlQR`, and `InverseEquivalentToVnlQR` assert agreement to `< 1e-10`, plus `A·A⁻¹ = I`.
- Builds under baseline, `ITK_LEGACY_REMOVE=ON`, and `ITK_LEGACY_REMOVE=ON + ITK_FUTURE_LEGACY_REMOVE=ON`; FEM links under FUTURE; all QR and FEM tests pass (FEM test failures are pre-existing missing-data, identical on unmodified code).

</details>

<details>
<summary>Out of scope (tracked separately)</summary>

- `itk::fem::LinearSystemWrapperItpack` / `dsrc2c.c` retirement for an Eigen wrapper (the `tqlrat` co-location is the interim unblock).
- VXL `vnl_*_eigensystem` test gating under FUTURE_LEGACY — separate companion PR.

</details>

<!--
provenance: claude-code session 2026-06-24
cdash: 11368783 Mac10.15-AppleClang-dbg surfaced the vnl_qr #error.
commits: ENH(Solve overload), COMP(gtest gates+LandmarkBased), ENH(Inverse), COMP(FEM vnl_qr), COMP(FEM tqlrat self-contained + drop determ_).
reviewer: dzenanz noted scope > COMP; retitled ENH and clarified ENH-as-prerequisite coupling.
-->
