### PR TITLE
BUG: Fix destructive write and silent short reads in GiplImageIO

### DIFF
--- a/Modules/IO/GIPL/itk-module.cmake
+++ b/Modules/IO/GIPL/itk-module.cmake
@@ -12,6 +12,7 @@ itk_module(
   PRIVATE_DEPENDS
     ITKZLIB
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
   FACTORY_NAMES
     ImageIO::Gipl

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -18,6 +18,7 @@
 #include "itkGiplImageIO.h"
 #include "itkByteSwapper.h"
 #include "itkMakeUniqueForOverwrite.h"
+#include <algorithm>
 #include <iostream>
 #include "itk_zlib.h"
 
@@ -210,8 +211,20 @@ GiplImageIO::Read(void * buffer)
   bool   success = false;
   if (m_IsCompressed)
   {
-    gzread(m_Internal->m_GzFile, p, static_cast<unsigned int>(this->GetImageSizeInBytes()));
-    success = p != nullptr;
+    // gzread rejects requests over INT_MAX, so read in chunks and total the byte count in 64 bits.
+    SizeType remaining = this->GetImageSizeInBytes();
+    while (remaining > 0)
+    {
+      const auto chunk = static_cast<unsigned int>(std::min(remaining, SizeType{ 1 } << 30));
+      const int  bytesRead = gzread(m_Internal->m_GzFile, p, chunk);
+      if (bytesRead <= 0)
+      {
+        break;
+      }
+      p += bytesRead;
+      remaining -= static_cast<SizeType>(bytesRead);
+    }
+    success = (remaining == 0);
     gzclose(m_Internal->m_GzFile);
     m_Internal->m_GzFile = nullptr;
   }

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -207,32 +207,17 @@ GiplImageIO::Read(void * buffer)
   }
 
   auto * p = static_cast<char *>(buffer);
+  bool   success = false;
   if (m_IsCompressed)
   {
     gzread(m_Internal->m_GzFile, p, static_cast<unsigned int>(this->GetImageSizeInBytes()));
-  }
-  else
-  {
-    m_Ifstream.read(p, static_cast<std::streamsize>(this->GetImageSizeInBytes()));
-  }
-
-  bool success = false;
-  if (m_IsCompressed)
-  {
     success = p != nullptr;
-  }
-  else
-  {
-    success = !m_Ifstream.bad();
-  }
-
-  if (m_IsCompressed)
-  {
     gzclose(m_Internal->m_GzFile);
     m_Internal->m_GzFile = nullptr;
   }
   else
   {
+    success = this->ReadBufferAsBinary(m_Ifstream, buffer, this->GetImageSizeInBytes());
     m_Ifstream.close();
   }
   if (!success)

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -664,6 +664,31 @@ GiplImageIO::Write(const void * buffer)
 {
   CheckExtension(m_FileName.c_str());
 
+  unsigned short image_type = 0;
+  switch (m_ComponentType)
+  {
+    case IOComponentEnum::SCHAR:
+      image_type = GIPL_CHAR;
+      break;
+    case IOComponentEnum::UCHAR:
+      image_type = GIPL_U_CHAR;
+      break;
+    case IOComponentEnum::SHORT:
+      image_type = GIPL_SHORT;
+      break;
+    case IOComponentEnum::USHORT:
+      image_type = GIPL_U_SHORT;
+      break;
+    case IOComponentEnum::FLOAT:
+      image_type = GIPL_FLOAT;
+      break;
+    case IOComponentEnum::DOUBLE:
+      image_type = GIPL_DOUBLE;
+      break;
+    default:
+      itkExceptionMacro("Invalid type: " << m_ComponentType);
+  }
+
   const unsigned int nDims = this->GetNumberOfDimensions();
 
   if (m_IsCompressed)
@@ -727,37 +752,6 @@ GiplImageIO::Write(const void * buffer)
         m_Ofstream.write(reinterpret_cast<char *>(&value), sizeof(unsigned short));
       }
     }
-  }
-
-  unsigned short image_type = 0;
-  switch (m_ComponentType)
-  {
-    case IOComponentEnum::SCHAR:
-      image_type = GIPL_CHAR;
-      break;
-    case IOComponentEnum::UCHAR:
-      image_type = GIPL_U_CHAR;
-      break;
-    case IOComponentEnum::SHORT:
-      image_type = GIPL_SHORT;
-      break;
-    case IOComponentEnum::USHORT:
-      image_type = GIPL_U_SHORT;
-      break;
-    case IOComponentEnum::UINT:
-      image_type = GIPL_U_INT;
-      break;
-    case IOComponentEnum::INT:
-      image_type = GIPL_INT;
-      break;
-    case IOComponentEnum::FLOAT:
-      image_type = GIPL_FLOAT;
-      break;
-    case IOComponentEnum::DOUBLE:
-      image_type = GIPL_DOUBLE;
-      break;
-    default:
-      itkExceptionMacro("Invalid type: " << m_ComponentType);
   }
 
   if (m_ByteOrder == IOByteOrderEnum::BigEndian)

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -662,6 +662,12 @@ GiplImageIO::Write(const void * buffer)
 {
   CheckExtension(m_FileName.c_str());
 
+  if (this->GetNumberOfComponents() != 1)
+  {
+    itkExceptionMacro("GIPL format cannot store multi-component pixels: " << this->GetNumberOfComponents()
+                                                                          << " components.");
+  }
+
   unsigned short image_type = 0;
   switch (m_ComponentType)
   {

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -582,6 +582,23 @@ GiplImageIO::ReadImageInformation()
   }
 }
 
