### PR TITLE
COMP: add MSVC warning suppression to VNL FFT compat headers

### DIFF
--- a/Modules/Filtering/FFT/include/itkVnlComplexToComplex1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlComplexToComplex1DFFTImageFilter.h
@@ -68,6 +68,9 @@ protected:
 #  if defined(__GNUC__) || defined(__clang__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#  elif defined(_MSC_VER)
+#    pragma warning(push)
+#    pragma warning(disable : 4996)
 #  endif
 template <>
 struct FFTImageFilterTraits<VnlComplexToComplex1DFFTImageFilter>
@@ -75,6 +78,8 @@ struct FFTImageFilterTraits<VnlComplexToComplex1DFFTImageFilter>
 {};
 #  if defined(__GNUC__) || defined(__clang__)
 #    pragma GCC diagnostic pop
+#  elif defined(_MSC_VER)
+#    pragma warning(pop)
 #  endif
 /** \endcond */
 } // namespace itk

--- a/Modules/Filtering/FFT/include/itkVnlComplexToComplexFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlComplexToComplexFFTImageFilter.h
@@ -68,6 +68,9 @@ protected:
 #  if defined(__GNUC__) || defined(__clang__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#  elif defined(_MSC_VER)
+#    pragma warning(push)
+#    pragma warning(disable : 4996)
 #  endif
 template <>
 struct FFTImageFilterTraits<VnlComplexToComplexFFTImageFilter>
@@ -75,6 +78,8 @@ struct FFTImageFilterTraits<VnlComplexToComplexFFTImageFilter>
 {};
 #  if defined(__GNUC__) || defined(__clang__)
 #    pragma GCC diagnostic pop
+#  elif defined(_MSC_VER)
+#    pragma warning(pop)
 #  endif
 /** \endcond */
 } // namespace itk

--- a/Modules/Filtering/FFT/include/itkVnlForward1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlForward1DFFTImageFilter.h
@@ -69,12 +69,17 @@ protected:
 #  if defined(__GNUC__) || defined(__clang__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#  elif defined(_MSC_VER)
+#    pragma warning(push)
+#    pragma warning(disable : 4996)
 #  endif
 template <>
 struct FFTImageFilterTraits<VnlForward1DFFTImageFilter> : public FFTImageFilterTraits<PocketFFTForward1DFFTImageFilter>
 {};
 #  if defined(__GNUC__) || defined(__clang__)
 #    pragma GCC diagnostic pop
+#  elif defined(_MSC_VER)
+#    pragma warning(pop)
 #  endif
 /** \endcond */
 } // namespace itk

--- a/Modules/Filtering/FFT/include/itkVnlForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlForwardFFTImageFilter.h
@@ -68,12 +68,17 @@ protected:
 #  if defined(__GNUC__) || defined(__clang__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#  elif defined(_MSC_VER)
+#    pragma warning(push)
+#    pragma warning(disable : 4996)
 #  endif
 template <>
 struct FFTImageFilterTraits<VnlForwardFFTImageFilter> : public FFTImageFilterTraits<PocketFFTForwardFFTImageFilter>
 {};
 #  if defined(__GNUC__) || defined(__clang__)
 #    pragma GCC diagnostic pop
+#  elif defined(_MSC_VER)
+#    pragma warning(pop)
 #  endif
 /** \endcond */
 } // namespace itk

--- a/Modules/Filtering/FFT/include/itkVnlHalfHermitianToRealInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlHalfHermitianToRealInverseFFTImageFilter.h
@@ -69,6 +69,9 @@ protected:
 #  if defined(__GNUC__) || defined(__clang__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#  elif defined(_MSC_VER)
+#    pragma warning(push)
+#    pragma warning(disable : 4996)
 #  endif
 template <>
 struct FFTImageFilterTraits<VnlHalfHermitianToRealInverseFFTImageFilter>
@@ -76,6 +79,8 @@ struct FFTImageFilterTraits<VnlHalfHermitianToRealInverseFFTImageFilter>
 {};
 #  if defined(__GNUC__) || defined(__clang__)
 #    pragma GCC diagnostic pop
+#  elif defined(_MSC_VER)
+#    pragma warning(pop)
 #  endif
 /** \endcond */
 } // namespace itk

--- a/Modules/Filtering/FFT/include/itkVnlInverse1DFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlInverse1DFFTImageFilter.h
@@ -70,12 +70,17 @@ protected:
 #  if defined(__GNUC__) || defined(__clang__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#  elif defined(_MSC_VER)
+#    pragma warning(push)
+#    pragma warning(disable : 4996)
 #  endif
 template <>
 struct FFTImageFilterTraits<VnlInverse1DFFTImageFilter> : public FFTImageFilterTraits<PocketFFTInverse1DFFTImageFilter>
 {};
 #  if defined(__GNUC__) || defined(__clang__)
 #    pragma GCC diagnostic pop
+#  elif defined(_MSC_VER)
+#    pragma warning(pop)
 #  endif
 /** \endcond */
 } // namespace itk

--- a/Modules/Filtering/FFT/include/itkVnlInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlInverseFFTImageFilter.h
@@ -68,12 +68,17 @@ protected:
 #  if defined(__GNUC__) || defined(__clang__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#  elif defined(_MSC_VER)
+#    pragma warning(push)
+#    pragma warning(disable : 4996)
 #  endif
 template <>
 struct FFTImageFilterTraits<VnlInverseFFTImageFilter> : public FFTImageFilterTraits<PocketFFTInverseFFTImageFilter>
 {};
 #  if defined(__GNUC__) || defined(__clang__)
 #    pragma GCC diagnostic pop
+#  elif defined(_MSC_VER)
+#    pragma warning(pop)
 #  endif
 /** \endcond */
 } // namespace itk

--- a/Modules/Filtering/FFT/include/itkVnlRealToHalfHermitianForwardFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkVnlRealToHalfHermitianForwardFFTImageFilter.h
@@ -69,6 +69,9 @@ protected:
 #  if defined(__GNUC__) || defined(__clang__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#  elif defined(_MSC_VER)
+#    pragma warning(push)
+#    pragma warning(disable : 4996)
 #  endif
 template <>
 struct FFTImageFilterTraits<VnlRealToHalfHermitianForwardFFTImageFilter>
@@ -76,6 +79,8 @@ struct FFTImageFilterTraits<VnlRealToHalfHermitianForwardFFTImageFilter>
 {};
 #  if defined(__GNUC__) || defined(__clang__)
 #    pragma GCC diagnostic pop
+#  elif defined(_MSC_VER)
+#    pragma warning(pop)
 #  endif
 /** \endcond */
 } // namespace itk


### PR DESCRIPTION
The deprecated VNL FFT alias headers suppress `-Wdeprecated-declarations` for GCC/Clang but lacked the equivalent MSVC pragma (`C4996`). Add `#pragma warning(disable: 4996)` around the `FFTImageFilterTraits` specialisation in each of the eight headers.

<details>
<summary>Root cause</summary>

The `FFTImageFilterTraits<VnlXxxFFTImageFilter>` specialisations must name the deprecated class, so the compiler emits a deprecation warning at that point. The existing GCC/Clang suppression used `#pragma GCC diagnostic` but the `#elif defined(_MSC_VER)` branch was absent, causing MSVC C4996 warnings on Windows CDash builds.

</details>

<details>
<summary>AI assistance</summary>

- GitHub Copilot identified the missing MSVC pragma branch across all 8 headers and applied the fix.
- Verified locally: `cmake --build --preset default --target ITKFFT` completes without warnings on GCC.

</details>