### PR TITLE
Avoid using the abbreviation "std" for standard deviation, in C++ code

### DIFF
--- a/Modules/Core/Common/include/itkAnnulusOperator.hxx
+++ b/Modules/Core/Common/include/itkAnnulusOperator.hxx
@@ -157,13 +157,13 @@ AnnulusOperator<TPixel, TDimension, TAllocator>::GenerateCoefficients() -> Coeff
     auto         num = static_cast<double>(countNotExterior);
     const double mean = sumNotExterior / num;
     const double var = (sumNotExteriorSq - (sumNotExterior * sumNotExterior / num)) / (num - 1.0);
-    const double std = std::sqrt(var);
+    const double standardDeviation = std::sqrt(var);
 
-    // convert std to a scaling factor k such that
+    // convert standardDeviation to a scaling factor k such that
     //
     //        || (coeffP - mean) / k || = 1.0
     //
-    const double k = std * std::sqrt(num - 1.0);
+    const double k = standardDeviation * std::sqrt(num - 1.0);
 
     // Run through the kernel again, shifting and normalizing the
     // elements that are not exterior to the annulus.  This forces the

--- a/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
+++ b/Modules/Filtering/Convolution/include/itkNormalizedCorrelationImageFilter.hxx
@@ -113,13 +113,13 @@ NormalizedCorrelationImageFilter<TInputImage, TMaskImage, TOutputImage, TOperato
   auto                      num = static_cast<OutputPixelRealType>(this->GetOperator().Size());
   const OutputPixelRealType mean = sum / num;
   const OutputPixelRealType var = (sumOfSquares - (sum * sum / num)) / (num - 1.0);
-  const OutputPixelRealType std = std::sqrt(var);
+  const OutputPixelRealType standardDeviation = std::sqrt(var);
 
-  // convert std to a scaling factor k such that
+  // convert standardDeviation to a scaling factor k such that
   //
   //        || (coeff - mean) / k || = 1.0
   //
-  const double k = std * std::sqrt(num - 1.0);
+  const double k = standardDeviation * std::sqrt(num - 1.0);
 
   // A zero-variance (constant) template has no defined direction to normalize
   // toward and correlates to zero everywhere; cancellation in the variance can

--- a/Modules/Filtering/TextureFeatures/test/itkFirstOrderTextureFeaturesImageFilterGTest.cxx
+++ b/Modules/Filtering/TextureFeatures/test/itkFirstOrderTextureFeaturesImageFilterGTest.cxx
@@ -95,7 +95,7 @@ TEST(TextureFeatures, FirstOrder_Test1)
 
     print_feature(p);
 
-    // The following is for a Gaussian sample with std dev of .1
+    // The following is for a Gaussian sample with standard deviation of .1
     // The expected value was analytically computed, while the
     // tolerances were estimated based on 10,000 different sample set
     // distributions in numpy.
@@ -165,7 +165,7 @@ TEST(TextureFeatures, FirstOrder_Test2)
 
     print_feature(p);
 
-    // The following is for a Gaussian sample with std dev of .1
+    // The following is for a Gaussian sample with standard deviation of .1
     // The expected value was analytically computed, while the
     // tolerances were estimated based on 10,000 different sample set
     // distributions in numpy.

--- a/Modules/Registration/Common/test/itkKullbackLeiblerCompareHistogramImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkKullbackLeiblerCompareHistogramImageToImageMetricTest.cxx
@@ -286,9 +286,9 @@ itkKullbackLeiblerCompareHistogramImageToImageMetricTest(int, char *[])
   std::cout << "Name of class: " << metric->GetNameOfClass() << std::endl;
   //  std::cout << "No. of samples used = " <<
   //    metric->GetNumberOfSpatialSamples() << std::endl;
-  //  std::cout << "Fixed image std dev = " <<
+  //  std::cout << "Fixed image standard deviation = " <<
   //    metric->GetFixedImageStandardDeviation() << std::endl;
-  //  std::cout << "Moving image std dev = " <<
+  //  std::cout << "Moving image standard deviation = " <<
   //    metric->GetMovingImageStandardDeviation() << std::endl;
 
   metric->Print(std::cout);
@@ -297,7 +297,7 @@ itkKullbackLeiblerCompareHistogramImageToImageMetricTest(int, char *[])
   //  metric->SetKernelFunction( theKernel );
   //  theKernel->Print( std::cout );
 
-  //  std::cout << "Try causing an exception by making std dev too small";
+  //  std::cout << "Try causing an exception by making standard deviation too small";
   //  std::cout << std::endl;
   //  metric->SetFixedImageStandardDeviation( 0.001 );
   //  try

--- a/Modules/Registration/Common/test/itkMutualInformationMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMutualInformationMetricTest.cxx
@@ -213,8 +213,8 @@ itkMutualInformationMetricTest(int, char *[])
   //-------------------------------------------------------
   std::cout << "Name of class: " << metric->GetNameOfClass() << std::endl;
   std::cout << "No. of samples used = " << metric->GetNumberOfSpatialSamples() << std::endl;
-  std::cout << "Fixed image std dev = " << metric->GetFixedImageStandardDeviation() << std::endl;
-  std::cout << "Moving image std dev = " << metric->GetMovingImageStandardDeviation() << std::endl;
+  std::cout << "Fixed image standard deviation = " << metric->GetFixedImageStandardDeviation() << std::endl;
+  std::cout << "Moving image standard deviation = " << metric->GetMovingImageStandardDeviation() << std::endl;
 
   metric->Print(std::cout);
 
