### PR TITLE
BUG: Guard division-by-zero NaN and UB-cast sites from issue 6575

### DIFF
--- a/Modules/Filtering/AnisotropicDiffusionLBR/include/itkStructureTensorImageFilter.hxx
+++ b/Modules/Filtering/AnisotropicDiffusionLBR/include/itkStructureTensorImageFilter.hxx
@@ -150,7 +150,8 @@ StructureTensorImageFilter<TImage, TTensorImage>::GenerateData()
 
   traceFilter->Update();
   maximumCalculator->ComputeMaximum();
-  m_PostRescaling = 1. / maximumCalculator->GetMaximum();
+  const auto maximum = maximumCalculator->GetMaximum();
+  m_PostRescaling = (maximum > 0.) ? 1. / maximum : 1.;
   scaleFilter->GetFunctor().scaling = m_PostRescaling;
   scaleFilter->Update();
   this->GraftOutput(scaleFilter->GetOutput());

--- a/Modules/Filtering/AnisotropicDiffusionLBR/test/CMakeLists.txt
+++ b/Modules/Filtering/AnisotropicDiffusionLBR/test/CMakeLists.txt
@@ -7,6 +7,7 @@ createtestdriver(AnisotropicDiffusionLBR  "${AnisotropicDiffusionLBR-Test_LIBRAR
 set(
   AnisotropicDiffusionLBRGTests
   itkLinearAnisotropicDiffusionLBRImageFilterGTest.cxx
+  itkStructureTensorImageFilterGTest.cxx
 )
 
 creategoogletestdriver(AnisotropicDiffusionLBR "${AnisotropicDiffusionLBR-Test_LIBRARIES}" "${AnisotropicDiffusionLBRGTests}")

--- a/Modules/Filtering/AnisotropicDiffusionLBR/test/itkStructureTensorImageFilterGTest.cxx
+++ b/Modules/Filtering/AnisotropicDiffusionLBR/test/itkStructureTensorImageFilterGTest.cxx
@@ -1,0 +1,51 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkStructureTensorImageFilter.h"
+#include "itkImageRegionConstIterator.h"
+#include "itkGTest.h"
+
+// A constant image has zero gradients, so the tensor-trace maximum is zero; the
+// adimensionizing rescale must not divide by it and poison the tensors with NaN
+// (issue #6575, B23).
+TEST(StructureTensorImageFilter, ConstantImageYieldsFiniteZeroTensors)
+{
+  using ImageType = itk::Image<float, 2>;
+  auto image = ImageType::New();
+  image->SetRegions(ImageType::RegionType{ ImageType::IndexType{}, ImageType::SizeType::Filled(16) });
+  image->Allocate();
+  image->FillBuffer(0.0F);
+
+  using FilterType = itk::StructureTensorImageFilter<ImageType>;
+  auto filter = FilterType::New();
+  filter->SetInput(image);
+  filter->SetRescaleForUnitMaximumTrace(true);
+  filter->Update();
+
+  using TensorImageType = FilterType::TensorImageType;
+  itk::ImageRegionConstIterator<TensorImageType> it(filter->GetOutput(), filter->GetOutput()->GetBufferedRegion());
+  for (it.GoToBegin(); !it.IsAtEnd(); ++it)
+  {
+    const auto & tensor = it.Get();
+    for (unsigned int c = 0; c < tensor.Size(); ++c)
+    {
+      ASSERT_TRUE(std::isfinite(tensor[c]));
+      ASSERT_NEAR(tensor[c], 0.0F, 1e-20);
+    }
+  }
+}

--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
@@ -38,6 +38,7 @@ ITK_GCC_SUPPRESS_Wfloat_equal
 #include "vnl/vnl_complex_traits.h"
 #include "complex"
 #include "itkPrintHelper.h"
+#include <algorithm> // For clamp and copy.
 ITK_GCC_PRAGMA_POP
 
 namespace itk
@@ -285,11 +286,19 @@ N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::Sharpen
       {
         binMaximum = pixel;
       }
-      else if (pixel < binMinimum)
+      if (pixel < binMinimum)
       {
         binMinimum = pixel;
       }
     }
