### PR TITLE
ENH: Add MaskedAssignImageFilter to ITKImageIntensity

### DIFF
--- a/Modules/Filtering/ImageFilterBase/include/itkTernaryGeneratorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkTernaryGeneratorImageFilter.hxx
@@ -193,7 +193,7 @@ TernaryGeneratorImageFilter<TInputImage1, TInputImage2, TInputImage3, TOutputIma
   const DataObject * input = nullptr;
   const auto *       inputPtr1 = dynamic_cast<const TInputImage1 *>(ProcessObject::GetInput(0));
   const auto *       inputPtr2 = dynamic_cast<const TInputImage2 *>(ProcessObject::GetInput(1));
-  const auto *       inputPtr3 = dynamic_cast<const TInputImage2 *>(ProcessObject::GetInput(2));
+  const auto *       inputPtr3 = dynamic_cast<const TInputImage3 *>(ProcessObject::GetInput(2));
 
   if (this->GetNumberOfInputs() >= 3)
   {

--- a/Modules/Filtering/ImageFilterBase/test/itkGeneratorImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkGeneratorImageFilterGTest.cxx
@@ -441,10 +441,6 @@ TEST(TernaryGeneratorImageFilter, Constants)
 }
 
 
-// Test that GenerateOutputInformation correctly propagates metadata from input3
-// when inputs 1 and 2 are constants and input types differ (TInputImage2 != TInputImage3).
-// This exercises the code path that was previously broken by a wrong dynamic_cast
-// (TInputImage2 used instead of TInputImage3 for input slot 2).
 TEST(TernaryGeneratorImageFilter, MetadataPropagatedFromInput3WhenOtherInputsAreConstants)
 {
   using Input1Type = itk::Image<float, 3>;

--- a/Modules/Filtering/ImageFilterBase/test/itkGeneratorImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkGeneratorImageFilterGTest.cxx
@@ -439,3 +439,43 @@ TEST(TernaryGeneratorImageFilter, Constants)
 
   EXPECT_NEAR(103.0, outputImage->GetPixel(idx), 1e-8);
 }
+
+
+// Test that GenerateOutputInformation correctly propagates metadata from input3
+// when inputs 1 and 2 are constants and input types differ (TInputImage2 != TInputImage3).
+// This exercises the code path that was previously broken by a wrong dynamic_cast
+// (TInputImage2 used instead of TInputImage3 for input slot 2).
+TEST(TernaryGeneratorImageFilter, MetadataPropagatedFromInput3WhenOtherInputsAreConstants)
+{
+  using Input1Type = itk::Image<float, 3>;
+  using Input2Type = itk::Image<unsigned char, 3>;
+  using Input3Type = itk::Image<float, 3>;
+  using OutputType = itk::Image<float, 3>;
+
+  auto                 assignImage = Input3Type::New();
+  Input3Type::SizeType size;
+  size.Fill(7);
+  Input3Type::SpacingType spacing;
+  spacing.Fill(2.5);
+  assignImage->SetRegions(Input3Type::RegionType(size));
+  assignImage->SetSpacing(spacing);
+  assignImage->Allocate();
+  assignImage->FillBuffer(42.0f);
+
+  using FilterType = itk::TernaryGeneratorImageFilter<Input1Type, Input2Type, Input3Type, OutputType>;
+  auto filter = FilterType::New();
+  filter->SetConstant1(0.0f);
+  filter->SetConstant2(static_cast<unsigned char>(1));
+  filter->SetInput3(assignImage);
+  filter->SetFunctor([](float, unsigned char mask, float v3) -> float { return mask ? v3 : 0.0f; });
+
+  EXPECT_NO_THROW(filter->Update());
+
+  const auto * output = filter->GetOutput();
+  ASSERT_TRUE(output != nullptr);
+  EXPECT_EQ(size, output->GetLargestPossibleRegion().GetSize());
+  EXPECT_EQ(spacing, output->GetSpacing());
+
+  const Input3Type::IndexType idx{ { 0, 0, 0 } };
+  EXPECT_NEAR(42.0, output->GetPixel(idx), 1e-6);
+}

--- a/Modules/Filtering/ImageFilterBase/wrapping/itkTernaryGeneratorImageFilter.wrap
+++ b/Modules/Filtering/ImageFilterBase/wrapping/itkTernaryGeneratorImageFilter.wrap
@@ -1,3 +1,8 @@
 itk_wrap_class("itk::TernaryGeneratorImageFilter" POINTER)
 itk_wrap_image_filter("${WRAP_ITK_SCALAR}" 4)
