### PR TITLE
BUG: Compute curvature whenever the reinitialization term needs it

### DIFF
--- a/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.hxx
+++ b/Modules/Nonunit/Review/include/itkRegionBasedLevelSetFunction.hxx
@@ -250,11 +250,18 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeUpdate(const 
 
   ScalarValueType dh = m_DomainFunction->EvaluateDerivative(-inputValue);
 
-  // Computing the curvature term
-  // Used to regularized using the length of contour
-  if ((dh != 0.) && (this->m_CurvatureWeight != ScalarValueType{}))
+  const bool useCurvatureTerm = (dh != 0.) && (this->m_CurvatureWeight != ScalarValueType{});
+  const bool useReinitializationTerm = (this->m_ReinitializationSmoothingWeight != ScalarValueType{});
+
+  if (useCurvatureTerm || useReinitializationTerm)
   {
     curvature = this->ComputeCurvature(it, offset, gd);
+  }
+
+  // Computing the curvature term
+  // Used to regularized using the length of contour
+  if (useCurvatureTerm)
+  {
     curvature_term = this->m_CurvatureWeight * curvature * this->CurvatureSpeed(it, offset, gd) * dh;
 
     gd->m_MaxCurvatureChange = std::max(gd->m_MaxCurvatureChange, itk::Math::Absolute(curvature_term));
@@ -262,7 +269,7 @@ RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>::ComputeUpdate(const 
 
   // Computing the laplacian term
   // Used in maintaining squared distance function
-  if (this->m_ReinitializationSmoothingWeight != ScalarValueType{})
+  if (useReinitializationTerm)
   {
     laplacian_term = this->ComputeLaplacian(gd) - curvature;
 

--- a/Modules/Nonunit/Review/test/CMakeLists.txt
+++ b/Modules/Nonunit/Review/test/CMakeLists.txt
@@ -668,5 +668,6 @@ set(
   ITKReviewGTests
   itkAreaOpeningImageFilterGTest.cxx
   itkFastApproximateRankImageFilterGTest.cxx
+  itkRegionBasedLevelSetFunctionGTest.cxx
 )
 creategoogletestdriver(ITKReview "${ITKReview-Test_LIBRARIES}" "${ITKReviewGTests}")

--- a/Modules/Nonunit/Review/test/itkRegionBasedLevelSetFunctionGTest.cxx
+++ b/Modules/Nonunit/Review/test/itkRegionBasedLevelSetFunctionGTest.cxx
@@ -1,0 +1,223 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkRegionBasedLevelSetFunction.h"
+#include "itkImageRegionIteratorWithIndex.h"
+#include "itkDataObject.h"
+#include "itkGTest.h"
+
+namespace itk
+{
+
+template <typename TInput, typename TOutput>
+class ConstantDerivativeHeavisideStepFunction : public HeavisideStepFunctionBase<TInput, TOutput>
+{
+public:
+  ITK_DISALLOW_COPY_AND_MOVE(ConstantDerivativeHeavisideStepFunction);
+
+  using Self = ConstantDerivativeHeavisideStepFunction;
+  using Superclass = HeavisideStepFunctionBase<TInput, TOutput>;
+  using Pointer = SmartPointer<Self>;
+
+  itkNewMacro(Self);
+  itkOverrideGetNameOfClassMacro(ConstantDerivativeHeavisideStepFunction);
+
+  using typename Superclass::InputType;
+  using typename Superclass::OutputType;
+
+  OutputType
+  Evaluate(const InputType &) const override
+  {
+    return OutputType{};
+  }
+
+  OutputType
+  EvaluateDerivative(const InputType &) const override
+  {
+    return m_DerivativeValue;
+  }
+
+  void
+  SetDerivativeValue(OutputType value)
+  {
+    m_DerivativeValue = value;
+  }
+
+protected:
+  ConstantDerivativeHeavisideStepFunction() = default;
+  ~ConstantDerivativeHeavisideStepFunction() override = default;
+
+private:
+  OutputType m_DerivativeValue{};
+};
+
+class RegionBasedLevelSetReinitTestSharedData : public DataObject
+{
+public:
+  ITK_DISALLOW_COPY_AND_MOVE(RegionBasedLevelSetReinitTestSharedData);
+
+  using Self = RegionBasedLevelSetReinitTestSharedData;
+  using Superclass = DataObject;
+  using Pointer = SmartPointer<Self>;
+
+  itkNewMacro(Self);
+  itkOverrideGetNameOfClassMacro(RegionBasedLevelSetReinitTestSharedData);
+
+  struct SingleData
+  {
+    double m_WeightedNumberOfPixelsInsideLevelSet{};
+
+    template <typename TIndex>
+    TIndex
+    GetFeatureIndex(const TIndex & index) const
+    {
+      return index;
+    }
+  };
+
+  unsigned long m_FunctionCount{ 1 };
+  SingleData    m_Data;
+  SingleData *  m_LevelSetDataPointerVector[1]{ &m_Data };
+
+protected:
+  RegionBasedLevelSetReinitTestSharedData() = default;
+  ~RegionBasedLevelSetReinitTestSharedData() override = default;
+};
+
+template <typename TInput, typename TFeature, typename TSharedData>
+class RegionBasedLevelSetReinitTestFunction : public RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>
+{
+public:
+  ITK_DISALLOW_COPY_AND_MOVE(RegionBasedLevelSetReinitTestFunction);
+
+  using Self = RegionBasedLevelSetReinitTestFunction;
+  using Superclass = RegionBasedLevelSetFunction<TInput, TFeature, TSharedData>;
+  using Pointer = SmartPointer<Self>;
+
+  itkNewMacro(Self);
+  itkOverrideGetNameOfClassMacro(RegionBasedLevelSetReinitTestFunction);
+
+  using typename Superclass::ScalarValueType;
+  using typename Superclass::FeaturePixelType;
+  using typename Superclass::FeatureIndexType;
+
+  ScalarValueType
+  ComputeInternalTerm(const FeaturePixelType &, const FeatureIndexType &) override
+  {
+    return ScalarValueType{};
+  }
+
+  ScalarValueType
+  ComputeExternalTerm(const FeaturePixelType &, const FeatureIndexType &) override
+  {
+    return ScalarValueType{};
+  }
+
+  ScalarValueType
+  ComputeOverlapParameters(const FeatureIndexType &, ScalarValueType & pr) override
+  {
+    pr = ScalarValueType{};
+    return ScalarValueType{};
+  }
+
+  void
+  ComputeParameters() override
+  {}
+
+  void
+  UpdateSharedDataParameters() override
+  {}
+
+protected:
+  RegionBasedLevelSetReinitTestFunction() = default;
+  ~RegionBasedLevelSetReinitTestFunction() override = default;
+};
+
+} // namespace itk
+
+namespace
+{
+using ImageType = itk::Image<double, 2>;
+using FunctionType =
+  itk::RegionBasedLevelSetReinitTestFunction<ImageType, ImageType, itk::RegionBasedLevelSetReinitTestSharedData>;
+
+// phi = x^2 + y^2 gives curvature 1 and Laplacian 4 at index (3,2), unit spacing.
+ImageType::Pointer
+MakeParaboloidImage()
+{
+  const ImageType::RegionType region(ImageType::SizeType::Filled(5));
+  auto                        image = ImageType::New();
+  image->SetRegions(region);
+  image->Allocate();
+  for (itk::ImageRegionIteratorWithIndex<ImageType> it(image, region); !it.IsAtEnd(); ++it)
+  {
+    const auto   index = it.GetIndex();
+    const double x = index[0] - 2.0;
+    const double y = index[1] - 2.0;
+    it.Set(x * x + y * y);
+  }
+  return image;
+}
+
+double
+ComputeReinitializationOnlyUpdate(double curvatureWeight, double heavisideDerivative)
+{
+  const auto phiImage = MakeParaboloidImage();
+
+  auto featureImage = ImageType::New();
+  featureImage->SetRegions(phiImage->GetLargestPossibleRegion());
+  featureImage->Allocate();
+  featureImage->FillBuffer(0.0);
+
+  auto domainFunction = itk::ConstantDerivativeHeavisideStepFunction<double, double>::New();
+  domainFunction->SetDerivativeValue(heavisideDerivative);
+
+  auto sharedData = itk::RegionBasedLevelSetReinitTestSharedData::New();
+
+  auto function = FunctionType::New();
+  function->SetFeatureImage(featureImage);
+  function->SetDomainFunction(domainFunction);
+  function->SetSharedData(sharedData);
+  function->SetFunctionId(0);
+  function->SetCurvatureWeight(curvatureWeight);
+  function->SetReinitializationSmoothingWeight(1.0);
+
+  const auto radius = itk::MakeFilled<FunctionType::RadiusType>(1);
+  function->Initialize(radius);
+
+  FunctionType::NeighborhoodType neighborhood(radius, phiImage, phiImage->GetLargestPossibleRegion());
+  neighborhood.SetLocation(ImageType::IndexType{ { 3, 2 } });
+
+  void *       globalData = function->GetGlobalDataPointer();
+  const double update = function->ComputeUpdate(neighborhood, globalData);
+  function->ReleaseGlobalDataPointer(globalData);
+
+  return update;
+}
+
+} // namespace
+
+TEST(RegionBasedLevelSetFunction, ReinitializationTermSubtractsCurvatureWhenCurvatureWeightIsZero)
+{
+  EXPECT_DOUBLE_EQ(ComputeReinitializationOnlyUpdate(0.0, 2.0), 3.0);
+}
+
+TEST(RegionBasedLevelSetFunction, ReinitializationTermSubtractsCurvatureWhenDerivativeIsZero)
+{
+  EXPECT_DOUBLE_EQ(ComputeReinitializationOnlyUpdate(1.0, 0.0), 3.0);
+}


### PR DESCRIPTION
The reinitialization term in `RegionBasedLevelSetFunction::ComputeUpdate()` subtracts a curvature that was only computed when the *curvature-length* term was active, so it silently degenerated to a bare Laplacian. Addresses B30 of #6575.

<details>
<summary>Root cause</summary>

`itkRegionBasedLevelSetFunction.hxx:255-269` — `curvature` is populated inside the curvature-length guard, then read by the reinitialization term, which has its own independent activation condition:

```cpp
if ((dh != 0.) && (this->m_CurvatureWeight != ScalarValueType{}))
{
  curvature = this->ComputeCurvature(it, offset, gd);      // only here
  curvature_term = this->m_CurvatureWeight * curvature * ... * dh;
}

if (this->m_ReinitializationSmoothingWeight != ScalarValueType{})
{
  laplacian_term = this->ComputeLaplacian(gd) - curvature; // but read here
}
```

Whenever `CurvatureWeight == 0`, or `dh == 0` at a pixel, `curvature` stays at its zero initializer and the term collapses to `Laplacian(phi)` alone — coupling two regularization weights that the class documents (`itkRegionBasedLevelSetFunction.h:445-448`) as independent, and dropping the `div(grad(phi)/|grad(phi)|)` half of `Laplacian(phi) - div(grad(phi)/|grad(phi)|)`. The `dh` factor belongs to the curvature-length term only; the reinitialization term has no `dh` in its formula.

`ComputeCurvature()` is now called once when either consumer needs it, and the two guards are separate.

</details>

<details>
<summary>Local validation</summary>

New GoogleTest `itkRegionBasedLevelSetFunctionGTest.cxx`, registered in `ITKReviewGTests`. `phi = x^2 + y^2` gives curvature 1 and Laplacian 4 at the probed pixel, so the correct reinitialization contribution is 3.0 and the buggy one is 4.0. One test per half of the guard:

- `ReinitializationTermSubtractsCurvatureWhenCurvatureWeightIsZero` — fail-before 4.0, pass-after 3.0.
- `ReinitializationTermSubtractsCurvatureWhenDerivativeIsZero` — fail-before 4.0, pass-after 3.0.

No ExternalData baseline changes. All six `ScalarChanAndVese*LevelSetImageFilter` regression tests were run with baselines downloaded, before and after the fix: `ImageError = 0` in every case. Test2_2 (`CurvatureWeight=0`, `ReinitializationSmoothingWeight=1`) is the one configuration that exercises the bug at every pixel, yet its output is unchanged — `MultiphaseDenseFiniteDifferenceImageFilter::ApplyUpdate()` re-runs a full `SignedMaurerDistanceMap` reinitialization every iteration (`m_ReinitializeCounter` defaults to 1), which rebuilds the level set from the sign of phi and discards the magnitude of the per-pixel correction.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the B30 analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
