### PR TITLE
COMP: Regenerate ShapeLabelMap baselines at full double precision

### DIFF
--- a/Modules/Filtering/LabelMap/test/itkShapeLabelMapFilterGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeLabelMapFilterGTest.cxx
@@ -151,21 +151,21 @@ TEST_F(ShapeLabelMapFixture, 3D_T1x1x1)
   ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(5.0, 7.0, 9.0), labelObject->GetCentroid(), 1e-10);
   EXPECT_EQ(0.0, labelObject->GetElongation());
   ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(0.0, 0.0, 0.0), labelObject->GetEquivalentEllipsoidDiameter(), 1e-10);
-  EXPECT_NEAR(4.83598, labelObject->GetEquivalentSphericalPerimeter(), 1e-4); // resulting value
-  EXPECT_NEAR(0.62035, labelObject->GetEquivalentSphericalRadius(), 1e-4);    // resulting value
+  EXPECT_NEAR(4.8359758620494109, labelObject->GetEquivalentSphericalPerimeter(), 1e-5); // resulting value
+  EXPECT_NEAR(0.62035049089940009, labelObject->GetEquivalentSphericalRadius(), 1e-5);   // resulting value
   EXPECT_EQ(0.0, labelObject->GetFeretDiameter());
   EXPECT_EQ(0.0, labelObject->GetFlatness());
   EXPECT_EQ(1u, labelObject->GetNumberOfPixels());
   EXPECT_EQ(0u, labelObject->GetNumberOfPixelsOnBorder());
   ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(1u, 1u, 1u), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
   ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(4.5, 6.5, 8.5), labelObject->GetOrientedBoundingBoxOrigin(), 1e-10);
-  EXPECT_NEAR(3.004, labelObject->GetPerimeter(), 1e-4); // resulting value
+  EXPECT_NEAR(3.0040803078963907, labelObject->GetPerimeter(), 1e-5); // resulting value
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorder());
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorderRatio());
   EXPECT_EQ(1.0, labelObject->GetPhysicalSize());
   // labelObject->GetPrincipalAxes();  degenerate case
   EXPECT_EQ(itk::MakeVector(0.0, 0.0, 0.0), labelObject->GetPrincipalMoments());
-  EXPECT_NEAR(1.6098, labelObject->GetRoundness(), 0.0001); // resulting value
+  EXPECT_NEAR(1.6098024574568734, labelObject->GetRoundness(), 1e-5); // resulting value
 
   EXPECT_EQ(labelObject->GetBoundingBox(), labelObject->GetRegion());
 
@@ -197,21 +197,21 @@ TEST_F(ShapeLabelMapFixture, 3D_T3x2x1)
   EXPECT_EQ(itk::MakePoint(6.0, 9.5, 11.0), labelObject->GetCentroid());
   EXPECT_NEAR(1.63299, labelObject->GetElongation(), 1e-4);
   ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(0.0, 0.0, 0.0), labelObject->GetEquivalentEllipsoidDiameter(), 1e-10);
-  EXPECT_NEAR(15.96804, labelObject->GetEquivalentSphericalPerimeter(), 1e-4); // resulting value
-  EXPECT_NEAR(1.12725, labelObject->GetEquivalentSphericalRadius(), 1e-4);     // resulting value
+  EXPECT_NEAR(15.96804047389762, labelObject->GetEquivalentSphericalPerimeter(), 1e-5); // resulting value
+  EXPECT_NEAR(1.1272516517868265, labelObject->GetEquivalentSphericalRadius(), 1e-5);   // resulting value
   EXPECT_NEAR(2.23606, labelObject->GetFeretDiameter(), 1e-4);
   EXPECT_EQ(0.0, labelObject->GetFlatness());
   EXPECT_EQ(6u, labelObject->GetNumberOfPixels());
   EXPECT_EQ(0u, labelObject->GetNumberOfPixelsOnBorder());
   ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(1u, 2u, 3u), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
   ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(7.5, 8.5, 10.5), labelObject->GetOrientedBoundingBoxOrigin(), 1e-10);
