### PR TITLE
COMP: Wrap ESMDemonsRegistrationFunction only with matching vector dim

### DIFF
--- a/Modules/Nonunit/Review/wrapping/itkESMDemonsRegistrationFunction.wrap
+++ b/Modules/Nonunit/Review/wrapping/itkESMDemonsRegistrationFunction.wrap
@@ -1,9 +1,11 @@
 itk_wrap_class("itk::ESMDemonsRegistrationFunction" POINTER)
-foreach(s ${WRAP_ITK_SCALAR})
-  itk_wrap_image_filter_combinations(
-    "${s}"
-    "${s}"
-    "${WRAP_ITK_VECTOR_REAL}"
-    2+)
+# This function needs to have image dimension == vector dimension
+foreach(d ${ITK_WRAP_IMAGE_DIMS})
+  foreach(t ${WRAP_ITK_SCALAR})
+    foreach(v ${WRAP_ITK_VECTOR_REAL})
+      itk_wrap_template("${ITKM_I${t}${d}}${ITKM_I${t}${d}}${ITKM_I${v}${d}${d}}"
+                        "${ITKT_I${t}${d}},${ITKT_I${t}${d}},${ITKT_I${v}${d}${d}}")
+    endforeach()
+  endforeach()
 endforeach()
 itk_end_wrap_class()


### PR DESCRIPTION
Restrict `itkESMDemonsRegistrationFunction.wrap` to vector dimension == image dimension, matching the sibling `DiffeomorphicDemonsRegistrationFilter` wrapping. This removes the root cause of the recurring GCC 11.4 nightly `-Waggressive-loop-optimizations` warnings in `itkWarpImageFilter.hxx` and `itkESMDemonsRegistrationFunction.hxx`.

<details>
<summary>Root cause</summary>

The wrap file generated cross products such as
`ESMDemonsRegistrationFunction<Image<float,3>, Image<float,3>, Image<Vector<float,2>,3>>`.
Those instantiations index a 2-component displacement vector with loops bound by
`ImageDimension` — undefined behavior if ever executed, and provably out of bounds
to GCC's unroller (`iteration 2 invokes undefined behavior`). Because
`ESMDemonsRegistrationFunction` holds a `WarpImageFilter` member, one bad combination
warns in both headers.

Reproduced locally with conda-forge gcc 11.4 (same as the `Ubuntu-22.04-gcc11.4-Rel-Python`
nightly): a single mismatched explicit instantiation emits exactly the four dashboard
warning sites; matched-dimension instantiations are clean.

Two earlier attempts patched the loop code instead of the instantiation: PR #6367
switched to a runtime `GetLength` bound, then commit d4a40cb1d20 reverted to
`ImageDimension` because the runtime bound traded one warning for another. Neither
addressed the mismatched instantiation, so the warning returned on the nightly.

The removed Python types (e.g. `itkESMDemonsRegistrationFunctionIF3IF3IVF23`) were
broken by construction: `NumericTraits::SetLength(update, ImageDimension)` cannot
resize a fixed `Vector<float,2>`, so any use was UB.

</details>

<!--
provenance: claude-code session 2026-07-12 (cdash-build-analysis)
key_facts: CDash 20260712 nightly Ubuntu-22.04-gcc11.4-Rel-Python; warning sites itkWarpImageFilter.hxx:305/307/335/337, itkESMDemonsRegistrationFunction.hxx:329/331/369/371
repro: template class itk::WarpImageFilter<itk::Image<float,3>,itk::Image<float,3>,itk::Image<itk::Vector<float,2>,3>>; with pixi exec --spec gxx_linux-64=11.4, -O2
related: PR #6367 (merged), commit d4a40cb1d20 — do not iterate on loop bounds again
-->
