### PR TITLE
Fail fast for system SWIG 4.4+ with Python limited API

### DIFF
--- a/Wrapping/Generators/SwigInterface/CMakeLists.txt
+++ b/Wrapping/Generators/SwigInterface/CMakeLists.txt
@@ -189,6 +189,23 @@ if(ITK_USE_SYSTEM_SWIG)
       "Swig version less than ${swig_version_min}: \"${SWIG_VERSION}\". Set ITK_USE_SYSTEM_SWIG=OFF or provide a newer swig."
     )
   endif()
+
+  # Known-broken combination: system SWIG 4.4+ with Python Limited API emits
+  # wrappers that fail at import time (missing delete_SwigPyIterator on moduledef).
+  if(
+    ITK_WRAP_PYTHON
+    AND
+      ITK_USE_PYTHON_LIMITED_API
+    AND
+      SWIG_VERSION
+        VERSION_GREATER_EQUAL
+        4.4.0
+  )
+    message(
+      FATAL_ERROR
+      "System SWIG ${SWIG_VERSION} with ITK_USE_PYTHON_LIMITED_API=ON is currently unsupported due to import-time wrapper failures. Use system SWIG 4.3.x, set ITK_USE_PYTHON_LIMITED_API=OFF, or set ITK_USE_SYSTEM_SWIG=OFF."
+    )
+  endif()
 elseif(swig_prebuilt)
   # Download and extract the prebuilt swig binary at configure time via
   # FetchContent so SWIG_EXECUTABLE exists immediately and can be verified.


### PR DESCRIPTION
## Summary
- add a configure-time guard for the known-broken combination:
  - ITK_USE_SYSTEM_SWIG=ON
  - ITK_WRAP_PYTHON=ON
  - ITK_USE_PYTHON_LIMITED_API=ON
  - SWIG_VERSION >= 4.4.0
- emit a clear actionable error instead of allowing a build that fails later at Python import time

## Why
Issue #6479 documents that this combination can compile/link but then fails at import with missing delete_SwigPyIterator from the generated limited-API wrapper module. This change prevents users from reaching that late failure mode.

## User guidance in error
The message recommends one of:
- use system SWIG 4.3.x
- set ITK_USE_PYTHON_LIMITED_API=OFF
- or set ITK_USE_SYSTEM_SWIG=OFF

## Testing
- CMake configure logic change only (no runtime behavior change outside guarded configuration path)
- patch validated by source inspection and targeted diff.