### PR TITLE
STYLE: Align maintenance script requires-python floor with ITK's 3.11

### DIFF
--- a/.github/skills/fix-nightly-warnings/scripts/get_build_warnings.py
+++ b/.github/skills/fix-nightly-warnings/scripts/get_build_warnings.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # /// script
-# requires-python = ">=3.8"
+# requires-python = ">=3.11"
 # ///
 """
 get_build_warnings.py — Fetch and summarize warnings or errors for a CDash build.

--- a/.github/skills/fix-nightly-warnings/scripts/list_nightly_warnings.py
+++ b/.github/skills/fix-nightly-warnings/scripts/list_nightly_warnings.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # /// script
-# requires-python = ">=3.8"
+# requires-python = ">=3.11"
 # ///
 """
 list_nightly_warnings.py — List ITK CDash builds that have warnings or errors.

--- a/.github/skills/fix-nightly-warnings/scripts/triage_nightly.py
+++ b/.github/skills/fix-nightly-warnings/scripts/triage_nightly.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # /// script
-# requires-python = ">=3.8"
+# requires-python = ">=3.11"
 # ///
 """
 triage_nightly.py — Single-command CDash nightly warning triage.


### PR DESCRIPTION
Bump the PEP 723 `requires-python` headers of the three `fix-nightly-warnings` maintenance scripts from `>=3.8` to `>=3.11`, matching ITK's enforced floor (`PYTHON_VERSION_MIN` in `CMake/ITKSetPython3Vars.cmake` and the runtime gate in `igenerator.py`).

<details>
<summary>Scope of the audit behind this change</summary>

A repo-wide sweep for sub-3.11 Python support references found the floor already enforced everywhere that matters (CMake configure, abi3/Limited-API floor, generated-code runtime gate) with no compat shims and no doc claims of older-version support. These three inline script headers were the only remaining places advertising an unsupported Python version. Release-note changelogs mentioning historical versions are immutable history and were left untouched.

</details>

<!--
provenance: claude-code session 2026-07-01
related: audit performed while planning validation suite for PR #6533
files: .github/skills/fix-nightly-warnings/scripts/{get_build_warnings,list_nightly_warnings,triage_nightly}.py line 3
-->
