### PR TITLE
COMP: Fix implicit copy deprecated by user-declared destructor

### DIFF
--- a/Modules/Core/Common/include/itkDefaultVectorPixelAccessor.h
+++ b/Modules/Core/Common/include/itkDefaultVectorPixelAccessor.h
@@ -124,6 +124,7 @@ public:
   {}
 
   ~DefaultVectorPixelAccessor() = default;
+  ITK_DEFAULT_COPY_AND_MOVE(DefaultVectorPixelAccessor);
 
 private:
   VectorLengthType m_VectorLength{ 0 };

--- a/Modules/Core/Common/include/itkPriorityQueueContainer.h
+++ b/Modules/Core/Common/include/itkPriorityQueueContainer.h
@@ -43,6 +43,7 @@ public:
 
   ElementWrapperInterface() = default;
   virtual ~ElementWrapperInterface() = default;
+  ITK_DEFAULT_COPY_AND_MOVE(ElementWrapperInterface);
 
   [[nodiscard]] virtual ElementIdentifierType
   GetLocation(const ElementType & element) const = 0;
@@ -76,6 +77,7 @@ public:
 
   ElementWrapperPointerInterface() = default;
   virtual ~ElementWrapperPointerInterface() = default;
+  ITK_DEFAULT_COPY_AND_MOVE(ElementWrapperPointerInterface);
 
   TElementIdentifier
   GetLocation(const ElementWrapperPointerType & element) const;
@@ -120,6 +122,7 @@ public:
   MinPriorityQueueElementWrapper(ElementType element, ElementPriorityType priority);
 
   ~MinPriorityQueueElementWrapper() override = default;
+  ITK_DEFAULT_COPY_AND_MOVE(MinPriorityQueueElementWrapper);
 
   bool
   operator>(const MinPriorityQueueElementWrapper & other) const;
@@ -167,6 +170,7 @@ public:
   MaxPriorityQueueElementWrapper(ElementType element, ElementPriorityType priority);
 
   ~MaxPriorityQueueElementWrapper() override = default;
+  ITK_DEFAULT_COPY_AND_MOVE(MaxPriorityQueueElementWrapper);
 
   virtual bool
   is_less(const MaxPriorityQueueElementWrapper & element1, const MaxPriorityQueueElementWrapper & element2) const;


### PR DESCRIPTION
Add `ITK_DEFAULT_COPY_AND_MOVE` to five classes that declare a destructor without explicit copy/move operations, silencing `-Wdeprecated-copy-with-dtor` (Apple Clang) and `-Wdeprecated-copy-with-user-provided-dtor` warnings.

<details>
<summary>Root cause</summary>

Apple Clang and newer GCC warn when a class declares any special member function (including `= default` destructor) without explicitly declaring all copy/move operations. ITK provides the `ITK_DEFAULT_COPY_AND_MOVE` macro for exactly this purpose.

Affected classes in ITK proper (ThirdParty/GDCM warnings excluded):

- `itk::DefaultVectorPixelAccessor` — `itkDefaultVectorPixelAccessor.h`
- `itk::ElementWrapperInterface` — `itkPriorityQueueContainer.h`
- `itk::ElementWrapperPointerInterface` — `itkPriorityQueueContainer.h`
- `itk::MinPriorityQueueElementWrapper` — `itkPriorityQueueContainer.h`
- `itk::MaxPriorityQueueElementWrapper` — `itkPriorityQueueContainer.h`

All classes have only POD or trivially copyable members, so the defaulted copy/move operations are semantically correct.

Reported on CDash build 11383687 (Mac14.x-AppleClang-dbg-Universal, 199 warnings).

</details>

<details>
<summary>AI assistance</summary>

Warnings identified via CDash API. Fixes applied and verified with a local build of `ITKCommon` — zero warnings from the edited files after the change.

</details>