### PR TITLE
COMP: Modernize deprecated macros in ingested filter/IO modules

### DIFF
--- a/Documentation/docs/migration_guides/itk_6_migration_guide.md
+++ b/Documentation/docs/migration_guides/itk_6_migration_guide.md
@@ -845,3 +845,24 @@ whereas `vnl_svd`'s signs depend on solver internals. Sign-invariant operations
 reads individual `U`/`V` columns as directions may see the same geometry from a
 different, equally-valid representative. Pass `canonicalizeSigns = false` to
 reproduce `vnl_svd`'s raw signs (e.g. for equivalence testing).
+
+## `FixedPointInverseDisplacementFieldImageFilter::OutputIterator` is now `ImageRegionIteratorWithIndex`
+
+The public nested type alias
+`FixedPointInverseDisplacementFieldImageFilter<...>::OutputIterator` changed from
+`ImageRegionIterator<OutputImageType>` to
+`ImageRegionIteratorWithIndex<OutputImageType>`. The filter calls `GetIndex()` on
+this iterator, which `ImageRegionIterator` only provides under the removed
+`ITK_FUTURE_LEGACY_REMOVE` API; `ImageRegionIteratorWithIndex` supplies it
+natively.
+
+### What you need to do
+
+Downstream code that names the concrete alias explicitly -- e.g. a template
+specialization or overload keyed on `ImageRegionIterator<OutputImageType>`, or a
+variable declared as `FilterType::OutputIterator` and then passed where an
+`ImageRegionIterator` is required -- must accept
+`ImageRegionIteratorWithIndex<OutputImageType>` instead. The two iterators are
+siblings in the iterator hierarchy, not subclasses, so such uses do not convert
+implicitly. Code that only iterates (`GoToBegin`/`IsAtEnd`/`Get`/`Set`) needs no
+change.

--- a/Modules/Filtering/Cuberille/include/itkCuberilleImageToMeshFilter.h
+++ b/Modules/Filtering/Cuberille/include/itkCuberilleImageToMeshFilter.h
@@ -127,7 +127,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(CuberilleImageToMeshFilter, ImageToMeshFilter);
+  itkOverrideGetNameOfClassMacro(CuberilleImageToMeshFilter);
 
   /** Compile-time configuration flags (formerly preprocessor macros).
    * Flip a flag to true and rebuild to enable the corresponding alternative

--- a/Modules/Filtering/FixedPointInverseDisplacementField/include/itkFixedPointInverseDisplacementFieldImageFilter.h
+++ b/Modules/Filtering/FixedPointInverseDisplacementField/include/itkFixedPointInverseDisplacementFieldImageFilter.h
@@ -24,6 +24,7 @@
 #include "itkWarpVectorImageFilter.h"
 #include "itkVectorLinearInterpolateImageFunction.h"
 #include "itkImageRegionIterator.h"
+#include "itkImageRegionIteratorWithIndex.h"
 #include "itkTimeProbe.h"
 
 namespace itk
@@ -70,7 +71,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(FixedPointInverseDisplacementFieldImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(FixedPointInverseDisplacementFieldImageFilter);
 
 
   /** Some type alias. */
@@ -101,7 +102,7 @@ public:
   using InputConstIterator = ImageRegionConstIterator<InputImageType>;
   using InputIterator = ImageRegionIterator<InputImageType>;
   using OutputConstIterator = ImageRegionConstIterator<OutputImageType>;
-  using OutputIterator = ImageRegionIterator<OutputImageType>;
+  using OutputIterator = ImageRegionIteratorWithIndex<OutputImageType>;
 
   using VectorWarperType = WarpVectorImageFilter<TOutputImage, TInputImage, TOutputImage>;
   using InterpolatorVectorType = typename NumericTraits<typename TOutputImage::PixelType>::RealType;

--- a/Modules/Filtering/SubdivisionQuadEdgeMeshFilter/include/itkModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
+++ b/Modules/Filtering/SubdivisionQuadEdgeMeshFilter/include/itkModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
@@ -76,8 +76,7 @@ public:
   using OutputPointIdIterator = typename Superclass::OutputPointIdIterator;
 
   /** Run-time type information (and related methods).   */
