### PR TITLE
COMP: Apply rule of zero to functors with user-declared destructors

### DIFF
--- a/Modules/Filtering/ImageIntensity/include/itkMaskImageFilter.h
+++ b/Modules/Filtering/ImageIntensity/include/itkMaskImageFilter.h
@@ -40,7 +40,6 @@ public:
 
   MaskInput() = default;
 
-  ~MaskInput() = default;
   bool
   operator==(const MaskInput &) const
   {

--- a/Modules/Segmentation/ConnectedComponents/include/itkScalarConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkScalarConnectedComponentImageFilter.h
@@ -58,8 +58,6 @@ public:
     : m_Threshold(TInput{})
   {}
 
-  ~SimilarPixelsFunctor() = default;
-
   bool
   operator==(const SimilarPixelsFunctor & other) const
   {

--- a/Modules/Segmentation/ConnectedComponents/include/itkVectorConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkVectorConnectedComponentImageFilter.h
@@ -53,8 +53,6 @@ class SimilarVectorsFunctor
 public:
   SimilarVectorsFunctor() = default;
 
-  ~SimilarVectorsFunctor() = default;
-
   void
   SetDistanceThreshold(const typename TInput::ValueType & thresh)
   {


### PR DESCRIPTION
Remove the defaulted non-virtual destructors from `MaskInput`, `SimilarPixelsFunctor`, and `SimilarVectorsFunctor` (rule of zero), silencing the remaining AppleClang `-Wdeprecated-copy-with-dtor` nightly warnings. Complements @blowekamp's #6538, which covers the polymorphic classes where `ITK_DEFAULT_COPY_AND_MOVE` is the right fix in cases where the rule-of-zero does not apply.

<details>
<summary>Verification</summary>

These three functors have only trivially-copyable members and no other user-declared
special members, so removing the destructor lets all special members be implicitly
generated with identical behavior — the rule-of-zero approach suggested in the #6538
review for non-virtual cases.

Verified locally with clang 18: a TU that copies and assigns all three functors emits
6 `-Wdeprecated-copy-with-dtor` warnings before this change and 0 after.
`ITKImageIntensityTestDriver` and `ITKConnectedComponentsTestDriver` build clean and
the affected tests (`itkMaskImageFilterTest`, `itkScalarConnectedComponentImageFilterTest`,
`itkVectorConnectedComponentImageFilterTest`) pass.

</details>

<!--
provenance: claude-code session 2026-07-12 (cdash-build-analysis)
key_facts: CDash 20260712 nightly Mac13/14/15 AppleClang dbg builds; warning sites itkMaskImageFilter.h:43, itkScalarConnectedComponentImageFilter.h:61, itkVectorConnectedComponentImageFilter.h:56
related: PR #6538 (blowekamp) covers itkDefaultVectorPixelAccessor.h + itkPriorityQueueContainer.h
-->
