### PR TITLE
BUG: Propagate input direction to subsampler in InverseDisplacementField

### DIFF
--- a/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInverseDisplacementFieldImageFilter.hxx
@@ -118,6 +118,7 @@ InverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::PrepareKernelBas
 
   resampler->SetInput(inputImage);
   resampler->SetOutputOrigin(inputImage->GetOrigin());
+  resampler->SetOutputDirection(inputImage->GetDirection());
 
   typename InputImageType::SpacingType spacing = inputImage->GetSpacing();
 

--- a/Modules/Filtering/DisplacementField/test/CMakeLists.txt
+++ b/Modules/Filtering/DisplacementField/test/CMakeLists.txt
@@ -201,6 +201,7 @@ itk_add_test(
 
 set(
   ITKDisplacementFieldGTests
+  itkInverseDisplacementFieldImageFilterGTest.cxx
   itkIterativeInverseDisplacementFieldImageFilterGTest.cxx
 )
 creategoogletestdriver(ITKDisplacementField "${ITKDisplacementField-Test_LIBRARIES}" "${ITKDisplacementFieldGTests}")

--- a/Modules/Filtering/DisplacementField/test/itkInverseDisplacementFieldImageFilterGTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkInverseDisplacementFieldImageFilterGTest.cxx
@@ -1,0 +1,64 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkInverseDisplacementFieldImageFilter.h"
+#include "itkThinPlateSplineKernelTransform.h"
+#include "itkImageRegionConstIterator.h"
+#include "itkGTest.h"
+
+namespace
+{
+using VectorType = itk::Vector<float, 2>;
+using FieldType = itk::Image<VectorType, 2>;
+using FilterType = itk::InverseDisplacementFieldImageFilter<FieldType, FieldType>;
+} // namespace
+
+// The kernel-spline subsampler must inherit the input direction; the exact inverse of a
+// constant displacement is its negation, reproduced exactly by the spline's affine part
+// (issue #6575, B32).
+TEST(InverseDisplacementFieldImageFilter, RecoversConstantInverseOnRotatedField)
+{
+  auto field = FieldType::New();
+  field->SetRegions(FieldType::RegionType{ FieldType::IndexType{}, FieldType::SizeType::Filled(32) });
+  FieldType::DirectionType direction;
+  direction(0, 0) = 0.0;
+  direction(0, 1) = -1.0;
+  direction(1, 0) = 1.0;
+  direction(1, 1) = 0.0;
+  field->SetDirection(direction);
+  field->Allocate();
+  field->FillBuffer(itk::MakeVector(2.0F, 3.0F));
+
+  auto filter = FilterType::New();
+  filter->SetInput(field);
+  filter->SetKernelTransform(itk::ThinPlateSplineKernelTransform<double, 2>::New());
+  filter->SetSubsamplingFactor(4);
+  filter->SetSize(FieldType::SizeType::Filled(16));
+  filter->SetOutputSpacing(itk::MakeFilled<FieldType::SpacingType>(1.0));
+  // Output window inside the subsampled landmark hull, so no sample extrapolates.
+  filter->SetOutputOrigin(itk::MakePoint(-16.0, 8.0));
+  filter->UpdateLargestPossibleRegion();
+
+  const FieldType *                        output = filter->GetOutput();
+  itk::ImageRegionConstIterator<FieldType> it(output, output->GetBufferedRegion());
+  for (it.GoToBegin(); !it.IsAtEnd(); ++it)
+  {
+    EXPECT_NEAR(it.Get()[0], -2.0, 0.05);
+    EXPECT_NEAR(it.Get()[1], -3.0, 0.05);
+  }
+}


### PR DESCRIPTION
Addresses item B32 of #6575.

`InverseDisplacementFieldImageFilter::PrepareKernelBaseSpline()` subsamples the input field with a `ResampleImageFilter` to generate kernel-spline landmarks, setting the resampler's output origin, spacing, size, and start index — but never its output direction, which `ResampleImageFilter`'s constructor leaves identity. For an input field with non-identity direction cosines two things go wrong at once: the resampler samples along an axis-aligned physical grid, so sample points fall outside the input buffer and silently take the default zero value; and the landmark read-back `TransformIndexToPhysicalPoint` on the subsampled image uses that identity direction, so the landmarks handed to the kernel transform are not on the input field's lattice at all. The kernel-spline inverse is then anchored on landmarks that do not correspond to the field being inverted.

The fix is one line: propagate `inputImage->GetDirection()` to the resampler, next to the existing origin propagation. Fields with identity direction are unaffected.

The new regression test builds a 32×32 field with a 90° rotation direction matrix and a constant displacement (2, 3), whose exact inverse is the constant (−2, −3) — reproduced exactly by the kernel spline's affine part once the landmarks are right. Unfixed, 56 of the 64 subsample points fall outside the rotated footprint and read zeros, and the recovered "inverse" is off by an order of magnitude (max error ≈ 9.3 against a 0.05 tolerance); fixed, the max error is ≈ 0.

Verified locally (Linux, GCC 13, Release): the new test fails on unmodified `main` (max error 9.3086) and passes with the fix; all 24 ITKDisplacementField and 12 ITKRegionGrowing tests pass with the fix applied.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

<details>
<summary>AI assistance</summary>

- Tool: Claude Code (claude-fable-5, with claude-opus-4-8 subagents)
- Role: implemented the fix and regression test from the analysis previously filed as item B32 of #6575; traced the buggy and fixed sampling geometry numerically before implementation
- Testing: built locally and verified the regression test fails before / passes after the fix; full ITKDisplacementField + ITKRegionGrowing test suites pass with the fix
- Note: clang-format 19.1.7 was not available locally; formatting was hand-matched to ITK style and may need the CI formatter's touch-up
</details>
