### PR TITLE
Remove any empty line prior to a curly brace (`{`)

### DIFF
--- a/Modules/Core/Common/include/itkDomainThreader.hxx
+++ b/Modules/Core/Common/include/itkDomainThreader.hxx
@@ -26,7 +26,6 @@ template <typename TDomainPartitioner, typename TAssociate>
 DomainThreader<TDomainPartitioner, TAssociate>::DomainThreader()
   : m_Associate(nullptr)
   , m_DomainPartitioner(DomainPartitionerType::New())
-
 {
   this->m_MultiThreader = MultiThreaderBase::New();
   this->m_NumberOfWorkUnits = this->m_MultiThreader->GetNumberOfWorkUnits();

--- a/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
+++ b/Modules/Core/Common/include/itkShapedFloodFilledFunctionConditionalConstIterator.hxx
@@ -28,7 +28,6 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::ShapedFloo
   FunctionType *    fnPtr,
   IndexType         startIndex)
   : m_Function(fnPtr)
-
 {
   this->m_Image = imagePtr;
   m_Seeds.push_back(startIndex);
@@ -43,7 +42,6 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::ShapedFloo
   FunctionType *           fnPtr,
   std::vector<IndexType> & startIndex)
   : m_Function(fnPtr)
-
 {
   this->m_Image = imagePtr; // can not be done in the initialization list
   for (unsigned int i = 0; i < startIndex.size(); ++i)
@@ -60,7 +58,6 @@ ShapedFloodFilledFunctionConditionalConstIterator<TImage, TFunction>::ShapedFloo
   const ImageType * imagePtr,
   FunctionType *    fnPtr)
   : m_Function(fnPtr)