-  itkTypeMacro(ModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter,
-               TriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
+  itkOverrideGetNameOfClassMacro(ModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
 
   /** New macro for creation of through a Smart Pointer   */
   itkNewMacro(Self);

--- a/Modules/Filtering/TotalVariation/include/itkProxTVImageFilter.h
+++ b/Modules/Filtering/TotalVariation/include/itkProxTVImageFilter.h
@@ -56,7 +56,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information. */
-  itkTypeMacro(ProxTVImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(ProxTVImageFilter);
 
   /** Standard New macro. */
   itkNewMacro(Self);

--- a/Modules/IO/IOMeshSTL/include/itkSTLMeshIO.h
+++ b/Modules/IO/IOMeshSTL/include/itkSTLMeshIO.h
@@ -50,7 +50,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(STLMeshIO, MeshIOBase);
+  itkOverrideGetNameOfClassMacro(STLMeshIO);
 
   /**-------- This part of the interfaces deals with reading data. ----- */
 

--- a/Modules/IO/IOMeshSTL/include/itkSTLMeshIOFactory.h
+++ b/Modules/IO/IOMeshSTL/include/itkSTLMeshIOFactory.h
@@ -52,7 +52,7 @@ public:
   itkFactorylessNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(STLMeshIOFactory, ObjectFactoryBase);
+  itkOverrideGetNameOfClassMacro(STLMeshIOFactory);
 
   /** Register one factory of this type  */
   static void

--- a/Modules/Registration/RANSAC/include/itkLandmarkRegistrationEstimator.h
+++ b/Modules/Registration/RANSAC/include/itkLandmarkRegistrationEstimator.h
@@ -50,7 +50,7 @@ public:
   using PointsLocatorType = itk::PointsLocator<itk::VectorContainer<IdentifierType, itk::Point<double, 3>>>;
   using PointsContainer = itk::VectorContainer<IdentifierType, itk::Point<double, 3>>;
 
-  itkTypeMacro(LandmarkRegistrationEstimator, ParametersEstimator);
+  itkOverrideGetNameOfClassMacro(LandmarkRegistrationEstimator);
   /** New method for creating an object using a factory. */
   itkNewMacro(Self);
 

--- a/Modules/Registration/RANSAC/include/itkParametersEstimator.h
+++ b/Modules/Registration/RANSAC/include/itkParametersEstimator.h
@@ -55,7 +55,7 @@ public:
   typedef SmartPointer<Self>       Pointer;
   typedef SmartPointer<const Self> ConstPointer;
 
-  itkTypeMacro(ParametersEstimator, Object);
+  itkOverrideGetNameOfClassMacro(ParametersEstimator);
 
   /**
    * Exact estimation of parameters.

--- a/Modules/Registration/RANSAC/include/itkRANSAC.h
+++ b/Modules/Registration/RANSAC/include/itkRANSAC.h
@@ -86,7 +86,7 @@ public:
   using ParametersEstimatorPointer = typename itk::ParametersEstimator<T, SType>::Pointer;
   using ParametersEstimatorType = typename itk::ParametersEstimator<T, SType>;
 
-  itkTypeMacro(RANSAC, Object);
+  itkOverrideGetNameOfClassMacro(RANSAC);
   /** New method for creating an object using a factory. */
   itkNewMacro(Self);
 


### PR DESCRIPTION
Modernizes deprecated macros in six ingested opt-in modules so they build under `ITK_FUTURE_LEGACY_REMOVE`, where these macros become hard errors. No behavior change.

<details>
<summary>What changed</summary>

`itkTypeMacro(class, super)` → `itkOverrideGetNameOfClassMacro(class)` in:
**Cuberille**, **FixedPointInverseDisplacementField**, **SubdivisionQuadEdgeMeshFilter**, **TotalVariation**, **IOMeshSTL**, **RANSAC**.

Plus `ImageRegionIterator::GetIndex()` → `ImageRegionIteratorWithIndex` in `FixedPointInverseDisplacementField` (the plain region iterator dropped `GetIndex()` under FUTURE_LEGACY).

</details>

<details>
<summary>Verification</summary>

- Baseline build: 0 errors; 112 tests pass across the six modules.
- The five self-contained modules (Cuberille, FixedPoint, Subdivision, TotalVariation, IOMeshSTL) build and link under `ITK_LEGACY_REMOVE=ON + ITK_FUTURE_LEGACY_REMOVE=ON`.
- RANSAC's *library* is FUTURE-clean. Its `itkRansacTest_LandmarkRegistration` test transitively pulls `LandmarkBasedTransformInitializer` → `vnl/algo/vnl_qr.h`, which is migrated in #6499; so that one test goes fully FUTURE-green once #6499 lands. RANSAC is opt-in (not in default CI).

</details>

<!--
provenance: claude-code session 2026-06-24
context: ingested (in-tree, canonical) opt-in modules surfaced by an all-in-tree-modules FUTURE/LEGACY build. itkTypeMacro/itkGetStaticConstMacro gated by ITK_FUTURE_LEGACY_REMOVE in itkMacro.h.
related: per-module campaign — SmoothingRecursiveYvv (#6501), VariationalRegistration (#6503), vnl_qr (#6499), VXL eigensystem tests (#6500).
dependency: RANSAC test full FUTURE-green depends on #6499 (LandmarkBased vnl_qr migration).
-->