+  }
+  if (binMaximum <= binMinimum)
+  {
+    // Degenerate intensity range: sharpening is an identity mapping.
+    const ImageBufferRange identityImageBufferRange{ *sharpenedImage };
+    std::copy(
+      unsharpenedImageBufferRange.cbegin(), unsharpenedImageBufferRange.cend(), identityImageBufferRange.begin());
+    return;
   }
   const RealType histogramSlope = (binMaximum - binMinimum) / static_cast<RealType>(this->m_NumberOfHistogramBins - 1);
 

--- a/Modules/Filtering/BiasCorrection/test/CMakeLists.txt
+++ b/Modules/Filtering/BiasCorrection/test/CMakeLists.txt
@@ -7,7 +7,11 @@ set(
 
 createtestdriver(ITKBiasCorrection "${ITKBiasCorrection-Test_LIBRARIES}" "${ITKBiasCorrectionTests}")
 
-set(ITKBiasCorrectionGTests itkCompositeValleyFunctionGTest.cxx)
+set(
+  ITKBiasCorrectionGTests
+  itkCompositeValleyFunctionGTest.cxx
+  itkN4BiasFieldCorrectionImageFilterGTest.cxx
+)
 
 creategoogletestdriver(ITKBiasCorrection "${ITKBiasCorrection-Test_LIBRARIES}" "${ITKBiasCorrectionGTests}")
 

--- a/Modules/Filtering/BiasCorrection/test/itkN4BiasFieldCorrectionImageFilterGTest.cxx
+++ b/Modules/Filtering/BiasCorrection/test/itkN4BiasFieldCorrectionImageFilterGTest.cxx
@@ -1,0 +1,45 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkN4BiasFieldCorrectionImageFilter.h"
+#include "itkImageRegionConstIterator.h"
+#include "itkGTest.h"
+
+// A constant image has a degenerate histogram range; sharpening must degrade to an
+// identity mapping instead of producing NaN bin indices (issue #6575, B2).
+TEST(N4BiasFieldCorrectionImageFilter, ConstantImageProducesFiniteOutput)
+{
+  using ImageType = itk::Image<float, 2>;
+  auto image = ImageType::New();
+  image->SetRegions(ImageType::RegionType{ ImageType::IndexType{}, ImageType::SizeType::Filled(32) });
+  image->Allocate();
+  image->FillBuffer(1.0F);
+
+  using FilterType = itk::N4BiasFieldCorrectionImageFilter<ImageType>;
+  auto filter = FilterType::New();
+  filter->SetInput(image);
+  filter->SetMaximumNumberOfIterations(FilterType::VariableSizeArrayType(1, 2));
+  filter->Update();
+
+  itk::ImageRegionConstIterator<ImageType> it(filter->GetOutput(), filter->GetOutput()->GetBufferedRegion());
+  for (it.GoToBegin(); !it.IsAtEnd(); ++it)
+  {
+    ASSERT_TRUE(std::isfinite(it.Get()));
+    ASSERT_NEAR(it.Get(), 1.0F, 1e-2) << " constant input must be (nearly) unchanged";
+  }
+}

--- a/Modules/Filtering/Deconvolution/include/itkWienerDeconvolutionImageFilter.h
+++ b/Modules/Filtering/Deconvolution/include/itkWienerDeconvolutionImageFilter.h
@@ -170,11 +170,14 @@ public:
     // minus the power spectral density of the noise.
     TPixel Pf = std::norm(I);
 
-    TPixel denominator = std::norm(H) + (Pn / (Pf - Pn));
     TPixel value{};
-    if (itk::Math::Absolute(denominator) >= m_KernelZeroMagnitudeThreshold)
+    if (Pf != Pn)
     {
-      value = I * (std::conj(H) / denominator);
+      const TPixel denominator = std::norm(H) + (Pn / (Pf - Pn));
+      if (itk::Math::Absolute(denominator) >= m_KernelZeroMagnitudeThreshold)
+      {
+        value = I * (std::conj(H) / denominator);
+      }
     }
 
     return value;

--- a/Modules/Filtering/Deconvolution/test/CMakeLists.txt
+++ b/Modules/Filtering/Deconvolution/test/CMakeLists.txt
@@ -15,6 +15,7 @@ createtestdriver(ITKDeconvolution "${ITKDeconvolution-Test_LIBRARIES}" "${ITKDec
 set(
   ITKDeconvolutionGTests
   itkProjectedIterativeDeconvolutionImageFilterGTest.cxx
+  itkWienerDeconvolutionImageFilterGTest.cxx
 )
 
 creategoogletestdriver(ITKDeconvolution "${ITKDeconvolution-Test_LIBRARIES}" "${ITKDeconvolutionGTests}")

--- a/Modules/Filtering/Deconvolution/test/itkWienerDeconvolutionImageFilterGTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkWienerDeconvolutionImageFilterGTest.cxx
@@ -1,0 +1,41 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkWienerDeconvolutionImageFilter.h"
+#include "itkGTest.h"
+#include <complex>
+
+// When the input power at a frequency equals the noise power spectral density, the
+// regularization term divides by zero; the functor must return zero instead of NaN
+// (issue #6575, B4).
+TEST(WienerDeconvolutionFunctor, ZeroSignalToNoiseYieldsZero)
+{
+  using ComplexType = std::complex<double>;
+  itk::Functor::WienerDeconvolutionFunctor<ComplexType> functor;
+  functor.SetNoisePowerSpectralDensityConstant(4.0);
+  functor.SetKernelZeroMagnitudeThreshold(1.0e-4);
+
+  // |I|^2 == Pn triggers the degenerate branch.
+  const ComplexType value = functor(ComplexType(2.0, 0.0), ComplexType(1.0, 0.0));
+  EXPECT_EQ(value, ComplexType(0.0, 0.0));
+
+  // A non-degenerate frequency still deconvolves finitely.
+  const ComplexType regular = functor(ComplexType(3.0, 0.0), ComplexType(1.0, 0.0));
+  EXPECT_TRUE(std::isfinite(regular.real()) && std::isfinite(regular.imag()));
+  EXPECT_NE(regular, ComplexType(0.0, 0.0));
+}

--- a/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
+++ b/Modules/Filtering/Denoising/include/itkPatchBasedDenoisingImageFilter.hxx
@@ -30,6 +30,7 @@
 #include "itkSpatialNeighborSubsampler.h"
 #include "itkMacro.h"
 #include "itkMath.h"
+#include <algorithm> // For clamp and copy.
 
 namespace itk
 {
@@ -2075,6 +2076,14 @@ PatchBasedDenoisingImageFilter<TInputImage, TOutputImage>::ThreadedComputeImageU
       // this->ApplyUpdate() will then copy the results to outputIt since we
       // have to wait until all threads have finished using outputIt to
       // compute the update
+      for (unsigned int pc = 0; pc < m_NumPixelComponents; ++pc)
+      {
+        // Clamp to the representable range: the float-to-integer conversion of an
+        // out-of-range update is undefined behavior.
+        const auto lowest = static_cast<RealValueType>(NumericTraits<PixelValueType>::NonpositiveMin());
+        const auto highest = static_cast<RealValueType>(NumericTraits<PixelValueType>::max());
+        this->SetComponent(result, pc, std::clamp(this->GetComponent(result, pc), lowest, highest));
+      }
       updateIt.Set(static_cast<PixelType>(result));
 
       ++updateIt;

--- a/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx
+++ b/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx
@@ -73,6 +73,8 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
   {
     last_p[i] = -10.0;
     last_q[i] = -10.0;
+    p[i] = 1.0;
+    q[i] = 1.0;
   }
 
   // Come up with an initial Wi which is simply the average of
@@ -158,8 +160,14 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
         out.NextLine();
       }
 
-      p[i] = p_num / p_denom;
-      q[i] = q_num / q_denom;
+      if (p_denom != 0.0)
+      {
+        p[i] = p_num / p_denom;
+      }
+      if (q_denom != 0.0)
+      {
+        q[i] = q_num / q_denom;
+      }
     }
 
     // Now recreate W using the new p's and q's

--- a/Modules/Filtering/ImageCompare/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageCompare/test/CMakeLists.txt
@@ -13,6 +13,9 @@ set(
 
 createtestdriver(ITKImageCompare "${ITKImageCompare-Test_LIBRARIES}" "${ITKImageCompareTests}")
 
+set(ITKImageCompareGTests itkSTAPLEImageFilterGTest.cxx)
+creategoogletestdriver(ITKImageCompare "${ITKImageCompare-Test_LIBRARIES}" "${ITKImageCompareGTests}")
+
 itk_add_test(
   NAME itkAbsoluteValueDifferenceImageFilterTest
   COMMAND

--- a/Modules/Filtering/ImageCompare/test/itkSTAPLEImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageCompare/test/itkSTAPLEImageFilterGTest.cxx
@@ -1,0 +1,56 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkSTAPLEImageFilter.h"
+#include "itkImageRegionConstIterator.h"
+#include "itkGTest.h"
+
+// All-background segmentations zero the weight image, so the sensitivity denominator is
+// zero; the estimates must stay finite instead of becoming NaN (issue #6575, B11).
+TEST(STAPLEImageFilter, AllBackgroundInputsStayFinite)
+{
+  using InputImageType = itk::Image<unsigned char, 2>;
+  using OutputImageType = itk::Image<double, 2>;
+
+  const auto makeImage = [] {
+    auto image = InputImageType::New();
+    image->SetRegions(InputImageType::RegionType{ InputImageType::IndexType{}, InputImageType::SizeType::Filled(16) });
+    image->Allocate();
+    image->FillBuffer(0);
+    return image;
+  };
+
+  using FilterType = itk::STAPLEImageFilter<InputImageType, OutputImageType>;
+  auto filter = FilterType::New();
+  filter->SetInput(0, makeImage());
+  filter->SetInput(1, makeImage());
+  filter->SetForegroundValue(1);
+  filter->SetMaximumIterations(5);
+  filter->Update();
+
+  for (unsigned int i = 0; i < 2; ++i)
+  {
+    EXPECT_TRUE(std::isfinite(filter->GetSensitivity(i))) << " input " << i;
+    EXPECT_TRUE(std::isfinite(filter->GetSpecificity(i))) << " input " << i;
+  }
+  itk::ImageRegionConstIterator<OutputImageType> it(filter->GetOutput(), filter->GetOutput()->GetBufferedRegion());
+  for (it.GoToBegin(); !it.IsAtEnd(); ++it)
+  {
+    ASSERT_TRUE(std::isfinite(it.Get()));
+  }
+}

--- a/Modules/Filtering/ImageStatistics/include/itkAdaptiveEqualizationHistogram.h
+++ b/Modules/Filtering/ImageStatistics/include/itkAdaptiveEqualizationHistogram.h
@@ -74,6 +74,11 @@ public:
     // AdaptiveHistogramEqualization compute kernel components with
     // float, but use double for accumulate and temporaries.
     const double iscale = static_cast<double>(m_Maximum) - m_Minimum;
+    if (iscale == 0.0)
+    {
+      // Constant image: equalization is an identity mapping.
+      return static_cast<TOutputPixel>(pixel);
+    }
 
     double         sum = 0.0;
     auto           itMap = m_Map.begin();

--- a/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkLabelOverlapMeasuresImageFilter.hxx
@@ -385,17 +385,16 @@ LabelOverlapMeasuresImageFilter<TLabelImage>::GetFalsePositiveError(LabelType la
     return 0.0;
   }
 
-  RealType value;
-  if (Math::ExactlyEquals(mapIt->second.m_Source, 0.0))
+  RealType   value;
+  const auto nComplementIntersection = nVox - mapIt->second.m_Union; // TN
+  const auto denominator = mapIt->second.m_SourceComplement + nComplementIntersection;
+  if (denominator == 0)
   {
     value = NumericTraits<RealType>::max();
   }
   else
   {
-    auto nComplementIntersection = nVox - mapIt->second.m_Union; // TN
-
-    value = static_cast<RealType>(mapIt->second.m_SourceComplement) /
-            static_cast<RealType>(mapIt->second.m_SourceComplement + nComplementIntersection);
+    value = static_cast<RealType>(mapIt->second.m_SourceComplement) / static_cast<RealType>(denominator);
   }
 
   return value;

--- a/Modules/Filtering/ImageStatistics/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageStatistics/test/CMakeLists.txt
@@ -467,6 +467,7 @@ itk_add_test(
 
 set(
   ITKImageStatisticsGTests
+  itkAdaptiveHistogramEqualizationImageFilterGTest.cxx
   itkLabelOverlapMeasuresImageFilterGTest.cxx
   itkMinimumMaximumImageFilterGTest.cxx
 )

--- a/Modules/Filtering/ImageStatistics/test/itkAdaptiveHistogramEqualizationImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkAdaptiveHistogramEqualizationImageFilterGTest.cxx
@@ -1,0 +1,44 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkAdaptiveHistogramEqualizationImageFilter.h"
+#include "itkImageRegionConstIterator.h"
+#include "itkGTest.h"
+
+// A constant image has zero intensity range; equalization must be an identity mapping
+// instead of dividing by zero and producing NaN everywhere (issue #6575, B9).
+TEST(AdaptiveHistogramEqualizationImageFilter, ConstantImageIsIdentity)
+{
+  using ImageType = itk::Image<float, 2>;
+  auto image = ImageType::New();
+  image->SetRegions(ImageType::RegionType{ ImageType::IndexType{}, ImageType::SizeType::Filled(16) });
+  image->Allocate();
+  image->FillBuffer(7.0F);
+
+  using FilterType = itk::AdaptiveHistogramEqualizationImageFilter<ImageType>;
+  auto filter = FilterType::New();
+  filter->SetInput(image);
+  filter->SetRadius(2);
+  filter->Update();
+
+  itk::ImageRegionConstIterator<ImageType> it(filter->GetOutput(), filter->GetOutput()->GetBufferedRegion());
+  for (it.GoToBegin(); !it.IsAtEnd(); ++it)
+  {
+    ASSERT_EQ(it.Get(), 7.0F);
+  }
+}

--- a/Modules/Filtering/ImageStatistics/test/itkLabelOverlapMeasuresImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkLabelOverlapMeasuresImageFilterGTest.cxx
@@ -204,3 +204,19 @@ TEST_F(LabelOverlapMeasuresImageFilterFixture, test3)
   EXPECT_NEAR(filter->GetFalsePositiveError(2), 4.76837612950e-07, 1e-17);
   EXPECT_NEAR(filter->GetFalseDiscoveryRate(2), 1.0 / 3.0, 0.0);
 }
+
+// A label covering the whole image has FP = TN = 0; the zero denominator must map to
+// the degenerate-value convention, not NaN (issue #6575, B12).
+TEST_F(LabelOverlapMeasuresImageFilterFixture, WholeImageLabelFalsePositiveError)
+{
+  auto source = Utils::CreateImage(1);
+  auto target = Utils::CreateImage(1);
+
+  auto filter = Utils::FilterType::New();
+  filter->SetSourceImage(source);
+  filter->SetTargetImage(target);
+  filter->Update();
+
+  using RealType = Utils::FilterType::RealType;
+  EXPECT_EQ(filter->GetFalsePositiveError(1), itk::NumericTraits<RealType>::max());
+}

--- a/Modules/Filtering/Smoothing/include/itkBoxUtilities.h
+++ b/Modules/Filtering/Smoothing/include/itkBoxUtilities.h
@@ -473,7 +473,9 @@ BoxSigmaCalculatorFunction(const TInputImage *               accImage,
           ++(cornerItVec[k]);
         }
 
-        oIt.Set(static_cast<OutputPixelType>(std::sqrt((squareSum - sum * sum / pixelscount) / (pixelscount - 1))));
+        oIt.Set(pixelscount > 1
+                  ? static_cast<OutputPixelType>(std::sqrt((squareSum - sum * sum / pixelscount) / (pixelscount - 1)))
+                  : OutputPixelType{});
       }
     }
     else
@@ -538,8 +540,9 @@ BoxSigmaCalculatorFunction(const TInputImage *               accImage,
           }
         }
 
