### PR TITLE
BUG: Skip voting-undecided pixels in MultiLabelSTAPLE seeding

### DIFF
--- a/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
@@ -143,7 +143,11 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::InitializeConf
 
     for (out.GoToBegin(); !out.IsAtEnd(); ++out, ++in)
     {
-      ++(this->m_ConfusionMatrixArray[k][in.Get()][out.Get()]);
+      // Voting-undecided pixels carry the label m_TotalLabelCount, one past the last matrix column.
+      if (static_cast<size_t>(out.Get()) < this->m_TotalLabelCount)
+      {
+        ++(this->m_ConfusionMatrixArray[k][in.Get()][out.Get()]);
+      }
     }
   }
 

--- a/Modules/Segmentation/LabelVoting/test/CMakeLists.txt
+++ b/Modules/Segmentation/LabelVoting/test/CMakeLists.txt
@@ -80,3 +80,6 @@ itk_add_test(
     ITKLabelVotingTestDriver
     itkMultiLabelSTAPLEImageFilterTest
 )
+
+set(ITKLabelVotingGTests itkMultiLabelSTAPLEImageFilterGTest.cxx)
+creategoogletestdriver(ITKLabelVoting "${ITKLabelVoting-Test_LIBRARIES}" "${ITKLabelVotingGTests}")

--- a/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterGTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterGTest.cxx
@@ -1,0 +1,80 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkMultiLabelSTAPLEImageFilter.h"
+#include "itkImageRegionIterator.h"
+#include "itkGTest.h"
+
+#include <array>
+
+namespace
+{
+using ImageType = itk::Image<unsigned char, 2>;
+using FilterType = itk::MultiLabelSTAPLEImageFilter<ImageType>;
+
+ImageType::Pointer
+MakeRaterImage(const std::array<unsigned char, 4> & labels)
+{
+  auto image = ImageType::New();
+  image->SetRegions(ImageType::RegionType{ ImageType::SizeType{ 4, 1 } });
+  image->Allocate();
+  itk::ImageRegionIterator<ImageType> it(image, image->GetBufferedRegion());
+  for (const unsigned char label : labels)
+  {
+    it.Set(label);
+    ++it;
+  }
+  return image;
+}
+} // namespace
+
+// Voting-tie pixels carry the undecided label (one past the confusion matrix's last column)
+// and must be skipped when seeding, not written past the row (issue #6575, B10).
+TEST(MultiLabelSTAPLEImageFilter, VotingUndecidedPixelsDoNotCorruptSeededConfusionMatrix)
+{
+  auto filter = FilterType::New();
+  filter->SetInput(0, MakeRaterImage({ 0, 1, 0, 1 }));
+  filter->SetInput(1, MakeRaterImage({ 0, 1, 1, 0 }));
+  // Zero EM iterations: the confusion matrices stay exactly as seeded by voting.
+  filter->SetMaximumNumberOfIterations(0);
+  filter->Update();
+  EXPECT_EQ(filter->GetElapsedNumberOfIterations(), 0u);
+
+  for (unsigned int rater = 0; rater < 2; ++rater)
+  {
+    const FilterType::ConfusionMatrixType & cm = filter->GetConfusionMatrix(rater);
+    ASSERT_EQ(cm.rows(), 3u);
+    ASSERT_EQ(cm.cols(), 2u);
+    const double expected[3][2] = { { 1.0, 0.0 }, { 0.0, 1.0 }, { 0.0, 0.0 } };
+    for (unsigned int r = 0; r < 3; ++r)
+    {
+      for (unsigned int c = 0; c < 2; ++c)
+      {
+        EXPECT_NEAR(cm(r, c), expected[r][c], 1e-6) << "rater " << rater << " (" << r << ',' << c << ')';
+      }
+    }
+  }
+
+  const unsigned char                 expectedOutput[4] = { 0, 1, 2, 2 };
+  itk::ImageRegionIterator<ImageType> out(filter->GetOutput(), filter->GetOutput()->GetBufferedRegion());
+  for (const unsigned char expectedLabel : expectedOutput)
+  {
+    EXPECT_EQ(out.Get(), expectedLabel);
+    ++out;
+  }
+}


### PR DESCRIPTION
Addresses item B10 of #6575.

`MultiLabelSTAPLEImageFilter` seeds each rater's confusion matrix from a `LabelVotingImageFilter` pass over the same inputs. On voting **ties** that filter writes its undecided label, which equals the total label count — one past the confusion matrix's last valid *column*. `Array2D::operator[]` is an unchecked row pointer into a flat row-major buffer, so `++CM[k][in][out]` with `out == m_TotalLabelCount` lands on `CM[k][in + 1][0]`: inside the allocation (the matrix has a spare row), but silently corrupting the NEXT observed label's row with phantom "rater observed `in+1`, estimated truth 0" counts. Every tie pixel in the seeding vote injects one such phantom count, skewing the row-normalized initial confusion matrices the EM iteration starts from — and the filter's public `GetConfusionMatrix()` output.

The EM loop and both normalizations only ever index rows and columns by real labels, so an undecided voting pixel has no legitimate slot in the matrix: it carries no (observed label, estimated true label) evidence. The fix skips such pixels in the seeding loop instead of letting the increment run past the row.

The new regression test engineers deterministic ties (two raters, four pixels, two of them split 1–1) and sets `MaximumNumberOfIterations = 0`, which leaves the matrices exactly as seeded. Unfixed, both raters' matrices come out with row 1 = [0.5, 0.5] and row 2 = [1, 0] (the leaked counts) and the output labels are wrong at three of four pixels ([0, 2, 0, 0]); fixed, the matrices are the exact row-normalized vote statistics (row 0 = [1, 0], row 1 = [0, 1], row 2 = [0, 0]) and the output is [0, 1, 2, 2] — agreements labeled, ties undecided. The full pass-by-pass trace is in the test's header comment.

Verified locally (Linux, GCC 13, Release): the new test fails on unmodified `main` (confusion matrix (1,0) = 0.5 expected 0, (2,0) = 1 expected 0; output [0, 2, 0, 0] expected [0, 1, 2, 2]) and passes with the fix; the full ITKLabelVoting suite plus the ITKImageStatistics, ITKReview, ITKDisplacementField, and ITKRegionGrowing suites pass with the fix applied.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

<details>
<summary>AI assistance</summary>

- Tool: Claude Code (claude-fable-5, with claude-opus-4-8 subagents)
- Role: implemented the fix and regression test from the analysis previously filed as item B10 of #6575; hand-traced the seeded matrices and final labeling (fixed and unfixed) before implementation
- Testing: built locally and verified the regression test fails before / passes after the fix; five module test suites pass with the fix
- Note: clang-format 19.1.7 was not available locally; formatting was hand-matched to ITK style and may need the CI formatter's touch-up
</details>
