### PR TITLE
GDCM: fix missing zlib include path when ITK_USE_SYSTEM_ZLIB

### DIFF
--- a/Modules/ThirdParty/GDCM/src/CMakeLists.txt
+++ b/Modules/ThirdParty/GDCM/src/CMakeLists.txt
@@ -41,7 +41,14 @@ set(OPENJPEG_INCLUDE_DIRS "")
 set(OPENJPEG_LIBRARIES "ITK::ITKOpenJPEGModule")
 # ZLIB:
 set(GDCM_USE_SYSTEM_ZLIB ON CACHE INTERNAL "")
-set(ZLIB_INCLUDE_DIRS "")
+if(ITK_USE_SYSTEM_ZLIB)
+  # ZLIB_INCLUDE_DIR is populated by find_package(ZLIB) in ITK's ZLIB module.
+  # Pass it explicitly so GDCM's root CMakeLists can find the real system <zlib.h>
+  set(ZLIB_INCLUDE_DIRS "${ZLIB_INCLUDE_DIR}")
+else()
+  # ITK's bundled zlib is provided through the target's INTERFACE_INCLUDE_DIRECTORIES
+  set(ZLIB_INCLUDE_DIRS "")
+endif()
 set(ZLIB_LIBRARIES "ITK::ITKZLIBModule")
 
 # Configure GDCM privately so its options do not appear to the user.


### PR DESCRIPTION
The original error message was:
```log
------ Build started: Project: gdcmCommon, Configuration: Debug x64 ------
  gdcmDeflateStream.cxx
M:\a\Slicer-deb\ITK-build\Modules\ThirdParty\ZLIB\src\itk_zlib.h(35,11): error C1083: Cannot open include file: 'zlib.h': No such file or directory
```
While trying to build within Slicer. While this does fix it for Slicer, I am not sure whether this is the best fix.


## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)