-        oIt.Set(
-          static_cast<OutputPixelType>(std::sqrt((squareSum - sum * sum / edgepixelscount) / (edgepixelscount - 1))));
+        oIt.Set(edgepixelscount > 1 ? static_cast<OutputPixelType>(
+                                        std::sqrt((squareSum - sum * sum / edgepixelscount) / (edgepixelscount - 1)))
+                                    : OutputPixelType{});
       }
     }
   }

--- a/Modules/Filtering/Smoothing/test/CMakeLists.txt
+++ b/Modules/Filtering/Smoothing/test/CMakeLists.txt
@@ -396,6 +396,7 @@ itk_add_test(
 
 set(
   ITKSmoothingGTests
+  itkBoxSigmaImageFilterGTest.cxx
   itkMeanImageFilterGTest.cxx
   itkMedianImageFilterGTest.cxx
 )

--- a/Modules/Filtering/Smoothing/test/itkBoxSigmaImageFilterGTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkBoxSigmaImageFilterGTest.cxx
@@ -1,0 +1,47 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkBoxSigmaImageFilter.h"
+#include "itkImageRegionConstIteratorWithIndex.h"
+#include "itkGTest.h"
+
+// A radius-0 window holds a single sample, so the (unbiased) standard deviation must be
+// zero, not sqrt(0/0) = NaN (issue #6575, B20).
+TEST(BoxSigmaImageFilter, RadiusZeroYieldsZeroNotNaN)
+{
+  using ImageType = itk::Image<float, 2>;
+  auto image = ImageType::New();
+  image->SetRegions(ImageType::RegionType{ ImageType::IndexType{}, ImageType::SizeType::Filled(8) });
+  image->Allocate();
+  for (itk::ImageRegionIteratorWithIndex<ImageType> it(image, image->GetBufferedRegion()); !it.IsAtEnd(); ++it)
+  {
+    it.Set(static_cast<float>(it.GetIndex()[0] + 10 * it.GetIndex()[1]));
+  }
+
+  using FilterType = itk::BoxSigmaImageFilter<ImageType, ImageType>;
+  auto filter = FilterType::New();
+  filter->SetInput(image);
+  filter->SetRadius(0);
+  filter->Update();
+
+  itk::ImageRegionConstIteratorWithIndex<ImageType> it(filter->GetOutput(), filter->GetOutput()->GetBufferedRegion());
+  for (it.GoToBegin(); !it.IsAtEnd(); ++it)
+  {
+    EXPECT_EQ(it.Get(), 0.0F) << " at index " << it.GetIndex();
+  }
+}

--- a/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkGaussianRandomSpatialNeighborSubsampler.hxx
@@ -48,14 +48,14 @@ GaussianRandomSpatialNeighborSubsampler<TSample, TRegion>::GetIntegerVariate(Ran
     itkExceptionMacro("upperBound (" << upperBound << ") not >= to lowerBound(" << lowerBound << ')');
   }
 
-  RandomIntType randInt = 0;
-
+  // Reject out-of-bound variates before the integer conversion: converting a
+  // negative value to an unsigned type is undefined behavior.
+  RealType floorVar = 0;
   do
   {
-    const RealType randVar = this->m_RandomNumberGenerator->GetNormalVariate(mean, m_Variance);
-    randInt = static_cast<RandomIntType>(std::floor(randVar));
-  } while ((randInt < lowerBound) || (randInt > upperBound));
-  return randInt;
+    floorVar = std::floor(this->m_RandomNumberGenerator->GetNormalVariate(mean, m_Variance));
+  } while ((floorVar < static_cast<RealType>(lowerBound)) || (floorVar > static_cast<RealType>(upperBound)));
+  return static_cast<RandomIntType>(floorVar);
 }
 
 template <typename TSample, typename TRegion>

