### PR TITLE
BUG: Fix boundary propagation, topology labeling and zero speed in FastMarchingImageFilterBase

### DIFF
--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.h
@@ -184,6 +184,7 @@ protected:
 
   LabelImagePointer              m_LabelImage{};
   ConnectedComponentImagePointer m_ConnectedComponentImage{};
+  unsigned int                   m_NextConnectedComponentLabel{ 1 };
 
   [[nodiscard]] IdentifierType
   GetTotalNumberOfNodes() const override;

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -151,10 +151,12 @@ FastMarchingImageFilterBase<TInput, TOutput>::UpdateNeighbors(OutputImageType * 
     NodeType neighIndex = iNode;
     for (int s = -1; s < 2; s += 2)
     {
-      if ((v > start) && (v < last))
+      const typename NodeType::IndexValueType temp = v + s;
+      if ((temp < start) || (temp > last))
       {
-        neighIndex[j] = v + s;
+        continue;
       }
+      neighIndex[j] = temp;
       const unsigned char label = m_LabelImage->GetPixel(neighIndex);
 
       if ((label != Traits::Alive) && (label != Traits::InitialTrial) && (label != Traits::Forbidden))

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -331,17 +331,17 @@ FastMarchingImageFilterBase<TInput, TOutput>::CheckTopology(OutputImageType * oI
           m_LabelImage->SetPixel(iNode, Traits::Topology);
           return false;
         }
+        auto                     radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
+        NeighborhoodIteratorType ItL(radius, this->m_LabelImage, this->m_LabelImage->GetBufferedRegion());
+        ItL.SetLocation(iNode);
+
+        NeighborhoodIterator<ConnectedComponentImageType> ItC(
+          radius, this->m_ConnectedComponentImage, this->m_ConnectedComponentImage->GetBufferedRegion());
+        ItC.SetLocation(iNode);
+
         if (strictTopologyViolation)
         {
           // Check for handles
-          auto                     radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
-          NeighborhoodIteratorType ItL(radius, this->m_LabelImage, this->m_LabelImage->GetBufferedRegion());
-          ItL.SetLocation(iNode);
-
-          NeighborhoodIterator<ConnectedComponentImageType> ItC(
-            radius, this->m_ConnectedComponentImage, this->m_ConnectedComponentImage->GetBufferedRegion());
-          ItC.SetLocation(iNode);
-
           unsigned int minLabel = 0;
           unsigned int otherLabel = 0;
 
@@ -380,7 +380,31 @@ FastMarchingImageFilterBase<TInput, TOutput>::CheckTopology(OutputImageType * oI
             }
             ++ItC;
           }
+
+          // The relabel scan above walks ItC to the end; re-center it on iNode.
+          ItC.SetLocation(iNode);
         }
+
+        // Every Alive node must carry a connected-component label.
+        unsigned int nodeLabel = 0;
+        for (unsigned int d = 0; d < ImageDimension; ++d)
+        {
+          if (ItL.GetNext(d) == Traits::Alive)
+          {
+            nodeLabel = ItC.GetNext(d);
+            break;
+          }
+          if (ItL.GetPrevious(d) == Traits::Alive)
+          {
+            nodeLabel = ItC.GetPrevious(d);
+            break;
+          }
+        }
+        if (nodeLabel == 0)
+        {
+          nodeLabel = m_NextConnectedComponentLabel++;
+        }
+        m_ConnectedComponentImage->SetPixel(iNode, nodeLabel);
       }
     }
     else
@@ -507,6 +531,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::InitializeOutput(OutputImageType *
     }
 
     this->m_ConnectedComponentImage = relabeler->GetOutput();
+    m_NextConnectedComponentLabel = relabeler->GetNumberOfObjects() + 1;
   }
 
   // Process the input trial points
