### PR TITLE
BUG: ScaleLogarithmicTransform Jacobian ignores the center

### DIFF
--- a/Modules/Core/Transform/include/itkScaleLogarithmicTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleLogarithmicTransform.hxx
@@ -77,7 +77,8 @@ ScaleLogarithmicTransform<TParametersValueType, VDimension>::ComputeJacobianWith
   const InputPointType & p,
   JacobianType &         jacobian) const
 {
-  const ScaleType & scales = this->GetScale();
+  const ScaleType &      scales = this->GetScale();
+  const InputPointType & center = this->GetCenter();
 
   jacobian.SetSize(SpaceDimension, this->GetNumberOfLocalParameters());
   jacobian.Fill(0);
@@ -85,7 +86,7 @@ ScaleLogarithmicTransform<TParametersValueType, VDimension>::ComputeJacobianWith
   {
     // the derivative with respect to Log(scale) = scale * derivative with
     // respect to scale.
-    jacobian(dim, dim) = scales[dim] * p[dim];
+    jacobian(dim, dim) = scales[dim] * (p[dim] - center[dim]);
   }
 }
 

--- a/Modules/Core/Transform/test/itkScaleLogarithmicTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkScaleLogarithmicTransformTest.cxx
@@ -16,6 +16,7 @@
  *
  *=========================================================================*/
 
+#include <cmath>
 #include <iostream>
 
 #include "itkScaleLogarithmicTransform.h"
@@ -263,6 +264,53 @@ itkScaleLogarithmicTransformTest(int, char *[])
 
       std::cout << "Successful SetParameters() / GetParameters() " << std::endl;
     }
+  }
+
+
+  // Exercise the Jacobian about a non-zero center
+  {
+    auto centeredTransform = TransformType::New();
+
+    TransformType::InputPointType center;
+    center[0] = 5;
+    center[1] = 6;
+    center[2] = 7;
+    centeredTransform->SetCenter(center);
+
+    TransformType::ParametersType parameters = centeredTransform->GetParameters();
+    parameters[0] = std::log(2.0);
+    parameters[1] = std::log(3.0);
+    parameters[2] = std::log(4.0);
+    centeredTransform->SetParameters(parameters);
+
+    constexpr TransformType::InputPointType::ValueType pInit[3]{ 10, 10, 10 };
+    const TransformType::InputPointType                p = pInit;
+
+    TransformType::JacobianType jacobian;
+    centeredTransform->ComputeJacobianWithRespectToParameters(p, jacobian);
+
+    const TransformType::ScaleType & scales = centeredTransform->GetScale();
+
+    testStatus = true;
+    for (unsigned int i = 0; i < N; ++i)
+    {
+      // d/dLog(scale[i]) of scale[i] * (p[i] - center[i]) + center[i]
+      const double expected = scales[i] * (p[i] - center[i]);
+      if (itk::Math::Absolute(jacobian(i, i) - expected) > epsilon)
+      {
+        testStatus = false;
+        break;
+      }
+    }
+    if (!testStatus)
+    {
+      std::cerr << "Error in ComputeJacobianWithRespectToParameters()." << std::endl;
+      std::cerr << "The center of the transformation was ignored." << std::endl;
+      std::cerr << "Jacobian: " << jacobian << std::endl;
+      return EXIT_FAILURE;
+    }
+
+    std::cout << "Successful ComputeJacobianWithRespectToParameters() " << std::endl;
   }
 
 


### PR DESCRIPTION
`ScaleLogarithmicTransform`'s Jacobian dropped the transform center: `d/dLog(scale[i])` is `scale[i] * (p[i] - center[i])`, not `scale[i] * p[i]`. Adds the missing Jacobian test case. Split out of #6569 per review.

<details>
<summary>Root cause</summary>

`itkScaleLogarithmicTransform.hxx` computed

```cpp
jacobian(dim, dim) = scales[dim] * p[dim];
```

but the transform (inherited from `ScaleTransform`) maps
`p -> scale * (p - center) + center`. `itkScaleTransform.hxx` already
differentiates about the center (`j(dim, dim) = p[dim] - center[dim]`), so
the log-scale chain rule gives `scale[dim] * (p[dim] - center[dim])`. With a
non-zero center, any `Optimizerv4` driving this transform received a wrong
gradient.

`itkScaleLogarithmicTransformTest` exercised no Jacobian at all. The added
case: center `(5, 6, 7)`, scales `(2, 3, 4)`, point `(10, 10, 10)` — expected
diagonal `(10, 12, 12)`; the old code returns `(20, 30, 40)`.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code (claude-opus-4-8)
- Role: found the defect while cross-checking an independent reimplementation
  of ITKv4 registration against this source
- Contribution: the patch and the new Jacobian test case
- Testing: this commit (same SHA) passed CI in #6569's previous run,
  including `itkScaleLogarithmicTransformTest`

</details>