--- a/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
+++ b/Modules/Segmentation/SuperPixel/include/itkSLICImageFilter.hxx
@@ -642,10 +642,17 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>::GenerateData()
     for (size_t i = 0; i * numberOfClusterComponents < m_Clusters.size(); ++i)
     {
 
-      ClusterType cluster(numberOfClusterComponents, &m_Clusters[i * numberOfClusterComponents]);
-      cluster /= clusterCount[i];
-
+      ClusterType       cluster(numberOfClusterComponents, &m_Clusters[i * numberOfClusterComponents]);
       const ClusterType oldCluster(numberOfClusterComponents, &m_OldClusters[i * numberOfClusterComponents]);
+      if (clusterCount[i] > 0)
+      {
+        cluster /= clusterCount[i];
+      }
+      else
+      {
+        // Empty cluster: keep the previous centroid to avoid a NaN center.
+        cluster.copy_in(oldCluster.data_block());
+      }
       l1Residual += Distance(cluster, oldCluster);
     }
 


### PR DESCRIPTION
Guards the easy division-by-zero → NaN → undefined-behavior sites catalogued in #6575: ten fixes (items B2, B3, B4, B9, B11, B12, B20, B23, B27, B29), one commit per item, with seven new GoogleTests. Five of the tests demonstrably fail on the pre-fix code; the full test suites of all nine touched modules pass (235/235 locally).

