### PR TITLE
BUG: Cast to real before squaring in MaskedFFTNormalizedCorrelation

### DIFF
--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.h
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.h
@@ -285,6 +285,9 @@ protected:
   CalculateInverseFFT(LocalInputImageType * inputImage, RealSizeType & combinedImageSize);
 
   // Helper math methods.
+  RealImagePointer
+  ElementSquareToReal(const InputImageType * inputImage);
+
   template <typename LocalInputImageType, typename LocalOutputImageType>
   typename LocalOutputImageType::Pointer
   ElementProduct(LocalInputImageType * inputImage1, LocalInputImageType * inputImage2);

--- a/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkMaskedFFTNormalizedCorrelationImageFilter.hxx
@@ -22,6 +22,7 @@
 #include "itkForwardFFTImageFilter.h"
 #include "itkInverseFFTImageFilter.h"
 #include "itkImageRegionIterator.h"
+#include "itkSquareImageFilter.h"
 #include "itkMultiplyImageFilter.h"
 #include "itkDivideImageFilter.h"
 #include "itkSubtractImageFilter.h"
@@ -198,8 +199,8 @@ MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>
   rotatedMovingFFT = nullptr; // No longer needed
 
   // Calculate the fixed part of the masked FFT NCC denominator.
-  FFTImagePointer fixedSquaredFFT = this->CalculateForwardFFT<RealImageType, FFTImageType>(
-    this->ElementProduct<InputImageType, RealImageType>(fixedImage, fixedImage), FFTImageSize);
+  FFTImagePointer fixedSquaredFFT =
+    this->CalculateForwardFFT<RealImageType, FFTImageType>(this->ElementSquareToReal(fixedImage), FFTImageSize);
   fixedImage = nullptr; // No longer needed
   RealImagePointer fixedDenom = this->ElementSubtraction<RealImageType>(
     this->CalculateInverseFFT<FFTImageType, RealImageType>(
@@ -214,8 +215,8 @@ MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>
   fixedDenom = this->ElementPositive<RealImageType>(fixedDenom);
 
   // Calculate the moving part of the masked FFT NCC denominator.
-  FFTImagePointer rotatedMovingSquaredFFT = this->CalculateForwardFFT<RealImageType, FFTImageType>(
-    this->ElementProduct<InputImageType, RealImageType>(rotatedMovingImage, rotatedMovingImage), FFTImageSize);
+  FFTImagePointer rotatedMovingSquaredFFT =
+    this->CalculateForwardFFT<RealImageType, FFTImageType>(this->ElementSquareToReal(rotatedMovingImage), FFTImageSize);
   rotatedMovingImage = nullptr; // No longer needed
   RealImagePointer rotatedMovingDenom = this->ElementSubtraction<RealImageType>(
     this->CalculateInverseFFT<FFTImageType, RealImageType>(
@@ -449,6 +450,21 @@ MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>
   multiplier->SetInput2(inputImage2);
   multiplier->Update();
   typename LocalOutputImageType::Pointer outputImage = multiplier->GetOutput();
+  outputImage->DisconnectPipeline();
+  return outputImage;
+}
+
+template <typename TInputImage, typename TOutputImage, typename TMaskImage>
+typename MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>::RealImagePointer
+MaskedFFTNormalizedCorrelationImageFilter<TInputImage, TOutputImage, TMaskImage>::ElementSquareToReal(
+  const InputImageType * inputImage)
+{
+  // Functor::Square promotes each pixel to its real type before multiplying, so integer pixels cannot overflow.
+  using SquareType = itk::SquareImageFilter<InputImageType, RealImageType>;
+  auto squarer = SquareType::New();
+  squarer->SetInput(inputImage);
+  squarer->Update();
+  RealImagePointer outputImage = squarer->GetOutput();
   outputImage->DisconnectPipeline();
   return outputImage;
 }

--- a/Modules/Filtering/Convolution/itk-module.cmake
+++ b/Modules/Filtering/Convolution/itk-module.cmake
@@ -17,5 +17,6 @@ itk_module(
     ITKGoogleTest
     ITKTestKernel
     ITKImageSources
+    ITKGoogleTest
   DESCRIPTION "${DOCUMENTATION}"
 )

--- a/Modules/Filtering/Convolution/test/CMakeLists.txt
+++ b/Modules/Filtering/Convolution/test/CMakeLists.txt
@@ -16,6 +16,14 @@ set(
 
 createtestdriver(ITKConvolution "${ITKConvolution-Test_LIBRARIES}" "${ITKConvolutionTests}")
 
+set(
+  ITKConvolutionGTests
+  itkMaskedFFTNormalizedCorrelationImageFilterGTest.cxx
+  itkNormalizedCorrelationImageFilterGTest.cxx
+)
+
+creategoogletestdriver(ITKConvolution "${ITKConvolution-Test_LIBRARIES}" "${ITKConvolutionGTests}")
+
 itk_add_test(
   NAME itkConvolutionImageFilterTestSobelX
   COMMAND
@@ -755,7 +763,3 @@ itk_add_test(
   ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterStreamingValidTestOutput.mha
 )
-
-set(ITKConvolutionGTests itkNormalizedCorrelationImageFilterGTest.cxx)
-
-creategoogletestdriver(ITKConvolution "${ITKConvolution-Test_LIBRARIES}" "${ITKConvolutionGTests}")

--- a/Modules/Filtering/Convolution/test/itkMaskedFFTNormalizedCorrelationImageFilterGTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkMaskedFFTNormalizedCorrelationImageFilterGTest.cxx
@@ -1,0 +1,77 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkGTest.h"
+
+#include "itkImage.h"
+#include "itkImageRegionIteratorWithIndex.h"
+#include "itkMaskedFFTNormalizedCorrelationImageFilter.h"
+#include "itkMinimumMaximumImageCalculator.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
+
+namespace
+{
+using InputImageType = itk::Image<int, 2>;
+using RealImageType = itk::Image<double, 2>;
+using FilterType = itk::MaskedFFTNormalizedCorrelationImageFilter<InputImageType, RealImageType>;
+
+class MaskedFFTNormalizedCorrelationImageFilterTestSuite : public ::testing::Test
+{
+protected:
+  static void
+  SetUpTestSuite()
+  {
+    RegisterRequiredFactories();
+  }
+};
+
+InputImageType::Pointer
+MakeCheckerboardImage(InputImageType::PixelType highValue, InputImageType::PixelType lowValue, unsigned int size)
+{
+  auto                             image = InputImageType::New();
+  const InputImageType::RegionType region(InputImageType::SizeType::Filled(size));
+  image->SetRegions(region);
+  image->Allocate();
+  for (itk::ImageRegionIteratorWithIndex<InputImageType> it(image, region); !it.IsAtEnd(); ++it)
+  {
+    const auto idx = it.GetIndex();
+    it.Set(((idx[0] + idx[1]) % 2 == 0) ? highValue : lowValue);
+  }
+  return image;
+}
+} // namespace
+
+// Pixel value 50000 exceeds sqrt(INT32_MAX), so the denominator sums require real-typed squaring.
+TEST_F(MaskedFFTNormalizedCorrelationImageFilterTestSuite, SelfCorrelationAlternatesSignForLargeIntegerPixels)
+{
+  auto image = MakeCheckerboardImage(50000, 0, 7);
+
+  auto filter = FilterType::New();
+  filter->SetFixedImage(image);
+  filter->SetMovingImage(image);
+  filter->Update();
+
+  using CalculatorType = itk::MinimumMaximumImageCalculator<RealImageType>;
+  auto calculator = CalculatorType::New();
+  calculator->SetImage(filter->GetOutput());
+  calculator->ComputeMaximum();
+  calculator->ComputeMinimum();
+
+  EXPECT_NEAR(calculator->GetMaximum(), 1.0, 1e-9);
+  EXPECT_NEAR(calculator->GetMinimum(), -1.0, 1e-9);
+}


### PR DESCRIPTION
Cast the input to the real image type before squaring it in `MaskedFFTNormalizedCorrelationImageFilter`, so integer pixels cannot overflow before the cast. Addresses B16 of #6575.

<details>
<summary>Root cause</summary>

`itkMaskedFFTNormalizedCorrelationImageFilter.hxx:202` (fixed image) and `:218` (moving image) squared via `ElementProduct<InputImageType, RealImageType>`, which instantiates `MultiplyImageFilter<InputImageType, InputImageType, RealImageType>`. The `Mult` functor computes `A * B` **in the input type** and casts to the real type only afterwards, so an `int32` pixel with `|value| >= 46341` overflows (signed overflow, UB) before the cast. The squares feed the NCC denominator.

The shared `Mult` functor in `itkArithmeticOpsFunctors.h` is used toolkit-wide and was deliberately left alone; the fix is at the two call sites, casting through `itk::CastImageFilter` first and squaring in the real type — the same pattern `itkStructuralSimilarityImageFilter.hxx` already uses.

</details>

<details>
<summary>Call sites audited</summary>

Anchor: `ElementProduct<InputImageType` (squaring a narrow input type).

- `.hxx:202`, `.hxx:218` — same defect, both fixed.
- `.hxx:365` (`PreProcessImage`) — multiplies by a 0/1 mask; the product never exceeds the operand. Distinct.
- `FFTNormalizedCorrelationImageFilter` — delegates to this `GenerateData()`, inherits the fix.
- `itkSobelEdgeDetectionImageFilter.hxx:90` — squares its own output type, no wider type discarded. Distinct.
- FFT/deconvolution/wavelet multiplies — `complex<float/double>` frequency data, no integer overflow.

</details>

<details>
<summary>Local validation</summary>

New GoogleTest `SelfCorrelationAlternatesSignForLargeIntegerPixels`: a checkerboard of `int32` pixels above the overflow threshold must still anti-correlate (min NCC ≈ -1) at one-pixel shifts.

A first attempt asserting the self-correlation peak (`== 1.0`) passed even against the buggy code: the overflow collapses every denominator to exactly 0, which drives the filter's own precision tolerance to 0 (`log2(0) = -inf`), giving `NCC = +Inf` everywhere, which the filter's `NCC > 1 -> 1.0` clamp turns into a uniform 1.0 image. The anti-correlation assertion is what actually distinguishes the two code paths.

Fail-before:
```
The difference between calculator->GetMinimum() and -1.0 is 2, which exceeds 1e-9, where
calculator->GetMinimum() evaluates to 1
[  FAILED  ] MaskedFFTNormalizedCorrelationImageFilterTestSuite.SelfCorrelationAlternatesSignForLargeIntegerPixels
```

Pass-after: `[  PASSED  ] 1 test.`

Not verified: the legacy `itkMaskedFFTNormalizedCorrelationImageFilterTest1-6` baselines could not be exercised in this build tree (ExternalData unfetched, the reader throws before `GenerateData()` runs) — CI will cover them.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the B16 analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