-  EXPECT_NEAR(14.62414, labelObject->GetPerimeter(), 1e-4); // resulting value
+  EXPECT_NEAR(14.624143852112988, labelObject->GetPerimeter(), 1e-5); // resulting value
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorder());
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorderRatio());
   EXPECT_EQ(6.0, labelObject->GetPhysicalSize());
   // labelObject->GetPrincipalAxes(); omitted
   ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(0.0, 0.25, 0.666667), labelObject->GetPrincipalMoments(), 1e-4);
-  EXPECT_NEAR(1.09189, labelObject->GetRoundness(), 1e-4); // resulting value
+  EXPECT_NEAR(1.0918957468809676, labelObject->GetRoundness(), 1e-5); // resulting value
 
   EXPECT_EQ(labelObject->GetBoundingBox(), labelObject->GetRegion());
 
@@ -249,25 +249,27 @@ TEST_F(ShapeLabelMapFixture, 3D_T3x2x1_Direction)
 
   ITK_EXPECT_VECTOR_NEAR(itk::MakeIndex(5, 9, 11), labelObject->GetBoundingBox().GetIndex(), 1e-99);
   ITK_EXPECT_VECTOR_NEAR(itk::MakeSize(3, 2, 1), labelObject->GetBoundingBox().GetSize(), 1e-99);
-  ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(5.06906, -3.25286, -14.5249), labelObject->GetCentroid(), 1e-4);
+  ITK_EXPECT_VECTOR_NEAR(
+    itk::MakePoint(5.0690644435107242, -3.2528635005915247, -14.524925635405358), labelObject->GetCentroid(), 1e-4);
   EXPECT_NEAR(1.63299, labelObject->GetElongation(), 1e-4);
   // ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(0.0,0.0,0.0), labelObject->GetEquivalentEllipsoidDiameter(), 1e-10);
-  EXPECT_NEAR(15.96804, labelObject->GetEquivalentSphericalPerimeter(), 1e-4); // resulting value
-  EXPECT_NEAR(1.12725, labelObject->GetEquivalentSphericalRadius(), 1e-4);     // resulting value
+  EXPECT_NEAR(15.96804047389762, labelObject->GetEquivalentSphericalPerimeter(), 1e-5); // resulting value
+  EXPECT_NEAR(1.1272516517868265, labelObject->GetEquivalentSphericalRadius(), 1e-5);   // resulting value
   EXPECT_NEAR(2.23606, labelObject->GetFeretDiameter(), 1e-4);
   // EXPECT_EQ(0.0, labelObject->GetFlatness()); unstable due to division near zero
   EXPECT_EQ(6u, labelObject->GetNumberOfPixels());
   EXPECT_EQ(0u, labelObject->GetNumberOfPixelsOnBorder());
   ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(1u, 2u, 3u), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
-  ITK_EXPECT_VECTOR_NEAR(
-    itk::MakePoint(6.02222, -4.47691, -15.57049), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4);
-  EXPECT_NEAR(14.62414, labelObject->GetPerimeter(), 1e-4); // resulting value
+  ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(6.0222153120831488, -4.4769132554776352, -15.570490372427054),
+                         labelObject->GetOrientedBoundingBoxOrigin(),
+                         1e-4);
+  EXPECT_NEAR(14.624143852112988, labelObject->GetPerimeter(), 1e-5); // resulting value
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorder());
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorderRatio());
   EXPECT_EQ(6.0, labelObject->GetPhysicalSize());
   // labelObject->GetPrincipalAxes(); omitted
   ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(0.0, 0.25, 0.666667), labelObject->GetPrincipalMoments(), 1e-4);
-  EXPECT_NEAR(1.09189, labelObject->GetRoundness(), 1e-4); // resulting value
+  EXPECT_NEAR(1.0918957468809676, labelObject->GetRoundness(), 1e-5); // resulting value
 
   if (::testing::Test::HasFailure())
   {
@@ -302,16 +304,17 @@ TEST_F(ShapeLabelMapFixture, 3D_T2x2x2_Spacing)
   ITK_EXPECT_VECTOR_NEAR(itk::MakeSize(2, 2, 2), labelObject->GetBoundingBox().GetSize(), 1e-99);
   ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(5.5, 10.45, 25.3), labelObject->GetCentroid(), 1e-4);
   EXPECT_NEAR(2.0, labelObject->GetElongation(), 1e-4);
