### PR TITLE
COMP: Modernize deprecated macros in HigherOrderAccurateGradient

### DIFF
--- a/Modules/Filtering/HigherOrderAccurateGradient/include/itkHigherOrderAccurateDerivativeImageFilter.h
+++ b/Modules/Filtering/HigherOrderAccurateGradient/include/itkHigherOrderAccurateDerivativeImageFilter.h
@@ -76,7 +76,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(HigherOrderAccurateDerivativeImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(HigherOrderAccurateDerivativeImageFilter);
 
   /** The output pixel type must be signed. */
 #ifdef ITK_USE_CONCEPT_CHECKING

--- a/Modules/Filtering/HigherOrderAccurateGradient/include/itkHigherOrderAccurateDerivativeOperator.h
+++ b/Modules/Filtering/HigherOrderAccurateGradient/include/itkHigherOrderAccurateDerivativeOperator.h
@@ -69,7 +69,7 @@ public:
   using PixelRealType = typename Superclass::PixelRealType;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(HigherOrderAccurateDerivativeOperator, NeighborhoodOperator);
+  itkOverrideGetNameOfClassMacro(HigherOrderAccurateDerivativeOperator);
 
   /** Constructor. */
   HigherOrderAccurateDerivativeOperator() = default;

--- a/Modules/Filtering/HigherOrderAccurateGradient/include/itkHigherOrderAccurateGradientImageFilter.h
+++ b/Modules/Filtering/HigherOrderAccurateGradient/include/itkHigherOrderAccurateGradientImageFilter.h
@@ -68,8 +68,8 @@ public:
   /** Convenient type alias for simplifying declarations. */
   using InputImageType = TInputImage;
   using InputImagePointer = typename InputImageType::Pointer;
-  using OutputImageType = Image<CovariantVector<TOutputValueType, itkGetStaticConstMacro(OutputImageDimension)>,
-                                itkGetStaticConstMacro(OutputImageDimension)>;
+  using OutputImageType =
+    Image<CovariantVector<TOutputValueType, Self::OutputImageDimension>, Self::OutputImageDimension>;
   using OutputImagePointer = typename OutputImageType::Pointer;
 
   /** Standard class type alias. */
@@ -81,13 +81,13 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(HigherOrderAccurateGradientImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(HigherOrderAccurateGradientImageFilter);
 
   /** Image type alias support. */
   using InputPixelType = typename InputImageType::PixelType;
   using OperatorValueType = TOperatorValueType;
   using OutputValueType = TOutputValueType;
-  using OutputPixelType = CovariantVector<OutputValueType, itkGetStaticConstMacro(OutputImageDimension)>;
+  using OutputPixelType = CovariantVector<OutputValueType, Self::OutputImageDimension>;
   using OutputImageRegionType = typename OutputImageType::RegionType;
 
   /** Set/Get whether or not the filter will use the spacing of the input


### PR DESCRIPTION
Modernizes deprecated macros in `HigherOrderAccurateGradient` so it builds under `ITK_FUTURE_LEGACY_REMOVE`. No behavior change.

<details>
<summary>What changed</summary>

`itkTypeMacro(class, super)` → `itkOverrideGetNameOfClassMacro(class)` and `itkGetStaticConstMacro(X)` → `Self::X` — both hard errors under `ITK_FUTURE_LEGACY_REMOVE`.

</details>

<details>
<summary>Verification</summary>

Builds under baseline, `ITK_LEGACY_REMOVE=ON`, and `+ITK_FUTURE_LEGACY_REMOVE=ON`; all 6 tests pass in baseline.

</details>

<!--
provenance: claude-code session 2026-06-24; ingested (in-tree canonical) opt-in module.
related: per-module FUTURE/LEGACY campaign — #6501, #6503, #6504, #6505.
-->
