### PR TITLE
BUG: Guard NormalizedCorrelationImageFilter zero-variance NaN

### DIFF
--- a/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
@@ -121,6 +121,21 @@ NormalizedCorrelationImageFilter<TInputImage, TMaskImage, TOutputImage, TOperato
   //
   const double k = std * std::sqrt(num - 1.0);
 
+  // A zero-variance (constant) template has no defined direction to normalize
+  // toward and correlates to zero everywhere; cancellation in the variance can
+  // round slightly negative, making k NaN, so test !(k > 0).
+  if (!(k > 0.0))
+  {
+    OutputImageType *     zeroOutput = this->GetOutput();
+    TotalProgressReporter zeroProgress(this, zeroOutput->GetRequestedRegion().GetNumberOfPixels());
+    for (ImageRegionIterator<OutputImageType> it(zeroOutput, outputRegionForThread); !it.IsAtEnd(); ++it)
+    {
+      it.Set(OutputPixelType{});
+    }
+    zeroProgress.Completed(outputRegionForThread.GetNumberOfPixels());
+    return;
+  }
+
   // normalize the template
   {
     typename OutputNeighborhoodType::ConstIterator tIt = this->GetOperator().Begin();
@@ -189,7 +204,7 @@ NormalizedCorrelationImageFilter<TInputImage, TMaskImage, TOutputImage, TOperato
         }
         OutputPixelRealType denominator = std::sqrt(sumOfSquares - (sum * sum / realTemplateSize));
 
-        it.Value() = numerator / denominator;
+        it.Value() = (denominator > OutputPixelRealType{}) ? numerator / denominator : zero;
 
         ++bit;
         ++it;
@@ -225,7 +240,7 @@ NormalizedCorrelationImageFilter<TInputImage, TMaskImage, TOutputImage, TOperato
           }
           OutputPixelRealType denominator = std::sqrt(sumOfSquares - (sum * sum / realTemplateSize));
 
