### PR TITLE
Default-member-initializers, default default-constructors in BinaryMathematicalMorphology

### DIFF
--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.h
@@ -115,7 +115,7 @@ protected:
   GenerateData() override;
 
 private:
-  InputPixelType m_ForegroundValue{};
+  InputPixelType m_ForegroundValue{ NumericTraits<InputPixelType>::max() };
 
   bool m_FullyConnected{};
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.h
@@ -96,7 +96,7 @@ public:
   itkBooleanMacro(FullyConnected);
   /** @ITKEndGrouping */
 protected:
-  BinaryClosingByReconstructionImageFilter();
+  BinaryClosingByReconstructionImageFilter() = default;
   ~BinaryClosingByReconstructionImageFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.hxx
@@ -32,8 +32,6 @@ namespace itk
 
 template <typename TInputImage, typename TKernel>
 BinaryClosingByReconstructionImageFilter<TInputImage, TKernel>::BinaryClosingByReconstructionImageFilter()
-  : m_ForegroundValue(NumericTraits<InputPixelType>::max())
-
 {}
 
 template <typename TInputImage, typename TKernel>

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryClosingByReconstructionImageFilter.hxx
@@ -29,11 +29,6 @@
 
 namespace itk
 {
-
-template <typename TInputImage, typename TKernel>
-BinaryClosingByReconstructionImageFilter<TInputImage, TKernel>::BinaryClosingByReconstructionImageFilter()
-{}
-
 template <typename TInputImage, typename TKernel>
 void
 BinaryClosingByReconstructionImageFilter<TInputImage, TKernel>::GenerateInputRequestedRegion()

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.h
@@ -112,9 +112,9 @@ protected:
   GenerateData() override;
 
 private:
-  InputPixelType m_ForegroundValue{};
+  InputPixelType m_ForegroundValue{ NumericTraits<InputPixelType>::max() };
 
-  bool m_SafeBorder{};
+  bool m_SafeBorder{ true };
 }; // end of class
 } // end namespace itk
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.h
@@ -101,7 +101,7 @@ public:
   itkBooleanMacro(SafeBorder);
   /** @ITKEndGrouping */
 protected:
-  BinaryMorphologicalClosingImageFilter();
+  BinaryMorphologicalClosingImageFilter() = default;
   ~BinaryMorphologicalClosingImageFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.hxx
