### PR TITLE
BUG: Reject transform names with no precision token

### DIFF
--- a/Modules/IO/TransformBase/include/itkTransformIOBase.h
+++ b/Modules/IO/TransformBase/include/itkTransformIOBase.h
@@ -190,6 +190,10 @@ TransformIOBaseTemplate<float>::CorrectTransformPrecisionType(std::string & inpu
   if (inputTransformName.find("float") == std::string::npos)
   {
     const std::string::size_type begin = inputTransformName.find("double");
+    if (begin == std::string::npos)
+    {
+      itkGenericExceptionMacro("Transform type name has neither float nor double precision: " << inputTransformName);
+    }
     inputTransformName.replace(begin, 6, "float");
   }
 }
@@ -202,6 +206,10 @@ TransformIOBaseTemplate<double>::CorrectTransformPrecisionType(std::string & inp
   if (inputTransformName.find("double") == std::string::npos)
   {
     const std::string::size_type begin = inputTransformName.find("float");
+    if (begin == std::string::npos)
+    {
+      itkGenericExceptionMacro("Transform type name has neither float nor double precision: " << inputTransformName);
+    }
     inputTransformName.replace(begin, 5, "double");
   }
 }

--- a/Modules/IO/TransformBase/itk-module.cmake
+++ b/Modules/IO/TransformBase/itk-module.cmake
@@ -14,6 +14,7 @@ itk_module(
   COMPILE_DEPENDS
     ITKDisplacementField
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
   DESCRIPTION "${DOCUMENTATION}"
 )

--- a/Modules/IO/TransformBase/test/CMakeLists.txt
+++ b/Modules/IO/TransformBase/test/CMakeLists.txt
@@ -19,3 +19,7 @@ itk_add_test(
     ITKIOTransformBaseTestDriver
     itkTransformFileWriterTest
 )
+
+set(ITKIOTransformBaseGTests itkTransformIOBaseGTest.cxx)
+
+creategoogletestdriver(ITKIOTransformBase "${ITKIOTransformBase-Test_LIBRARIES}" "${ITKIOTransformBaseGTests}")

--- a/Modules/IO/TransformBase/test/itkTransformIOBaseGTest.cxx
+++ b/Modules/IO/TransformBase/test/itkTransformIOBaseGTest.cxx
@@ -1,0 +1,45 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkTransformIOBase.h"
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+TEST(TransformIOBaseGTest, CorrectTransformPrecisionTypeThrowsWithoutPrecisionToken)
+{
+  std::string nameForFloat{ "UnknownTransform_3_3" };
+  EXPECT_THROW(itk::TransformIOBaseTemplate<float>::CorrectTransformPrecisionType(nameForFloat), itk::ExceptionObject);
+
+  std::string nameForDouble{ "UnknownTransform_3_3" };
+  EXPECT_THROW(itk::TransformIOBaseTemplate<double>::CorrectTransformPrecisionType(nameForDouble),
+               itk::ExceptionObject);
+}
+
+TEST(TransformIOBaseGTest, CorrectTransformPrecisionTypeCorrectsMismatchedPrecision)
+{
+  std::string doubleName{ "MatrixOffsetTransformBase_double_3_3" };
+  itk::TransformIOBaseTemplate<float>::CorrectTransformPrecisionType(doubleName);
+  EXPECT_EQ(doubleName, "MatrixOffsetTransformBase_float_3_3");
+
+  std::string floatName{ "MatrixOffsetTransformBase_float_3_3" };
+  itk::TransformIOBaseTemplate<double>::CorrectTransformPrecisionType(floatName);
+  EXPECT_EQ(floatName, "MatrixOffsetTransformBase_double_3_3");
+}


### PR DESCRIPTION
`TransformIOBaseTemplate::CorrectTransformPrecisionType()` indexes a string with an unchecked `find()` result, so a transform-type name naming neither precision throws `std::out_of_range` — not an `itk::ExceptionObject`. Addresses B47 of #6575.

<details>
<summary>Root cause</summary>

Both specializations (`itkTransformIOBase.h:187-207`) do:

```cpp
auto begin = inputTransformName.find("float");
inputTransformName.replace(begin, 5, "double");
```

When the name contains neither `"float"` nor `"double"`, `begin == std::string::npos` and `std::string::replace` throws `std::out_of_range`. That is a standard-library exception, so it propagates past every ITK handler — a caller doing `catch (itk::ExceptionObject &)` around a transform read does not catch it, and the message (`__pos (which is 18446744073709551615) > this->size()`) names nothing useful.

The `npos` case is now detected explicitly and raised as `itkGenericExceptionMacro` naming the offending transform-type string, matching the convention the unspecialized default already uses at `:152`. (`itkExceptionMacro` is unusable here — these are `static` methods with no `this`.)

Anchor `rg -n 'find\(' Modules/IO/TransformBase/`: the other hits (`itkTransformFileReader.cxx:173`, `itkCompositeTransformIOHelper.cxx:154-155,190-191`, `itkTransformFileWriterSpecializations.cxx:102,277`) all compare the result against `npos` as a boolean guard and never index with it — distinct, not touched.

</details>

<details>
<summary>Local validation</summary>

New GoogleTest `itkTransformIOBaseGTest.cxx` (the module had no GTest driver; added the block plus `ITKGoogleTest` to `TEST_DEPENDS`).

- `CorrectTransformPrecisionTypeThrowsWithoutPrecisionToken` — fail-before: `std::out_of_range: basic_string::replace: __pos (which is 18446744073709551615) > this->size() (which is 20)`. Pass-after: throws `itk::ExceptionObject`.
- `CorrectTransformPrecisionTypeCorrectsMismatchedPrecision` — control case; the normal float/double correction is unchanged, passes before and after.
- `itkTransformFileReaderTest`, `itkTransformFileWriterTest` pass, unchanged.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the B47 analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