-          it.Value() = numerator / denominator;
+          it.Value() = (denominator > OutputPixelRealType{}) ? numerator / denominator : zero;
         }
         else
         {

--- a/Modules/Filtering/Convolution/itk-module.cmake
+++ b/Modules/Filtering/Convolution/itk-module.cmake
@@ -14,6 +14,7 @@ itk_module(
     ITKImageIntensity
     ITKThresholding
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKImageSources
   DESCRIPTION "${DOCUMENTATION}"

--- a/Modules/Filtering/Convolution/test/CMakeLists.txt
+++ b/Modules/Filtering/Convolution/test/CMakeLists.txt
@@ -755,3 +755,7 @@ itk_add_test(
   ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/itkFFTConvolutionImageFilterStreamingValidTestOutput.mha
 )
+
+set(ITKConvolutionGTests itkNormalizedCorrelationImageFilterGTest.cxx)
+
+creategoogletestdriver(ITKConvolution "${ITKConvolution-Test_LIBRARIES}" "${ITKConvolutionGTests}")

--- a/Modules/Filtering/Convolution/test/itkNormalizedCorrelationImageFilterGTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkNormalizedCorrelationImageFilterGTest.cxx
@@ -1,0 +1,199 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// First include the header file to be tested:
+#include "itkNormalizedCorrelationImageFilter.h"
+
+#include "itkImage.h"
+#include "itkImageRegionConstIterator.h"
+#include "itkImageRegionIterator.h"
+
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+constexpr unsigned int Dimension = 2;
+using PixelType = float;
+using ImageType = itk::Image<PixelType, Dimension>;
+using FilterType = itk::NormalizedCorrelationImageFilter<ImageType, ImageType, ImageType>;
+using NeighborhoodType = FilterType::OutputNeighborhoodType;
+
+using DoubleImageType = itk::Image<double, Dimension>;
+using DoubleFilterType = itk::NormalizedCorrelationImageFilter<DoubleImageType, DoubleImageType, DoubleImageType>;
+using DoubleNeighborhoodType = DoubleFilterType::OutputNeighborhoodType;
+
+// Constant double whose 9-term sum-of-squares cancellation rounds negative, driving sqrt to NaN.
+constexpr double cancellationProneValue = 536680.0128080135;
+
+template <typename TImage = ImageType>
+itk::SmartPointer<TImage>
+MakeImage(typename TImage::PixelType fillValue)
+{
+  const typename TImage::SizeType size = { { 6, 6 } };
+  typename TImage::RegionType     region;
+  region.SetSize(size);
+
+  auto image = TImage::New();
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(fillValue);
+  return image;
+}
+
+template <typename TImage>
+void
+ExpectFiniteZeroOutput(const TImage & output)
+{
+  for (itk::ImageRegionConstIterator<TImage> it(&output, output.GetLargestPossibleRegion()); !it.IsAtEnd(); ++it)
+  {
+    EXPECT_FALSE(std::isnan(it.Get()));
+    EXPECT_EQ(it.Get(), typename TImage::PixelType{});
+  }
+}
+} // namespace
+
+TEST(NormalizedCorrelationImageFilterGTest, ConstantTemplateProducesFiniteZeroOutput)
+{
+  const auto image = MakeImage(0.0f);
+  float      value = 0.0f;
+  for (itk::ImageRegionIterator<ImageType> it(image, image->GetLargestPossibleRegion()); !it.IsAtEnd(); ++it, ++value)
+  {
+    it.Set(value);
+  }
+
+  NeighborhoodType constantTemplate;
+  constantTemplate.SetRadius(1);
+  for (unsigned int i = 0; i < constantTemplate.Size(); ++i)
+  {
+    constantTemplate[i] = 1.0f;
+  }
+
+  const auto filter = FilterType::New();
+  filter->SetInput(image);
+  filter->SetTemplate(constantTemplate);
+  filter->Update();
+
+  ExpectFiniteZeroOutput(*filter->GetOutput());
+}
+
+TEST(NormalizedCorrelationImageFilterGTest, ConstantNeighborhoodProducesFiniteZeroOutput)
+{
+  const auto image = MakeImage(5.0f);
+
+  NeighborhoodType varyingTemplate;
+  varyingTemplate.SetRadius(1);
+  for (unsigned int i = 0; i < varyingTemplate.Size(); ++i)
+  {
+    varyingTemplate[i] = static_cast<PixelType>(i);
+  }
+
+  const auto filter = FilterType::New();
+  filter->SetInput(image);
+  filter->SetTemplate(varyingTemplate);
+  filter->Update();
+
+  ExpectFiniteZeroOutput(*filter->GetOutput());
+}
+
+TEST(NormalizedCorrelationImageFilterGTest, ConstantNeighborhoodUnderMaskProducesFiniteZeroOutput)
+{
+  const auto image = MakeImage(5.0f);
+  const auto mask = MakeImage(1.0f);
+
+  NeighborhoodType varyingTemplate;
+  varyingTemplate.SetRadius(1);
+  for (unsigned int i = 0; i < varyingTemplate.Size(); ++i)
+  {
+    varyingTemplate[i] = static_cast<PixelType>(i);
+  }
+
+  const auto filter = FilterType::New();
+  filter->SetInput(image);
+  filter->SetTemplate(varyingTemplate);
+  filter->SetMaskImage(mask);
+  filter->Update();
+
+  ExpectFiniteZeroOutput(*filter->GetOutput());
+}
+
+TEST(NormalizedCorrelationImageFilterGTest, CancellationNaNTemplateProducesFiniteZeroOutput)
+{
+  const auto image = MakeImage<DoubleImageType>(0.0);
+  double     value = 0.0;
+  for (itk::ImageRegionIterator<DoubleImageType> it(image, image->GetLargestPossibleRegion()); !it.IsAtEnd();
+       ++it, ++value)
+  {
+    it.Set(value);
+  }
+
+  DoubleNeighborhoodType constantTemplate;
+  constantTemplate.SetRadius(1);
+  for (unsigned int i = 0; i < constantTemplate.Size(); ++i)
+  {
+    constantTemplate[i] = cancellationProneValue;
+  }
+
+  const auto filter = DoubleFilterType::New();
+  filter->SetInput(image);
+  filter->SetTemplate(constantTemplate);
+  filter->Update();
+
+  ExpectFiniteZeroOutput(*filter->GetOutput());
+}
+
+TEST(NormalizedCorrelationImageFilterGTest, CancellationNaNNeighborhoodProducesFiniteZeroOutput)
+{
+  const auto image = MakeImage<DoubleImageType>(cancellationProneValue);
+
+  DoubleNeighborhoodType varyingTemplate;
+  varyingTemplate.SetRadius(1);
+  for (unsigned int i = 0; i < varyingTemplate.Size(); ++i)
+  {
+    varyingTemplate[i] = static_cast<double>(i);
+  }
+
+  const auto filter = DoubleFilterType::New();
+  filter->SetInput(image);
+  filter->SetTemplate(varyingTemplate);
+  filter->Update();
+
+  ExpectFiniteZeroOutput(*filter->GetOutput());
+}
+
+TEST(NormalizedCorrelationImageFilterGTest, CancellationNaNNeighborhoodUnderMaskProducesFiniteZeroOutput)
+{
+  const auto image = MakeImage<DoubleImageType>(cancellationProneValue);
+  const auto mask = MakeImage<DoubleImageType>(1.0);
+
+  DoubleNeighborhoodType varyingTemplate;
+  varyingTemplate.SetRadius(1);
+  for (unsigned int i = 0; i < varyingTemplate.Size(); ++i)
+  {
+    varyingTemplate[i] = static_cast<double>(i);
+  }
+
+  const auto filter = DoubleFilterType::New();
+  filter->SetInput(image);
+  filter->SetTemplate(varyingTemplate);
+  filter->SetMaskImage(mask);
+  filter->Update();
+
+  ExpectFiniteZeroOutput(*filter->GetOutput());
+}


### PR DESCRIPTION
`NormalizedCorrelationImageFilter` divides by a norm that is exactly zero for a constant template or a locally-constant neighborhood, producing NaN or Inf. Addresses B46 of #6575.

<details>
<summary>Root cause</summary>

Three unguarded divisions in `itkNormalizedCorrelationImageFilter.hxx`: `/ k` at `:130` (the template norm) and `numerator / denominator` at `:192` and `:228` (the neighborhood norm, duplicated verbatim in the mask and no-mask branches). Each denominator is exactly zero when its signal has zero variance — a constant template, or a neighborhood that falls entirely inside a constant region of the image.

All three now yield the filter's existing `zero` sentinel. That is not a new convention: `origin/main` already returns `zero` for pixels outside the mask ("Not under the mask. Set the normalized correlation to zero."). This routes two more undefined cases through the same sentinel instead of through NaN/Inf. The ambiguity that `0` is also a legitimate correlation value for two orthogonal non-constant signals is pre-existing and unchanged.

</details>

<details>
<summary>Local validation</summary>

New GoogleTest `itkNormalizedCorrelationImageFilterGTest.cxx` (the module had no GTest driver).

- `ConstantTemplateProducesFiniteZeroOutput` — fail-before: `-nan` everywhere. Pass-after: all `0`.
- `ConstantNeighborhoodProducesFiniteZeroOutput` — fail-before: a mix of `-nan` and `inf` (the numerator is not bit-exactly zero after normalization rounding, so `0/0` sometimes resolved to `±inf`). Pass-after: `0`.
- `ConstantNeighborhoodUnderMaskProducesFiniteZeroOutput` — covers the duplicated mask branch. Fail-before: `inf`. Pass-after: `0`.

`ctest -L ITKConvolution` with ExternalData fetched, at `main` and at the branch: 44/45 pass at both, nothing flipped (the one Not Run is `ITKConvolutionKWStyleTest`, whose tool is not built locally). `itkNormalizedCorrelationImageFilterTest`, the only baseline consumer of this filter in the tree, reports `ImageError = 0` at both states — its `sf4.png`/`circle.png` fixture never drives the filter into a zero-variance case, which is consistent with the fact that no existing baseline contains non-finite pixels.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the B46 analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
