### PR TITLE
COMP: Stop setting deprecated EXECUTABLE_OUTPUT_PATH/LIBRARY_OUTPUT_PATH for GDCM

### DIFF
--- a/Modules/ThirdParty/GDCM/src/CMakeLists.txt
+++ b/Modules/ThirdParty/GDCM/src/CMakeLists.txt
@@ -61,10 +61,6 @@ set(GDCMV2_0_COMPATIBILITY ON CACHE INTERNAL "")
 set(GDCM_WRITE_ODD_LENGTH OFF CACHE INTERNAL "Do not change")
 set(GDCM_DEBUG_POSTFIX "" CACHE INTERNAL "")
 
-# GDCM uses these to refer to executable and library locations
-set(EXECUTABLE_OUTPUT_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-set(LIBRARY_OUTPUT_PATH ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-
 add_subdirectory(gdcm)
 
 foreach(lib


### PR DESCRIPTION
## Summary

Fixes the CMake configure-time deprecation warnings reported in #6551, which appear on `release-5.4` (RTK nightly builds, Linux and Windows) but not on `main`:

```
CMake Warning at Modules/ThirdParty/GDCM/src/gdcm/CMakeLists.txt:...
  EXECUTABLE_OUTPUT_PATH is deprecated. Use CMAKE_RUNTIME_OUTPUT_DIRECTORY instead.

CMake Warning at Modules/ThirdParty/GDCM/src/gdcm/CMakeLists.txt:...
  LIBRARY_OUTPUT_PATH is deprecated. Use CMAKE_LIBRARY_OUTPUT_DIRECTORY and
  CMAKE_ARCHIVE_OUTPUT_DIRECTORY instead.
```

## Root cause

The warnings are *emitted* by the vendored `Modules/ThirdParty/GDCM/src/gdcm/CMakeLists.txt`, whose newer compatibility shim warns whenever the legacy `EXECUTABLE_OUTPUT_PATH` / `LIBRARY_OUTPUT_PATH` variables are set:

```cmake
if(EXECUTABLE_OUTPUT_PATH)
  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${EXECUTABLE_OUTPUT_PATH})
  message(WARNING "EXECUTABLE_OUTPUT_PATH is deprecated. ...")
endif()
if(LIBRARY_OUTPUT_PATH)
  ...
  message(WARNING "LIBRARY_OUTPUT_PATH is deprecated. ...")
endif()
```

They are *triggered* by ITK's own wrapper one level up, `Modules/ThirdParty/GDCM/src/CMakeLists.txt`, which set both deprecated variables in the parent scope immediately before `add_subdirectory(gdcm)`:

```cmake
# GDCM uses these to refer to executable and library locations
set(EXECUTABLE_OUTPUT_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
set(LIBRARY_OUTPUT_PATH ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
```

The `src/gdcm/` subtree portion of the shim landed on `release-5.4` via the GDCM upstream update in #6059, but the corresponding wrapper cleanup was never backported — so on `release-5.4` the shim sees the variables set and warns, while `main` (which already dropped these `set()` calls) is silent.

## Fix

Backport of commit d5cf8de3ed33039499315163bdd9682f01ed573c ("ENH: Conform GDCM to use CMAKE_*OUTPUT_DIRECTORY"), applying only the `src/CMakeLists.txt` wrapper hunk — removing the two `set()` calls. The `src/gdcm/CMakeLists.txt` portion of that commit is already present on `release-5.4` (verified byte-identical), so it is intentionally omitted to avoid disturbing the vendored update.

With the wrapper no longer setting the legacy variables, the vendored shim's `if()` guards are false and the two `message(WARNING ...)` calls no longer fire. The vendored GDCM CMake still derives `EXECUTABLE_OUTPUT_PATH` / `LIBRARY_OUTPUT_PATH` internally from `CMAKE_RUNTIME_OUTPUT_DIRECTORY` / `CMAKE_LIBRARY_OUTPUT_DIRECTORY` / `CMAKE_ARCHIVE_OUTPUT_DIRECTORY` for its own use, so build output locations are unchanged.

This is a configuration-only change; no C++ is affected.

Fixes #6551.

🤖 Generated with [Claude Code](https://claude.com/claude-code)