### PR TITLE
STYLE: Remove empty lines from member initializer lists of constructors

### DIFF
--- a/Modules/Filtering/AnisotropicDiffusionLBR/include/itkAnisotropicDiffusionLBRImageFilter.hxx
+++ b/Modules/Filtering/AnisotropicDiffusionLBR/include/itkAnisotropicDiffusionLBRImageFilter.hxx
@@ -33,9 +33,7 @@ AnisotropicDiffusionLBRImageFilter<TImage, TScalar>::AnisotropicDiffusionLBRImag
   : m_NoiseScale(0.5)
   , m_FeatureScale(2)
   , m_RatioToMaxStableTimeStep(0.7)
-  ,
-
-  m_DiffusionTime(1)
+  , m_DiffusionTime(1)
 {}
 
 

--- a/Modules/Filtering/AnisotropicDiffusionLBR/include/itkLinearAnisotropicDiffusionLBRImageFilter.hxx
+++ b/Modules/Filtering/AnisotropicDiffusionLBR/include/itkLinearAnisotropicDiffusionLBRImageFilter.hxx
@@ -39,9 +39,7 @@ template <typename TImage, typename TScalar>
 LinearAnisotropicDiffusionLBRImageFilter<TImage, TScalar>::LinearAnisotropicDiffusionLBRImageFilter()
   : m_DiffusionTime(1)
   , m_RatioToMaxStableTimeStep(0.7)
-  ,
-
-  m_EffectiveDiffusionTime(0)
+  , m_EffectiveDiffusionTime(0)
 {
   this->SetNumberOfRequiredInputs(2);
 }

--- a/Modules/Filtering/IsotropicWavelets/include/itkRieszRotationMatrix.hxx
+++ b/Modules/Filtering/IsotropicWavelets/include/itkRieszRotationMatrix.hxx
@@ -28,9 +28,7 @@ template <unsigned int VImageDimension>
 RieszRotationMatrix<VImageDimension>::RieszRotationMatrix()
   : Superclass()
   , m_SpatialRotationMatrix()
-  ,
-
-  m_MaxAbsoluteDifferenceCloseToZero(1 * itk::NumericTraits<RealType>::epsilon())
+  , m_MaxAbsoluteDifferenceCloseToZero(1 * itk::NumericTraits<RealType>::epsilon())
 {}
 
 template <unsigned int VImageDimension>

--- a/Modules/Filtering/MorphologicalContourInterpolation/include/itkMorphologicalContourInterpolator.hxx
+++ b/Modules/Filtering/MorphologicalContourInterpolation/include/itkMorphologicalContourInterpolator.hxx
@@ -82,9 +82,7 @@ MorphologicalContourInterpolator<TImage>::ImagesEqual(typename BoolSliceType::Po
 template <typename TImage>
 MorphologicalContourInterpolator<TImage>::MorphologicalContourInterpolator()
   : m_Label(0)
-  ,
-
-  m_MinAlignIters(std::pow(2., static_cast<int>(TImage::ImageDimension)))
+  , m_MinAlignIters(std::pow(2., static_cast<int>(TImage::ImageDimension)))
   , // smaller of this and pixel count of the search image
   m_MaxAlignIters(std::pow(6., static_cast<int>(TImage::ImageDimension)))
   , // bigger of this and root of pixel count of the search image


### PR DESCRIPTION
Replaced `\r\n  ,\r\n\r\n  ` with `\r\n  , `, using Notepad++ (Search Mode: Extended).

It appears that these unnecessary empty lines were only there in "Filtering".

- Follow-up to pull request #6584 commit 1c9bf10946f1cf5fcb4c2d4978658d4f7609109a