-  ITK_EXPECT_VECTOR_NEAR(
-    itk::MakePoint(2.4814, 2.72954, 5.45908), labelObject->GetEquivalentEllipsoidDiameter(), 1e-4); // resulting value
-  EXPECT_NEAR(34.86751, labelObject->GetEquivalentSphericalPerimeter(), 1e-4);                      // resulting value
-  EXPECT_NEAR(1.66573, labelObject->GetEquivalentSphericalRadius(), 1e-4);                          // resulting value
+  ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(2.4814019635976252, 2.7295421599572678, 5.4590843199148482),
+                         labelObject->GetEquivalentEllipsoidDiameter(),
+                         1e-5);                                                          // resulting value
+  EXPECT_NEAR(34.867517413417708, labelObject->GetEquivalentSphericalPerimeter(), 1e-5); // resulting value
+  EXPECT_NEAR(1.6657337346779293, labelObject->GetEquivalentSphericalRadius(), 1e-5);    // resulting value
   EXPECT_NEAR(2.65518, labelObject->GetFeretDiameter(), 1e-4);
   EXPECT_NEAR(1.1, labelObject->GetFlatness(), 1e-4);
   EXPECT_EQ(8u, labelObject->GetNumberOfPixels());
   EXPECT_EQ(0u, labelObject->GetNumberOfPixelsOnBorder());
   ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(2.0, 2.2, 4.4), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
-  EXPECT_NEAR(28.3919, labelObject->GetPerimeter(), 1e-4); // resulting value
+  EXPECT_NEAR(28.391854811919647, labelObject->GetPerimeter(), 1e-5); // resulting value
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorder());
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorderRatio());
   EXPECT_NEAR(19.36, labelObject->GetPhysicalSize(), 1e-10);
@@ -321,7 +324,7 @@ TEST_F(ShapeLabelMapFixture, 3D_T2x2x2_Spacing)
   EXPECT_TRUE(Utils::TestListHasPoint(labelObject->GetOrientedBoundingBoxVertices(), itk::MakePoint(4.5, 9.35, 23.1)));
   // labelObject->GetPrincipalAxes(); omitted
   ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(0.25, 0.3025, 1.21), labelObject->GetPrincipalMoments(), 1e-4);
-  EXPECT_NEAR(1.22808, labelObject->GetRoundness(), 1e-4); // resulting value
+  EXPECT_NEAR(1.2280817031643669, labelObject->GetRoundness(), 1e-5); // resulting value
 
   if (::testing::Test::HasFailure())
   {
@@ -364,27 +367,30 @@ TEST_F(ShapeLabelMapFixture, 3D_T2x2x2_Spacing_Direction)
 
   ITK_EXPECT_VECTOR_NEAR(itk::MakeIndex(5, 9, 11), labelObject->GetBoundingBox().GetIndex(), 1e-99);
   ITK_EXPECT_VECTOR_NEAR(itk::MakeSize(2, 2, 2), labelObject->GetBoundingBox().GetSize(), 1e-99);
-  ITK_EXPECT_VECTOR_NEAR(
-    itk::MakePoint(10.13655, 4.21035, -25.67227), labelObject->GetCentroid(), 1e-4); // resulting value
+  ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(10.136550336022847, 4.2103580941358141, -25.672275551739141),
+                         labelObject->GetCentroid(),
+                         1e-4); // resulting value
   EXPECT_NEAR(2.0, labelObject->GetElongation(), 1e-4);
