### PR TITLE
COMP: Modernize deprecated macros in ParabolicMorphology

### DIFF
--- a/Modules/Filtering/ParabolicMorphology/include/itkBinaryCloseParabolicImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkBinaryCloseParabolicImageFilter.h
@@ -82,7 +82,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(BinaryCloseParabolicImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(BinaryCloseParabolicImageFilter);
 
   /** Pixel Type of the input image */
   using InputImageType = TInputImage;

--- a/Modules/Filtering/ParabolicMorphology/include/itkBinaryDilateParabolicImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkBinaryDilateParabolicImageFilter.h
@@ -80,7 +80,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(BinaryDilateParabolicImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(BinaryDilateParabolicImageFilter);
 
   /** Pixel Type of the input image */
   using InputImageType = TInputImage;

--- a/Modules/Filtering/ParabolicMorphology/include/itkBinaryErodeParabolicImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkBinaryErodeParabolicImageFilter.h
@@ -81,7 +81,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(BinaryErodeParabolicImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(BinaryErodeParabolicImageFilter);
 
   /** Pixel Type of the input image */
   using InputImageType = TInputImage;

--- a/Modules/Filtering/ParabolicMorphology/include/itkBinaryOpenParabolicImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkBinaryOpenParabolicImageFilter.h
@@ -82,7 +82,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(BinaryOpenParabolicImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(BinaryOpenParabolicImageFilter);
 
   /** Pixel Type of the input image */
   using InputImageType = TInputImage;

--- a/Modules/Filtering/ParabolicMorphology/include/itkMorphSDTHelperImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkMorphSDTHelperImageFilter.h
@@ -113,7 +113,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(MorphSDTHelperImageFilter, TernaryFunctorImageFilter);
+  itkOverrideGetNameOfClassMacro(MorphSDTHelperImageFilter);
 
   void
   SetVal(double val)

--- a/Modules/Filtering/ParabolicMorphology/include/itkMorphologicalDistanceTransformImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkMorphologicalDistanceTransformImageFilter.h
@@ -72,7 +72,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(MorphologicalDistanceTransformImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(MorphologicalDistanceTransformImageFilter);
 
   /** Pixel Type of the input image */
   using InputImageType = TInputImage;
@@ -121,9 +121,7 @@ public:
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */
-  itkConceptMacro(SameDimension,
-                  (Concept::SameDimension<itkGetStaticConstMacro(InputImageDimension),
-                                          itkGetStaticConstMacro(OutputImageDimension)>));
+  itkConceptMacro(SameDimension, (Concept::SameDimension<Self::InputImageDimension, Self::OutputImageDimension>));
 
   itkConceptMacro(Comparable, (Concept::Comparable<InputPixelType>));
 

--- a/Modules/Filtering/ParabolicMorphology/include/itkMorphologicalSharpeningImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkMorphologicalSharpeningImageFilter.h
@@ -79,7 +79,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(MorphologicalSharpeningImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(MorphologicalSharpeningImageFilter);
 
   /** Pixel Type of the input image */
   using InputImageType = TInputImage;
@@ -140,9 +140,7 @@ public:
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */
-  itkConceptMacro(SameDimension,
-                  (Concept::SameDimension<itkGetStaticConstMacro(InputImageDimension),
-                                          itkGetStaticConstMacro(OutputImageDimension)>));
+  itkConceptMacro(SameDimension, (Concept::SameDimension<Self::InputImageDimension, Self::OutputImageDimension>));
 
   itkConceptMacro(Comparable, (Concept::Comparable<InputPixelType>));
 

--- a/Modules/Filtering/ParabolicMorphology/include/itkMorphologicalSignedDistanceTransformImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkMorphologicalSignedDistanceTransformImageFilter.h
@@ -84,7 +84,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(MorphologicalSignedDistanceTransformImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(MorphologicalSignedDistanceTransformImageFilter);
 
   /** Pixel Type of the input image */
   using InputImageType = TInputImage;
@@ -164,9 +164,7 @@ public:
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */
-  itkConceptMacro(SameDimension,
-                  (Concept::SameDimension<itkGetStaticConstMacro(InputImageDimension),
-                                          itkGetStaticConstMacro(OutputImageDimension)>));
+  itkConceptMacro(SameDimension, (Concept::SameDimension<Self::InputImageDimension, Self::OutputImageDimension>));
 
   itkConceptMacro(Comparable, (Concept::Comparable<InputPixelType>));
 

--- a/Modules/Filtering/ParabolicMorphology/include/itkParabolicCloseImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkParabolicCloseImageFilter.h
@@ -63,7 +63,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(ParabolicCloseImageFilter, ParabolicOpenCloseSafeBorderImageFilter);
+  itkOverrideGetNameOfClassMacro(ParabolicCloseImageFilter);
 
   /** Pixel Type of the input image */
   using InputImageType = TInputImage;

--- a/Modules/Filtering/ParabolicMorphology/include/itkParabolicDilateImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkParabolicDilateImageFilter.h
@@ -62,7 +62,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(ParabolicDilateImageFilter, ParabolicErodeDilateImageFilter);
+  itkOverrideGetNameOfClassMacro(ParabolicDilateImageFilter);
 
   /** Pixel Type of the input image */
   using InputImageType = TInputImage;

--- a/Modules/Filtering/ParabolicMorphology/include/itkParabolicErodeDilateImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkParabolicErodeDilateImageFilter.h
@@ -95,7 +95,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(ParabolicErodeDilateImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(ParabolicErodeDilateImageFilter);
 
   /** Pixel Type of the input image */
   using InputImageType = TInputImage;
@@ -128,7 +128,7 @@ public:
 
   using InternalRealType = typename NumericTraits<PixelType>::FloatType;
   // using RealImageType = typename Image<InternalRealType,
-  // itkGetStaticConstMacro(ImageDimension) >;
+  // Self::ImageDimension >;
 
   // set all of the scales the same
   void
@@ -163,9 +163,7 @@ public:
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */
-  itkConceptMacro(SameDimension,
-                  (Concept::SameDimension<itkGetStaticConstMacro(InputImageDimension),
-                                          itkGetStaticConstMacro(OutputImageDimension)>));
+  itkConceptMacro(SameDimension, (Concept::SameDimension<Self::InputImageDimension, Self::OutputImageDimension>));
 
   itkConceptMacro(Comparable, (Concept::Comparable<PixelType>));
 

--- a/Modules/Filtering/ParabolicMorphology/include/itkParabolicErodeImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkParabolicErodeImageFilter.h
@@ -62,7 +62,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(ParabolicErodeImageFilter, ParabolicErodeDilateImageFilter);
+  itkOverrideGetNameOfClassMacro(ParabolicErodeImageFilter);
 
   /** Pixel Type of the input image */
   using InputImageType = TInputImage;

--- a/Modules/Filtering/ParabolicMorphology/include/itkParabolicOpenCloseImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkParabolicOpenCloseImageFilter.h
@@ -65,7 +65,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(ParabolicOpenCloseImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(ParabolicOpenCloseImageFilter);
 
   /** Pixel Type of the input image */
   using InputImageType = TInputImage;
@@ -98,7 +98,7 @@ public:
 
   using InternalRealType = typename NumericTraits<PixelType>::FloatType;
   // using RealImageType = typename Image<InternalRealType,
-  // itkGetStaticConstMacro(ImageDimension) >;
+  // Self::ImageDimension >;
 
   // set all of the scales the same
   void
@@ -131,9 +131,7 @@ public:
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */
-  itkConceptMacro(SameDimension,
-                  (Concept::SameDimension<itkGetStaticConstMacro(InputImageDimension),
-                                          itkGetStaticConstMacro(OutputImageDimension)>));
+  itkConceptMacro(SameDimension, (Concept::SameDimension<Self::InputImageDimension, Self::OutputImageDimension>));
 
   itkConceptMacro(Comparable, (Concept::Comparable<PixelType>));
 

--- a/Modules/Filtering/ParabolicMorphology/include/itkParabolicOpenCloseSafeBorderImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkParabolicOpenCloseSafeBorderImageFilter.h
@@ -45,7 +45,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(ParabolicOpenCloseSafeBorderImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(ParabolicOpenCloseSafeBorderImageFilter);
 
   /** Pixel Type of the input image */
   using InputImageType = TInputImage;

--- a/Modules/Filtering/ParabolicMorphology/include/itkSharpenOpImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkSharpenOpImageFilter.h
@@ -115,7 +115,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(SharpenOpImageFilter, TernaryFunctorImageFilter);
+  itkOverrideGetNameOfClassMacro(SharpenOpImageFilter);
 
 protected:
   SharpenOpImageFilter() = default;


### PR DESCRIPTION
Modernizes deprecated macros in `ParabolicMorphology` so it builds under `ITK_FUTURE_LEGACY_REMOVE`. No behavior change.

<details>
<summary>What changed</summary>

`itkTypeMacro(class, super)` → `itkOverrideGetNameOfClassMacro(class)` (15 sites) and `itkGetStaticConstMacro(X)` → `Self::X` (5 sites, in the `Concept::SameDimension` checks). Both become hard errors under `ITK_FUTURE_LEGACY_REMOVE`.

</details>

<details>
<summary>Verification</summary>

Builds and links under baseline, `ITK_LEGACY_REMOVE=ON`, and `ITK_LEGACY_REMOVE=ON + ITK_FUTURE_LEGACY_REMOVE=ON`; all 6 ParabolicMorphology tests pass in baseline.

</details>

<!--
provenance: claude-code session 2026-06-24; ingested (in-tree canonical) opt-in module.
related: per-module FUTURE/LEGACY campaign — #6501, #6503, #6504; vnl_qr #6499.
-->