-
 {
   this->m_Image = imagePtr;
   // Set up the temporary image

--- a/Modules/Core/Common/src/itkProgressTransformer.cxx
+++ b/Modules/Core/Common/src/itkProgressTransformer.cxx
@@ -39,7 +39,6 @@ public:
 
 ProgressTransformer::ProgressTransformer(float start, float end, ProcessObject * targetFilter)
   : m_TargetFilter(targetFilter)
-
 {
   m_Start = std::clamp(start, 0.0f, 1.0f);
   m_End = std::clamp(end, 0.0f, 1.0f);

--- a/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
+++ b/Modules/Core/ImageFunction/include/itkBSplineDecompositionImageFilter.hxx
@@ -37,7 +37,6 @@ namespace itk
 
 template <typename TInputImage, typename TOutputImage>
 BSplineDecompositionImageFilter<TInputImage, TOutputImage>::BSplineDecompositionImageFilter()
-
 {
   this->SetSplineOrder(3);
 }

--- a/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
+++ b/Modules/Core/ImageFunction/include/itkRayCastInterpolateImageFunction.hxx
@@ -1347,7 +1347,6 @@ RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastHelper::ZeroSt
 
 template <typename TInputImage, typename TCoordinate>
 RayCastInterpolateImageFunction<TInputImage, TCoordinate>::RayCastInterpolateImageFunction()
-
 {
   m_FocalPoint[0] = 0.;
   m_FocalPoint[1] = 0.;

--- a/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
+++ b/Modules/Core/Mesh/include/itkConnectedRegionsMeshFilter.hxx
@@ -43,7 +43,6 @@ ConnectedRegionsMeshFilter<TInputMesh, TOutputMesh>::ConnectedRegionsMeshFilter(
   : m_ExtractionMode(Self::LargestRegion)
   , m_NumberOfCellsInRegion(SizeValueType{})
   , m_RegionNumber(IdentifierType{})
-
 {
   m_ClosestPoint.Fill(0);
 }

--- a/Modules/Core/Mesh/include/itkMeshSource.hxx
+++ b/Modules/Core/Mesh/include/itkMeshSource.hxx
@@ -24,7 +24,6 @@ namespace itk
 
 template <typename TOutputMesh>
 MeshSource<TOutputMesh>::MeshSource()
-
 {
   // Create the output. We use static_cast<> here because we know the default
   // output must be of type TOutputMesh

--- a/Modules/Core/Mesh/src/itkSimplexMeshGeometry.cxx
+++ b/Modules/Core/Mesh/src/itkSimplexMeshGeometry.cxx
@@ -24,7 +24,6 @@
 namespace itk
 {
 SimplexMeshGeometry::SimplexMeshGeometry()
-
 {
   constexpr double    c{ 1.0 / 3.0 };
   constexpr PointType p{};

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToPointSetFilter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToPointSetFilter.hxx
@@ -24,7 +24,6 @@ namespace itk
 
 template <typename TPointBasedSpatialObject, typename TOutputPointSet>
 SpatialObjectToPointSetFilter<TPointBasedSpatialObject, TOutputPointSet>::SpatialObjectToPointSetFilter()
-
 {
   this->SetNumberOfRequiredInputs(1);
 }

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.hxx
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObjectPoint.hxx
@@ -25,7 +25,6 @@ namespace itk
 
 template <unsigned int TPointDimension>
 TubeSpatialObjectPoint<TPointDimension>::TubeSpatialObjectPoint()
-
 {
   m_TangentInObjectSpace.Fill(0);
   m_Normal1InObjectSpace.Fill(0);

--- a/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkPipelineMonitorImageFilter.hxx
@@ -26,7 +26,6 @@ namespace itk
 template <typename TImageType>
 PipelineMonitorImageFilter<TImageType>::PipelineMonitorImageFilter()
   : m_ClearPipelineOnGenerateOutputInformation(true)
-
 {
   this->ClearPipelineSavedInformation();
 }

--- a/Modules/Core/Transform/include/itkEuler3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkEuler3DTransform.hxx
@@ -26,7 +26,6 @@ namespace itk
 template <typename TParametersValueType>
 Euler3DTransform<TParametersValueType>::Euler3DTransform()
   : Superclass(ParametersDimension)
-
 {
   m_AngleX = m_AngleY = m_AngleZ = ScalarType{};
   this->m_FixedParameters.SetSize(SpaceDimension + 1);
@@ -35,7 +34,6 @@ Euler3DTransform<TParametersValueType>::Euler3DTransform()
 
 template <typename TParametersValueType>
 Euler3DTransform<TParametersValueType>::Euler3DTransform(const MatrixType & matrix, const OutputPointType & offset)
-
 {
   this->SetMatrix(matrix);
 
@@ -51,7 +49,6 @@ Euler3DTransform<TParametersValueType>::Euler3DTransform(const MatrixType & matr
 template <typename TParametersValueType>
 Euler3DTransform<TParametersValueType>::Euler3DTransform(unsigned int parametersDimension)
   : Superclass(parametersDimension)
-
 {
 
   m_AngleX = m_AngleY = m_AngleZ = ScalarType{};

--- a/Modules/Filtering/AnisotropicDiffusionLBR/include/itkAnisotropicDiffusionLBRImageFilter.hxx
+++ b/Modules/Filtering/AnisotropicDiffusionLBR/include/itkAnisotropicDiffusionLBRImageFilter.hxx
@@ -36,7 +36,6 @@ AnisotropicDiffusionLBRImageFilter<TImage, TScalar>::AnisotropicDiffusionLBRImag
   ,
 
   m_DiffusionTime(1)
-
 {}
 
 

--- a/Modules/Filtering/AnisotropicDiffusionLBR/include/itkLinearAnisotropicDiffusionLBRImageFilter.hxx
+++ b/Modules/Filtering/AnisotropicDiffusionLBR/include/itkLinearAnisotropicDiffusionLBRImageFilter.hxx
@@ -42,7 +42,6 @@ LinearAnisotropicDiffusionLBRImageFilter<TImage, TScalar>::LinearAnisotropicDiff
   ,
 
   m_EffectiveDiffusionTime(0)
-
 {
   this->SetNumberOfRequiredInputs(2);
 }

--- a/Modules/Filtering/AnisotropicDiffusionLBR/include/itkStructureTensorImageFilter.hxx
+++ b/Modules/Filtering/AnisotropicDiffusionLBR/include/itkStructureTensorImageFilter.hxx
@@ -33,7 +33,6 @@ template <typename TImage, typename TTensorImage>
 StructureTensorImageFilter<TImage, TTensorImage>::StructureTensorImageFilter()
   : m_FeatureScale(2)
   , m_NoiseScale(1)
-
 {}
 
 

--- a/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureNDAnisotropicDiffusionFunction.hxx
+++ b/Modules/Filtering/AnisotropicSmoothing/include/itkVectorCurvatureNDAnisotropicDiffusionFunction.hxx
@@ -26,7 +26,6 @@ double VectorCurvatureNDAnisotropicDiffusionFunction<TImage>::m_MIN_NORM = 1.0e-
 
 template <typename TImage>
 VectorCurvatureNDAnisotropicDiffusionFunction<TImage>::VectorCurvatureNDAnisotropicDiffusionFunction()
-
 {
   RadiusType r;
   for (unsigned int i = 0; i < ImageDimension; ++i)

--- a/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkMRASlabIdentifier.hxx
@@ -32,7 +32,6 @@ MRASlabIdentifier<TInputImage>::MRASlabIdentifier()
   , m_NumberOfSamples(10)
   , m_SlicingDirection(2)
   , m_BackgroundMinimumThreshold(NumericTraits<ImagePixelType>::min()) // default slicing axis is z
-
 {}
 
 template <typename TInputImage>

--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
@@ -48,7 +48,6 @@ N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::N4BiasF
   : m_MaskLabel(NumericTraits<MaskPixelType>::OneValue())
   , m_CurrentConvergenceMeasurement(RealType{})
   , m_LogBiasFieldControlPointLattice(nullptr)
-
 {
   // implicit:
   // #0 "Primary" required

--- a/Modules/Filtering/BoneEnhancement/include/itkKrcahPreprocessingImageToImageFilter.hxx
+++ b/Modules/Filtering/BoneEnhancement/include/itkKrcahPreprocessingImageToImageFilter.hxx
@@ -28,7 +28,6 @@ template <typename TInputImage, typename TOutputImage>
 KrcahPreprocessingImageToImageFilter<TInputImage, TOutputImage>::KrcahPreprocessingImageToImageFilter()
   : m_Sigma(1.0f)
   , m_ScalingConstant(10.0f)
-
 {
   /* Instantiate all filters */
   m_GaussianFilter = GaussianFilterType::New();

--- a/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkFFTConvolutionImageFilter.h
@@ -56,7 +56,6 @@ template <typename TInputImage,
           typename TInternalPrecision = double>
 class ITK_TEMPLATE_EXPORT FFTConvolutionImageFilter
   : public ConvolutionImageFilterBase<TInputImage, TKernelImage, TOutputImage>
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(FFTConvolutionImageFilter);

--- a/Modules/Filtering/Cuberille/include/itkCuberilleImageToMeshFilter.hxx
+++ b/Modules/Filtering/Cuberille/include/itkCuberilleImageToMeshFilter.hxx
@@ -34,7 +34,6 @@ template <typename TInputImage, typename TOutputMesh, typename TInterpolator>
 CuberilleImageToMeshFilter<TInputImage, TOutputMesh, TInterpolator>::CuberilleImageToMeshFilter()
   : m_IsoSurfaceValue(NumericTraits<InputPixelType>::One)
   , m_MaxSpacing(NumericTraits<SpacingValueType>::One)
-
 {
   this->SetNumberOfRequiredInputs(1);
   this->CalculateLabelsArray();

--- a/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowImageFilter.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowImageFilter.hxx
@@ -25,7 +25,6 @@ namespace itk
 
 template <typename TInputImage, typename TOutputImage>
 BinaryMinMaxCurvatureFlowImageFilter<TInputImage, TOutputImage>::BinaryMinMaxCurvatureFlowImageFilter()
-
 {
   auto cffp = BinaryMinMaxCurvatureFlowFunctionType::New();
 

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
@@ -41,7 +41,6 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
   , m_Threshold(NumericTraits<ReferencePixelType>::min())
   , m_BValue(1.0)
   , m_GradientImageTypeEnumeration(DiffusionTensor3DReconstructionImageFilterEnums::GradientImageFormat::Else)
-
 {
   // At least 1 inputs is necessary for a vector image.
   // For images added one at a time we need at least six

--- a/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineExponentialDiffeomorphicTransform.hxx
@@ -30,7 +30,6 @@ namespace itk
 
 template <typename TParametersValueType, unsigned int VDimension>
 BSplineExponentialDiffeomorphicTransform<TParametersValueType, VDimension>::BSplineExponentialDiffeomorphicTransform()
-
 {
   this->m_NumberOfControlPointsForTheConstantVelocityField.Fill(4);
   this->m_NumberOfControlPointsForTheUpdateField.Fill(4);

--- a/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransform.hxx
@@ -30,7 +30,6 @@ namespace itk
 template <typename TParametersValueType, unsigned int VDimension>
 BSplineSmoothingOnUpdateDisplacementFieldTransform<TParametersValueType,
                                                    VDimension>::BSplineSmoothingOnUpdateDisplacementFieldTransform()
-
 {
   this->m_NumberOfControlPointsForTheUpdateField.Fill(4);
   this->m_NumberOfControlPointsForTheTotalField.Fill(0);

--- a/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkConstantVelocityFieldTransform.hxx
@@ -33,7 +33,6 @@ ConstantVelocityFieldTransform<TParametersValueType, VDimension>::ConstantVeloci
   , m_LowerTimeBound(0.0)
   , m_UpperTimeBound(1.0)
   , m_NumberOfIntegrationSteps(10)
-
 {
   this->m_FixedParameters.SetSize(ConstantVelocityFieldDimension * (ConstantVelocityFieldDimension + 3));
   this->m_FixedParameters.Fill(0.0);

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldToBSplineImageFilter.hxx
@@ -34,7 +34,6 @@ template <typename TInputImage, typename TInputPointSet, typename TOutputImage>
 DisplacementFieldToBSplineImageFilter<TInputImage, TInputPointSet, TOutputImage>::
   DisplacementFieldToBSplineImageFilter()
   : m_PointWeights(nullptr)
-
 {
   // Input 0 DisplacementField optional
   Self::SetPrimaryInputName("DisplacementField");

--- a/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkInvertDisplacementFieldImageFilter.hxx
@@ -42,7 +42,6 @@ InvertDisplacementFieldImageFilter<TInputImage, TOutputImage>::InvertDisplacemen
   , m_MaxErrorNorm(0.0)
   , m_MeanErrorNorm(0.0)
   , m_Epsilon(0.0)
-
 {
   this->Self::SetPrimaryInputName("DisplacementField");
   this->Self::AddOptionalInputName("InverseFieldInitialEstimate");

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingBSplineVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingBSplineVelocityFieldTransform.hxx
@@ -32,7 +32,6 @@ namespace itk
 template <typename TParametersValueType, unsigned int VDimension>
 TimeVaryingBSplineVelocityFieldTransform<TParametersValueType, VDimension>::TimeVaryingBSplineVelocityFieldTransform()
   : m_SplineOrder(3)
-
 {
   this->m_VelocityFieldOrigin.Fill(0.0);
   this->m_VelocityFieldSpacing.Fill(1.0);

--- a/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTimeVaryingVelocityFieldIntegrationImageFilter.hxx
@@ -30,7 +30,6 @@ namespace itk
 template <typename TTimeVaryingVelocityField, typename TDisplacementField>
 TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField,
                                                TDisplacementField>::TimeVaryingVelocityFieldIntegrationImageFilter()
-
 {
   this->m_LowerTimeBound = 0.0, this->m_UpperTimeBound = 1.0, this->m_NumberOfIntegrationSteps = 100;
   this->SetNumberOfRequiredInputs(1);

--- a/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkTransformToDisplacementFieldFilter.hxx
@@ -28,7 +28,6 @@ namespace itk
 
 template <typename TOutputImage, typename TParametersValueType>
 TransformToDisplacementFieldFilter<TOutputImage, TParametersValueType>::TransformToDisplacementFieldFilter()
-
 {
   this->m_OutputSpacing.Fill(1.0);
   this->m_OutputOrigin.Fill(0.0);

--- a/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkVelocityFieldTransform.hxx
@@ -31,7 +31,6 @@ VelocityFieldTransform<TParametersValueType, VDimension>::VelocityFieldTransform
   : m_LowerTimeBound(0.0)
   , m_UpperTimeBound(1.0)
   , m_NumberOfIntegrationSteps(10)
-
 {
   this->m_FixedParameters.SetSize(VelocityFieldDimension * (VelocityFieldDimension + 3));
   this->m_FixedParameters.Fill(0.0);

--- a/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkDanielssonDistanceMapImageFilter.hxx
@@ -30,7 +30,6 @@ namespace itk
 
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
 DanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::DanielssonDistanceMapImageFilter()
-
 {
   // Make the outputs (distance map, voronoi map, distance vectors).
   ProcessObject::MakeRequiredOutputs(*this, 3);

--- a/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkSignedDanielssonDistanceMapImageFilter.hxx
@@ -31,7 +31,6 @@ namespace itk
 template <typename TInputImage, typename TOutputImage, typename TVoronoiImage>
 SignedDanielssonDistanceMapImageFilter<TInputImage, TOutputImage, TVoronoiImage>::
   SignedDanielssonDistanceMapImageFilter()
-
 {
   // Make the outputs (distance map, voronoi map, distance vectors).
   ProcessObject::MakeRequiredOutputs(*this, 3);

--- a/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWComplexToComplex1DFFTImageFilter.hxx
@@ -37,7 +37,6 @@ namespace itk
 
 template <typename TInputImage, typename TOutputImage>
 FFTWComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::FFTWComplexToComplex1DFFTImageFilter()
-
 {
   // We cannot split over the FFT direction
   this->m_ImageRegionSplitter = ImageRegionSplitterDirection::New();

--- a/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWForward1DFFTImageFilter.hxx
@@ -37,7 +37,6 @@ namespace itk
 
 template <typename TInputImage, typename TOutputImage>
 FFTWForward1DFFTImageFilter<TInputImage, TOutputImage>::FFTWForward1DFFTImageFilter()
-
 {
   // We cannot split over the FFT direction
   this->m_ImageRegionSplitter = ImageRegionSplitterDirection::New();

--- a/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.hxx
+++ b/Modules/Filtering/FFT/include/itkFFTWInverse1DFFTImageFilter.hxx
@@ -38,7 +38,6 @@ namespace itk
 
 template <typename TInputImage, typename TOutputImage>
 FFTWInverse1DFFTImageFilter<TInputImage, TOutputImage>::FFTWInverse1DFFTImageFilter()
-
 {
   // We cannot split over the FFT direction
   this->m_ImageRegionSplitter = ImageRegionSplitterDirection::New();

--- a/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkHalfHermitianToRealInverseFFTImageFilter.h
@@ -56,7 +56,6 @@ template <typename TInputImage,
           typename TOutputImage = Image<typename TInputImage::PixelType::value_type, TInputImage::ImageDimension>>
 class ITK_TEMPLATE_EXPORT HalfHermitianToRealInverseFFTImageFilter
   : public ImageToImageFilter<TInputImage, TOutputImage>
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(HalfHermitianToRealInverseFFTImageFilter);

--- a/Modules/Filtering/FFT/include/itkInverseFFTImageFilter.h
+++ b/Modules/Filtering/FFT/include/itkInverseFFTImageFilter.h
@@ -49,7 +49,6 @@ namespace itk
 template <typename TInputImage,
           typename TOutputImage = Image<typename TInputImage::PixelType::value_type, TInputImage::ImageDimension>>
 class ITK_TEMPLATE_EXPORT InverseFFTImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(InverseFFTImageFilter);

--- a/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
+++ b/Modules/Filtering/ImageCompose/include/itkJoinSeriesImageFilter.hxx
@@ -26,7 +26,6 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
 JoinSeriesImageFilter<TInputImage, TOutputImage>::JoinSeriesImageFilter()
-
 {
   this->DynamicMultiThreadingOn();
   this->ThreaderUpdateProgressOff();

--- a/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkBilateralImageFilter.hxx
@@ -37,7 +37,6 @@ BilateralImageFilter<TInputImage, TOutputImage>::BilateralImageFilter()
   , m_FilterDimensionality(ImageDimension)
   , m_AutomaticKernelSize(true)
   , m_NumberOfRangeGaussianSamples(100)
-
 {
   this->m_Radius.Fill(1);
   this->m_DomainSigma.Fill(4.0);

--- a/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianRecursiveGaussianImageFilter.hxx
@@ -27,7 +27,6 @@ namespace itk
 
 template <typename TInputImage, typename TOutputImage>
 HessianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::HessianRecursiveGaussianImageFilter()
-
 {
   std::generate(m_SmoothingFilters.begin(), m_SmoothingFilters.end(), [this] {
     const auto filter = GaussianFilterType::New();

--- a/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkHessianToObjectnessMeasureImageFilter.hxx
@@ -32,7 +32,6 @@ namespace itk
 
 template <typename TInputImage, typename TOutputImage>
 HessianToObjectnessMeasureImageFilter<TInputImage, TOutputImage>::HessianToObjectnessMeasureImageFilter()
-
 {
   this->DynamicMultiThreadingOn();
   this->ThreaderUpdateProgressOff();

--- a/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkLaplacianRecursiveGaussianImageFilter.hxx
@@ -28,7 +28,6 @@ namespace itk
 
 template <typename TInputImage, typename TOutputImage>
 LaplacianRecursiveGaussianImageFilter<TInputImage, TOutputImage>::LaplacianRecursiveGaussianImageFilter()
-
 {
   std::generate(m_SmoothingFilters.begin(), m_SmoothingFilters.end(), [this] {
     const auto filter = GaussianFilterType::New();

--- a/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.hxx
+++ b/Modules/Filtering/ImageFeature/include/itkMultiScaleHessianBasedMeasureImageFilter.hxx
@@ -44,7 +44,6 @@ MultiScaleHessianBasedMeasureImageFilter<TInputImage, THessianImage, TOutputImag
   , m_HessianToMeasureFilter(nullptr)
   , m_HessianFilter(HessianFilterType::New())
   , m_UpdateBuffer(UpdateBufferType::New())
-
 {
   auto scalesImage = ScalesImageType::New();
   auto hessianImage = HessianImageType::New();

--- a/Modules/Filtering/ImageFilterBase/include/itkBinaryGeneratorImageFilter.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkBinaryGeneratorImageFilter.hxx
@@ -165,7 +165,6 @@ template <typename TInputImage1, typename TInputImage2, typename TOutputImage>
 void
 BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>::DynamicThreadedGenerateData(
   const OutputImageRegionType & outputRegionForThread)
-
 {
   m_DynamicThreadedGenerateDataFunction(outputRegionForThread);
 }

--- a/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilterBase.hxx
+++ b/Modules/Filtering/ImageFilterBase/include/itkMovingHistogramImageFilterBase.hxx
@@ -29,7 +29,6 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage, typename TKernel>
 MovingHistogramImageFilterBase<TInputImage, TOutputImage, TKernel>::MovingHistogramImageFilterBase()
-
 {
   // call again SetKernel in that class, to have the offsets computed for
   // the default kernel. An AnalyzeKernel() method as in the binary

--- a/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.hxx
+++ b/Modules/Filtering/ImageFrequency/include/itkFrequencyBandImageFilter.hxx
@@ -30,7 +30,6 @@ template <typename TImageType, typename TFrequencyIterator>
 FrequencyBandImageFilter<TImageType, TFrequencyIterator>::FrequencyBandImageFilter()
   : m_LowFrequencyThreshold(0)
   , m_HighFrequencyThreshold(0.5)
-
 {
   this->InPlaceOff();
   this->DynamicMultiThreadingOn();

--- a/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.hxx
+++ b/Modules/Filtering/ImageFrequency/include/itkUnaryFrequencyDomainFilter.hxx
@@ -26,7 +26,6 @@ namespace itk
 {
 template <typename TImageType, typename TFrequencyIterator>
 UnaryFrequencyDomainFilter<TImageType, TFrequencyIterator>::UnaryFrequencyDomainFilter()
-
 {
   this->InPlaceOff();
   this->DynamicMultiThreadingOn();

--- a/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientMagnitudeRecursiveGaussianImageFilter.hxx
@@ -30,7 +30,6 @@ template <typename TInputImage, typename TOutputImage>
 GradientMagnitudeRecursiveGaussianImageFilter<TInputImage,
                                               TOutputImage>::GradientMagnitudeRecursiveGaussianImageFilter()
   : m_DerivativeFilter(DerivativeFilterType::New())
-
 {
   m_DerivativeFilter->SetOrder(GaussianOrderEnum::FirstOrder);
   m_DerivativeFilter->SetNormalizeAcrossScale(m_NormalizeAcrossScale);

--- a/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/ImageGradient/include/itkGradientRecursiveGaussianImageFilter.hxx
@@ -28,7 +28,6 @@ namespace itk
 
 template <typename TInputImage, typename TOutputImage>
 GradientRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GradientRecursiveGaussianImageFilter()
-
 {
   static_assert(ImageDimension > 0, "Images shall have one dimension at least");
   const unsigned int imageDimensionMinus1 = ImageDimension - 1;

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
@@ -33,7 +33,6 @@ namespace itk
 template <typename TInputImage, typename TOutputImage>
 BSplineControlPointImageFilter<TInputImage, TOutputImage>::BSplineControlPointImageFilter()
   : m_NumberOfLevels(1)
-
 {
   this->m_Size.Fill(0);
   this->m_Spacing.Fill(1.0);

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -32,7 +32,6 @@ namespace itk
 
 template <typename TInputPointSet, typename TOutputImage>
 BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::BSplineScatteredDataPointSetToImageFilter()
-
 {
   this->m_SplineOrder.Fill(3);
   this->DynamicMultiThreadingOff();

--- a/Modules/Filtering/ImageGrid/include/itkFlipImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkFlipImageFilter.hxx
@@ -26,7 +26,6 @@ namespace itk
 
 template <typename TImage>
 FlipImageFilter<TImage>::FlipImageFilter()
-
 {
   m_FlipAxes.Fill(false);
   this->DynamicMultiThreadingOn();

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
@@ -33,7 +33,6 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage, typename TDisplacementField>
 WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::WarpImageFilter()
-
 {
   // #0 implicit "Primary" input required
   // #1 "DisplacementField" required

--- a/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkHistogramMatchingImageFilter.hxx
@@ -33,7 +33,6 @@ HistogramMatchingImageFilter<TInputImage, TOutputImage, THistogramMeasurement>::
   , m_ReferenceMaxValue(THistogramMeasurement{})
   , m_SourceHistogram(HistogramType::New())
   , m_OutputHistogram(HistogramType::New())
-
 {
   this->SetNumberOfRequiredInputs(1);
   Self::SetPrimaryInputName("SourceImage");

--- a/Modules/Filtering/ImageIntensity/include/itkMaskImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskImageFilter.h
@@ -144,7 +144,6 @@ private:
  */
 template <typename TInputImage, typename TMaskImage, typename TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT MaskImageFilter : public BinaryGeneratorImageFilter<TInputImage, TMaskImage, TOutputImage>
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MaskImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkMaskedAssignImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskedAssignImageFilter.h
@@ -58,7 +58,6 @@ namespace itk
  */
 template <typename TInputImage, typename TMaskImage, typename TOutputImage = TInputImage>
 class MaskedAssignImageFilter : public TernaryGeneratorImageFilter<TInputImage, TMaskImage, TOutputImage, TOutputImage>
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(MaskedAssignImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkNaryFunctorImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNaryFunctorImageFilter.h
@@ -40,7 +40,6 @@ namespace itk
 
 template <typename TInputImage, typename TOutputImage, typename TFunction>
 class ITK_TEMPLATE_EXPORT NaryFunctorImageFilter : public InPlaceImageFilter<TInputImage, TOutputImage>
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(NaryFunctorImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkNotImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkNotImageFilter.h
@@ -57,7 +57,6 @@ class NotImageFilter
   : public UnaryFunctorImageFilter<TInputImage,
                                    TOutputImage,
                                    Functor::NOT<typename TInputImage::PixelType, typename TOutputImage::PixelType>>
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(NotImageFilter);

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMask2DImageFilter.hxx
@@ -37,7 +37,6 @@ PolylineMask2DImageFilter<TInputImage, TPolyline, TOutputImage>::PolylineMask2DI
 template <typename TInputImage, typename TPolyline, typename TOutputImage>
 void
 PolylineMask2DImageFilter<TInputImage, TPolyline, TOutputImage>::SetInput1(const TInputImage * input)
-
 {
   // Process object is not const-correct so the const_cast is required here
   this->ProcessObject::SetNthInput(0, const_cast<TInputImage *>(input));

--- a/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
+++ b/Modules/Filtering/ImageIntensity/include/itkPolylineMaskImageFilter.hxx
@@ -39,7 +39,6 @@ PolylineMaskImageFilter<TInputImage, TPolyline, TVector, TOutputImage>::Polyline
   , m_UpVector(MakeFilled<VectorType>(1))
   , m_CameraCenterPoint(0)
   , m_FocalPoint()
-
 {
   this->SetNumberOfRequiredInputs(2);
 

--- a/Modules/Filtering/ImageIntensity/include/itkWeightedAddImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkWeightedAddImageFilter.h
@@ -115,7 +115,6 @@ private:
 template <typename TInputImage1, typename TInputImage2, typename TOutputImage>
 class ITK_TEMPLATE_EXPORT WeightedAddImageFilter
   : public BinaryGeneratorImageFilter<TInputImage1, TInputImage2, TOutputImage>
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(WeightedAddImageFilter);

--- a/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkAdditiveGaussianNoiseImageFilter.hxx
@@ -29,7 +29,6 @@ namespace itk
 
 template <class TInputImage, class TOutputImage>
 AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>::AdditiveGaussianNoiseImageFilter()
-
 {
   this->DynamicMultiThreadingOff();
   this->ThreaderUpdateProgressOff();

--- a/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkNoiseBaseImageFilter.hxx
@@ -26,7 +26,6 @@ namespace itk
 
 template <class TInputImage, class TOutputImage>
 NoiseBaseImageFilter<TInputImage, TOutputImage>::NoiseBaseImageFilter()
-
 {
   Self::SetSeed();
 

--- a/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkShotNoiseImageFilter.hxx
@@ -30,7 +30,6 @@ namespace itk
 
 template <class TInputImage, class TOutputImage>
 ShotNoiseImageFilter<TInputImage, TOutputImage>::ShotNoiseImageFilter()
-
 {
   this->DynamicMultiThreadingOff();
   this->ThreaderUpdateProgressOff();

--- a/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
+++ b/Modules/Filtering/ImageNoise/include/itkSpeckleNoiseImageFilter.hxx
@@ -29,7 +29,6 @@ namespace itk
 
 template <class TInputImage, class TOutputImage>
 SpeckleNoiseImageFilter<TInputImage, TOutputImage>::SpeckleNoiseImageFilter()
-
 {
   this->DynamicMultiThreadingOff();
   this->ThreaderUpdateProgressOff();

--- a/Modules/Filtering/ImageSources/include/itkGaborImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGaborImageSource.hxx
@@ -28,7 +28,6 @@ namespace itk
 
 template <typename TOutputImage>
 GaborImageSource<TOutputImage>::GaborImageSource()
-
 {
   // Gabor parameters, defined so that the Gaussian
   // is centered in the default image

--- a/Modules/Filtering/ImageSources/include/itkGaussianImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGaussianImageSource.hxx
@@ -28,7 +28,6 @@ namespace itk
 
 template <typename TOutputImage>
 GaussianImageSource<TOutputImage>::GaussianImageSource()
-
 {
   // Gaussian parameters, defined so that the Gaussian
   // is centered in the default image

--- a/Modules/Filtering/ImageSources/include/itkGenerateImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGenerateImageSource.hxx
@@ -27,7 +27,6 @@ template <typename TOutputImage>
 GenerateImageSource<TOutputImage>::GenerateImageSource()
   : m_Spacing(MakeFilled<SpacingType>(1.0))
   , m_Origin()
-
 {
   this->m_Size.Fill(64); // arbitrary default size
   this->m_Direction.SetIdentity();

--- a/Modules/Filtering/ImageSources/include/itkGridImageSource.hxx
+++ b/Modules/Filtering/ImageSources/include/itkGridImageSource.hxx
@@ -28,7 +28,6 @@ namespace itk
 {
 template <typename TOutputImage>
 GridImageSource<TOutputImage>::GridImageSource()
-
 {
   this->m_Sigma.Fill(0.5);
   this->m_GridSpacing.Fill(4.0);

--- a/Modules/Filtering/ImageStatistics/include/itkAdaptiveHistogramEqualizationImageFilter.h
+++ b/Modules/Filtering/ImageStatistics/include/itkAdaptiveHistogramEqualizationImageFilter.h
@@ -73,7 +73,6 @@ class ITK_TEMPLATE_EXPORT AdaptiveHistogramEqualizationImageFilter
       TImageType,
       TKernel,
       Function::AdaptiveEqualizationHistogram<typename TImageType::PixelType, typename TImageType::PixelType>>
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(AdaptiveHistogramEqualizationImageFilter);

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
@@ -24,7 +24,6 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
 ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::ImagePCAShapeModelEstimator()
-
 {
   m_EigenVectors.set_size(0, 0);
   m_EigenValues.set_size(0);

--- a/Modules/Filtering/ImageStatistics/test/itkAdaptiveHistogramEqualizationImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkAdaptiveHistogramEqualizationImageFilterTest.cxx
@@ -25,7 +25,6 @@
 
 int
 itkAdaptiveHistogramEqualizationImageFilterTest(int argc, char * argv[])
-
 {
   if (argc < 6)
   {

--- a/Modules/Filtering/IsotropicWavelets/include/itkFrequencyShrinkImageFilter.hxx
+++ b/Modules/Filtering/IsotropicWavelets/include/itkFrequencyShrinkImageFilter.hxx
@@ -32,7 +32,6 @@ namespace itk
 {
 template <class TImageType>
 FrequencyShrinkImageFilter<TImageType>::FrequencyShrinkImageFilter()
-
 {
   for (unsigned int j = 0; j < ImageDimension; j++)
   {

--- a/Modules/Filtering/IsotropicWavelets/include/itkRieszFrequencyFilterBankGenerator.hxx
+++ b/Modules/Filtering/IsotropicWavelets/include/itkRieszFrequencyFilterBankGenerator.hxx
@@ -24,7 +24,6 @@ namespace itk
 template <typename TOutputImage, typename TRieszFunction, typename TFrequencyRegionIterator>
 RieszFrequencyFilterBankGenerator<TOutputImage, TRieszFunction, TFrequencyRegionIterator>::
   RieszFrequencyFilterBankGenerator()
-
 {
   this->m_Evaluator = RieszFunctionType::New();
   this->SetOrder(1);

--- a/Modules/Filtering/IsotropicWavelets/include/itkRieszFrequencyFunction.hxx
+++ b/Modules/Filtering/IsotropicWavelets/include/itkRieszFrequencyFunction.hxx
@@ -26,7 +26,6 @@ namespace itk
 {
 template <typename TFunctionValue, unsigned int VImageDimension, typename TInput>
 RieszFrequencyFunction<TFunctionValue, VImageDimension, TInput>::RieszFrequencyFunction()
-
 {
   // SetOrder also sets m_Indices.
   this->SetOrder(1);

--- a/Modules/Filtering/IsotropicWavelets/include/itkRieszRotationMatrix.hxx
+++ b/Modules/Filtering/IsotropicWavelets/include/itkRieszRotationMatrix.hxx
@@ -31,7 +31,6 @@ RieszRotationMatrix<VImageDimension>::RieszRotationMatrix()
   ,
 
   m_MaxAbsoluteDifferenceCloseToZero(1 * itk::NumericTraits<RealType>::epsilon())
-
 {}
 
 template <unsigned int VImageDimension>
@@ -41,7 +40,6 @@ RieszRotationMatrix<VImageDimension>::RieszRotationMatrix(const Self & rieszMatr
   , m_Order(rieszMatrix.GetOrder())
   , m_Components(rieszMatrix.GetComponents())
   , m_MaxAbsoluteDifferenceCloseToZero(1 * itk::NumericTraits<RealType>::epsilon())
-
 {}
 
 template <unsigned int VImageDimension>
@@ -50,7 +48,6 @@ RieszRotationMatrix<VImageDimension>::RieszRotationMatrix(const SpatialRotationM
   : Superclass()
   , m_SpatialRotationMatrix(spatialRotationMatrix)
   , m_MaxAbsoluteDifferenceCloseToZero(1 * itk::NumericTraits<RealType>::epsilon())
-
 {
   this->SetOrder(order);
   this->ComputeSteerableMatrix();

--- a/Modules/Filtering/IsotropicWavelets/include/itkStructureTensorImageFilter.hxx
+++ b/Modules/Filtering/IsotropicWavelets/include/itkStructureTensorImageFilter.hxx
@@ -32,8 +32,6 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
 StructureTensorImageFilter<TInputImage, TOutputImage>::StructureTensorImageFilter()
-
-
 {
   this->m_GaussianSource = GaussianSourceType::New();
 

--- a/Modules/Filtering/IsotropicWavelets/include/itkWaveletFrequencyFilterBankGenerator.hxx
+++ b/Modules/Filtering/IsotropicWavelets/include/itkWaveletFrequencyFilterBankGenerator.hxx
@@ -24,8 +24,6 @@ namespace itk
 template <typename TOutputImage, typename TWaveletFunction, typename TFrequencyRegionIterator>
 WaveletFrequencyFilterBankGenerator<TOutputImage, TWaveletFunction, TFrequencyRegionIterator>::
   WaveletFrequencyFilterBankGenerator()
-
-
 {
   this->SetHighPassSubBands(1);
   m_WaveletFunction = TWaveletFunction::New();

--- a/Modules/Filtering/IsotropicWavelets/include/itkWaveletFrequencyForward.hxx
+++ b/Modules/Filtering/IsotropicWavelets/include/itkWaveletFrequencyForward.hxx
@@ -30,8 +30,6 @@ namespace itk
 template <typename TInputImage, typename TOutputImage, typename TWaveletFilterBank, typename TFrequencyShrinkFilterType>
 WaveletFrequencyForward<TInputImage, TOutputImage, TWaveletFilterBank, TFrequencyShrinkFilterType>::
   WaveletFrequencyForward()
-
-
 {
   this->SetNumberOfRequiredInputs(1);
   m_WaveletFilterBank = WaveletFilterBankType::New();

--- a/Modules/Filtering/IsotropicWavelets/include/itkWaveletFrequencyForwardUndecimated.hxx
+++ b/Modules/Filtering/IsotropicWavelets/include/itkWaveletFrequencyForwardUndecimated.hxx
@@ -28,8 +28,6 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage, typename TWaveletFilterBank>
 WaveletFrequencyForwardUndecimated<TInputImage, TOutputImage, TWaveletFilterBank>::WaveletFrequencyForwardUndecimated()
-
-
 {
   this->SetNumberOfRequiredInputs(1);
   m_WaveletFilterBank = WaveletFilterBankType::New();

--- a/Modules/Filtering/IsotropicWavelets/include/itkWaveletFrequencyInverse.hxx
+++ b/Modules/Filtering/IsotropicWavelets/include/itkWaveletFrequencyInverse.hxx
@@ -31,8 +31,6 @@ namespace itk
 template <typename TInputImage, typename TOutputImage, typename TWaveletFilterBank, typename TFrequencyExpandFilterType>
 WaveletFrequencyInverse<TInputImage, TOutputImage, TWaveletFilterBank, TFrequencyExpandFilterType>::
   WaveletFrequencyInverse()
-
-
 {
   this->SetNumberOfRequiredOutputs(1);
   this->m_WaveletFilterBank = WaveletFilterBankType::New();

--- a/Modules/Filtering/IsotropicWavelets/include/itkWaveletFrequencyInverseUndecimated.hxx
+++ b/Modules/Filtering/IsotropicWavelets/include/itkWaveletFrequencyInverseUndecimated.hxx
@@ -29,8 +29,6 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage, typename TWaveletFilterBank>
 WaveletFrequencyInverseUndecimated<TInputImage, TOutputImage, TWaveletFilterBank>::WaveletFrequencyInverseUndecimated()
-
-
 {
   this->SetNumberOfRequiredOutputs(1);
   this->m_WaveletFilterBank = WaveletFilterBankType::New();

--- a/Modules/Filtering/LabelMap/include/itkAttributeOpeningLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAttributeOpeningLabelMapFilter.hxx
@@ -28,7 +28,6 @@ namespace itk
 template <typename TImage, typename TAttributeAccessor>
 AttributeOpeningLabelMapFilter<TImage, TAttributeAccessor>::AttributeOpeningLabelMapFilter()
   : m_Lambda(AttributeValueType{})
-
 {
   // create the output image for the removed objects
   this->SetNumberOfRequiredOutputs(2);

--- a/Modules/Filtering/LabelMap/include/itkAttributeSelectionLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAttributeSelectionLabelMapFilter.hxx
@@ -26,7 +26,6 @@ namespace itk
 
 template <typename TImage, typename TAttributeAccessor>
 AttributeSelectionLabelMapFilter<TImage, TAttributeAccessor>::AttributeSelectionLabelMapFilter()
-
 {
   m_AttributeSet.clear();
   this->SetNumberOfRequiredOutputs(2);

--- a/Modules/Filtering/LabelMap/include/itkBinaryFillholeImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryFillholeImageFilter.hxx
@@ -31,7 +31,6 @@ namespace itk
 template <typename TInputImage>
 BinaryFillholeImageFilter<TInputImage>::BinaryFillholeImageFilter()
   : m_ForegroundValue(NumericTraits<InputImagePixelType>::max())
-
 {}
 
 template <typename TInputImage>

--- a/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkBinaryImageToLabelMapFilter.hxx
@@ -33,7 +33,6 @@ BinaryImageToLabelMapFilter<TInputImage, TOutputImage>::BinaryImageToLabelMapFil
   : ScanlineFilterCommon<TInputImage, TOutputImage>(this)
   , m_OutputBackgroundValue(NumericTraits<OutputPixelType>::NonpositiveMin())
   , m_InputForegroundValue(NumericTraits<InputPixelType>::max())
-
 {}
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.hxx
@@ -32,7 +32,6 @@ template <typename TInputImage, typename TOutputImage>
 LabelMapMaskImageFilter<TInputImage, TOutputImage>::LabelMapMaskImageFilter()
   : m_Label(NumericTraits<InputImagePixelType>::OneValue())
   , m_BackgroundValue(OutputImagePixelType{})
-
 {
   this->SetNumberOfRequiredInputs(2);
   m_CropBorder.Fill(0);

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorCloseImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorCloseImageFilter.h
@@ -29,7 +29,6 @@ class AnchorCloseImageFilter
                                       TKernel,
                                       std::greater<typename TImage::PixelType>,
                                       std::less<typename TImage::PixelType>>
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(AnchorCloseImageFilter);

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorDilateImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorDilateImageFilter.h
@@ -26,7 +26,6 @@ namespace itk
 template <typename TImage, typename TKernel>
 class AnchorDilateImageFilter
   : public AnchorErodeDilateImageFilter<TImage, TKernel, std::greater<typename TImage::PixelType>>
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(AnchorDilateImageFilter);

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorErodeImageFilter.h
@@ -25,7 +25,6 @@ namespace itk
 template <typename TImage, typename TKernel>
 class AnchorErodeImageFilter
   : public AnchorErodeDilateImageFilter<TImage, TKernel, std::less<typename TImage::PixelType>>
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(AnchorErodeImageFilter);

--- a/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkAnchorOpenImageFilter.h
@@ -28,7 +28,6 @@ class AnchorOpenImageFilter
                                       TKernel,
                                       std::less<typename TImage::PixelType>,
                                       std::greater<typename TImage::PixelType>>
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(AnchorOpenImageFilter);

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedClosingImageFilter.hxx
@@ -27,7 +27,6 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
 GrayscaleConnectedClosingImageFilter<TInputImage, TOutputImage>::GrayscaleConnectedClosingImageFilter()
-
 {
   m_Seed.Fill(typename InputImageIndexType::OffsetValueType{});
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleConnectedOpeningImageFilter.hxx
@@ -27,7 +27,6 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
 GrayscaleConnectedOpeningImageFilter<TInputImage, TOutputImage>::GrayscaleConnectedOpeningImageFilter()
-
 {
   m_Seed.Fill(typename InputImageIndexType::OffsetValueType{});
 }

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicDilateImageFilter.hxx
@@ -34,7 +34,6 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
 GrayscaleGeodesicDilateImageFilter<TInputImage, TOutputImage>::GrayscaleGeodesicDilateImageFilter()
-
 {
   this->SetNumberOfRequiredInputs(2);
   this->DynamicMultiThreadingOn();

--- a/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
+++ b/Modules/Filtering/MathematicalMorphology/include/itkGrayscaleGeodesicErodeImageFilter.hxx
@@ -33,7 +33,6 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
 GrayscaleGeodesicErodeImageFilter<TInputImage, TOutputImage>::GrayscaleGeodesicErodeImageFilter()
-
 {
   this->SetNumberOfRequiredInputs(2);
   this->DynamicMultiThreadingOn();

--- a/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanErodeImageFilter.h
+++ b/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanErodeImageFilter.h
@@ -38,7 +38,6 @@ public:
 template <typename TImage, typename TKernel>
 class VanHerkGilWermanErodeImageFilter
   : public VanHerkGilWermanErodeDilateImageFilter<TImage, TKernel, MinFunctor<typename TImage::PixelType>>
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(VanHerkGilWermanErodeImageFilter);

--- a/Modules/Filtering/ParabolicMorphology/include/itkBinaryCloseParabolicImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkBinaryCloseParabolicImageFilter.h
@@ -67,7 +67,6 @@ namespace itk
 
 template <typename TInputImage, typename TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT BinaryCloseParabolicImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(BinaryCloseParabolicImageFilter);

--- a/Modules/Filtering/ParabolicMorphology/include/itkBinaryDilateParabolicImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkBinaryDilateParabolicImageFilter.h
@@ -65,7 +65,6 @@ namespace itk
 
 template <typename TInputImage, typename TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT BinaryDilateParabolicImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(BinaryDilateParabolicImageFilter);

--- a/Modules/Filtering/ParabolicMorphology/include/itkBinaryErodeParabolicImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkBinaryErodeParabolicImageFilter.h
@@ -66,7 +66,6 @@ namespace itk
 
 template <typename TInputImage, typename TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT BinaryErodeParabolicImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(BinaryErodeParabolicImageFilter);

--- a/Modules/Filtering/ParabolicMorphology/include/itkBinaryOpenParabolicImageFilter.h
+++ b/Modules/Filtering/ParabolicMorphology/include/itkBinaryOpenParabolicImageFilter.h
@@ -67,7 +67,6 @@ namespace itk
 
 template <typename TInputImage, typename TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT BinaryOpenParabolicImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(BinaryOpenParabolicImageFilter);

--- a/Modules/Filtering/ParabolicMorphology/include/itkMorphologicalSharpeningImageFilter.hxx
+++ b/Modules/Filtering/ParabolicMorphology/include/itkMorphologicalSharpeningImageFilter.hxx
@@ -21,7 +21,6 @@
 #include "itkProgressAccumulator.h"
 
 namespace itk
-
 {
 template <typename TInputImage, typename TOutputImage>
 MorphologicalSharpeningImageFilter<TInputImage, TOutputImage>::MorphologicalSharpeningImageFilter()

--- a/Modules/Filtering/Path/include/itkPathToChainCodePathFilter.hxx
+++ b/Modules/Filtering/Path/include/itkPathToChainCodePathFilter.hxx
@@ -24,7 +24,6 @@ namespace itk
 
 template <typename TInputPath, typename TOutputChainCodePath>
 PathToChainCodePathFilter<TInputPath, TOutputChainCodePath>::PathToChainCodePathFilter()
-
 {
   this->SetNumberOfRequiredInputs(1);
 }

--- a/Modules/Filtering/PhaseSymmetry/include/itkLogGaborFreqImageSource.hxx
+++ b/Modules/Filtering/PhaseSymmetry/include/itkLogGaborFreqImageSource.hxx
@@ -25,7 +25,6 @@ namespace itk
 
 template <typename TOutputImage>
 LogGaborFreqImageSource<TOutputImage>::LogGaborFreqImageSource()
-
 {
   // Gaussian parameters, defined so that the gaussian
   // is centered in the default image

--- a/Modules/Filtering/PhaseSymmetry/include/itkSinusoidImageSource.hxx
+++ b/Modules/Filtering/PhaseSymmetry/include/itkSinusoidImageSource.hxx
@@ -27,7 +27,6 @@ namespace itk
 
 template <typename TOutputImage>
 SinusoidImageSource<TOutputImage>::SinusoidImageSource()
-
 {
   m_Frequency.Fill(1.0);
 }

--- a/Modules/Filtering/PhaseSymmetry/include/itkSinusoidSpatialFunction.hxx
+++ b/Modules/Filtering/PhaseSymmetry/include/itkSinusoidSpatialFunction.hxx
@@ -25,7 +25,6 @@ namespace itk
 {
 template <typename TOutput, unsigned int VImageDimension, typename TInput>
 SinusoidSpatialFunction<TOutput, VImageDimension, TInput>::SinusoidSpatialFunction()
-
 {
   m_Frequency.Fill(1.0);
 }

--- a/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.hxx
+++ b/Modules/Filtering/Smoothing/include/itkSmoothingRecursiveGaussianImageFilter.hxx
@@ -26,7 +26,6 @@ namespace itk
 template <typename TInputImage, typename TOutputImage>
 SmoothingRecursiveGaussianImageFilter<TInputImage, TOutputImage>::SmoothingRecursiveGaussianImageFilter()
   : m_FirstSmoothingFilter(FirstGaussianFilterType::New())
-
 {
   // NB: The first filter is the last dimension because it does not
   // always run in-place. As this dimension provides the least amount

--- a/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkHistogramThresholdImageFilter.hxx
@@ -33,7 +33,6 @@ HistogramThresholdImageFilter<TInputImage, TOutputImage, TMaskImage>::HistogramT
   , m_OutsideValue(OutputPixelType{})
   , m_Threshold(InputPixelType{})
   , m_MaskValue(NumericTraits<MaskPixelType>::max())
-
 {
   this->SetNumberOfRequiredOutputs(1);
 

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.hxx
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsCalculator.hxx
@@ -24,7 +24,6 @@ namespace itk
 {
 template <typename TInputHistogram>
 OtsuMultipleThresholdsCalculator<TInputHistogram>::OtsuMultipleThresholdsCalculator()
-
 {
   m_Output.resize(m_NumberOfThresholds);
   std::fill(m_Output.begin(), m_Output.end(), MeasurementType{});

--- a/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.hxx
+++ b/Modules/Filtering/Thresholding/include/itkOtsuMultipleThresholdsImageFilter.hxx
@@ -26,7 +26,6 @@ namespace itk
 template <typename TInputImage, typename TOutputImage>
 OtsuMultipleThresholdsImageFilter<TInputImage, TOutputImage>::OtsuMultipleThresholdsImageFilter()
   : m_LabelOffset(OutputPixelType{})
-
 {}
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
@@ -330,7 +330,6 @@ ReadJCAMPDX(const std::string & filename, MetaDataDictionary & dict)
 } // namespace
 
 Bruker2dseqImageIO::Bruker2dseqImageIO()
-
 {
   // By default, only have 3 dimensions
   this->SetNumberOfDimensions(3);

--- a/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
@@ -30,7 +30,6 @@ namespace itk
 {
 
 HDF5ImageIO::HDF5ImageIO()
-
 {
 
   const char * extensions[] = { ".hdf", ".h4", ".hdf4", ".h5", ".hdf5", ".he4", ".he5", ".hd5" };

--- a/Modules/IO/IOScanco/src/itkScancoImageIO.cxx
+++ b/Modules/IO/IOScanco/src/itkScancoImageIO.cxx
@@ -49,7 +49,6 @@
 namespace itk
 {
 ScancoImageIO::ScancoImageIO()
-
 {
   this->m_FileType = IOFileEnum::Binary;
   this->m_ByteOrder = IOByteOrderEnum::LittleEndian;

--- a/Modules/IO/ImageBase/include/itkConvertPixelBuffer.hxx
+++ b/Modules/IO/ImageBase/include/itkConvertPixelBuffer.hxx
@@ -392,7 +392,6 @@ ConvertPixelBuffer<InputPixelType, OutputPixelType, OutputConvertTraits>::Conver
   const InputPixelType * inputData,
   OutputPixelType *      outputData,
   size_t                 size)
-
 {
   const InputPixelType * endInput = inputData + size;
 

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -234,7 +234,6 @@ MINCImageIO::CloseVolume()
 
 MINCImageIO::MINCImageIO()
   : m_MINCPImpl(std::make_unique<MINCImageIOPImpl>())
-
 {
   for (auto & dimensionIndex : m_MINCPImpl->m_DimensionIndices)
   {

--- a/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
+++ b/Modules/IO/MeshFreeSurfer/src/itkFreeSurferBinaryMeshIO.cxx
@@ -24,7 +24,6 @@
 namespace itk
 {
 FreeSurferBinaryMeshIO::FreeSurferBinaryMeshIO()
-
 {
   this->AddSupportedWriteExtension(".fsb");
   this->AddSupportedWriteExtension(".fcv");

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -206,8 +206,6 @@ TIFFImageIO::Read(void * buffer)
 TIFFImageIO::TIFFImageIO()
   : m_InternalImage(new TIFFReaderInternal)
   , m_ColorPalette(0)
-
-
 {
   this->SetNumberOfDimensions(2);
   this->Self::SetJPEGQuality(75);

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -25,7 +25,6 @@
 namespace itk
 {
 VTKImageIO::VTKImageIO()
-
 {
   this->SetNumberOfDimensions(2);
   m_ByteOrder = IOByteOrderEnum::LittleEndian;

--- a/Modules/Nonunit/Review/include/itkAreaClosingImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAreaClosingImageFilter.h
@@ -50,7 +50,6 @@ class AreaClosingImageFilter
                                               TOutputImage,
                                               TAttribute,
                                               std::less<typename TInputImage::PixelType>>
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(AreaClosingImageFilter);

--- a/Modules/Nonunit/Review/include/itkAreaOpeningImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkAreaOpeningImageFilter.h
@@ -52,7 +52,6 @@ class AreaOpeningImageFilter
                                               TOutputImage,
                                               TAttribute,
                                               std::greater<typename TInputImage::PixelType>>
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(AreaOpeningImageFilter);

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -169,7 +169,6 @@ CalculateOrientedImage(const itk::SymmetricEigenDecomposition<double> &         
 
 template <typename TLabelImage, typename TIntensityImage>
 LabelGeometryImageFilter<TLabelImage, TIntensityImage>::LabelGeometryImageFilter()
-
 {
   this->SetNumberOfRequiredInputs(1);
 }

--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.hxx
@@ -40,7 +40,6 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::RegionBasedLevelSetF
   , m_VolumeMatchingWeight(ScalarValueType{})
   , m_Volume(ScalarValueType{})
   , m_ReinitializationSmoothingWeight(ScalarValueType{})
-
 {
   m_CurvatureWeight = m_AdvectionWeight = ScalarValueType{};
 

--- a/Modules/Nonunit/Review/src/itkVoxBoCUBImageIO.cxx
+++ b/Modules/Nonunit/Review/src/itkVoxBoCUBImageIO.cxx
@@ -325,7 +325,6 @@ const char * VoxBoCUBImageIO::m_VB_DATATYPE_DOUBLE = "Double";
 
 /** Constructor */
 VoxBoCUBImageIO::VoxBoCUBImageIO()
-
 {
   InitializeOrientationMap();
   m_ByteOrder = IOByteOrderEnum::BigEndian;

--- a/Modules/Numerics/Optimizers/include/itkConjugateGradientOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkConjugateGradientOptimizer.h
@@ -33,7 +33,6 @@ namespace itk
  * \ingroup ITKOptimizers
  */
 class ITKOptimizers_EXPORT ConjugateGradientOptimizer : public SingleValuedNonLinearVnlOptimizer
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(ConjugateGradientOptimizer);

--- a/Modules/Numerics/Optimizers/include/itkNonLinearOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkNonLinearOptimizer.h
@@ -33,7 +33,6 @@ namespace itk
  * \ingroup ITKOptimizers
  */
 class ITKOptimizers_EXPORT NonLinearOptimizer : public Optimizer
-
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(NonLinearOptimizer);

--- a/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkCumulativeGaussianOptimizer.cxx
@@ -23,7 +23,6 @@ namespace itk
 {
 CumulativeGaussianOptimizer::CumulativeGaussianOptimizer()
   : m_DifferenceTolerance(1e-10)
-
 {
   // Set some initial values for the variables.
   m_StopConditionDescription << this->GetNameOfClass() << ": Constructed";

--- a/Modules/Numerics/Optimizers/src/itkLBFGSBOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkLBFGSBOptimizer.cxx
@@ -53,7 +53,6 @@ private:
  * Constructor
  */
 LBFGSBOptimizer::LBFGSBOptimizer()
-
 {
   m_LowerBound = InternalBoundValueType(0);
   m_UpperBound = InternalBoundValueType(0);

--- a/Modules/Numerics/Optimizers/src/itkMultipleValuedVnlCostFunctionAdaptor.cxx
+++ b/Modules/Numerics/Optimizers/src/itkMultipleValuedVnlCostFunctionAdaptor.cxx
@@ -23,7 +23,6 @@ namespace itk
 MultipleValuedVnlCostFunctionAdaptor::MultipleValuedVnlCostFunctionAdaptor(unsigned int spaceDimension,
                                                                            unsigned int numberOfValues)
   : vnl_least_squares_function(spaceDimension, numberOfValues)
-
 {
   this->m_Reporter = Object::New();
 }

--- a/Modules/Numerics/Optimizers/src/itkOnePlusOneEvolutionaryOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkOnePlusOneEvolutionaryOptimizer.cxx
@@ -30,7 +30,6 @@ OnePlusOneEvolutionaryOptimizer::OnePlusOneEvolutionaryOptimizer()
   , m_InitialRadius(1.01)
   , m_GrowthFactor(1.05)
   , m_ShrinkFactor(std::pow(m_GrowthFactor, -0.25))
-
 {
   m_StopConditionDescription.str("");
 }

--- a/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
+++ b/Modules/Numerics/Optimizers/src/itkParticleSwarmOptimizerBase.cxx
@@ -28,8 +28,6 @@ ParticleSwarmOptimizerBase::ParticleSwarmOptimizerBase()
   , m_NumberOfGenerationsWithMinimalImprovement(1)
   , m_PercentageParticlesConverged(0.6)
   , m_FunctionConvergenceTolerance(1e-4)
-
-
 {
   this->m_ParametersConvergenceTolerance.Fill(1e-8);
 }

--- a/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkPowellOptimizer.cxx
@@ -27,7 +27,6 @@ PowellOptimizer::PowellOptimizer()
   , m_StepLength(1.0)
   , m_StepTolerance(0.00001)
   , m_ValueTolerance(0.00001)
-
 {
   m_StopConditionDescription << this->GetNameOfClass() << ": ";
 }

--- a/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkRegularStepGradientDescentBaseOptimizer.cxx
@@ -32,8 +32,6 @@ RegularStepGradientDescentBaseOptimizer::RegularStepGradientDescentBaseOptimizer
   , m_RelaxationFactor(0.5)
   , m_StopCondition(StopConditionEnum::Unknown)
   , m_NumberOfIterations(100)
-
-
 {
   m_CostFunction = nullptr;
   m_Gradient.Fill(0.0f);

--- a/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearVnlOptimizer.cxx
+++ b/Modules/Numerics/Optimizers/src/itkSingleValuedNonLinearVnlOptimizer.cxx
@@ -23,7 +23,6 @@ namespace itk
 /** Constructor */
 SingleValuedNonLinearVnlOptimizer::SingleValuedNonLinearVnlOptimizer()
   : m_CostFunctionAdaptor(nullptr)
-
 {
   m_Command = CommandType::New();
   m_Command->SetCallbackFunction(this, &SingleValuedNonLinearVnlOptimizer::IterationReport);

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentLineSearchOptimizerv4.hxx
@@ -32,7 +32,6 @@ GradientDescentLineSearchOptimizerv4Template<
   , m_Resphi(2 - this->m_Phi)
   , m_Epsilon(0.01)
   , m_MaximumLineSearchIterations(20)
-
 {
   this->m_ReturnBestParametersAndValue = true;
 }

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerBasev4.hxx
@@ -32,7 +32,6 @@ GradientDescentOptimizerBasev4Template<TInternalComputationValueType>::GradientD
   , m_UseConvergenceMonitoring(true)
   , m_ConvergenceWindowSize(50)
   , m_StopCondition(StopConditionObjectToObjectOptimizerEnum::MAXIMUM_NUMBER_OF_ITERATIONS)
-
 {
   /** Threader for apply scales to gradient */
   const typename GradientDescentOptimizerBasev4ModifyGradientByScalesThreaderTemplate<

--- a/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkGradientDescentOptimizerv4.hxx
@@ -29,7 +29,6 @@ GradientDescentOptimizerv4Template<TInternalComputationValueType>::GradientDesce
   , m_MinimumConvergenceValue(1e-8)
   , m_ConvergenceValue(NumericTraits<TInternalComputationValueType>::max())
   , m_CurrentBestValue(NumericTraits<MeasureType>::max())
-
 {
   this->m_PreviousGradient.Fill(TInternalComputationValueType{});
 }

--- a/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkOnePlusOneEvolutionaryOptimizerv4.hxx
@@ -31,7 +31,6 @@ OnePlusOneEvolutionaryOptimizerv4<TInternalComputationValueType>::OnePlusOneEvol
   , m_GrowthFactor(1.05)
   , m_ShrinkFactor(std::pow(m_GrowthFactor, -0.25))
   , m_CurrentCost(0)
-
 {
   m_StopConditionDescription.str("");
 }

--- a/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkPowellOptimizerv4.hxx
@@ -24,7 +24,6 @@ namespace itk
 template <typename TInternalComputationValueType>
 PowellOptimizerv4<TInternalComputationValueType>::PowellOptimizerv4()
   : m_CurrentCost(0)
-
 {
   m_StopConditionDescription << this->GetNameOfClass() << ": ";
 }

--- a/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
@@ -29,7 +29,6 @@ QuasiNewtonOptimizerv4Template<TInternalComputationValueType>::QuasiNewtonOptimi
   , m_BestValue(0.0)
   , m_BestPosition(0)
   , m_MaximumNewtonStepSizeInPhysicalUnits(TInternalComputationValueType{})
-
 {
   this->m_LearningRate = NumericTraits<TInternalComputationValueType>::OneValue();
 

--- a/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4Base.cxx
+++ b/Modules/Numerics/Optimizersv4/src/itkLBFGSOptimizerv4Base.cxx
@@ -30,7 +30,6 @@ namespace itk
 
 template <typename TInternalVnlOptimizerType>
 LBFGSOptimizerBasev4<TInternalVnlOptimizerType>::LBFGSOptimizerBasev4()
-
 {
   Superclass::SetNumberOfIterations(500);
 }

--- a/Modules/Numerics/PrincipalComponentsAnalysis/include/itkVectorFieldPCA.hxx
+++ b/Modules/Numerics/PrincipalComponentsAnalysis/include/itkVectorFieldPCA.hxx
@@ -39,7 +39,6 @@ VectorFieldPCA<TVectorFieldElementType,
                KernelFunctionType,
                TPointSetType>::VectorFieldPCA()
   : m_BasisVectors(BasisSetType::New())
-
 {}
 
 template <typename TVectorFieldElementType,

--- a/Modules/Numerics/Statistics/include/itkHistogram.hxx
+++ b/Modules/Numerics/Statistics/include/itkHistogram.hxx
@@ -29,7 +29,6 @@ Histogram<TMeasurement, TFrequencyContainer>::Histogram()
   : m_Size(0)
   , m_OffsetTable(OffsetTableType(Superclass::GetMeasurementVectorSize() + 1))
   , m_FrequencyContainer(FrequencyContainerType::New())
-
 {
   for (unsigned int i = 0; i < this->GetMeasurementVectorSize() + 1; ++i)
   {

--- a/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
+++ b/Modules/Numerics/Statistics/include/itkImageToNeighborhoodSampleAdaptor.hxx
@@ -29,7 +29,6 @@ template <typename TImage, typename TBoundaryCondition>
 ImageToNeighborhoodSampleAdaptor<TImage, TBoundaryCondition>::ImageToNeighborhoodSampleAdaptor()
   : m_Image(nullptr)
   , m_InstanceIdentifierInternal(0)
-
 {
   m_Radius.Fill(0);
   m_NeighborIndexInternal.Fill(0);

--- a/Modules/Numerics/Statistics/include/itkKdTree.hxx
+++ b/Modules/Numerics/Statistics/include/itkKdTree.hxx
@@ -73,7 +73,6 @@ KdTree<TSample>::KdTree()
   , m_Root(nullptr)
   , m_EmptyTerminalNode(new KdTreeTerminalNode<TSample>())
   , m_DistanceMetric(DistanceMetricType::New())
-
 {}
 
 template <typename TSample>

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.hxx
@@ -22,7 +22,6 @@ namespace itk::Statistics
 {
 template <typename TVector>
 MahalanobisDistanceMetric<TVector>::MahalanobisDistanceMetric()
-
 {
   const MeasurementVectorSizeType size = this->GetMeasurementVectorSize();
 

--- a/Modules/Numerics/Statistics/include/itkRegionConstrainedSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkRegionConstrainedSubsampler.hxx
@@ -23,7 +23,6 @@ namespace itk::Statistics
 
 template <typename TSample, typename TRegion>
 RegionConstrainedSubsampler<TSample, TRegion>::RegionConstrainedSubsampler()
-
 {
   this->m_RequestMaximumNumberOfResults = true;
 }

--- a/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkSpatialNeighborSubsampler.hxx
@@ -23,7 +23,6 @@ namespace itk::Statistics
 
 template <typename TSample, typename TRegion>
 SpatialNeighborSubsampler<TSample, TRegion>::SpatialNeighborSubsampler()
-
 {
   this->m_Radius.Fill(1);
 }

--- a/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
@@ -24,7 +24,6 @@ namespace itk::Statistics
 
 template <typename TSample, typename TRegion>
 UniformRandomSpatialNeighborSubsampler<TSample, TRegion>::UniformRandomSpatialNeighborSubsampler()
-
 {
   m_RandomNumberGenerator = RandomGeneratorType::New();
   m_RandomNumberGenerator->SetSeed(this->m_Seed);

--- a/Modules/Numerics/Statistics/src/itkNormalVariateGenerator.cxx
+++ b/Modules/Numerics/Statistics/src/itkNormalVariateGenerator.cxx
@@ -25,7 +25,6 @@ NormalVariateGenerator::NormalVariateGenerator()
   : m_Scale(30000000.0)
   , m_Rscale(1.0 / m_Scale)
   , m_Rcons(1.0 / (2.0 * 1024.0 * 1024.0 * 1024.0))
-
 {
   this->Initialize(0);
 }

--- a/Modules/Registration/Common/include/itkBSplineExponentialDiffeomorphicTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkBSplineExponentialDiffeomorphicTransformParametersAdaptor.hxx
@@ -25,7 +25,6 @@ namespace itk
 template <typename TTransform>
 BSplineExponentialDiffeomorphicTransformParametersAdaptor<
   TTransform>::BSplineExponentialDiffeomorphicTransformParametersAdaptor()
-
 {
   this->m_NumberOfControlPointsForTheConstantVelocityField.Fill(4);
   this->m_NumberOfControlPointsForTheUpdateField.Fill(4);

--- a/Modules/Registration/Common/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
+++ b/Modules/Registration/Common/include/itkBSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor.hxx
@@ -26,7 +26,6 @@ namespace itk
 template <typename TTransform>
 BSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor<
   TTransform>::BSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor()
-
 {
   this->m_NumberOfControlPointsForTheUpdateField.Fill(4);
   this->m_NumberOfControlPointsForTheTotalField.Fill(0);

--- a/Modules/Registration/Common/include/itkImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkImageRegistrationMethod.hxx
@@ -32,7 +32,6 @@ ImageRegistrationMethod<TFixedImage, TMovingImage>::ImageRegistrationMethod()
   , m_Interpolator(nullptr)
   , m_InitialTransformParameters(ParametersType(1))
   , m_LastTransformParameters(ParametersType(1))
-
 {
   this->SetNumberOfRequiredOutputs(1); // for the Transform
   m_InitialTransformParameters.Fill(0.0f);

--- a/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkKappaStatisticImageToImageMetric.hxx
@@ -27,7 +27,6 @@ namespace itk
 template <typename TFixedImage, typename TMovingImage>
 KappaStatisticImageToImageMetric<TFixedImage, TMovingImage>::KappaStatisticImageToImageMetric()
   : m_ForegroundValue(255)
-
 {
   this->SetComputeGradient(true);
 }

--- a/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
+++ b/Modules/Registration/Common/include/itkMattesMutualInformationImageToImageMetric.hxx
@@ -37,7 +37,6 @@ MattesMutualInformationImageToImageMetric<TFixedImage, TMovingImage>::MattesMutu
   // Initialize memory
   m_MovingImageMarginalPDF(0)
   , m_MMIMetricPerThreadVariables(nullptr)
-
 {
   this->SetComputeGradient(false); // don't use the default gradient for now
   this->m_WithinThreadPreProcess = true;

--- a/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionImageRegistrationMethod.hxx
@@ -38,7 +38,6 @@ MultiResolutionImageRegistrationMethod<TFixedImage, TMovingImage>::MultiResoluti
   , m_InitialTransformParametersOfNextLevel(ParametersType(1))
   , m_LastTransformParameters(ParametersType(1))
   , m_NumberOfLevels(1)
-
 {
   this->SetNumberOfRequiredOutputs(1); // for the Transform
 

--- a/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
+++ b/Modules/Registration/Common/include/itkMultiResolutionPyramidImageFilter.hxx
@@ -35,7 +35,6 @@ namespace itk
 template <typename TInputImage, typename TOutputImage>
 MultiResolutionPyramidImageFilter<TInputImage, TOutputImage>::MultiResolutionPyramidImageFilter()
   : m_MaximumError(0.1)
-
 {
   this->SetNumberOfLevels(2);
 }

--- a/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.hxx
+++ b/Modules/Registration/Metricsv4/include/itkImageToImageMetricv4.hxx
@@ -51,7 +51,6 @@ ImageToImageMetricv4<TFixedImage, TMovingImage, TVirtualImage, TInternalComputat
   /* Interpolators for image gradient filters */
   , m_DerivativeResult(nullptr)
   , m_FloatingPointCorrectionResolution(1e6)
-
 {
   /* Setup default gradient filter. It gets initialized with default
    * parameters during Initialize. */

--- a/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.hxx
+++ b/Modules/Registration/Metricsv4/include/itkManifoldParzenWindowsPointSetFunction.hxx
@@ -30,7 +30,6 @@ ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordinate>::Manifold
   : m_PointsLocator(nullptr)
   , m_RegularizationSigma(1.0)
   , m_KernelSigma(1.0)
-
 {
   m_MultiThreader = MultiThreaderBase::New();
 }

--- a/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkDemonsRegistrationFilter.hxx
@@ -23,7 +23,6 @@ namespace itk
 
 template <typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 DemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>::DemonsRegistrationFilter()
-
 {
   auto drfp = DemonsRegistrationFunctionType::New();
   this->SetDifferenceFunction(static_cast<FiniteDifferenceFunctionType *>(drfp.GetPointer()));

--- a/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkDiffeomorphicDemonsRegistrationFilter.hxx
@@ -30,7 +30,6 @@ DiffeomorphicDemonsRegistrationFilter<TFixedImage, TMovingImage, TDisplacementFi
   , m_Exponentiator(FieldExponentiatorType::New())
   , m_Warper(VectorWarperType::New())
   , m_Adder(AdderType::New())
-
 {
   auto drfp = DemonsRegistrationFunctionType::New();
   this->SetDifferenceFunction(drfp);

--- a/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
+++ b/Modules/Registration/PDEDeformable/include/itkSymmetricForcesDemonsRegistrationFunction.hxx
@@ -34,7 +34,6 @@ SymmetricForcesDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplaceme
   , m_IntensityDifferenceThreshold(0.001)
   , m_Metric(NumericTraits<double>::max())
   , m_RMSChange(NumericTraits<double>::max())
-
 {
   constexpr RadiusType r{};
   this->SetRadius(r);

--- a/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
+++ b/Modules/Registration/RegistrationMethodsv4/include/itkTimeVaryingVelocityFieldImageRegistrationMethodv4.hxx
@@ -45,7 +45,6 @@ TimeVaryingVelocityFieldImageRegistrationMethodv4<TFixedImage,
                                                   TPointSet>::TimeVaryingVelocityFieldImageRegistrationMethodv4()
   : m_LearningRate(0.25)
   , m_ConvergenceThreshold(1.0e-7)
-
 {
   this->m_NumberOfIterationsPerLevel.SetSize(3);
   this->m_NumberOfIterationsPerLevel[0] = 20;

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierImageFilter.hxx
@@ -40,7 +40,6 @@ template <typename TInputVectorImage,
 BayesianClassifierImageFilter<TInputVectorImage, TLabelsType, TPosteriorsPrecisionType, TPriorsPrecisionType>::
   BayesianClassifierImageFilter()
   : m_SmoothingFilter(nullptr)
-
 {
   this->SetNumberOfRequiredOutputs(2);
   const PosteriorsImagePointer p = static_cast<PosteriorsImageType *>(this->MakeOutput(1).GetPointer());

--- a/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.hxx
@@ -36,7 +36,6 @@ ThresholdMaximumConnectedComponentsImageFilter<TInputImage,
   , m_MinMaxCalculator(MinMaxCalculatorType::New())
   , m_OutsideValue(OutputPixelType{})
   , m_InsideValue(NumericTraits<OutputPixelType>::max())
-
 {
   //
   // Connecting the internal pipeline.

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkKLMRegionGrowImageFilter.hxx
@@ -22,7 +22,6 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
 KLMRegionGrowImageFilter<TInputImage, TOutputImage>::KLMRegionGrowImageFilter()
-
 {
   m_InitialRegionMean.set_size(InputImageVectorDimension);
   m_InitialRegionMean.fill(0);

--- a/Modules/Segmentation/KLMRegionGrowing/include/itkRegionGrowImageFilter.hxx
+++ b/Modules/Segmentation/KLMRegionGrowing/include/itkRegionGrowImageFilter.hxx
@@ -24,7 +24,6 @@ namespace itk
 {
 template <typename TInputImage, typename TOutputImage>
 RegionGrowImageFilter<TInputImage, TOutputImage>::RegionGrowImageFilter()
-
 {
   m_GridSize.Fill(2);
 }

--- a/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
@@ -30,7 +30,6 @@ namespace itk
 template <typename TInputImage, typename TOutputImage>
 LabelVotingImageFilter<TInputImage, TOutputImage>::LabelVotingImageFilter()
   : m_LabelForUndecidedPixels(0)
-
 {
   this->ThreaderUpdateProgressOff();
 }

--- a/Modules/Segmentation/LabelVoting/include/itkVotingBinaryIterativeHoleFillingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkVotingBinaryIterativeHoleFillingImageFilter.hxx
@@ -37,7 +37,6 @@ VotingBinaryIterativeHoleFillingImageFilter<TInputImage>::VotingBinaryIterativeH
   , m_BackgroundValue(InputPixelType{})
   , m_MaximumNumberOfIterations(10)
   , m_MajorityThreshold(1)
-
 {
   m_Radius.Fill(1);
 }

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetNeighborhoodExtractor.hxx
@@ -35,7 +35,6 @@ LevelSetNeighborhoodExtractor<TLevelSet>::LevelSetNeighborhoodExtractor()
   , m_InputLevelSet(nullptr)
   , m_InputNarrowBand(nullptr)
   , m_LargeValue(NumericTraits<PixelType>::max())
-
 {
   m_NodesUsed.resize(SetDimension);
 }

--- a/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkLevelSetFunctionTest.cxx
@@ -70,7 +70,6 @@ square(unsigned int x, unsigned int y)
 // Evaluates a function at each pixel in the itk image
 void
 evaluate_function(itk::Image<float, 2> * im, float (*f)(unsigned int, unsigned int))
-
 {
   itk::Image<float, 2>::IndexType idx;
   for (unsigned int x = 0; x < WIDTH; ++x)

--- a/Modules/Segmentation/LevelSets/test/itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkSparseFieldFourthOrderLevelSetImageFilterTest.cxx
@@ -63,7 +63,6 @@ square(unsigned int x, unsigned int y)
 // Evaluates a function at each pixel in the itk image
 void
 evaluate_function(itk::Image<float, 2> * im, float (*f)(unsigned int, unsigned int))
-
 {
   itk::Image<float, 2>::IndexType idx;
   for (unsigned int x = 0; x < WIDTH; ++x)

--- a/Modules/Segmentation/LevelSets/test/itkUnsharpMaskLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkUnsharpMaskLevelSetImageFilterTest.cxx
@@ -41,7 +41,6 @@ square(unsigned int x, unsigned int y)
 // Evaluates a function at each pixel in the itk image
 void
 evaluate_function(itk::Image<float, 2> * im, float (*f)(unsigned int, unsigned int))
-
 {
   itk::Image<float, 2>::IndexType idx;
   for (unsigned int x = 0; x < WIDTH; ++x)

--- a/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
+++ b/Modules/Segmentation/MarkovRandomFieldsClassifiers/include/itkRGBGibbsPriorFilter.hxx
@@ -38,7 +38,6 @@ RGBGibbsPriorFilter<TInputImage, TClassifiedImage>::RGBGibbsPriorFilter()
   , m_ClassifierPtr(nullptr)
   , m_MediumImage(nullptr)
   , m_LowPoint()
-
 {
   m_StartPoint.Fill(0);
   this->SetMaximumNumberOfIterations(10);

--- a/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
+++ b/Modules/Segmentation/RegionGrowing/include/itkIsolatedConnectedImageFilter.hxx
@@ -37,7 +37,6 @@ IsolatedConnectedImageFilter<TInputImage, TOutputImage>::IsolatedConnectedImageF
   , m_IsolatedValue(InputImagePixelType{})
   , m_IsolatedValueTolerance(NumericTraits<InputImagePixelType>::OneValue())
   , m_FindUpperThreshold(true)
-
 {}
 
 template <typename TInputImage, typename TOutputImage>

--- a/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
+++ b/Modules/Segmentation/Voronoi/include/itkVoronoiDiagram2DGenerator.hxx
@@ -34,7 +34,6 @@ template <typename TCoordinate>
 VoronoiDiagram2DGenerator<TCoordinate>::VoronoiDiagram2DGenerator()
   : m_OutputVD(Self::GetOutput())
   , m_BottomSite(nullptr)
-
 {
   m_VorBoundary.Fill(0.0);
 }

--- a/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.hxx
+++ b/Modules/Segmentation/Watersheds/include/itkMorphologicalWatershedFromMarkersImageFilter.hxx
@@ -33,8 +33,6 @@ namespace itk
 
 template <typename TInputImage, typename TLabelImage>
 MorphologicalWatershedFromMarkersImageFilter<TInputImage, TLabelImage>::MorphologicalWatershedFromMarkersImageFilter()
-
-
 {
   this->SetNumberOfRequiredInputs(2);
 }

--- a/Modules/Video/Core/src/itkTemporalDataObject.cxx
+++ b/Modules/Video/Core/src/itkTemporalDataObject.cxx
@@ -36,7 +36,6 @@ TemporalDataObject::TemporalDataObject()
   : m_LargestPossibleTemporalRegion()
   , m_RequestedTemporalRegion()
   , m_BufferedTemporalRegion()
-
 {
   m_DataObjectBuffer = BufferType::New();
 }

--- a/Modules/Video/IO/include/itkVideoFileWriter.hxx
+++ b/Modules/Video/IO/include/itkVideoFileWriter.hxx
@@ -33,7 +33,6 @@ VideoFileWriter<TInputVideoStream>::VideoFileWriter()
   : m_FileName("")
   , m_VideoIO(nullptr)
   , m_FourCC("MP42")
-
 {
   // TemporalProcessObject inherited members
   this->TemporalProcessObject::m_UnitInputNumberOfFrames = 1;


### PR DESCRIPTION
This is just a matter of taste, I guess  🤷 I don't really _like_ an extra line break before a curly break. But obviously, global text searches throughout the source tree will be easier when we have a more consistent formatting.