### PR TITLE
BUG: Fix system Eigen include failures with ITK_EIGEN macros

### DIFF
--- a/Modules/Core/Common/include/itkMatrixExponential.h
+++ b/Modules/Core/Common/include/itkMatrixExponential.h
@@ -19,8 +19,9 @@
 #define itkMatrixExponential_h
 
 #include "itkMatrix.h"
+#include "itk_eigen.h"
 // Eigen's matrix exponential lives in the unsupported MatrixFunctions module.
-#include "itkeigen/unsupported/Eigen/MatrixFunctions"
+#include ITK_EIGEN_UNSUPPORTED(MatrixFunctions)
 
 namespace itk
 {

--- a/Modules/Numerics/Optimizers/src/itkEigenLevenbergMarquardtEngine.cxx
+++ b/Modules/Numerics/Optimizers/src/itkEigenLevenbergMarquardtEngine.cxx
@@ -19,9 +19,9 @@
 #include "itkEigenLevenbergMarquardtEngine.h"
 
 #include "itk_eigen.h"
-#include "itkeigen/Eigen/Core"
-#include "itkeigen/unsupported/Eigen/NonLinearOptimization"
-#include "itkeigen/unsupported/Eigen/NumericalDiff"
+#include ITK_EIGEN(Core)
+#include ITK_EIGEN_UNSUPPORTED(NonLinearOptimization)
+#include ITK_EIGEN_UNSUPPORTED(NumericalDiff)
 
 #include <vector>
 

--- a/Modules/ThirdParty/Eigen3/src/itk_eigen.h.in
+++ b/Modules/ThirdParty/Eigen3/src/itk_eigen.h.in
@@ -38,6 +38,7 @@
 #cmakedefine ITK_USE_SYSTEM_EIGEN
 #ifdef ITK_USE_SYSTEM_EIGEN
 #define ITK_EIGEN(x) ITK_EIGEN_STR(Eigen/x)
+#define ITK_EIGEN_UNSUPPORTED(x) ITK_EIGEN_STR(unsupported/Eigen/x)
 #else
 // ITK should only be using MPL2 Eigen code internally.
 #cmakedefine ITK_USE_EIGEN_MPL2_ONLY
@@ -47,6 +48,7 @@
 #endif
 #endif
 #define ITK_EIGEN(x) ITK_EIGEN_STR(itkeigen/Eigen/x)
+#define ITK_EIGEN_UNSUPPORTED(x) ITK_EIGEN_STR(itkeigen/unsupported/Eigen/x)
 #endif
 
 // Disable these warnings which occur only in Eigen and not elsewhere in ITK.

--- a/Modules/ThirdParty/VNL/itk-module.cmake
+++ b/Modules/ThirdParty/VNL/itk-module.cmake
@@ -5,4 +5,4 @@ href=\"http://vxl.sourceforge.net\">VNL</a> numeric library from the VXL vision
 library suite."
 )
 
-itk_module(ITKVNL DESCRIPTION "${DOCUMENTATION}")
+itk_module(ITKVNL DEPENDS ITKEigen3 DESCRIPTION "${DOCUMENTATION}")

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/CMakeLists.txt
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/CMakeLists.txt
@@ -75,11 +75,8 @@ endif()
 vxl_add_library(LIBRARY_NAME itkvnl_algo
   LIBRARY_SOURCES ${vnl_algo_sources}
   HEADER_INSTALL_DIR vnl/algo)
-target_link_libraries( itkvnl_algo PUBLIC itkv3p_netlib itkvnl )
+target_link_libraries( itkvnl_algo PUBLIC itkv3p_netlib itkvnl ITK::ITKEigen3Module )
 
-# Eigen-backed vnl_levenberg_marquardt needs the vendored Eigen headers (private, header-only).
-target_include_directories( itkvnl_algo
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../Eigen3/src )
 set(CURR_LIB_NAME vnl_algo)
 set_vxl_library_properties(
    TARGET_NAME itk${CURR_LIB_NAME}

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_levenberg_marquardt.cxx
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_levenberg_marquardt.cxx
@@ -15,8 +15,9 @@
 #include "vnl/vnl_vector_ref.h"
 #include "vnl/vnl_least_squares_function.h"
 
-#include "itkeigen/unsupported/Eigen/NonLinearOptimization"
-#include "itkeigen/unsupported/Eigen/NumericalDiff"
+#include "itk_eigen.h"
+#include ITK_EIGEN_UNSUPPORTED(NonLinearOptimization)
+#include ITK_EIGEN_UNSUPPORTED(NumericalDiff)
 
 namespace
 {


### PR DESCRIPTION
Fix build failures when `ITK_USE_SYSTEM_EIGEN=ON`. Hard-coded `itkeigen/` paths in three source files do not exist with system Eigen; replace them with the portable `ITK_EIGEN(x)` / `ITK_EIGEN_UNSUPPORTED(x)` macros and wire up the missing CMake module dependency. Closes #6485.

<details>
<summary>Changes</summary>

- `itk_eigen.h.in`: add `ITK_EIGEN_UNSUPPORTED(x)` macro alongside `ITK_EIGEN(x)` for headers under `unsupported/Eigen/`
- `itkEigenLevenbergMarquardtEngine.cxx`: replace hard-coded `itkeigen/Eigen/Core` and `itkeigen/unsupported/…` includes
- `itkMatrixExponential.h`: replace hard-coded `itkeigen/unsupported/Eigen/MatrixFunctions`
- `vnl_levenberg_marquardt.cxx`: replace hard-coded `itkeigen/unsupported/…` includes
- `ITKVNL/itk-module.cmake` + `CMakeLists.txt`: declare `DEPENDS ITKEigen3` and link `ITK::ITKEigen3Module` so the generated `itk_eigen.h` and system Eigen include dirs propagate correctly via the ITK module system

</details>

<details>
<summary>AI assistance</summary>

GitHub Copilot (Claude Sonnet 4.6) identified affected files, authored the macro additions and include replacements, and resolved the CMake dependency wiring. Changes reviewed and tested locally with the `system` preset (`ITK_USE_SYSTEM_EIGEN=ON`).

</details>