### PR TITLE
COMP: Modernize deprecated APIs in VariationalRegistration

### DIFF
--- a/Modules/Registration/VariationalRegistration/include/itkContinuousBorderWarpImageFilter.h
+++ b/Modules/Registration/VariationalRegistration/include/itkContinuousBorderWarpImageFilter.h
@@ -71,7 +71,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(ContinuousBorderWarpImageFilter, WarpImageFilter);
+  itkOverrideGetNameOfClassMacro(ContinuousBorderWarpImageFilter);
 
   /** Typedef to describe the output image region type. */
   using OutputImageRegionType = typename Superclass::OutputImageRegionType;

--- a/Modules/Registration/VariationalRegistration/include/itkVariationalDiffeomorphicRegistrationFilter.h
+++ b/Modules/Registration/VariationalRegistration/include/itkVariationalDiffeomorphicRegistrationFilter.h
@@ -95,7 +95,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(VariationalDiffeomorphicRegistrationFilter, VariationalRegistrationFilter);
+  itkOverrideGetNameOfClassMacro(VariationalDiffeomorphicRegistrationFilter);
 
   /** Get image dimension. */
   static constexpr unsigned int ImageDimension = Superclass::ImageDimension;

--- a/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationCurvatureRegularizer.h
+++ b/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationCurvatureRegularizer.h
@@ -75,7 +75,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(VariationalRegistrationCurvatureRegularizer, VariationalRegistrationRegularizer);
+  itkOverrideGetNameOfClassMacro(VariationalRegistrationCurvatureRegularizer);
 
   /** Dimensionality of input and output data is assumed to be the same. */
   static constexpr unsigned int ImageDimension = TDisplacementField::ImageDimension;

--- a/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationDemonsFunction.h
+++ b/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationDemonsFunction.h
@@ -69,7 +69,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VariationalRegistrationDemonsFunction, VariationalRegistrationFunction);
+  itkOverrideGetNameOfClassMacro(VariationalRegistrationDemonsFunction);
 
   /** Get image dimension. */
   static constexpr unsigned int ImageDimension = Superclass::ImageDimension;

--- a/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationDiffusionRegularizer.h
+++ b/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationDiffusionRegularizer.h
@@ -63,7 +63,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(VariationalRegistrationDiffusionRegularizer, VariationalRegistrationRegularizer);
+  itkOverrideGetNameOfClassMacro(VariationalRegistrationDiffusionRegularizer);
 
   /** Dimensionality of input and output data is assumed to be the same. */
   static constexpr unsigned int ImageDimension = TDisplacementField::ImageDimension;

--- a/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationElasticRegularizer.h
+++ b/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationElasticRegularizer.h
@@ -71,7 +71,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(VariationalRegistrationElasticRegularizer, VariationalRegistrationRegularizer);
+  itkOverrideGetNameOfClassMacro(VariationalRegistrationElasticRegularizer);
 
   /** Dimensionality of input and output data is assumed to be the same. */
   static constexpr unsigned int ImageDimension = TDisplacementField::ImageDimension;

--- a/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationFastNCCFunction.h
+++ b/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationFastNCCFunction.h
@@ -79,7 +79,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VariationalRegistrationFastNCCFunction, VariationalRegistrationNCCFunction);
+  itkOverrideGetNameOfClassMacro(VariationalRegistrationFastNCCFunction);
 
   /** Get image dimension. */
   static constexpr unsigned int ImageDimension = Superclass::ImageDimension;

--- a/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationFilter.h
+++ b/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationFilter.h
@@ -111,7 +111,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(VariationalRegistrationFilter, DenseFiniteDifferenceImageFilter);
+  itkOverrideGetNameOfClassMacro(VariationalRegistrationFilter);
 
   /** Get image dimension. */
   static constexpr unsigned int ImageDimension = Superclass::ImageDimension;