+foreach(t ${WRAP_ITK_ALL_TYPES})
+  if(NOT "${t}" STREQUAL "UC")
+    itk_wrap_image_filter_combinations("${t}" "UC" "${t}" "${t}")
+  endif()
+endforeach()
 itk_end_wrap_class()

--- a/Modules/Filtering/ImageIntensity/include/itkMaskedAssignImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskedAssignImageFilter.h
@@ -34,7 +34,7 @@ namespace itk
  *
  * The first input is the "input image", the second is the "mask image",
  * the third is the "assign image". Any of the images can be set as constants,
- * with third input can be set as constant with the `SetAssignConstant` method.
+ * and the third input can also be set as a constant using the `SetAssignConstant` method.
  *
  * For the "masked input" non-zero values are considered the mask, and assigned values
  * from the "assign input".

--- a/Modules/Filtering/ImageIntensity/include/itkMaskedAssignImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskedAssignImageFilter.h
@@ -1,0 +1,130 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkMaskedAssignImageFilter_h
+#define itkMaskedAssignImageFilter_h
+
+#include "itkTernaryGeneratorImageFilter.h"
+#include "itkNumericTraits.h"
+
+namespace itk
+{
+
+/**
+ *\class MaskedAssignImageFilter
+ * \brief Assign values to a masked set of pixels.
+ *
+ * This class is templated over the types of the
+ * input image, the mask image and the type of the output image.
+ * Numeric conversions (castings) are done by the C++ defaults.
+ *
+ * The first input is the "input image", the second is the "mask image",
+ * the third is the "assign image". Any of the images can be set as constants,
+ * with third input can be set as constant with the `SetAssignConstant` method.
+ *
+ * For the "masked input" non-zero values are considered the mask, and assigned values
+ * from the "assign input".
+ *
+ * The following is the logic applied per pixel (pixel value or constant value) :
+ *
+   \code
+          if pixel_from_mask_image != 0
+               pixel_output_image = pixel_assign_image
+          else
+               pixel_output_image = pixel_input_image
+   \endcode
+ *
+ * The pixel from the "input image" is cast to the pixel type of the output image.
+ *
+ * Note all images must be geometrically congruent.
+ *
+ * \sa MaskImageFilter
+ * \ingroup ITKImageIntensity
+ *
+ */
+template <typename TInputImage, typename TMaskImage, typename TOutputImage = TInputImage>
+class MaskedAssignImageFilter : public TernaryGeneratorImageFilter<TInputImage, TMaskImage, TOutputImage, TOutputImage>
+
+{
+public:
+  ITK_DISALLOW_COPY_AND_MOVE(MaskedAssignImageFilter);
+
+  /** Standard class type aliases. */
+  using Self = MaskedAssignImageFilter;
+  using Superclass = TernaryGeneratorImageFilter<TInputImage, TMaskImage, TOutputImage, TOutputImage>;
+
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
+
+  /** Runtime information support. */
+  itkOverrideGetNameOfClassMacro(MaskedAssignImageFilter);
+
+  /** Typedefs **/
+  using InputImageType = TInputImage;
+  using MaskImageType = TMaskImage;
+  using AssignImageType = TOutputImage;
+  using OutputImageType = TOutputImage;
+
+  using OutputPixelType = typename OutputImageType::PixelType;
+
+  virtual void
+  SetMaskImage(const MaskImageType * mask)
+  {
+    this->SetInput2(mask);
+  }
+  virtual const MaskImageType *
+  GetMaskImage() const
+  {
+    return dynamic_cast<const MaskImageType *>(this->ProcessObject::GetInput(1));
+  }
+
+  virtual void
+  SetAssignImage(const AssignImageType * assign)
+  {
+    this->SetInput3(assign);
+  }
+  virtual const AssignImageType *
+  GetAssignImage() const
+  {
+    return dynamic_cast<const AssignImageType *>(this->ProcessObject::GetInput(2));
+  }
+
+  virtual void
+  SetAssignConstant(const OutputPixelType & v)
+  {
+    this->SetConstant3(v);
+  }
+  virtual OutputPixelType
+  GetAssignConstant() const
+  {
+    return this->GetConstant3();
+  }
+
+protected:
+  MaskedAssignImageFilter();
+  ~MaskedAssignImageFilter() override = default;
+};
+} // end namespace itk
+
+#endif
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "itkMaskedAssignImageFilter.hxx"
+#endif

