### PR TITLE
BUG: Reject class counts that overflow non-contiguous labels

### DIFF
--- a/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.h
+++ b/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.h
@@ -146,6 +146,7 @@ public:
   itkGetConstReferenceMacro(ImageRegion, ImageRegionType);
 
   itkConceptMacro(InputHasNumericTraitsCheck, (Concept::HasNumericTraits<InputPixelType>));
+  itkConceptMacro(OutputPixelTypeIsInteger, (Concept::IsInteger<OutputPixelType>));
 
 protected:
   ScalarImageKmeansImageFilter() = default;

--- a/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkScalarImageKmeansImageFilter.hxx
@@ -20,6 +20,8 @@
 
 #include "itkImageRegionExclusionIteratorWithIndex.h"
 
+#include <cstdint>
+
 #include "itkDistanceToCentroidMembershipFunction.h"
 
 #include "itkProgressReporter.h"
@@ -44,6 +46,15 @@ ScalarImageKmeansImageFilter<TInputImage, TOutputImage>::VerifyPreconditions() c
   if (this->m_InitialMeans.empty())
   {
     itkExceptionStringMacro("At least one InitialMean is required.");
+  }
+
+  // Non-contiguous labels need 2*N <= max() (the interval max()/N - 1 must stay >= 1);
+  // contiguous labels plus the out-of-region sentinel at N need N <= max().
+  const auto numberOfClasses = static_cast<std::uintmax_t>(this->m_InitialMeans.size());
+  const auto maxLabel = static_cast<std::uintmax_t>(NumericTraits<OutputPixelType>::max());
+  if (m_UseNonContiguousLabels ? (2 * numberOfClasses > maxLabel) : (numberOfClasses > maxLabel))
+  {
+    itkExceptionStringMacro("Too many classes to produce distinct labels in the output pixel type.");
   }
 }
 
@@ -109,18 +120,18 @@ ScalarImageKmeansImageFilter<TInputImage, TOutputImage>::GenerateData()
   classLabels.resize(numberOfClasses);
 
   // Spread the labels over the intensity range
-  unsigned int labelInterval = 1;
+  std::uintmax_t labelInterval = 1;
   if (m_UseNonContiguousLabels)
   {
-    labelInterval = (NumericTraits<OutputPixelType>::max() / numberOfClasses) - 1;
+    labelInterval = static_cast<std::uintmax_t>(NumericTraits<OutputPixelType>::max() / numberOfClasses) - 1;
   }
 
