### PR TITLE
ENH: add GetInput1/2/3 and GetInput to TernaryGeneratorImageFilter

### DIFF
--- a/Modules/Filtering/ImageFilterBase/include/itkTernaryGeneratorImageFilter.h
+++ b/Modules/Filtering/ImageFilterBase/include/itkTernaryGeneratorImageFilter.h
@@ -155,6 +155,21 @@ public:
   virtual const Input3ImagePixelType &
   GetConstant3() const;
 
+  /** Get the first input image, or nullptr if it is set as a constant. */
+  const Input1ImageType *
+  GetInput1() const;
+
+  /** Get the second input image, or nullptr if it is set as a constant. */
+  const Input2ImageType *
+  GetInput2() const;
+
+  /** Get the third input image, or nullptr if it is set as a constant. */
+  const Input3ImageType *
+  GetInput3() const;
+
+  /** Override to return nullptr (instead of throwing) if input 1 is set as a constant. */
+  const Input1ImageType *
+  GetInput() const;
 
 #if !defined(ITK_WRAPPING_PARSER)
   /** Set the pixel functor

--- a/Modules/Filtering/ImageFilterBase/include/itkTernaryGeneratorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkTernaryGeneratorImageFilter.hxx
@@ -182,6 +182,34 @@ const typename TernaryGeneratorImageFilter<TInputImage1, TInputImage2, TInputIma
   return input->Get();
 }
 
+template <typename TInputImage1, typename TInputImage2, typename TInputImage3, typename TOutputImage>
+const typename TernaryGeneratorImageFilter<TInputImage1, TInputImage2, TInputImage3, TOutputImage>::Input1ImageType *
+TernaryGeneratorImageFilter<TInputImage1, TInputImage2, TInputImage3, TOutputImage>::GetInput1() const
+{
+  return dynamic_cast<const Input1ImageType *>(this->ProcessObject::GetInput(0));
+}
+
+template <typename TInputImage1, typename TInputImage2, typename TInputImage3, typename TOutputImage>
+const typename TernaryGeneratorImageFilter<TInputImage1, TInputImage2, TInputImage3, TOutputImage>::Input2ImageType *
+TernaryGeneratorImageFilter<TInputImage1, TInputImage2, TInputImage3, TOutputImage>::GetInput2() const
+{
+  return dynamic_cast<const Input2ImageType *>(this->ProcessObject::GetInput(1));
+}
+
+template <typename TInputImage1, typename TInputImage2, typename TInputImage3, typename TOutputImage>
+const typename TernaryGeneratorImageFilter<TInputImage1, TInputImage2, TInputImage3, TOutputImage>::Input3ImageType *
+TernaryGeneratorImageFilter<TInputImage1, TInputImage2, TInputImage3, TOutputImage>::GetInput3() const
+{
+  return dynamic_cast<const Input3ImageType *>(this->ProcessObject::GetInput(2));
+}
+
+template <typename TInputImage1, typename TInputImage2, typename TInputImage3, typename TOutputImage>
+const typename TernaryGeneratorImageFilter<TInputImage1, TInputImage2, TInputImage3, TOutputImage>::Input1ImageType *
+TernaryGeneratorImageFilter<TInputImage1, TInputImage2, TInputImage3, TOutputImage>::GetInput() const
+{
+  return this->GetInput1();
+}
+
 /**
  * BeforeThreadedGenerateData function. Validate inputs
  */

--- a/Modules/Filtering/ImageFilterBase/test/itkGeneratorImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkGeneratorImageFilterGTest.cxx
@@ -439,3 +439,98 @@ TEST(TernaryGeneratorImageFilter, Constants)
 
   EXPECT_NEAR(103.0, outputImage->GetPixel(idx), 1e-8);
 }