--- a/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationFunction.h
+++ b/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationFunction.h
@@ -63,7 +63,7 @@ public:
   using TimeStepType = typename Superclass::TimeStepType;
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(VariationalRegistrationFunction, FiniteDifferenceFunction);
+  itkOverrideGetNameOfClassMacro(VariationalRegistrationFunction);
 
   /** Get image dimension. */
   static constexpr unsigned int ImageDimension = Superclass::ImageDimension;

--- a/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationGaussianRegularizer.h
+++ b/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationGaussianRegularizer.h
@@ -59,7 +59,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(VariationalRegistrationGaussianRegularizer, VariationalRegistrationRegularizer);
+  itkOverrideGetNameOfClassMacro(VariationalRegistrationGaussianRegularizer);
 
   /** Dimensionality of input and output data is assumed to be the same. */
   static constexpr unsigned int ImageDimension = TDisplacementField::ImageDimension;

--- a/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationMultiResolutionFilter.h
+++ b/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationMultiResolutionFilter.h
@@ -93,7 +93,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VariationalRegistrationMultiResolutionFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(VariationalRegistrationMultiResolutionFilter);
 
   /** Fixed image type. */
   using FixedImageType = TFixedImage;
@@ -119,7 +119,7 @@ public:
   using MaskImageConstPointer = typename MaskImageType::ConstPointer;
 
   /** Internal float image type. */
-  using FloatImageType = Image<TRealType, itkGetStaticConstMacro(ImageDimension)>;
+  using FloatImageType = Image<TRealType, Self::ImageDimension>;
 
   /** The internal registration type. */
   using RegistrationType = VariationalRegistrationFilter<FixedImageType, MovingImageType, DisplacementFieldType>;

--- a/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationNCCFunction.h
+++ b/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationNCCFunction.h
@@ -78,7 +78,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VariationalRegistrationNCCFunction, VariationalRegistrationFunction);
+  itkOverrideGetNameOfClassMacro(VariationalRegistrationNCCFunction);
 
   /** Get image dimension. */
   static constexpr unsigned int ImageDimension = Superclass::ImageDimension;

--- a/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationRegularizer.h
+++ b/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationRegularizer.h
@@ -59,7 +59,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(VariationalRegistrationRegularizer, InPlaceImageFilter);
+  itkOverrideGetNameOfClassMacro(VariationalRegistrationRegularizer);
 
   static constexpr unsigned int ImageDimension = TDisplacementField::ImageDimension;
 

--- a/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationSSDFunction.h
+++ b/Modules/Registration/VariationalRegistration/include/itkVariationalRegistrationSSDFunction.h
@@ -66,7 +66,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VariationalRegistrationSSDFunction, VariationalRegistrationFunction);
+  itkOverrideGetNameOfClassMacro(VariationalRegistrationSSDFunction);
 
   /** Get image dimension. */
   static constexpr unsigned int ImageDimension = Superclass::ImageDimension;

--- a/Modules/Registration/VariationalRegistration/include/itkVariationalSymmetricDiffeomorphicRegistrationFilter.h
+++ b/Modules/Registration/VariationalRegistration/include/itkVariationalSymmetricDiffeomorphicRegistrationFilter.h
@@ -104,7 +104,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(VariationalSymmetricDiffeomorphicRegistrationFilter, VariationalDiffeomorphicRegistrationFilter);
+  itkOverrideGetNameOfClassMacro(VariationalSymmetricDiffeomorphicRegistrationFilter);
 
   /** Get image dimension. */
   static constexpr unsigned int ImageDimension = Superclass::ImageDimension;

--- a/Modules/Registration/VariationalRegistration/src/VariationalRegistrationMain.cxx
+++ b/Modules/Registration/VariationalRegistration/src/VariationalRegistrationMain.cxx
@@ -58,6 +58,7 @@ extern "C"
 #include "itkConfigure.h"
 #include "itkVariationalRegistrationIncludeRequiredIOFactories.h"
 
+#include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkExponentialDisplacementFieldImageFilter.h"
 
 #include "itkVariationalRegistrationMultiResolutionFilter.h"
@@ -918,8 +919,8 @@ main(int argc, char * argv[])
 
       writeField->Allocate();
 
