### PR TITLE
COMP: Use SpacePrecisionType for direction array in shape GTest

### DIFF
--- a/Modules/Filtering/LabelMap/test/itkShapeLabelMapFilterGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkShapeLabelMapFilterGTest.cxx
@@ -551,10 +551,10 @@ TEST_F(ShapeLabelMapFixture, 3D_DegenerateFlatObject_NumericallyStableEllipsoidD
   image->SetRegions(Utils::ImageType::RegionType(imageSize));
   image->AllocateInitialized();
 
-  const double  d[9] = { 0.7950707161543119,     -0.44533237368675166, 0.41175433605536305,
-                         -0.6065167008084678,    -0.5840224148057925,  0.5394954222649374,
-                         0.00021898465942798317, -0.6786728931900383,  -0.7344406416415056 };
-  DirectionType direction = DirectionType::InternalMatrixType(d);
+  const itk::SpacePrecisionType d[9] = { 0.7950707161543119,     -0.44533237368675166, 0.41175433605536305,
+                                         -0.6065167008084678,    -0.5840224148057925,  0.5394954222649374,
+                                         0.00021898465942798317, -0.6786728931900383,  -0.7344406416415056 };
+  DirectionType                 direction = DirectionType::InternalMatrixType(d);
 
   image->SetDirection(direction);
   image->SetSpacing(itk::MakeVector(0.9, 1.1, 1.7));


### PR DESCRIPTION
Fix compilation with `ITK_USE_FLOAT_SPACE_PRECISION=ON`: change the direction
initialization array from `double` to `itk::SpacePrecisionType` so it matches
the `vnl_matrix_fixed<SpacePrecisionType,N,N>` constructor's element type.

<details>
<summary>Root cause</summary>

`DirectionType::InternalMatrixType` becomes `vnl_matrix_fixed<float,3,3>` when
`ITK_USE_FLOAT_SPACE_PRECISION=ON`. Its only pointer constructor is
`explicit vnl_matrix_fixed(const T*)`, which requires `const float*`. Passing
`const double*` has no implicit conversion path, so the build fails.

Introduced in `8d2df4ed91` ("BUG: Fix floating-point exception in
ShapeLabelMapFilter") — identified via `git bisect`.

</details>

<details>
<summary>AI assistance</summary>

- GitHub Copilot (Claude Sonnet 4.6): identified root cause, applied fix,
  ran `git bisect` to pinpoint the introducing commit.
- Tested locally: `cmake --build --preset float-space` succeeds after the fix.

</details>