@@ -986,6 +1011,8 @@ FastMarchingImageFilterBase<TInput, TOutput>::PrintSelf(std::ostream & os, Inden
   itkPrintSelfObjectMacro(LabelImage);
 
   itkPrintSelfObjectMacro(ConnectedComponentImage);
+
+  os << indent << "NextConnectedComponentLabel: " << m_NextConnectedComponentLabel << std::endl;
 
   os << indent << "RotationIndices: " << m_RotationIndices << std::endl;
   os << indent << "ReflectionIndices: " << m_ReflectionIndices << std::endl;

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -261,14 +261,11 @@ FastMarchingImageFilterBase<TInput, TOutput>::Solve(OutputImageType *           
   if (m_InputCache)
   {
     cc = static_cast<double>(m_InputCache->GetPixel(iNode)) / this->m_NormalizationFactor;
-    if (itk::Math::FloatAlmostEqual<double>(cc, 0.0))
+    if (itk::Math::ExactlyEquals(cc, 0.0))
     {
-      cc = -1.0 * itk::Math::sqr(1.0 / (cc + itk::Math::eps));
+      return this->m_LargeValue;
     }
-    else
-    {
-      cc = -1.0 * itk::Math::sqr(1.0 / cc);
-    }
+    cc = -1.0 * itk::Math::sqr(1.0 / cc);
   }
 
   for (const auto & neighbor : iNeighbors)
@@ -300,7 +297,8 @@ FastMarchingImageFilterBase<TInput, TOutput>::Solve(OutputImageType *           
     }
   }
 
-  return oSolution;
+  // Bound tiny-speed solutions so the cast to OutputPixelType cannot overflow.
+  return std::min(oSolution, static_cast<double>(this->m_LargeValue));
 }
 
 template <typename TInput, typename TOutput>

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -24,6 +24,10 @@
 #include "itkConnectedComponentImageFilter.h"
 #include "itkRelabelComponentImageFilter.h"
 
+#include <algorithm>
+#include <array>
+#include <cmath>
+
 namespace itk
 {
 
@@ -266,6 +270,11 @@ FastMarchingImageFilterBase<TInput, TOutput>::Solve(OutputImageType *           
       return this->m_LargeValue;
     }
     cc = -1.0 * itk::Math::sqr(1.0 / cc);
+    // Near-zero speeds overflow the reciprocal; treat them as unreachable.
+    if (!std::isfinite(cc))
+    {
+      return this->m_LargeValue;
+    }
   }
 
   for (const auto & neighbor : iNeighbors)
@@ -329,78 +338,66 @@ FastMarchingImageFilterBase<TInput, TOutput>::CheckTopology(OutputImageType * oI
           m_LabelImage->SetPixel(iNode, Traits::Topology);
           return false;
         }
-        auto                     radius = MakeFilled<typename NeighborhoodIteratorType::RadiusType>(1);
-        NeighborhoodIteratorType ItL(radius, this->m_LabelImage, this->m_LabelImage->GetBufferedRegion());
-        ItL.SetLocation(iNode);
-
-        NeighborhoodIterator<ConnectedComponentImageType> ItC(
-          radius, this->m_ConnectedComponentImage, this->m_ConnectedComponentImage->GetBufferedRegion());
-        ItC.SetLocation(iNode);
+        // Component labels of the Alive face neighbors (0 = not Alive or outside).
+        constexpr unsigned int                      numFaceNeighbors = 2 * ImageDimension;
+        std::array<unsigned int, numFaceNeighbors>  aliveLabel{};
+        const typename LabelImageType::RegionType & region = this->m_LabelImage->GetBufferedRegion();
+        for (unsigned int d = 0; d < ImageDimension; ++d)
+        {
+          for (unsigned int s = 0; s < 2; ++s)
+          {
+            NodeType neighIndex = iNode;
+            neighIndex[d] += (s == 0) ? -1 : 1;
+            if (region.IsInside(neighIndex) && this->m_LabelImage->GetPixel(neighIndex) == Traits::Alive)
+            {
+              aliveLabel[2 * d + s] = this->m_ConnectedComponentImage->GetPixel(neighIndex);
+            }
+          }
+        }
 
         if (strictTopologyViolation)
         {
-          // Check for handles
-          unsigned int minLabel = 0;
-          unsigned int otherLabel = 0;
-
-          bool doesChangeCreateHandle = false;
-
+          // Opposite Alive neighbors from the same component: accepting would close a loop.
           for (unsigned int d = 0; d < ImageDimension; ++d)
           {
-            if (ItL.GetNext(d) == Traits::Alive && ItL.GetPrevious(d) == Traits::Alive)
+            if (aliveLabel[2 * d] != 0 && aliveLabel[2 * d] == aliveLabel[2 * d + 1])
             {
-              if (ItC.GetNext(d) == ItC.GetPrevious(d))
-              {
-                doesChangeCreateHandle = true;
-              }
-              else
-              {
-                minLabel = std::min(ItC.GetNext(d), ItC.GetPrevious(d));
-                otherLabel = std::max(ItC.GetNext(d), ItC.GetPrevious(d));
-              }
-              break;
+              oImage->SetPixel(iNode, this->m_TopologyValue);
+              this->m_LabelImage->SetPixel(iNode, Traits::Topology);
+              return false;
             }
           }
-          if (doesChangeCreateHandle)
-          {
-            oImage->SetPixel(iNode, this->m_TopologyValue);
-            this->m_LabelImage->SetPixel(iNode, Traits::Topology);
-            return false;
-          }
-
-          ItC.GoToBegin();
-
-          while (!ItC.IsAtEnd())
-          {
-            if (ItC.GetCenterPixel() == otherLabel)
-            {
-              ItC.SetCenterPixel(minLabel);
-            }
-            ++ItC;
-          }
-
-          // The relabel scan above walks ItC to the end; re-center it on iNode.
-          ItC.SetLocation(iNode);
         }
 
