### PR TITLE
COMP: Modernize deprecated macros in PrincipalComponentsAnalysis

### DIFF
--- a/Modules/Numerics/PrincipalComponentsAnalysis/include/itkVectorFieldPCA.h
+++ b/Modules/Numerics/PrincipalComponentsAnalysis/include/itkVectorFieldPCA.h
@@ -62,7 +62,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(GaussianDistanceKernel, KernelFunction);
+  itkOverrideGetNameOfClassMacro(GaussianDistanceKernel);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -123,7 +123,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VectorFieldPCA, Object);
+  itkOverrideGetNameOfClassMacro(VectorFieldPCA);
 
   /** Type definitions for the PointSet. */
   using InputPointSetType = TPointSetType;
@@ -144,7 +144,7 @@ public:
   /**
    * \brief Input PointSet dimension
    */
-  itkStaticConstMacro(InputMeshDimension, unsigned int, TPointSetType::PointDimension);
+  static constexpr unsigned int InputMeshDimension = TPointSetType::PointDimension;
 
   /** type for the vector fields. */
   using VectorFieldType = vnl_matrix<TVectorFieldElementType>;


### PR DESCRIPTION
Modernizes deprecated macros in `PrincipalComponentsAnalysis` so it builds under `ITK_FUTURE_LEGACY_REMOVE`. No behavior change.

<details>
<summary>What changed</summary>

`itkTypeMacro(class, super)` → `itkOverrideGetNameOfClassMacro(class)`, `itkStaticConstMacro(name, type, value)` → `static constexpr type name = value`, and `itkGetStaticConstMacro(X)` → `Self::X` — all hard errors under `ITK_FUTURE_LEGACY_REMOVE`.

</details>

<details>
<summary>Verification</summary>

Builds under baseline, `ITK_LEGACY_REMOVE=ON`, and `+ITK_FUTURE_LEGACY_REMOVE=ON`; all 3 tests pass in baseline.

</details>

<!--
provenance: claude-code session 2026-06-24; ingested (in-tree canonical) opt-in module.
related: per-module FUTURE/LEGACY campaign — #6501, #6503, #6504, #6505, #6506, #6507.
-->
