### PR TITLE
COMP: Include itkMacro.h before the itk namespace in itkFileTools.h

### DIFF
--- a/Modules/IO/XML/include/itkFileTools.h
+++ b/Modules/IO/XML/include/itkFileTools.h
@@ -19,6 +19,8 @@
 #ifndef itkFileTools_h
 #define itkFileTools_h
 
+#include "itkMacro.h"
+
 #include <string>
 
 namespace itk
@@ -46,8 +48,6 @@ public:
 // here comes the implementation
 
 #include "itksys/SystemTools.hxx"
-#include "itkMacro.h"
-
 namespace itk
 {
 


### PR DESCRIPTION
Move `#include "itkMacro.h"` in `itkFileTools.h` above the first `namespace itk` block, so the header's dependencies are available before the namespace is opened rather than only before the out-of-line implementation.

**This is not required to build ITK** — stock `itkFileTools.h` compiles fine with the include in its original mid-file position. It is a small include-ordering hygiene improvement that additionally supports building ITK in a **customized namespace**, as 3D Slicer does when it bundles ITK (a major consumer of and contributor to ITK), where the `namespace itk` token expands from a macro that must be defined before first use.

Authored by Andras Lasso (3D Slicer); surfaced while validating Slicer's vendored ITK against current `main`.

<details>
<summary>Context</summary>

Slicer vendors ITK built in a custom namespace to avoid symbol clashes when multiple ITK-based libraries are loaded in one process. Under that build, `namespace itk` is a macro, so `itkMacro.h` (which defines it) must be included before the header first opens the namespace. This one-line relocation makes `itkFileTools.h` robust to that without changing behavior for a normal ITK build. The larger custom-namespace support is a separate, still-draft effort; this hygiene change stands on its own and is offered independently.

</details>
