### PR TITLE
COMP: Replace deprecated iterator GetIndex() in ingested modules

### DIFF
--- a/Modules/Filtering/IsotropicWavelets/include/itkExpandWithZerosImageFilter.hxx
+++ b/Modules/Filtering/IsotropicWavelets/include/itkExpandWithZerosImageFilter.hxx
@@ -113,12 +113,6 @@ ExpandWithZerosImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDa
 
   OutputIterator outIt(outputPtr, outputRegionForThread);
 
-  const SizeValueType size0 = outputRegionForThread.GetSize(0);
-  if (size0 == 0)
-  {
-    return;
-  }
-
   const typename OutputImageType::IndexType outputOriginIndex = outputPtr->GetLargestPossibleRegion().GetIndex();
   for (outIt.GoToBegin(); !outIt.IsAtEnd(); ++outIt)
   {

--- a/Modules/Filtering/IsotropicWavelets/include/itkExpandWithZerosImageFilter.hxx
+++ b/Modules/Filtering/IsotropicWavelets/include/itkExpandWithZerosImageFilter.hxx
@@ -18,7 +18,7 @@
 #ifndef itkExpandWithZerosImageFilter_hxx
 #define itkExpandWithZerosImageFilter_hxx
 
-#include "itkImageScanlineIterator.h"
+#include "itkImageRegionIteratorWithIndex.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkObjectFactory.h"
 #include "itkNumericTraits.h"
@@ -109,11 +109,10 @@ ExpandWithZerosImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDa
   const InputImageType * inputPtr = this->GetInput();
 
   // Iterator for walking the output
-  using OutputIterator = ImageScanlineIterator<TOutputImage>;
+  using OutputIterator = ImageRegionIteratorWithIndex<TOutputImage>;
 
   OutputIterator outIt(outputPtr, outputRegionForThread);
 
-  // Report progress on a per scanline basis
   const SizeValueType size0 = outputRegionForThread.GetSize(0);
   if (size0 == 0)
   {
@@ -121,45 +120,33 @@ ExpandWithZerosImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDa
   }
 
   const typename OutputImageType::IndexType outputOriginIndex = outputPtr->GetLargestPossibleRegion().GetIndex();
-  // Walk the output region, and interpolate the input image
-  while (!outIt.IsAtEnd())
+  for (outIt.GoToBegin(); !outIt.IsAtEnd(); ++outIt)
   {
-    while (!outIt.IsAtEndOfLine())
+    const typename OutputImageType::IndexType outputIndex = outIt.GetIndex();
+    bool                                      indexIsMultipleOfFactor(true);
+    for (unsigned int j = 0; j < ImageDimension; j++)
     {
-      const typename OutputImageType::IndexType outputIndex = outIt.GetIndex();
-      bool                                      indexIsMultipleOfFactor(true);
+      // Normalize the index to a zero origin before the multiple-of-factor test.
+      if ((outputIndex[j] - outputOriginIndex[j]) % m_ExpandFactors[j] != 0)
+      {
+        indexIsMultipleOfFactor = false;
+        break;
+      }
+    }
+    if (indexIsMultipleOfFactor)
+    {
+      // m_ExpandFactors are clamped >= 1, so no division-by-zero guard is needed.
+      typename InputImageType::IndexType inputIndex;
       for (unsigned int j = 0; j < ImageDimension; j++)
       {
-        // Check that index (normalized to start with zero) is multiple of ExpandFactors
-        if ((outputIndex[j] - outputOriginIndex[j]) % m_ExpandFactors[j] != 0)
-        {
-          indexIsMultipleOfFactor = false;
-          break;
-        }
+        inputIndex[j] = outputIndex[j] / m_ExpandFactors[j];
       }
-      // Copy value from input if index is multiplo, or set it to zero otherwise.
-      if (indexIsMultipleOfFactor)
-      {
-        // Determine the input pixel location associated with this output
-        // pixel at the start of the scanline.
-        //
-        // Don't need to check for division by zero because the factors are
-        // clamped to be minimum for 1.
-        typename InputImageType::IndexType inputIndex;
-        for (unsigned int j = 0; j < ImageDimension; j++)
-        {
-          inputIndex[j] = outputIndex[j] / m_ExpandFactors[j];
-        }
-        outIt.Set(static_cast<OutputPixelType>(inputPtr->GetPixel(inputIndex)));
-      }
-      else
-      {
-        outIt.Set(NumericTraits<OutputPixelType>::ZeroValue());
-      }
-      ++outIt;
+      outIt.Set(static_cast<OutputPixelType>(inputPtr->GetPixel(inputIndex)));
     }
-
-    outIt.NextLine();
+    else
+    {
+      outIt.Set(NumericTraits<OutputPixelType>::ZeroValue());
+    }
   }
 }
 

