### PR TITLE
BUG: Use TIFF::TIFF target instead of TIFF_LIBRARIES variable

### DIFF
--- a/Modules/ThirdParty/TIFF/CMakeLists.txt
+++ b/Modules/ThirdParty/TIFF/CMakeLists.txt
@@ -8,9 +8,23 @@ if(ITK_USE_SYSTEM_TIFF)
     ${ITKTIFF_BINARY_DIR}/src
     ${TIFF_INCLUDE_DIRS}
   )
-  set(ITKTIFF_SYSTEM_INCLUDE_DIRS)
-  set(ITKTIFF_LIBRARIES "${TIFF_LIBRARIES}")
+  set(ITKTIFF_LIBRARIES "TIFF::TIFF")
   set(ITKTIFF_NO_SRC 1)
+
+  set(
+    ITKTIFF_EXPORT_CODE_INSTALL
+    "
+  find_package(TIFF REQUIRED)
+  "
+  )
+  set(
+    ITKTIFF_EXPORT_CODE_BUILD
+    "
+  if(NOT ITK_BINARY_DIR)
+    find_package(TIFF REQUIRED)
+  endif()
+  "
+  )
 else()
   set(
     ITKTIFF_INCLUDE_DIRS


### PR DESCRIPTION
Use the modern `TIFF::TIFF` imported target instead of `${TIFF_LIBRARIES}` when `ITK_USE_SYSTEM_TIFF=ON`. Closes #6529.

<details>
<summary>Root cause</summary>

CMake's `FindTIFF.cmake` populates the legacy `TIFF_LIBRARIES` variable for
backward compatibility by querying `LOCATION_RELEASE` and `LOCATION_DEBUG` on
the `TIFF::tiff` imported target. When libtiff is built with
`CMAKE_BUILD_TYPE=None` (Arch Linux packaging convention), the targets file
only registers `IMPORTED_LOCATION_NONE`. CMake falls back to that path for
both `LOCATION_RELEASE` and `LOCATION_DEBUG` queries, returning the same
path twice. `FindTIFF.cmake` lacks a `NOT STREQUAL` guard (unlike
`SelectLibraryConfigurations.cmake`) and emits:

```
TIFF_LIBRARIES = optimized;/usr/lib/libtiff.so.6.2.0;debug;/usr/lib/libtiff.so.6.2.0
```

ITK's `itk_module_impl()` loop in `ITKModuleMacros.cmake` then prepends the
`ITK::` namespace to any token that is not a file path or already namespaced,
turning `optimized` → `ITK::optimized` and `debug` → `ITK::debug`.
`REMOVE_DUPLICATES` strips the second copy of the path, leaving:

```cmake
set(ITKTIFF_LIBRARIES "ITK::optimized;/usr/lib/libtiff.so.6.2.0;ITK::debug")
```

`target_link_libraries` then fails because `ITK::optimized` is not a target.

The upstream CMake bug (missing `STREQUAL` guard in `FindTIFF.cmake`) was
introduced in Sep 2023 and remains unfixed as of CMake master (Dec 2025).

</details>

<details>
<summary>Fix</summary>

`Modules/ThirdParty/TIFF/CMakeLists.txt`: replace `"${TIFF_LIBRARIES}"` with
`"TIFF::TIFF"`. The `TIFF::TIFF` imported target is always created by
`FindTIFF.cmake` when TIFF is found (since CMake 3.5), contains `::` so it
passes through `itk_module_impl()`'s namespace loop unchanged, and correctly
encapsulates all per-configuration link details internally.

Export code (`ITKTIFF_EXPORT_CODE_INSTALL` / `ITKTIFF_EXPORT_CODE_BUILD`) is
added so that downstream `find_package(ITK)` calls re-invoke
`find_package(TIFF)` and recreate the `TIFF::TIFF` target.

</details>

<details>
<summary>AI assistance</summary>

- Tool: GitHub Copilot (Claude Sonnet 4.6)
- Role: root-cause analysis, Docker reproduction environment, fix authorship
- Reproduction: Arch Linux Docker image (`archlinux:latest`) with PKGBUILD
  dependencies, mounting the ITK source read-only, running cmake configure
  only — confirmed `ITK::optimized` in generated `ITKTIFF.cmake`.

</details>