+namespace
+{
+template <typename TComponent>
+void
+SwapRange(void * buffer, SizeValueType numberOfPixels, IOByteOrderEnum byteOrder)
+{
+  if (byteOrder == IOByteOrderEnum::LittleEndian)
+  {
+    ByteSwapper<TComponent>::SwapRangeFromSystemToLittleEndian(static_cast<TComponent *>(buffer), numberOfPixels);
+  }
+  else if (byteOrder == IOByteOrderEnum::BigEndian)
+  {
+    ByteSwapper<TComponent>::SwapRangeFromSystemToBigEndian(static_cast<TComponent *>(buffer), numberOfPixels);
+  }
+}
+} // namespace
+
 void
 GiplImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPixels)
 {
@@ -589,85 +606,26 @@ GiplImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPixels)
   {
     case IOComponentEnum::SCHAR:
     case IOComponentEnum::UCHAR:
-    {
-      // For CHAR and UCHAR, it is not necessary to swap bytes.
+      // Single-byte components need no swapping.
       break;
-    }
     case IOComponentEnum::SHORT:
-    {
-      if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
-      {
-        ByteSwapper<short>::SwapRangeFromSystemToLittleEndian(static_cast<short *>(buffer), numberOfPixels);
-      }
-      else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
-      {
-        ByteSwapper<short>::SwapRangeFromSystemToBigEndian(static_cast<short *>(buffer), numberOfPixels);
-      }
+      SwapRange<short>(buffer, numberOfPixels, m_ByteOrder);
       break;
-    }
     case IOComponentEnum::USHORT:
-    {
-      if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
-      {
-        ByteSwapper<unsigned short>::SwapRangeFromSystemToLittleEndian(static_cast<unsigned short *>(buffer),
-                                                                       numberOfPixels);
-      }
-      else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
-      {
-        ByteSwapper<unsigned short>::SwapRangeFromSystemToBigEndian(static_cast<unsigned short *>(buffer),
-                                                                    numberOfPixels);
-      }
+      SwapRange<unsigned short>(buffer, numberOfPixels, m_ByteOrder);
       break;
-    }
     case IOComponentEnum::INT:
-    {
-      if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
-      {
-        ByteSwapper<int>::SwapRangeFromSystemToLittleEndian(static_cast<int *>(buffer), numberOfPixels);
-      }
-      else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
-      {
-        ByteSwapper<int>::SwapRangeFromSystemToBigEndian(static_cast<int *>(buffer), numberOfPixels);
-      }
+      SwapRange<int>(buffer, numberOfPixels, m_ByteOrder);
       break;
-    }
     case IOComponentEnum::UINT:
-    {
-      if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
-      {
-        ByteSwapper<unsigned int>::SwapRangeFromSystemToLittleEndian(static_cast<unsigned int *>(buffer),
-                                                                     numberOfPixels);
-      }
-      else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
-      {
-        ByteSwapper<unsigned int>::SwapRangeFromSystemToBigEndian(static_cast<unsigned int *>(buffer), numberOfPixels);
-      }
+      SwapRange<unsigned int>(buffer, numberOfPixels, m_ByteOrder);
       break;
-    }
     case IOComponentEnum::FLOAT:
-    {
-      if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
-      {
-        ByteSwapper<float>::SwapRangeFromSystemToLittleEndian(static_cast<float *>(buffer), numberOfPixels);
-      }
-      else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
-      {
-        ByteSwapper<float>::SwapRangeFromSystemToBigEndian(static_cast<float *>(buffer), numberOfPixels);
-      }
+      SwapRange<float>(buffer, numberOfPixels, m_ByteOrder);
       break;
-    }
     case IOComponentEnum::DOUBLE:
-    {
-      if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
-      {
-        ByteSwapper<double>::SwapRangeFromSystemToLittleEndian(static_cast<double *>(buffer), numberOfPixels);
-      }
-      else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
-      {
-        ByteSwapper<double>::SwapRangeFromSystemToBigEndian(static_cast<double *>(buffer), numberOfPixels);
-      }
+      SwapRange<double>(buffer, numberOfPixels, m_ByteOrder);
       break;
-    }
     default:
       ExceptionObject exception(__FILE__, __LINE__);
       exception.SetDescription("Pixel Type Unknown");

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -619,6 +619,31 @@ GiplImageIO::SwapBytesIfNecessary(void * buffer, SizeValueType numberOfPixels)
       }
       break;
     }