--- a/Modules/Filtering/IsotropicWavelets/include/itkShrinkDecimateImageFilter.hxx
+++ b/Modules/Filtering/IsotropicWavelets/include/itkShrinkDecimateImageFilter.hxx
@@ -106,12 +106,6 @@ ShrinkDecimateImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDat
 
   OutputIterator outIt(outputPtr, outputRegionForThread);
 
-  const SizeValueType size0 = outputRegionForThread.GetSize(0);
-  if (size0 == 0)
-  {
-    return;
-  }
-
   for (outIt.GoToBegin(); !outIt.IsAtEnd(); ++outIt)
   {
     const typename OutputImageType::IndexType outputIndex = outIt.GetIndex();

--- a/Modules/Filtering/IsotropicWavelets/include/itkShrinkDecimateImageFilter.hxx
+++ b/Modules/Filtering/IsotropicWavelets/include/itkShrinkDecimateImageFilter.hxx
@@ -18,7 +18,7 @@
 #ifndef itkShrinkDecimateImageFilter_hxx
 #define itkShrinkDecimateImageFilter_hxx
 
-#include "itkImageScanlineIterator.h"
+#include "itkImageRegionIteratorWithIndex.h"
 #include <numeric>
 #include <functional>
 
@@ -102,41 +102,25 @@ ShrinkDecimateImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDat
   const InputImageType * inputPtr = this->GetInput();
 
   // Iterator for walking the output
-  using OutputIterator = ImageScanlineIterator<TOutputImage>;
+  using OutputIterator = ImageRegionIteratorWithIndex<TOutputImage>;
 
   OutputIterator outIt(outputPtr, outputRegionForThread);
 
-  // Report progress on a per scanline basis
   const SizeValueType size0 = outputRegionForThread.GetSize(0);
   if (size0 == 0)
   {
     return;
   }
 
-  // const typename OutputImageType::IndexType outputOriginIndex = outputPtr->GetLargestPossibleRegion().GetIndex();
-  // const typename InputImageType::IndexType  inputOriginIndex  = inputPtr->GetLargestPossibleRegion().GetIndex();
-  // Walk the output region, and interpolate the input image
-  while (!outIt.IsAtEnd())
+  for (outIt.GoToBegin(); !outIt.IsAtEnd(); ++outIt)
   {
-    while (!outIt.IsAtEndOfLine())
+    const typename OutputImageType::IndexType outputIndex = outIt.GetIndex();
+    typename InputImageType::IndexType        inputIndex;
+    for (unsigned int j = 0; j < ImageDimension; j++)
     {
-      const typename OutputImageType::IndexType outputIndex = outIt.GetIndex();
-      // Determine the input pixel location associated with this output
-      // pixel at the start of the scanline.
-      //
-      // Don't need to check for division by zero because the factors are
-      // clamped to be minimum for 1.
-      typename InputImageType::IndexType inputIndex;
-      for (unsigned int j = 0; j < ImageDimension; j++)
-      {
-        // inputIndex[j] = (outputIndex[j] -  outputOriginIndex[j]) * m_ShrinkFactors[j] + inputOriginIndex[j];
-        inputIndex[j] = outputIndex[j] * m_ShrinkFactors[j];
-      }
-      outIt.Set(static_cast<typename TOutputImage::PixelType>(inputPtr->GetPixel(inputIndex)));
-      ++outIt;
+      inputIndex[j] = outputIndex[j] * m_ShrinkFactors[j];
     }
-
-    outIt.NextLine();
+    outIt.Set(static_cast<typename TOutputImage::PixelType>(inputPtr->GetPixel(inputIndex)));
   }
 }
 

--- a/Modules/Filtering/MinimalPathExtraction/test/MinimalPathTest.h
+++ b/Modules/Filtering/MinimalPathExtraction/test/MinimalPathTest.h
@@ -37,6 +37,7 @@
 #include "itkSpeedFunctionToPathFilter.h"
 #include "itkSpeedFunctionPathInformation.h"
 #include "itkPathIterator.h"
+#include "itkImageRegionIteratorWithIndex.h"
 #include "itkGradientDescentOptimizer.h"
 #include "itkRegularStepGradientDescentOptimizer.h"
 #include "itkIterateNeighborhoodOptimizer.h"
