### PR TITLE
BUG: Reject duplicate CTest names; rename ITKIOMeshVTK collision

### DIFF
--- a/CMake/ITKModuleTest.cmake
+++ b/CMake/ITKModuleTest.cmake
@@ -121,6 +121,30 @@ function(itk_add_test)
     set(_iat_testname ${_iat_arg0})
   endif()
 
+  # Duplicate names share the Cleanup_<name> fixture and race under ctest -j.
+  # Remote modules live in separate repositories, so a collision they cause
+  # cannot be fixed in this tree; warn instead of failing the configure.
+  get_property(_iat_dup GLOBAL PROPERTY "ITK_TEST_NAME_${_iat_testname}")
+  if(_iat_dup)
+    if("${CMAKE_CURRENT_LIST_FILE}" MATCHES "/Modules/Remote/")
+      message(
+        AUTHOR_WARNING
+        "Duplicate test name '${_iat_testname}' (already added in ${_iat_dup}); rename it in the remote module."
+      )
+    else()
+      message(
+        FATAL_ERROR
+        "Duplicate test name '${_iat_testname}' (already added in ${_iat_dup})."
+      )
+    endif()
+  endif()
+  set_property(
+    GLOBAL
+    PROPERTY
+      "ITK_TEST_NAME_${_iat_testname}"
+        "${CMAKE_CURRENT_LIST_FILE}"
+  )
+
   if(itk-module)
     set(_label ${itk-module})
     if(TARGET ${itk-module}-all AND "${_iat_args}" MATCHES "DATA{")

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -995,7 +995,7 @@ itk_add_test(
     itkTimeProbeTest
 )
 itk_add_test(
-  NAME itkTimeProbeTest2
+  NAME itkTimeProbeCommonTest2
   COMMAND
     ITKCommon1TestDriver
     itkTimeProbeTest2

--- a/Modules/Core/Mesh/wrapping/test/CMakeLists.txt
+++ b/Modules/Core/Mesh/wrapping/test/CMakeLists.txt
@@ -24,14 +24,6 @@ if(ITK_WRAP_PYTHON)
     EXPRESSION "instance = itk.MeshFileWriter.New()"
   )
   itk_python_expression_add_test(
-    NAME itkOBJMeshIOPythonTest
-    EXPRESSION "instance = itk.OBJMeshIO.New()"
-  )
-  itk_python_expression_add_test(
-    NAME itkOFFMeshIOPythonTest
-    EXPRESSION "instance = itk.OFFMeshIO.New()"
-  )
-  itk_python_expression_add_test(
     NAME itkVTKPolyDataMeshIOPythonTest
     EXPRESSION "instance = itk.VTKPolyDataMeshIO.New()"
   )

--- a/Modules/Filtering/MeshToPolyData/wrapping/test/CMakeLists.txt
+++ b/Modules/Filtering/MeshToPolyData/wrapping/test/CMakeLists.txt
@@ -23,7 +23,7 @@ execute_process(
 if(_have_numpy_return_code EQUAL 0)
   itk_python_add_test(NAME itkPolyLineCellTest COMMAND itkPolyLineCellTest.py)
   itk_python_add_test(
-    NAME itkPyVectorContainerTest
+    NAME itkMeshToPolyDataPyVectorContainerTest
     COMMAND
       ${CMAKE_CURRENT_SOURCE_DIR}/itkPyVectorContainerTest.py
   )

--- a/Modules/IO/MeshVTK/test/CMakeLists.txt
+++ b/Modules/IO/MeshVTK/test/CMakeLists.txt
@@ -23,7 +23,7 @@ itk_add_test(
     ${ITK_TEST_OUTPUT_DIR}/sphere00.vtk
 )
 itk_add_test(
-  NAME itkMeshFileReadWriteTest01
+  NAME itkMeshFileReadWriteVTKTest01
   COMMAND
     ITKIOMeshVTKTestDriver
     itkMeshFileReadWriteTest


### PR DESCRIPTION
Renames the `itkMeshFileReadWriteTest01` name collision between `ITKIOMesh` and `ITKIOMeshVTK`, and makes `itk_add_test` fail the configure when a test name is registered twice.

<details>
<summary>Why duplicate test names are harmful</summary>

CMake permits identical `add_test` names in different directories, but CTest matches fixtures and `DEPENDS` by name string. Duplicates therefore share the `Cleanup_<name>` fixture and race under `ctest -j`, and `ctest -R '^name$'` runs an arbitrary one. The new guard in `itk_add_test` records each name in a global property and reports both registration locations on a collision. Registrations from `Modules/Remote/` downgrade to `AUTHOR_WARNING` — remote modules are separate repositories whose collisions cannot be fixed in this tree.

</details>

<details>
<summary>Collisions the guard has already caught in CI</summary>

- `itkTimeProbeTest2`: Core/Common vs the ITKPerformanceBenchmarking remote module (asv job). Core registration renamed to `itkTimeProbeCommonTest2`; remote-module collisions now warn instead of failing.
- `itkOBJMeshIOPythonTest` / `itkOFFMeshIOPythonTest`: identical smoke tests registered in both `Modules/Core/Mesh/wrapping` and the owning modules (`IO/MeshOBJ`, `IO/MeshOFF`). Core copies dropped.
- `itkPyVectorContainerTest`: divergent scripts in `Bridge/NumPy` and `Filtering/MeshToPolyData`; the latter renamed to `itkMeshToPolyDataPyVectorContainerTest`.

</details>

<details>
<summary>Local validation</summary>

- Fail-before: with the guard active and the old duplicate name restored, configure fails with `Duplicate test name 'itkMeshFileReadWriteTest01' (already added in .../Modules/IO/Mesh/test/CMakeLists.txt)`.
- Pass-after: full ITK configure (default modules + testing, C++-only) completes cleanly; Python-wrapped collisions were exposed by CI and fixed in follow-up commits.
- `pre-commit run --all-files` exits 0.

</details>

<!--
provenance: claude-code session 2026-07-13; branch authored on another machine, validated + rebased here
key_facts: guard uses GLOBAL property ITK_TEST_NAME_<name> in CMake/ITKModuleTest.cmake itk_add_test
-->