@@ -38,10 +38,6 @@
 namespace itk
 {
 template <typename TInputImage, typename TOutputImage, typename TKernel>
-BinaryMorphologicalClosingImageFilter<TInputImage, TOutputImage, TKernel>::BinaryMorphologicalClosingImageFilter()
-{}
-
-template <typename TInputImage, typename TOutputImage, typename TKernel>
 void
 BinaryMorphologicalClosingImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
 {

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalClosingImageFilter.hxx
@@ -39,8 +39,6 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage, typename TKernel>
 BinaryMorphologicalClosingImageFilter<TInputImage, TOutputImage, TKernel>::BinaryMorphologicalClosingImageFilter()
-  : m_ForegroundValue(NumericTraits<InputPixelType>::max())
-  , m_SafeBorder(true)
 {}
 
 template <typename TInputImage, typename TOutputImage, typename TKernel>

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.h
@@ -99,7 +99,7 @@ public:
   itkGetConstMacro(BackgroundValue, PixelType);
 
 protected:
-  BinaryMorphologicalOpeningImageFilter();
+  BinaryMorphologicalOpeningImageFilter() = default;
   ~BinaryMorphologicalOpeningImageFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.h
@@ -110,7 +110,7 @@ protected:
   GenerateData() override;
 
 private:
-  PixelType m_ForegroundValue{};
+  PixelType m_ForegroundValue{ NumericTraits<PixelType>::max() };
 
   PixelType m_BackgroundValue{};
 }; // end of class

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.hxx
@@ -35,10 +35,6 @@
 namespace itk
 {
 template <typename TInputImage, typename TOutputImage, typename TKernel>
-BinaryMorphologicalOpeningImageFilter<TInputImage, TOutputImage, TKernel>::BinaryMorphologicalOpeningImageFilter()
-{}
-
-template <typename TInputImage, typename TOutputImage, typename TKernel>
 void
 BinaryMorphologicalOpeningImageFilter<TInputImage, TOutputImage, TKernel>::GenerateData()
 {

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologicalOpeningImageFilter.hxx
@@ -36,8 +36,6 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage, typename TKernel>
 BinaryMorphologicalOpeningImageFilter<TInputImage, TOutputImage, TKernel>::BinaryMorphologicalOpeningImageFilter()
-  : m_ForegroundValue(NumericTraits<PixelType>::max())
-  , m_BackgroundValue(PixelType{})
 {}
 
 template <typename TInputImage, typename TOutputImage, typename TKernel>

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.h
@@ -226,10 +226,10 @@ protected:
 
 private:
   /** Pixel value to dilate */
-  InputPixelType m_ForegroundValue{};
+  InputPixelType m_ForegroundValue{ NumericTraits<InputPixelType>::max() };
 
   /** Pixel value for background */
-  OutputPixelType m_BackgroundValue{};
+  OutputPixelType m_BackgroundValue{ NumericTraits<OutputPixelType>::NonpositiveMin() };
 
   /** Difference sets definition */
   NeighborIndexContainerContainer m_KernelDifferenceSets{};

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryMorphologyImageFilter.hxx
@@ -31,8 +31,6 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage, typename TKernel>
 BinaryMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::BinaryMorphologyImageFilter()
-  : m_ForegroundValue(NumericTraits<InputPixelType>::max())
-  , m_BackgroundValue(NumericTraits<OutputPixelType>::NonpositiveMin())
 {
   // this->SetNumberOfWorkUnits(1);
   this->AnalyzeKernel();

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.h
@@ -101,7 +101,7 @@ public:
   itkBooleanMacro(FullyConnected);
   /** @ITKEndGrouping */
 protected:
-  BinaryOpeningByReconstructionImageFilter();
+  BinaryOpeningByReconstructionImageFilter() = default;
   ~BinaryOpeningByReconstructionImageFilter() override = default;
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.h
@@ -120,7 +120,7 @@ protected:
   GenerateData() override;
 
 private:
-  PixelType m_ForegroundValue{};
+  PixelType m_ForegroundValue{ NumericTraits<PixelType>::max() };
 
   PixelType m_BackgroundValue{};
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.hxx
@@ -28,8 +28,6 @@ namespace itk
 
 template <typename TInputImage, typename TKernel>
 BinaryOpeningByReconstructionImageFilter<TInputImage, TKernel>::BinaryOpeningByReconstructionImageFilter()
-  : m_ForegroundValue(NumericTraits<PixelType>::max())
-  , m_BackgroundValue(PixelType{})
 {}
 
 template <typename TInputImage, typename TKernel>

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryOpeningByReconstructionImageFilter.hxx
@@ -25,11 +25,6 @@
 
 namespace itk
 {
-
-template <typename TInputImage, typename TKernel>
-BinaryOpeningByReconstructionImageFilter<TInputImage, TKernel>::BinaryOpeningByReconstructionImageFilter()
-{}
-
 template <typename TInputImage, typename TKernel>
 void
 BinaryOpeningByReconstructionImageFilter<TInputImage, TKernel>::GenerateInputRequestedRegion()

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.h
@@ -133,7 +133,7 @@ protected:
   ComputePruneImage();
 
 private:
-  unsigned int m_Iteration{};
+  unsigned int m_Iteration{ 3 };
 }; // end of BinaryThinningImageFilter class
 } // end namespace itk
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkBinaryPruningImageFilter.hxx
@@ -29,7 +29,6 @@ namespace itk
  */
 template <typename TInputImage, typename TOutputImage>
 BinaryPruningImageFilter<TInputImage, TOutputImage>::BinaryPruningImageFilter()
-  : m_Iteration(3)
 {
   this->SetNumberOfRequiredOutputs(1);
 

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkErodeObjectMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkErodeObjectMorphologyImageFilter.hxx
@@ -23,7 +23,6 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage, typename TKernel>
 ErodeObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::ErodeObjectMorphologyImageFilter()
-  : m_BackgroundValue(PixelType{})
 {
   m_ErodeBoundaryCondition.SetConstant(NumericTraits<PixelType>::max());
   this->OverrideBoundaryCondition(&m_ErodeBoundaryCondition);

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.h
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.h
@@ -215,7 +215,7 @@ protected:
   KernelType m_Kernel{};
 
   /** Pixel value that indicates the object be operated upon */
-  PixelType m_ObjectValue{};
+  PixelType m_ObjectValue{ NumericTraits<PixelType>::OneValue() };
 
   void
   BeforeThreadedGenerateData() override;

--- a/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
+++ b/Modules/Filtering/BinaryMathematicalMorphology/include/itkObjectMorphologyImageFilter.hxx
@@ -31,8 +31,6 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage, typename TKernel>
 ObjectMorphologyImageFilter<TInputImage, TOutputImage, TKernel>::ObjectMorphologyImageFilter()
-  : m_Kernel()
-  , m_ObjectValue(NumericTraits<PixelType>::OneValue())
 {
   m_DefaultBoundaryCondition.SetConstant(PixelType{});
   m_BoundaryCondition = &m_DefaultBoundaryCondition;


### PR DESCRIPTION
Style improvements BinaryMathematicalMorphology:

- Moved initialization values of non-static data members from the member-initializer-lists of default-constructors to their
default-member-initializers. Following C++ Core Guidelines, [Prefer default member initializers to member initializers in constructors for constant initializers](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c48-prefer-default-member-initializers-to-member-initializers-in-constructors-for-constant-initializers)
- Defaulted four empty default-constructors inside the definition of their classes.

Will make Doxygen generated documentation more informative, as default-member-initializers appear in the class documentation, and defaulted constructors will be marked "default" in the class documentation.