### PR TITLE
BUG: Fix LabelMap and label-statistics correctness bugs from issue 6575

### DIFF
--- a/Modules/Filtering/ImageFusion/include/itkLabelMapContourOverlayImageFilter.hxx
+++ b/Modules/Filtering/ImageFusion/include/itkLabelMapContourOverlayImageFilter.hxx
@@ -155,7 +155,7 @@ LabelMapContourOverlayImageFilter<TLabelMap, TFeatureImage, TOutputImage>::Befor
   RadiusType srad{};
   for (unsigned int i = 0, j = 0; i < ImageDimension; ++i)
   {
-    if (j != static_cast<unsigned int>(m_SliceDimension) && (j < (ImageDimension - 1)))
+    if (i != static_cast<unsigned int>(m_SliceDimension) && (j < (ImageDimension - 1)))
     {
       srad[j] = m_ContourThickness[i];
       ++j;

--- a/Modules/Filtering/LabelMap/include/itkAttributeUniqueLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkAttributeUniqueLabelMapFilter.hxx
@@ -236,7 +236,7 @@ AttributeUniqueLabelMapFilter<TImage, TAttributeAccessor>::GenerateData()
 
   // remove objects without lines
   typename ImageType::Iterator it(this->GetLabelMap());
-  while (it.IsAtEnd())
+  while (!it.IsAtEnd())
   {
     const typename LabelObjectType::LabelType label = it.GetLabel();
     LabelObjectType *                         labelObject = it.GetLabelObject();

--- a/Modules/Filtering/LabelMap/include/itkLabelMap.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMap.hxx
@@ -414,6 +414,7 @@ LabelMap<TLabelObject>::PushLabelObject(LabelObjectType * labelObject)
       // search for an unused label
       LabelType                         label = firstLabel;
       LabelObjectContainerConstIterator it;
+      bool                              foundFreeLabel = false;
       for (it = m_LabelObjectContainer.begin(); it != m_LabelObjectContainer.end(); ++it, ++label)
       {
         assert((it->second.IsNotNull()));
@@ -424,10 +425,11 @@ LabelMap<TLabelObject>::PushLabelObject(LabelObjectType * labelObject)
         if (label != it->first)
         {
           labelObject->SetLabel(label);
+          foundFreeLabel = true;
           break;
         }
       }
-      if (label == lastLabel)
+      if (!foundFreeLabel)
       {
         itkExceptionStringMacro("Can't push the label object: the label map is full.");
       }

--- a/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkLabelMapMaskImageFilter.hxx
@@ -140,10 +140,19 @@ LabelMapMaskImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
         }
 
         // Final computation
-        SizeType regionSize;
-        for (unsigned int i = 0; i < ImageDimension; ++i)
+        SizeType regionSize{};
+        if (maxs[0] >= mins[0])
         {
-          regionSize[i] = maxs[i] - mins[i] + 1;
+          for (unsigned int i = 0; i < ImageDimension; ++i)
+          {
+            regionSize[i] = maxs[i] - mins[i] + 1;
+          }
+        }
+        else
+        {
+          // No matching object lines: use an empty region rather than overflowing
+          // the size with the uninitialized min/max sentinels.
+          mins.Fill(0);
         }
         cropRegion = { mins, regionSize };
       }
@@ -194,10 +203,19 @@ LabelMapMaskImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
           ++lit;
         }
         // Final computation
-        SizeType regionSize;
-        for (unsigned int i = 0; i < ImageDimension; ++i)
+        SizeType regionSize{};
+        if (maxs[0] >= mins[0])
         {
-          regionSize[i] = maxs[i] - mins[i] + 1;
+          for (unsigned int i = 0; i < ImageDimension; ++i)
+          {
+            regionSize[i] = maxs[i] - mins[i] + 1;
+          }
+        }
+        else
+        {
+          // No matching object lines: use an empty region rather than overflowing
+          // the size with the uninitialized min/max sentinels.
+          mins.Fill(0);
         }
         cropRegion = { mins, regionSize };
       }

