### PR TITLE
BUG: Fix ParallelSparseFieldLevelSet deadlock under work-pool backends

### DIFF
--- a/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkParallelSparseFieldLevelSetImageFilter.hxx
@@ -25,6 +25,8 @@
 #include "itkNeighborhoodAlgorithm.h"
 #include <iostream>
 #include <fstream>
+#include <exception>
+#include <thread>
 #include "itkMath.h"
 #include "itkPlatformMultiThreader.h"
 #include "itkPrintHelper.h"
@@ -1163,16 +1165,42 @@ ParallelSparseFieldLevelSetImageFilter<TInputImage, TOutputImage>::Iterate()
       return;
     }
 
-    mt->ParallelizeArray(
-      0,
-      m_NumOfWorkUnits,
-      [this](SizeValueType threadId) {
-        this->ThreadedApplyUpdate(m_TimeStep, threadId);
-        // We only need to wait for neighbors because ThreadedCalculateChange
-        // requires information only from the neighbors.
-        this->SignalNeighborsAndWait(threadId);
-      },
-      nullptr);
+    // SignalNeighborsAndWait blocks each work unit on its boundary neighbors, so
+    // all work units must run concurrently; a work pool (e.g. TBB) can leave a
+    // neighbor queued behind the blocked unit and deadlock. Run this phase with
+    // one dedicated thread per work unit.
+    {
+      std::vector<std::exception_ptr> applyErrors(m_NumOfWorkUnits, nullptr);
+      auto                            applyUpdate = [this, &applyErrors](ThreadIdType threadId) {
+        try
+        {
+          this->ThreadedApplyUpdate(m_TimeStep, threadId);
+          this->SignalNeighborsAndWait(threadId);
+        }
+        catch (...)
+        {
+          applyErrors[threadId] = std::current_exception();
+        }
+      };
+      std::vector<std::thread> applyThreads;
+      applyThreads.reserve(m_NumOfWorkUnits - 1);
+      for (ThreadIdType threadId = 1; threadId < m_NumOfWorkUnits; ++threadId)
+      {
+        applyThreads.emplace_back(applyUpdate, threadId);
+      }
+      applyUpdate(0);
+      for (auto & t : applyThreads)
+      {
+        t.join();
+      }
+      for (const auto & e : applyErrors)
+      {
+        if (e)
+        {
+          std::rethrow_exception(e);
+        }
+      }
+    }
 
 
     if (this->GetElapsedIterations() % LOAD_BALANCE_ITERATION_FREQUENCY == 0)


### PR DESCRIPTION
Fixes a deadlock in `ParallelSparseFieldLevelSetImageFilter` under work-pool
MultiThreader backends (notably TBB). The apply-update phase blocks each work
unit on its boundary neighbors, which requires gang scheduling that
`ParallelizeArray` does not guarantee; this dispatches only that phase on one
dedicated thread per work unit. Addresses the `ParallelSparseFieldLevelSetRobustness`
intermittent CI failures tracked in #6518.

<details>
<summary>Root cause</summary>

`Iterate()` dispatches each iteration's apply-update via
`mt->ParallelizeArray(0, m_NumOfWorkUnits, body)`. That `body`
(`ThreadedApplyUpdate` → `SignalNeighborsAndWait` / `WaitForNeighbor`) blocks
work unit `i` on a `std::condition_variable` until work units `i±1` signal —
an inter-work-unit barrier that requires **all** work units to run
concurrently (gang scheduling). `ParallelizeArray` is the contract for
*independent* work units and guarantees no such concurrency: a work-pool/TBB
backend can run a queued work unit on the very thread already blocked waiting
for it, so a unit waits forever. The `min(workUnits, GetMaximumNumberOfThreads())`
clamp does not prevent it under a shared/oversubscribed arena (e.g. several
concurrent pipelines). It is the only one of the six `ParallelizeArray`
dispatches in `Iterate()` that blocks across work units; the other five are
independent and unchanged.

</details>

<details>
<summary>The fix</summary>

Replace the single neighbor-blocking dispatch with a dedicated `std::thread`
per work unit (gang scheduling), with per-thread `std::exception_ptr` capture
and rethrow on the main thread to preserve `ParallelizeArray`'s error
semantics. Backend-agnostic: the apply-update phase no longer depends on any
MultiThreader's scheduling guarantees.

</details>

<details>
<summary>Validation</summary>

The filter-level race is rare (380 oversubscribed local runs produced 0 hangs —
too rare to trigger on 16 fast cores), so the mechanism was isolated into a
deterministic minimal reproducer: a barrier-style inter-task wait run on a
bounded executor (2 workers, 8 tasks) **deadlocks**, while a dedicated-thread
gang **completes**.

| Check | Result |
|---|---|
| Deterministic mechanism reproducer | bounded executor deadlocks / gang completes |
| `ParallelSparseFieldLevelSetRobustness` GTests (TBB) | pass |
| Baseline comparison (`itkParallelSparseFieldLevelSetImageFilterTest`) | bit-identical to known-good |
| `Determinism` GTest (3 runs) | bit-identical |
| 90/90 oversubscribed TBB stability runs | clean |
| `pre-commit run --all-files` | clean |

</details>

<!--
provenance: claude-code session 2026-06-25
root_cause: Iterate() line ~1166 ParallelizeArray apply-update blocks work units
  on neighbors (SignalNeighborsAndWait/WaitForNeighbor) -> requires gang
  scheduling; pool/TBB doesn't provide it -> deadlock.
fix: dedicated std::thread per work unit for that single phase only.
validated_under: ITK_USE_TBB=ON, baseline bit-identical, 90/90 stress clean.
related: issue #6518 (flaky-CI tracking); robustness test added by bf38f7e0e45.
-->
