### PR TITLE
BUG: Fix MultiLabelSTAPLE label-loop wrap and undecided-label propagation

### DIFF
--- a/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
@@ -154,21 +154,22 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::InitializeConf
   // normalize matrix rows to unit probability sum
   for (unsigned int k = 0; k < numberOfInputs; ++k)
   {
-    for (InputPixelType inLabel = 0; inLabel < this->m_TotalLabelCount + 1; ++inLabel)
+    for (size_t inLabel = 0; inLabel < this->m_TotalLabelCount + 1; ++inLabel)
     {
+      const auto inRow = static_cast<unsigned int>(inLabel);
       // compute sum over all output labels for given input label
       WeightsType sum = 0;
-      for (OutputPixelType outLabel = 0; outLabel < this->m_TotalLabelCount; ++outLabel)
+      for (size_t outLabel = 0; outLabel < this->m_TotalLabelCount; ++outLabel)
       {
-        sum += this->m_ConfusionMatrixArray[k][inLabel][outLabel];
+        sum += this->m_ConfusionMatrixArray[k][inRow][outLabel];
       }
       // make sure that this input label did in fact show up in the input!!
       if (sum > 0)
       {
         // normalize
-        for (OutputPixelType outLabel = 0; outLabel < this->m_TotalLabelCount; ++outLabel)
+        for (size_t outLabel = 0; outLabel < this->m_TotalLabelCount; ++outLabel)
         {
-          this->m_ConfusionMatrixArray[k][inLabel][outLabel] /= sum;
+          this->m_ConfusionMatrixArray[k][inRow][outLabel] /= sum;
         }
       }
     }
@@ -205,11 +206,11 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::InitializePrio
     }
 
     WeightsType totalProbMass = 0.0;
-    for (InputPixelType l = 0; l < this->m_TotalLabelCount; ++l)
+    for (size_t l = 0; l < this->m_TotalLabelCount; ++l)
     {
       totalProbMass += this->m_PriorProbabilities[l];
     }
-    for (InputPixelType l = 0; l < this->m_TotalLabelCount; ++l)
+    for (size_t l = 0; l < this->m_TotalLabelCount; ++l)
     {
       this->m_PriorProbabilities[l] /= totalProbMass;
     }
