### PR TITLE
COMP: Link namespaced DCMTK targets in the DCMTK IO modules

### DIFF
--- a/Modules/IO/DCMTK/src/CMakeLists.txt
+++ b/Modules/IO/DCMTK/src/CMakeLists.txt
@@ -21,12 +21,12 @@ target_include_directories(ITKIODCMTK PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(
   ITKIODCMTK
   PRIVATE
-    dcmdata
-    dcmimgle
-    dcmimage
-    dcmjpeg
-    dcmjpls
-    oflog
+    DCMTK::dcmdata
+    DCMTK::dcmimgle
+    DCMTK::dcmimage
+    DCMTK::dcmjpeg
+    DCMTK::dcmjpls
+    DCMTK::oflog
 )
 
 if(DEFINED DCMTK_HAVE_CONFIG_H_OPTIONAL AND NOT DCMTK_HAVE_CONFIG_H_OPTIONAL)

--- a/Modules/IO/IOTransformDCMTK/src/CMakeLists.txt
+++ b/Modules/IO/IOTransformDCMTK/src/CMakeLists.txt
@@ -10,7 +10,7 @@ list(REMOVE_ITEM ITK_MODULE_IOTransformDCMTK_PRIVATE_DEPENDS ITKDCMTK)
 
 itk_module_add_library(IOTransformDCMTK ${IOTransformDCMTK_SRCS})
 
-target_link_libraries(IOTransformDCMTK PRIVATE dcmdata)
+target_link_libraries(IOTransformDCMTK PRIVATE DCMTK::dcmdata)
 
 # itkDCMTKTransformIO.hxx is a private implementation header in this directory.
 target_include_directories(IOTransformDCMTK PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/Modules/ThirdParty/DCMTK/CMakeLists.txt
+++ b/Modules/ThirdParty/DCMTK/CMakeLists.txt
@@ -107,6 +107,9 @@ else(ITK_USE_SYSTEM_DCMTK)
 
   # DCMTK build options; compiler and language-standard settings inherit from ITK's scope.
   set(BUILD_APPS OFF)
+  # Per-library targets only: a single-library build renames targets with a
+  # suffix the DCMTK IO modules' DCMTK::<lib> link names cannot match.
+  set(BUILD_SINGLE_SHARED_LIBRARY OFF)
   set(DCMTK_ENABLE_CXX11 ON)
   set(DCMTK_FORCE_FPIC_ON_UNIX ON)
   set(DCMTK_DEFAULT_DICT builtin)
@@ -148,21 +151,15 @@ else(ITK_USE_SYSTEM_DCMTK)
   # namespaced name in ITKTargets.cmake, matching what find_package(DCMTK)
   # yields for downstream consumers.
   foreach(_dcmtk_lib IN LISTS _ITKDCMTK_LIB_NAMES)
-    set(_dcmtk_target "${_dcmtk_lib}${DCMTK_LIBRARY_SUFFIX}")
-    if(TARGET "${_dcmtk_target}")
-      if(NOT TARGET "DCMTK::${_dcmtk_target}")
-        add_library("DCMTK::${_dcmtk_target}" INTERFACE IMPORTED GLOBAL)
-        target_link_libraries(
-          "DCMTK::${_dcmtk_target}"
-          INTERFACE
-            "${_dcmtk_target}"
-        )
+    if(TARGET "${_dcmtk_lib}")
+      if(NOT TARGET "DCMTK::${_dcmtk_lib}")
+        add_library("DCMTK::${_dcmtk_lib}" INTERFACE IMPORTED GLOBAL)
+        target_link_libraries("DCMTK::${_dcmtk_lib}" INTERFACE "${_dcmtk_lib}")
       endif()
-      list(APPEND ITKDCMTK_LIBRARIES "DCMTK::${_dcmtk_target}")
+      list(APPEND ITKDCMTK_LIBRARIES "DCMTK::${_dcmtk_lib}")
     endif()
   endforeach()
   unset(_dcmtk_lib)
-  unset(_dcmtk_target)
 
   # Build-tree consumers: locate DCMTKConfig.cmake in ITK's build root.
   set(

--- a/Modules/ThirdParty/DCMTK/itk-module-init.cmake
+++ b/Modules/ThirdParty/DCMTK/itk-module-init.cmake
@@ -5,7 +5,8 @@ option(ITK_USE_SYSTEM_DCMTK "Use an outside build of DCMTK." OFF)
 if(ITK_USE_SYSTEM_DCMTK)
   # Use local FindDCMTK.cmake.
   list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}/CMake")
-  find_package(DCMTK REQUIRED NO_MODULE)
+  # 3.7.0 matches the vendored DCMTK and guarantees DCMTK::-namespaced targets.
+  find_package(DCMTK 3.7.0 REQUIRED NO_MODULE)
 else()
   # Change default from OFF to ON for portability.
   option(


### PR DESCRIPTION
Link the DCMTK IO modules against `DCMTK::`-namespaced targets so the exported link interface resolves for external consumers, and require DCMTK 3.7.0+ for `ITK_USE_SYSTEM_DCMTK` (the first release whose package config exports those namespaced targets).

<details>
<summary>Why</summary>

Bare `dcmdata`/`dcmimgle`/... names survive only inside ITK's own build scope; the exported link interface then carries `$<LINK_ONLY:dcmdata>`, which no external consumer of the ITK build tree can resolve. The `DCMTK::` wrapper targets export as `DCMTK::dcmdata`, which consumers resolve through `find_package(DCMTK)`.

`BUILD_SINGLE_SHARED_LIBRARY` is pinned OFF with a plain `set()` (per review): a single-library build renames the per-library targets with a suffix the `DCMTK::<lib>` link names cannot match.

</details>

<details>
<summary>Testing</summary>

Configured and built `Module_ITKIODCMTK` + `IOTransformDCMTK` locally with the vendored DCMTK; all 46 DCMTK tests pass. Also verified the stale-cache scenario from review: with a poisoned `BUILD_SINGLE_SHARED_LIBRARY:BOOL=ON` cache entry, configure/generate still produce the per-library targets (the plain `set()` shadows the cache).

</details>

The build-tree export repair for the `DCMTK::ITK::*Module` mis-prefix (formerly the third commit here) is split out to #6548 (draft) for closer inspection, per @blowekamp. **Note:** #6548 should land with or promptly after this PR — with the namespaced linking alone, an external *build-tree* consumer fails at generate resolving `DCMTK::ITK::*Module` (verified repro in #6548; on current `main` the same consumer instead fails at link time, so no working flow regresses). Install-tree consumers are unaffected.

<!--
provenance: claude-code 2026-07-03
split: third commit (bcc43b3d91b) moved to follow-up PR per blowekamp request
review_fix: BUILD_SINGLE_SHARED_LIBRARY plain set() per blowekamp inline (thread 3516761077)
key_files: Modules/ThirdParty/DCMTK/CMakeLists.txt ; Modules/IO/DCMTK/src/CMakeLists.txt ; Modules/ThirdParty/DCMTK/itk-module-init.cmake
-->
