### PR TITLE
BUG: Decouple CurvatureFlowFunction derivative scale from radius

### DIFF
--- a/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.hxx
+++ b/Modules/Filtering/CurvatureFlow/include/itkCurvatureFlowFunction.hxx
@@ -61,11 +61,20 @@ CurvatureFlowFunction<TImage>::ComputeUpdate(const NeighborhoodType & it,
   // get the center pixel position
   const IdentifierType center = it.Size() / 2;
 
-  const NeighborhoodScalesType neighborhoodScales = this->ComputeNeighborhoodScales();
-  PixelRealType                magnitudeSqr = 0.0;
-  PixelRealType                firstderiv[ImageDimension];
-  PixelRealType                secderiv[ImageDimension];
-  PixelRealType                crossderiv[ImageDimension][ImageDimension] = {};
+  // Derivatives below sample adjacent pixels, one voxel apart in each dimension.
+  PixelRealType neighborhoodScales[ImageDimension];
+  this->GetScaleCoefficients(neighborhoodScales);
+  for (unsigned int i = 0; i < ImageDimension; ++i)
+  {
+    if (it.GetRadius()[i] == 0)
+    {
+      neighborhoodScales[i] = 0.0;
+    }
+  }
+  PixelRealType magnitudeSqr = 0.0;
+  PixelRealType firstderiv[ImageDimension];
+  PixelRealType secderiv[ImageDimension];
+  PixelRealType crossderiv[ImageDimension][ImageDimension] = {};
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     // compute first order derivatives

--- a/Modules/Filtering/CurvatureFlow/test/CMakeLists.txt
+++ b/Modules/Filtering/CurvatureFlow/test/CMakeLists.txt
@@ -7,7 +7,11 @@ set(
 
 createtestdriver(ITKCurvatureFlow "${ITKCurvatureFlow-Test_LIBRARIES}" "${ITKCurvatureFlowTests}")
 
-set(ITKCurvatureFlowGTests itkMinMaxCurvatureFlowFunctionGTest.cxx)
+set(
+  ITKCurvatureFlowGTests
+  itkCurvatureFlowFunctionGTest.cxx
+  itkMinMaxCurvatureFlowFunctionGTest.cxx
+)
 
 creategoogletestdriver(ITKCurvatureFlow "${ITKCurvatureFlow-Test_LIBRARIES}" "${ITKCurvatureFlowGTests}")
 

--- a/Modules/Filtering/CurvatureFlow/test/itkCurvatureFlowFunctionGTest.cxx
+++ b/Modules/Filtering/CurvatureFlow/test/itkCurvatureFlowFunctionGTest.cxx
@@ -1,0 +1,74 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkCurvatureFlowFunction.h"
+#include "itkImage.h"
+#include "itkMath.h"
+#include "itkGTest.h"
+
+namespace
+{
+using ImageType = itk::Image<double, 3>;
+using FunctionType = itk::CurvatureFlowFunction<ImageType>;
+
+FunctionType::PixelType
+ComputeUpdateAtRadius(FunctionType * function, const ImageType * image, unsigned int radiusValue)
+{
+  FunctionType::RadiusType radius;
+  radius.Fill(radiusValue);
+  function->SetRadius(radius);
+
+  FunctionType::NeighborhoodType it(radius, image, image->GetBufferedRegion());
+  it.SetLocation(ImageType::IndexType{ { 7, 5, 6 } });
+
+  return function->ComputeUpdate(it, nullptr);
+}
+} // namespace
+
+TEST(CurvatureFlowFunction, ComputeUpdateIsIndependentOfRadius)
+{
+  auto                  image = ImageType::New();
+  ImageType::RegionType region;
+  region.SetSize(ImageType::SizeType::Filled(13));
+  image->SetRegions(region);
+  image->Allocate();
+
+  ImageType::IndexType index;
+  for (index[0] = 0; index[0] < 13; ++index[0])
+  {
+    for (index[1] = 0; index[1] < 13; ++index[1])
+    {
+      for (index[2] = 0; index[2] < 13; ++index[2])
+      {
+        const double x = index[0];
+        const double y = index[1];
+        const double z = index[2];
+        const double value = 0.5 * (itk::Math::sqr(x - 5.0) + itk::Math::sqr(y - 5.0) + itk::Math::sqr(z - 5.0));
+        image->SetPixel(index, value);
+      }
+    }
+  }
+
+  auto function = FunctionType::New();
+
+  const FunctionType::PixelType resultRadius1 = ComputeUpdateAtRadius(function, image, 1);
+  const FunctionType::PixelType resultRadius2 = ComputeUpdateAtRadius(function, image, 2);
+
+  EXPECT_DOUBLE_EQ(resultRadius1, 2.0);
+  EXPECT_DOUBLE_EQ(resultRadius2, 2.0);
+}


### PR DESCRIPTION
`CurvatureFlowFunction::ComputeUpdate()` samples its derivatives at unit stride but scaled them by the inherited radius-divided neighborhood scale, understating the update by `1/radius^2`. Addresses B8 of #6575.

<details>
<summary>Root cause</summary>

`FiniteDifferenceFunction::ComputeNeighborhoodScales()` divides by the radius:

```cpp
neighborhoodScales[i] = this->m_ScaleCoefficients[i] / this->m_Radius[i];
```

which is correct for a function whose derivative stencil widens with the radius. `CurvatureFlowFunction::ComputeUpdate()` is not such a function — it addresses neighbors through `it.GetStride(i)`, a fixed 1-pixel step, whatever the radius is. The two only agree because every other `FiniteDifferenceFunction` subclass leaves the radius at 1.

`MinMaxCurvatureFlowFunction::SetStencilRadius()` breaks that coincidence: it enlarges `m_Radius` so the neighborhood cache can reach the stencil, without changing how `ComputeUpdate()` (inherited, unmodified) samples. First derivatives then come out `1/r` too small and the update `1/r^2` too small — 4x at the default stencil radius of 2.

The fix sources the scale where it is consumed: `ComputeUpdate()` reads `GetScaleCoefficients()` directly, stating that its derivatives are unit-stride. No new API, no override, and `ComputeNeighborhoodScales()` keeps its meaning for every other caller. `MinMaxCurvatureFlowFunction` is the only `FiniteDifferenceFunction` subclass in the tree that both enlarges its radius and routes it through this scale (`VariationalRegistrationNCCFunction` sets radius 2 but never calls `ComputeNeighborhoodScales()`).

</details>

<details>
<summary>Local validation</summary>

New GoogleTest `itkCurvatureFlowFunctionGTest.cxx`, registered in a new `ITKCurvatureFlowGTests` driver.

- `CurvatureFlowFunction.ComputeUpdateIsIndependentOfRadius` — fail-before: `resultRadius1 = 2`, `resultRadius2 = 0.5`, exactly the predicted `1/r^2` ratio. Pass-after: both `2`.
- `ctest -R CurvatureFlow`: `itkMinMaxCurvatureFlowImageFilterTest`, `itkBinaryMinMaxCurvatureFlowImageFilterTest`, `itkCurvatureFlowTesti` pass before and after — they are tolerance-based convergence checks, which is why a 4x per-step magnitude change does not flip them.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the B8 analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