--- a/Modules/Filtering/ImageIntensity/include/itkMaskedAssignImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskedAssignImageFilter.hxx
@@ -1,0 +1,49 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkMaskedAssignImageFilter_hxx
+#define itkMaskedAssignImageFilter_hxx
+
+#include "itkMaskedAssignImageFilter.h"
+
+namespace itk
+{
+template <typename TInputImage, typename TMaskImage, typename TOutputImage>
+MaskedAssignImageFilter<TInputImage, TMaskImage, TOutputImage>::MaskedAssignImageFilter()
+{
+  this->SetPrimaryInputName("InputImage");
+  this->AddRequiredInputName("MaskImage", 1);
+  this->AddRequiredInputName("AssignImage", 2);
+
+  auto func = [](const typename InputImageType::PixelType &  input,
+                 const typename MaskImageType::PixelType &   mask,
+                 const typename AssignImageType::PixelType & assign) -> OutputPixelType {
+    if (mask != NumericTraits<typename MaskImageType::PixelType>::Zero)
+    {
+      return assign;
+    }
+    else
+    {
+      return static_cast<OutputPixelType>(input);
+    }
+  };
+  this->SetFunctor(func);
+}
+
+} // end namespace itk
+
+#endif

--- a/Modules/Filtering/ImageIntensity/include/itkMaskedAssignImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskedAssignImageFilter.hxx
@@ -32,7 +32,7 @@ MaskedAssignImageFilter<TInputImage, TMaskImage, TOutputImage>::MaskedAssignImag
   auto func = [](const typename InputImageType::PixelType &  input,
                  const typename MaskImageType::PixelType &   mask,
                  const typename AssignImageType::PixelType & assign) -> OutputPixelType {
-    if (mask != NumericTraits<typename MaskImageType::PixelType>::Zero)
+    if (mask != NumericTraits<typename MaskImageType::PixelType>::ZeroValue())
     {
       return assign;
     }

--- a/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageIntensity/test/CMakeLists.txt
@@ -791,6 +791,7 @@ set(
   itkGreaterGTest.cxx
   itkLessEqualGTest.cxx
   itkLessGTest.cxx
+  itkMaskedAssignImageFilterGTest.cxx
   itkNotEqualGTest.cxx
   itkRoundImageFilterGTest.cxx
   itkSquareImageFilterGTest.cxx

--- a/Modules/Filtering/ImageIntensity/test/itkMaskedAssignImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMaskedAssignImageFilterGTest.cxx
@@ -209,9 +209,9 @@ TEST_F(MaskedAssignFixture, Test1)
   EXPECT_NO_THROW(filter->SetAssignConstant(5));
   EXPECT_EQ(5, filter->GetAssignConstant());
 
-  mask->SetPixel({ { 0, 0 } }, 1);
-
-  mask->SetPixel({ { 20, 21 } }, 1);
+  mask->SetPixel({ { 0, 0, 0 } }, 1);
+  mask->SetPixel({ { 20, 21, 0 } }, 1);
+  mask->SetPixel({ { 10, 10, 5 } }, 1);
 
   filter->SetInput(image);
   filter->SetMaskImage(mask);
@@ -219,14 +219,12 @@ TEST_F(MaskedAssignFixture, Test1)
   filter->Update();
   auto output = filter->GetOutput();
 
-  EXPECT_EQ(5, output->GetPixel({ { 0, 0 } }));
-  EXPECT_EQ(99, output->GetPixel({ { 0, 1 } }));
-
-  EXPECT_EQ(99, output->GetPixel({ { 1, 1 } }));
-
-  EXPECT_EQ(5, output->GetPixel({ { 20, 21 } }));
-
-  EXPECT_EQ("b28618b5cccaa828028a29b44d88c728", MD5Hash(output));
+  EXPECT_EQ(5, output->GetPixel({ { 0, 0, 0 } }));
+  EXPECT_EQ(99, output->GetPixel({ { 0, 1, 0 } }));
+  EXPECT_EQ(99, output->GetPixel({ { 1, 1, 0 } }));
+  EXPECT_EQ(5, output->GetPixel({ { 20, 21, 0 } }));
+  EXPECT_EQ(5, output->GetPixel({ { 10, 10, 5 } }));
+  EXPECT_EQ(99, output->GetPixel({ { 10, 10, 4 } }));
 }
 
 
@@ -250,9 +248,9 @@ TEST_F(MaskedAssignFixture, VectorTest2)
 
   auto mask = Utils::CreateMaskImage(21);
   mask->FillBuffer(0);
-  mask->SetPixel({ { 2, 2 } }, 1);
-
-  mask->SetPixel({ { 3, 19 } }, 1);
+  mask->SetPixel({ { 2, 2, 0 } }, 1);
+  mask->SetPixel({ { 3, 19, 0 } }, 1);
+  mask->SetPixel({ { 5, 5, 5 } }, 1);
 
   filter->SetInput(image);
   filter->SetMaskImage(mask);
@@ -260,10 +258,9 @@ TEST_F(MaskedAssignFixture, VectorTest2)
   filter->Update();
   auto output = filter->GetOutput();
 
-  EXPECT_EQ(p, output->GetPixel({ { 0, 0 } }));
-  EXPECT_EQ(c, output->GetPixel({ { 2, 2 } }));
-  EXPECT_EQ(c, output->GetPixel({ { 3, 19 } }));
-
-
-  EXPECT_EQ("f089464fcbec9429f409ee779788cca3", MD5Hash(output));
+  EXPECT_EQ(p, output->GetPixel({ { 0, 0, 0 } }));
+  EXPECT_EQ(c, output->GetPixel({ { 2, 2, 0 } }));
+  EXPECT_EQ(c, output->GetPixel({ { 3, 19, 0 } }));
+  EXPECT_EQ(c, output->GetPixel({ { 5, 5, 5 } }));
+  EXPECT_EQ(p, output->GetPixel({ { 5, 5, 4 } }));
 }