-  ITK_EXPECT_VECTOR_NEAR(
-    itk::MakePoint(2.4814, 2.72954, 5.45908), labelObject->GetEquivalentEllipsoidDiameter(), 1e-4); // resulting value
-  EXPECT_NEAR(34.86751, labelObject->GetEquivalentSphericalPerimeter(), 1e-4);                      // resulting value
-  EXPECT_NEAR(1.66573, labelObject->GetEquivalentSphericalRadius(), 1e-4);                          // resulting value
+  ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(2.4814019635976252, 2.7295421599572678, 5.4590843199148482),
+                         labelObject->GetEquivalentEllipsoidDiameter(),
+                         1e-5);                                                          // resulting value
+  EXPECT_NEAR(34.867517413417708, labelObject->GetEquivalentSphericalPerimeter(), 1e-5); // resulting value
+  EXPECT_NEAR(1.6657337346779293, labelObject->GetEquivalentSphericalRadius(), 1e-5);    // resulting value
   EXPECT_NEAR(2.65518, labelObject->GetFeretDiameter(), 1e-4);
   EXPECT_NEAR(1.1, labelObject->GetFlatness(), 1e-4);
   EXPECT_EQ(8u, labelObject->GetNumberOfPixels());
   EXPECT_EQ(0u, labelObject->GetNumberOfPixelsOnBorder());
   ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(2.0, 2.2, 4.4), labelObject->GetOrientedBoundingBoxSize(), 1e-10);
-  ITK_EXPECT_VECTOR_NEAR(
-    itk::MakePoint(9.75747, 5.36134, -28.03480), labelObject->GetOrientedBoundingBoxOrigin(), 1e-4); // resulting value
-  EXPECT_NEAR(28.3919, labelObject->GetPerimeter(), 1e-4);                                           // resulting value
+  ITK_EXPECT_VECTOR_NEAR(itk::MakePoint(9.7574735481346888, 5.3613400676410672, -28.034804130519035),
+                         labelObject->GetOrientedBoundingBoxOrigin(),
+                         1e-4);                                       // resulting value
+  EXPECT_NEAR(28.391854811919647, labelObject->GetPerimeter(), 1e-5); // resulting value
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorder());
   EXPECT_EQ(0.0, labelObject->GetPerimeterOnBorderRatio());
   EXPECT_NEAR(19.36, labelObject->GetPhysicalSize(), 1e-10);
   // labelObject->GetPrincipalAxes(); omitted
   ITK_EXPECT_VECTOR_NEAR(itk::MakeVector(0.25, 0.3025, 1.21), labelObject->GetPrincipalMoments(), 1e-4);
-  EXPECT_NEAR(1.22808, labelObject->GetRoundness(), 1e-4); // resulting value
+  EXPECT_NEAR(1.2280817031643669, labelObject->GetRoundness(), 1e-5); // resulting value
 
   if (::testing::Test::HasFailure())
   {


### PR DESCRIPTION
Regenerates the `ShapeLabelMapFixture` "resulting value" baselines at full `double` precision and **tightens** most tolerances, instead of loosening them. Highest-volume flaky candidate tracked in #6518 (187 failures / 30 days, dominated by Windows MSVC).

<details>
<summary>Root cause (Windows-only scalar group)</summary>

The "resulting value" baselines were stored at only 4–5 decimal places. For `Perimeter ≈ 28.39` that rounding is ~5e-5, which skews the fixed `1e-4` *absolute* tolerance window asymmetrically: the true (macOS) value sits only ~5e-6 inside the lower edge, so an MSVC RelWithDebInfo build that differs by just ~5e-6 fails. The computation was always `double` precision — the **stored baselines** were the lossy part.

</details>

<details>
<summary>What changed</summary>

- Regenerated the computed baselines at full 17-digit `double` precision (captured at `setprecision(17)`).
- **Tightened to `1e-5`** (10× tighter than the original `1e-4`) for the rotation-invariant scalars (`Perimeter`, `EquivalentSphericalPerimeter/Radius`, `Roundness`) and the magnitude-invariant `EquivalentEllipsoidDiameter`.
- **Kept `1e-4`** on the orientation-dependent positions (`Centroid` / `OrientedBoundingBoxOrigin` in the `_Direction` tests): they traverse the principal-axes path, where the eigenvalue order and sign canonicalization now fix the result deterministically.
- Single file; no helper, no relative-tolerance machinery. Independently-verified and exact (`1e-99`/`1e-10`) asserts untouched.

All 12 `ShapeLabelMapFixture` tests pass locally (macOS arm64); clang-format clean.

</details>

<!--
provenance: full-precision baselines (commit 2ed4092ecb4), supersedes the earlier relative-tolerance approach (b63c56db647). Tracked in #6518.
-->