--- a/Modules/Filtering/LabelMap/include/itkMergeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkMergeLabelMapFilter.hxx
@@ -71,12 +71,12 @@ MergeLabelMapFilter<TImage>::MergeWithKeep()
   ImageType * output = this->GetOutput();
 
   using VectorType = std::deque<LabelObjectPointer>;
-  VectorType labelObjects;
 
   ProgressReporter progress(this, 0, 1);
 
   for (unsigned int i = 1; i < this->GetNumberOfIndexedInputs(); ++i)
   {
+    VectorType                        labelObjects;
     typename ImageType::ConstIterator it2(this->GetInput(i));
     while (!it2.IsAtEnd())
     {

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
@@ -233,7 +233,7 @@ StatisticsLabelMapFilter<TImage, TFeatureImage>::ThreadedProcessLabelObject(Labe
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       //    principalMoments[i] = 4 * std::sqrt( pm(i,i) );
-      principalMoments[i] = pm(i);
+      principalMoments[i] = std::max(pm(i), 0.0);
     }
     principalAxes = eigen.V.transpose();
 
@@ -258,12 +258,18 @@ StatisticsLabelMapFilter<TImage, TFeatureImage>::ThreadedProcessLabelObject(Labe
       elongation = 1;
       flatness = 1;
     }
-    else if (Math::NotAlmostEquals(principalMoments[0], typename VectorType::ValueType{}))
+    else
     {
-      //    elongation = principalMoments[ImageDimension-1] /
-      // principalMoments[0];
-      elongation = std::sqrt(principalMoments[ImageDimension - 1] / principalMoments[ImageDimension - 2]);
-      flatness = std::sqrt(principalMoments[1] / principalMoments[0]);
+      if (Math::NotAlmostEquals(principalMoments[0], typename VectorType::ValueType{}))
+      {
+        const double flatnessRatio = principalMoments[1] / principalMoments[0];
+        flatness = (flatnessRatio > 0.0) ? std::sqrt(flatnessRatio) : 0.0;
+      }
+      if (Math::NotAlmostEquals(principalMoments[ImageDimension - 2], typename VectorType::ValueType{}))
+      {
+        const double elongationRatio = principalMoments[ImageDimension - 1] / principalMoments[ImageDimension - 2];
+        elongation = (elongationRatio > 0.0) ? std::sqrt(elongationRatio) : 0.0;
+      }
     }
   }
   else

--- a/Modules/Filtering/LabelMap/test/CMakeLists.txt
+++ b/Modules/Filtering/LabelMap/test/CMakeLists.txt
@@ -1796,6 +1796,7 @@ itk_add_test(
 set(
   ITKLabelMapGTests
   itkShapeLabelMapFilterGTest.cxx
+  itkLabelMapBugfixGTest.cxx
   itkStatisticsLabelMapFilterGTest.cxx
   itkUniqueLabelMapFiltersGTest.cxx
 )

--- a/Modules/Filtering/LabelMap/test/itkLabelMapBugfixGTest.cxx
+++ b/Modules/Filtering/LabelMap/test/itkLabelMapBugfixGTest.cxx
@@ -1,0 +1,110 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkLabelMap.h"
+#include "itkLabelObject.h"
+#include "itkStatisticsLabelObject.h"
+#include "itkStatisticsLabelMapFilter.h"
+#include "itkLabelUniqueLabelMapFilter.h"
+#include "itkGTest.h"
+
+// A completely full label range must make PushLabelObject throw, not silently
+// overwrite an existing entry (issue #6575, B44).
+TEST(LabelMap, PushLabelObjectThrowsWhenFull)
+{
+  using LabelObjectType = itk::LabelObject<unsigned char, 2>;
+  using LabelMapType = itk::LabelMap<LabelObjectType>;
+
+  auto labelMap = LabelMapType::New();
+  labelMap->SetRegions(LabelMapType::RegionType{ LabelMapType::IndexType{}, LabelMapType::SizeType::Filled(4) });
+
+  // Background is 0; occupy every remaining label 1..255.
+  for (unsigned int label = 1; label <= 255; ++label)
+  {
+    labelMap->SetLine(LabelMapType::IndexType{}, 1, static_cast<unsigned char>(label));
+  }
+  ASSERT_EQ(labelMap->GetNumberOfLabelObjects(), 255u);
+
+  auto extra = LabelObjectType::New();
+  extra->AddLine(itk::MakeIndex(0, 1), 1);
+  EXPECT_THROW(labelMap->PushLabelObject(extra), itk::ExceptionObject);
+}
+
+// Weighted elongation/flatness must stay finite when a signed feature image makes
+// the weighted covariance indefinite (issue #6575, B45).
+TEST(StatisticsLabelMapFilter, WeightedShapeFinelyDefinedForSignedFeature)
+{
+  using LabelObjectType = itk::StatisticsLabelObject<unsigned char, 2>;
+  using LabelMapType = itk::LabelMap<LabelObjectType>;
+  using FeatureImageType = itk::Image<float, 2>;
+
+  auto labelMap = LabelMapType::New();
+  labelMap->SetRegions(LabelMapType::RegionType{ LabelMapType::IndexType{}, LabelMapType::SizeType::Filled(9) });
+  // A cross: horizontal arm (y == 4, x in 2..6) and vertical arm (x == 4, y in 2,3,5,6).
+  labelMap->SetLine(itk::MakeIndex(2, 4), 5, 1);
+  labelMap->SetLine(itk::MakeIndex(4, 2), 1, 1);
+  labelMap->SetLine(itk::MakeIndex(4, 3), 1, 1);
+  labelMap->SetLine(itk::MakeIndex(4, 5), 1, 1);
+  labelMap->SetLine(itk::MakeIndex(4, 6), 1, 1);
+
+  // Positive weights along the x arm, negative along the y arm: the weighted
+  // second moment is positive in xx and negative in yy -> indefinite covariance.
+  auto feature = FeatureImageType::New();
+  feature->SetRegions(labelMap->GetLargestPossibleRegion());
+  feature->Allocate();
+  feature->FillBuffer(0.0F);
+  for (int x = 2; x <= 6; ++x)
+  {
+    feature->SetPixel(itk::MakeIndex(x, 4), 2.0F);
+  }
+  for (int y : { 2, 3, 5, 6 })
+  {
+    feature->SetPixel(itk::MakeIndex(4, y), -1.0F);
+  }
+
+  auto filter = itk::StatisticsLabelMapFilter<LabelMapType, FeatureImageType>::New();
+  filter->SetInput(labelMap);
+  filter->SetFeatureImage(feature);
+  filter->Update();
+
+  const auto * object = filter->GetOutput()->GetLabelObject(1);
+  EXPECT_TRUE(std::isfinite(object->GetWeightedElongation())) << " weighted elongation";
+  EXPECT_TRUE(std::isfinite(object->GetWeightedFlatness())) << " weighted flatness";
+}
+
+// A label object whose every pixel is claimed by a higher-priority object becomes
+// empty and must be removed; the removal pass used an inverted loop condition and
+// never ran (issue #6575, B43).
+TEST(LabelUniqueLabelMapFilter, EmptiedObjectIsRemoved)
+{
+  using LabelObjectType = itk::LabelObject<unsigned char, 2>;
+  using LabelMapType = itk::LabelMap<LabelObjectType>;
+
+  auto labelMap = LabelMapType::New();
+  labelMap->SetRegions(LabelMapType::RegionType{ LabelMapType::IndexType{}, LabelMapType::SizeType::Filled(8) });
+  // Two objects covering exactly the same pixels: after uniqueness one is emptied.
+  labelMap->SetLine(itk::MakeIndex(0, 0), 4, 1);
+  labelMap->SetLine(itk::MakeIndex(0, 0), 4, 2);
+  ASSERT_EQ(labelMap->GetNumberOfLabelObjects(), 2u);
+
+  auto unique = itk::LabelUniqueLabelMapFilter<LabelMapType>::New();
+  unique->SetInput(labelMap);
+  unique->Update();
+
+  EXPECT_EQ(unique->GetOutput()->GetNumberOfLabelObjects(), 1u);
+}


### PR DESCRIPTION
Fixes six LabelMap / label-statistics correctness bugs catalogued in #6575 (items B40–B45): one `BUG:` commit per item. All in-memory logic, no fixtures; three items ship dedicated fail-before/pass-after GoogleTests and the rest are covered by the module regression (136/136 local).

<details>
<summary>Per-item summary</summary>

| Item | Site | Fix |
|---|---|---|
| B40 | `MergeLabelMapFilter` (KEEP) | The collision-deferred deque was declared outside the per-input loop and never cleared, so with ≥3 inputs an object deferred on one input was pushed again on the next — aliasing one object under two label keys. Declare the deque inside the loop. |
| B41 | `LabelMapContourOverlayImageFilter` (SLICE_CONTOUR) | The slice-radius guard tested the write cursor `j` against `SliceDimension` where it meant the read index `i`; `SliceDimension == 0` left the radius all-zero and drew no contour. Test the read index. |
| B42 | `LabelMapMaskImageFilter` (Crop) | An empty/zero-line object set left the bounding-box min/max sentinels untouched, so `maxs - mins + 1` overflowed (UB) and the filter allocated a 2×2 image at index 2⁶³−1. Use an empty region when no lines are found (both crop sites). |
| B43 | `AttributeUniqueLabelMapFilter` | The "remove objects without lines" pass used an inverted condition (`while (it.IsAtEnd())`) and never ran, so an object whose pixels were all claimed by a higher-priority object survived with zero lines (and fed the B42 crop path). |
| B44 | `LabelMap::PushLabelObject` | On a completely full label range the gap scan found no free label but the "map full" test (`label == lastLabel`) never held, so `AddLabelObject` silently overwrote the object's own entry. Track whether a free label was found and throw otherwise. |
| B45 | `StatisticsLabelMapFilter` | Weighted elongation/flatness used unclamped principal moments and one shared guard, so an indefinite weighted covariance from a signed feature image produced NaN where `ShapeLabelMapFilter` returns 0. Clamp the moments and guard each ratio, matching `ShapeLabelMapFilter`. |

</details>

<details>
<summary>Testing</summary>

New `itkLabelMapBugfixGTest.cxx` adds three tests, each verified to fail on the unfixed tree and pass after:
- **B44** — a full 8-bit label range makes `PushLabelObject` throw (silently overwrote before).
- **B45** — a cross-shaped object with positive x-arm / negative y-arm feature weights gives an indefinite weighted covariance; weighted elongation/flatness stay finite (NaN before).
- **B43** — two fully-overlapping objects: uniqueness empties one, which is then removed (count 2 → 1; stayed 2 before).

B40/B41/B42 are covered by the existing ITKLabelMap + ITKImageFusion regression (136/136 pass locally); dedicated fail-before tests for those can be added on request. `pre-commit run --all-files` is clean.

</details>

Findings and analysis by the #6575 reporter; see that ledger for the full derivations.

<!--
provenance: claude-code session 2026-07-11 (hjmjohnson)
fail_before_confirmed: B43 (count stays 2), B44 (no throw), B45 (NaN elongation/flatness)
regression_only: B40, B41, B42 (136/136 ITKLabelMap+ITKImageFusion)
files: itkMergeLabelMapFilter.hxx, itkLabelMapContourOverlayImageFilter.hxx, itkLabelMapMaskImageFilter.hxx, itkAttributeUniqueLabelMapFilter.hxx, itkLabelMap.hxx, itkStatisticsLabelMapFilter.hxx, test/itkLabelMapBugfixGTest.cxx
post_merge_action: mark B40-B45 done in #6575; consider adding B40/B41/B42 dedicated tests
-->
