### PR TITLE
COMP: Add ITKGoogleTest to Montage TEST_DEPENDS

### DIFF
--- a/Modules/Registration/Montage/itk-module.cmake
+++ b/Modules/Registration/Montage/itk-module.cmake
@@ -21,6 +21,7 @@ itk_module(
   TEST_DEPENDS
     ITKIOTransformInsightLegacy
     ITKTestKernel
+    ITKGoogleTest
   DESCRIPTION "${DOCUMENTATION}"
   EXCLUDE_FROM_DEFAULT
   ENABLE_SHARED


### PR DESCRIPTION
Fixes CMake configure error on macOS nightly: `MontageGTestDriver` links to `GTest::gtest` but the target was not found because `ITKGoogleTest` was missing from the module's `TEST_DEPENDS`.

<details>
<summary>CDash failure</summary>

https://open.cdash.org/builds/11381334/configure

```
CMake Error at CMake/ITKModuleTest.cmake:296 (target_link_libraries):
  Target "MontageGTestDriver" links to:
    GTest::gtest
  but the target was not found.
Call Stack (most recent call first):
  Modules/Registration/Montage/test/CMakeLists.txt:18 (creategoogletestdriver)
```

</details>

<details>
<summary>AI assistance</summary>

- Tool: GitHub Copilot (Claude Sonnet 4.6)
- Role: branch creation, commit, and PR from user-prepared staged change

</details>