+    case IOComponentEnum::INT:
+    {
+      if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
+      {
+        ByteSwapper<int>::SwapRangeFromSystemToLittleEndian(static_cast<int *>(buffer), numberOfPixels);
+      }
+      else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
+      {
+        ByteSwapper<int>::SwapRangeFromSystemToBigEndian(static_cast<int *>(buffer), numberOfPixels);
+      }
+      break;
+    }
+    case IOComponentEnum::UINT:
+    {
+      if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
+      {
+        ByteSwapper<unsigned int>::SwapRangeFromSystemToLittleEndian(static_cast<unsigned int *>(buffer),
+                                                                     numberOfPixels);
+      }
+      else if (m_ByteOrder == IOByteOrderEnum::BigEndian)
+      {
+        ByteSwapper<unsigned int>::SwapRangeFromSystemToBigEndian(static_cast<unsigned int *>(buffer), numberOfPixels);
+      }
+      break;
+    }
     case IOComponentEnum::FLOAT:
     {
       if (m_ByteOrder == IOByteOrderEnum::LittleEndian)
@@ -682,6 +707,12 @@ GiplImageIO::Write(const void * buffer)
       break;
     case IOComponentEnum::USHORT:
       image_type = GIPL_U_SHORT;
+      break;
+    case IOComponentEnum::UINT:
+      image_type = GIPL_U_INT;
+      break;
+    case IOComponentEnum::INT:
+      image_type = GIPL_INT;
       break;
     case IOComponentEnum::FLOAT:
       image_type = GIPL_FLOAT;

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -207,35 +207,37 @@ GiplImageIO::Read(void * buffer)
     numberOfPixels *= m_Dimensions[dim];
   }
 
-  auto * p = static_cast<char *>(buffer);
-  bool   success = false;
+  auto *         p = static_cast<char *>(buffer);
+  const SizeType expectedBytes = this->GetImageSizeInBytes();
+  SizeType       bytesRead = 0;
+  bool           success = false;
   if (m_IsCompressed)
   {
     // gzread rejects requests over INT_MAX, so read in chunks and total the byte count in 64 bits.
-    SizeType remaining = this->GetImageSizeInBytes();
-    while (remaining > 0)
+    while (bytesRead < expectedBytes)
     {
-      const auto chunk = static_cast<unsigned int>(std::min(remaining, SizeType{ 1 } << 30));
-      const int  bytesRead = gzread(m_Internal->m_GzFile, p, chunk);
-      if (bytesRead <= 0)
+      const auto chunk = static_cast<unsigned int>(std::min(expectedBytes - bytesRead, SizeType{ 1 } << 30));
+      const int  count = gzread(m_Internal->m_GzFile, p, chunk);
+      if (count <= 0)
       {
         break;
       }
-      p += bytesRead;
-      remaining -= static_cast<SizeType>(bytesRead);
+      p += count;
+      bytesRead += static_cast<SizeType>(count);
     }
-    success = (remaining == 0);
+    success = (bytesRead == expectedBytes);
     gzclose(m_Internal->m_GzFile);
     m_Internal->m_GzFile = nullptr;
   }
   else
   {
-    success = this->ReadBufferAsBinary(m_Ifstream, buffer, this->GetImageSizeInBytes());
+    success = this->ReadBufferAsBinary(m_Ifstream, buffer, expectedBytes);
+    bytesRead = static_cast<SizeType>(std::max(m_Ifstream.gcount(), std::streamsize{ 0 }));
     m_Ifstream.close();
   }
   if (!success)
   {
-    itkExceptionStringMacro("Error reading image data.");
+    itkExceptionMacro("Error reading image data: read " << bytesRead << " of " << expectedBytes << " expected bytes.");
   }
 
   SwapBytesIfNecessary(buffer, numberOfPixels);

