### PR TITLE
BUG: Fix polar angle in MinMaxCurvatureFlowFunction threshold

### DIFF
--- a/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkMinMaxCurvatureFlowFunction.hxx
@@ -308,7 +308,7 @@ MinMaxCurvatureFlowFunction<TImage>::ComputeThreshold(const Dispatch<3> &, const
     return threshold;
   }
 
-  gradMagnitude = std::sqrt(gradMagnitude) / static_cast<PixelType>(m_StencilRadius);
+  gradMagnitude = std::sqrt(gradMagnitude);
 
   for (double & j : gradient)
   {

--- a/Modules/Filtering/CurvatureFlow/test/CMakeLists.txt
+++ b/Modules/Filtering/CurvatureFlow/test/CMakeLists.txt
@@ -7,6 +7,10 @@ set(
 
 createtestdriver(ITKCurvatureFlow "${ITKCurvatureFlow-Test_LIBRARIES}" "${ITKCurvatureFlowTests}")
 
+set(ITKCurvatureFlowGTests itkMinMaxCurvatureFlowFunctionGTest.cxx)
+
+creategoogletestdriver(ITKCurvatureFlow "${ITKCurvatureFlow-Test_LIBRARIES}" "${ITKCurvatureFlowGTests}")
+
 itk_add_test(
   NAME itkBinaryMinMaxCurvatureFlowImageFilterTest
   COMMAND

--- a/Modules/Filtering/CurvatureFlow/test/itkMinMaxCurvatureFlowFunctionGTest.cxx
+++ b/Modules/Filtering/CurvatureFlow/test/itkMinMaxCurvatureFlowFunctionGTest.cxx
@@ -1,0 +1,66 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkMinMaxCurvatureFlowFunction.h"
+#include "itkImage.h"
+#include "itkMath.h"
+#include "itkGTest.h"
+
+namespace
+{
+using ImageType = itk::Image<double, 3>;
+using FunctionType = itk::MinMaxCurvatureFlowFunction<ImageType>;
+} // namespace
+
+TEST(MinMaxCurvatureFlowFunction, ComputeUpdateUsesCorrectPolarAngleAtRadiusTwo)
+{
+  auto                  image = ImageType::New();
+  ImageType::RegionType region;
+  region.SetSize(ImageType::SizeType::Filled(13));
+  image->SetRegions(region);
+  image->Allocate();
+
+  ImageType::IndexType index;
+  for (index[0] = 0; index[0] < 13; ++index[0])
+  {
+    for (index[1] = 0; index[1] < 13; ++index[1])
+    {
+      for (index[2] = 0; index[2] < 13; ++index[2])
+      {
+        const double x = index[0];
+        const double y = index[1];
+        const double z = index[2];
+        const double value = 0.5 * (itk::Math::sqr(x - 5.0) + itk::Math::sqr(y - 5.0) + itk::Math::sqr(z - 5.0)) +
+                             5.0 * itk::Math::sqr(x - 7.0);
+        image->SetPixel(index, value);
+      }
+    }
+  }
+
+  auto function = FunctionType::New();
+  function->SetStencilRadius(2);
+
+  FunctionType::NeighborhoodType::RadiusType radius;
+  radius.Fill(2);
+  FunctionType::NeighborhoodType it(radius, image, image->GetBufferedRegion());
+  it.SetLocation(ImageType::IndexType{ { 7, 5, 6 } });
+
+  const FunctionType::PixelType result = function->ComputeUpdate(it, nullptr);
+
+  EXPECT_DOUBLE_EQ(result, 0.0);
+}


### PR DESCRIPTION
The 3-D min/max threshold rescaled the gradient to length `StencilRadius` and then passed a component of it to `acos()`, which needs a unit-length cosine. Addresses B7 of #6575.

<details>
<summary>Root cause</summary>

`MinMaxCurvatureFlowFunction::ComputeThreshold(const Dispatch<3> &, ...)` (`itkMinMaxCurvatureFlowFunction.hxx:311`):

```cpp
gradMagnitude = std::sqrt(gradMagnitude) / static_cast<PixelType>(m_StencilRadius);
...
theta = std::acos(gradient[2]);   // :326
```

After that division each `gradient[k]` is `r * cos(theta_k)`, not `cos(theta_k)`. The clamp to `[-1, 1]` just below hides the domain violation, so no NaN appears — the function silently returns the wrong polar angle. With the default `StencilRadius` of 2, a true `cos(theta) = 0.4` (`theta = 66.4 deg`) is evaluated as `acos(0.8) = 36.9 deg`, which puts the stencil's perpendicular sample points on the wrong ring and selects the wrong min/max curvature update.

Normalizing to unit length is the fix: the downstream position reconstruction already multiplies by `m_StencilRadius` explicitly. The 2-D dispatch (`:246`) shares the rescale but reaches `atan2` on a ratio, where the length cancels — no defect there, left alone.

</details>

<details>
<summary>Local validation</summary>

New GoogleTest `itkMinMaxCurvatureFlowFunctionGTest.cxx`, registered in a new `ITKCurvatureFlowGTests` driver.

- `MinMaxCurvatureFlowFunction.ComputeUpdateUsesCorrectPolarAngleAtRadiusTwo` — fail-before: `result = 1` (the buggy angle selects the wrong branch). Pass-after: `result = 0`. Both values were derived from the test field's geometry before running.
- `ctest -R CurvatureFlow`: `itkMinMaxCurvatureFlowImageFilterTest`, `itkBinaryMinMaxCurvatureFlowImageFilterTest`, `itkCurvatureFlowTesti` all pass before and after. They are 100-iteration convergence checks with tolerances, so they do not pin the per-step angle.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the B7 analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>


Historical context for the removed division and the measured downstream impact (SimpleITK baselines) are documented in #6619.