<details>
<summary>Per-item summary</summary>

| Item | Site | Guard |
|---|---|---|
| B2 | `N4BiasFieldCorrectionImageFilter::SharpenImage` | Independent min/max scans; degenerate bin range → identity mapping (was NaN bin index → UB int cast → unchecked indexing) |
| B3 | `SLICImageFilter` | Empty cluster keeps its previous centroid (was 0/0 NaN centroid → UB rounding) |
| B4 | `WienerDeconvolutionImageFilter` functor | `Pf == Pn` → zero output (was complex division by zero; the magnitude guard passes on inf) |
| B9 | `AdaptiveEqualizationHistogram` | Zero intensity range → identity (was NaN everywhere on constant input) |
| B11 | `STAPLEImageFilter` | Initialize p/q; keep previous estimate on a zero denominator (was NaN on all-background inputs) |
| B12 | `LabelOverlapMeasuresImageFilter` | FalsePositiveError guard now tests the actual FP+TN denominator (was NaN for a whole-image label) |
| B20 | `BoxSigmaImageFilter` (`itkBoxUtilities.h`, both body and edge paths) | Single-sample window → 0 (was sqrt(0/0) NaN at radius 0) |
| B23 | `StructureTensorImageFilter` (AnisotropicDiffusionLBR) | Zero maximum trace → no rescale (was ×inf → NaN tensors → UB negative step count downstream) |
| B27 | `PatchBasedDenoisingImageFilter` | Clamp the update to the representable pixel range before the cast (negative float → unsigned is UB) |
| B29 | `GaussianRandomSpatialNeighborSubsampler` | Bound-check the variate in floating point before the integer conversion (negative float → unsigned is UB) |