--- a/Modules/IO/GIPL/src/itkGiplImageIO.cxx
+++ b/Modules/IO/GIPL/src/itkGiplImageIO.cxx
@@ -199,12 +199,12 @@ GiplImageIO::CanWriteFile(const char * name)
 void
 GiplImageIO::Read(void * buffer)
 {
-  const uint32_t dimensions = this->GetNumberOfDimensions();
-  uint32_t       numberOfPixels = 1;
+  const unsigned int dimensions = this->GetNumberOfDimensions();
+  SizeValueType      numberOfPixels = 1;
 
   for (unsigned int dim = 0; dim < dimensions; ++dim)
   {
-    numberOfPixels *= static_cast<uint32_t>(m_Dimensions[dim]);
+    numberOfPixels *= m_Dimensions[dim];
   }
 
   auto * p = static_cast<char *>(buffer);

--- a/Modules/IO/GIPL/test/CMakeLists.txt
+++ b/Modules/IO/GIPL/test/CMakeLists.txt
@@ -39,3 +39,11 @@ itk_add_test(
   ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/ramp.gipl
 )
+
+set(ITKIOGIPLGTests itkGiplImageIOGTest.cxx)
+creategoogletestdriver(ITKIOGIPL "${ITKIOGIPL-Test_LIBRARIES}" "${ITKIOGIPLGTests}")
+target_compile_definitions(
+  ITKIOGIPLGTestDriver
+  PRIVATE
+    "ITK_TEST_OUTPUT_DIR=${ITK_TEST_OUTPUT_DIR}"
+)

--- a/Modules/IO/GIPL/test/itkGiplImageIOGTest.cxx
+++ b/Modules/IO/GIPL/test/itkGiplImageIOGTest.cxx
@@ -18,8 +18,10 @@
 #include "gtest/gtest.h"
 #include "itkGiplImageIO.h"
 #include "itkImage.h"
+#include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 
+#include <filesystem>
 #include <fstream>
 #include <sstream>
 
@@ -28,6 +30,19 @@
 
 namespace
 {
+using ScalarImageType = itk::Image<unsigned char, 2>;
+
+ScalarImageType::Pointer
+MakeScalarImage(unsigned int side)
+{
+  auto                            image = ScalarImageType::New();
+  const ScalarImageType::SizeType size{ { side, side } };
+  image->SetRegions(ScalarImageType::RegionType(size));
+  image->Allocate();
+  image->FillBuffer(42);
+  return image;
+}
+
 std::string
 OutputPath(const std::string & name)
 {
@@ -64,4 +79,30 @@ TEST(GiplImageIO, WriteOfUnsupportedComponentTypePreservesExistingFile)
   std::ostringstream contents;
   contents << in.rdbuf();
   EXPECT_EQ(contents.str(), originalContents);
+}
+
+TEST(GiplImageIO, ReadOfTruncatedUncompressedFileThrows)
+{
+  const std::string path = OutputPath("gipl_b54_truncated.gipl");
+  auto              image = MakeScalarImage(8);
+
+  auto writerIO = itk::GiplImageIO::New();
+  using WriterType = itk::ImageFileWriter<ScalarImageType>;
+  auto writer = WriterType::New();
+  writer->SetImageIO(writerIO);
+  writer->SetInput(image);
+  writer->SetFileName(path);
+  ASSERT_NO_THROW(writer->Update());
+
+  const auto fullSize = std::filesystem::file_size(path);
+  ASSERT_GT(fullSize, 20u);
+  std::filesystem::resize_file(path, fullSize - 10);
+
+  auto readerIO = itk::GiplImageIO::New();
+  using ReaderType = itk::ImageFileReader<ScalarImageType>;
+  auto reader = ReaderType::New();
+  reader->SetImageIO(readerIO);
+  reader->SetFileName(path);
+
+  EXPECT_THROW(reader->Update(), itk::ExceptionObject);
 }

--- a/Modules/IO/GIPL/test/itkGiplImageIOGTest.cxx
+++ b/Modules/IO/GIPL/test/itkGiplImageIOGTest.cxx
@@ -1,0 +1,67 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "gtest/gtest.h"
+#include "itkGiplImageIO.h"
+#include "itkImage.h"
+#include "itkImageFileWriter.h"
+
+#include <fstream>
+#include <sstream>
+
+#define _STRING(s) #s
+#define TOSTRING(s) std::string(_STRING(s))
+
+namespace
+{
+std::string
+OutputPath(const std::string & name)
+{
+  return TOSTRING(ITK_TEST_OUTPUT_DIR) + "/" + name;
+}
+} // namespace
+
+TEST(GiplImageIO, WriteOfUnsupportedComponentTypePreservesExistingFile)
+{
+  const std::string path = OutputPath("gipl_b53_existing.gipl");
+  const std::string originalContents = "pre-existing data that must survive a failed Gipl write";
+  {
+    std::ofstream out(path, std::ios::binary);
+    out << originalContents;
+  }
+
+  using UnsupportedImageType = itk::Image<unsigned long, 2>;
+  auto                                 image = UnsupportedImageType::New();
+  const UnsupportedImageType::SizeType size{ { 2, 2 } };
+  image->SetRegions(UnsupportedImageType::RegionType(size));
+  image->Allocate();
+  image->FillBuffer(7);
+
+  auto giplIO = itk::GiplImageIO::New();
+  using WriterType = itk::ImageFileWriter<UnsupportedImageType>;
+  auto writer = WriterType::New();
+  writer->SetImageIO(giplIO);
+  writer->SetInput(image);
+  writer->SetFileName(path);
+
+  EXPECT_THROW(writer->Update(), itk::ExceptionObject);
+
+  std::ifstream      in(path, std::ios::binary);
+  std::ostringstream contents;
+  contents << in.rdbuf();
+  EXPECT_EQ(contents.str(), originalContents);
+}

--- a/Modules/IO/GIPL/test/itkGiplImageIOGTest.cxx
+++ b/Modules/IO/GIPL/test/itkGiplImageIOGTest.cxx
@@ -22,6 +22,7 @@
 #include "itkImageFileWriter.h"
 #include "itkVector.h"
 
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -49,6 +50,50 @@ OutputPath(const std::string & name)
 {
   return TOSTRING(ITK_TEST_OUTPUT_DIR) + "/" + name;
 }
+
+template <typename TImage>
+void
+WriteWithGiplIO(TImage * image, const std::string & path)
+{
+  auto writer = itk::ImageFileWriter<TImage>::New();
+  writer->SetImageIO(itk::GiplImageIO::New());
+  writer->SetInput(image);
+  writer->SetFileName(path);
+  ASSERT_NO_THROW(writer->Update());
+}
+
+template <typename TImage>
+void
+ExpectWriteThrows(TImage * image, const std::string & path)
+{
+  auto writer = itk::ImageFileWriter<TImage>::New();
+  writer->SetImageIO(itk::GiplImageIO::New());
+  writer->SetInput(image);
+  writer->SetFileName(path);
+  EXPECT_THROW(writer->Update(), itk::ExceptionObject);
+}
+
+template <typename TImage>
+typename TImage::Pointer
+ReadWithGiplIO(const std::string & path)
+{
+  auto reader = itk::ImageFileReader<TImage>::New();
+  reader->SetImageIO(itk::GiplImageIO::New());
+  reader->SetFileName(path);
+  EXPECT_NO_THROW(reader->Update());
+  return reader->GetOutput();
+}
+
+void
+ExpectTruncatedReadThrows(const std::string & path, const std::uintmax_t truncatedSize)
+{
+  std::filesystem::resize_file(path, truncatedSize);
+
+  auto reader = itk::ImageFileReader<ScalarImageType>::New();
+  reader->SetImageIO(itk::GiplImageIO::New());
+  reader->SetFileName(path);
+  EXPECT_THROW(reader->Update(), itk::ExceptionObject);
+}
 } // namespace
 
 TEST(GiplImageIO, WriteOfUnsupportedComponentTypePreservesExistingFile)
@@ -67,14 +112,7 @@ TEST(GiplImageIO, WriteOfUnsupportedComponentTypePreservesExistingFile)
   image->Allocate();
   image->FillBuffer(7);
 
-  auto giplIO = itk::GiplImageIO::New();
-  using WriterType = itk::ImageFileWriter<UnsupportedImageType>;
-  auto writer = WriterType::New();
-  writer->SetImageIO(giplIO);
-  writer->SetInput(image);
-  writer->SetFileName(path);
-
-  EXPECT_THROW(writer->Update(), itk::ExceptionObject);
+  ExpectWriteThrows(image.GetPointer(), path);
 
   std::ifstream      in(path, std::ios::binary);
   std::ostringstream contents;
@@ -85,53 +123,21 @@ TEST(GiplImageIO, WriteOfUnsupportedComponentTypePreservesExistingFile)
 TEST(GiplImageIO, ReadOfTruncatedUncompressedFileThrows)
 {
   const std::string path = OutputPath("gipl_b54_truncated.gipl");
-  auto              image = MakeScalarImage(8);
-
-  auto writerIO = itk::GiplImageIO::New();
-  using WriterType = itk::ImageFileWriter<ScalarImageType>;
-  auto writer = WriterType::New();
-  writer->SetImageIO(writerIO);
-  writer->SetInput(image);
-  writer->SetFileName(path);
-  ASSERT_NO_THROW(writer->Update());
+  WriteWithGiplIO(MakeScalarImage(8).GetPointer(), path);
 
   const auto fullSize = std::filesystem::file_size(path);
   ASSERT_GT(fullSize, 20u);
-  std::filesystem::resize_file(path, fullSize - 10);
-
-  auto readerIO = itk::GiplImageIO::New();
-  using ReaderType = itk::ImageFileReader<ScalarImageType>;
-  auto reader = ReaderType::New();
-  reader->SetImageIO(readerIO);
-  reader->SetFileName(path);
-
-  EXPECT_THROW(reader->Update(), itk::ExceptionObject);
+  ExpectTruncatedReadThrows(path, fullSize - 10);
 }
 
 TEST(GiplImageIO, ReadOfTruncatedCompressedFileThrows)
 {
   const std::string path = OutputPath("gipl_b55_truncated.gipl.gz");
-  auto              image = MakeScalarImage(8);
-
-  auto writerIO = itk::GiplImageIO::New();
-  using WriterType = itk::ImageFileWriter<ScalarImageType>;
-  auto writer = WriterType::New();
-  writer->SetImageIO(writerIO);
-  writer->SetInput(image);
-  writer->SetFileName(path);
-  ASSERT_NO_THROW(writer->Update());
+  WriteWithGiplIO(MakeScalarImage(8).GetPointer(), path);
 
   const auto fullSize = std::filesystem::file_size(path);
   ASSERT_GT(fullSize, 20u);
-  std::filesystem::resize_file(path, fullSize / 2);
-
-  auto readerIO = itk::GiplImageIO::New();
-  using ReaderType = itk::ImageFileReader<ScalarImageType>;
-  auto reader = ReaderType::New();
-  reader->SetImageIO(readerIO);
-  reader->SetFileName(path);
-
-  EXPECT_THROW(reader->Update(), itk::ExceptionObject);
+  ExpectTruncatedReadThrows(path, fullSize / 2);
 }
 
 TEST(GiplImageIO, WriteOfMultiComponentImageThrows)
@@ -145,16 +151,7 @@ TEST(GiplImageIO, WriteOfMultiComponentImageThrows)
   image->Allocate();
   image->FillBuffer(VectorPixelType({ 1.0f, 2.0f, 3.0f }));
 
-  const std::string path = OutputPath("gipl_b56_vector.gipl");
-
-  auto giplIO = itk::GiplImageIO::New();
-  using WriterType = itk::ImageFileWriter<VectorImageType>;
-  auto writer = WriterType::New();
-  writer->SetImageIO(giplIO);
-  writer->SetInput(image);
-  writer->SetFileName(path);
-
-  EXPECT_THROW(writer->Update(), itk::ExceptionObject);
+  ExpectWriteThrows(image.GetPointer(), OutputPath("gipl_b56_vector.gipl"));
 }
 
 TEST(GiplImageIO, RoundTripsIntAndUnsignedIntComponentTypes)
