### PR TITLE
BUG: Undecided-vote label silently wraps to a real label

### DIFF
--- a/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.h
+++ b/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.h
@@ -63,7 +63,9 @@ namespace itk
  * \par PARAMETERS
  * The label used for "undecided" labels can be set using
  * SetLabelForUndecidedPixels. This functionality can be unset by calling
- * UnsetLabelForUndecidedPixels.
+ * UnsetLabelForUndecidedPixels. If no label is set and the automatically
+ * chosen one does not fit in the output pixel type, Update() throws an
+ * exception.
  *
  * \author Torsten Rohlfing, SRI International, Neuroscience Program
  *

--- a/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkLabelVotingImageFilter.hxx
@@ -70,7 +70,11 @@ LabelVotingImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()
   {
     if (this->m_TotalLabelCount > itk::NumericTraits<OutputPixelType>::max())
     {
-      itkWarningMacro("No new label for undecided pixels, using zero.");
+      itkExceptionMacro(
+        "No label available for undecided pixels: total label count ("
+        << this->m_TotalLabelCount << ") exceeds the output pixel type maximum ("
+        << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(NumericTraits<OutputPixelType>::max())
+        << "). Call SetLabelForUndecidedPixels() to choose one explicitly.");
     }
     this->m_LabelForUndecidedPixels = static_cast<OutputPixelType>(this->m_TotalLabelCount);
   }

--- a/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.h
+++ b/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.h
@@ -85,7 +85,9 @@ namespace itk
  * \par PARAMETERS
  * The label used for "undecided" labels can be set using
  * SetLabelForUndecidedPixels. This functionality can be unset by calling
- * UnsetLabelForUndecidedPixels.
+ * UnsetLabelForUndecidedPixels. If no label is set and the automatically
+ * chosen one does not fit in the output pixel type, Update() throws an
+ * exception.
  *
  * A termination threshold for the EM iteration can be defined by calling
  * SetTerminationUpdateThreshold. The iteration terminates once no single

--- a/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
@@ -225,6 +225,14 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::GenerateData()
 
   if (!this->m_HasLabelForUndecidedPixels)
   {
+    if (this->m_TotalLabelCount > itk::NumericTraits<OutputPixelType>::max())
+    {
+      itkExceptionMacro(
+        "No label available for undecided pixels: total label count ("
+        << this->m_TotalLabelCount << ") exceeds the output pixel type maximum ("
+        << static_cast<typename NumericTraits<OutputPixelType>::PrintType>(NumericTraits<OutputPixelType>::max())
+        << "). Call SetLabelForUndecidedPixels() to choose one explicitly.");
+    }
     this->m_LabelForUndecidedPixels = static_cast<OutputPixelType>(this->m_TotalLabelCount);
   }
 

--- a/Modules/Segmentation/LabelVoting/itk-module.cmake
+++ b/Modules/Segmentation/LabelVoting/itk-module.cmake
@@ -14,6 +14,7 @@ itk_module(
     ITKThresholding
   TEST_DEPENDS
     ITKTestKernel
+    ITKGoogleTest
     ITKMetaIO
     ITKDoubleConversion
   DESCRIPTION "${DOCUMENTATION}"

--- a/Modules/Segmentation/LabelVoting/test/CMakeLists.txt
+++ b/Modules/Segmentation/LabelVoting/test/CMakeLists.txt
@@ -80,6 +80,10 @@ itk_add_test(
     ITKLabelVotingTestDriver
     itkMultiLabelSTAPLEImageFilterTest
 )
+set(
+  ITKLabelVotingGTests
+  itkLabelVotingImageFilterGTest.cxx
+  itkMultiLabelSTAPLEImageFilterGTest.cxx
+)
 
-set(ITKLabelVotingGTests itkMultiLabelSTAPLEImageFilterGTest.cxx)
 creategoogletestdriver(ITKLabelVoting "${ITKLabelVoting-Test_LIBRARIES}" "${ITKLabelVotingGTests}")

--- a/Modules/Segmentation/LabelVoting/test/itkLabelVotingImageFilterGTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkLabelVotingImageFilterGTest.cxx
@@ -1,0 +1,77 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkGTest.h"
+
+#include "itkImage.h"
+#include "itkImageRegionConstIterator.h"
+#include "itkLabelVotingImageFilter.h"
+
+namespace
+{
+using PixelType = unsigned char;
+constexpr unsigned int Dimension = 2;
+using ImageType = itk::Image<PixelType, Dimension>;
+using FilterType = itk::LabelVotingImageFilter<ImageType>;
+
+ImageType::Pointer
+MakeImage(PixelType value)
+{
+  auto image = ImageType::New();
+  image->SetRegions(ImageType::SizeType::Filled(2));
+  image->Allocate();
+  image->FillBuffer(value);
+  return image;
+}
+} // namespace
+
+TEST(LabelVotingImageFilterTest, ThrowsWhenUndecidedLabelDoesNotFitOutputType)
+{
+  auto filter = FilterType::New();
+  filter->SetInput(0, MakeImage(0));
+  filter->SetInput(1, MakeImage(255));
+
+  EXPECT_THROW(filter->Update(), itk::ExceptionObject);
+}
+
+TEST(LabelVotingImageFilterTest, ExplicitUndecidedLabelOverridesOverflow)
+{
+  auto filter = FilterType::New();
+  filter->SetInput(0, MakeImage(0));
+  filter->SetInput(1, MakeImage(255));
+  filter->SetLabelForUndecidedPixels(128);
+
+  EXPECT_NO_THROW(filter->Update());
+  EXPECT_EQ(128, filter->GetLabelForUndecidedPixels());
+
+  const itk::ImageRegionConstIterator<ImageType> out(filter->GetOutput(), filter->GetOutput()->GetBufferedRegion());
+  EXPECT_EQ(128, out.Get());
+}
+
+TEST(LabelVotingImageFilterTest, DefaultUndecidedLabelWhenRepresentable)
+{
+  auto filter = FilterType::New();
+  filter->SetInput(0, MakeImage(3));
+  filter->SetInput(1, MakeImage(5));
+
+  EXPECT_NO_THROW(filter->Update());
+  EXPECT_EQ(6, filter->GetLabelForUndecidedPixels());
+
+  const itk::ImageRegionConstIterator<ImageType> out(filter->GetOutput(), filter->GetOutput()->GetBufferedRegion());
+  EXPECT_EQ(6, out.Get());
+}

--- a/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterGTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterGTest.cxx
@@ -41,6 +41,20 @@ MakeRaterImage(const std::array<unsigned char, 4> & labels)
   }
   return image;
 }