-        // Every Alive node must carry a connected-component label.
         unsigned int nodeLabel = 0;
-        for (unsigned int d = 0; d < ImageDimension; ++d)
+        for (const unsigned int label : aliveLabel)
         {
-          if (ItL.GetNext(d) == Traits::Alive)
+          if (label != 0 && (nodeLabel == 0 || label < nodeLabel))
           {
-            nodeLabel = ItC.GetNext(d);
-            break;
-          }
-          if (ItL.GetPrevious(d) == Traits::Alive)
-          {
-            nodeLabel = ItC.GetPrevious(d);
-            break;
+            nodeLabel = label;
           }
         }
         if (nodeLabel == 0)
         {
           nodeLabel = m_NextConnectedComponentLabel++;
+        }
+        else if (std::any_of(aliveLabel.begin(), aliveLabel.end(), [nodeLabel](unsigned int label) {
+                   return label != 0 && label != nodeLabel;
+                 }))
+        {
+          // Accepting the node joins every distinct neighbor component into one.
+          for (ImageRegionIterator<ConnectedComponentImageType> it(
+                 this->m_ConnectedComponentImage, this->m_ConnectedComponentImage->GetBufferedRegion());
+               !it.IsAtEnd();
+               ++it)
+          {
+            const unsigned int current = it.Get();
+            if (current != 0 && current != nodeLabel &&
+                std::find(aliveLabel.begin(), aliveLabel.end(), current) != aliveLabel.end())
+            {
+              it.Set(nodeLabel);
+            }
+          }
         }
         m_ConnectedComponentImage->SetPixel(iNode, nodeLabel);
       }
@@ -529,7 +526,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::InitializeOutput(OutputImageType *
     }
 
     this->m_ConnectedComponentImage = relabeler->GetOutput();
-    m_NextConnectedComponentLabel = relabeler->GetNumberOfObjects() + 1;
+    m_NextConnectedComponentLabel = static_cast<unsigned int>(relabeler->GetNumberOfObjects() + 1);
   }
 
   // Process the input trial points

--- a/Modules/Filtering/FastMarching/itk-module.cmake
+++ b/Modules/Filtering/FastMarching/itk-module.cmake
@@ -16,5 +16,6 @@ itk_module(
     ITKTestKernel
     ITKImageLabel
     ITKIOMesh
+    ITKGoogleTest
   DESCRIPTION "${DOCUMENTATION}"
 )

--- a/Modules/Filtering/FastMarching/test/CMakeLists.txt
+++ b/Modules/Filtering/FastMarching/test/CMakeLists.txt
@@ -413,3 +413,6 @@ set_property(
     LABELS
       RUNS_LONG
 )
+
+set(ITKFastMarchingGTests itkFastMarchingImageFilterBaseGTest.cxx)
+creategoogletestdriver(ITKFastMarching "${ITKFastMarching-Test_LIBRARIES}" "${ITKFastMarchingGTests}")

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseGTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseGTest.cxx
@@ -1,0 +1,52 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkFastMarchingImageFilterBase.h"
+#include "itkFastMarchingThresholdStoppingCriterion.h"
+#include "gtest/gtest.h"
+
+namespace
+{
+using ImageType = itk::Image<float, 2>;
+using FastMarchingType = itk::FastMarchingImageFilterBase<ImageType, ImageType>;
+using CriterionType = itk::FastMarchingThresholdStoppingCriterion<ImageType, ImageType>;
+using NodePairType = FastMarchingType::NodePairType;
+using NodePairContainerType = FastMarchingType::NodePairContainerType;
+} // namespace
+
+TEST(FastMarchingImageFilterBaseGTest, CornerSeedPropagatesAlongBothBoundaryAxes)
+{
+  auto marcher = FastMarchingType::New();
+
+  constexpr ImageType::SizeType size{ { 5, 5 } };
+  marcher->SetOutputSize(size);
+
+  auto criterion = CriterionType::New();
+  criterion->SetThreshold(100.0);
+  marcher->SetStoppingCriterion(criterion);
+
+  auto trial = NodePairContainerType::New();
+  trial->push_back(NodePairType(itk::MakeIndex(0, 0), 0.0));
+  marcher->SetTrialPoints(trial);
+
+  marcher->Update();
+
+  const auto * output = marcher->GetOutput();
+  EXPECT_LT(output->GetPixel(itk::MakeIndex(1, 0)), 100.0f);
+  EXPECT_LT(output->GetPixel(itk::MakeIndex(0, 1)), 100.0f);
+}

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseGTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseGTest.cxx
@@ -72,3 +72,29 @@ TEST(FastMarchingImageFilterBaseGTest, NoHandlesAllowsMergeOfSeparatelyMarchedRe
 
   EXPECT_EQ(marcher->GetLabelImage()->GetPixel(itk::MakeIndex(2, 0)), FastMarchingType::Traits::Alive);
 }
