### PR TITLE
COMP: Remove non-functional CCACHE_BASEDIR setting from ITK_USE_CCACHE

### DIFF
--- a/CMake/itkCCacheSupport.cmake
+++ b/CMake/itkCCacheSupport.cmake
@@ -42,14 +42,6 @@ if(ITK_USE_CCACHE)
     message(STATUS "ccache version: ${CCACHE_VERSION} at ${CCACHE_EXECUTABLE}")
     set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}")
     set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}")
-    # ccache hashes absolute source and include paths into the cache key.
-    # ITK developers utilizing ccache often will be using git worktrees
-    # where the absolute paths differ, producing cache misses.
-    # By setting CCACHE_BASEDIR, increased cache hits occur based on
-    # hits relative to the ITK_SOURCE_DIR.
-    # Export CCACHE_BASEDIR for all build commands to the base of the
-    set(ENV{CCACHE_BASEDIR} "${ITK_SOURCE_DIR}")
-    message(STATUS "Set CCACHE_BASEDIR = $ENV{CCACHE_BASEDIR}")
   else()
     message(FATAL_ERROR "ccache not found, turn off ITK_USE_CCACHE")
   endif()


### PR DESCRIPTION
Removes the non-functional `set(ENV{CCACHE_BASEDIR})` from `ITK_USE_CCACHE`. `set(ENV{...})` only mutates the configure-time CMake process environment, so it never reached the compiler invocations run at build time. ccache base-dir configuration is left to the developer to set per build tree.

<details>
<summary>Why not auto-set CCACHE_BASEDIR in the compiler launcher?</summary>

An earlier revision of this PR baked `CCACHE_BASEDIR`/`CCACHE_NOHASHDIR` into `CMAKE_CXX_COMPILER_LAUNCHER` via `cmake -E env`. Per review (@blowekamp), that approach has too many sharp edges to justify in-tree:

- Under FetchContent, `CMAKE_SOURCE_DIR` is the super-project, not the ITK checkout; remote-module / FetchContent sources may also live outside the ITK source tree.
- A developer's deliberate `ccache.conf` settings would be silently overridden by the injected environment.

Developers building across git worktrees or out-of-source trees can export the `CCACHE_*` variables (e.g. `CCACHE_BASEDIR`) themselves, scoped to each tree.

</details>

<!--
provenance: claude-code session 2026-06-25. Scope reduced to a pure removal of the no-op set(ENV{CCACHE_BASEDIR}); launcher-injection approach dropped per blowekamp review (FetchContent CMAKE_SOURCE_DIR, ccache.conf override, remote-module source locations).
related_files: CMake/itkCCacheSupport.cmake
-->
