### PR TITLE
COMP: Gate VXL eigensystem tests under ITK_FUTURE_LEGACY_REMOVE

### DIFF
--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/tests/CMakeLists.txt
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This is core/vnl/algo/tests/CMakeLists.txt
 
-add_executable( vnl_algo_test_all
+set(vnl_algo_test_sources
   # Driver source and utilities
   test_driver.cxx
   test_util.cxx       test_util.h
@@ -11,7 +11,6 @@ add_executable( vnl_algo_test_all
   test_cholesky.cxx
   test_complex_algo.cxx
   test_determinant.cxx
-  test_generalized_eigensystem.cxx
   test_ldl_cholesky.cxx
   test_levenberg_marquardt.cxx
   test_matrix_update.cxx
@@ -19,17 +18,30 @@ add_executable( vnl_algo_test_all
   test_powell.cxx
   test_qr.cxx
   test_rank.cxx
-  test_real_eigensystem.cxx
   test_sparse_matrix.cxx
   test_svd.cxx
   test_svd_fixed.cxx
-  test_symmetric_eigensystem.cxx
   test_integral.cxx
   test_solve_qp.cxx
   test_sparse_lu.cxx
   test_bracket_minimum.cxx
   test_brent_minimizer.cxx
 )
+
+# The eispack-backed vnl_*_eigensystem solvers are excluded from the build under
+# ITK_FUTURE_LEGACY_REMOVE, so their tests cannot link there.
+if(NOT ITK_FUTURE_LEGACY_REMOVE)
+  list(APPEND vnl_algo_test_sources
+    test_generalized_eigensystem.cxx
+    test_real_eigensystem.cxx
+    test_symmetric_eigensystem.cxx
+  )
+endif()
+
+add_executable( vnl_algo_test_all ${vnl_algo_test_sources} )
+if(ITK_FUTURE_LEGACY_REMOVE)
+  target_compile_definitions( vnl_algo_test_all PRIVATE VNL_EISPACK_REMOVED )
+endif()
 
 target_link_libraries( vnl_algo_test_all itkvnl_algo itktestlib ${CMAKE_THREAD_LIBS} )
 
@@ -38,7 +50,6 @@ add_test( NAME vnl_algo_test_amoeba COMMAND vnl_algo_test_all test_amoeba       
 add_test( NAME vnl_algo_test_cholesky COMMAND vnl_algo_test_all test_cholesky                )
 add_test( NAME vnl_algo_test_complex_algo COMMAND vnl_algo_test_all test_complex_algo            )
 add_test( NAME vnl_algo_test_determinant COMMAND vnl_algo_test_all test_determinant             )
-add_test( NAME vnl_algo_test_generalized_eigensystem COMMAND vnl_algo_test_all test_generalized_eigensystem )
 add_test( NAME vnl_algo_test_ldl_cholesky COMMAND vnl_algo_test_all test_ldl_cholesky            )
 add_test( NAME vnl_algo_test_levenberg_marquardt COMMAND vnl_algo_test_all test_levenberg_marquardt     )
 add_test( NAME vnl_algo_test_matrix_update COMMAND vnl_algo_test_all test_matrix_update           )
@@ -46,16 +57,20 @@ add_test( NAME vnl_algo_test_minimizers COMMAND vnl_algo_test_all test_minimizer
 add_test( NAME vnl_algo_test_powell COMMAND vnl_algo_test_all test_powell                  )
 add_test( NAME vnl_algo_test_qr COMMAND vnl_algo_test_all test_qr                      )
 add_test( NAME vnl_algo_test_rank COMMAND vnl_algo_test_all test_rank                    )
-add_test( NAME vnl_algo_test_real_eigensystem COMMAND vnl_algo_test_all test_real_eigensystem        )
 add_test( NAME vnl_algo_test_integral COMMAND vnl_algo_test_all test_integral                )
 add_test( NAME vnl_algo_test_solve_qp COMMAND vnl_algo_test_all test_solve_qp                )
 add_test( NAME vnl_algo_test_sparse_lu COMMAND vnl_algo_test_all test_sparse_lu               )
 add_test( NAME vnl_algo_test_bracket_minimum COMMAND vnl_algo_test_all test_bracket_minimum         )
 add_test( NAME vnl_algo_test_brent_minimizer COMMAND vnl_algo_test_all test_brent_minimizer         )
-add_test( NAME vnl_algo_test_symmetric_eigensystem COMMAND vnl_algo_test_all test_symmetric_eigensystem   )
 add_test( NAME vnl_algo_test_sparse_matrix COMMAND vnl_algo_test_all test_sparse_matrix           )
 add_test( NAME vnl_algo_test_svd COMMAND vnl_algo_test_all test_svd                     )
 add_test( NAME vnl_algo_test_svd_fixed COMMAND vnl_algo_test_all test_svd_fixed               )
+
+if(NOT ITK_FUTURE_LEGACY_REMOVE)
+  add_test( NAME vnl_algo_test_generalized_eigensystem COMMAND vnl_algo_test_all test_generalized_eigensystem )
+  add_test( NAME vnl_algo_test_real_eigensystem COMMAND vnl_algo_test_all test_real_eigensystem )
+  add_test( NAME vnl_algo_test_symmetric_eigensystem COMMAND vnl_algo_test_all test_symmetric_eigensystem )
+endif()
 
 add_executable( vnl_algo_test_include test_include.cxx )
 target_link_libraries( vnl_algo_test_include itkvnl_algo )

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/tests/test_driver.cxx
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/tests/test_driver.cxx
@@ -1,10 +1,14 @@
 #include "testlib/testlib_register.h"
 
+// VNL_EISPACK_REMOVED is defined by CMake under ITK_FUTURE_LEGACY_REMOVE, where
+// the eispack-backed vnl_*_eigensystem solvers are excluded from the build.
 DECLARE(test_amoeba);
 DECLARE(test_cholesky);
 DECLARE(test_determinant);
 DECLARE(test_rank);
+#ifndef VNL_EISPACK_REMOVED
 DECLARE(test_generalized_eigensystem);
+#endif
 DECLARE(test_ldl_cholesky);
 DECLARE(test_levenberg_marquardt);
 DECLARE(test_matrix_update);
@@ -12,12 +16,16 @@ DECLARE(test_minimizers);
 DECLARE(test_powell);
 DECLARE(test_qr);
 DECLARE(test_rational);
+#ifndef VNL_EISPACK_REMOVED
 DECLARE(test_real_eigensystem);
+#endif
 DECLARE(test_sparse_matrix);
 DECLARE(test_integral);
 DECLARE(test_svd);
 DECLARE(test_svd_fixed);
+#ifndef VNL_EISPACK_REMOVED
 DECLARE(test_symmetric_eigensystem);
+#endif
 DECLARE(test_algo);
 DECLARE(test_solve_qp);
 DECLARE(test_sparse_lu);
@@ -32,19 +40,25 @@ register_tests()
   REGISTER(test_cholesky);
   REGISTER(test_determinant);
   REGISTER(test_rank);
+#ifndef VNL_EISPACK_REMOVED
   REGISTER(test_generalized_eigensystem);
+#endif
   REGISTER(test_ldl_cholesky);
   REGISTER(test_levenberg_marquardt);
   REGISTER(test_matrix_update);
   REGISTER(test_minimizers);
   REGISTER(test_powell);
   REGISTER(test_qr);
+#ifndef VNL_EISPACK_REMOVED
   REGISTER(test_real_eigensystem);
+#endif
   REGISTER(test_integral);
   REGISTER(test_sparse_matrix);
   REGISTER(test_svd);
   REGISTER(test_svd_fixed);
+#ifndef VNL_EISPACK_REMOVED
   REGISTER(test_symmetric_eigensystem);
+#endif
   REGISTER(test_algo);
   REGISTER(test_solve_qp);
   REGISTER(test_sparse_lu);


### PR DESCRIPTION
Completes the eispack removal of #6488-era commit `34c7abf2b4c`: that commit excluded the `vnl_*_eigensystem` solvers under `ITK_FUTURE_LEGACY_REMOVE` but left their tests, so `vnl_algo_test_all` fails to link in that configuration. This gates the three eigensystem tests off under the same flag.

<details>
<summary>Root cause</summary>

`34c7abf2b4c` empties the netlib `eispack` sources under `ITK_FUTURE_LEGACY_REMOVE`, removing the implementations of `vnl_symmetric_eigensystem` / `vnl_real_eigensystem` / `vnl_generalized_eigensystem`. The VXL `vnl_algo_test_all` driver still compiled and linked `test_{symmetric,real,generalized}_eigensystem.cxx`, which reference those classes → undefined references at link. This is latent in the `Mac10.15-AppleClang-dbg` FUTURE_LEGACY nightly (ninja stops at the first error elsewhere); a default-module FUTURE build shows it as the sole remaining failure.

</details>

<details>
<summary>Fix</summary>

Under `ITK_FUTURE_LEGACY_REMOVE`, in `core/vnl/algo/tests/`:
- exclude the three `test_*_eigensystem.cxx` from the `vnl_algo_test_all` sources and their `add_test` registrations;
- skip their `DECLARE`/`REGISTER` in `test_driver.cxx` via a CMake-defined `VNL_EISPACK_REMOVED` macro — the ThirdParty VXL translation units do not have `itkConfigure.h` on their include path, so the flag cannot be tested with the preprocessor directly.

The tests remain fully present and registered in all non-FUTURE configurations.

</details>

<details>
<summary>Verification</summary>

- FUTURE (default modules, `ITK_LEGACY_REMOVE=ON` + `ITK_FUTURE_LEGACY_REMOVE=ON`): `vnl_algo_test_all` links, 0 eigensystem undefined references; the 3 eigensystem tests are absent from `ctest -N`.
- Non-FUTURE: `vnl_algo_test_all` builds and the 3 eigensystem tests are present (`ctest -N` shows `vnl_algo_test_{generalized,real,symmetric}_eigensystem`).

</details>

<!--
provenance: claude-code session 2026-06-24
root: commit 34c7abf2b4c "Deprecate vnl_scatter_3x3; drop eispack under ITK_FUTURE_LEGACY_REMOVE" gated the classes, not the tests.
mechanism: VNL_EISPACK_REMOVED is set by target_compile_definitions only under ITK_FUTURE_LEGACY_REMOVE; ThirdParty VXL TUs lack itkConfigure.h so cannot test ITK_FUTURE_LEGACY_REMOVE directly.
related: companion vnl_qr removal PR (FEM + Core/Common gtests). Both needed for a green FUTURE nightly.
-->
