### PR TITLE
BUG: Fix silent-corruption defects in VTKImageIO read and write

### DIFF
--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -204,8 +204,11 @@ VTKImageIO::InternalReadImageInformation(std::ifstream & file)
 
   if (text.find("dimensions") < text.length())
   {
-    unsigned int dims[3];
-    sscanf(text.c_str(), "%*s %u %u %u", dims, dims + 1, dims + 2);
+    unsigned int dims[3]{};
+    if (sscanf(text.c_str(), "%*s %u %u %u", dims, dims + 1, dims + 2) != 3)
+    {
+      itkExceptionMacro("Malformed DIMENSIONS line: " << text);
+    }
     if (dims[1] <= 1 && dims[2] <= 1)
     {
       this->SetNumberOfDimensions(2);
@@ -234,12 +237,16 @@ VTKImageIO::InternalReadImageInformation(std::ifstream & file)
 
     if (text.find("spacing") < text.length() || text.find("aspect_ratio") < text.length())
     {
-      double spacing[3];
+      double spacing[3]{};
       // save and reset old locale
       const std::locale currentLocale = std::locale::global(std::locale::classic());
-      sscanf(text.c_str(), "%*s %lf %lf %lf", spacing, spacing + 1, spacing + 2);
+      const int numSpacingFieldsRead = sscanf(text.c_str(), "%*s %lf %lf %lf", spacing, spacing + 1, spacing + 2);
       // reset locale
       std::locale::global(currentLocale);
+      if (numSpacingFieldsRead != 3)
+      {
+        itkExceptionMacro("Malformed SPACING line: " << text);
+      }
       for (unsigned int i = 0; i < m_NumberOfDimensions; ++i)
       {
         this->SetSpacing(i, spacing[i]);
@@ -248,12 +255,16 @@ VTKImageIO::InternalReadImageInformation(std::ifstream & file)
 
     else if (text.find("origin") < text.length())
     {
-      double origin[3];
+      double origin[3]{};
       // save and reset old locale
       const std::locale currentLocale = std::locale::global(std::locale::classic());
-      sscanf(text.c_str(), "%*s %lf %lf %lf", origin, origin + 1, origin + 2);
+      const int         numOriginFieldsRead = sscanf(text.c_str(), "%*s %lf %lf %lf", origin, origin + 1, origin + 2);
       // reset locale
       std::locale::global(currentLocale);
+      if (numOriginFieldsRead != 3)
+      {
+        itkExceptionMacro("Malformed ORIGIN line: " << text);
+      }
       for (unsigned int i = 0; i < m_NumberOfDimensions; ++i)
       {
         this->SetOrigin(i, origin[i]);
@@ -266,8 +277,11 @@ VTKImageIO::InternalReadImageInformation(std::ifstream & file)
 
       this->SetNumberOfComponents(3);
       this->SetPixelType(IOPixelEnum::VECTOR);
-      char pixelType[256];
-      sscanf(text.c_str(), "%*s %*s %255s", pixelType);
+      char pixelType[256]{};
+      if (sscanf(text.c_str(), "%*s %*s %255s", pixelType) != 1)
+      {
+        itkExceptionMacro("Malformed VECTORS line: " << text);
+      }
       text = pixelType;
 
       this->SetPixelTypeFromString(text);
@@ -311,10 +325,13 @@ VTKImageIO::InternalReadImageInformation(std::ifstream & file)
     {
       readAttribute = true;
 
-      char         pixelType[256];
+      char         pixelType[256]{};
       unsigned int numComp = 1;
       // numComp is optional
-      sscanf(text.c_str(), "%*s %*s %255s %u", pixelType, &numComp);
+      if (sscanf(text.c_str(), "%*s %*s %255s %u", pixelType, &numComp) < 1)
+      {
+        itkExceptionMacro("Malformed SCALARS line: " << text);
+      }
       text = pixelType;
       if (numComp == 1)
       {
@@ -342,8 +359,11 @@ VTKImageIO::InternalReadImageInformation(std::ifstream & file)
     {
       readAttribute = true;
 
-      char pixelType[256];
-      sscanf(text.c_str(), "%*s %*s %255s", pixelType);
+      char pixelType[256]{};
+      if (sscanf(text.c_str(), "%*s %*s %255s", pixelType) != 1)
+      {
+        itkExceptionMacro("Malformed TENSORS line: " << text);
+      }
       text = pixelType;
       this->SetPixelType(IOPixelEnum::SYMMETRICSECONDRANKTENSOR);
       this->SetNumberOfComponents(6);

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -594,7 +594,10 @@ VTKImageIO::Read(void * buffer)
       }
       else
       {
-        this->ReadBufferAsBinary(file, buffer, this->GetImageSizeInBytes());
+        if (!this->ReadBufferAsBinary(file, buffer, this->GetImageSizeInBytes()))
+        {
+          itkExceptionMacro("Failed reading binary pixel data: " << m_FileName);
+        }
       }
 
       switch (this->GetComponentSize())

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -24,6 +24,21 @@
 
 namespace itk
 {
+namespace
+{
+std::string
+FirstToken(const std::string & line)
+{
+  const auto start = line.find_first_not_of(" \t");
+  if (start == std::string::npos)
+  {
+    return {};
+  }
+  const auto end = line.find_first_of(" \t", start);
+  return line.substr(start, end - start);
+}
+} // namespace
+
 VTKImageIO::VTKImageIO()
 {
   this->SetNumberOfDimensions(2);
@@ -204,11 +219,15 @@ VTKImageIO::InternalReadImageInformation(std::ifstream & file)
 
   if (text.find("dimensions") < text.length())
   {
-    unsigned int dims[3]{};
-    if (sscanf(text.c_str(), "%*s %u %u %u", dims, dims + 1, dims + 2) != 3)
+    long long signedDims[3]{};
+    if (sscanf(text.c_str(), "%*s %lld %lld %lld", signedDims, signedDims + 1, signedDims + 2) != 3 ||
+        signedDims[0] < 1 || signedDims[1] < 1 || signedDims[2] < 1)
     {
       itkExceptionMacro("Malformed DIMENSIONS line: " << text);
     }
+    unsigned int dims[3]{ static_cast<unsigned int>(signedDims[0]),
+                          static_cast<unsigned int>(signedDims[1]),
+                          static_cast<unsigned int>(signedDims[2]) };
     if (dims[1] <= 1 && dims[2] <= 1)
     {
       this->SetNumberOfDimensions(2);
@@ -235,10 +254,7 @@ VTKImageIO::InternalReadImageInformation(std::ifstream & file)
   {
     this->GetNextLine(file, text);
 
-    const auto        keywordStart = text.find_first_not_of(" \t");
-    const auto        keywordEnd = text.find_first_of(" \t", keywordStart);
-    const std::string keyword =
-      (keywordStart == std::string::npos) ? std::string() : text.substr(keywordStart, keywordEnd - keywordStart);
+    const std::string keyword = FirstToken(text);
 
     if (keyword == "spacing" || keyword == "aspect_ratio")
     {
@@ -403,8 +419,8 @@ VTKImageIO::ReadHeaderSize(std::ifstream & file)
   {
     this->GetNextLine(file, text); // SPACING|ORIGIN|COLOR_SCALARS|SCALARS|VECTOR|TENSORS
 
-    if (text.find("scalars") < text.length() || text.find("vector") < text.length() ||
-        text.find("color_scalars") < text.length() || text.find("tensors") < text.length())
+    const std::string keyword = FirstToken(text);
+    if (keyword == "scalars" || keyword == "vectors" || keyword == "color_scalars" || keyword == "tensors")
     {
       readAttribute = true;
 

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -83,17 +83,17 @@ VTKImageIO::CanReadFile(const char * filename)
   try
   {
     this->OpenFileForReading(file, fname);
+
+    // Check to see if its a vtk structured points file
+    this->GetNextLine(file, fname);
+    this->GetNextLine(file, fname);
+    this->GetNextLine(file, fname);
+    this->GetNextLine(file, fname);
   }
   catch (...)
   {
     return false;
   }
-
-  // Check to see if its a vtk structured points file
-  this->GetNextLine(file, fname);
-  this->GetNextLine(file, fname);
-  this->GetNextLine(file, fname);
-  this->GetNextLine(file, fname);
 
   if (fname.find("structured_points") < fname.length())
   {

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -235,7 +235,12 @@ VTKImageIO::InternalReadImageInformation(std::ifstream & file)
   {
     this->GetNextLine(file, text);
 
-    if (text.find("spacing") < text.length() || text.find("aspect_ratio") < text.length())
+    const auto        keywordStart = text.find_first_not_of(" \t");
+    const auto        keywordEnd = text.find_first_of(" \t", keywordStart);
+    const std::string keyword =
+      (keywordStart == std::string::npos) ? std::string() : text.substr(keywordStart, keywordEnd - keywordStart);
+
+    if (keyword == "spacing" || keyword == "aspect_ratio")
     {
       double spacing[3]{};
       // save and reset old locale
@@ -253,7 +258,7 @@ VTKImageIO::InternalReadImageInformation(std::ifstream & file)
       }
     }
 
-    else if (text.find("origin") < text.length())
+    else if (keyword == "origin")
     {
       double origin[3]{};
       // save and reset old locale
@@ -271,7 +276,7 @@ VTKImageIO::InternalReadImageInformation(std::ifstream & file)
       }
     }
 
-    else if (text.find("vector") < text.length())
+    else if (keyword == "vectors")
     {
       readAttribute = true;
 
@@ -287,7 +292,7 @@ VTKImageIO::InternalReadImageInformation(std::ifstream & file)
       this->SetPixelTypeFromString(text);
     }
 
-    else if (text.find("color_scalars") < text.length())
+    else if (keyword == "color_scalars")
     {
       readAttribute = true;
 
@@ -321,7 +326,7 @@ VTKImageIO::InternalReadImageInformation(std::ifstream & file)
       }
     }
 
-    else if (text.find("scalars") < text.length())
+    else if (keyword == "scalars")
     {
       readAttribute = true;
 
@@ -355,7 +360,7 @@ VTKImageIO::InternalReadImageInformation(std::ifstream & file)
       }
     } // found scalars
 
-    else if (text.find("tensors") < text.length())
+    else if (keyword == "tensors")
     {
       readAttribute = true;
 

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -1038,6 +1038,8 @@ VTKImageIO::Write(const void * buffer)
     // Write the actual pixel data
     if (m_FileType == IOFileEnum::ASCII)
     {
+      file.setf(std::ios::scientific, std::ios::floatfield);
+      file.precision(16);
       this->WriteBufferAsASCII(file, buffer, this->GetComponentType(), this->GetImageSizeInComponents());
     }
     else // binary

--- a/Modules/IO/VTK/src/itkVTKImageIO.cxx
+++ b/Modules/IO/VTK/src/itkVTKImageIO.cxx
@@ -439,37 +439,35 @@ void
 ReadTensorBuffer(std::istream & is, TComponent * buffer, const ImageIOBase::SizeType num)
 {
   using PrintType = typename itk::NumericTraits<TComponent>::PrintType;
-  PrintType             temp;
   TComponent *          ptr = buffer;
   ImageIOBase::SizeType i = 0;
   // More than the resulting components because of symmetry.
   const ImageIOBase::SizeType fileComponents = num / 6 * 9;
+
+  auto readComponent = [&is]() {
+    PrintType temp{};
+    is >> temp;
+    if (is.fail())
+    {
+      itkGenericExceptionMacro("Failed reading ASCII tensor component");
+    }
+    return static_cast<TComponent>(temp);
+  };
+
   while (i < fileComponents)
   {
     // First row: hit hit hit
-    is >> temp;
-    *ptr = static_cast<TComponent>(temp);
-    ++ptr;
-    is >> temp;
-    *ptr = static_cast<TComponent>(temp);
-    ++ptr;
-    is >> temp;
-    *ptr = static_cast<TComponent>(temp);
-    ++ptr;
+    *ptr++ = readComponent();
+    *ptr++ = readComponent();
+    *ptr++ = readComponent();
     // Second row: skip hit hit
-    is >> temp;
-    is >> temp;
-    *ptr = static_cast<TComponent>(temp);
-    ++ptr;
-    is >> temp;
-    *ptr = static_cast<TComponent>(temp);
-    ++ptr;
+    static_cast<void>(readComponent());
+    *ptr++ = readComponent();
+    *ptr++ = readComponent();
     // Third row: skip skip hit
-    is >> temp;
-    is >> temp;
-    is >> temp;
-    *ptr = static_cast<TComponent>(temp);
-    ++ptr;
+    static_cast<void>(readComponent());
+    static_cast<void>(readComponent());
+    *ptr++ = readComponent();
     i += 9;
   }
 }

--- a/Modules/IO/VTK/test/CMakeLists.txt
+++ b/Modules/IO/VTK/test/CMakeLists.txt
@@ -20,6 +20,7 @@ set(
   itkVTIImageIOFutureFeaturesGTest.cxx
   itkVTIImageIOGeneratedFixturesGTest.cxx
   itkVTIImageIOSwapBufferGTest.cxx
+  itkVTKImageIOGTest.cxx
 )
 creategoogletestdriver(ITKIOVTK "${ITKIOVTK-Test_LIBRARIES}" "${ITKIOVTKGTests}")
 

--- a/Modules/IO/VTK/test/itkVTKImageIOGTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOGTest.cxx
@@ -1,0 +1,50 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkImageFileReader.h"
+#include "itkVTKImageIO.h"
+#include "itkGTest.h"
+
+#include <fstream>
+#include <string>
+
+TEST(VTKImageIO, TruncatedBinaryFileThrowsOnRead)
+{
+  using ImageType = itk::Image<unsigned char, 2>;
+  const std::string path = std::string(::testing::TempDir()) + "/itkVTKImageIOGTest_truncated.vtk";
+  {
+    std::ofstream ofs(path, std::ios::binary);
+    ofs << "# vtk DataFile Version 3.0\n"
+        << "truncated binary fixture\n"
+        << "BINARY\n"
+        << "DATASET STRUCTURED_POINTS\n"
+        << "DIMENSIONS 2 2 1\n"
+        << "SPACING 1 1 1\n"
+        << "ORIGIN 0 0 0\n"
+        << "POINT_DATA 4\n"
+        << "SCALARS scalars unsigned_char 1\n"
+        << "LOOKUP_TABLE default\n";
+    const unsigned char partialPixelData[2] = { 1, 2 };
+    ofs.write(reinterpret_cast<const char *>(partialPixelData), sizeof(partialPixelData));
+  }
+
+  auto reader = itk::ImageFileReader<ImageType>::New();
+  reader->SetImageIO(itk::VTKImageIO::New());
+  reader->SetFileName(path);
+  EXPECT_THROW(reader->Update(), itk::ExceptionObject);
+}

--- a/Modules/IO/VTK/test/itkVTKImageIOGTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOGTest.cxx
@@ -172,3 +172,18 @@ TEST(VTKImageIO, AsciiWriteRetainsDoublePrecision)
     EXPECT_NEAR(readIt.Get(), writtenIt.Get(), 1e-10 * std::abs(writtenIt.Get()) + 1e-12);
   }
 }
+
+TEST(VTKImageIO, CanReadFileReturnsFalseOnShortFile)
+{
+  const std::string path = std::string(::testing::TempDir()) + "/itkVTKImageIOGTest_short.vtk";
+  {
+    std::ofstream ofs(path);
+    ofs << "# vtk DataFile Version 3.0\n"
+        << "only two lines\n";
+  }
+
+  auto vtkIO = itk::VTKImageIO::New();
+  bool canRead = true;
+  EXPECT_NO_THROW(canRead = vtkIO->CanReadFile(path.c_str()));
+  EXPECT_FALSE(canRead);
+}

--- a/Modules/IO/VTK/test/itkVTKImageIOGTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOGTest.cxx
@@ -48,3 +48,25 @@ TEST(VTKImageIO, TruncatedBinaryFileThrowsOnRead)
   reader->SetFileName(path);
   EXPECT_THROW(reader->Update(), itk::ExceptionObject);
 }
+
+TEST(VTKImageIO, MalformedDimensionsLineThrows)
+{
+  const std::string path = std::string(::testing::TempDir()) + "/itkVTKImageIOGTest_malformed_dims.vtk";
+  {
+    std::ofstream ofs(path);
+    ofs << "# vtk DataFile Version 3.0\n"
+        << "malformed dimensions fixture\n"
+        << "ASCII\n"
+        << "DATASET STRUCTURED_POINTS\n"
+        << "DIMENSIONS 5\n"
+        << "SPACING 1 1 1\n"
+        << "ORIGIN 0 0 0\n"
+        << "SCALARS scalars float 1\n"
+        << "LOOKUP_TABLE default\n"
+        << "1 2 3 4 5\n";
+  }
+
+  auto vtkIO = itk::VTKImageIO::New();
+  vtkIO->SetFileName(path);
+  EXPECT_THROW(vtkIO->ReadImageInformation(), itk::ExceptionObject);
+}

--- a/Modules/IO/VTK/test/itkVTKImageIOGTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOGTest.cxx
@@ -70,3 +70,59 @@ TEST(VTKImageIO, MalformedDimensionsLineThrows)
   vtkIO->SetFileName(path);
   EXPECT_THROW(vtkIO->ReadImageInformation(), itk::ExceptionObject);
 }
+
+TEST(VTKImageIO, ScalarsNameContainingVectorSubstringParsesAsScalars)
+{
+  const std::string path = std::string(::testing::TempDir()) + "/itkVTKImageIOGTest_scalars_vector_substr.vtk";
+  {
+    std::ofstream ofs(path);
+    ofs << "# vtk DataFile Version 3.0\n"
+        << "scalars array name containing the substring vector\n"
+        << "ASCII\n"
+        << "DATASET STRUCTURED_POINTS\n"
+        << "DIMENSIONS 2 1 1\n"
+        << "SPACING 1 1 1\n"
+        << "ORIGIN 0 0 0\n"
+        << "POINT_DATA 2\n"
+        << "SCALARS vector_field float\n"
+        << "LOOKUP_TABLE default\n"
+        << "1.0 2.0\n";
+  }
+
+  auto vtkIO = itk::VTKImageIO::New();
+  vtkIO->SetFileName(path);
+  ASSERT_NO_THROW(vtkIO->ReadImageInformation());
+
+  EXPECT_EQ(vtkIO->GetPixelType(), itk::IOPixelEnum::SCALAR);
+  EXPECT_EQ(vtkIO->GetNumberOfComponents(), 1u);
+}
+
+TEST(VTKImageIO, IndentedAttributeKeywordsParse)
+{
+  const std::string path = std::string(::testing::TempDir()) + "/itkVTKImageIOGTest_indented_keywords.vtk";
+  {
+    std::ofstream ofs(path);
+    ofs << "# vtk DataFile Version 3.0\n"
+        << "attribute keywords with leading whitespace\n"
+        << "ASCII\n"
+        << "DATASET STRUCTURED_POINTS\n"
+        << "DIMENSIONS 2 1 1\n"
+        << "  SPACING 2 3 1\n"
+        << "\tORIGIN 5 6 0\n"
+        << "POINT_DATA 2\n"
+        << " \t SCALARS scalars float 1\n"
+        << "LOOKUP_TABLE default\n"
+        << "1.0 2.0\n";
+  }
+
+  auto vtkIO = itk::VTKImageIO::New();
+  vtkIO->SetFileName(path);
+  ASSERT_NO_THROW(vtkIO->ReadImageInformation());
+
+  EXPECT_EQ(vtkIO->GetPixelType(), itk::IOPixelEnum::SCALAR);
+  EXPECT_EQ(vtkIO->GetNumberOfComponents(), 1u);
+  EXPECT_DOUBLE_EQ(vtkIO->GetSpacing(0), 2.0);
+  EXPECT_DOUBLE_EQ(vtkIO->GetSpacing(1), 3.0);
+  EXPECT_DOUBLE_EQ(vtkIO->GetOrigin(0), 5.0);
+  EXPECT_DOUBLE_EQ(vtkIO->GetOrigin(1), 6.0);
+}

--- a/Modules/IO/VTK/test/itkVTKImageIOGTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOGTest.cxx
@@ -75,6 +75,28 @@ TEST(VTKImageIO, MalformedDimensionsLineThrows)
   EXPECT_THROW(vtkIO->ReadImageInformation(), itk::ExceptionObject);
 }
 
+TEST(VTKImageIO, NegativeDimensionsLineThrows)
+{
+  const std::string path = std::string(::testing::TempDir()) + "/itkVTKImageIOGTest_negative_dims.vtk";
+  {
+    std::ofstream ofs(path);
+    ofs << "# vtk DataFile Version 3.0\n"
+        << "negative dimensions fixture\n"
+        << "ASCII\n"
+        << "DATASET STRUCTURED_POINTS\n"
+        << "DIMENSIONS 10 -2 1\n"
+        << "SPACING 1 1 1\n"
+        << "ORIGIN 0 0 0\n"
+        << "SCALARS scalars float 1\n"
+        << "LOOKUP_TABLE default\n"
+        << "1 2 3\n";
+  }
+
+  auto vtkIO = itk::VTKImageIO::New();
+  vtkIO->SetFileName(path);
+  EXPECT_THROW(vtkIO->ReadImageInformation(), itk::ExceptionObject);
+}
+
 TEST(VTKImageIO, ScalarsNameContainingVectorSubstringParsesAsScalars)
 {
   const std::string path = std::string(::testing::TempDir()) + "/itkVTKImageIOGTest_scalars_vector_substr.vtk";
@@ -189,7 +211,7 @@ TEST(VTKImageIO, CanReadFileReturnsFalseOnShortFile)
   EXPECT_FALSE(canRead);
 }
 
-TEST(VTKImageIO, TensorOverflowingFieldThrowsOnRead)
+TEST(VTKImageIO, TensorNonNumericFieldThrowsOnRead)
 {
   using TensorType = itk::SymmetricSecondRankTensor<float, 3>;
   using ImageType = itk::Image<TensorType, 2>;

--- a/Modules/IO/VTK/test/itkVTKImageIOGTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOGTest.cxx
@@ -17,9 +17,12 @@
  *=========================================================================*/
 
 #include "itkImageFileReader.h"
+#include "itkImageFileWriter.h"
+#include "itkImageRegionIterator.h"
 #include "itkVTKImageIO.h"
 #include "itkGTest.h"
 
+#include <cmath>
 #include <fstream>
 #include <string>
 
@@ -125,4 +128,47 @@ TEST(VTKImageIO, IndentedAttributeKeywordsParse)
   EXPECT_DOUBLE_EQ(vtkIO->GetSpacing(1), 3.0);
   EXPECT_DOUBLE_EQ(vtkIO->GetOrigin(0), 5.0);
   EXPECT_DOUBLE_EQ(vtkIO->GetOrigin(1), 6.0);
+}
+
+TEST(VTKImageIO, AsciiWriteRetainsDoublePrecision)
+{
+  using ImageType = itk::Image<double, 2>;
+
+  auto                image = ImageType::New();
+  ImageType::SizeType size;
+  size.Fill(2);
+  const ImageType::RegionType region(size);
+  image->SetRegions(region);
+  image->Allocate();
+
+  itk::ImageRegionIterator<ImageType> initIt(image, region);
+  initIt.Set(1.0 / 3.0);
+  ++initIt;
+  initIt.Set(2.0 / 3.0);
+  ++initIt;
+  initIt.Set(-1.0 / 7.0);
+  ++initIt;
+  initIt.Set(123456.0 / 9.0);
+
+  const std::string path = std::string(::testing::TempDir()) + "/itkVTKImageIOGTest_ascii_precision.vtk";
+
+  auto writer = itk::ImageFileWriter<ImageType>::New();
+  auto writeIO = itk::VTKImageIO::New();
+  writeIO->SetFileTypeToASCII();
+  writer->SetImageIO(writeIO);
+  writer->SetFileName(path);
+  writer->SetInput(image);
+  ASSERT_NO_THROW(writer->Update());
+
+  auto reader = itk::ImageFileReader<ImageType>::New();
+  reader->SetImageIO(itk::VTKImageIO::New());
+  reader->SetFileName(path);
+  ASSERT_NO_THROW(reader->Update());
+
+  itk::ImageRegionIterator<ImageType> writtenIt(image, region);
+  itk::ImageRegionIterator<ImageType> readIt(reader->GetOutput(), region);
+  for (; !writtenIt.IsAtEnd(); ++writtenIt, ++readIt)
+  {
+    EXPECT_NEAR(readIt.Get(), writtenIt.Get(), 1e-10 * std::abs(writtenIt.Get()) + 1e-12);
+  }
 }

--- a/Modules/IO/VTK/test/itkVTKImageIOGTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOGTest.cxx
@@ -19,6 +19,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkImageRegionIterator.h"
+#include "itkSymmetricSecondRankTensor.h"
 #include "itkVTKImageIO.h"
 #include "itkGTest.h"
 
@@ -186,4 +187,31 @@ TEST(VTKImageIO, CanReadFileReturnsFalseOnShortFile)
   bool canRead = true;
   EXPECT_NO_THROW(canRead = vtkIO->CanReadFile(path.c_str()));
   EXPECT_FALSE(canRead);
+}
+
+TEST(VTKImageIO, TensorOverflowingFieldThrowsOnRead)
+{
+  using TensorType = itk::SymmetricSecondRankTensor<float, 3>;
+  using ImageType = itk::Image<TensorType, 2>;
+
+  const std::string path = std::string(::testing::TempDir()) + "/itkVTKImageIOGTest_tensor_bad_field.vtk";
+  {
+    std::ofstream ofs(path);
+    ofs << "# vtk DataFile Version 3.0\n"
+        << "tensor fixture with a malformed field\n"
+        << "ASCII\n"
+        << "DATASET STRUCTURED_POINTS\n"
+        << "DIMENSIONS 2 1 1\n"
+        << "SPACING 1 1 1\n"
+        << "ORIGIN 0 0 0\n"
+        << "POINT_DATA 2\n"
+        << "TENSORS tensors float\n"
+        << "1 2 3 2 bad 5 3 5 6\n"
+        << "10 20 30 20 40 50 30 50 60\n";
+  }
+
+  auto reader = itk::ImageFileReader<ImageType>::New();
+  reader->SetImageIO(itk::VTKImageIO::New());
+  reader->SetFileName(path);
+  EXPECT_THROW(reader->Update(), itk::ExceptionObject);
 }


### PR DESCRIPTION
Six defects in `VTKImageIO`'s reader and writer: truncated files read as success, `sscanf` results ignored over uninitialized locals, substring-based attribute dispatch, ASCII precision loss, and `CanReadFile()` throwing. Addresses B57–B60, B62 of #6575 (and the `ReadTensorBuffer` sibling of B61).

<details>
<summary>The six commits</summary>

- **B57** — `VTKImageIO::Read()`'s non-streaming binary path discarded `ReadBufferAsBinary()`'s `bool`, so a truncated file returned partially-uninitialized pixels as success. The other call sites (in `StreamReadBufferAsBinary` / `StreamWriteBufferAsBinary`) already throw internally before returning false — distinct, untouched.
- **B58** — six `sscanf` calls in `InternalReadImageInformation()` discarded their returned field count while writing into uninitialized locals, so a malformed `DIMENSIONS 5` line sized the image from indeterminate values. All six destinations are now zero-initialized and the field count is checked, throwing and naming the malformed line. `color_scalars`/`scalars` `numComp` already had a default assigned before the `sscanf` — an undercount leaves a defined value there, so those are distinct and untouched.
- **B59** — attribute dispatch was an ordered substring test (`text.find("vector") < text.length()`), so `SCALARS vector_field float` matched the `vector` arm and was misparsed as a 3-component VECTORS line. Now dispatches on the line's first whitespace-delimited token.
- **B60** — ASCII write set `precision(16)` on the header stream, but the pixel data went out through a second stream at the default 6 significant digits. The precision is now set on the stream that actually writes the pixels.
- **B62** — four `GetNextLine()` calls sat outside `CanReadFile()`'s try block, so a `.vtk` file shorter than four lines threw "Premature EOF" out through the IO factory. `CanReadFile()` must never throw; the calls moved inside.
- **B61 sibling** — `ReadTensorBuffer()` has the identical defect B61 fixes in `ImageIOBase` (see #6609): a `PrintType temp` hoisted outside the read loop with no stream check, so one bad field latches its stale value into every later component. Fixed here because it is the same defect family and lives in this file. Each of the nine per-tensor extractions now goes through a helper that zero-initializes a fresh value, extracts, and throws on `is.fail()` — including the redundant symmetric "skip" reads, which previously swallowed corruption silently.

Sweep of the rest of the file for the same anchors turned up nothing else: the `os <<` ASCII writes have no stale-latch failure mode, and the remaining `.find()` calls are single-purpose presence gates, not differentiated dispatch.

</details>

<details>
<summary>Local validation</summary>

New GoogleTest `itkVTKImageIOGTest.cxx` (the module had no GTest driver). Every fixture is synthesized byte-for-byte in the test body — no ExternalData added.

| Test | Fail-before | Pass-after |
|---|---|---|
| `TruncatedBinaryFileThrowsOnRead` (B57) | no throw, silent short read | throws |
| `MalformedDimensionsLineThrows` (B58) | no throw | throws |
| `ScalarsNameContainingVectorSubstringParsesAsScalars` (B59) | parsed as 3-component VECTOR | 1-component SCALAR |
| `AsciiWriteRetainsDoublePrecision` (B60) | `EXPECT_NEAR` failed | passes |
| `CanReadFileReturnsFalseOnShortFile` (B62) | threw | returns false |
| `TensorOverflowingFieldThrowsOnRead` (B61 sibling) | no throw | throws |

`ctest -R "VTKImageIO|VTIImageIO"`: **46/46 pass**, no pre-existing test changed result.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the B57–B62 analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
