### PR TITLE
ENH: Vendor pocketfft as the ITKPocketFFT third-party module

### DIFF
--- a/Modules/Filtering/FFT/include/itkPocketFFTCommon.h
+++ b/Modules/Filtering/FFT/include/itkPocketFFTCommon.h
@@ -18,7 +18,7 @@
 #ifndef itkPocketFFTCommon_h
 #define itkPocketFFTCommon_h
 
-#include "pocketfft_hdronly.h"
+#include "itk_pocketfft.h"
 
 namespace itk
 {
@@ -31,10 +31,10 @@ namespace PocketFFTCommon
 /** pocketfft shape is listed slowest-varying axis first; the ITK buffer is
  * x-fastest, so ITK dimension i maps to shape index (Dimension - 1 - i). */
 template <typename TSize>
-inline pocketfft::shape_t
+inline itk::detail::pocketfft::shape_t
 MakeShape(const TSize & itkSize, const unsigned int dimension)
 {
-  pocketfft::shape_t shape(dimension);
+  itk::detail::pocketfft::shape_t shape(dimension);
   for (unsigned int i = 0; i < dimension; ++i)
   {
     shape[dimension - 1 - i] = itkSize[i];
@@ -44,11 +44,11 @@ MakeShape(const TSize & itkSize, const unsigned int dimension)
 
 /** Contiguous-buffer strides in bytes for a pixel of size pixelBytes. */
 template <typename TSize>
-inline pocketfft::stride_t
+inline itk::detail::pocketfft::stride_t
 MakeStride(const TSize & itkSize, const unsigned int dimension, const size_t pixelBytes)
 {
-  pocketfft::stride_t stride(dimension);
-  ptrdiff_t           byteStride = static_cast<ptrdiff_t>(pixelBytes);
+  itk::detail::pocketfft::stride_t stride(dimension);
+  ptrdiff_t                        byteStride = static_cast<ptrdiff_t>(pixelBytes);
   for (unsigned int i = 0; i < dimension; ++i)
   {
     stride[dimension - 1 - i] = byteStride;
@@ -59,10 +59,10 @@ MakeStride(const TSize & itkSize, const unsigned int dimension, const size_t pix
 
 /** All axes, ordered so axes.back() is the ITK x dimension (the axis
  * pocketfft halves in r2c/c2r). */
-inline pocketfft::shape_t
+inline itk::detail::pocketfft::shape_t
 MakeAxes(const unsigned int dimension)
 {
-  pocketfft::shape_t axes(dimension);
+  itk::detail::pocketfft::shape_t axes(dimension);
   for (unsigned int i = 0; i < dimension; ++i)
   {
     axes[i] = i;
@@ -75,9 +75,9 @@ template <typename TValue>
 inline void
 Transform1D(std::complex<TValue> * data, const size_t lineLength, const bool forward, const TValue scale)
 {
-  const pocketfft::shape_t  shape{ lineLength };
-  const pocketfft::stride_t stride{ static_cast<ptrdiff_t>(sizeof(std::complex<TValue>)) };
-  pocketfft::c2c(shape, stride, stride, { 0 }, forward, data, data, scale);
+  const itk::detail::pocketfft::shape_t  shape{ lineLength };
+  const itk::detail::pocketfft::stride_t stride{ static_cast<ptrdiff_t>(sizeof(std::complex<TValue>)) };
+  itk::detail::pocketfft::c2c(shape, stride, stride, { 0 }, forward, data, data, scale);
 }
 
 } // namespace PocketFFTCommon

--- a/Modules/Filtering/FFT/include/itkPocketFFTComplexToComplexFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkPocketFFTComplexToComplexFFTImageFilter.hxx
@@ -48,9 +48,10 @@ PocketFFTComplexToComplexFFTImageFilter<TInputImage, TOutputImage>::GenerateData
   // Copy the input to the output and transform in place on the output.
   ImageAlgorithm::Copy<InputImageType, OutputImageType>(input, output, bufferedRegion, bufferedRegion);
 
-  const pocketfft::shape_t  shape = PocketFFTCommon::MakeShape(imageSize, ImageDimension);
-  const pocketfft::stride_t stride = PocketFFTCommon::MakeStride(imageSize, ImageDimension, sizeof(PixelType));
-  const pocketfft::shape_t  axes = PocketFFTCommon::MakeAxes(ImageDimension);
+  const itk::detail::pocketfft::shape_t  shape = PocketFFTCommon::MakeShape(imageSize, ImageDimension);
+  const itk::detail::pocketfft::stride_t stride =
+    PocketFFTCommon::MakeStride(imageSize, ImageDimension, sizeof(PixelType));
+  const itk::detail::pocketfft::shape_t axes = PocketFFTCommon::MakeAxes(ImageDimension);
 
   using ValueType = typename PixelType::value_type;
   PixelType * buffer = output->GetBufferPointer();
@@ -59,15 +60,15 @@ PocketFFTComplexToComplexFFTImageFilter<TInputImage, TOutputImage>::GenerateData
   const auto scale =
     inverse ? ValueType{ 1 } / static_cast<ValueType>(bufferedRegion.GetNumberOfPixels()) : ValueType{ 1 };
 
-  pocketfft::c2c(shape,
-                 stride,
-                 stride,
-                 axes,
-                 inverse ? pocketfft::BACKWARD : pocketfft::FORWARD,
-                 buffer,
-                 buffer,
-                 scale,
-                 this->GetMultiThreader()->GetMaximumNumberOfThreads());
+  itk::detail::pocketfft::c2c(shape,
+                              stride,
+                              stride,
+                              axes,
+                              inverse ? itk::detail::pocketfft::BACKWARD : itk::detail::pocketfft::FORWARD,
+                              buffer,
+                              buffer,
+                              scale,
+                              this->GetMultiThreader()->GetMaximumNumberOfThreads());
 }
 
 } // namespace itk

--- a/Modules/Filtering/FFT/include/itkPocketFFTForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkPocketFFTForwardFFTImageFilter.hxx
@@ -20,7 +20,6 @@
 
 #include "itkProgressReporter.h"
 #include "itkPocketFFTCommon.h"
-#include "pocketfft_hdronly.h"
 
 namespace itk
 {
@@ -44,9 +43,10 @@ PocketFFTForwardFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
   outputPtr->SetBufferedRegion(outputPtr->GetRequestedRegion());
   outputPtr->Allocate();
 
-  const pocketfft::shape_t  shape = PocketFFTCommon::MakeShape(inputSize, ImageDimension);
-  const pocketfft::stride_t stride = PocketFFTCommon::MakeStride(inputSize, ImageDimension, sizeof(OutputPixelType));
-  const pocketfft::shape_t  axes = PocketFFTCommon::MakeAxes(ImageDimension);
+  const itk::detail::pocketfft::shape_t  shape = PocketFFTCommon::MakeShape(inputSize, ImageDimension);
+  const itk::detail::pocketfft::stride_t stride =
+    PocketFFTCommon::MakeStride(inputSize, ImageDimension, sizeof(OutputPixelType));
+  const itk::detail::pocketfft::shape_t axes = PocketFFTCommon::MakeAxes(ImageDimension);
 
   const SizeValueType    totalSize = inputPtr->GetLargestPossibleRegion().GetNumberOfPixels();
   const InputPixelType * in = inputPtr->GetBufferPointer();
@@ -56,15 +56,15 @@ PocketFFTForwardFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
     out[i] = OutputPixelType(in[i], 0);
   }
 
-  pocketfft::c2c(shape,
-                 stride,
-                 stride,
-                 axes,
-                 pocketfft::FORWARD,
-                 out,
-                 out,
-                 InputPixelType{ 1 },
-                 this->GetMultiThreader()->GetMaximumNumberOfThreads());
+  itk::detail::pocketfft::c2c(shape,
+                              stride,
+                              stride,
+                              axes,
+                              itk::detail::pocketfft::FORWARD,
+                              out,
+                              out,
+                              InputPixelType{ 1 },
+                              this->GetMultiThreader()->GetMaximumNumberOfThreads());
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/FFT/include/itkPocketFFTHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkPocketFFTHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -45,24 +45,25 @@ PocketFFTHalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::Ge
   const OutputSizeType outputSize = outputPtr->GetLargestPossibleRegion().GetSize();
 
   // c2r takes the shape of the real (output) image.
-  const pocketfft::shape_t  shape = PocketFFTCommon::MakeShape(outputSize, ImageDimension);
-  const pocketfft::stride_t strideIn = PocketFFTCommon::MakeStride(inputSize, ImageDimension, sizeof(InputPixelType));
-  const pocketfft::stride_t strideOut =
+  const itk::detail::pocketfft::shape_t  shape = PocketFFTCommon::MakeShape(outputSize, ImageDimension);
+  const itk::detail::pocketfft::stride_t strideIn =
+    PocketFFTCommon::MakeStride(inputSize, ImageDimension, sizeof(InputPixelType));
+  const itk::detail::pocketfft::stride_t strideOut =
     PocketFFTCommon::MakeStride(outputSize, ImageDimension, sizeof(OutputPixelType));
-  const pocketfft::shape_t axes = PocketFFTCommon::MakeAxes(ImageDimension);
+  const itk::detail::pocketfft::shape_t axes = PocketFFTCommon::MakeAxes(ImageDimension);
 
   const SizeValueType   totalOutputSize = outputPtr->GetLargestPossibleRegion().GetNumberOfPixels();
   const OutputPixelType scale = OutputPixelType{ 1 } / static_cast<OutputPixelType>(totalOutputSize);
 
-  pocketfft::c2r(shape,
-                 strideIn,
-                 strideOut,
-                 axes,
-                 pocketfft::BACKWARD,
-                 inputPtr->GetBufferPointer(),
-                 outputPtr->GetBufferPointer(),
-                 scale,
-                 this->GetMultiThreader()->GetMaximumNumberOfThreads());
+  itk::detail::pocketfft::c2r(shape,
+                              strideIn,
+                              strideOut,
+                              axes,
+                              itk::detail::pocketfft::BACKWARD,
+                              inputPtr->GetBufferPointer(),
+                              outputPtr->GetBufferPointer(),
+                              scale,
+                              this->GetMultiThreader()->GetMaximumNumberOfThreads());
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/FFT/include/itkPocketFFTInverseFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkPocketFFTInverseFFTImageFilter.hxx
@@ -20,7 +20,6 @@
 
 #include "itkProgressReporter.h"
 #include "itkPocketFFTCommon.h"
-#include "pocketfft_hdronly.h"
 
 #include <vector>
 
@@ -46,24 +45,25 @@ PocketFFTInverseFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
   outputPtr->SetBufferedRegion(outputPtr->GetRequestedRegion());
   outputPtr->Allocate();
 
-  const pocketfft::shape_t  shape = PocketFFTCommon::MakeShape(outputSize, ImageDimension);
-  const pocketfft::stride_t stride = PocketFFTCommon::MakeStride(outputSize, ImageDimension, sizeof(InputPixelType));
-  const pocketfft::shape_t  axes = PocketFFTCommon::MakeAxes(ImageDimension);
-  const SizeValueType       totalSize = outputPtr->GetLargestPossibleRegion().GetNumberOfPixels();
+  const itk::detail::pocketfft::shape_t  shape = PocketFFTCommon::MakeShape(outputSize, ImageDimension);
+  const itk::detail::pocketfft::stride_t stride =
+    PocketFFTCommon::MakeStride(outputSize, ImageDimension, sizeof(InputPixelType));
+  const itk::detail::pocketfft::shape_t axes = PocketFFTCommon::MakeAxes(ImageDimension);
+  const SizeValueType                   totalSize = outputPtr->GetLargestPossibleRegion().GetNumberOfPixels();
 
   const InputPixelType *      in = inputPtr->GetBufferPointer();
   std::vector<InputPixelType> work(in, in + totalSize);
 
   const OutputPixelType scale = OutputPixelType{ 1 } / static_cast<OutputPixelType>(totalSize);
-  pocketfft::c2c(shape,
-                 stride,
-                 stride,
-                 axes,
-                 pocketfft::BACKWARD,
-                 work.data(),
-                 work.data(),
-                 scale,
-                 this->GetMultiThreader()->GetMaximumNumberOfThreads());
+  itk::detail::pocketfft::c2c(shape,
+                              stride,
+                              stride,
+                              axes,
+                              itk::detail::pocketfft::BACKWARD,
+                              work.data(),
+                              work.data(),
+                              scale,
+                              this->GetMultiThreader()->GetMaximumNumberOfThreads());
 
   OutputPixelType * out = outputPtr->GetBufferPointer();
   for (SizeValueType i = 0; i < totalSize; ++i)

--- a/Modules/Filtering/FFT/include/itkPocketFFTRealToHalfHermitianForwardFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkPocketFFTRealToHalfHermitianForwardFFTImageFilter.hxx
@@ -44,21 +44,22 @@ PocketFFTRealToHalfHermitianForwardFFTImageFilter<TInputImage, TOutputImage>::Ge
   outputPtr->Allocate();
   const OutputSizeType outputSize = outputPtr->GetLargestPossibleRegion().GetSize();
 
-  const pocketfft::shape_t  shape = PocketFFTCommon::MakeShape(inputSize, ImageDimension);
-  const pocketfft::stride_t strideIn = PocketFFTCommon::MakeStride(inputSize, ImageDimension, sizeof(InputPixelType));
-  const pocketfft::stride_t strideOut =
+  const itk::detail::pocketfft::shape_t  shape = PocketFFTCommon::MakeShape(inputSize, ImageDimension);
+  const itk::detail::pocketfft::stride_t strideIn =
+    PocketFFTCommon::MakeStride(inputSize, ImageDimension, sizeof(InputPixelType));
+  const itk::detail::pocketfft::stride_t strideOut =
     PocketFFTCommon::MakeStride(outputSize, ImageDimension, sizeof(OutputPixelType));
-  const pocketfft::shape_t axes = PocketFFTCommon::MakeAxes(ImageDimension);
+  const itk::detail::pocketfft::shape_t axes = PocketFFTCommon::MakeAxes(ImageDimension);
 
-  pocketfft::r2c(shape,
-                 strideIn,
-                 strideOut,
-                 axes,
-                 pocketfft::FORWARD,
-                 inputPtr->GetBufferPointer(),
-                 outputPtr->GetBufferPointer(),
-                 InputPixelType{ 1 },
-                 this->GetMultiThreader()->GetMaximumNumberOfThreads());
+  itk::detail::pocketfft::r2c(shape,
+                              strideIn,
+                              strideOut,
+                              axes,
+                              itk::detail::pocketfft::FORWARD,
+                              inputPtr->GetBufferPointer(),
+                              outputPtr->GetBufferPointer(),
+                              InputPixelType{ 1 },
+                              this->GetMultiThreader()->GetMaximumNumberOfThreads());
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/FFT/itk-module.cmake
+++ b/Modules/Filtering/FFT/itk-module.cmake
@@ -19,6 +19,7 @@ itk_module(
   ENABLE_SHARED
   DEPENDS
     ITKCommon
+    ITKPocketFFT
   COMPILE_DEPENDS
     ITKImageGrid
   TEST_DEPENDS

--- a/Modules/ThirdParty/PocketFFT/CMakeLists.txt
+++ b/Modules/ThirdParty/PocketFFT/CMakeLists.txt
@@ -1,0 +1,37 @@
+project(ITKPocketFFT)
+set(ITKPocketFFT_THIRD_PARTY 1)
+
+option(
+  ITK_USE_SYSTEM_POCKETFFT
+  "Use an outside build of pocketfft."
+  ${ITK_USE_SYSTEM_LIBRARIES}
+)
+mark_as_advanced(ITK_USE_SYSTEM_POCKETFFT)
+
+# pocketfft is header-only, so no library linking is required.  itk_pocketfft.h
+# is the single entry point: it is the only header that includes pocketfft and
+# applies ITK's POCKETFFT_NAMESPACE / POCKETFFT_CACHE_SIZE configuration.
+set(ITKPocketFFT_LIBRARIES "")
+
+if(ITK_USE_SYSTEM_POCKETFFT)
+  find_path(POCKETFFT_INCLUDE_DIR NAMES pocketfft_hdronly.h REQUIRED)
+  mark_as_advanced(POCKETFFT_INCLUDE_DIR)
+  set(ITKPocketFFT_INCLUDE_DIRS ${POCKETFFT_INCLUDE_DIR})
+  set(ITKPocketFFT_NO_SRC 1)
+else()
+  # The vendored header is reached through the "itkpocketfft/" prefix.
+  set(ITKPocketFFT_INCLUDE_DIRS ${ITKPocketFFT_SOURCE_DIR}/src)
+endif()
+
+# For the generated itk_pocketfft.h
+list(APPEND ITKPocketFFT_INCLUDE_DIRS ${ITKPocketFFT_BINARY_DIR}/src)
+
+itk_module_impl()
+
+configure_file(src/itk_pocketfft.h.in src/itk_pocketfft.h)
+install(
+  FILES
+    ${ITKPocketFFT_BINARY_DIR}/src/itk_pocketfft.h
+  DESTINATION ${ITKPocketFFT_INSTALL_INCLUDE_DIR}
+  COMPONENT Development
+)

--- a/Modules/ThirdParty/PocketFFT/UpdateFromUpstream.sh
+++ b/Modules/ThirdParty/PocketFFT/UpdateFromUpstream.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+shopt -s dotglob
+
+readonly name="PocketFFT"
+readonly ownership="PocketFFT Upstream <kwrobot@kitware.com>"
+readonly subtree="Modules/ThirdParty/PocketFFT/src/itkpocketfft"
+readonly exact_tree_match=false
+readonly repo="https://github.com/InsightSoftwareConsortium/pocketfft"
+readonly tag="for/itk-pocketfft-cpp-c90e55b"
+readonly paths="
+pocketfft_hdronly.h
+LICENSE.md
+"
+
+extract_source () {
+    git_archive
+}
+
+source "${BASH_SOURCE%/*}/../../../Utilities/Maintenance/update-third-party.bash"

--- a/Modules/ThirdParty/PocketFFT/itk-module.cmake
+++ b/Modules/ThirdParty/PocketFFT/itk-module.cmake
@@ -1,0 +1,7 @@
+set(
+  DOCUMENTATION
+  "This module contains the third party <a href=\"https://github.com/mreineck/pocketfft\">pocketfft</a> library.
+pocketfft is a header-only C++ Fast Fourier Transform implementation used as a default FFT backend in ITK."
+)
+
+itk_module(ITKPocketFFT DEPENDS DESCRIPTION "${DOCUMENTATION}")

--- a/Modules/ThirdParty/PocketFFT/src/CMakeLists.txt
+++ b/Modules/ThirdParty/PocketFFT/src/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Install the vendored upstream files.  This install lives OUTSIDE the
+# itkpocketfft/ subtree because UpdateFromUpstream.sh overwrites that subtree
+# wholesale with the upstream-provided file set.
+install(
+  FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/itkpocketfft/pocketfft_hdronly.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/itkpocketfft/LICENSE.md
+  DESTINATION ${ITKPocketFFT_INSTALL_INCLUDE_DIR}/itkpocketfft
+  COMPONENT Development
+)

--- a/Modules/ThirdParty/PocketFFT/src/itk_pocketfft.h.in
+++ b/Modules/ThirdParty/PocketFFT/src/itk_pocketfft.h.in
@@ -1,0 +1,53 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef itk_pocketfft_h
+#define itk_pocketfft_h
+
+// The single entry point for pocketfft in ITK: this header is the only place
+// that includes pocketfft_hdronly.h.  All ITK code includes itk_pocketfft.h.
+//
+// ITK-specific configuration is applied here (not in the vendored upstream
+// copy) so the fork stays a faithful mirror of upstream.
+
+// Must be included before any pocketfft_hdronly.h: if pocketfft was already
+// pulled in (e.g. a system copy via another library) its symbols are in
+// ::pocketfft and ITK's itk::detail::pocketfft API will not resolve.
+#ifdef POCKETFFT_HDRONLY_H
+#  error "pocketfft_hdronly.h was included before itk_pocketfft.h; include itk_pocketfft.h first so ITK's namespace isolation applies."
+#endif
+
+// Confine pocketfft to an ITK-private namespace so its symbols never collide
+// with a ::pocketfft from another library (mreineck/pocketfft#30).
+#ifndef POCKETFFT_NAMESPACE
+#  define POCKETFFT_NAMESPACE itk::detail::pocketfft
+#endif
+
+// Reuse up to 16 cached plans for repeated same-size transforms.
+#ifndef POCKETFFT_CACHE_SIZE
+#  define POCKETFFT_CACHE_SIZE 16
+#endif
+
+#cmakedefine ITK_USE_SYSTEM_POCKETFFT
+#ifdef ITK_USE_SYSTEM_POCKETFFT
+#  include <pocketfft_hdronly.h>
+#else
+#  include "itkpocketfft/pocketfft_hdronly.h"
+#endif
+
+#endif

--- a/Modules/ThirdParty/PocketFFT/src/itkpocketfft/LICENSE.md
+++ b/Modules/ThirdParty/PocketFFT/src/itkpocketfft/LICENSE.md
@@ -1,0 +1,25 @@
+Copyright (C) 2010-2018 Max-Planck-Society
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+* Neither the name of the copyright holder nor the names of its contributors may
+  be used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Modules/ThirdParty/PocketFFT/src/itkpocketfft/pocketfft_hdronly.h
+++ b/Modules/ThirdParty/PocketFFT/src/itkpocketfft/pocketfft_hdronly.h
@@ -58,12 +58,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #ifndef POCKETFFT_CACHE_SIZE
-// ITK default: save up to 16 plans so repeated same-size transforms (e.g. the
-// per-iteration N3/N4 histogram FFT) reuse a plan instead of rebuilding it.
-// Any nonzero size is a robust choice: it gives a significant speedup over 0
-// across every tested ITK environment (including the ANTs and BRAINSTools
-// test suites); 16 covers typical multi-size pipelines with no measured cost.
-#define POCKETFFT_CACHE_SIZE 16
+#define POCKETFFT_CACHE_SIZE 0
 #endif
 
 #include <cmath>
@@ -244,7 +239,7 @@ template<typename T> class arr
 #endif
 
   public:
-    arr() : p(0), sz(0) {}
+    arr() : p(nullptr), sz(0) {}
     explicit arr(size_t n) : p(ralloc(n)), sz(n) {}
     arr(arr &&other) noexcept
       : p(other.p), sz(other.sz)

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_fft_1d.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_fft_1d.h
@@ -10,7 +10,7 @@
 // sign convention (dir=+1 applies exp(+2*pi*i*j*k/N)) and no normalization.
 // Unlike the Temperton backend, any signal length is supported.
 //
-// Requires the ITKFFT module on the include path (for pocketfft_hdronly.h):
+// Requires the ITKFFT module on the include path (for itk_pocketfft.h):
 // a consumer that includes this header must depend on ITKFFT.
 
 #if defined(ITK_FUTURE_LEGACY_REMOVE) || defined(ITK_LEGACY_REMOVE)
@@ -24,7 +24,7 @@
 #    include <vcl_msvc_warnings.h>
 #  endif
 #  include <vnl/vnl_vector.h>
-#  include "pocketfft_hdronly.h" // provided by the ITKFFT module include directory
+#  include "itk_pocketfft.h" // provided by the ITKPocketFFT module include directory
 
 #  if defined(ITK_LEGACY_SILENT)
 #    define VNL_FFT_1D_DEPRECATED
@@ -55,11 +55,11 @@ struct VNL_FFT_1D_DEPRECATED vnl_fft_1d
   void
   transform(std::complex<T> * signal, int dir)
   {
-    const pocketfft::shape_t  shape{ size_ };
-    const pocketfft::stride_t stride{ static_cast<ptrdiff_t>(sizeof(std::complex<T>)) };
-    const pocketfft::shape_t  axes{ 0 };
+    const itk::detail::pocketfft::shape_t  shape{ size_ };
+    const itk::detail::pocketfft::stride_t stride{ static_cast<ptrdiff_t>(sizeof(std::complex<T>)) };
+    const itk::detail::pocketfft::shape_t  axes{ 0 };
     // vnl dir=+1 is exp(+i...), which is pocketfft's backward direction.
-    pocketfft::c2c(shape, stride, stride, axes, dir < 0, signal, signal, static_cast<T>(1));
+    itk::detail::pocketfft::c2c(shape, stride, stride, axes, dir < 0, signal, signal, static_cast<T>(1));
   }
 
   //: dir = +1/-1 according to direction of transform.


### PR DESCRIPTION
Move the header-only pocketfft from the FFT module include directory into a
proper `Modules/ThirdParty/PocketFFT` module, vendored from the
[InsightSoftwareConsortium/pocketfft](https://github.com/InsightSoftwareConsortium/pocketfft)
fork via the standard `UpdateFromUpstream.sh` mechanism.

This gives pocketfft **parity with every other ITK third-party inclusion** —
even though it is a single header file — so that future upstream pocketfft
updates are maintained the same consistent way as eigen, DCMTK, VNL, etc.
(fork with a `welcome` branch, `for/itk-*` overlay, `UpdateFromUpstream.sh`).

Upstream pocketfft has also already merged the fix for the compiler warnings
reported on the CDash build
https://open.cdash.org/builds/11378398/build
(mreineck/pocketfft#32), so the vendored copy is warning-clean with no
ITK-local patch required.

<details>
<summary>What changed</summary>

- New `Modules/ThirdParty/PocketFFT` module (Eigen3 header-only model):
  `itk-module.cmake`, `CMakeLists.txt` with an `ITK_USE_SYSTEM_POCKETFFT`
  switch, and `UpdateFromUpstream.sh` pinned to
  `for/itk-pocketfft-cpp-c90e55b`.
- `itk_pocketfft.h` is the **single entry point**: it is the only header that
  includes `pocketfft_hdronly.h`. ITK-specific configuration lives here (not in
  the vendored copy), applied before the include:
  - `POCKETFFT_NAMESPACE = itk::detail::pocketfft` — confines pocketfft symbols
    to an ITK-private namespace so they cannot collide with a `::pocketfft`
    from another library (mreineck/pocketfft#30).
  - `POCKETFFT_CACHE_SIZE = 16`.
- The vendored `pocketfft_hdronly.h` keeps upstream defaults, so the fork stays
  a faithful mirror of upstream `cpp` (which includes mreineck/pocketfft#32).
- `ITKFFT` now `DEPENDS ITKPocketFFT`; the FFT filters and the deprecated
  `vnl_fft_1d` shim include `itk_pocketfft.h` and use the fully-qualified
  `itk::detail::pocketfft::` API.

</details>

<details>
<summary>Validation</summary>

- `ITKFFT` builds; all 20 PocketFFT tests pass.
- Install places `itk_pocketfft.h` and `itkpocketfft/{pocketfft_hdronly.h,
  LICENSE.md}` under a single include root; an external consumer including only
  `itk_pocketfft.h` compiles and links, with `POCKETFFT_CACHE_SIZE == 16`.
- Symbol check: zero global `::pocketfft` symbols; all in
  `itk::detail::pocketfft`.
- `UpdateFromUpstream.sh` re-import reproduces the vendored header byte-for-byte
  with correct two-parent merge topology.
- `pre-commit run --all-files` passes.

</details>

<!--
provenance: claude-code session 2026-06-30
fork: InsightSoftwareConsortium/pocketfft (welcome default; cpp mirror;
  for/itk-pocketfft-cpp-c90e55b overlay, currently == cpp tip, no ITK patches)
pin: Modules/ThirdParty/PocketFFT/UpdateFromUpstream.sh tag=for/itk-pocketfft-cpp-c90e55b
cdash_build: 11378398 (warnings fixed upstream by mreineck/pocketfft#32)
note: macOS/Homebrew git needs --allow-unrelated-histories; update-third-party.bash
  auto-detect misses non-Apple git -> candidate follow-up fix.
-->
