### PR TITLE
COMP: Compare timing pointers before freeing the array

### DIFF
--- a/Modules/Core/Common/test/itkFixedArrayTest2.cxx
+++ b/Modules/Core/Common/test/itkFixedArrayTest2.cxx
@@ -100,12 +100,12 @@ itkFixedArrayTest2(int, char *[])
   std::cout << "Execution time: " << time2 << "ms\n";
 
 
+  const bool sameptr = (vec == vec2);
+
   // Free up the memory
   delete[] vec;
 
   const double ratio = 100.0 * (time1 - time2) / time2;
-
-  const bool sameptr = (vec == vec2);
   if (sameptr)
   {
     std::cout << "Same pointers: true" << std::endl;


### PR DESCRIPTION
Compute the same-pointer check in `itkFixedArrayTest2` before `delete[]`, so the test no longer compares a dangling pointer. Found by the Clang main `-Wlifetime-safety-use-after-free` diagnostic on the `Mac26.x-ClangMain-dbg-arm64` nightly.

<!--
provenance: claude-code session 2026-07-12 (cdash-build-analysis)
key_facts: CDash 20260712 ClangMain nightly; itkFixedArrayTest2.cxx compared vec after delete[] at former line 108
note: remaining ~33 -Wlifetime-safety-invalidation warnings on ClangMain are experimental-diagnostic false positives (x = f(x) reference-parameter reassignment patterns); recommend no action until the diagnostic stabilizes upstream
-->
