### PR TITLE
ENH: Serve SWIG/PCRE archives via direct-file IPFS CIDs (release-5.4)

### DIFF
--- a/Wrapping/Generators/SwigInterface/CMakeLists.txt
+++ b/Wrapping/Generators/SwigInterface/CMakeLists.txt
@@ -3,13 +3,20 @@
 # This means that ITK cannot be built in a path that contains spaces
 # See https://www.swig.org/Doc1.3/Windows.html
 if("${CMAKE_BINARY_DIR}" MATCHES "^.* .*$")
-  message(FATAL_ERROR "Swig and PCRE do not support paths with space characters. Please change build directory name.")
+  message(
+    FATAL_ERROR
+    "Swig and PCRE do not support paths with space characters. Please change build directory name."
+  )
 endif()
 
 ###############################################################################
 # Build swig
 
-option(ITK_USE_SYSTEM_SWIG "Use system swig. If OFF, swig is built as an external project." OFF)
+option(
+  ITK_USE_SYSTEM_SWIG
+  "Use system swig. If OFF, swig is built as an external project."
+  OFF
+)
 mark_as_advanced(ITK_USE_SYSTEM_SWIG)
 
 # Minimal swig version
@@ -19,50 +26,93 @@ set(ITK_SWIG_VERSION 2024-03-26-master)
 
 if(WIN32)
   set(swig_cmake_version 4.3.0)
