### PR TITLE
BUG: Terminate subsampler Search() on single-point region

### DIFF
--- a/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
+++ b/Modules/Numerics/Statistics/include/itkUniformRandomSpatialNeighborSubsampler.hxx
@@ -112,6 +112,14 @@ UniformRandomSpatialNeighborSubsampler<TSample, TRegion>::Search(const InstanceI
     return;
   }
 
+  // A region of size 1 is just the query point; !CanSelectQuery has nothing to pick.
+  if (!this->m_CanSelectQuery && numberOfPoints <= 1)
+  {
+    itkWarningMacro("Search region around query point (" << query << ") contains only the query point itself."
+                                                         << "  No matching points found.");
+    return;
+  }
+
   if (!this->m_RequestMaximumNumberOfResults && (m_NumberOfResultsRequested < numberOfPoints))
   {
     numberOfPoints = m_NumberOfResultsRequested;

--- a/Modules/Numerics/Statistics/test/CMakeLists.txt
+++ b/Modules/Numerics/Statistics/test/CMakeLists.txt
@@ -985,6 +985,7 @@ set(
   itkRandomVariateGeneratorBaseGTest.cxx
   itkStatisticsTypesGTest.cxx
   itkTDistributionGTest.cxx
+  itkUniformRandomSpatialNeighborSubsamplerGTest.cxx
   itkVectorContainerToListSampleAdaptorGTest.cxx
 )
 creategoogletestdriver(ITKStatistics "${ITKStatistics-Test_LIBRARIES}" "${ITKStatisticsGTests}")

--- a/Modules/Numerics/Statistics/test/itkUniformRandomSpatialNeighborSubsamplerGTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkUniformRandomSpatialNeighborSubsamplerGTest.cxx
@@ -1,0 +1,78 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkImageToNeighborhoodSampleAdaptor.h"
+#include "itkZeroFluxNeumannBoundaryCondition.h"
+#include "itkUniformRandomSpatialNeighborSubsampler.h"
+#include "itkGTest.h"
+
+#include <chrono>
+#include <future>
+#include <thread>
+
+namespace
+{
+using ImageType = itk::Image<float, 2>;
+using RegionType = ImageType::RegionType;
+using BoundaryCondition = itk::ZeroFluxNeumannBoundaryCondition<ImageType>;
+using AdaptorType = itk::Statistics::ImageToNeighborhoodSampleAdaptor<ImageType, BoundaryCondition>;
+using SamplerType = itk::Statistics::UniformRandomSpatialNeighborSubsampler<AdaptorType, RegionType>;
+} // namespace
+
+TEST(UniformRandomSpatialNeighborSubsampler, SearchTerminatesWhenOnlyQueryPointIsSelectable)
+{
+  constexpr ImageType::SizeType::value_type regionSizeVal = 5;
+  constexpr auto                            sz = ImageType::SizeType::Filled(regionSizeVal);
+  const RegionType                          region{ sz };
+
+  auto image = ImageType::New();
+  image->SetRegions(region);
+  image->AllocateInitialized();
+
+  auto sample = AdaptorType::New();
+  sample->SetImage(image);
+
+  auto sampler = SamplerType::New();
+  sampler->SetSample(sample);
+  sampler->SetSampleRegion(region);
+  sampler->SetRadius(0);
+  sampler->CanSelectQueryOff();
+  sampler->SetNumberOfResultsRequested(1);
+
+  const SamplerType::InstanceIdentifier query = 12; // interior point (2, 2)
+  SamplerType::SubsamplePointer         results = SamplerType::SubsampleType::New();
+
+  auto              done = std::make_shared<std::promise<void>>();
+  std::future<void> future = done->get_future();
+  std::thread       worker([sampler, query, results, done]() mutable {
+    sampler->Search(query, results);
+    done->set_value();
+  });
+
+  const bool finished = (future.wait_for(std::chrono::seconds(30)) == std::future_status::ready);
+  if (finished)
+  {
+    worker.join();
+  }
+  else
+  {
+    worker.detach();
+  }
+  ASSERT_TRUE(finished) << "Search did not terminate for a single-point search region";
+  EXPECT_EQ(results->GetTotalFrequency(), 0);
+}


### PR DESCRIPTION
`UniformRandomSpatialNeighborSubsampler::Search()` with `CanSelectQuery` off spins forever when the search region collapses to the query point alone. Reproduced as a live hang, not source analysis. Addresses B28 of #6575.

<details>
<summary>Root cause</summary>

`itkUniformRandomSpatialNeighborSubsampler.hxx:150-166`, the `!m_CanSelectQuery` branch:

```cpp
while (pointsFound < numberOfPoints)
{
  // randomly select an index from [searchStartIndex, searchEndIndex]
  if (index != queryIndex)
  {
    results->AddInstance(...);
    ++pointsFound;
  }
}
```

The query point is inside that box by construction, so when the box holds exactly one point — `Radius(0)`, or a region constraint that clips it to size 1 — every draw equals `queryIndex`, `pointsFound` never advances, and the only loop exit is unreachable. `Search()` returns zero results immediately in that case instead.

The `m_CanSelectQuery` branch (`:133`) is a distinct case: drawing the query point is a legal result there, so it always makes progress. `SpatialNeighborSubsampler::Search()` iterates the box exhaustively rather than by rejection sampling and cannot spin. `GaussianRandomSpatialNeighborSubsampler` overrides only `GetIntegerVariate()` / `InternalClone()` / `PrintSelf()`, so it inherits this `Search()` and is fixed by the same change.

</details>

<details>
<summary>Local validation</summary>

New GoogleTest `itkUniformRandomSpatialNeighborSubsamplerGTest.cxx`, registered in `ITKStatisticsGTests`. `Search()` runs on a detached thread behind a 2 s watchdog so a regression fails the test instead of hanging the driver.

- `UniformRandomSpatialNeighborSubsampler.SearchTerminatesWhenOnlyQueryPointIsSelectable` — fail-before: `[ FAILED ]`, the watchdog expired with `Search()` still spinning (confirmed under `timeout --signal=KILL 30`, a live spin rather than a deadlock). Pass-after: `[ OK ]` in 0 ms, zero results.
- `ctest -L ITKStatistics` (101 tests): identical results before and after, including the 12 pre-existing failures caused by missing ExternalData inputs in the local build.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the B28 analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