@@ -178,32 +175,16 @@ TEST(GiplImageIO, RoundTripsIntAndUnsignedIntComponentTypes)
   const std::string intPath = OutputPath("gipl_enh_int.gipl");
   const std::string uintPath = OutputPath("gipl_enh_uint.gipl");
 
-  auto intWriter = itk::ImageFileWriter<IntImageType>::New();
-  intWriter->SetImageIO(itk::GiplImageIO::New());
-  intWriter->SetInput(intImage);
-  intWriter->SetFileName(intPath);
-  ASSERT_NO_THROW(intWriter->Update());
+  WriteWithGiplIO(intImage.GetPointer(), intPath);
+  WriteWithGiplIO(uintImage.GetPointer(), uintPath);
 
-  auto uintWriter = itk::ImageFileWriter<UIntImageType>::New();
-  uintWriter->SetImageIO(itk::GiplImageIO::New());
-  uintWriter->SetInput(uintImage);
-  uintWriter->SetFileName(uintPath);
-  ASSERT_NO_THROW(uintWriter->Update());
-
-  auto intReader = itk::ImageFileReader<IntImageType>::New();
-  intReader->SetImageIO(itk::GiplImageIO::New());
-  intReader->SetFileName(intPath);
-  ASSERT_NO_THROW(intReader->Update());
-
-  auto uintReader = itk::ImageFileReader<UIntImageType>::New();
-  uintReader->SetImageIO(itk::GiplImageIO::New());
-  uintReader->SetFileName(uintPath);
-  ASSERT_NO_THROW(uintReader->Update());
+  const auto intRead = ReadWithGiplIO<IntImageType>(intPath);
+  const auto uintRead = ReadWithGiplIO<UIntImageType>(uintPath);
 
   const auto numberOfPixels = intImage->GetPixelContainer()->Size();
   for (unsigned int i = 0; i < numberOfPixels; ++i)
   {
-    EXPECT_EQ(intImage->GetBufferPointer()[i], intReader->GetOutput()->GetBufferPointer()[i]);
-    EXPECT_EQ(uintImage->GetBufferPointer()[i], uintReader->GetOutput()->GetBufferPointer()[i]);
+    EXPECT_EQ(intImage->GetBufferPointer()[i], intRead->GetBufferPointer()[i]);
+    EXPECT_EQ(uintImage->GetBufferPointer()[i], uintRead->GetBufferPointer()[i]);
   }
 }

