### PR TITLE
COMP: Modernize deprecated macros in SmoothingRecursiveYvvGaussianFilter

### DIFF
--- a/Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/include/itkGPUSmoothingRecursiveYvvGaussianImageFilter.h
+++ b/Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/include/itkGPUSmoothingRecursiveYvvGaussianImageFilter.h
@@ -86,20 +86,20 @@ public:
   using GPUOutputImage = typename itk::GPUTraits<TOutputImage>::Type;
 
   /** Runtime information support. */
-  itkTypeMacro(GPUSmoothingRecursiveYvvGaussianImageFilter, GPUImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(GPUSmoothingRecursiveYvvGaussianImageFilter);
 
   /** Image dimension. */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   /** Define the type for the sigma array */
-  using SigmaArrayType = FixedArray<ScalarRealType, itkGetStaticConstMacro(ImageDimension)>;
+  using SigmaArrayType = FixedArray<ScalarRealType, Self::ImageDimension>;
 
   /** Define the image type for internal computations
    RealType is usually 'double' in NumericTraits.
    Here we prefer float in order to save memory.  */
 
   using InternalRealType = typename NumericTraits<PixelType>::FloatType;
-  using RealImageType = GPUImage<InternalRealType, itkGetStaticConstMacro(ImageDimension)>;
+  using RealImageType = GPUImage<InternalRealType, Self::ImageDimension>;
 
   /**  Pointer to the Output Image */
   using OutputImagePointer = typename OutputImageType::Pointer;
@@ -159,7 +159,7 @@ protected:
    * the pipeline execution model.
    * \sa ImageToImageFilter::GenerateInputRequestedRegion() */
   void
-  GenerateInputRequestedRegion() ITK_NOEXCEPT override;
+  GenerateInputRequestedRegion() noexcept override;
 
   // Override since the filter produces the entire dataset
   void

--- a/Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/include/itkGPUSmoothingRecursiveYvvGaussianImageFilter.hxx
+++ b/Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/include/itkGPUSmoothingRecursiveYvvGaussianImageFilter.hxx
@@ -227,7 +227,7 @@ GPUSmoothingRecursiveYvvGaussianImageFilter<TInputImage, TOutputImage>::SetNorma
 
 template <typename TInputImage, typename TOutputImage>
 void
-GPUSmoothingRecursiveYvvGaussianImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion() ITK_NOEXCEPT
+GPUSmoothingRecursiveYvvGaussianImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion() noexcept
 {
   // call the superclass' implementation of this method. this should
   // copy the output requested region to the input requested region

--- a/Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/include/itkRecursiveLineYvvGaussianImageFilter.h
+++ b/Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/include/itkRecursiveLineYvvGaussianImageFilter.h
@@ -57,7 +57,7 @@ public:
   itkNewMacro(Self);
 
   /** Type macro that defines a name for this class. */
-  itkTypeMacro(RecursiveLineYvvGaussianImageFilter, InPlaceImageFilter);
+  itkOverrideGetNameOfClassMacro(RecursiveLineYvvGaussianImageFilter);
 
   /** Smart pointer type alias support.  */
   using InputImagePointer = typename TInputImage::Pointer;

--- a/Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/include/itkSmoothingRecursiveYvvGaussianImageFilter.h
+++ b/Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/include/itkSmoothingRecursiveYvvGaussianImageFilter.h
@@ -68,13 +68,13 @@ public:
 #endif
 
   /** Runtime information support. */
-  itkTypeMacro(SmoothingRecursiveYvvGaussianImageFilter, InPlaceImageFilter);
+  itkOverrideGetNameOfClassMacro(SmoothingRecursiveYvvGaussianImageFilter);
 
   /** Image dimension. */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   /** Define the type for the sigma array */
-  using SigmaArrayType = FixedArray<ScalarRealType, itkGetStaticConstMacro(ImageDimension)>;
+  using SigmaArrayType = FixedArray<ScalarRealType, Self::ImageDimension>;
 
   /** Define the image type for internal computations
    RealType is usually 'double' in NumericTraits.
@@ -152,7 +152,7 @@ protected:
    * the pipeline execution model.
    * \sa ImageToImageFilter::GenerateInputRequestedRegion() */
   void
-  GenerateInputRequestedRegion() ITK_NOEXCEPT override;
+  GenerateInputRequestedRegion() noexcept override;
 
   // Override since the filter produces the entire dataset
   void

--- a/Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/include/itkSmoothingRecursiveYvvGaussianImageFilter.hxx
+++ b/Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/include/itkSmoothingRecursiveYvvGaussianImageFilter.hxx
@@ -185,7 +185,7 @@ SmoothingRecursiveYvvGaussianImageFilter<TInputImage, TOutputImage>::SetNormaliz
 
 template <typename TInputImage, typename TOutputImage>
 void
-SmoothingRecursiveYvvGaussianImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion() ITK_NOEXCEPT
+SmoothingRecursiveYvvGaussianImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion() noexcept
 {
   // call the superclass' implementation of this method. this should
   // copy the output requested region to the input requested region


### PR DESCRIPTION
Modernizes three deprecated macros in `SmoothingRecursiveYvvGaussianFilter` so the module builds under `ITK_LEGACY_REMOVE` and `ITK_FUTURE_LEGACY_REMOVE`, where those macros become hard errors. No behavior change.

<details>
<summary>What changed</summary>

| Replacement | Removed under | Sites |
|---|---|---|
| `ITK_NOEXCEPT` → `noexcept` | `ITK_LEGACY_REMOVE` | 4 |
| `itkTypeMacro(class, super)` → `itkOverrideGetNameOfClassMacro(class)` | `ITK_FUTURE_LEGACY_REMOVE` | 3 |
| `itkGetStaticConstMacro(X)` → `Self::X` | `ITK_FUTURE_LEGACY_REMOVE` | 3 |

Each replacement is the exact modern equivalent the deprecation message points to.

</details>

<details>
<summary>Verification</summary>

- Compiles and links under **baseline**, `ITK_LEGACY_REMOVE=ON`, and `ITK_LEGACY_REMOVE=ON + ITK_FUTURE_LEGACY_REMOVE=ON`.
- All 7 `Yvv*` tests pass in the baseline build (no behavior change).
- The two `itkGPUSmoothingRecursiveYvv*` files received the same mechanical edits but were **not compiled locally** — the GPU module requires OpenCL, unavailable on this workstation. They are exercised by GPU-enabled CI.

</details>

<!--
provenance: claude-code session 2026-06-24
context: opt-in module surfaced by an all-in-tree-modules FUTURE/LEGACY build; itkGetStaticConstMacro/itkStaticConstMacro/itkTypeMacro are gated by ITK_FUTURE_LEGACY_REMOVE in itkMacro.h, ITK_NOEXCEPT by the legacy guard.
campaign: more modules remain — itkGetStaticConstMacro in ParabolicMorphology/HigherOrderAccurateGradient/VariationalRegistration; itkTypeMacro across many; iterator GetIndex() in IsotropicWavelets/MinimalPathExtraction/PhaseSymmetry/MGHIO/VariationalRegistration.
related: independent of the vnl_qr (#6499) and VXL eigensystem (#6500) PRs from the same session.
-->
