### PR TITLE
BUG: Fix bisection midpoint in ThresholdMaximumConnectedComponents

### DIFF
--- a/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.hxx
+++ b/Modules/Segmentation/ConnectedComponents/include/itkThresholdMaximumConnectedComponentsImageFilter.hxx
@@ -103,7 +103,7 @@ ThresholdMaximumConnectedComponentsImageFilter<TInputImage, TOutputImage>::Gener
   m_ThresholdFilter->SetInsideValue(m_InsideValue);
   m_ThresholdFilter->SetUpperThreshold(m_UpperBoundary);
 
-  PixelType midpoint = (upperBound - lowerBound) / 2;
+  PixelType midpoint = lowerBound + (upperBound - lowerBound) / 2;
   PixelType midpointL = (lowerBound + (midpoint - lowerBound) / 2);
   PixelType midpointR = (upperBound - (upperBound - midpoint) / 2);
 

--- a/Modules/Segmentation/ConnectedComponents/test/CMakeLists.txt
+++ b/Modules/Segmentation/ConnectedComponents/test/CMakeLists.txt
@@ -204,6 +204,7 @@ set(
   ITKConnectedComponentsGTests
   itkConnectedComponentImageFilterGTest.cxx
   itkRelabelComponentImageFilterGTest.cxx
+  itkThresholdMaximumConnectedComponentsImageFilterGTest.cxx
 )
 creategoogletestdriver(ITKConnectedComponents "${ITKConnectedComponents-Test_LIBRARIES}"
                        "${ITKConnectedComponentsGTests}"

--- a/Modules/Segmentation/ConnectedComponents/test/itkThresholdMaximumConnectedComponentsImageFilterGTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkThresholdMaximumConnectedComponentsImageFilterGTest.cxx
@@ -1,0 +1,75 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkGTest.h"
+#include "itkImage.h"
+#include "itkThresholdMaximumConnectedComponentsImageFilter.h"
+
+namespace
+{
+itk::Image<unsigned int, 2>::Pointer
+CreateDumbbellImage(unsigned int offset)
+{
+  using namespace itk::GTest::TypedefsAndConstructors::Dimension2;
+
+  using PixelType = unsigned int;
+  using ImageType = itk::Image<PixelType, Dimension>;
+
+  auto image = ImageType::New();
+  image->SetRegions(ImageType::RegionType(itk::MakeSize(9u, 3u)));
+  image->AllocateInitialized();
+
+  for (unsigned int x = 0; x < 9; ++x)
+  {
+    image->SetPixel({ { x, 0 } }, offset);
+    image->SetPixel({ { x, 2 } }, offset);
+  }
+  for (unsigned int x = 0; x < 3; ++x)
+  {
+    image->SetPixel({ { x, 1 } }, offset + 20);
+  }
+  for (unsigned int x = 3; x < 6; ++x)
+  {
+    image->SetPixel({ { x, 1 } }, offset + 5);
+  }
+  for (unsigned int x = 6; x < 9; ++x)
+  {
+    image->SetPixel({ { x, 1 } }, offset + 20);
+  }
+
+  return image;
+}
+} // namespace
+
+TEST(ThresholdMaximumConnectedComponentsImageFilter, BisectionIsTranslationInvariant)
+{
+  using ImageType = itk::Image<unsigned int, 2>;
+  using FilterType = itk::ThresholdMaximumConnectedComponentsImageFilter<ImageType>;
+
+  auto filterA = FilterType::New();
+  filterA->SetInput(CreateDumbbellImage(0));
+  filterA->Update();
+
+  constexpr unsigned int offset{ 3000000000u };
+  auto                   filterB = FilterType::New();
+  filterB->SetInput(CreateDumbbellImage(offset));
+  filterB->Update();
+
+  EXPECT_EQ(filterB->GetNumberOfObjects(), filterA->GetNumberOfObjects());
+  EXPECT_EQ(filterB->GetThresholdValue(), filterA->GetThresholdValue() + offset);
+}


### PR DESCRIPTION
Seed the bisection search at `lowerBound + span/2` instead of `span/2` in `ThresholdMaximumConnectedComponentsImageFilter`. Addresses B13 of #6575.

<details>
<summary>Root cause</summary>

`itkThresholdMaximumConnectedComponentsImageFilter.hxx:107`:

```cpp
PixelType midpoint = (upperBound - lowerBound) / 2;                  // span/2, not the midpoint
PixelType midpointL = (lowerBound + (midpoint - lowerBound) / 2);
PixelType midpointR = (upperBound - (upperBound - midpoint) / 2);
```

The seed is the span, correct only when `lowerBound == 0`. For a nonzero lower bound `midpoint` lands below `lowerBound`, so the next line's unsigned `midpoint - lowerBound` wraps and corrupts the initial search bounds before the loop starts. The in-loop update at `:147-148` already uses the correct `lowerBound + (upperBound - lowerBound) / 2` form — the fix makes the seed use the same rule.

</details>

<details>
<summary>Local validation</summary>

New GoogleTest `ThresholdMaximumConnectedComponentsImageFilter.BisectionIsTranslationInvariant`: the same image, translated by an intensity offset of 3,000,000,000 (`unsigned int` pixels), must yield the same object count and a threshold shifted by exactly that offset.

Fail-before:
```
filterB->GetNumberOfObjects() = 1, filterA->GetNumberOfObjects() = 2
filterB->GetThresholdValue() = 11, filterA->GetThresholdValue() + offset = 3000000011
[  FAILED  ] ThresholdMaximumConnectedComponentsImageFilter.BisectionIsTranslationInvariant
```

Pass-after: `[  PASSED  ] 8 tests.` (whole module GTest driver)

`ctest -L ITKConnectedComponents`: 15/16 pass, including `itkThresholdMaximumConnectedComponentsImageFilterTest1`/`Test2` (real-image baselines) — unchanged. The 1 non-pass is `ITKConnectedComponentsKWStyleTest`, "Not Run" (KWStyle binary absent in this build tree; pre-existing, affects all KWStyle tests).

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the B13 analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
