### PR TITLE
COMP: Auto-install pixi pre-commit env for git worktrees (supersedes #6522)

### DIFF
--- a/Documentation/docs/contributing/index.md
+++ b/Documentation/docs/contributing/index.md
@@ -41,6 +41,14 @@ the [`setup-git-aliases`] script for general Git tasks in ITK.
 Visit the *Pro Git: Setup* resource in [Git Help] for further
 information on setting up your local Git environment.
 
+If you develop in additional [git worktrees], note that the commit-message
+hooks run Python from a [Pixi] environment resolved relative to each
+checkout's root. Provision it once per worktree:
+
+```bash
+pixi install -e pre-commit
+```
+
 (build)=
 Local Build and Testing
 -----------------------
@@ -470,6 +478,8 @@ python_packaging.md
 [build and test ITK]: ./build_test_itk.md
 
 [`SetupForDevelopment.sh`]: https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/SetupForDevelopment.sh
+[git worktrees]: https://git-scm.com/docs/git-worktree
+[Pixi]: https://pixi.sh/
 [`setup-git-aliases`]: https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/GitSetup/setup-git-aliases
 
 [ITK's Discourse]: https://discourse.itk.org/

--- a/Utilities/Hooks/run-pixi-python.sh
+++ b/Utilities/Hooks/run-pixi-python.sh
@@ -8,9 +8,15 @@ else
     PYTHON_EXE="./.pixi/envs/pre-commit/bin/python"
 fi
 
-# Verify Python executable exists
+# The pixi env is per-worktree; provision it on first use in fresh worktrees.
+if [[ ! -x "$PYTHON_EXE" ]] && command -v pixi >/dev/null 2>&1; then
+    echo "pre-commit pixi environment missing; running 'pixi install -e pre-commit'..." >&2
+    pixi install -e pre-commit >&2 || true
+fi
+
 if [[ ! -x "$PYTHON_EXE" ]]; then
     echo "Error: Python executable not found at $PYTHON_EXE" >&2
+    echo "Run 'pixi install -e pre-commit' in this checkout to create it." >&2
     exit 1
 fi
 


### PR DESCRIPTION
Keeps the per-worktree pixi mechanism (per @thewtex on #6522) but removes the fresh-worktree trap: `run-pixi-python.sh` now installs the `pre-commit` pixi env on first use, and the contributing guide documents `pixi install -e pre-commit` for worktrees. Supersedes #6522.

<details>
<summary>Details</summary>

- `Utilities/Hooks/run-pixi-python.sh`: when `./.pixi/envs/pre-commit` is missing and `pixi` is on PATH, runs `pixi install -e pre-commit` before resolving the interpreter; if it still cannot resolve, the error message names the exact command to run instead of the bare "Python executable not found".
- `Documentation/docs/contributing/index.md`: notes that each additional git worktree needs `pixi install -e pre-commit` once, since the commit-msg hooks resolve the pixi env relative to the checkout root.
- Unlike #6522, this does not move the hooks to `language: python`, so no system Python is assumed (the Windows concern raised by @blowekamp and @thewtex).

Verified locally in a fresh worktree with `.pixi/envs/pre-commit` deleted: the launcher auto-installed the env and both kw commit-msg hooks passed during a real `git commit`.

</details>

<!--
provenance: repurposed from PR #6522 per reviewer feedback (thewtex: keep per-worktree pixi envs; document the install step)
branch: hjmjohnson/ITK comp-worktree-pixi-precommit-env
commits: 873786e06bd (COMP launcher fallback), b12e20240a7 (DOC contributing/index.md)
post_merge_action: none; local skill itk-start-worktree already runs pixi install -e pre-commit at worktree creation
-->