</details>

<details>
<summary>Test coverage and verification notes</summary>

New GoogleTests: N4 constant-image (BiasCorrection — new GTest driver entry), Wiener functor zero-SNR (Deconvolution), AdaptiveHistogramEqualization constant-image + LabelOverlapMeasures whole-image label (ImageStatistics), BoxSigma radius-0 (Smoothing), STAPLE all-background (ImageCompare — new GTest driver block), StructureTensor constant-image (AnisotropicDiffusionLBR).

Fail-before/pass-after was verified locally by rebuilding each test against the pre-fix sources: the AHE, LabelOverlap, BoxSigma, STAPLE, and StructureTensor tests fail before the fix. The N4 and Wiener tests pass pre-fix on arm64/macOS because the underlying UB (NaN→int conversion, libc complex division) happens to be benign there — they pin the now-defined behavior and would catch regressions under UBSan or on other platforms.

Untested-by-design: B3 (an empty SLIC cluster is not deterministically constructible from the public API), B27 and B29 (UB-only guards with no observable defined-behavior change on this platform).

</details>

Findings and analysis by the #6575 reporter; see that ledger for the full derivations.

<!--
provenance: claude-code session 2026-07-10 (hjmjohnson)
key_facts: fail-before confirmed for AHE/LabelOverlap/BoxSigma/STAPLE/StructureTensor; 235/235 module tests green locally; STAPLE p/q were previously uninitialized (make_unique_for_overwrite) — init added with the guard; StructureTensor test needs SetRescaleForUnitMaximumTrace(true) and an all-zero image (constant nonzero leaves ~5e-32 recursive-Gaussian fuzz)
remaining_6575_items: B1 B5 B6 B7 B8 B13 B14 B15 B16 B17 B21 B22 B24 B26 B28 B30 + 24 quirks
post_merge_action: update #6575 status table
-->
