### PR TITLE
BUG: Preserve OutputRegionMode in IterativeDeconvolutionImageFilter

### DIFF
--- a/Modules/Filtering/Deconvolution/include/itkIterativeDeconvolutionImageFilter.hxx
+++ b/Modules/Filtering/Deconvolution/include/itkIterativeDeconvolutionImageFilter.hxx
@@ -107,13 +107,8 @@ IterativeDeconvolutionImageFilter<TInputImage, TKernelImage, TOutputImage, TInte
   auto progress = ProgressAccumulator::New();
   progress->SetMiniPipelineFilter(this);
 
-  const typename Superclass::InputImageConstPointer inputPtr = this->GetInput();
-  const typename Superclass::OutputImagePointer     outputPtr = this->GetOutput(0);
-
-  outputPtr->SetRequestedRegion(inputPtr->GetRequestedRegion());
-  outputPtr->SetBufferedRegion(inputPtr->GetBufferedRegion());
-  outputPtr->SetLargestPossibleRegion(inputPtr->GetLargestPossibleRegion());
-  outputPtr->Allocate();
+  const typename Superclass::OutputImagePointer outputPtr = this->GetOutput(0);
+  outputPtr->SetRequestedRegion(outputPtr->GetLargestPossibleRegion());
 
   // Set up progress tracking
   const float iterationWeight = 0.8f / static_cast<float>(m_NumberOfIterations);

