### PR TITLE
BUG: Propagate rank to the last axis in FastApproximateRank

### DIFF
--- a/Modules/Nonunit/Review/include/itkFastApproximateRankImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkFastApproximateRankImageFilter.h
@@ -86,7 +86,7 @@ public:
     if (m_Rank != rank)
     {
       m_Rank = rank;
-      for (unsigned int i = 0; i < TInputImage::ImageDimension - 1; ++i)
+      for (unsigned int i = 0; i < TInputImage::ImageDimension; ++i)
       {
         this->m_Filters[i]->SetRank(m_Rank);
       }

--- a/Modules/Nonunit/Review/test/CMakeLists.txt
+++ b/Modules/Nonunit/Review/test/CMakeLists.txt
@@ -664,5 +664,9 @@ itk_add_test(
     0.0
 )
 
-set(ITKReviewGTests itkAreaOpeningImageFilterGTest.cxx)
+set(
+  ITKReviewGTests
+  itkAreaOpeningImageFilterGTest.cxx
+  itkFastApproximateRankImageFilterGTest.cxx
+)
 creategoogletestdriver(ITKReview "${ITKReview-Test_LIBRARIES}" "${ITKReviewGTests}")

--- a/Modules/Nonunit/Review/test/itkFastApproximateRankImageFilterGTest.cxx
+++ b/Modules/Nonunit/Review/test/itkFastApproximateRankImageFilterGTest.cxx
@@ -1,0 +1,59 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkFastApproximateRankImageFilter.h"
+#include "itkImageRegionIteratorWithIndex.h"
+#include "itkGTest.h"
+
+namespace
+{
+using ImageType = itk::Image<int, 2>;
+} // namespace
+
+// SetRank() must reach the separable sub-filter of every axis, including the last
+// (issue #6575, B18). Constant along axis 0, increasing along axis 1: only the
+// last-axis pass changes the result, and rank 0.02 selects the window minimum.
+TEST(FastApproximateRankImageFilter, RankReachesLastAxis)
+{
+  const ImageType::RegionType region(ImageType::SizeType::Filled(7));
+  auto                        image = ImageType::New();
+  image->SetRegions(region);
+  image->Allocate();
+  for (itk::ImageRegionIteratorWithIndex<ImageType> it(image, region); !it.IsAtEnd(); ++it)
+  {
+    it.Set(100 * (static_cast<int>(it.GetIndex()[1]) + 1));
+  }
+
+  using FilterType = itk::FastApproximateRankImageFilter<ImageType, ImageType>;
+  auto filter = FilterType::New();
+  filter->SetRadius(itk::MakeFilled<FilterType::RadiusType>(1));
+  filter->SetRank(0.02F);
+  ASSERT_EQ(filter->GetRank(), 0.02F);
+  filter->SetInput(image);
+  filter->Update();
+
+  // Interior rows only; boundary rows have cropped windows.
+  const ImageType * output = filter->GetOutput();
+  for (itk::IndexValueType y = 1; y <= 5; ++y)
+  {
+    for (itk::IndexValueType x = 0; x <= 6; ++x)
+    {
+      EXPECT_EQ(output->GetPixel({ { x, y } }), 100 * y) << "at (" << x << ',' << y << ')';
+    }
+  }
+}


### PR DESCRIPTION
Addresses item B18 of #6575.

`FastApproximateRankImageFilter` is a separable mini-pipeline of one per-axis `RankImageFilter` per image dimension. Its `SetRank()` forwards the caller's rank to only the first `ImageDimension - 1` sub-filters:

```cpp
for (unsigned int i = 0; i < TInputImage::ImageDimension - 1; ++i)
{
  this->m_Filters[i]->SetRank(m_Rank);
}
```

so the **last axis always runs at the sub-filter default of 0.5** — a median — regardless of the requested rank, and for 1-D images the loop body never runs at all. `GetRank()` still reports the requested value, so the mismatch is silent. The fix is the loop bound: `ImageDimension - 1` → `ImageDimension` (`MiniPipelineSeparableImageFilter` holds exactly `ImageDimension` sub-filters, one per axis).

The new regression test isolates the last axis: a 7×7 image constant along axis 0 and strictly increasing along axis 1, radius (1, 1), rank 0.02. The axis-0 pass is an identity on constant data, so the axis-1 (last-axis) pass is the discriminator: per `RankHistogram`'s selection rule (`target = rank * (entries - 1) + 1`), rank 0.02 over a 3-sample window selects the minimum while the default 0.5 selects the median. Interior pixels must equal the window minimum `100·y`; unfixed, they come out as the median `100·(y+1)`.

Verified locally (Linux, GCC 13, Release): the new test fails on unmodified `main` (interior pixels 200, expected 100 — the last axis still ran at rank 0.5) and passes with the fix; the full ITKReview suite plus the ITKImageStatistics, ITKLabelVoting, ITKDisplacementField, and ITKRegionGrowing suites pass with the fix applied.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

<details>
<summary>AI assistance</summary>

- Tool: Claude Code (claude-fable-5, with claude-opus-4-8 subagents)
- Role: implemented the fix and regression test from the analysis previously filed as item B18 of #6575; derived the expected test values from RankHistogram's selection rule before implementation
- Testing: built locally and verified the regression test fails before / passes after the fix; five module test suites pass with the fix
- Note: clang-format 19.1.7 was not available locally; formatting was hand-matched to ITK style and may need the CI formatter's touch-up
</details>