+
+
+TEST(TernaryGeneratorImageFilter, GetInputWithConstants)
+{
+  // Verify that GetInput1/2/3() and GetInput() return nullptr (rather than
+  // throwing) when the corresponding input is set as a constant. This tests
+  // the fix for itkDynamicCastInDebugMode throwing when the input slot holds
+  // a SimpleDataObjectDecorator instead of an image.
+
+  using Utils = Utilities<3>;
+  using FilterType =
+    itk::TernaryGeneratorImageFilter<Utils::ImageType, Utils::ImageType, Utils::ImageType, Utils::ImageType>;
+
+  auto image = Utils::CreateImage();
+  auto filter = FilterType::New();
+
+  // Input 1: image → then constant
+  filter->SetInput1(image);
+  EXPECT_EQ(image, filter->GetInput1());
+  EXPECT_EQ(image, filter->GetInput());
+  EXPECT_ANY_THROW(filter->GetConstant1());
+
+  filter->SetConstant1(1.0f);
+  EXPECT_EQ(nullptr, filter->GetInput1());
+  EXPECT_EQ(nullptr, filter->GetInput());
+  EXPECT_EQ(1.0f, filter->GetConstant1());
+
+  // Input 2: image → then constant
+  filter->SetInput2(image);
+  EXPECT_EQ(image, filter->GetInput2());
+  EXPECT_ANY_THROW(filter->GetConstant2());
+
+  filter->SetConstant2(2.0f);
+  EXPECT_EQ(nullptr, filter->GetInput2());
+  EXPECT_EQ(2.0f, filter->GetConstant2());
+
+  // Input 3: image → then constant
+  filter->SetInput3(image);
+  EXPECT_EQ(image, filter->GetInput3());
+  EXPECT_ANY_THROW(filter->GetConstant3());
+
+  filter->SetConstant3(3.0f);
+  EXPECT_EQ(nullptr, filter->GetInput3());
+  EXPECT_EQ(3.0f, filter->GetConstant3());
+}
+
+
+TEST(TernaryGeneratorImageFilter, SwitchInputAndConstant)
+{
+  // Verify that switching from image → constant → image (round-trip) on each
+  // input does not throw, and that getter state is correct at each step.
+
+  using Utils = Utilities<3>;
+  using FilterType =
+    itk::TernaryGeneratorImageFilter<Utils::ImageType, Utils::ImageType, Utils::ImageType, Utils::ImageType>;
+
+  auto image = Utils::CreateImage();
+  auto filter = FilterType::New();
+
+  // Round-trip input 1: image → constant → image
+  EXPECT_NO_THROW(filter->SetInput1(image));
+  EXPECT_EQ(image, filter->GetInput1());
+
+  EXPECT_NO_THROW(filter->SetConstant1(1.0f));
+  EXPECT_EQ(nullptr, filter->GetInput1());
+  EXPECT_EQ(1.0f, filter->GetConstant1());
+
+  EXPECT_NO_THROW(filter->SetInput1(image));
+  EXPECT_EQ(image, filter->GetInput1());
+  EXPECT_ANY_THROW(filter->GetConstant1());
+
+  // Round-trip input 2: image → constant → image
+  EXPECT_NO_THROW(filter->SetInput2(image));
+  EXPECT_EQ(image, filter->GetInput2());
+
+  EXPECT_NO_THROW(filter->SetConstant2(2.0f));
+  EXPECT_EQ(nullptr, filter->GetInput2());
+  EXPECT_EQ(2.0f, filter->GetConstant2());
+
+  EXPECT_NO_THROW(filter->SetInput2(image));
+  EXPECT_EQ(image, filter->GetInput2());
+  EXPECT_ANY_THROW(filter->GetConstant2());
+
+  // Round-trip input 3: image → constant → image
+  EXPECT_NO_THROW(filter->SetInput3(image));
+  EXPECT_EQ(image, filter->GetInput3());
+
+  EXPECT_NO_THROW(filter->SetConstant3(3.0f));
+  EXPECT_EQ(nullptr, filter->GetInput3());
+  EXPECT_EQ(3.0f, filter->GetConstant3());
+
+  EXPECT_NO_THROW(filter->SetInput3(image));
+  EXPECT_EQ(image, filter->GetInput3());
+  EXPECT_ANY_THROW(filter->GetConstant3());
+}


### PR DESCRIPTION
Add `GetInput1()`, `GetInput2()`, `GetInput3()`, and shadow `GetInput()` on `TernaryGeneratorImageFilter` to return `nullptr` instead of throwing when the slot holds a constant.

<details>
<summary>Root cause</summary>

When `SetConstant1/2/3(v)` is called, input slot 0/1/2 is replaced by a `SimpleDataObjectDecorator<PixelType>`. The `GetInput()` inherited from `ImageToImageFilter` calls `itkDynamicCastInDebugMode`, which throws in debug builds when the actual object is a decorator rather than an image. In release builds the same code silently produces UB via `static_cast`.

The new methods use non-throwing `dynamic_cast` and return `nullptr` when the slot holds a constant, consistent with ITK's convention that a null pointer means "not connected as an image."

This affects all five direct subclasses: `TernaryAddImageFilter`, `TernaryMagnitudeImageFilter`, `TernaryMagnitudeSquaredImageFilter`, `TernaryOperatorImageFilter`, and `MaskedAssignImageFilter`.

</details>

<details>
<summary>AI assistance</summary>

GitHub Copilot (Claude Sonnet 4.6) performed root-cause analysis and implemented the fix. Changes were reviewed and tested locally before committing.

</details>

<details>
<summary>Test results</summary>

```
ctest -R "TernaryGeneratorImageFilter.GetInputWithConstants|MaskedAssign" -V
100% tests passed, 4 tests passed out of 4
```

New gtest `TernaryGeneratorImageFilter.GetInputWithConstants` covers the image → constant → query cycle for all three input slots.

</details>