### PR TITLE
COMP: Update DCMTK to add printf format attribute in offile.h

### DIFF
--- a/Modules/ThirdParty/DCMTK/DCMTKGitTag.cmake
+++ b/Modules/ThirdParty/DCMTK/DCMTKGitTag.cmake
@@ -41,4 +41,7 @@ set(
 #Bradley Lowekamp (1):
 #COMP: prefix CMake check commands with DCMTK_ to avoid leaking
 
-set(DCMTK_GIT_TAG "4ac9b4489d8f8fb1873a943dd214824bd2b11a6d") # for/itk-dcmtk-3.7.0-ccfd10b
+#Hans Johnson (1):
+#COMP: Add printf format attribute to OFFile printf wrappers
+
+set(DCMTK_GIT_TAG "84c8047dbb02a6d59807eb08e08598186a13b57e") # for/itk-dcmtk-3.7.0-ccfd10b


### PR DESCRIPTION
Updates the vendored DCMTK to add `__attribute__((format(printf, ...)))` to `OFFile::fprintf`/`OFFile::vfprintf`, fixing two clang `-Wformat-nonliteral` warnings emitted in every ITK translation unit that includes `offile.h` (e.g. via `itkDCMTKFileReader.h`).

<details>
<summary>Details</summary>

- Fork commit: InsightSoftwareConsortium/DCMTK@84c8047dbb02a6d59807eb08e08598186a13b57e, fast-forwarded onto `for/itk-dcmtk-3.7.0-ccfd10b`.
- The attribute marks the `format` parameter as a valid forwarding target (silencing the wrapper-internal false positive) and enables format/argument checking at all call sites.
- Chosen over pragma suppression so the fix is acceptable to upstream DCMTK, whose master has the same code; the same patch is being submitted upstream.
- Verified locally: full `ITKIODCMTKTestDriver` rebuild (all of DCMTK + ITK IODCMTK tests) against the new pin with zero warnings/errors.

</details>

<!--
provenance: claude-code session 2026-07-10
fork_commit: 84c8047dbb02a6d59807eb08e08598186a13b57e on for/itk-dcmtk-3.7.0-ccfd10b
files: Modules/ThirdParty/DCMTK/DCMTKGitTag.cmake; offile.h in fork
post_merge_action: track upstream DCMTK PR of the same patch; drop overlay commit on next DCMTK version bump if merged upstream
-->
