### PR TITLE
BUG: Validate PNG pixel type and component count before truncating the output file

### DIFF
--- a/Modules/IO/PNG/itk-module.cmake
+++ b/Modules/IO/PNG/itk-module.cmake
@@ -12,6 +12,7 @@ itk_module(
   PRIVATE_DEPENDS
     ITKPNG
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
   FACTORY_NAMES
     ImageIO::PNG

--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -525,6 +525,12 @@ PNGImageIO::WriteSlice(const std::string & fileName, const void * const buffer)
       itkExceptionMacro("PNG supports unsigned char and unsigned short");
   }
 
+  const unsigned int numComp = this->GetNumberOfComponents();
+  if (numComp < 1 || numComp > 4)
+  {
+    itkExceptionMacro("PNG supports 1 to 4 components per pixel");
+  }
+
   // use this class so return will call close
   const PNGFileWrapper pngfp(fileName.c_str(), "wb");
   FILE *               fp = pngfp.m_FilePointer;
@@ -556,8 +562,7 @@ PNGImageIO::WriteSlice(const std::string & fileName, const void * const buffer)
                                                             << "Reason: " << itksys::SystemTools::GetLastSystemError());
   }
 
-  int                colorType = 0;
-  const unsigned int numComp = this->GetNumberOfComponents();
+  int colorType = 0;
   switch (numComp)
   {
     case 1:
@@ -576,7 +581,7 @@ PNGImageIO::WriteSlice(const std::string & fileName, const void * const buffer)
     case 3:
       colorType = PNG_COLOR_TYPE_RGB;
       break;
-    default:
+    case 4:
       colorType = PNG_COLOR_TYPE_RGB_ALPHA;
       break;
   }

--- a/Modules/IO/PNG/src/itkPNGImageIO.cxx
+++ b/Modules/IO/PNG/src/itkPNGImageIO.cxx
@@ -510,23 +510,6 @@ PNGImageIO::Write(const void * buffer)
 void
 PNGImageIO::WriteSlice(const std::string & fileName, const void * const buffer)
 {
-  // use this class so return will call close
-  const PNGFileWrapper pngfp(fileName.c_str(), "wb");
-  FILE *               fp = pngfp.m_FilePointer;
-
-  if (!fp)
-  {
-    // IMPORTANT: The itkExceptionMacro() cannot be used here due to a bug in
-    // Visual
-    //            Studio 7.1 in release mode. That compiler will corrupt the
-    // RTTI type
-    //            of the Exception and prevent the catch() from recognizing it.
-    //            For details, see Bug #1872 in the bugtracker.
-
-    itk::ExceptionObject excp(__FILE__, __LINE__, "Problem while opening the file.", ITK_LOCATION);
-    throw excp;
-  }
-
   volatile int bitDepth = 0;
   switch (this->GetComponentType())
   {
@@ -539,17 +522,16 @@ PNGImageIO::WriteSlice(const std::string & fileName, const void * const buffer)
       break;
 
     default:
-    {
-      // IMPORTANT: The itkExceptionMacro() cannot be used here due to a bug in
-      // Visual
-      //            Studio 7.1 in release mode. That compiler will corrupt the
-      // RTTI type
-      //            of the Exception and prevent the catch() from recognizing
-      // it.
-      //            For details, see Bug #1872 in the bugtracker.
-      itk::ExceptionObject excp(__FILE__, __LINE__, "PNG supports unsigned char and unsigned short", ITK_LOCATION);
-      throw excp;
-    }
+      itkExceptionMacro("PNG supports unsigned char and unsigned short");
+  }
+
+  // use this class so return will call close
+  const PNGFileWrapper pngfp(fileName.c_str(), "wb");
+  FILE *               fp = pngfp.m_FilePointer;
+
+  if (!fp)
+  {
+    itkExceptionMacro("Problem while opening the file.");
   }
 
   png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, (png_voidp) nullptr, nullptr, nullptr);

--- a/Modules/IO/PNG/test/CMakeLists.txt
+++ b/Modules/IO/PNG/test/CMakeLists.txt
@@ -224,3 +224,12 @@ itk_add_test(
     itkPNGImageIOTest3
     DATA{Input/corrupted.png}
 )
+
+set(ITKIOPNGGTests itkPNGImageIOGTest.cxx)
+creategoogletestdriver(ITKIOPNG "${ITKIOPNG-Test_LIBRARIES}" "${ITKIOPNGGTests}")
+
+target_compile_definitions(
+  ITKIOPNGGTestDriver
+  PRIVATE
+    "-DITK_TEST_OUTPUT_DIR=${ITK_TEST_OUTPUT_DIR}"
+)