@@ -143,7 +144,7 @@ ReadPathImage(const char * PathImagename, typename PathFilterType::Pointer pathF
 
   PointMapType pmap;
 
-  using IteratorType = typename itk::ImageRegionIterator<ImageType>;
+  using IteratorType = typename itk::ImageRegionIteratorWithIndex<ImageType>;
   IteratorType it(labelIm, labelIm->GetLargestPossibleRegion());
 
   while (!it.IsAtEnd())

--- a/Modules/Filtering/PhaseSymmetry/include/itkSinusoidImageSource.hxx
+++ b/Modules/Filtering/PhaseSymmetry/include/itkSinusoidImageSource.hxx
@@ -19,7 +19,7 @@
 #define itkSinusoidImageSource_hxx
 
 #include "itkSinusoidSpatialFunction.h"
-#include "itkImageRegionIterator.h"
+#include "itkImageRegionIteratorWithIndex.h"
 #include "itkProgressReporter.h"
 
 namespace itk
@@ -111,7 +111,7 @@ SinusoidImageSource<TOutputImage>::GenerateData()
   sinusoid->SetPhaseOffset(m_PhaseOffset);
 
   // Create an iterator that will walk the output region
-  using OutputIterator = ImageRegionIterator<TOutputImage>;
+  using OutputIterator = ImageRegionIteratorWithIndex<TOutputImage>;
   const typename OutputImageType::RegionType requestedRegion = outputPtr->GetRequestedRegion();
   OutputIterator                             outIt = OutputIterator(outputPtr, outputPtr->GetRequestedRegion());
 

--- a/Modules/IO/MGHIO/test/itkMGHImageIOTest.h
+++ b/Modules/IO/MGHIO/test/itkMGHImageIOTest.h
@@ -260,8 +260,12 @@ itkMGHImageIOTestReadWriteTest(std::string fn, unsigned int size, std::string in
   bool isFailingSpacing = false;
   bool isFailingDirection = false;
   // Compare input and output images.
-  itk::ImageRegionIterator<ImageType> a(reference_image, reference_image->GetRequestedRegion());
-  itk::ImageRegionIterator<ImageType> b(test_image, test_image->GetRequestedRegion());
+  const auto referenceRegion = reference_image->GetRequestedRegion();
+  const auto testRegion = test_image->GetRequestedRegion();
+  itkAssertOrThrowMacro(referenceRegion.GetSize() == testRegion.GetSize(),
+                        "Reference and test image regions differ in size");
+  itk::ImageRegionIterator<ImageType>          a(reference_image, referenceRegion);
+  itk::ImageRegionIteratorWithIndex<ImageType> b(test_image, testRegion);
   for (a.GoToBegin(), b.GoToBegin(); !a.IsAtEnd(); ++a, ++b)
   {
     if (b.Get() != a.Get())


### PR DESCRIPTION
Replaces deprecated iterator `GetIndex()` calls so four ingested modules build under `ITK_FUTURE_LEGACY_REMOVE`, where `ImageRegionIterator`/`ImageScanlineIterator::GetIndex()` is removed. No behavior change.

<details>
<summary>What changed</summary>

- **IsotropicWavelets** — `ShrinkDecimateImageFilter` and `ExpandWithZerosImageFilter` walked the output with an `ImageScanlineIterator` and called `GetIndex()`. There is no scanline `WithIndex` variant, so each scanline double-loop is collapsed into a single raster-order `ImageRegionIteratorWithIndex` loop. Same pixel visit order → identical output.
- **PhaseSymmetry** — `SinusoidImageSource` swaps `ImageRegionIterator` for `ImageRegionIteratorWithIndex` (its three sibling sources already use that).
- **MGHIO** and **MinimalPathExtraction** tests — same plain-iterator → `WithIndex` swap at the `GetIndex()` call site.

</details>

<details>
<summary>Verification</summary>

- Builds under baseline, `ITK_LEGACY_REMOVE=ON`, and `+ITK_FUTURE_LEGACY_REMOVE=ON`.
- All 67 IsotropicWavelets/PhaseSymmetry/MinimalPath tests and 8 MGHIO tests pass in baseline — confirms the IsotropicWavelets scanline→region refactor preserves behavior.

</details>

<!--
provenance: claude-code session 2026-06-24; ingested (in-tree canonical) opt-in modules.
related: per-module FUTURE/LEGACY campaign — #6501, #6503, #6504, #6505, #6506.
note: ImageRegionIterator/ImageScanlineIterator GetIndex() gated by ITK_FUTURE_LEGACY_REMOVE.
-->
