### PR TITLE
COMP: Stall-based watchdog for ParallelSparseFieldLevelSet robustness tests

### DIFF
--- a/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterRobustnessGTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterRobustnessGTest.cxx
@@ -23,13 +23,16 @@
 
 #include "gtest/gtest.h"
 
+#include "itkCommand.h"
 #include "itkLevelSetFunction.h"
 #include "itkParallelSparseFieldLevelSetImageFilter.h"
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cmath>
 #include <condition_variable>
+#include <cstdint>
 #include <future>
 #include <iostream>
 #include <mutex>
@@ -42,26 +45,34 @@ namespace PSFLSIFR
 constexpr unsigned int DIM = 32;
 constexpr int          RADIUS = DIM / 4;
 
-// Abort the process if body does not finish within the deadline, so a
-// ParallelizeArray dispatch deadlock fails the test instead of hanging the
-// driver. The watchdog runs on its own OS thread, outside the work-unit pool
-// that the deadlock pins.
+// Abort if `body` makes no forward progress for `stallSeconds`: a real
+// dispatch deadlock freezes the heartbeat, while valgrind/TSan/Debug runs keep
+// advancing it however slowly. `body` bumps the heartbeat as it completes
+// work. The watchdog runs on its own OS thread, outside the work-unit pool
+// that a deadlock pins.
 template <typename TFunctor>
 void