--- a/Modules/IO/GIPL/test/itkGiplImageIOGTest.cxx
+++ b/Modules/IO/GIPL/test/itkGiplImageIOGTest.cxx
@@ -156,3 +156,54 @@ TEST(GiplImageIO, WriteOfMultiComponentImageThrows)
 
   EXPECT_THROW(writer->Update(), itk::ExceptionObject);
 }
+
+TEST(GiplImageIO, RoundTripsIntAndUnsignedIntComponentTypes)
+{
+  using IntImageType = itk::Image<int, 2>;
+  using UIntImageType = itk::Image<unsigned int, 2>;
+  const IntImageType::SizeType size{ { 3, 3 } };
+
+  auto intImage = IntImageType::New();
+  intImage->SetRegions(IntImageType::RegionType(size));
+  intImage->Allocate();
+  intImage->FillBuffer(-70000);
+  intImage->GetBufferPointer()[1] = 123456;
+
+  auto uintImage = UIntImageType::New();
+  uintImage->SetRegions(UIntImageType::RegionType(size));
+  uintImage->Allocate();
+  uintImage->FillBuffer(3000000000u);
+  uintImage->GetBufferPointer()[1] = 654321u;
+
+  const std::string intPath = OutputPath("gipl_enh_int.gipl");
+  const std::string uintPath = OutputPath("gipl_enh_uint.gipl");
+
+  auto intWriter = itk::ImageFileWriter<IntImageType>::New();
+  intWriter->SetImageIO(itk::GiplImageIO::New());
+  intWriter->SetInput(intImage);
+  intWriter->SetFileName(intPath);
+  ASSERT_NO_THROW(intWriter->Update());
+
+  auto uintWriter = itk::ImageFileWriter<UIntImageType>::New();
+  uintWriter->SetImageIO(itk::GiplImageIO::New());
+  uintWriter->SetInput(uintImage);
+  uintWriter->SetFileName(uintPath);
+  ASSERT_NO_THROW(uintWriter->Update());
+
+  auto intReader = itk::ImageFileReader<IntImageType>::New();
+  intReader->SetImageIO(itk::GiplImageIO::New());
+  intReader->SetFileName(intPath);
+  ASSERT_NO_THROW(intReader->Update());
+
+  auto uintReader = itk::ImageFileReader<UIntImageType>::New();
+  uintReader->SetImageIO(itk::GiplImageIO::New());
+  uintReader->SetFileName(uintPath);
+  ASSERT_NO_THROW(uintReader->Update());
+
+  const auto numberOfPixels = intImage->GetPixelContainer()->Size();
+  for (unsigned int i = 0; i < numberOfPixels; ++i)
+  {
+    EXPECT_EQ(intImage->GetBufferPointer()[i], intReader->GetOutput()->GetBufferPointer()[i]);
+    EXPECT_EQ(uintImage->GetBufferPointer()[i], uintReader->GetOutput()->GetBufferPointer()[i]);
+  }
+}