--- a/Modules/Filtering/ImageIntensity/test/itkMaskedAssignImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkMaskedAssignImageFilterGTest.cxx
@@ -1,0 +1,269 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkGTest.h"
+
+#include "itkMaskedAssignImageFilter.h"
+#include "itkVectorImage.h"
+
+#include "itkTestDriverIncludeRequiredIOFactories.h"
+#include "itkTestingHashImageFilter.h"
+
+namespace
+{
+class MaskedAssignFixture : public ::testing::Test
+{
+public:
+  MaskedAssignFixture() = default;
+  ~MaskedAssignFixture() override = default;
+
+protected:
+  void
+  SetUp() override
+  {
+    RegisterRequiredFactories();
+  }
+
+  template <typename TImageType>
+  static std::string
+  MD5Hash(const TImageType * image)
+  {
+
+    using HashFilter = itk::Testing::HashImageFilter<TImageType>;
+    typename HashFilter::Pointer hasher = HashFilter::New();
+    hasher->SetInput(image);
+    hasher->InPlaceOff();
+    hasher->Update();
+    return hasher->GetHash();
+  }
+
+  template <typename TInputImage, typename TMaskImage = TInputImage>
+  struct FixtureUtilities
+  {
+    static const unsigned int Dimension = TInputImage::ImageDimension;
+
+    using PixelType = typename TInputImage::PixelType;
+    using OutputPixelType = PixelType;
+    using InputImageType = TInputImage;
+    using OutputImageType = TInputImage;
+    using RegionType = typename InputImageType::RegionType;
+    using SizeType = typename TInputImage::SizeType;
+    using IndexType = typename TInputImage::IndexType;
+
+
+    using MaskImageType = TMaskImage;
+    using MaskRegionType = typename MaskImageType::RegionType;
+    using MaskSizeType = typename MaskImageType::SizeType;
+    using MaskIndexType = typename MaskImageType::IndexType;
+
+    using FilterType = itk::MaskedAssignImageFilter<InputImageType, MaskImageType, OutputImageType>;
+
+    // Create a black image or empty
+    template <typename TImage>
+    static typename TImage::Pointer
+    CreateImageT(unsigned int size = 100)
+    {
+      typename TImage::Pointer image = TImage::New();
+
+      typename TImage::SizeType imageSize;
+      imageSize.Fill(size);
+      image->SetRegions(typename TImage::RegionType(imageSize));
+      InitializeImage(image.GetPointer());
+
+      return image;
+    }
+
+    template <typename TPixelType, unsigned int D>
+    static void
+    InitializeImage(itk::Image<TPixelType, D> * image)
+    {
+      image->Allocate();
+      image->FillBuffer(itk::NumericTraits<TPixelType>::ZeroValue());
+    }
+
+
+    template <typename TPixelType, unsigned int D>
+    static void
+    InitializeImage(itk::VectorImage<TPixelType, D> * image)
+    {
+      constexpr unsigned int sz = 3;
+      image->SetNumberOfComponentsPerPixel(sz);
+      image->Allocate();
+      itk::VariableLengthVector<TPixelType> p{ sz };
+      p.Fill(itk::NumericTraits<TPixelType>::ZeroValue());
+      image->FillBuffer(p);
+    }
+
+    static constexpr auto CreateImage = CreateImageT<InputImageType>;
+    static constexpr auto CreateMaskImage = CreateImageT<MaskImageType>;
+  };
+};
+} // namespace
+
+
+TEST_F(MaskedAssignFixture, SetGetPrint)
+{
+  using Utils = FixtureUtilities<itk::Image<float, 3>>;
+
+  auto filter = Utils::FilterType::New();
+
+  auto image = Utils::CreateImage(100);
+
+
+  EXPECT_STREQ("MaskedAssignImageFilter", filter->GetNameOfClass());
+
+  EXPECT_NO_THROW(filter->SetInput(image));
+  EXPECT_EQ(image, filter->GetInput());
+  EXPECT_ANY_THROW(filter->GetConstant1());
+
+  image = Utils::CreateImage(100);
+  EXPECT_NO_THROW(filter->SetInput1(image));
+  EXPECT_EQ(image, filter->GetInput());
+  EXPECT_ANY_THROW(filter->GetConstant1());
+
+  EXPECT_NO_THROW(filter->SetConstant1(1));
+  // EXPECT_NO_THROW(filter->GetInput()); Base methods do not support multiple types in an input
+  EXPECT_EQ(1, filter->GetConstant1());
+
+  EXPECT_NO_THROW(filter->SetInput(image));
+  EXPECT_EQ(image, filter->GetInput());
+  EXPECT_ANY_THROW(filter->GetConstant1());
+
+
+  image = Utils::CreateImage(100);
+  EXPECT_NO_THROW(filter->SetInput2(image));
+  EXPECT_EQ(image, filter->GetMaskImage());
+  EXPECT_ANY_THROW(filter->GetConstant2());
+
+  image = Utils::CreateImage(100);
+  EXPECT_NO_THROW(filter->SetMaskImage(image));
+  EXPECT_EQ(image, filter->GetMaskImage());
+  EXPECT_ANY_THROW(filter->GetConstant2());
+
+  EXPECT_NO_THROW(filter->SetConstant2(2));
+  EXPECT_NO_THROW(filter->GetMaskImage());
+  EXPECT_EQ(2, filter->GetConstant2());
+
+  EXPECT_NO_THROW(filter->SetMaskImage(image));
+  EXPECT_EQ(image, filter->GetMaskImage());
+  EXPECT_ANY_THROW(filter->GetConstant2());
+
+
+  image = Utils::CreateImage(100);
+  EXPECT_NO_THROW(filter->SetInput3(image));
+  EXPECT_EQ(image, filter->GetAssignImage());
+  EXPECT_ANY_THROW(filter->GetConstant3());
+  EXPECT_ANY_THROW(filter->GetAssignConstant());
+
+  image = Utils::CreateImage(100);
+  EXPECT_NO_THROW(filter->SetAssignImage(image));
+  EXPECT_EQ(image, filter->GetAssignImage());
+  EXPECT_ANY_THROW(filter->GetConstant3());
+  EXPECT_ANY_THROW(filter->GetAssignConstant());
+
+  EXPECT_NO_THROW(filter->SetConstant3(3));
+  EXPECT_NO_THROW(filter->GetMaskImage());
+  EXPECT_EQ(3, filter->GetConstant3());
+
+  EXPECT_NO_THROW(filter->SetAssignImage(image));
+  EXPECT_EQ(image, filter->GetAssignImage());
+  EXPECT_ANY_THROW(filter->GetConstant3());
+  EXPECT_ANY_THROW(filter->GetAssignConstant());
+
+  EXPECT_NO_THROW(filter->SetAssignConstant(4));
+  EXPECT_NO_THROW(filter->GetMaskImage());
+  EXPECT_EQ(4, filter->GetConstant3());
+  EXPECT_EQ(4, filter->GetAssignConstant());
+}
+
+
+TEST_F(MaskedAssignFixture, Test1)
+{
+
+  using Utils = FixtureUtilities<itk::Image<float, 3>, itk::Image<unsigned char, 3>>;
+
+
+  auto image = Utils::CreateImage(100);
+  image->FillBuffer(99);
+
+  auto mask = Utils::CreateMaskImage(100);
+  mask->FillBuffer(0);
+
+  auto filter = Utils::FilterType::New();
+
+  EXPECT_NO_THROW(filter->SetAssignConstant(5));
+  EXPECT_EQ(5, filter->GetAssignConstant());
+
+  mask->SetPixel({ { 0, 0 } }, 1);
+
+  mask->SetPixel({ { 20, 21 } }, 1);
+
+  filter->SetInput(image);
+  filter->SetMaskImage(mask);
+
+  filter->Update();
+  auto output = filter->GetOutput();
+
+  EXPECT_EQ(5, output->GetPixel({ { 0, 0 } }));
+  EXPECT_EQ(99, output->GetPixel({ { 0, 1 } }));
+
+  EXPECT_EQ(99, output->GetPixel({ { 1, 1 } }));
+
+  EXPECT_EQ(5, output->GetPixel({ { 20, 21 } }));
+
+  EXPECT_EQ("b28618b5cccaa828028a29b44d88c728", MD5Hash(output));
+}
+
+
+TEST_F(MaskedAssignFixture, VectorTest2)
+{
+
+  using Utils = FixtureUtilities<itk::VectorImage<unsigned char, 3>, itk::Image<unsigned char, 3>>;
+
+  auto             image = Utils::CreateImage(21);
+  Utils::PixelType p{ image->GetNumberOfComponentsPerPixel() };
+  p.Fill(12);
+  image->FillBuffer(p);
+
+  auto filter = Utils::FilterType::New();
+
+  Utils::PixelType c{ 3 };
+  c.Fill(0);
+  EXPECT_NO_THROW(filter->SetAssignConstant(c));
+  EXPECT_EQ(c, filter->GetAssignConstant());
+
+
+  auto mask = Utils::CreateMaskImage(21);
+  mask->FillBuffer(0);
+  mask->SetPixel({ { 2, 2 } }, 1);
+
+  mask->SetPixel({ { 3, 19 } }, 1);
+
+  filter->SetInput(image);
+  filter->SetMaskImage(mask);
+
+  filter->Update();
+  auto output = filter->GetOutput();
+
+  EXPECT_EQ(p, output->GetPixel({ { 0, 0 } }));
+  EXPECT_EQ(c, output->GetPixel({ { 2, 2 } }));
+  EXPECT_EQ(c, output->GetPixel({ { 3, 19 } }));
+
+
+  EXPECT_EQ("f089464fcbec9429f409ee779788cca3", MD5Hash(output));
+}