@@ -281,14 +282,14 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::GenerateData()
     while (!it[0].IsAtEnd())
     {
       // the following is the E step
-      for (OutputPixelType ci = 0; ci < this->m_TotalLabelCount; ++ci)
+      for (size_t ci = 0; ci < this->m_TotalLabelCount; ++ci)
       {
         W[ci] = this->m_PriorProbabilities[ci];
       }
       for (unsigned int k = 0; k < numberOfInputs; ++k)
       {
         const InputPixelType j = it[k].Get();
-        for (OutputPixelType ci = 0; ci < this->m_TotalLabelCount; ++ci)
+        for (size_t ci = 0; ci < this->m_TotalLabelCount; ++ci)
         {
           W[ci] *= this->m_ConfusionMatrixArray[k][j][ci];
         }
@@ -296,14 +297,14 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::GenerateData()
 
       // the following is the M step
       WeightsType sumW = W[0];
-      for (OutputPixelType ci = 1; ci < this->m_TotalLabelCount; ++ci)
+      for (size_t ci = 1; ci < this->m_TotalLabelCount; ++ci)
       {
         sumW += W[ci];
       }
 
       if (sumW)
       {
-        for (OutputPixelType ci = 0; ci < this->m_TotalLabelCount; ++ci)
+        for (size_t ci = 0; ci < this->m_TotalLabelCount; ++ci)
         {
           W[ci] /= sumW;
         }
@@ -312,7 +313,7 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::GenerateData()
       for (unsigned int k = 0; k < numberOfInputs; ++k)
       {
         const InputPixelType j = it[k].Get();
-        for (OutputPixelType ci = 0; ci < this->m_TotalLabelCount; ++ci)
+        for (size_t ci = 0; ci < this->m_TotalLabelCount; ++ci)
         {
           this->m_UpdatedConfusionMatrixArray[k][j][ci] += W[ci];
         }
@@ -327,20 +328,20 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::GenerateData()
     for (unsigned int k = 0; k < numberOfInputs; ++k)
     {
       // compute sum over all output classifications
-      for (OutputPixelType ci = 0; ci < this->m_TotalLabelCount; ++ci)
+      for (size_t ci = 0; ci < this->m_TotalLabelCount; ++ci)
       {
         WeightsType sumW = this->m_UpdatedConfusionMatrixArray[k][0][ci];
-        for (InputPixelType j = 1; j < 1 + this->m_TotalLabelCount; ++j)
+        for (size_t j = 1; j < 1 + this->m_TotalLabelCount; ++j)
         {
-          sumW += this->m_UpdatedConfusionMatrixArray[k][j][ci];
+          sumW += this->m_UpdatedConfusionMatrixArray[k][static_cast<unsigned int>(j)][ci];
         }
 
         // normalize with for each class ci
         if (sumW)
         {
-          for (InputPixelType j = 0; j < 1 + this->m_TotalLabelCount; ++j)
+          for (size_t j = 0; j < 1 + this->m_TotalLabelCount; ++j)
           {
-            this->m_UpdatedConfusionMatrixArray[k][j][ci] /= sumW;
+            this->m_UpdatedConfusionMatrixArray[k][static_cast<unsigned int>(j)][ci] /= sumW;
           }
         }
       }
@@ -351,16 +352,17 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::GenerateData()
     WeightsType maximumUpdate = 0;
     for (unsigned int k = 0; k < numberOfInputs; ++k)
     {
-      for (InputPixelType j = 0; j < 1 + this->m_TotalLabelCount; ++j)
+      for (size_t j = 0; j < 1 + this->m_TotalLabelCount; ++j)
       {
-        for (OutputPixelType ci = 0; ci < this->m_TotalLabelCount; ++ci)
+        const auto row = static_cast<unsigned int>(j);
+        for (size_t ci = 0; ci < this->m_TotalLabelCount; ++ci)
         {
-          const WeightsType thisParameterUpdate =
-            itk::Math::Absolute(this->m_UpdatedConfusionMatrixArray[k][j][ci] - this->m_ConfusionMatrixArray[k][j][ci]);
+          const WeightsType thisParameterUpdate = itk::Math::Absolute(this->m_UpdatedConfusionMatrixArray[k][row][ci] -
+                                                                      this->m_ConfusionMatrixArray[k][row][ci]);
 
           maximumUpdate = std::max(maximumUpdate, thisParameterUpdate);
 
-          this->m_ConfusionMatrixArray[k][j][ci] = this->m_UpdatedConfusionMatrixArray[k][j][ci];
+          this->m_ConfusionMatrixArray[k][row][ci] = this->m_UpdatedConfusionMatrixArray[k][row][ci];
         }
       }
     }
@@ -393,7 +395,7 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::GenerateData()
   for (OutputIteratorType out(output, output->GetRequestedRegion()); !out.IsAtEnd(); ++out)
   {
     // basically, we'll repeat the E step from above
-    for (OutputPixelType ci = 0; ci < this->m_TotalLabelCount; ++ci)
+    for (size_t ci = 0; ci < this->m_TotalLabelCount; ++ci)
     {
       W[ci] = this->m_PriorProbabilities[ci];
     }
@@ -401,7 +403,7 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::GenerateData()
     for (unsigned int k = 0; k < numberOfInputs; ++k)
     {
       const InputPixelType j = it[k].Get();
-      for (OutputPixelType ci = 0; ci < this->m_TotalLabelCount; ++ci)
+      for (size_t ci = 0; ci < this->m_TotalLabelCount; ++ci)
       {
         W[ci] *= this->m_ConfusionMatrixArray[k][j][ci];
       }
@@ -411,12 +413,12 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::GenerateData()
     // now determine the label with the maximum W
     auto        winningLabel = this->m_LabelForUndecidedPixels;
     WeightsType winningLabelW = 0;
-    for (OutputPixelType ci = 0; ci < this->m_TotalLabelCount; ++ci)
+    for (size_t ci = 0; ci < this->m_TotalLabelCount; ++ci)
     {
       if (W[ci] > winningLabelW)
       {
         winningLabelW = W[ci];
-        winningLabel = ci;
+        winningLabel = static_cast<OutputPixelType>(ci);
       }
       else if (!(W[ci] < winningLabelW))
       {

--- a/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
@@ -117,10 +117,14 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::InitializeConf
 {
   const auto numberOfInputs = static_cast<const unsigned int>(this->GetNumberOfInputs());
 
-  using LabelVotingFilterType = LabelVotingImageFilter<TInputImage, TOutputImage>;
+  // The undecided sentinel (one past the last label) must be representable and distinct.
+  using VotingLabelType = typename NumericTraits<InputPixelType>::AccumulateType;
+  using VotingImageType = Image<VotingLabelType, ImageDimension>;
+  using LabelVotingFilterType = LabelVotingImageFilter<TInputImage, VotingImageType>;
   using LabelVotingFilterPointer = typename LabelVotingFilterType::Pointer;
 
-  typename OutputImageType::Pointer votingOutput;
+  typename VotingImageType::Pointer votingOutput;
+  VotingLabelType                   votingUndecidedLabel{};
 
   { // begin scope for local filter allocation
     const LabelVotingFilterPointer votingFilter = LabelVotingFilterType::New();
@@ -131,9 +135,11 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::InitializeConf
     }
     votingFilter->Update();
     votingOutput = votingFilter->GetOutput();
+    votingUndecidedLabel = votingFilter->GetLabelForUndecidedPixels();
   } // begin scope for local filter allocation; de-allocate filter
 
-  OutputIteratorType out(votingOutput, votingOutput->GetRequestedRegion());
+  using VotingIteratorType = ImageRegionConstIterator<VotingImageType>;
+  VotingIteratorType out(votingOutput, votingOutput->GetRequestedRegion());
 
   for (unsigned int k = 0; k < numberOfInputs; ++k)
   {
@@ -143,8 +149,7 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::InitializeConf
 
     for (out.GoToBegin(); !out.IsAtEnd(); ++out, ++in)
     {
-      // Voting-undecided pixels carry the label m_TotalLabelCount, one past the last matrix column.
-      if (static_cast<size_t>(out.Get()) < this->m_TotalLabelCount)
+      if (out.Get() != votingUndecidedLabel)
       {
         ++(this->m_ConfusionMatrixArray[k][in.Get()][out.Get()]);
       }
@@ -226,7 +231,7 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::GenerateData()
 
   if (!this->m_HasLabelForUndecidedPixels)
   {
-    if (this->m_TotalLabelCount > itk::NumericTraits<OutputPixelType>::max())
+    if (this->m_TotalLabelCount > static_cast<size_t>(NumericTraits<OutputPixelType>::max()))
     {
       itkExceptionMacro(
         "No label available for undecided pixels: total label count ("

--- a/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterGTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterGTest.cxx
@@ -21,6 +21,9 @@
 #include "itkGTest.h"
 
 #include <array>
+#include <chrono>
+#include <future>
+#include <thread>
 
 namespace
 {
@@ -111,4 +114,25 @@ TEST(MultiLabelSTAPLEImageFilter, DefaultUndecidedLabelWhenRepresentable)
 
   EXPECT_NO_THROW(filter->Update());
   EXPECT_EQ(256, filter->GetLabelForUndecidedPixels());
+}
+
+// Loop counters bounded by m_TotalLabelCount must not be pixel-typed: a saturated
+// unsigned char label space (issue #6575, B84) wraps such a counter and never terminates.
+TEST(MultiLabelSTAPLEImageFilter, SaturatedUnsignedCharLabelCountDoesNotHang)
+{
+  auto filter = FilterType::New();
+  filter->SetInput(0, MakeRaterImage({ 255, 0, 0, 0 }));
+  filter->SetInput(1, MakeRaterImage({ 255, 1, 1, 1 }));
+  filter->SetLabelForUndecidedPixels(0);
+  filter->SetMaximumNumberOfIterations(1);
+
+  auto              done = std::make_shared<std::promise<void>>();
+  std::future<void> future = done->get_future();
+  std::thread([filter, done]() mutable {
+    filter->Update();
+    done->set_value();
+  }).detach();
+
+  ASSERT_EQ(future.wait_for(std::chrono::seconds(2)), std::future_status::ready)
+    << "Update() did not terminate for a saturated unsigned char label count";
 }

--- a/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterGTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkMultiLabelSTAPLEImageFilterGTest.cxx
@@ -22,7 +22,9 @@
 
 #include <array>
 #include <chrono>
+#include <cstdlib>
 #include <future>
+#include <iostream>
 #include <thread>
 
 namespace
@@ -60,8 +62,7 @@ MakeUniformImage(typename TImage::PixelType value)
 }
 } // namespace
 
-// Voting-tie pixels carry the undecided label (one past the confusion matrix's last column)
-// and must be skipped when seeding, not written past the row (issue #6575, B10).
+// Voting-tie pixels must be skipped when seeding, not written past the matrix row (issue #6575).
 TEST(MultiLabelSTAPLEImageFilter, VotingUndecidedPixelsDoNotCorruptSeededConfusionMatrix)
 {
   auto filter = FilterType::New();
@@ -128,11 +129,79 @@ TEST(MultiLabelSTAPLEImageFilter, SaturatedUnsignedCharLabelCountDoesNotHang)
 
   auto              done = std::make_shared<std::promise<void>>();
   std::future<void> future = done->get_future();
-  std::thread([filter, done]() mutable {
+  std::thread       worker([filter, done]() mutable {
     filter->Update();
     done->set_value();
-  }).detach();
+  });
 
-  ASSERT_EQ(future.wait_for(std::chrono::seconds(2)), std::future_status::ready)
-    << "Update() did not terminate for a saturated unsigned char label count";
+  const bool finished = (future.wait_for(std::chrono::seconds(30)) == std::future_status::ready);
+  if (!finished)
+  {
+    // A stuck Update() cannot be killed portably; abort rather than detach and
+    // leak a CPU-spinning thread that would corrupt later tests in this binary.
+    std::cerr << "Update() did not terminate for a saturated unsigned char label count" << std::endl;
+    std::abort();
+  }
+  worker.join();
+}
+
+// A saturated label space leaves no representable undecided label, so the filter
+// must refuse rather than silently wrap the default onto real label 0 (issue #6575).
+TEST(MultiLabelSTAPLEImageFilter, SaturatedLabelsWithoutExplicitUndecidedLabelThrows)
+{
+  auto filter = FilterType::New();
+  filter->SetInput(0, MakeRaterImage({ 255, 0, 0, 0 }));
+  filter->SetInput(1, MakeRaterImage({ 255, 1, 1, 1 }));
+  filter->SetMaximumNumberOfIterations(1);
+  EXPECT_THROW(filter->Update(), itk::ExceptionObject);
+}
+
+// Saturated label space (max label 255 -> m_TotalLabelCount 256) with the caller
+// mapping undecided pixels to real label 0: genuine label-0 consensus must still
+// seed the matrices. The voting-undecided sentinel must not collide with label 0.
+TEST(MultiLabelSTAPLEImageFilter, SaturatedConsensusOnLabelZeroSeedsMatrixWhenUndecidedLabelIsZero)
+{
+  auto filter = FilterType::New();
+  // Pixel 0: unanimous label 255 -> saturates unsigned char (m_TotalLabelCount = 256).
+  // Pixels 1-3: unanimous label 0 (genuine consensus, no ties).
+  filter->SetInput(0, MakeRaterImage({ 255, 0, 0, 0 }));
+  filter->SetInput(1, MakeRaterImage({ 255, 0, 0, 0 }));
+  filter->SetLabelForUndecidedPixels(0);
+  filter->SetMaximumNumberOfIterations(0);
+  filter->Update();
+
+  for (unsigned int rater = 0; rater < 2; ++rater)
+  {
+    const FilterType::ConfusionMatrixType & cm = filter->GetConfusionMatrix(rater);
+    EXPECT_NEAR(cm(0, 0), 1.0, 1e-6) << "rater " << rater << ": label-0 consensus excluded from seeding";
+    EXPECT_NEAR(cm(255, 255), 1.0, 1e-6) << "rater " << rater << ": label-255 consensus";
+  }
+}
+
+// Consensus on label 0 must seed the matrices even when the caller maps undecided
+// pixels to 0; only genuine ties are excluded (issue #6575).
+TEST(MultiLabelSTAPLEImageFilter, ConsensusOnLabelZeroSeedsMatrixWhenUndecidedLabelIsZero)
+{
+  auto filter = FilterType::New();
+  filter->SetInput(0, MakeRaterImage({ 0, 1, 0, 0 }));
+  filter->SetInput(1, MakeRaterImage({ 0, 0, 0, 0 }));
+  filter->SetLabelForUndecidedPixels(0);
+  filter->SetMaximumNumberOfIterations(0);
+  filter->Update();
+
+  // Pixels 0, 2, 3 are label-0 consensus and must be counted; pixel 1 is a tie and is skipped.
+  for (unsigned int rater = 0; rater < 2; ++rater)
+  {
+    const FilterType::ConfusionMatrixType & cm = filter->GetConfusionMatrix(rater);
+    ASSERT_EQ(cm.rows(), 3u);
+    ASSERT_EQ(cm.cols(), 2u);
+    const double expected[3][2] = { { 1.0, 0.0 }, { 0.0, 0.0 }, { 0.0, 0.0 } };
+    for (unsigned int r = 0; r < 3; ++r)
+    {
+      for (unsigned int c = 0; c < 2; ++c)
+      {
+        EXPECT_NEAR(cm(r, c), expected[r][c], 1e-6) << "rater " << rater << " (" << r << ',' << c << ')';
+      }
+    }
+  }
 }


### PR DESCRIPTION
`MultiLabelSTAPLEImageFilter` hangs forever on a saturated `uint8` label space, and its voting-seeded confusion matrices count ties as label-0 consensus. Addresses B84 and B85 of #6575. Follows #6579 and #6597 in the same filter.

<details>
<summary>B84 — infinite loop (reproduced, not source analysis)</summary>

18 loop counters in `itkMultiLabelSTAPLEImageFilter.hxx` are bounded by `m_TotalLabelCount` (a `size_t`) but typed by the pixel type:

```cpp
for (InputPixelType l = 0; l < this->m_TotalLabelCount; ++l)
```

With `InputPixelType == unsigned char` and all 256 label values in use, `m_TotalLabelCount == 256`, the counter wraps `255 -> 0`, and the loop never terminates. The first one reached is in `InitializeConfusionMatrixArrayFromVoting()`, before `InitializePriorProbabilities()` or the E-M loop. This was hit as a live hang (process pinned at 100% CPU) while testing #6597 — it is a path #6597's new exception does not cover, because an explicit `SetLabelForUndecidedPixels()` is legal there.

All 18 counters are retyped to `size_t`, matching what `m_TotalLabelCount` actually is. `itkLabelVotingImageFilter.hxx:125` already does this, which is why the sibling filter never had the bug. Anchor `rg 'for \((InputPixelType|OutputPixelType|PixelType)\s+\w+\s*='` over `Modules/Segmentation/LabelVoting/include/`: 18 hits, all in this one file, all fixed; no sibling file has any.

</details>

<details>
<summary>B85 — voting-seed sentinel collides with a real label</summary>

`InitializeConfusionMatrixArrayFromVoting()` seeds the confusion matrices from an internal `LabelVotingImageFilter`, whose automatic undecided sentinel is `m_TotalLabelCount` cast to its output pixel type. Instantiated on `TOutputImage`, a saturated label space wraps that cast onto real label 0. Tie pixels then seed label-0 consensus, and the skip test

```cpp
if (static_cast<size_t>(out.Get()) < this->m_TotalLabelCount)
```

never excludes them, because it only means "is this the undecided sentinel" while the sentinel happens to equal the auto-computed default.

The seed pass now votes into `NumericTraits<InputPixelType>::AccumulateType` — one step wider than the input — so the sentinel is always representable and distinct from every real label, and the skip test compares against the sentinel the voting filter actually used. `LabelVotingImageFilter` constrains its input to an unsigned integer (`InputUnsignedIntCheck`), so `AccumulateType` is always a wider unsigned integer here.

Note that the caller's `SetLabelForUndecidedPixels()` is deliberately **not** forwarded to the internal voting filter. The seed pass needs a sentinel disjoint from every real label, not the caller's output label; forwarding it reintroduces the collision whenever the caller picks a label that is also in use (e.g. `SetLabelForUndecidedPixels(0)`).

The intermediate voting image is `AccumulateType` rather than a fixed-width `SizeValueType`, keeping it at 2 bytes/voxel for the common `uint8` case instead of 8.

</details>

<details>
<summary>Local validation</summary>

Four tests added to the existing `itkMultiLabelSTAPLEImageFilterGTest.cxx`:

- `SaturatedUnsignedCharLabelCountDoesNotHang` — runs the filter on a worker thread behind a watchdog, aborting rather than leaking a spinning thread into the rest of the driver. Fail-before: watchdog expires, still spinning.
- `SaturatedLabelsWithoutExplicitUndecidedLabelThrows` — a saturated space with no representable undecided label must refuse rather than wrap the default onto real label 0.
- `SaturatedConsensusOnLabelZeroSeedsMatrixWhenUndecidedLabelIsZero` — label-0 consensus must still seed the matrices when the caller maps undecided pixels to 0.
- `ConsensusOnLabelZeroSeedsMatrixWhenUndecidedLabelIsZero` — same invariant unsaturated; only genuine ties are excluded.

`ctest -R "LabelVoting|MultiLabelSTAPLE"`: 14/14 pass, including #6579's `VotingUndecidedPixelsDoNotCorruptSeededConfusionMatrix` and the pre-existing `itkMultiLabelSTAPLEImageFilterTest`, unchanged. Both test drivers build without warnings.

Negative control, to confirm the new tests have teeth rather than merely passing: forcing `VotingLabelType = InputPixelType` makes `SaturatedConsensusOnLabelZeroSeedsMatrixWhenUndecidedLabelIsZero` fail and `SaturatedUnsignedCharLabelCountDoesNotHang` abort on its watchdog.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code (claude-opus-4-8)
- Role: implementation and regression-test authoring from the B84/B85 analysis in #6575; selection of the seed-sentinel type
- Contribution: identified that forwarding the caller's undecided label to the seed pass reintroduces the label-0 collision, and that the sentinel must instead be carried in a type one step wider than the input
- All code was reviewed, built, and tested locally before committing

</details>

<!--
provenance: rebased onto upstream/main c01a2705b2; commit 2 message corrected
  (previously claimed the caller's undecided label is propagated to the voting
  seed, which the code deliberately does not do and must not do).
seed_sentinel_type: NumericTraits<InputPixelType>::AccumulateType. AccumulateType
  stops widening at unsigned int (unsigned int -> unsigned int), so a uint32 input
  saturated to 2^32-1 would collide again; unreachable because the confusion matrix
  is (count+1) x count doubles and InitializeConfusionMatrixArray already truncates
  via static_cast<unsigned int>(m_TotalLabelCount).
key_files: Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx:120
  (VotingLabelType), :148 (sentinel skip test)
local_validation: build-standard (Release/Ninja), ctest -R "LabelVoting|MultiLabelSTAPLE"
  14/14; pre-commit run --all-files exit 0.
-->