@@ -222,7 +222,7 @@ itkMutualInformationMetricTest(int, char *[])
   metric->SetKernelFunction(theKernel);
   theKernel->Print(std::cout);
 
-  std::cout << "Try causing an exception by making std dev too small";
+  std::cout << "Try causing an exception by making standard deviation too small";
   std::cout << std::endl;
   metric->SetFixedImageStandardDeviation(0.001);
   try

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest.cxx
@@ -221,7 +221,7 @@ itkGeodesicActiveContourShapePriorLevelSetImageFilterTest(int, char *[])
   CostFunctionType::ArrayType mean(shape->GetNumberOfShapeParameters());
   CostFunctionType::ArrayType stddev(shape->GetNumberOfShapeParameters());
 
-  // Assume the sphere radius has a mean value of 25 and std dev of 3
+  // Assume the sphere radius has a mean value of 25 and standard deviation of 3
   mean[0] = 25.0;
   stddev[0] = 3.0;
 

--- a/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest_2.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkGeodesicActiveContourShapePriorLevelSetImageFilterTest_2.cxx
@@ -289,7 +289,7 @@ itkGeodesicActiveContourShapePriorLevelSetImageFilterTest_2(int, char *[])
   CostFunctionType::ArrayType mean(shape->GetNumberOfShapeParameters());
   CostFunctionType::ArrayType stddev(shape->GetNumberOfShapeParameters());
 
-  // Assume the pca component has a mean value of -15.0 and std dev of 3
+  // Assume the pca component has a mean value of -15.0 and standard deviation of 3
   mean[0] = -15.0;
   stddev[0] = 3.0;
 

--- a/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationImageFilterTest.cxx
+++ b/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationImageFilterTest.cxx
@@ -28,9 +28,10 @@ itkVoronoiSegmentationImageFilterTest(int argc, char * argv[])
   if (argc != 9)
   {
     std::cerr << "Missing Parameters." << std::endl;
-    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv)
-              << " mean std meanTolerance stdTolerance numberOfSeeds steps meanPercentError stdPercentError"
-              << std::endl;
+    std::cerr
+      << "Usage: " << itkNameOfTestExecutableMacro(argv)
+      << " mean standardDeviation meanTolerance stdTolerance numberOfSeeds steps meanPercentError stdPercentError"
+      << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -101,9 +102,9 @@ itkVoronoiSegmentationImageFilterTest(int argc, char * argv[])
   voronoiSegmenter->SetMean(mean);
   ITK_TEST_SET_GET_VALUE(mean, voronoiSegmenter->GetMean());
 
-  auto std = std::stod(argv[2]);
-  voronoiSegmenter->SetSTD(std);
-  ITK_TEST_SET_GET_VALUE(std, voronoiSegmenter->GetSTD());
+  auto standardDeviation = std::stod(argv[2]);
+  voronoiSegmenter->SetSTD(standardDeviation);
+  ITK_TEST_SET_GET_VALUE(standardDeviation, voronoiSegmenter->GetSTD());
 
   auto meanTolerance = std::stod(argv[3]);
   voronoiSegmenter->SetMeanTolerance(meanTolerance);

--- a/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationRGBImageFilterTest.cxx
+++ b/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationRGBImageFilterTest.cxx
@@ -210,8 +210,8 @@ TestNoPrior(ImageType::Pointer inputImage)
   std::cout << "Setting filter input" << std::endl;
   filter->SetInput(inputImage);
 
-  // explicitly set mean and std
-  std::cout << "Setting up mean and std for filter" << std::endl;
+  // explicitly set mean and standard deviation
+  std::cout << "Setting up mean and standard deviation for filter" << std::endl;
   double mean[6];
   mean[0] = fgMean;
   mean[1] = fgMean;
@@ -220,14 +220,14 @@ TestNoPrior(ImageType::Pointer inputImage)
   mean[4] = 0;
   mean[5] = 50;
   filter->SetMean(mean);
-  double std[6];
-  std[0] = fgStd;
-  std[1] = fgStd;
-  std[2] = fgStd;
-  std[3] = 255;
-  std[4] = 10;
-  std[5] = 10;
-  filter->SetSTD(std);
+  double standardDeviation[6];
+  standardDeviation[0] = fgStd;
+  standardDeviation[1] = fgStd;
+  standardDeviation[2] = fgStd;
+  standardDeviation[3] = 255;
+  standardDeviation[4] = 10;
+  standardDeviation[5] = 10;
+  filter->SetSTD(standardDeviation);
   filter->SetNumberOfSeeds(400);
   filter->SetSteps(5);
   filter->SetMaxValueOfRGB(255);


### PR DESCRIPTION
Two little style commits:
- Rename `std` variables to `standardDeviation` (following the Naming Conventions of the Coding Style Guide from the [ITK Software Guide](https://github.com/InsightSoftwareConsortium/ITKSoftwareGuide): "Names are generally spelled out; use of abbreviations is discouraged.")
- Replace "std dev" with "standard deviation", in tests

Aims to improve human readability of the code, and avoid confusion with the `std` namespace.