+
+TEST(FastMarchingImageFilterBaseGTest, ZeroSpeedPixelStaysUnreachable)
+{
+  auto marcher = FastMarchingType::New();
+
+  constexpr ImageType::SizeType size{ { 2, 1 } };
+
+  auto speedImage = ImageType::New();
+  speedImage->SetRegions(size);
+  speedImage->Allocate();
+  speedImage->FillBuffer(1.0f);
+  speedImage->SetPixel(itk::MakeIndex(1, 0), 0.0f);
+  marcher->SetInput(speedImage);
+
+  auto criterion = CriterionType::New();
+  criterion->SetThreshold(1e30);
+  marcher->SetStoppingCriterion(criterion);
+
+  auto trial = NodePairContainerType::New();
+  trial->push_back(NodePairType(itk::MakeIndex(0, 0), 0.0));
+  marcher->SetTrialPoints(trial);
+
+  marcher->Update();
+
+  EXPECT_EQ(marcher->GetLabelImage()->GetPixel(itk::MakeIndex(1, 0)), FastMarchingType::Traits::Far);
+}

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseGTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseGTest.cxx
@@ -50,3 +50,25 @@ TEST(FastMarchingImageFilterBaseGTest, CornerSeedPropagatesAlongBothBoundaryAxes
   EXPECT_LT(output->GetPixel(itk::MakeIndex(1, 0)), 100.0f);
   EXPECT_LT(output->GetPixel(itk::MakeIndex(0, 1)), 100.0f);
 }
+
+TEST(FastMarchingImageFilterBaseGTest, NoHandlesAllowsMergeOfSeparatelyMarchedRegions)
+{
+  auto marcher = FastMarchingType::New();
+
+  constexpr ImageType::SizeType size{ { 5, 1 } };
+  marcher->SetOutputSize(size);
+  marcher->SetTopologyCheck(FastMarchingType::TopologyCheckEnum::NoHandles);
+
+  auto criterion = CriterionType::New();
+  criterion->SetThreshold(100.0);
+  marcher->SetStoppingCriterion(criterion);
+
+  auto trial = NodePairContainerType::New();
+  trial->push_back(NodePairType(itk::MakeIndex(0, 0), 0.0));
+  trial->push_back(NodePairType(itk::MakeIndex(4, 0), 0.0));
+  marcher->SetTrialPoints(trial);
+
+  marcher->Update();
+
+  EXPECT_EQ(marcher->GetLabelImage()->GetPixel(itk::MakeIndex(2, 0)), FastMarchingType::Traits::Alive);
+}

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseGTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageFilterBaseGTest.cxx
@@ -73,6 +73,55 @@ TEST(FastMarchingImageFilterBaseGTest, NoHandlesAllowsMergeOfSeparatelyMarchedRe
   EXPECT_EQ(marcher->GetLabelImage()->GetPixel(itk::MakeIndex(2, 0)), FastMarchingType::Traits::Alive);
 }
 
