### PR TITLE
Declare SpatialObjects dependency on ZLIB

### DIFF
--- a/Modules/Core/SpatialObjects/itk-module.cmake
+++ b/Modules/Core/SpatialObjects/itk-module.cmake
@@ -14,6 +14,7 @@ itk_module(
     ITKTransform
   PRIVATE_DEPENDS
     ITKCommon
+    ITKZLIB
   COMPILE_DEPENDS
     ITKImageFunction
     ITKMetaIO


### PR DESCRIPTION
The error message was:
```log
------ Build started: Project: ITKSpatialObjects, Configuration: Debug x64 ------
  itkMetaEvent.cxx
M:\a\Slicer-deb\ITK-build\Modules\ThirdParty\ZLIB\src\itk_zlib.h(35,11): error C1083: Cannot open include file: 'zlib.h': No such file or directory
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
