### PR TITLE
KWSys: use allocator_traits::rebind_alloc for C++20 (hashtable.hxx)

### DIFF
--- a/Modules/ThirdParty/KWSys/src/KWSys/hashtable.hxx.in
+++ b/Modules/ThirdParty/KWSys/src/KWSys/hashtable.hxx.in
@@ -249,13 +249,15 @@ private:
   typedef _Hashtable_node<_Val> _Node;
 
 public:
-  typedef typename _Alloc::template rebind<_Val>::other allocator_type;
+  typedef typename std::allocator_traits<_Alloc>::template rebind_alloc<_Val>
+    allocator_type;
   allocator_type get_allocator() const { return _M_node_allocator; }
 private:
+  typedef typename std::allocator_traits<_Alloc>::template rebind_alloc<_Node>
+    _M_node_allocator_type;
   typedef
-    typename _Alloc::template rebind<_Node>::other _M_node_allocator_type;
-  typedef
-    typename _Alloc::template rebind<_Node*>::other _M_node_ptr_allocator_type;
+    typename std::allocator_traits<_Alloc>::template rebind_alloc<_Node*>
+      _M_node_ptr_allocator_type;
   typedef std::vector<_Node*, _M_node_ptr_allocator_type> _M_buckets_type;
 
 private:


### PR DESCRIPTION
## Problem

`std::allocator::rebind` was deprecated in C++17 and **removed in C++20**. On newer toolchains (e.g. GCC 14/15 shipping in Fedora 44) libstdc++ no longer provides `std::allocator<T>::rebind`, so the vendored KWSys `hashtable.hxx` template fails to compile:

```
error: no type named 'other' in 'std::allocator<...>::rebind<...>'
```

This breaks any consumer that pulls in `itksys/hash_map.hxx` / `hash_set.hxx` when built in C++20 mode.

## Fix

Replace the three `typename _Alloc::template rebind<X>::other` typedefs in `Modules/ThirdParty/KWSys/src/KWSys/hashtable.hxx.in` with the standard C++11 replacement:

```cpp
typename std::allocator_traits<_Alloc>::template rebind_alloc<X>
```

`std::allocator_traits` has been the portable way to rebind since C++11 and works across C++11 → C++20. `<memory>` is already included by this header, so no new include is needed. No behavior change on older standards.

Only `hashtable.hxx.in` uses `rebind`; `hash_map.hxx.in` / `hash_set.hxx.in` are unaffected.

## Notes

- This file is vendored from upstream KWSys (Kitware/KWSys); the same fix likely belongs there too, but this targets `release-4.14` directly since that branch is pinned by downstream consumers (e.g. minc-toolkit-v2) and currently fails on Fedora 44.
- Not yet verified by a full local Fedora 44 build; this is the canonical, mechanical C++20 migration of the construct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)