-  set(swigwin_hash
-      "cec9eeebfec7f2a8ccf7b166a11cf8dbbc5e1eacca35563e4f0882b2b261658f394f6607243813d7083e7e2a2bbec23c5cf8b4dd92ad85838c6eb971f3833715"
+  set(
+    swigwin_hash
+    "cec9eeebfec7f2a8ccf7b166a11cf8dbbc5e1eacca35563e4f0882b2b261658f394f6607243813d7083e7e2a2bbec23c5cf8b4dd92ad85838c6eb971f3833715"
   )
   set(swigwin_cid "bafybeibavyfwb5fenlrjxvhd4pj55brbbvphcgpuwlmbyusrwn44rs2hcq")
 
-  set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swigwin-amd64-${ITK_SWIG_VERSION}/bin/swig.exe")
-elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64"))
-  set(swig_cmake_version 4.3.0)
-  if (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
-    set(swiglinux_hash
-        "9a3cfa330235ac78799c7401299506db5ea7459314b781bf27f2db8ddb582508ec5b15c2fa96fc241d5b832c4f702cd9ef043a61e37a574cac7ca78e4aba8f78"
+  set(
+    swig_ep
+    "${CMAKE_CURRENT_BINARY_DIR}/swigwin-amd64-${ITK_SWIG_VERSION}/bin/swig.exe"
+  )
+elseif(
+  CMAKE_HOST_SYSTEM_NAME
+    MATCHES
+    "Linux"
+  AND
+    (
+      CMAKE_HOST_SYSTEM_PROCESSOR
+        STREQUAL
+        "x86_64"
+      OR
+        CMAKE_HOST_SYSTEM_PROCESSOR
+          STREQUAL
+          "aarch64"
     )
-    set(swiglinux_cid "bafybeiasuvglbnjji24hiqpzry65kpqszjxyg4bup5ophfel4noykqemwy")
+)
+  set(swig_cmake_version 4.3.0)
+  if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
+    set(
+      swiglinux_hash
+      "9a3cfa330235ac78799c7401299506db5ea7459314b781bf27f2db8ddb582508ec5b15c2fa96fc241d5b832c4f702cd9ef043a61e37a574cac7ca78e4aba8f78"
+    )
+    set(
+      swiglinux_cid
+      "bafybeiasuvglbnjji24hiqpzry65kpqszjxyg4bup5ophfel4noykqemwy"
+    )
     set(swiglinux_arch "arm64")
   else()
-    set(swiglinux_hash
-        "bdf82ad5281dfdba4b24c83b0d15c76e83cd58c6c78ecfc7a449f869f524d12fad9ad7f517995f864c2c00e61e7cd04132a442038197b92821b4011673a7d4fe"
+    set(
+      swiglinux_hash
+      "bdf82ad5281dfdba4b24c83b0d15c76e83cd58c6c78ecfc7a449f869f524d12fad9ad7f517995f864c2c00e61e7cd04132a442038197b92821b4011673a7d4fe"
     )
-    set(swiglinux_cid "bafybeiemc7gbf6bgh4yopzudhp56dsb36ks6eltq7m5sny4ifr5n2vrulu")
+    set(
+      swiglinux_cid
+      "bafybeiemc7gbf6bgh4yopzudhp56dsb36ks6eltq7m5sny4ifr5n2vrulu"
+    )
     set(swiglinux_arch "amd64")
   endif()
 
-  set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swiglinux-${swiglinux_arch}-${ITK_SWIG_VERSION}/bin/swig")
+  set(
+    swig_ep
+    "${CMAKE_CURRENT_BINARY_DIR}/swiglinux-${swiglinux_arch}-${ITK_SWIG_VERSION}/bin/swig"
+  )
 elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
   set(swig_cmake_version 4.3.0)
-  if (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")
-    set(swigmacos_hash
+  if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")
+    set(
+      swigmacos_hash
       "96eec93fd9e1df35813f8cc194a8811c8c84f265284c1515ec81aa7e696aee2c952f426e5155c011c163376e76245f5d7f479525f0d1ea8396524629ed6b8aec"
     )
-    set(swigmacos_cid "bafybeihhw3wktwsi4evq3sfy4rujb5eia4shzqtw7dvgt6s2zsag2ealmm")
+    set(
+      swigmacos_cid
+      "bafybeihhw3wktwsi4evq3sfy4rujb5eia4shzqtw7dvgt6s2zsag2ealmm"
+    )
     set(swigmacos_arch "arm64")
   else()
-    set(swigmacos_hash
+    set(
+      swigmacos_hash
       "169760d2a34c2a95a907e80d93c1dc7ebc33a7dd34eb7ed7a9841866db3e25f7d7e93bf49ea28db01843aca5c2c6712756c1f01f6531d6ee027dc6eb293d95d7"
     )
-    set(swigmacos_cid "bafybeiegnvdxavxc7gcf5nfkalpej64p6stn54mzv7nfdwtr5k4vkjvbte")
+    set(
+      swigmacos_cid
+      "bafybeiegnvdxavxc7gcf5nfkalpej64p6stn54mzv7nfdwtr5k4vkjvbte"
+    )
     set(swigmacos_arch "amd64")
   endif()
 
-  set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swigmacos-${swigmacos_arch}-${ITK_SWIG_VERSION}/bin/swig")
+  set(
+    swig_ep
+    "${CMAKE_CURRENT_BINARY_DIR}/swigmacos-${swigmacos_arch}-${ITK_SWIG_VERSION}/bin/swig"
+  )
 else()
   # Build from source
 
-  set(swig_hash "9292f6786abed379278b8024f91b91f293f1be9764fe3c1a19023f7891c4e40587f965680ac6a595a5610cfb6650a73fd2f3932a83d5effad83f351fa70810a9")
+  set(
+    swig_hash
+    "9292f6786abed379278b8024f91b91f293f1be9764fe3c1a19023f7891c4e40587f965680ac6a595a5610cfb6650a73fd2f3932a83d5effad83f351fa70810a9"
+  )
   set(swig_cid "bafybeidevegcr53m6hrfhvel2ahpyla5rfddu5ycsxsjv5ylmzo4czuubu")
 
   # follow the standard EP_PREFIX locations
@@ -74,7 +124,6 @@ else()
 endif()
 
 if(ITK_USE_SYSTEM_SWIG)
-
   # the path set for the EP build prevents find_package to do its job
   if("${SWIG_EXECUTABLE}" STREQUAL "${swig_ep}")
     unset(SWIG_DIR CACHE)
@@ -87,9 +136,11 @@ if(ITK_USE_SYSTEM_SWIG)
 
   # Check for the swig version
   if(${SWIG_VERSION} VERSION_LESS ${swig_version_min})
-    message(WARNING "Swig version less than ${swig_version_min}: \"${SWIG_VERSION}\".")
+    message(
+      WARNING
+      "Swig version less than ${swig_version_min}: \"${SWIG_VERSION}\"."
+    )
   endif()
-
 else()
   if(NOT TARGET swig)
     # Install swig ourselves
@@ -103,7 +154,11 @@ else()
     if(${CMAKE_VERSION} VERSION_LESS 3.24)
       set(download_extract_timestamp_flag)
     else()
-      set(download_extract_timestamp_flag DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
+      set(
+        download_extract_timestamp_flag
+        DOWNLOAD_EXTRACT_TIMESTAMP
+        TRUE
+      )
     endif()
 
     if(WIN32)
@@ -113,39 +168,70 @@ else()
       endif()
       ExternalProject_Add(
         swig
-        URL "https://data.kitware.com/api/v1/file/hashsum/sha512/${swigwin_hash}/download"
-            "https://itk.mypinata.cloud/ipfs/${swigwin_cid}"
-            "https://ipfs.io/ipfs/${swigwin_cid}"
-            "https://gateway.pinata.cloud/ipfs/${swigwin_cid}"
-            "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/${swigwin_cid}"
-            "https://ipfs.filebase.io/ipfs/${swigwin_cid}"
+        URL
+          "https://data.kitware.com/api/v1/file/hashsum/sha512/${swigwin_hash}/download"
+          "https://itk.mypinata.cloud/ipfs/${swigwin_cid}"
+          "https://ipfs.io/ipfs/${swigwin_cid}"
+          "https://gateway.pinata.cloud/ipfs/${swigwin_cid}"
+          "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/${swigwin_cid}"
+          "https://ipfs.filebase.io/ipfs/${swigwin_cid}"
         URL_HASH SHA512=${swigwin_hash}
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/swigwin-amd64-${SWIG_VERSION}
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND ""
-        INSTALL_COMMAND "" ${download_extract_timestamp_flag})
-      set(SWIG_DIR ${CMAKE_CURRENT_BINARY_DIR}/swigwin-amd64-${SWIG_VERSION}/bin)
-    elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64"))
+        CONFIGURE_COMMAND
+          ""
+        BUILD_COMMAND
+          ""
+        INSTALL_COMMAND
+          "" ${download_extract_timestamp_flag}
+      )
+      set(
+        SWIG_DIR
+        ${CMAKE_CURRENT_BINARY_DIR}/swigwin-amd64-${SWIG_VERSION}/bin
+      )
+    elseif(
+      CMAKE_HOST_SYSTEM_NAME
+        MATCHES
+        "Linux"
+      AND
+        (
+          CMAKE_HOST_SYSTEM_PROCESSOR
+            STREQUAL
+            "x86_64"
+          OR
+            CMAKE_HOST_SYSTEM_PROCESSOR
+              STREQUAL
+              "aarch64"
+        )
+    )
       # If we are building ITK
       if(ITK_BINARY_DIR)
         itk_download_attempt_check(SWIG)
       endif()
       ExternalProject_Add(
         swig
-        URL "https://data.kitware.com/api/v1/file/hashsum/sha512/${swiglinux_hash}/download"
-            "https://itk.mypinata.cloud/ipfs/${swiglinux_cid}"
-            "https://ipfs.io/ipfs/${swiglinux_cid}"
-            "https://gateway.pinata.cloud/ipfs/${swiglinux_cid}"
-            "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/${swiglinux_cid}"
-            "https://ipfs.filebase.io/ipfs/${swiglinux_cid}"
+        URL
+          "https://data.kitware.com/api/v1/file/hashsum/sha512/${swiglinux_hash}/download"
+          "https://itk.mypinata.cloud/ipfs/${swiglinux_cid}"
+          "https://ipfs.io/ipfs/${swiglinux_cid}"
+          "https://gateway.pinata.cloud/ipfs/${swiglinux_cid}"
+          "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/${swiglinux_cid}"
+          "https://ipfs.filebase.io/ipfs/${swiglinux_cid}"
         URL_HASH SHA512=${swiglinux_hash}
-        SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/swiglinux-${swiglinux_arch}-${SWIG_VERSION}
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND ""
-        INSTALL_COMMAND "" ${download_extract_timestamp_flag})
-      set(SWIG_DIR
-          ${CMAKE_CURRENT_BINARY_DIR}/swiglinux-${swiglinux_arch}-${SWIG_VERSION}/share/swig/${swig_cmake_version}
-          CACHE FILEPATH "swig directory.")
+        SOURCE_DIR
+          ${CMAKE_CURRENT_BINARY_DIR}/swiglinux-${swiglinux_arch}-${SWIG_VERSION}
+        CONFIGURE_COMMAND
+          ""
+        BUILD_COMMAND
+          ""
+        INSTALL_COMMAND
+          "" ${download_extract_timestamp_flag}
+      )
+      set(
+        SWIG_DIR
+        ${CMAKE_CURRENT_BINARY_DIR}/swiglinux-${swiglinux_arch}-${SWIG_VERSION}/share/swig/${swig_cmake_version}
+        CACHE FILEPATH
+        "swig directory."
+      )
     elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
       # If we are building ITK
       if(ITK_BINARY_DIR)
@@ -153,20 +239,29 @@ else()
       endif()
       ExternalProject_Add(
         swig
-        URL "https://data.kitware.com/api/v1/file/hashsum/sha512/${swigmacos_hash}/download"
-            "https://itk.mypinata.cloud/ipfs/${swigmacos_cid}"
-            "https://ipfs.io/ipfs/${swigmacos_cid}"
-            "https://gateway.pinata.cloud/ipfs/${swigmacos_cid}"
-            "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/${swigmacos_cid}"
-            "https://ipfs.filebase.io/ipfs/${swigmacos_cid}"
+        URL
+          "https://data.kitware.com/api/v1/file/hashsum/sha512/${swigmacos_hash}/download"
+          "https://itk.mypinata.cloud/ipfs/${swigmacos_cid}"
+          "https://ipfs.io/ipfs/${swigmacos_cid}"
+          "https://gateway.pinata.cloud/ipfs/${swigmacos_cid}"
+          "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/${swigmacos_cid}"
+          "https://ipfs.filebase.io/ipfs/${swigmacos_cid}"
         URL_HASH SHA512=${swigmacos_hash}
-        SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/swigmacos-${swigmacos_arch}-${SWIG_VERSION}
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND ""
-        INSTALL_COMMAND "" ${download_extract_timestamp_flag})
-      set(SWIG_DIR
-          ${CMAKE_CURRENT_BINARY_DIR}/swigmacos-${swigmacos_arch}-${SWIG_VERSION}/share/swig/${swig_cmake_version}
-          CACHE FILEPATH "swig directory.")
+        SOURCE_DIR
+          ${CMAKE_CURRENT_BINARY_DIR}/swigmacos-${swigmacos_arch}-${SWIG_VERSION}
+        CONFIGURE_COMMAND
+          ""
+        BUILD_COMMAND
+          ""
+        INSTALL_COMMAND
+          "" ${download_extract_timestamp_flag}
+      )
+      set(
+        SWIG_DIR
+        ${CMAKE_CURRENT_BINARY_DIR}/swigmacos-${swigmacos_arch}-${SWIG_VERSION}/share/swig/${swig_cmake_version}
+        CACHE FILEPATH
+        "swig directory."
+      )
     else()
       # build swig as an external project
 
@@ -176,43 +271,53 @@ else()
       endif()
       set(compiler_information)
       if(NOT CMAKE_CROSSCOMPILING)
-        set(CMAKE_CXX_COMPILER_LAUNCHER_FLAG -DCMAKE_CXX_COMPILER_LAUNCHER:FILEPATH=${CMAKE_CXX_COMPILER_LAUNCHER})
-        set(CMAKE_C_COMPILER_LAUNCHER_FLAG -DCMAKE_C_COMPILER_LAUNCHER:FILEPATH=${CMAKE_C_COMPILER_LAUNCHER})
-        set(compiler_information
-            -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
-            ${CMAKE_CXX_COMPILER_LAUNCHER_FLAG}
-            "-DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS} -w"
-            -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
-            ${CMAKE_C_COMPILER_LAUNCHER_FLAG}
-            "-DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS} -w")
+        set(
+          CMAKE_CXX_COMPILER_LAUNCHER_FLAG
+          -DCMAKE_CXX_COMPILER_LAUNCHER:FILEPATH=${CMAKE_CXX_COMPILER_LAUNCHER}
+        )
+        set(
+          CMAKE_C_COMPILER_LAUNCHER_FLAG
+          -DCMAKE_C_COMPILER_LAUNCHER:FILEPATH=${CMAKE_C_COMPILER_LAUNCHER}
+        )
+        set(
+          compiler_information
+          -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
+          ${CMAKE_CXX_COMPILER_LAUNCHER_FLAG}
+          "-DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS} -w"
+          -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+          ${CMAKE_C_COMPILER_LAUNCHER_FLAG}
+          "-DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS} -w"
+        )
       endif()
-      set(pcre_hash
-          "e1183226ea3e56a1c7ec97e2c7d7ad5a163b9b576930c997e6ac4c26f1c92fc7e9491b5b297b1dd68d43432f7fbbddcc6207a189beb37ef158ad68bad5598988"
+      set(
+        pcre_hash
+        "e1183226ea3e56a1c7ec97e2c7d7ad5a163b9b576930c997e6ac4c26f1c92fc7e9491b5b297b1dd68d43432f7fbbddcc6207a189beb37ef158ad68bad5598988"
       )
-      set(pcre_cid "bafybeig5jsstzxtwy4g3ap6rplfsnpcuptgi7uxzw2kftjnkly6tbnbiwi")
+      set(
+        pcre_cid
+        "bafybeig5jsstzxtwy4g3ap6rplfsnpcuptgi7uxzw2kftjnkly6tbnbiwi"
+      )
       ExternalProject_Add(
         PCRE
-        URL "https://data.kitware.com/api/v1/file/hashsum/sha512/${pcre_hash}/download"
-            "https://itk.mypinata.cloud/ipfs/${pcre_cid}"
-            "https://ipfs.io/ipfs/${pcre_cid}"
-            "https://gateway.pinata.cloud/ipfs/${pcre_cid}"
-            "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/${pcre_cid}"
-            "https://ipfs.filebase.io/ipfs/${pcre_cid}"
+        URL
+          "https://data.kitware.com/api/v1/file/hashsum/sha512/${pcre_hash}/download"
+          "https://itk.mypinata.cloud/ipfs/${pcre_cid}"
+          "https://ipfs.io/ipfs/${pcre_cid}"
+          "https://gateway.pinata.cloud/ipfs/${pcre_cid}"
+          "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/${pcre_cid}"
+          "https://ipfs.filebase.io/ipfs/${pcre_cid}"
         URL_HASH SHA512=${pcre_hash}
         CMAKE_GENERATOR "${CMAKE_GENERATOR}"
         CMAKE_CACHE_ARGS
-          ${compiler_information}
-          -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+          ${compiler_information} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
           -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
         INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/PCRE2
         ${download_extract_timestamp_flag}
-        )
+      )
 
       # swig uses bison find it by cmake and pass it down
       find_package(BISON)
-      set(BISON_FLAGS
-          ""
-          CACHE STRING "Flags used by bison")
+      set(BISON_FLAGS "" CACHE STRING "Flags used by bison")
       mark_as_advanced(BISON_FLAGS)
 
       # If we are building ITK
@@ -222,54 +327,73 @@ else()
 
       ExternalProject_Add(
         swig
-        URL "https://data.kitware.com/api/v1/file/hashsum/sha512/${swig_hash}/download"
-            "https://itk.mypinata.cloud/ipfs/${swig_cid}"
-            "https://ipfs.io/ipfs/${swig_cid}"
-            "https://gateway.pinata.cloud/ipfs/${swig_cid}"
-            "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/${swig_cid}"
-            "https://ipfs.filebase.io/ipfs/${swig_cid}"
+        URL
+          "https://data.kitware.com/api/v1/file/hashsum/sha512/${swig_hash}/download"
+          "https://itk.mypinata.cloud/ipfs/${swig_cid}"
+          "https://ipfs.io/ipfs/${swig_cid}"
+          "https://gateway.pinata.cloud/ipfs/${swig_cid}"
+          "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/${swig_cid}"
+          "https://ipfs.filebase.io/ipfs/${swig_cid}"
         URL_HASH SHA512=${swig_hash}
         CMAKE_GENERATOR "${CMAKE_GENERATOR}"
         CMAKE_CACHE_ARGS
-          ${compiler_information}
-          -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+          ${compiler_information} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
           -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
           -DPCRE2_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/PCRE2
         INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/swig
-        DEPENDS PCRE ${download_extract_timestamp_flag}
-        )
+        DEPENDS
+          PCRE
+          ${download_extract_timestamp_flag}
+      )
     endif()
 
-    set(SWIG_DIR
-        ${CMAKE_CURRENT_BINARY_DIR}/swig/share/swig/${SWIG_VERSION}
-        CACHE FILEPATH "swig directory.")
+    set(
+      SWIG_DIR
+      ${CMAKE_CURRENT_BINARY_DIR}/swig/share/swig/${SWIG_VERSION}
+      CACHE FILEPATH
+      "swig directory."
+    )
     mark_as_advanced(SWIG_DIR)
-    set(SWIG_EXECUTABLE
-        ${swig_ep}
-        CACHE FILEPATH "swig executable." FORCE)
+    set(SWIG_EXECUTABLE ${swig_ep} CACHE FILEPATH "swig executable." FORCE)
   endif()
   mark_as_advanced(SWIG_EXECUTABLE)
 endif()
 
-set(PYGCCXML_DIR
-    ${ITK_CMAKE_DIR}/../Modules/ThirdParty/pygccxml/src
-    CACHE INTERNAL "pygccxml path")
+set(
+  PYGCCXML_DIR
+  ${ITK_CMAKE_DIR}/../Modules/ThirdParty/pygccxml/src
+  CACHE INTERNAL
+  "pygccxml path"
+)
 
 ###############################################################################
 # store the current dir, so it can be reused later
-set(ITK_WRAP_SWIGINTERFACE_SOURCE_DIR
-    "${CMAKE_CURRENT_SOURCE_DIR}"
-    CACHE INTERNAL "swig interface source dir")
-set(ITK_WRAP_SWIGINTERFACE_BINARY_DIR
-    "${CMAKE_CURRENT_BINARY_DIR}"
-    CACHE INTERNAL "swig interface binary dir")
+set(
+  ITK_WRAP_SWIGINTERFACE_SOURCE_DIR
+  "${CMAKE_CURRENT_SOURCE_DIR}"
+  CACHE INTERNAL
+  "swig interface source dir"
+)
+set(
+  ITK_WRAP_SWIGINTERFACE_BINARY_DIR
+  "${CMAKE_CURRENT_BINARY_DIR}"
+  CACHE INTERNAL
+  "swig interface binary dir"
+)
 
-set(WRAPPER_MASTER_INDEX_OUTPUT_DIR
-    "${ITK_DIR}/Wrapping/Typedefs"
-    CACHE INTERNAL "typedefs dir")
-set(IGENERATOR
-    "${CMAKE_CURRENT_SOURCE_DIR}/igenerator.py"
-    CACHE INTERNAL "igenerator.py path" FORCE)
+set(
+  WRAPPER_MASTER_INDEX_OUTPUT_DIR
+  "${ITK_DIR}/Wrapping/Typedefs"
+  CACHE INTERNAL
+  "typedefs dir"
+)
+set(
+  IGENERATOR
+  "${CMAKE_CURRENT_SOURCE_DIR}/igenerator.py"
+  CACHE INTERNAL
+  "igenerator.py path"
+  FORCE
+)
 
 macro(itk_wrap_simple_type_swig_interface wrap_class swig_name)
   string(APPEND SWIG_INTERFACE_TYPEDEFS "using ${swig_name} = ${wrap_class};\n")

--- a/Wrapping/Generators/SwigInterface/CMakeLists.txt
+++ b/Wrapping/Generators/SwigInterface/CMakeLists.txt
@@ -22,7 +22,7 @@ if(WIN32)
   set(swigwin_hash
       "cec9eeebfec7f2a8ccf7b166a11cf8dbbc5e1eacca35563e4f0882b2b261658f394f6607243813d7083e7e2a2bbec23c5cf8b4dd92ad85838c6eb971f3833715"
   )
-  set(swigwin_cid "bafybeibljxzip2irc3q3w5qlh2ae5ns27xpi7mo6iskxni45dcmwtk2x6a")
+  set(swigwin_cid "bafybeibavyfwb5fenlrjxvhd4pj55brbbvphcgpuwlmbyusrwn44rs2hcq")
 
   set(swig_ep "${CMAKE_CURRENT_BINARY_DIR}/swigwin-amd64-${ITK_SWIG_VERSION}/bin/swig.exe")
 elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64"))
@@ -31,13 +31,13 @@ elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" AND (CMAKE_HOST_SYSTEM_PROCESSOR S
     set(swiglinux_hash
         "9a3cfa330235ac78799c7401299506db5ea7459314b781bf27f2db8ddb582508ec5b15c2fa96fc241d5b832c4f702cd9ef043a61e37a574cac7ca78e4aba8f78"
     )
-    set(swiglinux_cid "bafybeiaa2xv7oxnvaz6qupdaykgwakldrmahk54n2pp2z2ianuvq57uvmy")
+    set(swiglinux_cid "bafybeiasuvglbnjji24hiqpzry65kpqszjxyg4bup5ophfel4noykqemwy")
     set(swiglinux_arch "arm64")
   else()
     set(swiglinux_hash
         "bdf82ad5281dfdba4b24c83b0d15c76e83cd58c6c78ecfc7a449f869f524d12fad9ad7f517995f864c2c00e61e7cd04132a442038197b92821b4011673a7d4fe"
     )
-    set(swiglinux_cid "bafybeihp7hk4ljxuf7duqzei2h7y7xshzyhahxaot5mapv2xevkvwuci5m")
+    set(swiglinux_cid "bafybeiemc7gbf6bgh4yopzudhp56dsb36ks6eltq7m5sny4ifr5n2vrulu")
     set(swiglinux_arch "amd64")
   endif()
 
@@ -48,13 +48,13 @@ elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
     set(swigmacos_hash
       "96eec93fd9e1df35813f8cc194a8811c8c84f265284c1515ec81aa7e696aee2c952f426e5155c011c163376e76245f5d7f479525f0d1ea8396524629ed6b8aec"
     )
-    set(swigmacos_cid "bafybeialov6ur5q2yli4mtclrvqoirk2nsteum3vgnswjypquwejwomxnm")
+    set(swigmacos_cid "bafybeihhw3wktwsi4evq3sfy4rujb5eia4shzqtw7dvgt6s2zsag2ealmm")
     set(swigmacos_arch "arm64")
   else()
     set(swigmacos_hash
       "169760d2a34c2a95a907e80d93c1dc7ebc33a7dd34eb7ed7a9841866db3e25f7d7e93bf49ea28db01843aca5c2c6712756c1f01f6531d6ee027dc6eb293d95d7"
     )
-    set(swigmacos_cid "bafybeifkl5wfscum7pnsjdmwhshrv5v6srilinkrftunq5g4gqzgqmyqf4")
+    set(swigmacos_cid "bafybeiegnvdxavxc7gcf5nfkalpej64p6stn54mzv7nfdwtr5k4vkjvbte")
     set(swigmacos_arch "amd64")
   endif()
 
@@ -63,7 +63,7 @@ else()
   # Build from source
 
   set(swig_hash "9292f6786abed379278b8024f91b91f293f1be9764fe3c1a19023f7891c4e40587f965680ac6a595a5610cfb6650a73fd2f3932a83d5effad83f351fa70810a9")
-  set(swig_cid "bafybeib56uexrqtccgzxjgmlammjii5ntwush4732kbkr6okbtjhzcmvia")
+  set(swig_cid "bafybeidevegcr53m6hrfhvel2ahpyla5rfddu5ycsxsjv5ylmzo4czuubu")
 
   # follow the standard EP_PREFIX locations
   set(swig_binary_dir ${CMAKE_CURRENT_BINARY_DIR}/swig-prefix/src/swig-build)
@@ -114,9 +114,11 @@ else()
       ExternalProject_Add(
         swig
         URL "https://data.kitware.com/api/v1/file/hashsum/sha512/${swigwin_hash}/download"
-            "https://dweb.link/ipfs/${swigwin_cid}/swigwin-amd64-${SWIG_VERSION}.zip"
-            "https://itk.mypinata.cloud/ipfs/${swigwin_cid}/swigwin-amd64-${SWIG_VERSION}.zip"
-            "https://w3s.link/ipfs/${swigwin_cid}/swigwin-amd64-${SWIG_VERSION}.zip"
+            "https://itk.mypinata.cloud/ipfs/${swigwin_cid}"
+            "https://ipfs.io/ipfs/${swigwin_cid}"
+            "https://gateway.pinata.cloud/ipfs/${swigwin_cid}"
+            "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/${swigwin_cid}"
+            "https://ipfs.filebase.io/ipfs/${swigwin_cid}"
         URL_HASH SHA512=${swigwin_hash}
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/swigwin-amd64-${SWIG_VERSION}
         CONFIGURE_COMMAND ""
@@ -131,9 +133,11 @@ else()
       ExternalProject_Add(
         swig
         URL "https://data.kitware.com/api/v1/file/hashsum/sha512/${swiglinux_hash}/download"
-            "https://dweb.link/ipfs/${swiglinux_cid}/swiglinux-${swiglinux_arch}-${SWIG_VERSION}.zip"
-            "https://itk.mypinata.cloud/ipfs/${swiglinux_cid}/swiglinux-${swiglinux_arch}-${SWIG_VERSION}.zip"
-            "https://w3s.link/ipfs/${swiglinux_cid}/swiglinux-${swiglinux_arch}-${SWIG_VERSION}.zip"
+            "https://itk.mypinata.cloud/ipfs/${swiglinux_cid}"
+            "https://ipfs.io/ipfs/${swiglinux_cid}"
+            "https://gateway.pinata.cloud/ipfs/${swiglinux_cid}"
+            "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/${swiglinux_cid}"
+            "https://ipfs.filebase.io/ipfs/${swiglinux_cid}"
         URL_HASH SHA512=${swiglinux_hash}
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/swiglinux-${swiglinux_arch}-${SWIG_VERSION}
         CONFIGURE_COMMAND ""
@@ -150,9 +154,11 @@ else()
       ExternalProject_Add(
         swig
         URL "https://data.kitware.com/api/v1/file/hashsum/sha512/${swigmacos_hash}/download"
-            "https://dweb.link/ipfs/${swigmacos_cid}/swigmacos-${swigmacos_arch}-${SWIG_VERSION}.zip"
-            "https://itk.mypinata.cloud/ipfs/${swigmacos_cid}/swigmacos-${swigmacos_arch}-${SWIG_VERSION}.zip"
-            "https://w3s.link/ipfs/${swigmacos_cid}/swigmacos-${swigmacos_arch}-${SWIG_VERSION}.zip"
+            "https://itk.mypinata.cloud/ipfs/${swigmacos_cid}"
+            "https://ipfs.io/ipfs/${swigmacos_cid}"
+            "https://gateway.pinata.cloud/ipfs/${swigmacos_cid}"
+            "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/${swigmacos_cid}"
+            "https://ipfs.filebase.io/ipfs/${swigmacos_cid}"
         URL_HASH SHA512=${swigmacos_hash}
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/swigmacos-${swigmacos_arch}-${SWIG_VERSION}
         CONFIGURE_COMMAND ""
@@ -183,13 +189,15 @@ else()
       set(pcre_hash
           "e1183226ea3e56a1c7ec97e2c7d7ad5a163b9b576930c997e6ac4c26f1c92fc7e9491b5b297b1dd68d43432f7fbbddcc6207a189beb37ef158ad68bad5598988"
       )
-      set(pcre_cid "bafybeicnpyjts3vq4lpdfhktr5qioq4qdifmtjkbemyyqpkayxjsqtwz74")
+      set(pcre_cid "bafybeig5jsstzxtwy4g3ap6rplfsnpcuptgi7uxzw2kftjnkly6tbnbiwi")
       ExternalProject_Add(
         PCRE
         URL "https://data.kitware.com/api/v1/file/hashsum/sha512/${pcre_hash}/download"
-            "https://dweb.link/ipfs/${pcre_cid}/pcre-10.43.tar.gz"
-            "https://itk.pinata.cloud/ipfs/${pcre_cid}/pcre-10.43.tar.gz"
-            "https://w3s.link/ipfs/${pcre_cid}/pcre-10.43.tar.gz"
+            "https://itk.mypinata.cloud/ipfs/${pcre_cid}"
+            "https://ipfs.io/ipfs/${pcre_cid}"
+            "https://gateway.pinata.cloud/ipfs/${pcre_cid}"
+            "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/${pcre_cid}"
+            "https://ipfs.filebase.io/ipfs/${pcre_cid}"
         URL_HASH SHA512=${pcre_hash}
         CMAKE_GENERATOR "${CMAKE_GENERATOR}"
         CMAKE_CACHE_ARGS
@@ -215,9 +223,11 @@ else()
       ExternalProject_Add(
         swig
         URL "https://data.kitware.com/api/v1/file/hashsum/sha512/${swig_hash}/download"
-            "https://dweb.link/ipfs/${swig_cid}/swig-4.0.2.tar.gz"
-            "https://itk.pinata.cloud/ipfs/${swig_cid}/swig-4.0.2.tar.gz"
-            "https://w3s.link/ipfs/${swig_cid}/swig-4.0.2.tar.gz"
+            "https://itk.mypinata.cloud/ipfs/${swig_cid}"
+            "https://ipfs.io/ipfs/${swig_cid}"
+            "https://gateway.pinata.cloud/ipfs/${swig_cid}"
+            "https://insightsoftwareconsortium.github.io/ITKTestingData/CID/${swig_cid}"
+            "https://ipfs.filebase.io/ipfs/${swig_cid}"
         URL_HASH SHA512=${swig_hash}
         CMAKE_GENERATOR "${CMAKE_GENERATOR}"
         CMAKE_CACHE_ARGS


### PR DESCRIPTION
## Summary

Re-hosts the SWIG and PCRE archives used by the Python-wrapping toolchain as
**direct-file IPFS CIDs** and refreshes the content-addressed mirror list in
`Wrapping/Generators/SwigInterface/CMakeLists.txt`.

Previously each `*_cid` pointed at a UnixFS *directory* that wrapped the archive,
so every download URL carried a trailing `/<filename>` path segment. Each archive
is now added to IPFS as a file using the kubo `unixfs-v1-2025` import profile
(CIDv1, raw leaves, 1 MiB chunks, 1024 links/node, balanced layout), so the CID
resolves to the archive bytes directly and the URLs reference the CID with no
path suffix.

## New CIDs

| variable | archive | CID |
| --- | --- | --- |
| `swigwin_cid` | swigwin-amd64-2024-03-26-master.zip | `bafybeibavyfwb5fenlrjxvhd4pj55brbbvphcgpuwlmbyusrwn44rs2hcq` |
| `swiglinux_cid` (arm64) | swiglinux-arm64-2024-03-26-master.zip | `bafybeiasuvglbnjji24hiqpzry65kpqszjxyg4bup5ophfel4noykqemwy` |
| `swiglinux_cid` (amd64) | swiglinux-amd64-2024-03-26-master.zip | `bafybeiemc7gbf6bgh4yopzudhp56dsb36ks6eltq7m5sny4ifr5n2vrulu` |
| `swigmacos_cid` (arm64) | swigmacos-arm64-2024-03-26-master.zip | `bafybeihhw3wktwsi4evq3sfy4rujb5eia4shzqtw7dvgt6s2zsag2ealmm` |
| `swigmacos_cid` (amd64) | swigmacos-amd64-2024-03-26-master.zip | `bafybeiegnvdxavxc7gcf5nfkalpej64p6stn54mzv7nfdwtr5k4vkjvbte` |
| `swig_cid` (source) | swig-4.0.2.tar.gz | `bafybeidevegcr53m6hrfhvel2ahpyla5rfddu5ycsxsjv5ylmzo4czuubu` |
| `pcre_cid` | pcre-10.43.tar.gz | `bafybeig5jsstzxtwy4g3ap6rplfsnpcuptgi7uxzw2kftjnkly6tbnbiwi` |

## Gateways

The mirror list is updated to the gateways currently serving ITK content
(each URL is now `${gateway}${cid}`):

- `https://itk.mypinata.cloud/ipfs/`
- `https://ipfs.io/ipfs/`
- `https://gateway.pinata.cloud/ipfs/`
- `https://insightsoftwareconsortium.github.io/ITKTestingData/CID/`
- `https://ipfs.filebase.io/ipfs/`

`https://data.kitware.com/.../sha512/<hash>/download` is retained as the primary
source, and `URL_HASH SHA512=...` continues to validate whichever mirror responds.

## Hosting / pinning

- Archives pinned on the `itk-filebase` and `itk-pinata` remote pinning services
  via the kubo CLI.
- Mirrored for GitHub Pages in ITKTestingData under `CID/` — companion PR:
  InsightSoftwareConsortium/ITKTestingData#72.

## Verification

- SHA512 of every archive verified against the existing hashes before import.
- CIDs reproducible with `ipfs add --only-hash --cid-version=1`.
- Fetched each new CID through the `itk.mypinata.cloud`, `ipfs.io`, and
  `ipfs.filebase.io` gateways and confirmed the returned bytes match the
  expected SHA512.

## Commits

1. **ENH** — swap the CIDs and gateway list.
2. **STYLE** — format with gersemi 0.19.3 using ITK `main`'s profile (indent 2,
   line length 80, `list_expansion: favour-expansion`). Whitespace-only: the
   non-whitespace token stream is byte-identical to commit 1, so the file matches
   `main`'s formatting and forward-merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