--- a/Modules/IO/PNG/test/itkPNGImageIOGTest.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOGTest.cxx
@@ -1,0 +1,95 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "itkPNGImageIO.h"
+
+#include "itkGTest.h"
+
+#include <fstream>
+#include <iterator>
+#include <vector>
+
+#define _STRING(s) #s
+#define TOSTRING(s) _STRING(s)
+
+namespace
+{
+
+std::string
+MakeOutputPath(const std::string & name)
+{
+  return std::string(TOSTRING(ITK_TEST_OUTPUT_DIR)) + "/" + name;
+}
+
+std::vector<char>
+ReadFileBytes(const std::string & path)
+{
+  std::ifstream ifs(path, std::ios::binary);
+  return std::vector<char>((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+}
+
+itk::PNGImageIO::Pointer
+MakeWriter(const std::string &  path,
+           unsigned int         width,
+           unsigned int         height,
+           itk::IOComponentEnum componentType = itk::IOComponentEnum::UCHAR)
+{
+  auto io = itk::PNGImageIO::New();
+  io->SetFileName(path);
+  io->SetNumberOfDimensions(2);
+  io->SetDimensions(0, width);
+  io->SetDimensions(1, height);
+  io->SetPixelType(itk::IOPixelEnum::SCALAR);
+  io->SetComponentType(componentType);
+  io->SetNumberOfComponents(1);
+  return io;
+}
+
+void
+WriteValidGrayscalePNG(const std::string & path, unsigned int width, unsigned int height)
+{
+  const auto                       io = MakeWriter(path, width, height);
+  const std::vector<unsigned char> buffer(static_cast<size_t>(width) * height, 128);
+  io->Write(buffer.data());
+}
+
+} // namespace
+
+TEST(PNGImageIOWriteSlice, RejectsUnsupportedComponentTypeAndPreservesExistingFile)
+{
+  const std::string path = MakeOutputPath("PNGImageIOWriteSlice_B70.png");
+  WriteValidGrayscalePNG(path, 4, 4);
+  const std::vector<char> before = ReadFileBytes(path);
+  ASSERT_FALSE(before.empty());
+
+  const auto               io = MakeWriter(path, 4, 4, itk::IOComponentEnum::SHORT);
+  const std::vector<short> buffer(4 * 4, 0);
+  EXPECT_THROW(io->Write(buffer.data()), itk::ExceptionObject);
+
+  const std::vector<char> after = ReadFileBytes(path);
+  EXPECT_EQ(before, after);
+
+  const auto readIO = itk::PNGImageIO::New();
+  ASSERT_TRUE(readIO->CanReadFile(path.c_str()));
+  readIO->SetFileName(path);
+  ASSERT_NO_THROW(readIO->ReadImageInformation());
+  EXPECT_EQ(readIO->GetComponentType(), itk::IOComponentEnum::UCHAR);
+
+  std::vector<unsigned char> readBuffer(4 * 4, 0);
+  ASSERT_NO_THROW(readIO->Read(readBuffer.data()));
+  EXPECT_EQ(readBuffer[0], 128);
+}

--- a/Modules/IO/PNG/test/itkPNGImageIOGTest.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOGTest.cxx
@@ -46,16 +46,24 @@ itk::PNGImageIO::Pointer
 MakeWriter(const std::string &  path,
            unsigned int         width,
            unsigned int         height,
-           itk::IOComponentEnum componentType = itk::IOComponentEnum::UCHAR)
+           itk::IOComponentEnum componentType = itk::IOComponentEnum::UCHAR,
+           unsigned int         numComp = 1)
 {
   auto io = itk::PNGImageIO::New();
   io->SetFileName(path);
   io->SetNumberOfDimensions(2);
   io->SetDimensions(0, width);
   io->SetDimensions(1, height);
-  io->SetPixelType(itk::IOPixelEnum::SCALAR);
+  if (numComp > 1)
+  {
+    io->SetPixelType(itk::IOPixelEnum::VECTOR);
+  }
+  else
+  {
+    io->SetPixelType(itk::IOPixelEnum::SCALAR);
+  }
   io->SetComponentType(componentType);
-  io->SetNumberOfComponents(1);
+  io->SetNumberOfComponents(numComp);
   return io;
 }
 
@@ -92,4 +100,19 @@ TEST(PNGImageIOWriteSlice, RejectsUnsupportedComponentTypeAndPreservesExistingFi
   std::vector<unsigned char> readBuffer(4 * 4, 0);
   ASSERT_NO_THROW(readIO->Read(readBuffer.data()));
   EXPECT_EQ(readBuffer[0], 128);
+}
+
+TEST(PNGImageIOWriteSlice, RejectsUnsupportedComponentCountAndPreservesExistingFile)
+{
+  const std::string path = MakeOutputPath("PNGImageIOWriteSlice_B72.png");
+  WriteValidGrayscalePNG(path, 4, 4);
+  const std::vector<char> before = ReadFileBytes(path);
+  ASSERT_FALSE(before.empty());
+
+  const auto                       io = MakeWriter(path, 4, 4, itk::IOComponentEnum::UCHAR, 5);
+  const std::vector<unsigned char> buffer(4 * 4 * 5, 3);
+  EXPECT_THROW(io->Write(buffer.data()), itk::ExceptionObject);
+
+  const std::vector<char> after = ReadFileBytes(path);
+  EXPECT_EQ(before, after);
 }


### PR DESCRIPTION
`PNGImageIO::WriteSlice()` opened (and thus truncated) the output file before validating the component type, and silently mapped any component count above 4 to RGBA. Addresses B70 and B72 of #6575.

<details>
<summary>B70 — the file is destroyed before validation</summary>

`PNGFileWrapper pngfp(fileName.c_str(), "wb")` truncates an existing file the moment it is constructed. The component-type `switch` that rejects unsupported types ran *after* that, so writing an unsupported pixel type over an existing PNG threw an exception and left a zero-byte file behind. The `switch` now runs first; the file is opened only once the pixel type is known to be writable.

</details>

<details>
<summary>B72 — component counts PNG cannot represent</summary>

The `colorType` switch used `default: PNG_COLOR_TYPE_RGB_ALPHA`, so a 5-component image was handed to libpng as RGBA and the extra components were written as adjacent pixel data. The count is now validated (1 to 4) before the file is opened, and the switch ends at `case 4:`.

</details>

<details>
<summary>Local validation</summary>

New GoogleTest `itkPNGImageIOGTest.cxx` in a new `ITKIOPNGGTests` driver. Both tests write a valid PNG first, then attempt the bad write, then assert the original file is still intact — fail-before, pass-after. No new ExternalData; the fixtures are synthesized in the test body.

`ctest -R PNG`: `itkPNGImageIOTest1Grey` and the rest of the locally-runnable set pass unchanged.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the B70/B72 analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
