### PR TITLE
BUG: Replace hard-coded itkeigen/ path in itkSpecialFunctions.h

### DIFF
--- a/Modules/Core/Common/include/itkSpecialFunctions.h
+++ b/Modules/Core/Common/include/itkSpecialFunctions.h
@@ -18,7 +18,8 @@
 #ifndef itkSpecialFunctions_h
 #define itkSpecialFunctions_h
 
-#include "itkeigen/unsupported/Eigen/SpecialFunctions"
+#include "itk_eigen.h"
+#include ITK_EIGEN_UNSUPPORTED(SpecialFunctions)
 #include <type_traits>
 
 namespace itk


### PR DESCRIPTION
Fix the remaining hard-coded `itkeigen/unsupported/Eigen/SpecialFunctions` include in `itkSpecialFunctions.h` that breaks compilation when `ITK_USE_SYSTEM_EIGEN=ON`.

Replaces the path with `ITK_EIGEN_UNSUPPORTED(SpecialFunctions)` and adds the required `#include "itk_eigen.h"`, consistent with the fix in commit 8543e2f6e9 that addressed the same pattern in `itkMatrixExponential.h`, `itkEigenLevenbergMarquardtEngine.cxx`, and `vnl_levenberg_marquardt.cxx`.

<details>
<summary>AI assistance</summary>

- GitHub Copilot (Claude Sonnet 4.6) identified this remaining instance by searching for `#include "itkeigen/` patterns after reviewing the referenced commit.

</details>