+
+using WideImageType = itk::Image<unsigned short, 2>;
+using WideFilterType = itk::MultiLabelSTAPLEImageFilter<WideImageType>;
+
+template <typename TImage>
+typename TImage::Pointer
+MakeUniformImage(typename TImage::PixelType value)
+{
+  auto image = TImage::New();
+  image->SetRegions(TImage::SizeType::Filled(2));
+  image->Allocate();
+  image->FillBuffer(value);
+  return image;
+}
 } // namespace
 
 // Voting-tie pixels carry the undecided label (one past the confusion matrix's last column)
@@ -77,4 +91,24 @@ TEST(MultiLabelSTAPLEImageFilter, VotingUndecidedPixelsDoNotCorruptSeededConfusi
     EXPECT_EQ(out.Get(), expectedLabel);
     ++out;
   }
+}
+
+TEST(MultiLabelSTAPLEImageFilter, ThrowsWhenUndecidedLabelDoesNotFitOutputType)
+{
+  auto filter = FilterType::New();
+  filter->SetInput(0, MakeUniformImage<ImageType>(0));
+  filter->SetInput(1, MakeUniformImage<ImageType>(255));
+
+  EXPECT_THROW(filter->Update(), itk::ExceptionObject);
+}
+
+TEST(MultiLabelSTAPLEImageFilter, DefaultUndecidedLabelWhenRepresentable)
+{
+  auto filter = WideFilterType::New();
+  filter->SetInput(0, MakeUniformImage<WideImageType>(0));
+  filter->SetInput(1, MakeUniformImage<WideImageType>(255));
+  filter->SetMaximumNumberOfIterations(0);
+
+  EXPECT_NO_THROW(filter->Update());
+  EXPECT_EQ(256, filter->GetLabelForUndecidedPixels());
 }


### PR DESCRIPTION
Throw instead of silently wrapping the automatic undecided-pixel label onto a real label, in `LabelVotingImageFilter` and `MultiLabelSTAPLEImageFilter`. Addresses B15 of #6575.

<details>
<summary>Root cause</summary>

Both filters default the undecided label to `m_TotalLabelCount` (max input label + 1) cast to `OutputPixelType`:

```cpp
if (this->m_TotalLabelCount > itk::NumericTraits<OutputPixelType>::max())
  itkWarningMacro("No new label for undecided pixels, using zero.");
this->m_LabelForUndecidedPixels = static_cast<OutputPixelType>(this->m_TotalLabelCount);
```

With all 256 labels of a `UInt8` image in use, `m_TotalLabelCount == 256` and the cast wraps to **0** — undecided pixels become indistinguishable from genuine label-0 votes. `LabelVotingImageFilter` warned but proceeded; `MultiLabelSTAPLEImageFilter` (`:220-225`) had no check at all. Both now throw, and `SetLabelForUndecidedPixels()` remains the way to pick a label explicitly when the output type is wider.

</details>

<details>
<summary>Local validation</summary>

New GoogleTest `itkLabelVotingImageFilterGTest.cxx`, plus two tests appended to the existing `itkMultiLabelSTAPLEImageFilterGTest.cxx` from #6579.

- `ThrowsWhenUndecidedLabelDoesNotFitOutputType` — fail-before: pre-fix took the warning path (`WARNING: ... using zero.`) and `EXPECT_THROW` failed with "it throws nothing". Pass-after: OK.
- `ExplicitUndecidedLabelOverridesOverflow`, `DefaultUndecidedLabelWhenRepresentable` — control cases, pass before and after.

Whole-module driver after rebase onto current `main`: `[  PASSED  ] 6 tests.` — includes #6579's `VotingUndecidedPixelsDoNotCorruptSeededConfusionMatrix`, still passing. `ctest -L ITKLabelVoting`: `itkLabelVotingImageFilterTest` and `itkMultiLabelSTAPLEImageFilterTest` pass before and after.

</details>

<details>
<summary>Adjacent bug found while testing — not fixed here</summary>

`MultiLabelSTAPLEImageFilter`'s loop counters are typed `InputPixelType` but bounded by `m_TotalLabelCount`, e.g. `InitializePriorProbabilities()`:

```cpp
for (InputPixelType l = 0; l < this->m_TotalLabelCount; ++l)
```

With `InputPixelType == unsigned char` and `m_TotalLabelCount == 256`, the counter wraps 255 → 0 and the loop never terminates. This was hit directly (process pinned at 100% CPU) while testing an explicit `SetLabelForUndecidedPixels()` override on a saturated `uint8` input, which is a path this PR's exception does not cover. It is a separate defect shape in a different function — flagging it for triage rather than folding it in.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the B15 analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