-  unsigned int                 label = 0;
+  std::uintmax_t               label = 0;
   MembershipFunctionVectorType membershipFunctions;
 
   for (unsigned int k = 0; k < numberOfClasses; ++k)
   {
-    classLabels[k] = label;
+    classLabels[k] = static_cast<typename ClassLabelVectorType::value_type>(label);
     label += labelInterval;
     const MembershipFunctionPointer membershipFunction = MembershipFunctionType::New();
     MembershipFunctionOriginType    origin(adaptor->GetMeasurementVectorSize());
@@ -186,7 +197,7 @@ ScalarImageKmeansImageFilter<TInputImage, TOutputImage>::GenerateData()
     exIt.GoToBegin();
     if (m_UseNonContiguousLabels)
     {
-      const OutputPixelType outsideLabel = labelInterval * numberOfClasses;
+      const auto outsideLabel = static_cast<OutputPixelType>(labelInterval * numberOfClasses);
       while (!exIt.IsAtEnd())
       {
         exIt.Set(outsideLabel);

--- a/Modules/Segmentation/Classifiers/itk-module.cmake
+++ b/Modules/Segmentation/Classifiers/itk-module.cmake
@@ -15,6 +15,7 @@ itk_module(
     ITKStatistics
     ITKConnectedComponents
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKAnisotropicSmoothing
   DESCRIPTION "${DOCUMENTATION}"

--- a/Modules/Segmentation/Classifiers/test/CMakeLists.txt
+++ b/Modules/Segmentation/Classifiers/test/CMakeLists.txt
@@ -153,3 +153,7 @@ itk_add_test(
   ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/KmeansTest_T1KmeansPrelimSegmentation.nii.gz
 )
+
+set(ITKClassifiersGTests itkScalarImageKmeansImageFilterGTest.cxx)
+
+creategoogletestdriver(ITKClassifiers "${ITKClassifiers-Test_LIBRARIES}" "${ITKClassifiersGTests}")

--- a/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilterGTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilterGTest.cxx
@@ -1,0 +1,110 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkGTest.h"
+#include "itkImage.h"
+#include "itkImageRegionIterator.h"
+#include "itkImageRegionConstIterator.h"
+#include "itkScalarImageKmeansImageFilter.h"
+
+namespace
+{
+itk::Image<unsigned char, 2>::Pointer
+CreateTestImage()
+{
+  using ImageType = itk::Image<unsigned char, 2>;
+
+  auto image = ImageType::New();
+  image->SetRegions(ImageType::RegionType(itk::MakeSize(4u, 4u)));
+  image->AllocateInitialized();
+  return image;
+}
+} // namespace
+
+TEST(ScalarImageKmeansImageFilter, NonContiguousLabelsTooManyClassesThrows)
+{
+  using FilterType = itk::ScalarImageKmeansImageFilter<itk::Image<unsigned char, 2>>;
+
+  auto filter = FilterType::New();
+  filter->SetInput(CreateTestImage());
+  filter->UseNonContiguousLabelsOn();
+
+  for (unsigned int i = 0; i < 300; ++i)
+  {
+    filter->AddClassWithInitialMean(static_cast<double>(i));
+  }
+
+  EXPECT_THROW(filter->Update(), itk::ExceptionObject);
+}
+
+TEST(ScalarImageKmeansImageFilter, ContiguousLabelsTooManyClassesThrows)
+{
+  using FilterType = itk::ScalarImageKmeansImageFilter<itk::Image<unsigned char, 2>>;
+
+  auto filter = FilterType::New();
+  filter->SetInput(CreateTestImage());
+
+  for (unsigned int i = 0; i < 300; ++i)
+  {
+    filter->AddClassWithInitialMean(static_cast<double>(i));
+  }
+
+  EXPECT_THROW(filter->Update(), itk::ExceptionObject);
+}
+
+TEST(ScalarImageKmeansImageFilter, NonContiguousLabelsValidClassCountProducesDistinctSpreadLabels)
+{
+  using ImageType = itk::Image<unsigned char, 2>;
+  using FilterType = itk::ScalarImageKmeansImageFilter<ImageType>;
+
+  auto image = ImageType::New();
+  image->SetRegions(ImageType::RegionType(itk::MakeSize(4u, 4u)));
+  image->AllocateInitialized();
+
+  // Two well-separated intensity clusters make the assignment deterministic.
+  unsigned int linearIndex = 0;
+  for (itk::ImageRegionIterator<ImageType> it(image, image->GetBufferedRegion()); !it.IsAtEnd(); ++it, ++linearIndex)
+  {
+    it.Set(linearIndex < 8 ? 10 : 200);
+  }
+
+  auto filter = FilterType::New();
+  filter->SetInput(image);
+  filter->UseNonContiguousLabelsOn();
+  filter->AddClassWithInitialMean(10.0);
+  filter->AddClassWithInitialMean(200.0);
+
+  EXPECT_NO_THROW(filter->Update());
+
+  // 2 classes on unsigned char spread to { 0, max()/2 - 1 } == { 0, 126 }; both must appear.
+  constexpr unsigned char lowLabel = 0;
+  constexpr unsigned char highLabel = 126;
+  bool                    sawLow = false;
+  bool                    sawHigh = false;
+  for (itk::ImageRegionConstIterator<ImageType> it(filter->GetOutput(), filter->GetOutput()->GetBufferedRegion());
+       !it.IsAtEnd();
+       ++it)
+  {
+    const unsigned char value = it.Get();
+    EXPECT_TRUE(value == lowLabel || value == highLabel);
+    sawLow = sawLow || value == lowLabel;
+    sawHigh = sawHigh || value == highLabel;
+  }
+  EXPECT_TRUE(sawLow);
+  EXPECT_TRUE(sawHigh);
+}


### PR DESCRIPTION
Reject class counts whose non-contiguous labels cannot be represented in the output pixel type, instead of computing a wrapped label interval. Addresses B14 of #6575.

<details>
<summary>Root cause</summary>

`itkScalarImageKmeansImageFilter.hxx:112-116`:

```cpp
unsigned int labelInterval = 1;
if (m_UseNonContiguousLabels)
  labelInterval = (NumericTraits<OutputPixelType>::max() / numberOfClasses) - 1;
```

`numberOfClasses` is `m_InitialMeans.size()`. For a `uint8` output the quotient reaches 0 once the class count exceeds 255, and `0 - 1` in unsigned arithmetic gives `labelInterval == 0xFFFFFFFF`; the later `label += labelInterval` (`:124`) and the outside-region label `labelInterval * numberOfClasses` (`:189`) then wrap. Short of full wraparound the interval already degenerates to 0 once the class count passes half the pixel range, collapsing every class label — and the outside label — onto the same value. `VerifyPreconditions()` only rejected an empty mean list.

The fix adds the exact representability precondition (`2 * numberOfClasses <= NumericTraits<OutputPixelType>::max()`, the condition under which `max()/N - 1 >= 1` holds) rather than clamping the arithmetic, so an unrepresentable configuration is diagnosed instead of silently producing indistinguishable labels.

</details>

<details>
<summary>Local validation</summary>

New GoogleTest `ScalarImageKmeansImageFilter.NonContiguousLabelsTooManyClassesThrows` (module had no GTest driver; one is added).

Fail-before: `Expected: filter->Update() throws an exception of type itk::ExceptionObject. Actual: it throws nothing.`
Pass-after: `[  PASSED  ] 1 test.`

`ctest -L ITKClassifiers`: identical pass/fail set before and after, verified against a pristine checkout (the failures are missing ExternalData baselines and KWStyle in this offline build tree, not regressions). `itkScalarImageKmeansImageFilter3DTest`, which exercises `UseNonContiguousLabels(true)` on real data, passes both before and after.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the B14 analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
