### PR TITLE
BUG: Use NonpositiveMin for colormap negative-value scaling

### DIFF
--- a/Modules/Filtering/Colormap/include/itkColormapFunction.h
+++ b/Modules/Filtering/Colormap/include/itkColormapFunction.h
@@ -76,7 +76,7 @@ public:
 
 protected:
   ColormapFunction()
-    : m_MinimumInputValue(NumericTraits<TScalar>::min())
+    : m_MinimumInputValue(NumericTraits<TScalar>::NonpositiveMin())
     , m_MaximumInputValue(NumericTraits<TScalar>::max())
     , m_MinimumRGBComponentValue(NumericTraits<RGBComponentType>::min())
     , m_MaximumRGBComponentValue(NumericTraits<RGBComponentType>::max())

--- a/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.hxx
+++ b/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.hxx
@@ -72,7 +72,7 @@ ScalarToRGBColormapImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerat
     ImageRegionConstIterator It(this->GetInput(), this->GetInput()->GetRequestedRegion());
 
     InputImagePixelType minimumValue = NumericTraits<InputImagePixelType>::max();
-    InputImagePixelType maximumValue = NumericTraits<InputImagePixelType>::min();
+    InputImagePixelType maximumValue = NumericTraits<InputImagePixelType>::NonpositiveMin();
 
     for (It.GoToBegin(); !It.IsAtEnd(); ++It)
     {

--- a/Modules/Filtering/Colormap/itk-module.cmake
+++ b/Modules/Filtering/Colormap/itk-module.cmake
@@ -11,5 +11,6 @@ itk_module(
     ITKCommon
   TEST_DEPENDS
     ITKTestKernel
+    ITKGoogleTest
   DESCRIPTION "${DOCUMENTATION}"
 )

--- a/Modules/Filtering/Colormap/test/CMakeLists.txt
+++ b/Modules/Filtering/Colormap/test/CMakeLists.txt
@@ -211,3 +211,7 @@ itk_add_test(
   ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/RGBColormapTest_overunder.png
 )
+
+set(ITKColormapGTests itkScalarToRGBColormapImageFilterGTest.cxx)
+
+creategoogletestdriver(ITKColormap "${ITKColormap-Test_LIBRARIES}" "${ITKColormapGTests}")

--- a/Modules/Filtering/Colormap/test/itkScalarToRGBColormapImageFilterGTest.cxx
+++ b/Modules/Filtering/Colormap/test/itkScalarToRGBColormapImageFilterGTest.cxx
@@ -1,0 +1,65 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkGTest.h"
+
+#include "itkImage.h"
+#include "itkRGBPixel.h"
+#include "itkScalarToRGBColormapImageFilter.h"
+#include "itkGreyColormapFunction.h"
+
+#include <limits>
+
+namespace
+{
+using ImageType = itk::Image<float, 2>;
+using OutputImageType = itk::Image<itk::RGBPixel<unsigned char>, 2>;
+using FilterType = itk::ScalarToRGBColormapImageFilter<ImageType, OutputImageType>;
+} // namespace
+
+TEST(ScalarToRGBColormapImageFilterGTest, NegativeFloatRangeSpansColormap)
+{
+  constexpr float minValue = -1000.0f;
+  constexpr float maxValue = -999.0f;
+
+  auto image = ImageType::New();
+  image->SetRegions(ImageType::SizeType::Filled(2));
+  image->Allocate();
+  image->FillBuffer(maxValue);
+  image->SetPixel(ImageType::IndexType{ { 0, 0 } }, minValue);
+
+  auto filter = FilterType::New();
+  filter->SetInput(image);
+  filter->Update();
+
+  const auto * colormap = filter->GetColormap();
+  EXPECT_EQ(colormap->GetMinimumInputValue(), minValue);
+  EXPECT_EQ(colormap->GetMaximumInputValue(), maxValue);
+
+  const auto & lowOutput = filter->GetOutput()->GetPixel(ImageType::IndexType{ { 0, 0 } });
+  const auto & highOutput = filter->GetOutput()->GetPixel(ImageType::IndexType{ { 1, 0 } });
+  EXPECT_EQ(lowOutput[0], 0);
+  EXPECT_EQ(highOutput[0], 255);
+}
+
+TEST(ScalarToRGBColormapImageFilterGTest, ColormapFunctionDefaultMinimumIsMostNegative)
+{
+  using ColormapType = itk::Function::GreyColormapFunction<float, OutputImageType::PixelType>;
+  auto colormap = ColormapType::New();
+  EXPECT_EQ(colormap->GetMinimumInputValue(), std::numeric_limits<float>::lowest());
+}


### PR DESCRIPTION
`NumericTraits<T>::min()` is the smallest *positive* value for floating-point types, so seeding a colormap's range floor and its running maximum with it discards negative pixel data. Addresses B39 of #6575.

<details>
<summary>Root cause</summary>

`ColormapFunction` initialized `m_MinimumInputValue` to `NumericTraits<TScalar>::min()`, and `ScalarToRGBColormapImageFilter::BeforeThreadedGenerateData()` seeded its running maximum the same way. For `float`/`double` that is `1.17549435e-38`, not `-3.40282347e+38`.

The running maximum is the visible failure: for an all-negative image no pixel ever exceeds the seed, so the maximum stays at the tiny positive seed and the whole image maps to the bottom of the colormap. `NonpositiveMin()` returns the true lower bound for both integer and floating-point types.

</details>

<details>
<summary>Local validation</summary>

New GoogleTest `itkScalarToRGBColormapImageFilterGTest.cxx` in a new `ITKColormapGTests` driver, two cases, both verified to fail on `origin/main` and pass with the fix:

- `NegativeFloatRangeSpansColormap` — fail-before: `GetMaximumInputValue() = 1.17549435e-38` for an all-negative image, so the top of the range maps to component `0` instead of `255`.
- `ColormapFunctionDefaultMinimumIsMostNegative` — fail-before: `GetMinimumInputValue() = 1.17549435e-38`, expected `-3.40282347e+38`.

`ctest -R Colormap` (30 tests, ExternalData fetched): unchanged, all `RGBColormapTest_*` baseline comparisons pass. They use `unsigned char` pixels, where `NonpositiveMin() == min()` — which is why this went unnoticed.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the B39 analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