-      ImageRegionConstIterator<DisplacementFieldType> defIterator(outputDisplacementField,
-                                                                  outputDisplacementField->GetRequestedRegion());
+      ImageRegionConstIteratorWithIndex<DisplacementFieldType> defIterator(
+        outputDisplacementField, outputDisplacementField->GetRequestedRegion());
 
       while (!defIterator.IsAtEnd())
       {

--- a/Modules/Registration/VariationalRegistration/test/VariationalRegistrationFilterTest.cxx
+++ b/Modules/Registration/VariationalRegistration/test/VariationalRegistrationFilterTest.cxx
@@ -224,8 +224,8 @@ VariationalRegistrationFilterTest(int, char *[])
   using WarperType = itk::ContinuousBorderWarpImageFilter<ImageType, ImageType, FieldType>;
   WarperType::Pointer warper = WarperType::New();
 
-  using CoordRepType = WarperType::CoordRepType;
-  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordRepType>;
+  using CoordinateType = WarperType::CoordinateType;
+  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordinateType>;
   InterpolatorType::Pointer interpolator = InterpolatorType::New();
 
   warper->SetInput(moving);

--- a/Modules/Registration/VariationalRegistration/test/VariationalRegistrationMultiResolutionFilterTest.cxx
+++ b/Modules/Registration/VariationalRegistration/test/VariationalRegistrationMultiResolutionFilterTest.cxx
@@ -237,8 +237,8 @@ VariationalRegistrationMultiResolutionFilterTest(int, char *[])
   using WarperType = itk::ContinuousBorderWarpImageFilter<ImageType, ImageType, FieldType>;
   WarperType::Pointer warper = WarperType::New();
 
-  using CoordRepType = WarperType::CoordRepType;
-  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordRepType>;
+  using CoordinateType = WarperType::CoordinateType;
+  using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, CoordinateType>;
   InterpolatorType::Pointer interpolator = InterpolatorType::New();
 
 


### PR DESCRIPTION
Modernizes deprecated APIs in `VariationalRegistration` so the module builds under `ITK_LEGACY_REMOVE` and `ITK_FUTURE_LEGACY_REMOVE`. It was the largest offender among the ingested remote modules (~157 errors in an all-modules FUTURE build). No behavior change.

<details>
<summary>What changed</summary>

| Replacement | Removed under | Sites |
|---|---|---|
| `itkTypeMacro(class, super)` → `itkOverrideGetNameOfClassMacro(class)` | `ITK_FUTURE_LEGACY_REMOVE` | 15 |
| `itkGetStaticConstMacro(X)` → `Self::X` | `ITK_FUTURE_LEGACY_REMOVE` | 1 |
| `ImageRegionConstIterator::GetIndex()` → `ImageRegionConstIteratorWithIndex` | `ITK_FUTURE_LEGACY_REMOVE` | 1 |
| `CoordRepType` → `CoordinateType` (tests) | `ITK_FUTURE_LEGACY_REMOVE` | 2 |

Each is the exact modern equivalent the deprecation message points to. The later two surfaced only after the macro fixes (cascading), which is why the module is fixed end-to-end here.

</details>

<details>
<summary>Verification</summary>

- Builds and links under **baseline**, `ITK_LEGACY_REMOVE=ON`, and `ITK_LEGACY_REMOVE=ON + ITK_FUTURE_LEGACY_REMOVE=ON`.
- All 23 `VariationalRegistration*` tests pass in the baseline build (no behavior change).

</details>

<!--
provenance: claude-code session 2026-06-24
context: opt-in ingested remote module surfaced by an all-in-tree-modules FUTURE/LEGACY build. Part of a per-module cleanup of ingested remote-module technical debt.
related: SmoothingRecursiveYvv (#6501); vnl_qr (#6499); VXL eigensystem tests (#6500). Same campaign.
remaining: itkTypeMacro/itkGetStaticConstMacro/GetIndex in ParabolicMorphology, HigherOrderAccurateGradient, IsotropicWavelets, MinimalPathExtraction, PhaseSymmetry, MGHIO, Cuberille, etc.
-->