-runWithDeadline(unsigned int seconds, TFunctor && body)
+runWithStallDeadline(unsigned int stallSeconds, TFunctor && body)
 {
-  std::mutex              m;
-  std::condition_variable cv;
-  bool                    done = false;
-  std::thread             watchdog([&] {
+  std::mutex                 m;
+  std::condition_variable    cv;
+  bool                       done = false;
+  std::atomic<std::uint64_t> heartbeat{ 0 };
+  std::thread                watchdog([&] {
+    std::uint64_t                last = heartbeat.load();
     std::unique_lock<std::mutex> lk(m);
-    if (!cv.wait_for(lk, std::chrono::seconds(seconds), [&] { return done; }))
+    while (!cv.wait_for(lk, std::chrono::seconds(stallSeconds), [&] { return done; }))
     {
-      std::cerr << "Deadline exceeded (" << seconds << "s): ParallelizeArray dispatch deadlock\n";
-      std::abort();
+      const std::uint64_t current = heartbeat.load();
+      if (current == last)
+      {
+        std::cerr << "No progress for " << stallSeconds << "s: ParallelizeArray dispatch deadlock\n";
+        std::abort();
+      }
+      last = current;
     }
   });
-  body();
+  body(heartbeat);
   {
     const std::lock_guard<std::mutex> lk(m);
     done = true;
@@ -218,8 +229,41 @@ make_target_image()
   return im;
 }
 
+// Bumps a heartbeat counter on each solver IterationEvent so the stall
+// watchdog sees continuous progress even when valgrind serializes the
+// concurrent pipelines' threads.
+class HeartbeatCommand : public itk::Command
+{
+public:
+  using Self = HeartbeatCommand;
+  using Pointer = itk::SmartPointer<Self>;
+  itkNewMacro(Self);
+
+  std::atomic<std::uint64_t> * m_Heartbeat{ nullptr };
+
+  void
+  Execute(itk::Object *, const itk::EventObject &) override
+  {
+    if (m_Heartbeat != nullptr)
+    {
+      ++(*m_Heartbeat);
+    }
+  }
+  void
+  Execute(const itk::Object *, const itk::EventObject &) override
+  {
+    if (m_Heartbeat != nullptr)
+    {
+      ++(*m_Heartbeat);
+    }
+  }
+
+protected:
+  HeartbeatCommand() = default;
+};
+
 ImageType::Pointer
-run_one(unsigned int workUnits, unsigned int iterations)
+run_one(unsigned int workUnits, unsigned int iterations, std::atomic<std::uint64_t> * heartbeat = nullptr)
 {
   auto init = make_init_image();
   auto target = make_target_image();
@@ -230,6 +274,12 @@ run_one(unsigned int workUnits, unsigned int iterations)
   mf->SetNumberOfWorkUnits(workUnits);
   mf->SetNumberOfLayers(3);
   mf->SetIsoSurfaceValue(0.0);
+  if (heartbeat != nullptr)
+  {
+    auto cmd = HeartbeatCommand::New();
+    cmd->m_Heartbeat = heartbeat;
+    mf->AddObserver(itk::IterationEvent(), cmd);
+  }
   mf->Update();
   ImageType::Pointer out = mf->GetOutput();
   out->DisconnectPipeline();
@@ -274,7 +324,7 @@ images_identical(ImageType * a, ImageType * b)
 TEST(ParallelSparseFieldLevelSetRobustness, SweepRepeat)
 {
   using namespace PSFLSIFR;
-  runWithDeadline(300, [] {
+  runWithStallDeadline(120, [](std::atomic<std::uint64_t> & heartbeat) {
     const std::vector<unsigned int> sweep{ 1, 2, 4, 8, 11, 16, 32 };
     constexpr unsigned int          kSweepRepeats = 10;
     constexpr unsigned int          kSweepIterations = 30;
@@ -282,7 +332,7 @@ TEST(ParallelSparseFieldLevelSetRobustness, SweepRepeat)
     {
       for (const unsigned int wu : sweep)
       {
-        auto         out = run_one(wu, kSweepIterations);
+        auto         out = run_one(wu, kSweepIterations, &heartbeat);
         const double summary = image_summary(out);
         EXPECT_TRUE(std::isfinite(summary));
         EXPECT_GT(summary, 0.0);
@@ -296,11 +346,11 @@ TEST(ParallelSparseFieldLevelSetRobustness, SweepRepeat)
 TEST(ParallelSparseFieldLevelSetRobustness, Determinism)
 {
   using namespace PSFLSIFR;
-  runWithDeadline(300, [] {
-    auto run0 = run_one(11, 100);
+  runWithStallDeadline(120, [](std::atomic<std::uint64_t> & heartbeat) {
+    auto run0 = run_one(11, 100, &heartbeat);
     for (unsigned int rep = 1; rep < 3; ++rep)
     {
-      auto runN = run_one(11, 100);
+      auto runN = run_one(11, 100, &heartbeat);
       EXPECT_TRUE(images_identical(run0, runN)) << "run " << rep << " differs from run 0";
     }
   });
@@ -311,7 +361,7 @@ TEST(ParallelSparseFieldLevelSetRobustness, Determinism)
 TEST(ParallelSparseFieldLevelSetRobustness, ConcurrentMultiPipeline)
 {
   using namespace PSFLSIFR;
-  runWithDeadline(300, [] {
+  runWithStallDeadline(120, [](std::atomic<std::uint64_t> & heartbeat) {
     constexpr unsigned int kConcurrentReps = 6;
     constexpr unsigned int kConcurrentPipelines = 8;
     for (unsigned int rep = 0; rep < kConcurrentReps; ++rep)
@@ -320,7 +370,7 @@ TEST(ParallelSparseFieldLevelSetRobustness, ConcurrentMultiPipeline)
       futures.reserve(kConcurrentPipelines);
       for (unsigned int p = 0; p < kConcurrentPipelines; ++p)
       {
-        futures.emplace_back(std::async(std::launch::async, [] { return run_one(11, 60); }));
+        futures.emplace_back(std::async(std::launch::async, [&heartbeat] { return run_one(11, 60, &heartbeat); }));
       }
       for (auto & f : futures)
       {


### PR DESCRIPTION
Fixes the nightly `itk-valgrind` failures of `ParallelSparseFieldLevelSetRobustness.SweepRepeat` and `.ConcurrentMultiPipeline` (tracked in #6518). The tests' own watchdog used a fixed 300 s wall-clock deadline that cannot distinguish a real dispatch deadlock from slow-but-progressing execution; under valgrind these solves legitimately run past 300 s and the watchdog `std::abort()`-ed them. The watchdog now fires on absence of *forward progress* instead.

<details>
<summary>Root cause</summary>

The three robustness GTests wrap their body in a watchdog thread meant to turn a `ParallelizeArray` dispatch deadlock into a clean failure rather than a hung driver. A total-elapsed-time budget is the wrong signal: valgrind/TSan/Debug runs are slow but make steady progress, so the fixed 300 s deadline false-aborts them. CDash showed this deterministically every night — `SweepRepeat` ~304 s and `ConcurrentMultiPipeline` ~310–312 s against the 300 s deadline. This is the second time a fixed number was outgrown (an earlier change had already raised it 30 s → 300 s).

</details>

<details>
<summary>The fix</summary>

Drive the watchdog off a heartbeat counter that advances with solver progress, and abort only when the heartbeat does not advance for the stall window. An `itk::IterationEvent` observer attached to the filter in `run_one` bumps the heartbeat once per level-set iteration. A real deadlock freezes the heartbeat (no iterations complete) and still aborts promptly; valgrind/TSan/Debug runs keep it advancing regardless of total runtime. The per-iteration granularity is what makes `ConcurrentMultiPipeline` robust under valgrind's thread serialization, where no whole-pipeline `future` completes for minutes.

</details>

<details>
<summary>Validation</summary>

Built and ran locally before pushing (per local-test-first discipline).

| Check | Result |
|---|---|
| Native `ctest -R ParallelSparseFieldLevelSetRobustness` | 3/3 pass (3.9 s) |
| valgrind memcheck `ConcurrentMultiPipeline` | **PASS @ 1002 s** (was abort @ 300 s) |
| valgrind memcheck `SweepRepeat` | **PASS @ 672 s** (was abort @ 300 s) |
| `pre-commit run --all-files` | clean |

An intermediate version that bumped the heartbeat only at whole-pipeline completion false-aborted `ConcurrentMultiPipeline` at 123 s under valgrind; the per-iteration observer fixes that and was re-validated above.

</details>

<!--
provenance: claude-code session 2026-06-29
scope: test-only change to Modules/Segmentation/LevelSets/test/itkParallelSparseFieldLevelSetImageFilterRobustnessGTest.cxx (+71 -21)
tracking_issue: #6518 (ParallelSparseFieldLevelSetRobustness.* row)
related: #6519 (closed; deadlock hypothesis withdrawn after 770+ hangless runs). Supersedes the earlier 30->300 s watchdog bump on fork branch fix-pslsif-robustness-watchdog-timeout (never opened as a PR).
out_of_scope: MaskedAssignFixture.SetGetPrint also reds the itk-valgrind build but is a fast assertion failure in a remote module, not a timeout.
validated_under: valgrind 3.22 memcheck, x86_64 linux; per-iteration IterationEvent heartbeat, 120 s stall window.
-->