--- a/Modules/Filtering/ImageIntensity/wrapping/itkMaskedAssignImageFilter.wrap
+++ b/Modules/Filtering/ImageIntensity/wrapping/itkMaskedAssignImageFilter.wrap
@@ -1,5 +1,5 @@
 itk_wrap_class("itk::MaskedAssignImageFilter" POINTER)
 foreach(t ${WRAP_ITK_ALL_TYPES})
-  itk_wrap_image_filter_combinations("${t}" "${WRAP_ITK_INT}" "${t}")
+  itk_wrap_image_filter_combinations("${t}" "UC" "${t}")
 endforeach()
 itk_end_wrap_class()

--- a/Modules/Filtering/ImageIntensity/wrapping/itkMaskedAssignImageFilter.wrap
+++ b/Modules/Filtering/ImageIntensity/wrapping/itkMaskedAssignImageFilter.wrap
@@ -1,0 +1,5 @@
+itk_wrap_class("itk::MaskedAssignImageFilter" POINTER)
+foreach(t ${WRAP_ITK_ALL_TYPES})
+  itk_wrap_image_filter_combinations("${t}" "${WRAP_ITK_INT}" "${t}")
+endforeach()
+itk_end_wrap_class()


### PR DESCRIPTION
Move `MaskedAssignImageFilter` from the `SimpleITKFilters` remote module into the `ITKImageIntensity` core module.

<details>
<summary>Details</summary>

- Copies `itkMaskedAssignImageFilter.h/.hxx` to `Modules/Filtering/ImageIntensity/include/`; updates `\ingroup` annotation
- Copies Google Test to `Modules/Filtering/ImageIntensity/test/`; adds wrapping (`itkMaskedAssignImageFilter.wrap`)
- Removes the files from `ITKSimpleITKFilters` via companion PR
- All 3 Google Tests pass locally

</details>