### PR TITLE
DOC: exclude FetchContent _deps from CDash coverage

### DIFF
--- a/CMake/CTestCustom.cmake.in
+++ b/CMake/CTestCustom.cmake.in
@@ -51,6 +51,9 @@ set(CTEST_CUSTOM_COVERAGE_EXCLUDE
  ".*/ThirdParty/.*"
  ".*/Utilities/.*"
 
+ # Exclude FetchContent-downloaded dependencies (e.g. DCMTK via _deps)
+ ".*/_deps/.*"
+
  # Exclude files from the Wrapping directories
  ".*/Wrapping/.*"
  )


### PR DESCRIPTION
The `_deps/` build directory is used by CMake's FetchContent for
downloaded dependencies. Without this exclusion, sources from those
dependencies (e.g. DCMTK) inflate the coverage denominator and reduce
the reported line-coverage percentage on CDash.

Adds `".*/_deps/.*"` to `CTEST_CUSTOM_COVERAGE_EXCLUDE` in
`CMake/CTestCustom.cmake.in`, alongside the existing `ThirdParty`
and `Utilities` exclusions.

<details>
<summary>AI assistance</summary>

- GitHub Copilot identified the exclusion file and drafted the fix.
- Change verified by the author against the CDash coverage report at
  https://open.cdash.org/builds/11381885/coverage.

</details>