### PR TITLE
BUG: Check stream state after each ASCII component read

### DIFF
--- a/Modules/IO/ImageBase/src/itkImageIOBase.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOBase.cxx
@@ -802,11 +802,15 @@ void
 ReadBuffer(std::istream & is, TComponent * buffer, ImageIOBase::SizeType num)
 {
   using PrintType = typename itk::NumericTraits<TComponent>::PrintType;
-  PrintType    temp;
   TComponent * ptr = buffer;
   for (ImageIOBase::SizeType i = 0; i < num; i++, ptr++)
   {
+    PrintType temp{};
     is >> temp;
+    if (is.fail())
+    {
+      itkGenericExceptionMacro("Failed reading ASCII component " << i << " of " << num);
+    }
     *ptr = static_cast<TComponent>(temp);
   }
 }

--- a/Modules/IO/ImageBase/test/itkImageIOBaseGTest.cxx
+++ b/Modules/IO/ImageBase/test/itkImageIOBaseGTest.cxx
@@ -24,6 +24,8 @@
 
 #include "itkImageIOFactory.h" // required to instantiate an instance of ImageIOBase
 
+#include <sstream>
+
 namespace
 {
 // Tests `MapPixelType<TPixel>::CType` and the estimation of component type traits.
@@ -324,4 +326,50 @@ TEST(ImageIOBase, ConvertedLegacyTest)
     EXPECT_EQ(imageIO->GetPixelType(), IOPixelEnum::VARIABLESIZEMATRIX);
     EXPECT_EQ(imageIO->GetComponentType(), IOComponentEnum::DOUBLE);
   }
+}
+
+namespace
+{
+class TestableImageIOBase : public itk::ImageIOBase
+{
+public:
+  using Self = TestableImageIOBase;
+  using Superclass = itk::ImageIOBase;
+  using Pointer = itk::SmartPointer<Self>;
+
+  itkNewMacro(Self);
+
+  using itk::ImageIOBase::ReadBufferAsASCII;
+
+  bool
+  CanReadFile(const char *) override
+  {
+    return false;
+  }
+  void
+  ReadImageInformation() override
+  {}
+  void
+  Read(void *) override
+  {}
+  bool
+  CanWriteFile(const char *) override
+  {
+    return false;
+  }
+  void
+  WriteImageInformation() override
+  {}
+  void
+  Write(const void *) override
+  {}
+};
+} // namespace
+
+TEST(ImageIOBase, ReadBufferAsASCIIThrowsOnOverflowingField)
+{
+  std::istringstream           is("5 99999 7 8");
+  short                        buffer[4] = { 0, 0, 0, 0 };
+  TestableImageIOBase::Pointer io = TestableImageIOBase::New();
+  EXPECT_THROW(io->ReadBufferAsASCII(is, buffer, itk::IOComponentEnum::SHORT, 4), itk::ExceptionObject);
 }


### PR DESCRIPTION
`ImageIOBase::ReadBufferAsASCII()` never checks the stream after an extraction, so one bad field latches its value into every remaining component. Reading `5 99999 7 8` as `short` yields `[5, 32767, 32767, 32767]`. Addresses B61 of #6575.

<details>
<summary>Root cause</summary>

The `ReadBuffer` template in `Modules/IO/ImageBase/src/itkImageIOBase.cxx` declares its extraction variable once, outside the loop, and never inspects the stream:

```cpp
PrintType temp;
for (SizeType i = 0; i < num; ++i)
{
  is >> temp;
  buffer[i] = static_cast<TComponent>(temp);
}
```

C++11 changed `operator>>` on overflow to clamp the value and set `failbit`. So `99999` into a `short` writes `32767` and latches `failbit`; from then on every `is >> temp` is a no-op, `temp` keeps its stale saturated value, and that value is written into every remaining slot. The real data after the bad field is dropped with no error at all.

`temp` is now declared inside the loop with `{}` zero-init — removing its cross-iteration dual meaning of "freshly read value" versus "stale leftover" — and the stream is checked after each extraction, throwing immediately on failure.

Anchor `rg 'is >> temp'` in `Modules/IO/ImageBase/src/`: exactly one hit, fixed. The same shape exists in `VTKImageIO::ReadTensorBuffer` — that is a different module and is fixed on the VTK branch for this issue rather than folded in here.

</details>

<details>
<summary>Local validation</summary>

Test added to the existing `itkImageIOBaseGTest.cxx`.

- `ImageIOBase.ReadBufferAsASCIIThrowsOnOverflowingField` — synthesizes `"5 99999 7 8"` read as four `short`s. Fail-before: `EXPECT_THROW` failed, "it throws nothing" (the buffer silently came back as `[5, 32767, 32767, 32767]`). Pass-after: OK.
- `ctest -R "ImageIOBase|ConvertBuffer|IOCommon|VTKImageIO|VTIImageIO"`: all pass. The failures in this local run (`itkImageFileReaderStreamingTest*`, `itkImageFileReaderDimensionsTest_NRRD`, …) are missing ExternalData fixtures in the local cache and throw at file lookup, before any ASCII buffer read.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the B61 analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