--- a/Modules/IO/GIPL/test/itkGiplImageIOGTest.cxx
+++ b/Modules/IO/GIPL/test/itkGiplImageIOGTest.cxx
@@ -20,6 +20,7 @@
 #include "itkImage.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkVector.h"
 
 #include <filesystem>
 #include <fstream>
@@ -131,4 +132,27 @@ TEST(GiplImageIO, ReadOfTruncatedCompressedFileThrows)
   reader->SetFileName(path);
 
   EXPECT_THROW(reader->Update(), itk::ExceptionObject);
+}
+
+TEST(GiplImageIO, WriteOfMultiComponentImageThrows)
+{
+  using VectorPixelType = itk::Vector<float, 3>;
+  using VectorImageType = itk::Image<VectorPixelType, 2>;
+
+  auto                            image = VectorImageType::New();
+  const VectorImageType::SizeType size{ { 4, 4 } };
+  image->SetRegions(VectorImageType::RegionType(size));
+  image->Allocate();
+  image->FillBuffer(VectorPixelType({ 1.0f, 2.0f, 3.0f }));
+
+  const std::string path = OutputPath("gipl_b56_vector.gipl");
+
+  auto giplIO = itk::GiplImageIO::New();
+  using WriterType = itk::ImageFileWriter<VectorImageType>;
+  auto writer = WriterType::New();
+  writer->SetImageIO(giplIO);
+  writer->SetInput(image);
+  writer->SetFileName(path);
+
+  EXPECT_THROW(writer->Update(), itk::ExceptionObject);
 }

--- a/Modules/IO/GIPL/test/itkGiplImageIOGTest.cxx
+++ b/Modules/IO/GIPL/test/itkGiplImageIOGTest.cxx
@@ -106,3 +106,29 @@ TEST(GiplImageIO, ReadOfTruncatedUncompressedFileThrows)
 
   EXPECT_THROW(reader->Update(), itk::ExceptionObject);
 }
