### PR TITLE
COMP: Pin DCMTK with single-export namespace fix

### DIFF
--- a/Modules/ThirdParty/DCMTK/DCMTKGitTag.cmake
+++ b/Modules/ThirdParty/DCMTK/DCMTKGitTag.cmake
@@ -38,7 +38,9 @@ set(
 #COMP: fix WASI compiler errors
 #COMP: fix missing <csetjmp> header issue
 
-#Bradley Lowekamp (1):
+#Bradley Lowekamp (3):
 #COMP: prefix CMake check commands with DCMTK_ to avoid leaking
+#COMP: Add printf format attribute to OFFile printf wrappers
+#COMP: Use single export() call to fix namespace corruption
 
-set(DCMTK_GIT_TAG "4ac9b4489d8f8fb1873a943dd214824bd2b11a6d") # for/itk-dcmtk-3.7.0-ccfd10b
+set(DCMTK_GIT_TAG "554b74475ba1734655c61988b94bc69daf6690c7") # for/itk-dcmtk-3.7.0-ccfd10b


### PR DESCRIPTION
Pin DCMTK to the head of InsightSoftwareConsortium/DCMTK#3 (@blowekamp's fix: one `export()` call instead of three `export(APPEND)` calls), so the build-tree `DCMTKTargets.cmake` records ITK's codec targets as `ITK::*` instead of the nonexistent `DCMTK::ITK::*`. Replaces the earlier ITK-side repair loop; external build-tree consumers (e.g. an ANTs SuperBuild) now survive CMake generate with no workaround in ITK.

**Blocked on:** InsightSoftwareConsortium/DCMTK#3 landing on a `for/itk-…` branch; the pin currently points at blowekamp/DCMTK because the fix SHA is not clone-reachable from the ISC repo. Flip `DCMTK_GIT_REPOSITORY` back once merged.

<details>
<summary>Root cause (from blowekamp's analysis on this PR)</summary>

CMake's `export(TARGETS ... APPEND)` skips the cross-export-set namespace lookup (`HandleMissingTarget`) and blindly prefixes the current namespace onto foreign dependency targets. DCMTK's `GenerateCMakeExports.cmake` built `DCMTKTargets.cmake` with three `APPEND` calls, so ITK's codec targets were recorded as `DCMTK::ITK::ITK{ZLIB,TIFF,JPEG,PNG}Module`. A single non-append `export()` resolves them to their real `ITK::` names. Intentional (undocumented) CMake behavior, not a CMake bug. The install-tree export (`install(EXPORT)`) was never affected.

</details>

<details>
<summary>Testing performed (2026-07-13, pin commit f9b03206a14)</summary>

- Build-tree `DCMTKTargets.cmake`: zero `DCMTK::ITK::*` entries; deps export as `ITK::ITK{ZLIB,TIFF,JPEG,PNG}Module`.
- Minimal external consumer against the build tree (`find_package(ITK COMPONENTS ITKIODCMTK)` + `itk::DCMTKImageIO::New()`, same compiler as the ITK build): configure + generate + link + run all succeed. On unpatched `main` (post-#6543) the same consumer fails at generate with `target DCMTK::ITK::ITKZLIBModule not found`.
- `ctest -R DCMTK`: 38/39 pass; sole `Not Run` is `ITKIODCMTKKWStyleTest` (KWStyle not installed locally — unrelated).

</details>

<!--
provenance: claude-code session 2026-07-13 (hjmjohnson); supersedes repair-loop approach (old head ec1ff34f189)
key_facts: DCMTK fix SHA 26222d3573be3771c5faf6623c403826302f5251 on blowekamp/DCMTK fix-export-append-namespace, descendant of ISC pin 4ac9b4489d8f (+2 commits incl. unrelated printf-format-attribute commit)
post_merge_action: after ISC/DCMTK#3 merges, restore DCMTK_GIT_REPOSITORY=InsightSoftwareConsortium/DCMTK.git, re-pin, drop TODO comment in DCMTKGitTag.cmake; DCMTK/dcmtk#150 upstream draft can note the ITK-side resolution
-->