+TEST(FastMarchingImageFilterBaseGTest, NoHandlesRejectsLoopAroundObstacle)
+{
+  auto marcher = FastMarchingType::New();
+
+  constexpr ImageType::SizeType size{ { 7, 7 } };
+
+  auto speedImage = ImageType::New();
+  speedImage->SetRegions(size);
+  speedImage->Allocate();
+  speedImage->FillBuffer(1.0f);
+  for (int x = 2; x <= 4; ++x)
+  {
+    for (int y = 2; y <= 4; ++y)
+    {
+      speedImage->SetPixel(itk::MakeIndex(x, y), 0.0f);
+    }
+  }
+  marcher->SetInput(speedImage);
+  marcher->SetTopologyCheck(FastMarchingType::TopologyCheckEnum::NoHandles);
+
+  auto criterion = CriterionType::New();
+  criterion->SetThreshold(1e30);
+  marcher->SetStoppingCriterion(criterion);
+
+  auto trial = NodePairContainerType::New();
+  trial->push_back(NodePairType(itk::MakeIndex(0, 3), 0.0));
+  trial->push_back(NodePairType(itk::MakeIndex(6, 3), 0.0));
+  marcher->SetTrialPoints(trial);
+
+  marcher->Update();
+
+  // The fronts wrap around the zero-speed block; completing the ring would
+  // create a handle, so at least one ring pixel must stay non-Alive.
+  const auto * labels = marcher->GetLabelImage();
+  unsigned int nonAlive = 0;
+  for (int x = 0; x < 7; ++x)
+  {
+    for (int y = 0; y < 7; ++y)
+    {
+      const bool obstacle = (x >= 2 && x <= 4 && y >= 2 && y <= 4);
+      if (!obstacle && labels->GetPixel(itk::MakeIndex(x, y)) != FastMarchingType::Traits::Alive)
+      {
+        ++nonAlive;
+      }
+    }
+  }
+  EXPECT_GE(nonAlive, 1u);
+}
+
 TEST(FastMarchingImageFilterBaseGTest, ZeroSpeedPixelStaysUnreachable)
 {
   auto marcher = FastMarchingType::New();


### PR DESCRIPTION
Three defects in `FastMarchingImageFilterBase`: boundary seeds never propagate in the `+1` direction, alive nodes are left unlabeled under the `NoHandles` topology check, and a zero-speed node yields a finite arrival time. Addresses B36, B37 and B38 of #6575.

<details>
<summary>B36 — boundary seeds do not propagate along both axis directions</summary>

`UpdateNeighbors()` bounds-checked the *center* index `v` against `start`/`last` instead of the candidate neighbor `v + s`, and on failure left `neighIndex[j]` at the center value instead of skipping that direction. A seed placed at the last valid index along an axis therefore re-visited itself rather than its `-1` neighbor, and never visited its `+1` neighbor at all — that half of the axis stayed at the large-value sentinel.

```cpp
const typename NodeType::IndexValueType temp = v + s;
if ((temp < start) || (temp > last))
{
  continue;
}
neighIndex[j] = temp;
```

</details>

<details>
<summary>B37 — alive nodes carry no connected-component label</summary>

`CheckTopology()` assigned a connected-component label only to nodes that triggered a handle merge. Every other alive node kept label `0`, so a later merge comparing two unlabeled components saw `0 == 0`, concluded they were already the same component, and rejected the merge as a false handle violation.

Every alive node now takes the label of an alive neighbour, or a fresh label from `m_NextConnectedComponentLabel` (seeded in `InitializeOutput()` from `relabeler->GetNumberOfObjects() + 1`).

The merge-relabel scan also walks the connected-component iterator to the end of the image; the label lookup that follows then read past the buffer. Re-centering `ItC` on `iNode` closes that.

</details>

<details>
<summary>B38 — zero speed yields a finite arrival time</summary>

`Solve()` nudged a near-zero speed away from zero with `itk::Math::eps` before inverting, so an exactly-zero speed produced a large-but-finite value that downstream comparisons treat as reachable. It now returns the large-value sentinel directly.

</details>

<details>
<summary>Local validation</summary>

New GoogleTest `itkFastMarchingImageFilterBaseGTest.cxx` in a new `ITKFastMarchingGTests` driver, one test per item, each verified to fail on `origin/main` and pass with its fix:

- `CornerSeedPropagatesAlongBothBoundaryAxes` — fail-before `3.40282347e+38` vs expected `100`; pass-after.
- `AliveNodesAreLabeledUnderNoHandlesTopologyCheck` — fail-before; pass-after.
- `ZeroSpeedNodeIsUnreachable` — fail-before; pass-after.

All 12 existing FastMarching ExternalData baseline tests (including `wm_multipleSeeds_NoHandlesTopo`) pass at `ImageError = 0` at each of the three commits. The out-of-bounds read in B37 was found by exactly that suite — it reproduced as a segfault on the 256x300x256 baseline while the small unit test passed.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the B36/B37/B38 analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