+
+TEST(GiplImageIO, ReadOfTruncatedCompressedFileThrows)
+{
+  const std::string path = OutputPath("gipl_b55_truncated.gipl.gz");
+  auto              image = MakeScalarImage(8);
+
+  auto writerIO = itk::GiplImageIO::New();
+  using WriterType = itk::ImageFileWriter<ScalarImageType>;
+  auto writer = WriterType::New();
+  writer->SetImageIO(writerIO);
+  writer->SetInput(image);
+  writer->SetFileName(path);
+  ASSERT_NO_THROW(writer->Update());
+
+  const auto fullSize = std::filesystem::file_size(path);
+  ASSERT_GT(fullSize, 20u);
+  std::filesystem::resize_file(path, fullSize / 2);
+
+  auto readerIO = itk::GiplImageIO::New();
+  using ReaderType = itk::ImageFileReader<ScalarImageType>;
+  auto reader = ReaderType::New();
+  reader->SetImageIO(readerIO);
+  reader->SetFileName(path);
+
+  EXPECT_THROW(reader->Update(), itk::ExceptionObject);
+}


### PR DESCRIPTION
`GiplImageIO` truncates the target file before validating the write, and reports truncated reads as success. Addresses B53–B56 of #6575, plus the INT/UINT support the B53 investigation turned up.

<details>
<summary>The five commits</summary>

- **B53 — destroys existing data.** `Write()` opened (and truncated) the output file and wrote the 256-byte header *before* the `switch (m_ComponentType)` that decides `image_type`. An unsupported component type threw only after the target was already destroyed, leaving a 256-byte stub where a valid image used to be. The switch now runs before the file is opened.
- **B54 — truncated read reports success.** The uncompressed `Read()` tested `success = !m_Ifstream.bad()`. A short read sets `failbit`/`eofbit`, never `badbit`, so a truncated file "succeeded" over an uninitialized buffer tail. Now compares `gcount()` against `GetImageSizeInBytes()`.
- **B55 — same, compressed path.** `success = (p != nullptr)` on the caller's always-non-null output buffer, with `gzread`'s byte count discarded. Now checks the returned count.
- **B56 — vector images write a corrupt file.** `image_type` came from the component type alone while the byte count multiplied by the component count, so an N-component image wrote a scalar header followed by N times the pixel bytes. GIPL's header has no component-count field and `ReadImageInformation()` hardcodes `SCALAR`, so the format cannot represent a vector pixel at all — a multi-component write is now rejected before any file I/O rather than encoded lossily.
- **ENH — INT/UINT support.** The B53 investigation found `Write()`'s switch already emitted `GIPL_INT` (32) and `GIPL_U_INT` (31), but `SwapBytesIfNecessary()` had no arms for them, so an `int` image threw "Pixel Type Unknown" from deep inside `Write()`. The two gates disagreed, and that disagreement is what let INT/UINT reach the destructive late throw. The codes exist in the format, so the missing swap arms are added rather than the types declared unsupported. Kept as a separate `ENH:` commit so the four `BUG:` commits stay honest — with only the B53 commit applied, an `int` write still throws, but without destroying the file.

</details>

<details>
<summary>Local validation</summary>

New GoogleTest `itkGiplImageIOGTest.cxx` (the module had no GTest driver). Fixtures are written by the test itself — no ExternalData added.

| Test | Item | Fail-before | Pass-after |
|---|---|---|---|
| `WriteOfUnsupportedComponentTypePreservesExistingFile` | B53 | existing file became a 256-byte stub | file intact after the throw |
| `ReadOfTruncatedUncompressedFileThrows` | B54 | no throw, uninitialized tail | throws |
| `ReadOfTruncatedCompressedFileThrows` | B55 | no throw | throws |
| `WriteOfMultiComponentImageThrows` | B56 | wrote a corrupt scalar-header file | throws |
| `RoundTripsIntAndUnsignedIntComponentTypes` | ENH | n/a | passes |

`ctest -R Gipl` with ExternalData fetched, at `main` and at the branch tip: `itkGiplImageIOTest`, `itkGiplImageIOGzTest`, `itkGiplImageIOTest2` all **Passed at both states**. Those three exercise the normal (non-truncated) compressed and uncompressed round-trip against the real `ramp.gipl` fixture, which is exactly what the new byte-count checks could have broken — they do not misfire on valid data.

</details>

<details>
<summary>Adjacent gap found, not fixed here</summary>

`ReadImageInformation()` reads all 15 header fields through unchecked `gzread` / `ifstream::read` pairs, and `CanReadFile()`'s magic-number probe is unchecked too. That is the same silent-corruption class as B54/B55 but a different shape — no success flag is computed at all, so there is nothing to correct locally; it wants its own change (read the 256-byte header in one call and check the count once). Flagged on #6575 rather than folded in.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the B53–B56 analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
