### PR TITLE
BUG: Reset smallestError per pixel in IterativeInverseDisplacementField

### DIFF
--- a/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.hxx
@@ -93,7 +93,6 @@ IterativeInverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::Generat
     const FieldInterpolatorPointer inputFieldInterpolator = FieldInterpolatorType::New();
     inputFieldInterpolator->SetInputImage(inputPtr);
 
-    double smallestError = 0;
     InputIt.GoToBegin();
     OutputIt.GoToBegin();
     while (!OutputIt.IsAtEnd())
@@ -105,6 +104,9 @@ IterativeInverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::Generat
 
       int    stillSamePoint = 0;
       double step = spacing;
+
+      // Reset per pixel: an unevaluable initial guess must not inherit the previous pixel's error bar.
+      double smallestError = NumericTraits<double>::max();
 
       // get the required displacement
       OutputImagePixelType displacement = OutputIt.Get();

--- a/Modules/Filtering/DisplacementField/test/CMakeLists.txt
+++ b/Modules/Filtering/DisplacementField/test/CMakeLists.txt
@@ -198,3 +198,9 @@ itk_add_test(
     ITKDisplacementFieldTestDriver
     itkExponentialDisplacementFieldImageFilterTest
 )
+
+set(
+  ITKDisplacementFieldGTests
+  itkIterativeInverseDisplacementFieldImageFilterGTest.cxx
+)
+creategoogletestdriver(ITKDisplacementField "${ITKDisplacementField-Test_LIBRARIES}" "${ITKDisplacementFieldGTests}")

--- a/Modules/Filtering/DisplacementField/test/itkIterativeInverseDisplacementFieldImageFilterGTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkIterativeInverseDisplacementFieldImageFilterGTest.cxx
@@ -1,0 +1,75 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkIterativeInverseDisplacementFieldImageFilter.h"
+#include "itkMath.h"
+#include "itkGTest.h"
+
+namespace
+{
+using VectorType = itk::Vector<float, 2>;
+using FieldType = itk::Image<VectorType, 2>;
+using FilterType = itk::IterativeInverseDisplacementFieldImageFilter<FieldType, FieldType>;
+
+// Zero field except pixel (20,20), whose first inverse guess maps outside the buffer.
+FieldType::Pointer
+MakeForwardField()
+{
+  auto field = FieldType::New();
+  field->SetRegions(FieldType::RegionType{ FieldType::IndexType{}, FieldType::SizeType::Filled(24) });
+  field->Allocate();
+  field->FillBuffer(VectorType{});
+  field->SetPixel({ { 20, 20 } }, itk::MakeVector(0.0F, 2.0F));
+  field->SetPixel({ { 20, 18 } }, itk::MakeVector(0.0F, -4.0F));
+  return field;
+}
+
+VectorType
+InverseAt(const FieldType::IndexType & index, const unsigned int iterations)
+{
+  auto filter = FilterType::New();
+  filter->SetInput(MakeForwardField());
+  filter->SetNumberOfIterations(iterations);
+  filter->SetStopValue(0.0);
+  filter->UpdateLargestPossibleRegion();
+  return filter->GetOutput()->GetPixel(index);
+}
+} // namespace
+
+// Refinement must not compare probes against the previous pixel's residual (issue #6575, B31).
+TEST(IterativeInverseDisplacementFieldImageFilter, RefinesPixelWhoseFirstGuessMapsOutsideBuffer)
+{
+  const FieldType::IndexType index{ { 20, 20 } };
+
+  const VectorType guess = InverseAt(index, 0);
+  ASSERT_NEAR(guess[0], 0.0, 1e-4);
+  ASSERT_NEAR(guess[1], 4.0, 1e-4);
+
+  const VectorType refined = InverseAt(index, 5);
+  EXPECT_GT((refined - guess).GetNorm(), 0.5);
+}
+
+TEST(IterativeInverseDisplacementFieldImageFilter, ZeroFieldPixelStaysNearZero)
+{
+  const VectorType inverse = InverseAt({ { 4, 4 } }, 5);
+  for (unsigned int j = 0; j < 2; ++j)
+  {
+    EXPECT_TRUE(itk::Math::isfinite(static_cast<double>(inverse[j])));
+  }
+  EXPECT_LE(inverse.GetNorm(), 0.5);
+}


### PR DESCRIPTION
Addresses item B31 of #6575.

`IterativeInverseDisplacementFieldImageFilter` declares the coordinate-descent residual bar `smallestError` outside the per-pixel loop and reassigns it only when a pixel's initial mapped point lies inside the input buffer. A pixel whose initial mapped point falls *outside* the buffer therefore inherits the previous pixel's residual as the value its probes must beat: probes that land back inside the buffer are accepted or rejected based on how well the *previous* pixel converged, so the inverse field's values at such pixels depend on raster order.

The fix moves the declaration inside the per-pixel loop, initialized to `NumericTraits<double>::max()`: the bar a probe must beat is the error of *this* pixel's current guess when that guess is evaluable (the existing inside-buffer branch still sets it), and "unknown — accept any evaluable probe" otherwise. Behavior for pixels whose initial guess is evaluable is unchanged.

The new regression test builds a 24×24 field where the pixel before the affected one in raster order converges to a zero residual (poisoning the stale bar) and the affected pixel's first guess maps just outside the interpolation buffer, with an in-buffer probe available one step away. Unfixed, the probe loses to the stale zero bar and the pixel never moves off its zero-iteration first guess; fixed, the descent accepts the probe and refines the estimate.

Verified locally (Linux, GCC 13, Release): the new test fails on unmodified `main` (`moved by 0`) and passes with the fix; all 24 ITKDisplacementField and 12 ITKRegionGrowing tests pass with the fix applied.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

<details>
<summary>AI assistance</summary>

- Tool: Claude Code (claude-fable-5, with claude-opus-4-8 subagents)
- Role: implemented the fix and regression test from the analysis previously filed as item B31 of #6575; hand-traced the failing scenario before implementation
- Testing: built locally and verified the regression test fails before / passes after the fix; full ITKDisplacementField + ITKRegionGrowing test suites pass with the fix
- Note: clang-format 19.1.7 was not available locally; formatting was hand-matched to ITK style and may need the CI formatter's touch-up
</details>
