### PR TITLE
DOC: Document itkDCMTKFileReader privatization in ITKv6 migration guide

### DIFF
--- a/Documentation/docs/migration_guides/itk_6_migration_guide.md
+++ b/Documentation/docs/migration_guides/itk_6_migration_guide.md
@@ -874,6 +874,35 @@ siblings in the iterator hierarchy, not subclasses, so such uses do not convert
 implicitly. Code that only iterates (`GoToBegin`/`IsAtEnd`/`Get`/`Set`) needs no
 change.
 
+## `itkDCMTKFileReader.h` is now a private header of `ITKIODCMTK`
+
+`itkDCMTKFileReader.h` and `itkDCMTKFileReader.cxx` moved from the module's
+installed `include/` directory to `src/`, making `ITKDCMTK` a private dependency
+of `ITKIODCMTK`. The reader (`itk::DCMTKFileReader`, `itk::DCMTKSequence`,
+`itk::DCMTKItem`) is no longer installed and is not part of the public ITK API.
+Downstream code that did `#include "itkDCMTKFileReader.h"` no longer resolves.
+
+### What you need to do
+
+Because the header is now private, its contents may change without notice or
+API-stability guarantees. Do not depend on it as an installed header. Instead,
+vendor a private copy of both files into your own project from the last commit
+where they were the public interface:
+
+```
+ITK commit db492d9b092a6ca585ab6b12e896ca63229ad8e8
+  Modules/IO/DCMTK/src/itkDCMTKFileReader.h
+  Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
+```
+
+Pin to that exact hash rather than tracking `main`; the file lives outside the
+public interface now and may diverge substantially in future ITK versions.
+Compile the vendored `.cxx` into your target and neutralize the
+`ITKIODCMTK_EXPORT` macro (define it empty) since the reader is no longer
+exported from a shared library. This is the approach taken by the Slicer
+`SUVFactorCalculatorCLI` and `PETStandardUptakeValueComputation` CLIs and by
+BRAINSTools `DWIConvert`.
+
 ## `GDCMSeriesFileNames` reimplemented on `gdcm::Scanner`/`IPPSorter`
 
 `itk::GDCMSeriesFileNames` no longer uses the GDCM-deprecated


### PR DESCRIPTION
Documents in the ITKv6 migration guide that `itkDCMTKFileReader.h`/`.cxx` became private (installed `include/` → `src/`) in db492d9b09 / #6496, and tells downstream consumers to vendor the files from that pinned commit rather than depend on the now-private header.

Validated against real downstream consumers: the privatization broke two builds that had to be fixed by vendoring, while a third had already done so.

- **BRAINSTools `DWIConvert`** — broke; fixed by vendoring the reader (BRAINSia/BRAINSTools#615).
- **Slicer core `PETStandardUptakeValueComputation` CLI** — broke; fixed by vendoring the reader (Slicer/Slicer#9267).
- **SlicerExt PET DICOM `SUVFactorCalculatorCLI`** — already internally vendored the interface, and served as the reference pattern for the two fixes above.

<details>
<summary>What the new section says</summary>

- `itk::DCMTKFileReader` / `DCMTKSequence` / `DCMTKItem` are no longer installed or part of the public API.
- Vendor both files from the exact commit where they were still the public interface:
  `db492d9b092a6ca585ab6b12e896ca63229ad8e8` → `Modules/IO/DCMTK/src/itkDCMTKFileReader.{h,cxx}`.
- Pin to that hash, not `main` — the private file may diverge substantially.
- Compile the vendored `.cxx` and neutralize `ITKIODCMTK_EXPORT` (define empty), as done by the three CLIs above.

</details>

<!--
provenance: claude-code session 2026-07-05
doc: Documentation/docs/migration_guides/itk_6_migration_guide.md
pin_commit: db492d9b092a6ca585ab6b12e896ca63229ad8e8 (privatization; #6496)
downstream_fixes: BRAINSTools DWIConvert (BRAINSia #615), Slicer PET CLI (Slicer/Slicer#9267)
prior_art: SlicerExt SUVFactorCalculatorCLI already self-vendored
forest_validation: svdc forest Slicer build compiled+linked DWIConvert and PET past prior breakage
-->