--- a/Modules/Filtering/Deconvolution/test/CMakeLists.txt
+++ b/Modules/Filtering/Deconvolution/test/CMakeLists.txt
@@ -14,6 +14,7 @@ createtestdriver(ITKDeconvolution "${ITKDeconvolution-Test_LIBRARIES}" "${ITKDec
 
 set(
   ITKDeconvolutionGTests
+  itkIterativeDeconvolutionImageFilterGTest.cxx
   itkProjectedIterativeDeconvolutionImageFilterGTest.cxx
   itkWienerDeconvolutionImageFilterGTest.cxx
 )

--- a/Modules/Filtering/Deconvolution/test/itkIterativeDeconvolutionImageFilterGTest.cxx
+++ b/Modules/Filtering/Deconvolution/test/itkIterativeDeconvolutionImageFilterGTest.cxx
@@ -1,0 +1,98 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkImage.h"
+#include "itkLandweberDeconvolutionImageFilter.h"
+#include "itkGTest.h"
+#include "itkTestDriverIncludeRequiredFactories.h"
+
+namespace
+{
+using ImageType = itk::Image<float, 2>;
+
+ImageType::Pointer
+MakeConstantImage(const ImageType::SizeType & size, float value)
+{
+  auto                        image = ImageType::New();
+  const ImageType::RegionType region(size);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(value);
+  return image;
+}
+} // namespace
+
+class IterativeDeconvolutionImageFilterTest : public ::testing::Test
+{
+protected:
+  void
+  SetUp() override
+  {
+    RegisterRequiredFactories();
+  }
+};
+
+TEST_F(IterativeDeconvolutionImageFilterTest, OutputRegionModeSameMatchesInput)
+{
+  using FilterType = itk::LandweberDeconvolutionImageFilter<ImageType>;
+
+  const ImageType::SizeType inputSize = { { 10, 10 } };
+  const ImageType::Pointer  input = MakeConstantImage(inputSize, 1.0f);
+  const ImageType::SizeType kernelSize = { { 3, 3 } };
+  const ImageType::Pointer  kernel = MakeConstantImage(kernelSize, 1.0f / 9.0f);
+
+  auto filter = FilterType::New();
+  filter->SetInput(input);
+  filter->SetKernelImage(kernel);
+  filter->SetNumberOfIterations(2);
+  filter->Update();
+
+  EXPECT_EQ(filter->GetOutput()->GetLargestPossibleRegion(), input->GetLargestPossibleRegion());
+  EXPECT_EQ(filter->GetOutput()->GetBufferedRegion(), input->GetLargestPossibleRegion());
+}
+
+TEST_F(IterativeDeconvolutionImageFilterTest, OutputRegionModeValidShrinksOutputRegion)
+{
+  using FilterType = itk::LandweberDeconvolutionImageFilter<ImageType>;
+
+  const ImageType::SizeType inputSize = { { 10, 10 } };
+  const ImageType::Pointer  input = MakeConstantImage(inputSize, 1.0f);
+  const ImageType::SizeType kernelSize = { { 3, 3 } };
+  const ImageType::Pointer  kernel = MakeConstantImage(kernelSize, 1.0f / 9.0f);
+
+  auto filter = FilterType::New();
+  filter->SetInput(input);
+  filter->SetKernelImage(kernel);
+  filter->SetNumberOfIterations(2);
+  filter->SetOutputRegionModeToValid();
+  filter->Update();
+
+  ImageType::IndexType expectedValidIndex;
+  ImageType::SizeType  expectedValidSize;
+  for (unsigned int i = 0; i < ImageType::ImageDimension; ++i)
+  {
+    const ImageType::SizeValueType radius = kernelSize[i] / 2;
+    expectedValidIndex[i] = static_cast<ImageType::IndexValueType>(radius);
+    expectedValidSize[i] = inputSize[i] - 2 * radius;
+  }
+  const ImageType::RegionType expectedValidRegion(expectedValidIndex, expectedValidSize);
+
+  EXPECT_EQ(filter->GetOutput()->GetRequestedRegion(), expectedValidRegion);
+  EXPECT_EQ(filter->GetOutput()->GetBufferedRegion(), expectedValidRegion);
+  EXPECT_EQ(filter->GetOutput()->GetLargestPossibleRegion(), expectedValidRegion);
+}


### PR DESCRIPTION
Stop `IterativeDeconvolutionImageFilter::GenerateData()` from overwriting the output region metadata that `GenerateOutputInformation()` had already computed, which made `OutputRegionMode` a no-op. Addresses B17 of #6575.

<details>
<summary>Root cause</summary>

`itkIterativeDeconvolutionImageFilter.hxx:113-116`:

```cpp
outputPtr->SetRequestedRegion(inputPtr->GetRequestedRegion());
outputPtr->SetBufferedRegion(inputPtr->GetBufferedRegion());
outputPtr->SetLargestPossibleRegion(inputPtr->GetLargestPossibleRegion());
```

`ConvolutionImageFilterBase::GenerateOutputInformation()` (`itkConvolutionImageFilterBase.hxx:39-45`) has already shrunk the output's largest-possible region for `OutputRegionModeEnum::VALID` by the time `GenerateData()` runs — and these three lines overwrite it with the input's (mode-blind) regions. `PadInput` and `CropOutput` (`itkFFTConvolutionImageFilter.hxx:157`, `:468`) read the output's requested region *after* the overwrite, so `SetOutputRegionModeToValid()` was accepted and silently ignored by Landweber, ProjectedLandweber, and RichardsonLucy alike.

The requested region is now derived from the output's own largest-possible region, which already reflects the selected mode. The manual buffered-region assignment and `Allocate()` were redundant: `CropOutput()` calls `AllocateOutputs()`, which sets the buffered region and allocates.

</details>

<details>
<summary>Local validation</summary>

New GoogleTest `itkIterativeDeconvolutionImageFilterGTest.cxx`.

Fail-before (`OutputRegionModeValidShrinksOutputRegion`): the filter returned the full 10x10 region instead of the expected 8x8 VALID-mode region.

Pass-after:
```
1/3 IterativeDeconvolutionImageFilterTest.OutputRegionModeSameMatchesInput ......... Passed
2/3 IterativeDeconvolutionImageFilterTest.OutputRegionModeValidShrinksOutputRegion .. Passed
3/3 ProjectedIterativeDeconvolutionImageFilterTest.BasicObjectMethods ............... Passed
100% tests passed
```

`ctest -R Deconvolution` (33 tests): identical results with the fix applied and reverted — the 14 legacy baseline tests fail identically in both, on `ExternalData` images this offline build tree never fetched (`ExternalData_URL_TEMPLATES` empty in the cache), i.e. before `GenerateData()` is reached. No baseline result changed because of this fix; CI will exercise them for real.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the B17 analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
